### PR TITLE
Add vision_visp system dependencies.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -593,3 +593,7 @@ zziplib:
   opensuse: zziplib-devel
   rhel: zziplib-devel
   ubuntu: libzzip-0-13 libzzip-dev
+liblapack:
+  debian: liblapack-dev
+  fedora: lapack-devel
+  ubuntu: liblapack-dev

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -597,3 +597,5 @@ liblapack:
   debian: liblapack-dev
   fedora: lapack-devel
   ubuntu: liblapack-dev
+libcoin60:
+  ubuntu: libcoin60-dev

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -602,3 +602,6 @@ libcoin60:
 libpng:
   fedora: libpng-devel
   ubuntu: libpng12-dev
+libsoqt4:
+  fedora: SoQt-devel
+  ubuntu: libsoqt4-dev

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -599,3 +599,6 @@ liblapack:
   ubuntu: liblapack-dev
 libcoin60:
   ubuntu: libcoin60-dev
+libpng:
+  fedora: libpng-devel
+  ubuntu: libpng12-dev

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -605,3 +605,7 @@ libpng:
 libsoqt4:
   fedora: SoQt-devel
   ubuntu: libsoqt4-dev
+ipopt:
+  ubuntu: coinor-libipopt-dev
+omniORB4:
+  ubuntu: omniorb4 omniorb4-idl libomniorb4-dev


### PR DESCRIPTION
Hello,
I would like to release vision_visp into Fuerte.

To do so, I need the following system dependencies to be added.
Can you pull these modifications?

Thanks,
