### PR TITLE
added rule for libqglviewer

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -418,6 +418,9 @@ pkg-config:
 protobuf:
   ubuntu:
     oneiric: libprotobuf7
+libqglviewer-qt4-dev:
+  ubuntu: libqglviewer-qt4-dev
+  debian: libqglviewer-qt4-dev
 libqt4-dev:
   ubuntu: libqt4-dev
   arch: qt
@@ -430,6 +433,7 @@ libqt4-dev:
   ubuntu: libqt4-dev
 libqt4-opengl-dev:
   ubuntu: libqt4-opengl-dev
+  debian: libqt4-opengl-dev
 qt4-qmake:
   ubuntu: qt4-qmake
 readline-dev:


### PR DESCRIPTION
necessary rosdep for a catkin release of octovis (OctoMap visualization)
