### PR TITLE
Additional rosdep rules for base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -373,6 +373,10 @@ gtk2:
   opensuse: gtk2-devel
   rhel: gtk2-devel
   ubuntu: libgtk2.0-dev
+gtk-doc-tools:
+  ubuntu: gtk-doc-tools
+gv:
+  ubuntu: gv
 hddtemp:
   arch: hddtemp
   ubuntu: hddtemp
@@ -839,6 +843,8 @@ m4:
   fedora: m4
   opensuse: m4
   ubuntu: m4
+maven:
+  ubuntu: maven
 mercurial:
   arch: mercurial
   debian: mercurial

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -96,6 +96,8 @@ automake:
   opensuse: automake
   rhel: automake
   ubuntu: automake
+autopoint:
+  ubuntu: autopoint
 avahi-daemon:
   ubuntu: avahi-daemon
 avr-libc:
@@ -472,6 +474,8 @@ libglew-dev:
   arch: glew
   ubuntu: libglew1.5-dev
   fedora: glew-devel
+libglib-dev:
+  ubuntu: libglib2.0-dev
 libglui-dev:
   arch: glui
   ubuntu: libglui-dev


### PR DESCRIPTION
I've added some rosdep rules for a new stack that wraps the April Tag Fiducial Marker system. 
