### PR TITLE
Add gentoo rosdep mappings.

### DIFF
--- a/rosdep/gentoo.yaml
+++ b/rosdep/gentoo.yaml
@@ -38,3 +38,5 @@ libqt4-opengl-dev:
   gentoo: x11-libs/qt-opengl
 pcl:
   gentoo: sci-libs/pcl
+yaml:
+  gentoo: dev-libs/libyaml

--- a/rosdep/gentoo.yaml
+++ b/rosdep/gentoo.yaml
@@ -40,3 +40,5 @@ pcl:
   gentoo: sci-libs/pcl
 yaml:
   gentoo: dev-libs/libyaml
+swig-wx:
+  gentoo: dev-lang/swig

--- a/rosdep/gentoo.yaml
+++ b/rosdep/gentoo.yaml
@@ -23,7 +23,7 @@ opencv2:
 opencv2.3:
   gentoo: media-libs/opencv
 libjpeg:
-  gentoo: media-libs/jpeg
+  gentoo: virtual/jpeg
 libx11:
   gentoo: x11-libs/libX11
 uuid:

--- a/rosdep/gentoo.yaml
+++ b/rosdep/gentoo.yaml
@@ -31,7 +31,7 @@ uuid:
 qt4-qmake:
   gentoo: x11-libs/qt-core
 python-qt-bindings:
-  gentoo: x11-libs/PyQt4
+  gentoo: dev-python/PyQt4
 tbb:
   gentoo: dev-cpp/tbb
 libqt4-opengl-dev:

--- a/rosdep/gentoo.yaml
+++ b/rosdep/gentoo.yaml
@@ -18,3 +18,19 @@ yaml-cpp:
   gentoo: 
     portage: 
       packages: dev-cpp/yaml-cpp
+opencv2:
+  gentoo: media-libs/opencv
+opencv2.3:
+  gentoo: media-libs/opencv
+libjpeg:
+  gentoo: media-libs/jpeg
+libx11:
+  gentoo: x11-libs/libX11
+uuid:
+  gentoo: dev-libs/ossp-uuid
+qt4-qmake:
+  gentoo: x11-libs/qt-core
+python-qt-bindings:
+  gentoo: x11-libs/PyQt4
+tbb:
+  gentoo: dev-cpp/tbb

--- a/rosdep/gentoo.yaml
+++ b/rosdep/gentoo.yaml
@@ -36,3 +36,5 @@ tbb:
   gentoo: dev-cpp/tbb
 libqt4-opengl-dev:
   gentoo: x11-libs/qt-opengl
+pcl:
+  gentoo: sci-libs/pcl

--- a/rosdep/gentoo.yaml
+++ b/rosdep/gentoo.yaml
@@ -34,3 +34,5 @@ python-qt-bindings:
   gentoo: x11-libs/PyQt4
 tbb:
   gentoo: dev-cpp/tbb
+libqt4-opengl-dev:
+  gentoo: x11-libs/qt-opengl


### PR DESCRIPTION
Use pcl from the ezod overlay (listed as the install method for gentoo on pcl's home page).

Lie about swig-wx due to swig-wx being a ros specific package.
