### PR TITLE
Missing OpenNI keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -426,6 +426,8 @@ mercurial:
   macports: mercurial
   opensuse: mercurial
   ubuntu: mercurial
+nite-dev:
+  ubuntu: nite-dev
 nvidia-cg:
   ubuntu: nvidia-cg-toolkit
   debian: nvidia-cg-toolkit
@@ -474,6 +476,8 @@ pkg-config:
 protobuf:
   ubuntu:
     oneiric: libprotobuf7
+ps-engine:
+  ubuntu: ps-engine
 libqt4-dev:
   ubuntu: libqt4-dev
   arch: qt


### PR DESCRIPTION
Added ps-engine and nite-dev keys required by openni_kinect stack.
