### PR TITLE
New definitions for rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -718,6 +718,8 @@ libsoqt4-dev:
   fedora: SoQt-devel
   ubuntu: libsoqt4-dev
   debian: libsoqt4-dev
+libsqlite3-dev:
+  ubuntu: libsqlite3-dev
 libstdc++5:
   arch: libstdc++5
   ubuntu: libstdc++5
@@ -987,6 +989,8 @@ sdl-image:
   macports: libsdl_image
   gentoo: sdl-image
   freebsd: sdl_image
+sqlite3:
+  ubuntu: sqlite3
 subversion:
   arch: subversion
   debian: subversion

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -563,6 +563,8 @@ libleptonica-dev:
   ubuntu: libleptonica-dev
 libmotif-dev:
   ubuntu: libmotif-dev
+libmp3lame-dev:
+  ubuntu: libmp3lame-dev
 libmysqlclient-dev:
   ubuntu: libmysqlclient-dev
   fedora: mysql


### PR DESCRIPTION
Added libmp3lame-dev, sqlite3 and libsqlite3-dev definitions to rosdep/base.yaml (for ubuntu only).
