### PR TITLE
Arch pkgs3

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -390,7 +390,7 @@ libjpeg:
   debian: libjpeg62-dev
   fedora: libjpeg-devel
   macports: jpeg
-  arch: libjpeg
+  arch: libjpeg-turbo
 liblapack-dev:
   arch: lapack
   debian: liblapack-dev

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -12,6 +12,7 @@ apr:
   rhel: apr-devel apr-util
   ubuntu: libapr1-dev libaprutil1-dev
 ant:
+  arch: apache-ant
   ubuntu: 
     lucid: ant1.8
     maverick: ant 
@@ -52,9 +53,11 @@ automake:
   rhel: automake
   ubuntu: automake
 avr-libc:
+  arch: avr-libc
   ubuntu: avr-libc
   gentoo: cross-avr/avr-libc
 bazaar:
+  arch: bzr
   debian: bzr
   fedora: bazaar
   freebsd: bazaar
@@ -63,6 +66,7 @@ bazaar:
   opensuse: bzr
   ubuntu: bzr
 beep:
+  arch: beep
   ubuntu: beep
 bison:
   arch: bison
@@ -129,6 +133,7 @@ cmake:
 coinor-libipopt-dev:
   ubuntu: coinor-libipopt-dev
 coreutils:
+  arch: coreutils
   ubuntu: coreutils
   debian: coreutils
 cppunit:
@@ -151,6 +156,7 @@ curl:
   opensuse: libcurl-devel
   ubuntu: libcurl4-openssl-dev
 daemontools:
+  arch: daemontools
   ubuntu: daemontools
 doxygen:
   arch: doxygen
@@ -210,6 +216,7 @@ freeimage:
   gentoo: freeimage
   fedora: freeimage-devel
 gcc-avr:
+  arch: avr-gcc
   ubuntu: gcc-avr
   gentoo: cross-avr/gcc
 gforth:
@@ -253,9 +260,11 @@ graphviz:
   rhel: graphviz
   ubuntu: graphviz
 gstreamer0.10-plugins-good:
+  arch: gstreamer0.10-good-plugins
   ubuntu:
     gstreamer0.10-plugins-good
 gstreamer0.10-plugins-ugly:
+  arch: gstreamer0.10-ugly-plugins
   ubuntu:
     lucid: gstreamer0.10-plugins-ugly-multiverse
     maverick: gstreamer0.10-plugins-ugly-multiverse
@@ -281,8 +290,10 @@ gtk2:
   rhel: gtk2-devel
   ubuntu: libgtk2.0-dev
 hddtemp:
+  arch: hddtemp
   ubuntu: hddtemp
 hostapd:
+  arch: hostapd
   ubuntu: hostapd
 intltool:
   arch: intltool
@@ -292,6 +303,7 @@ intltool:
   gentoo: dev-util/intltool
   freebsd: intltool
 ipmitool:
+  arch: ipmitool
   ubuntu: ipmitool
 jasper:
   ubuntu: libjasper-dev
@@ -311,6 +323,7 @@ libann-dev:
   arch: ann
   ubuntu: libann-dev
 libapache2-mod-python:
+  arch: mod_python
   ubuntu: libapache2-mod-python
 libbluetooth-dev:
   arch: bluez
@@ -334,6 +347,7 @@ libcoin60-dev:
   arch: coin
   ubuntu: libcoin60-dev
 libdbus-dev:
+  arch: dbus-core
   ubuntu: libdbus-1-dev
 libdevil-dev:
   arch: devil
@@ -351,12 +365,17 @@ libgphoto-dev:
   arch: libgphoto2
   ubuntu: libgphoto2-2-dev
 libgstreamer0.10-dev:
+  arch: gstreamer0.10
   ubuntu:
     libgstreamer0.10-dev
 libgstreamer-plugins-base0.10-dev:
+  arch: gstreamer0.10-base-plugins
   ubuntu:
     libgstreamer-plugins-base0.10-dev
 libhal-dev:
+  arch:
+    pacman:
+      packages: [hal]
   ubuntu:
     apt:
       packages: [libhal-dev]
@@ -383,6 +402,7 @@ libleptonica-dev:
 libmysqlclient-dev:
   ubuntu: libmysqlclient-dev
 libnl-dev:
+  arch: libnl
   ubuntu: libnl-dev
 libogg:
   arch: libogg
@@ -411,6 +431,7 @@ libpcap:
     pacman:
       packages: [libpcap]
 libpcsclite-dev:
+  arch: pcsclite
   ubuntu: libpcsclite-dev
 libpng12-dev:
   arch: libpng
@@ -439,6 +460,7 @@ libqt4-opengl-dev:
   arch: qt
   ubuntu: libqt4-opengl-dev
 libqwt5-qt4-dev:
