### PR TITLE
Fixed package name of libqglviewer-qt4

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -607,8 +607,8 @@ libpq-dev:
   arch: postgresql-libs
   ubuntu: libpq-dev
 libqglviewer-qt4:
-  ubuntu: libqglviewer-qt4
-  debian: libqglviewer-qt4
+  ubuntu: libqglviewer-qt4-2
+  debian: libqglviewer-qt4-2
 libqglviewer-qt4-dev:
   ubuntu: libqglviewer-qt4-dev
   debian: libqglviewer-qt4-dev


### PR DESCRIPTION
The package is called "libqglviewer-qt4-2" for ubuntu and debian
