### PR TITLE
Added rosdep dependencies needed by roslisp_support and added rosemacs debian package

### DIFF
--- a/releases/backports.yaml
+++ b/releases/backports.yaml
@@ -1,2 +1,5 @@
 - url: https://kforge.ros.org/rosrelease/yamlcppdebs
-  target: all 
+  target: all
+- name: rosemacs-el
+  uri: https://github.com/moesenle/rosemacs-debs.git
+  target: all

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -125,6 +125,8 @@ cmake:
   ubuntu: cmake
 coinor-libipopt-dev:
   ubuntu: coinor-libipopt-dev
+coreutils:
+  ubuntu: coreutils
 cppunit:
   arch: cppunit
   debian: libcppunit-dev

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -127,6 +127,7 @@ coinor-libipopt-dev:
   ubuntu: coinor-libipopt-dev
 coreutils:
   ubuntu: coreutils
+  debian: coreutils
 cppunit:
   arch: cppunit
   debian: libcppunit-dev
@@ -631,6 +632,8 @@ readline-dev:
   fedora: readline-devel
 sbcl:
   ubuntu: sbcl
+  debian: sbcl
+  arch: sbcl
 scons:
   arch: scons
   debian: scons

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -629,6 +629,8 @@ readline-dev:
   arch: readline
   ubuntu: libreadline-dev
   fedora: readline-devel
+sbcl:
+  ubuntu: sbcl
 scons:
   arch: scons
   debian: scons


### PR DESCRIPTION
Added dependencies coreutils and sbcl that are needed by roslisp_support and added rosemacs to backports.yaml for debian generation.

I'm not sure if my change to backports.yaml is fine so please review and comment on it.
