### PR TITLE
Add Ubuntu Precise python-qt-bindings packages

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -119,6 +119,7 @@ python-qt-bindings:
   ubuntu:
     lucid: python-qt4 python-qt4-dev python-sip-dev python-qt4-gl
     oneiric: python-pyside.qtcore python-pyside.qtgui libpyside-dev libshiboken-dev shiboken libgenrunner-dev python-qt4 python-qt4-dev python-sip-dev python-qt4-gl
+    precise: python-pyside.qtcore python-pyside.qtgui libpyside-dev libshiboken-dev shiboken libgenrunner-dev python-qt4 python-qt4-dev python-sip-dev python-qt4-gl
 python-rospkg:
   ubuntu: python-rospkg
 python-scapy:


### PR DESCRIPTION
Hi. I needed this packages for Ubuntu Precise. They are the same as in Oneiric.
