### PR TITLE
Update rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -198,3 +198,5 @@ python-yaml:
         python setup.py install 
       fi
   freebsd: py27-yaml
+python-pymodbus:
+  ubuntu: python-pymodbus


### PR DESCRIPTION
Add the package python-pymodbus to python.yaml.

This package is for communicating with industrial devices using the Mobdus RTU and Modbus TCP protocols.
