### PR TITLE
fix omniorb and ruby osdeps and add some rhel rosdeps

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1046,6 +1046,7 @@ tinyxml:
   arch: tinyxml
   debian: libtinyxml-dev
   fedora: tinyxml-devel
+  rhel: tinyxml-devel
   ubuntu: libtinyxml-dev
 tbb:
   arch: intel-tbb

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -36,6 +36,7 @@ assimp:
   debian:
     source: {md5sum: d5137302d8f00241ee10e623b97f9d22, uri: 'https://kforge.ros.org/rosrelease/viewvc/sourcedeps/assimp/assimp-2.0.86-1.rdmanifest'}
   fedora: assimp-devel
+  rhel: assimp-devel
   ubuntu:
     lucid: 
       apt:
@@ -216,6 +217,7 @@ curl:
   arch: curl
   debian: libcurl4-openssl-dev
   fedora: libcurl-devel
+  rhel: libcurl-devel
   freebsd: curl
   gentoo: net-misc/curl
   macports: curl
@@ -287,6 +289,7 @@ freeimage:
   arch: freeimage
   gentoo: freeimage
   fedora: freeimage-devel
+  rhel: freeimage-devel
 ftdi-eeprom:
   ubuntu: ftdi-eeprom
 gcc-avr:
@@ -323,6 +326,7 @@ glut:
   ubuntu: freeglut3-dev
   debian: libglut3-dev
   fedora: freeglut-devel
+  rhel: freeglut-devel
   arch: freeglut
   gentoo: freeglut
   macports: mesa
@@ -362,6 +366,7 @@ gtest:
   arch: gtest
   debian: libgtest-dev
   fedora: gtest-devel
+  rhel: gtest-devel
   freebsd: googletest
   gentoo: dev-cpp/gtest
   macports: google-test
@@ -649,6 +654,7 @@ libqt4:
   arch: qt
   debian: libqt4
   fedora: qt
+  rhel: qt
   freebsd: qt4-corelib
   gentoo: '>=x11-libs/qt-core-4'
   macports: qt4-mac
@@ -658,6 +664,7 @@ libqt4-dev:
   arch: qt
   debian: libqt4-dev
   fedora: qt-devel
+  rhel: qt-devel
   freebsd: qt4-corelib
   gentoo: '>=x11-libs/qt-core-4'
   macports: qt4-mac
@@ -792,6 +799,7 @@ libxml2:
   arch: libxml2
   debian: libxml2-dev
   fedora: libxml2-devel
+  rhel: libxml2-devel
   freebsd: libxml2
   gentoo: dev-libs/libxml2
   macports: libxml2
@@ -901,6 +909,7 @@ pcre-dev:
   arch: pcre
   ubuntu: libpcre++-dev
   fedora: pcre-devel
+  rhel: pcre-devel
 pcre:
   arch: pcre
   ubuntu: libpcre3-dev
@@ -1086,6 +1095,7 @@ uuid:
   ubuntu: uuid-dev
   debian: uuid-dev
   fedora: libuuid-devel
+  rhel: libuuid-devel
   macports: ossp-uuid
   freebsd: e2fsprogs-libuuid
 unrar:
@@ -1165,6 +1175,7 @@ yaml-cpp:
     maverick: yaml-cpp0.2.6-dev
     lucid: yaml-cpp0.2.6-dev
   fedora: yaml-cpp-devel 
+  rhel: yaml-cpp-devel 
 yasm:
   ubuntu: yasm
 zlib:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -858,6 +858,7 @@ libxrandr:
   gentoo: x11-libs/libXrandr
   macports: xorg-libXrandr
   fedora: libXrandr-devel
+  rhel: libXrandr-devel
 linux-headers-generic:
   ubuntu: linux-headers-generic
 log4cxx:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -701,11 +701,13 @@ libqt4-opengl:
   ubuntu: libqt4-opengl
   debian: libqt4-opengl
   fedora: qt
+  rhel: qt
 libqt4-opengl-dev:
   arch: qt
   ubuntu: libqt4-opengl-dev
   debian: libqt4-opengl-dev
   fedora: qt-devel
+  rhel: qt-devel
 libqtgui4:
   ubuntu: libqtgui4
   debian: libqtgui4
@@ -950,6 +952,7 @@ pcre:
   arch: pcre
   ubuntu: libpcre3-dev
   fedora: pcre-devel
+  rhel: pcre-devel
   debian: libpcre3-dev
 pkg-config:
   arch: pkg-config
@@ -979,6 +982,7 @@ qt4-qmake:
   arch: qt
   ubuntu: qt4-qmake
   fedora: qt-devel
+  rhel: qt-devel
 qhull-bin:
   ubuntu: qhull-bin        
 readline-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -614,14 +614,12 @@ libsimage-dev:
   ubuntu: libsimage-dev
 omniorb:
   ubuntu:
