### PR TITLE
Adds deap to python 

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -201,3 +201,5 @@ python-yaml:
 python-pymodbus:
   ubuntu: 
     precise: python-pymodbus
+python-deap:
+  pip: deap

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -202,4 +202,5 @@ python-pymodbus:
   ubuntu: 
     precise: python-pymodbus
 python-deap:
-  pip: deap
+  ubuntu:
+    pip: deap

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -201,6 +201,6 @@ python-yaml:
 python-pymodbus:
   ubuntu: 
     precise: python-pymodbus
-python-deap:
+python-deap-pip:
   ubuntu:
     pip: deap


### PR DESCRIPTION
DEAP is a evolutionary algorithm optimizer in python. It is already used by an other package (rtcus_cognitive). As the main developer of the package I prefer make it a system dependency that a ros package. Moreover, as the Debian packages are usually way behind our development process I made it a pip install dependency.

The API of DEAP is pretty stable now as the next release (0.9) will mostly contain documentation updates and the next one (1.0) will just discard DTM in favour of the externally developed SCOOP.

Note: I already contacted the maintainer of rtcus_cognitive for him to change to the dependency.
