### PR TITLE
Depend on libcurl-ssl-dev instead of libcurl4-openssl-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -197,13 +197,13 @@ cppunit:
   ubuntu: libcppunit-dev
 curl:
   arch: curl
-  debian: libcurl4-openssl-dev
+  debian: libcurl-ssl-dev
   fedora: libcurl-devel
   freebsd: curl
   gentoo: net-misc/curl
   macports: curl
   opensuse: libcurl-devel
-  ubuntu: libcurl4-openssl-dev
+  ubuntu: libcurl-ssl-dev
 daemontools:
   arch: daemontools
   ubuntu: daemontools


### PR DESCRIPTION
The openssl version conflicts with libcurl4-gnutls-dev, which
is required by some system packages. libcurl-ssl-dev is a virtual
package satisfied by -openssl, -gnutls or -nss.