-    'quantal': omniorb omniidl omniorb-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
-    'precise': omniorb omniidl omniorb-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
-    'oneiric': omniorb omniidl omniorb-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
-    '11.04': omniorb4 omniidl4 omniorb4-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
-    '10.10': omniorb4 omniidl4 omniorb4-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
-    '10.04': omniorb4 omniidl4 omniorb4-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
-    '9.10': omniorb4 omniidl4 omniorb4-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
-    '9.04': omniorb4 omniidl4 omniorb4-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
+    quantal: omniorb omniidl omniorb-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
+    precise: omniorb omniidl omniorb-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
+    oneiric: omniorb omniidl omniorb-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
+    natty: omniorb4 omniidl4 omniorb4-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
+    maverick: omniorb4 omniidl4 omniorb4-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
+    lucid: omniorb4 omniidl4 omniorb4-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
   debian: omniorb4 omniidl4 omniorb4-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
   fedora: |
     #!/bin/bash
@@ -996,14 +994,12 @@ redis-server:
   ubuntu: redis-server
 ruby:
   ubuntu:
-    'quantal': ruby1.8-dev libruby1.8 rubygems1.8
-    'precise': ruby1.8-dev libruby1.8 rubygems1.8
-    'oneiric': ruby1.8-dev libruby1.8 rubygems1.8
-    '11.04': ruby1.8-dev libruby1.8 rubygems1.8
-    '10.10': ruby1.8-dev libruby1.8 rubygems1.8
-    '10.04': ruby1.8-dev libopenssl-ruby1.8 rubygems1.8
-    '9.10': ruby1.8-dev libopenssl-ruby1.8 rubygems1.8
-    '9.04': ruby1.8-dev libopenssl-ruby1.8 rubygems1.8
+    quantal: ruby1.8-dev libruby1.8 rubygems1.8
+    precise: ruby1.8-dev libruby1.8 rubygems1.8
+    oneiric: ruby1.8-dev libruby1.8 rubygems1.8
+    natty: ruby1.8-dev libruby1.8 rubygems1.8
+    maverick: ruby1.8-dev libruby1.8 rubygems1.8
+    lucid: ruby1.8-dev libopenssl-ruby1.8 rubygems1.8
   fedora: ruby ruby-devel openssl-devel rubygems
   debian: ruby1.8-dev libruby1.8 rubygems1.8
 sbcl:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -822,6 +822,7 @@ libxrandr:
   gentoo: x11-libs/libXrandr
   macports: xorg-libXrandr
   fedora: libXrandr-devel
+  rhel: libXrandr-devel
 linux-headers-generic:
   ubuntu: linux-headers-generic
 log4cxx:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -251,6 +251,7 @@ eigen:
     apt:
       packages: [libeigen3-dev]
   fedora: eigen3-devel
+  rhel: eigen3-devel
 epydoc:
   arch: epydoc
   debian: python-epydoc

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -36,6 +36,7 @@ assimp:
   debian:
     source: {md5sum: d5137302d8f00241ee10e623b97f9d22, uri: 'https://kforge.ros.org/rosrelease/viewvc/sourcedeps/assimp/assimp-2.0.86-1.rdmanifest'}
   fedora: assimp-devel
+  rhel: assimp-devel
   ubuntu:
     lucid: 
       apt:
@@ -218,6 +219,7 @@ curl:
   arch: curl
   debian: libcurl4-openssl-dev
   fedora: libcurl-devel
+  rhel: libcurl-devel
   freebsd: curl
   gentoo: net-misc/curl
   macports: curl
@@ -298,6 +300,7 @@ freeimage:
   arch: freeimage
   gentoo: freeimage
   fedora: freeimage-devel
+  rhel: freeimage-devel
 ftdi-eeprom:
   ubuntu: ftdi-eeprom
 gcc-avr:
@@ -336,6 +339,7 @@ glut:
   ubuntu: freeglut3-dev
   debian: libglut3-dev
   fedora: freeglut-devel
+  rhel: freeglut-devel
   arch: freeglut
   gentoo: freeglut
   macports: mesa
@@ -375,6 +379,7 @@ gtest:
   arch: gtest
   debian: libgtest-dev
   fedora: gtest-devel
+  rhel: gtest-devel
   freebsd: googletest
   gentoo: dev-cpp/gtest
   macports: google-test
@@ -676,6 +681,7 @@ libqt4:
   arch: qt
   debian: libqt4-core
   fedora: qt
+  rhel: qt
   freebsd: qt4-corelib
   gentoo: '>=x11-libs/qt-core-4'
   macports: qt4-mac
@@ -685,6 +691,7 @@ libqt4-dev:
   arch: qt
   debian: libqt4-dev
   fedora: qt-devel
+  rhel: qt-devel
   freebsd: qt4-corelib
   gentoo: '>=x11-libs/qt-core-4'
   macports: qt4-mac
