### PR TITLE
Update rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -644,9 +644,9 @@ libqhull:
   fedora: qhull-devel
   macports: qhull
 libqt4:
-  ubuntu: libqt4
+  ubuntu: libqt4-core
   arch: qt
-  debian: libqt4
+  debian: libqt4-core
   fedora: qt
   freebsd: qt4-corelib
   gentoo: '>=x11-libs/qt-core-4'
@@ -673,6 +673,7 @@ libqt4-opengl-dev:
   fedora: qt-devel
 libqtgui4:
   ubuntu: libqtgui4
+  debian: libqtgui4
   fedora: qt-x11
 libqwt5-qt4-dev:
   arch: qwt5


### PR DESCRIPTION
Fixed qt4 library name for ubuntu and debian (libqt4-core), added libqtgui4 for debian. libqt4 does not exist, renders depending packages non-installable
