### PR TITLE
Add nmea_gps_driver python-serial rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -128,3 +128,5 @@ python-qt-bindings:
   ubuntu:
     lucid: python-qt4 python-qt4-dev python-sip-dev python-qt4-gl
     oneiric: python-pyside.qtcore python-pyside.qtgui libpyside-dev libshiboken-dev shiboken libgenrunner-dev python-qt4 python-qt4-dev python-sip-dev python-qt4-gl
+python-serial:
+  ubuntu: python-serial


### PR DESCRIPTION
In order to release the new nmea_gps_driver stack info Fuerte, I need to add a rosdep for python-serial.