@@ -826,6 +833,7 @@ libxml2:
   arch: libxml2
   debian: libxml2-dev
   fedora: libxml2-devel
+  rhel: libxml2-devel
   freebsd: libxml2
   gentoo: dev-libs/libxml2
   macports: libxml2
@@ -937,6 +945,7 @@ pcre-dev:
   arch: pcre
   ubuntu: libpcre++-dev
   fedora: pcre-devel
+  rhel: pcre-devel
 pcre:
   arch: pcre
   ubuntu: libpcre3-dev
@@ -1138,6 +1147,7 @@ uuid:
   ubuntu: uuid-dev
   debian: uuid-dev
   fedora: libuuid-devel
+  rhel: libuuid-devel
   macports: ossp-uuid
   freebsd: e2fsprogs-libuuid
 unrar:
@@ -1236,6 +1246,7 @@ yaml-cpp:
     maverick: yaml-cpp0.2.6-dev
     lucid: yaml-cpp0.2.6-dev
   fedora: yaml-cpp-devel 
+  rhel: yaml-cpp-devel 
 yasm:
   ubuntu: yasm
 zlib:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1088,6 +1088,7 @@ tinyxml:
   arch: tinyxml
   debian: libtinyxml-dev
   fedora: tinyxml-devel
+  rhel: tinyxml-devel
   ubuntu: libtinyxml-dev
 tbb:
   arch: intel-tbb

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -242,6 +242,7 @@ eigen:
     apt:
       packages: [libeigen3-dev]
   fedora: eigen3-devel
+  rhel: eigen3-devel
 epydoc:
   arch: epydoc
   debian: python-epydoc

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6,6 +6,7 @@ paramiko:
   debian: python-paramiko
   opensuse: python-paramiko 
   fedora: python-paramiko
+  rhel: python-paramiko
   macports: py26-paramiko
   gentoo: dev-python/paramiko
   freebsd: py27-paramiko
@@ -138,6 +139,7 @@ python-qt-bindings:
     oneiric: python-pyside libpyside-dev libshiboken-dev shiboken libgenrunner-dev python-qt4 python-qt4-dev python-sip-dev
     precise: python-pyside libpyside-dev libshiboken-dev shiboken libgenrunner-dev python-qt4 python-qt4-dev python-sip-dev
     quantal: python-pyside libpyside-dev libshiboken-dev shiboken python-qt4 python-qt4-dev python-sip-dev
+  rhel: PyQt4 PyQt4-devel sip-devel
 python-qt-bindings-gl:
   ubuntu: python-qt4-gl
 python-qt-bindings-qwt5:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -171,6 +171,7 @@ python-sip:
   ubuntu: python-sip-dev
   debian: python-sip4-dev sip4
   fedora: sip-devel
+  rhel: sip-devel
   macports: py26-sip
   osxbrew:
     homebrew:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -175,6 +175,7 @@ python-sip:
   ubuntu: python-sip-dev
   debian: python-sip4-dev sip4
   fedora: sip-devel
+  rhel: sip-devel
   macports: py26-sip
   osxbrew:
     homebrew:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6,6 +6,7 @@ paramiko:
   debian: python-paramiko
   opensuse: python-paramiko 
   fedora: python-paramiko
+  rhel: python-paramiko
   macports: py26-paramiko
   gentoo: dev-python/paramiko
   freebsd: py27-paramiko
@@ -136,6 +137,7 @@ python-qt-bindings:
     oneiric: python-pyside libpyside-dev libshiboken-dev shiboken libgenrunner-dev python-qt4 python-qt4-dev python-sip-dev
     precise: python-pyside libpyside-dev libshiboken-dev shiboken libgenrunner-dev python-qt4 python-qt4-dev python-sip-dev
     quantal: python-pyside libpyside-dev libshiboken-dev shiboken python-qt4 python-qt4-dev python-sip-dev
+  rhel: PyQt4 PyQt4-devel sip-devel
 python-qt-bindings-gl:
   ubuntu: python-qt4-gl
 python-qt-bindings-qwt5:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -97,7 +97,7 @@ python-numpy:
   debian: python-numpy
   fedora: numpy
   opensuse: python-numpy 
-  rhel: python-numpy
+  rhel: numpy
   arch: python2-numpy
   macports: py26-numpy
   gentoo: dev-python/numpy
@@ -117,6 +117,7 @@ python-paramiko:
   debian: python-paramiko
   opensuse: python-paramiko 
   fedora: python-paramiko
+  rhel: python-paramiko
   macports: py26-paramiko
   gentoo: dev-python/paramiko
   freebsd: py27-paramiko


### PR DESCRIPTION
Hi,

I fixed the omniorb and ruby osdeps that are blocking a new orocos_toolchain release and added some rhel rosdeps to make it possible to build the core ros packages on RHEL6
