### PR TITLE
Added rosdep definitions required by rosjava_jni

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -368,7 +368,7 @@ jasper:
   gentoo: jasper
   fedora: jasper-devel
 java:
-  ubuntu: openjdk-6-jdk
+  ubuntu: default-jdk
   debian: openjdk-6-jdk
   arch: openjdk6
   gentoo: dev-java/sun-jdk

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -367,6 +367,12 @@ jasper:
   arch: jasper
   gentoo: jasper
   fedora: jasper-devel
+java:
+  ubuntu: openjdk-6-jdk
+  debian: openjdk-6-jdk
+  arch: openjdk6
+  gentoo: dev-java/sun-jdk
+  freebsd: openjdk6
 joystick:
   arch: joyutils
   debian: joystick


### PR DESCRIPTION
Since some people are still using rosjava_jni, I would like to release it. Please merge in the rosdep entry for java.
