### PR TITLE
base.yaml: added libgsl dep for ubuntu and debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -464,6 +464,9 @@ libgstreamer-plugins-base0.10-dev:
   ubuntu:
     libgstreamer-plugins-base0.10-dev
   fedora: gstreamer-plugins-base-devel
+libgsl:
+  ubuntu: libgsl0-dev
+  debian: libgsl0-dev
 libgts:
   arch: gts
   ubuntu: libgts-dev


### PR DESCRIPTION
base.yaml: added libgsl dep for ubuntu and debian

needed by scan_tools in ccny-ros-pkg