+  arch: qwt5
   ubuntu:
     apt:
       packages: [libqwt5-qt4-dev]
@@ -459,6 +481,7 @@ libraw1394-dev:
     yum:
       packages: [libraw1394-devel]
 libreadline-dev:
+  arch: readline
   ubuntu: libreadline-dev
 libsoqt4-dev:
   arch: soqt
@@ -592,6 +615,7 @@ mercurial:
   opensuse: mercurial
   ubuntu: mercurial
 nite-dev:
+  arch: nite
   ubuntu: nite-dev
 nvidia-cg:
   arch: nvidia-cg-toolkit
@@ -613,6 +637,7 @@ opengl:
   rhel: mesa-libGL-devel mesa-libGLU-devel
   ubuntu: libgl1-mesa-dev libglu1-mesa-dev
 openni-dev:
+  arch: openni
   ubuntu: openni-dev
 netpbm:
   ubuntu: libnetpbm10-dev
@@ -689,6 +714,7 @@ suitesparse:
   arch: suitesparse
   ubuntu: libsuitesparse-dev
 sysstat:
+  arch: sysstat
   ubuntu: sysstat
 tinyxml:
   arch: tinyxml
@@ -706,6 +732,7 @@ texlive-latex-base:
   arch: texlive-base
   ubuntu: texlive-latex-base
 udhcpc:
+  arch: udhcp
   ubuntu: udhcpc
 uuid:
   arch: util-linux
@@ -750,9 +777,11 @@ xulrunner-dev:
   ubuntu: libv8-dev
   fedora: libv8-devel
 yaml:
+  arch: libyaml
   fedora: libyaml-devel
   ubuntu: libyaml-dev
 yaml-cpp:
+  arch: yaml-cpp
   debian:
     source: {md5sum: f7fb81fd4a2fbd5022daa7686e816359, uri: 'https://kforge.ros.org/rosrelease/viewvc/sourcedeps/yaml-cpp/yaml-cpp-0.2.5.rdmanifest'}
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -13,7 +13,7 @@ paramiko:
 python:
   ubuntu: python-dev
   debian: python-dev
-  arch: python
+  arch: python2
   opensuse: python-devel
   fedora: python-devel
   rhel: python-devel
@@ -73,7 +73,7 @@ python-libpcap:
   ubuntu: python-libpcap
 python-matplotlib:
   ubuntu: python-matplotlib
-  arch: python-matplotlib
+  arch: python2-matplotlib
   debian: python-matplotlib
   macports: py26-matplotlib
   opensuse: python-matplotlib
@@ -84,6 +84,7 @@ python-matplotlib:
 python-mechanize:
   ubuntu: python-mechanize
 python-nose:
+  arch: python2-nose
   ubuntu: python-nose
 python-numpy:
   ubuntu: python-numpy
@@ -105,6 +106,7 @@ python-paramiko:
   freebsd: py27-paramiko
   arch: python-paramiko
 python-qt-bindings:
+  arch: python2-pyqt
   ubuntu:
     lucid: python-qt4 python-qt4-dev python-sip-dev python-qt4-gl
     oneiric: python-pyside.qtcore python-pyside.qtgui libpyside-dev libshiboken-dev shiboken libgenrunner-dev python-qt4 python-qt4-dev python-sip-dev python-qt4-gl
@@ -115,7 +117,7 @@ python-scapy:
 python-scipy:
   ubuntu: python-scipy
   debian: python-scipy
-  arch: python-scipy
+  arch: python2-scipy
   opensuse: python-scipy
   fedora: scipy
   macports: py26-scipy
@@ -125,6 +127,7 @@ python-scipy:
 python-serial:
   ubuntu: python-serial
 python-setuptools:
+  arch: python2-distribute
   ubuntu: python-setuptools
 python-sip:
   ubuntu: python-sip-dev
@@ -135,9 +138,10 @@ python-sip:
     homebrew:
       packages: [ sip ]
   gentoo: dev-python/sip
-  arch: sip
+  arch: sip python2-sip
   freebsd: py26-sip
 python-sphinx:
+  arch: python2-sphinx
   debian: python-sphinx
   fedora: python-sphinx
   freebsd: py27-sphinx
@@ -156,7 +160,7 @@ python-yaml:
   fedora: PyYAML
   rhel: PyYAML
   centos: PyYAML
-  arch: python-yaml
+  arch: python2-yaml
   macports: py26-yaml
   gentoo: pyyaml
   cygwin: |


### PR DESCRIPTION
- Added arch entries for a lot more packages in base.yaml including critical yaml/yaml-cpp
- Update arch entries in python.yaml to reflect archlinux naming change from python to python2. A few pkgs remain python-xxx and reflect current status in archlinux.
