### PR TITLE
Adds distro files for documentation jobs, also adds rosdoc_lite to groovy debs

### DIFF
--- a/releases/fuerte-doc.yaml
+++ b/releases/fuerte-doc.yaml
@@ -114,4 +114,8 @@ repositories:
     type: git
     url: git://github.com/ros/std_msgs.git
     version: fuerte-devel
-type: devel
+  navigation:
+    type: hg
+    url: https://kforge.ros.org/navigation/navigation
+    version: fuerte
+type: doc

--- a/releases/fuerte-doc.yaml
+++ b/releases/fuerte-doc.yaml
@@ -1,202 +1,117 @@
-gbp-repos: {You must update to a newer rosdep version by calling..sudo apt-get update && sudo apt-get install python-rosdep (make sure to uninstall the pip version on Ubuntu):}
 release-name: fuerte
 repositories:
   actionlib:
-    url: git://github.com/wg-debs/actionlib-release.git
-    version: 1.8.7
+    type: hg
+    url: https://kforge.ros.org/common/actionlib
+    version: fuerte-devel
   catkin:
-    url: git://github.com/wg-debs/catkin-release.git
-    version: 0.4.5
+    type: git
+    url: git://github.com/ros/catkin.git
+    version: fuerte-devel
   common_msgs:
-    url: git://github.com/wg-debs/common_msgs-release.git
-    version: 1.8.13
-  console_bridge:
-    url: git://github.com/wg-debs/console_bridge.git
-    version: 0.1.2
+    type: git
+    url: git://github.com/ros/common_msgs.git
+    version: fuerte-devel
   ecto:
+    type: git
     url: git://github.com/wg-debs/ecto-release.git
-    version: 0.4.1
+    version: master
   ecto_image_pipeline:
+    type: git
     url: git://github.com/wg-debs/ecto_image_pipeline-release.git
-    version: 0.4.1
+    version: master
   ecto_opencv:
+    type: git
     url: git://github.com/wg-debs/ecto_opencv-release.git
-    version: 0.4.2
+    version: master
   ecto_openni:
+    type: git
     url: git://github.com/wg-debs/ecto_openni-release.git
-    version: 0.3.3
+    version: master
   ecto_pcl:
+    type: git
     url: git://github.com/wg-debs/ecto_pcl-release.git
-    version: 0.3.6
+    version: master
   ecto_ros:
+    type: git
     url: git://github.com/wg-debs/ecto_ros-release.git
-    version: 0.3.12
-  fcl:
-    url: git://github.com/wg-debs/fcl.git
-    version: 0.2.3
-  flann:
-    url: git://github.com/wg-debs/flann.git
-    version: 1.7.1
-  flirtlib:
-    url: git://github.com/wg-debs/flirtlib-release.git
-    version: 0.1.4
+    version: master
   gencpp:
-    url: git://github.com/wg-debs/gencpp-release.git
-    version: 0.3.4
+    type: git
+    url: git://github.com/ros/gencpp.git
+    version: fuerte-devel
   genlisp:
-    url: git://github.com/wg-debs/genlisp-release.git
-    version: 0.3.3
+    type: git
+    url: git://github.com/ros/genlisp.git
+    version: fuerte-devel
   genmsg:
-    url: git://github.com/wg-debs/genmsg-release.git
-    version: 0.3.10
+    type: git
+    url: git://github.com/ros/genmsg.git
+    version: fuerte-devel
   genpy:
-    url: git://github.com/wg-debs/genpy-release.git
-    version: 0.3.7
+    type: git
+    url: git://github.com/ros/genpy.git
+    version: fuerte-devel
   langs:
-    url: git://github.com/wg-debs/langs-release.git
-    version: 0.3.5
-  langs-dev:
-    url: git://github.com/wg-debs/langs-dev-release.git
-    version: 0.1.3
-  libccd:
-    url: git://github.com/wg-debs/libccd.git
-    version: 1.4.0
-  libg2o:
-    url: git://github.com/wg-debs/libg2o-release.git
-    version: 0.0.26
-  moveit_core:
-    url: git://github.com/wg-debs/moveit_core-release.git
-    version: 0.1.4
-  moveit_msgs:
-    url: git://github.com/wg-debs/moveit_msgs-release.git
-    version: 0.2.7
+    type: git
+    url: git://github.com/ros/langs.git
+    version: fuerte-devel
   object_recognition_capture:
+    type: git
     url: git://github.com/wg-debs/object_recognition_capture-release.git
-    version: 0.2.10
+    version: master
   object_recognition_core:
+    type: git
     url: git://github.com/wg-debs/object_recognition_core-release.git
-    version: 0.4.2
+    version: master
   object_recognition_linemod:
+    type: git
     url: git://github.com/wg-debs/object_recognition_linemod-release.git
-    version: 0.2.0
+    version: master
   object_recognition_msgs:
+    type: git
     url: git://github.com/wg-debs/object_recognition_msgs-release.git
-    version: 0.3.3
+    version: master
   object_recognition_reconstruction:
+    type: git
     url: git://github.com/wg-debs/object_recognition_reconstruction-release.git
-    version: 0.2.8
+    version: master
   object_recognition_tabletop:
-    url: git://github.com/wg-debs/object_recognition_tabletop-release.git
+    type: git
+    url: git://github.com/wg-perception/tabletop.git
     version: 0.2.6
   object_recognition_tod:
+    type: git
     url: git://github.com/wg-debs/object_recognition_tod-release.git
-    version: 0.4.3
+    version: master
   object_recognition_transparent_objects:
+    type: git
     url: git://github.com/wg-debs/object_recognition_transparent_objects-release.git
-    version: 0.3.2
-  octomap:
-    url: git://github.com/wg-debs/octomap-release.git
-    version: 1.4.2
-  octomap_msgs:
-    url: git://github.com/wg-debs/octomap_msgs-release.git
-    version: 0.1.4
-  octovis:
-    url: git://github.com/wg-debs/octovis-release.git
-    version: 1.4.2
-  ompl:
-    url: git://github.com/wg-debs/ompl.git
-    version: 0.11.1002045
-  opencv2:
-    url: git://github.com/wg-debs/opencv2-release.git
-    version: 2.4.2
-  pcl:
-    url: git://github.com/wg-debs/pcl.git
-    version: 1.5.2
-  random_numbers:
-    url: git://github.com/wg-debs/random_numbers-release.git
-    version: 0.1.1
+    version: master
   ros:
-    url: git://github.com/wg-debs/ros-release.git
-    version: 1.8.10
+    type: svn
+    url: https://code.ros.org/svn/ros/stacks/ros/branches/ros-1.8
   ros_comm:
-    url: git://github.com/wg-debs/ros_comm-release.git
-    version: 1.8.15
+    type: git
+    url: git://github.com/ros/ros_comm.git
+    version: fuerte-devel
   ros_tutorials:
-    url: git://github.com/wg-debs/ros_tutorials-release.git
-    version: 0.2.19
-  rosconsole_bridge:
-    url: git://github.com/wg-debs/rosconsole_bridge-release.git
-    version: 0.1.0
+    type: git
+    url: git://github.com/ros/ros_tutorials.git
+    version: fuerte-devel
   roscpp_core:
-    url: git://github.com/wg-debs/roscpp_core-release.git
-    version: 0.2.6
+    type: git
+    url: git://github.com/ros/roscpp_core.git
+    version: fuerte-devel
   rospack:
-    url: git://github.com/wg-debs/rospack-release.git
-    version: 2.0.13
+    type: hg
+    url: https://kforge.ros.org/rosrelease/rospack
+    version: fuerte-devel
   rx:
-    url: git://github.com/wg-debs/rx-release.git
-    version: 1.8.9
-  sbpl:
-    url: git://github.com/wg-debs/sbpl.git
-    version: 1.1.0
-  shape_tools:
-    url: git://github.com/wg-debs/shape_tools-release.git
-    version: 0.1.8
-  srdfdom:
-    url: git://github.com/wg-debs/srdfdom-release.git
-    version: 0.1.1
+    type: svn
+    url: https://code.ros.org/svn/ros/stacks/rx/branches/fuerte-devel
   std_msgs:
-    url: git://github.com/wg-debs/std_msgs-release.git
-    version: 0.4.11
-  swig-wx:
-    url: git://github.com/wg-debs/swig-wx.git
-    version: 1.3.29
-  urdfdom:
-    url: git://github.com/wg-debs/urdfdom.git
-    version: 0.2.2
-  urdfdom_headers:
-    url: git://github.com/wg-debs/urdfdom_headers-release.git
-    version: 0.2.0
-type: gbp
-variants:
-  moveit-full:
-  - actionlib
-  - common_msgs
-  - console_bridge
-  - octomap
-  - octomap_msgs
-  - ompl
-  - ros
-  - ros_comm
-  - roscpp_core
-  - rx
-  - std_msgs
-  - urdfdom
-  ros-base:
-  - actionlib
-  - catkin
-  - common_msgs
-  - gencpp
-  - genlisp
-  - genmsg
-  - genpy
-  - ros
-  - ros_comm
-  - roscpp_core
-  - rospack
-  - std_msgs
-  ros-full:
-  - actionlib
-  - catkin
-  - common_msgs
-  - gencpp
-  - genlisp
-  - genmsg
-  - genpy
-  - ros
-  - ros_comm
-  - ros_tutorials
-  - roscpp_core
-  - rospack
-  - rx
-  - std_msgs
+    type: git
+    url: git://github.com/ros/std_msgs.git
+    version: fuerte-devel
+type: devel

--- a/releases/fuerte-doc.yaml
+++ b/releases/fuerte-doc.yaml
@@ -1,0 +1,202 @@
+gbp-repos: {You must update to a newer rosdep version by calling..sudo apt-get update && sudo apt-get install python-rosdep (make sure to uninstall the pip version on Ubuntu):}
+release-name: fuerte
+repositories:
+  actionlib:
+    url: git://github.com/wg-debs/actionlib-release.git
+    version: 1.8.7
+  catkin:
+    url: git://github.com/wg-debs/catkin-release.git
+    version: 0.4.5
+  common_msgs:
+    url: git://github.com/wg-debs/common_msgs-release.git
+    version: 1.8.13
+  console_bridge:
+    url: git://github.com/wg-debs/console_bridge.git
+    version: 0.1.2
+  ecto:
+    url: git://github.com/wg-debs/ecto-release.git
+    version: 0.4.1
+  ecto_image_pipeline:
+    url: git://github.com/wg-debs/ecto_image_pipeline-release.git
+    version: 0.4.1
+  ecto_opencv:
+    url: git://github.com/wg-debs/ecto_opencv-release.git
+    version: 0.4.2
+  ecto_openni:
+    url: git://github.com/wg-debs/ecto_openni-release.git
+    version: 0.3.3
+  ecto_pcl:
+    url: git://github.com/wg-debs/ecto_pcl-release.git
+    version: 0.3.6
+  ecto_ros:
+    url: git://github.com/wg-debs/ecto_ros-release.git
+    version: 0.3.12
+  fcl:
+    url: git://github.com/wg-debs/fcl.git
+    version: 0.2.3
+  flann:
+    url: git://github.com/wg-debs/flann.git
+    version: 1.7.1
+  flirtlib:
+    url: git://github.com/wg-debs/flirtlib-release.git
+    version: 0.1.4
+  gencpp:
+    url: git://github.com/wg-debs/gencpp-release.git
+    version: 0.3.4
+  genlisp:
+    url: git://github.com/wg-debs/genlisp-release.git
+    version: 0.3.3
+  genmsg:
+    url: git://github.com/wg-debs/genmsg-release.git
+    version: 0.3.10
+  genpy:
+    url: git://github.com/wg-debs/genpy-release.git
+    version: 0.3.7
+  langs:
+    url: git://github.com/wg-debs/langs-release.git
+    version: 0.3.5
+  langs-dev:
+    url: git://github.com/wg-debs/langs-dev-release.git
+    version: 0.1.3
+  libccd:
+    url: git://github.com/wg-debs/libccd.git
+    version: 1.4.0
+  libg2o:
+    url: git://github.com/wg-debs/libg2o-release.git
+    version: 0.0.26
+  moveit_core:
+    url: git://github.com/wg-debs/moveit_core-release.git
+    version: 0.1.4
+  moveit_msgs:
+    url: git://github.com/wg-debs/moveit_msgs-release.git
+    version: 0.2.7
+  object_recognition_capture:
+    url: git://github.com/wg-debs/object_recognition_capture-release.git
+    version: 0.2.10
+  object_recognition_core:
+    url: git://github.com/wg-debs/object_recognition_core-release.git
+    version: 0.4.2
+  object_recognition_linemod:
+    url: git://github.com/wg-debs/object_recognition_linemod-release.git
+    version: 0.2.0
+  object_recognition_msgs:
+    url: git://github.com/wg-debs/object_recognition_msgs-release.git
+    version: 0.3.3
+  object_recognition_reconstruction:
+    url: git://github.com/wg-debs/object_recognition_reconstruction-release.git
+    version: 0.2.8
+  object_recognition_tabletop:
+    url: git://github.com/wg-debs/object_recognition_tabletop-release.git
+    version: 0.2.6
+  object_recognition_tod:
+    url: git://github.com/wg-debs/object_recognition_tod-release.git
+    version: 0.4.3
+  object_recognition_transparent_objects:
+    url: git://github.com/wg-debs/object_recognition_transparent_objects-release.git
+    version: 0.3.2
+  octomap:
+    url: git://github.com/wg-debs/octomap-release.git
+    version: 1.4.2
+  octomap_msgs:
+    url: git://github.com/wg-debs/octomap_msgs-release.git
+    version: 0.1.4
+  octovis:
+    url: git://github.com/wg-debs/octovis-release.git
+    version: 1.4.2
+  ompl:
+    url: git://github.com/wg-debs/ompl.git
+    version: 0.11.1002045
+  opencv2:
+    url: git://github.com/wg-debs/opencv2-release.git
+    version: 2.4.2
+  pcl:
+    url: git://github.com/wg-debs/pcl.git
+    version: 1.5.2
+  random_numbers:
+    url: git://github.com/wg-debs/random_numbers-release.git
+    version: 0.1.1
+  ros:
+    url: git://github.com/wg-debs/ros-release.git
+    version: 1.8.10
+  ros_comm:
+    url: git://github.com/wg-debs/ros_comm-release.git
+    version: 1.8.15
+  ros_tutorials:
+    url: git://github.com/wg-debs/ros_tutorials-release.git
+    version: 0.2.19
+  rosconsole_bridge:
+    url: git://github.com/wg-debs/rosconsole_bridge-release.git
+    version: 0.1.0
+  roscpp_core:
+    url: git://github.com/wg-debs/roscpp_core-release.git
+    version: 0.2.6
+  rospack:
+    url: git://github.com/wg-debs/rospack-release.git
+    version: 2.0.13
+  rx:
+    url: git://github.com/wg-debs/rx-release.git
+    version: 1.8.9
+  sbpl:
+    url: git://github.com/wg-debs/sbpl.git
+    version: 1.1.0
+  shape_tools:
+    url: git://github.com/wg-debs/shape_tools-release.git
+    version: 0.1.8
+  srdfdom:
+    url: git://github.com/wg-debs/srdfdom-release.git
+    version: 0.1.1
+  std_msgs:
+    url: git://github.com/wg-debs/std_msgs-release.git
+    version: 0.4.11
+  swig-wx:
+    url: git://github.com/wg-debs/swig-wx.git
+    version: 1.3.29
+  urdfdom:
+    url: git://github.com/wg-debs/urdfdom.git
+    version: 0.2.2
+  urdfdom_headers:
+    url: git://github.com/wg-debs/urdfdom_headers-release.git
+    version: 0.2.0
+type: gbp
+variants:
+  moveit-full:
+  - actionlib
+  - common_msgs
+  - console_bridge
+  - octomap
+  - octomap_msgs
+  - ompl
+  - ros
+  - ros_comm
+  - roscpp_core
+  - rx
+  - std_msgs
+  - urdfdom
+  ros-base:
+  - actionlib
+  - catkin
+  - common_msgs
+  - gencpp
+  - genlisp
+  - genmsg
+  - genpy
+  - ros
+  - ros_comm
+  - roscpp_core
+  - rospack
+  - std_msgs
+  ros-full:
+  - actionlib
+  - catkin
+  - common_msgs
+  - gencpp
+  - genlisp
+  - genmsg
+  - genpy
+  - ros
+  - ros_comm
+  - ros_tutorials
+  - roscpp_core
+  - rospack
+  - rx
+  - std_msgs

--- a/releases/groovy-doc.yaml
+++ b/releases/groovy-doc.yaml
@@ -1,241 +1,129 @@
-gbp-repos: {You must update to a newer rosdep version by calling..sudo apt-get update && sudo apt-get install python-rosdep (make sure to uninstall the pip version on Ubuntu):}
 release-name: groovy
 repositories:
   actionlib:
-    url: git://github.com/wg-debs/actionlib-release.git
-    version: 1.9.3
+    type: hg
+    url: https://kforge.ros.org/common/actionlib
+    version: default
   catkin:
-    url: git://github.com/wg-debs/catkin-release.git
-    version: 0.5.13
+    type: git
+    url: git://github.com/ros/catkin.git
+    version: master
   common_msgs:
-    url: git://github.com/wg-debs/common_msgs-release.git
-    version: 1.9.2
-  console_bridge:
-    url: git://github.com/wg-debs/console_bridge.git
-    version: 0.1.2
+    type: git
+    url: git://github.com/ros/common_msgs.git
+    version: master
   ecto:
+    type: git
     url: git://github.com/wg-debs/ecto-release.git
-    version: 0.4.1
+    version: master
   ecto_image_pipeline:
+    type: git
     url: git://github.com/wg-debs/ecto_image_pipeline-release.git
-    version: 0.4.1
+    version: master
   ecto_opencv:
+    type: git
     url: git://github.com/wg-debs/ecto_opencv-release.git
-    version: 0.4.2
+    version: master
   ecto_openni:
+    type: git
     url: git://github.com/wg-debs/ecto_openni-release.git
-    version: 0.3.4
+    version: master
   ecto_pcl:
+    type: git
     url: git://github.com/wg-debs/ecto_pcl-release.git
-    version: 0.3.6
+    version: master
   ecto_ros:
+    type: git
     url: git://github.com/wg-debs/ecto_ros-release.git
-    version: 0.3.12
-  eigen_stl_containers:
-    url: git://github.com/wg-debs/eigen_stl_containers-release.git
-    version: 0.1.0
-  fcl:
-    url: git://github.com/wg-debs/fcl.git
-    version: 0.2.3
-  flann:
-    url: git://github.com/wg-debs/flann.git
-    version: 1.7.1
-  flirtlib:
-    url: git://github.com/wg-debs/flirtlib-release.git
-    version: 0.1.5
+    version: master
   gencpp:
-    url: git://github.com/wg-debs/gencpp-release.git
-    version: 0.4.2
+    type: git
+    url: git://github.com/ros/gencpp.git
+    version: master
   genlisp:
-    url: git://github.com/wg-debs/genlisp-release.git
-    version: 0.4.2
+    type: git
+    url: git://github.com/ros/genlisp.git
+    version: master
   genmsg:
-    url: git://github.com/wg-debs/genmsg-release.git
-    version: 0.4.5
+    type: git
+    url: git://github.com/ros/genmsg.git
+    version: master
   genpy:
-    url: git://github.com/wg-debs/genpy-release.git
-    version: 0.4.2
-  geometric_shapes:
-    url: git://github.com/wg-debs/geometric_shapes-release.git
-    version: 0.1.3
-  geometry:
-    url: git://github.com/wg-debs/geometry-release.git
-    version: 1.9.8
-  geometry_angles_utils:
-    url: git://github.com/wg-debs/geometry_angles_utils-release.git
-    version: 1.9.3
+    type: git
+    url: git://github.com/ros/genpy.git
+    version: master
   image_common:
-    uri: git@github.com:wg-debs/image_common-release.git
-    version: 1.9.1
+    type: git
+    url: git://github.com/wg_perception/image_common.git
+    version: master
   image_pipeline:
-    uri: git@github.com:wg-debs/image_pipeline-release.git
-    version: 1.9.0
+    type: git
+    url: git://github.com/wg_perception/image_pipeline.git
+    version: master
   langs:
-    url: git://github.com/wg-debs/langs-release.git
-    version: 0.4.0
-  langs-dev:
-    url: git://github.com/wg-debs/langs-dev-release.git
-    version: 0.2.0
-  libccd:
-    url: git://github.com/wg-debs/libccd.git
-    version: 1.4.0
-  libg2o:
-    url: git://github.com/wg-debs/libg2o-release.git
-    version: 0.0.26
-  moveit_core:
-    url: git://github.com/wg-debs/moveit_core-release.git
-    version: 0.1.4
-  moveit_msgs:
-    url: git://github.com/wg-debs/moveit_msgs-release.git
-    version: 0.3.0
+    type: git
+    url: git://github.com/ros/langs.git
+    version: master
   object_recognition_capture:
+    type: git
     url: git://github.com/wg-debs/object_recognition_capture-release.git
-    version: 0.2.10
+    version: master
   object_recognition_core:
+    type: git
     url: git://github.com/wg-debs/object_recognition_core-release.git
-    version: 0.4.2
+    version: master
   object_recognition_linemod:
+    type: git
     url: git://github.com/wg-debs/object_recognition_linemod-release.git
-    version: 0.2.0
+    version: master
   object_recognition_msgs:
+    type: git
     url: git://github.com/wg-debs/object_recognition_msgs-release.git
-    version: 0.3.3
+    version: master
   object_recognition_reconstruction:
+    type: git
     url: git://github.com/wg-debs/object_recognition_reconstruction-release.git
-    version: 0.2.8
+    version: master
   object_recognition_tabletop:
+    type: git
     url: git://github.com/wg-debs/object_recognition_tabletop-release.git
-    version: 0.2.6
+    version: master
   object_recognition_tod:
+    type: git
     url: git://github.com/wg-debs/object_recognition_tod-release.git
-    version: 0.4.3
+    version: master
   object_recognition_transparent_objects:
+    type: git
     url: git://github.com/wg-debs/object_recognition_transparent_objects-release.git
-    version: 0.3.2
-  octomap:
-    url: git://github.com/wg-debs/octomap-release.git
-    version: 1.5.0
-  octomap_msgs:
-    url: git://github.com/wg-debs/octomap_msgs-release.git
-    version: 0.2.0
-  octovis:
-    url: git://github.com/wg-debs/octovis-release.git
-    version: 1.5.0
-  ompl:
-    url: git://github.com/wg-debs/ompl.git
-    version: 0.11.1002053
-  opencv2:
-    url: git://github.com/wg-debs/opencv2-release.git
-    version: 2.4.2
-  orocos_kdl:
-    url: git://github.com/wg-debs/orocos_kdl-release.git
-    version: 1.1.99
-  pcl:
-    url: git://github.com/wg-debs/pcl-release.git
-    version: 1.6.0
-  pluginlib:
-    url: git://github.com/wg-debs/pluginlib-release.git
-    version: 1.8.2
-  python_orocos_kdl:
-    url: git://github.com/wg-debs/python_orocos_kdl-release.git
-    version: 1.1.99
-  random_numbers:
-    url: git://github.com/wg-debs/random_numbers-release.git
-    version: 0.1.1
-  robot_model:
-    url: git://github.com/wg-debs/robot_model-release.git
-    version: 1.9.6
-  robot_state_publisher:
-    url: git://github.com/wg-debs/robot_state_publisher-release.git
-    version: 1.9.1
+    version: master
   ros:
-    url: git://github.com/wg-debs/ros-release.git
-    version: 1.9.6
+    type: svn
+    url: https://code.ros.org/svn/ros/stacks/ros/trunk
   ros_comm:
-    url: git://github.com/wg-debs/ros_comm-release.git
-    version: 1.9.6
+    type: git
+    url: git://github.com/ros/ros_comm.git
+    version: master
   ros_tutorials:
-    url: git://github.com/wg-debs/ros_tutorials-release.git
-    version: 0.3.2
-  rosconsole_bridge:
-    url: git://github.com/wg-debs/rosconsole_bridge-release.git
-    version: 0.2.0
+    type: git
+    url: git://github.com/ros/ros_tutorials.git
+    version: master
   roscpp_core:
-    url: git://github.com/wg-debs/roscpp_core-release.git
-    version: 0.3.3
+    type: git
+    url: git://github.com/ros/roscpp_core.git
+    version: master
   rospack:
-    url: git://github.com/wg-debs/rospack-release.git
-    version: 2.1.3
+    type: hg
+    url: https://kforge.ros.org/rosrelease/rospack
+    version: default
   rx:
-    url: git://github.com/wg-debs/rx-release.git
-    version: 1.9.2
-  sbpl:
-    url: git://github.com/wg-debs/sbpl.git
-    version: 1.1.2
-  shape_tools:
-    url: git://github.com/wg-debs/shape_tools-release.git
-    version: 0.1.8
-  srdfdom:
-    url: git://github.com/wg-debs/srdfdom-release.git
-    version: 0.1.1
+    type: svn
+    url: https://code.ros.org/svn/ros/stacks/rx/trunk
   std_msgs:
-    url: git://github.com/wg-debs/std_msgs-release.git
-    version: 0.5.2
-  swig-wx:
-    url: git://github.com/wg-debs/swig-wx.git
-    version: 1.3.29
-  urdfdom:
-    url: git://github.com/wg-debs/urdfdom.git
-    version: 0.2.2
-  urdfdom_headers:
-    url: git://github.com/wg-debs/urdfdom_headers-release.git
-    version: 0.2.0
-  usdfdom:
-    url: git://github.com/wg-debs/usdfdom-release.git
-    version: 0.1.3
+    type: git
+    url: git://github.com/ros/std_msgs.git
+    version: master
   vision_opencv:
-    url: git://github.com/wg-debs/vision_opencv-release.git
-    version: 1.9.2
-type: gbp
-variants:
-  moveit-full:
-  - actionlib
-  - common_msgs
-  - console_bridge
-  - octomap
-  - octomap_msgs
-  - ompl
-  - ros
-  - ros_comm
-  - roscpp_core
-  - rx
-  - std_msgs
-  - urdfdom
-  ros-base:
-  - actionlib
-  - catkin
-  - common_msgs
-  - gencpp
-  - genlisp
-  - genmsg
-  - genpy
-  - ros
-  - ros_comm
-  - roscpp_core
-  - rospack
-  - std_msgs
-  ros-full:
-  - actionlib
-  - catkin
-  - common_msgs
-  - gencpp
-  - genlisp
-  - genmsg
-  - genpy
-  - ros
-  - ros_comm
-  - ros_tutorials
-  - roscpp_core
-  - rospack
-  - rx
-  - std_msgs
+    type: git
+    url: git://github.com/wg-perception/vision_opencv.git
+    version: master
+type: devel

--- a/releases/groovy-doc.yaml
+++ b/releases/groovy-doc.yaml
@@ -1,0 +1,241 @@
+gbp-repos: {You must update to a newer rosdep version by calling..sudo apt-get update && sudo apt-get install python-rosdep (make sure to uninstall the pip version on Ubuntu):}
+release-name: groovy
+repositories:
+  actionlib:
+    url: git://github.com/wg-debs/actionlib-release.git
+    version: 1.9.3
+  catkin:
+    url: git://github.com/wg-debs/catkin-release.git
+    version: 0.5.13
+  common_msgs:
+    url: git://github.com/wg-debs/common_msgs-release.git
+    version: 1.9.2
+  console_bridge:
+    url: git://github.com/wg-debs/console_bridge.git
+    version: 0.1.2
+  ecto:
+    url: git://github.com/wg-debs/ecto-release.git
+    version: 0.4.1
+  ecto_image_pipeline:
+    url: git://github.com/wg-debs/ecto_image_pipeline-release.git
+    version: 0.4.1
+  ecto_opencv:
+    url: git://github.com/wg-debs/ecto_opencv-release.git
+    version: 0.4.2
+  ecto_openni:
+    url: git://github.com/wg-debs/ecto_openni-release.git
+    version: 0.3.4
+  ecto_pcl:
+    url: git://github.com/wg-debs/ecto_pcl-release.git
+    version: 0.3.6
+  ecto_ros:
+    url: git://github.com/wg-debs/ecto_ros-release.git
+    version: 0.3.12
+  eigen_stl_containers:
+    url: git://github.com/wg-debs/eigen_stl_containers-release.git
+    version: 0.1.0
+  fcl:
+    url: git://github.com/wg-debs/fcl.git
+    version: 0.2.3
+  flann:
+    url: git://github.com/wg-debs/flann.git
+    version: 1.7.1
+  flirtlib:
+    url: git://github.com/wg-debs/flirtlib-release.git
+    version: 0.1.5
+  gencpp:
+    url: git://github.com/wg-debs/gencpp-release.git
+    version: 0.4.2
+  genlisp:
+    url: git://github.com/wg-debs/genlisp-release.git
+    version: 0.4.2
+  genmsg:
+    url: git://github.com/wg-debs/genmsg-release.git
+    version: 0.4.5
+  genpy:
+    url: git://github.com/wg-debs/genpy-release.git
+    version: 0.4.2
+  geometric_shapes:
+    url: git://github.com/wg-debs/geometric_shapes-release.git
+    version: 0.1.3
+  geometry:
+    url: git://github.com/wg-debs/geometry-release.git
+    version: 1.9.8
+  geometry_angles_utils:
+    url: git://github.com/wg-debs/geometry_angles_utils-release.git
+    version: 1.9.3
+  image_common:
+    uri: git@github.com:wg-debs/image_common-release.git
+    version: 1.9.1
+  image_pipeline:
+    uri: git@github.com:wg-debs/image_pipeline-release.git
+    version: 1.9.0
+  langs:
+    url: git://github.com/wg-debs/langs-release.git
+    version: 0.4.0
+  langs-dev:
+    url: git://github.com/wg-debs/langs-dev-release.git
+    version: 0.2.0
+  libccd:
+    url: git://github.com/wg-debs/libccd.git
+    version: 1.4.0
+  libg2o:
+    url: git://github.com/wg-debs/libg2o-release.git
+    version: 0.0.26
+  moveit_core:
+    url: git://github.com/wg-debs/moveit_core-release.git
+    version: 0.1.4
+  moveit_msgs:
+    url: git://github.com/wg-debs/moveit_msgs-release.git
+    version: 0.3.0
+  object_recognition_capture:
+    url: git://github.com/wg-debs/object_recognition_capture-release.git
+    version: 0.2.10
+  object_recognition_core:
+    url: git://github.com/wg-debs/object_recognition_core-release.git
+    version: 0.4.2
+  object_recognition_linemod:
+    url: git://github.com/wg-debs/object_recognition_linemod-release.git
+    version: 0.2.0
+  object_recognition_msgs:
+    url: git://github.com/wg-debs/object_recognition_msgs-release.git
+    version: 0.3.3
+  object_recognition_reconstruction:
+    url: git://github.com/wg-debs/object_recognition_reconstruction-release.git
+    version: 0.2.8
+  object_recognition_tabletop:
+    url: git://github.com/wg-debs/object_recognition_tabletop-release.git
+    version: 0.2.6
+  object_recognition_tod:
+    url: git://github.com/wg-debs/object_recognition_tod-release.git
+    version: 0.4.3
+  object_recognition_transparent_objects:
+    url: git://github.com/wg-debs/object_recognition_transparent_objects-release.git
+    version: 0.3.2
+  octomap:
+    url: git://github.com/wg-debs/octomap-release.git
+    version: 1.5.0
+  octomap_msgs:
+    url: git://github.com/wg-debs/octomap_msgs-release.git
+    version: 0.2.0
+  octovis:
+    url: git://github.com/wg-debs/octovis-release.git
+    version: 1.5.0
+  ompl:
+    url: git://github.com/wg-debs/ompl.git
+    version: 0.11.1002053
+  opencv2:
+    url: git://github.com/wg-debs/opencv2-release.git
+    version: 2.4.2
+  orocos_kdl:
+    url: git://github.com/wg-debs/orocos_kdl-release.git
+    version: 1.1.99
+  pcl:
+    url: git://github.com/wg-debs/pcl-release.git
+    version: 1.6.0
+  pluginlib:
+    url: git://github.com/wg-debs/pluginlib-release.git
+    version: 1.8.2
+  python_orocos_kdl:
+    url: git://github.com/wg-debs/python_orocos_kdl-release.git
+    version: 1.1.99
+  random_numbers:
+    url: git://github.com/wg-debs/random_numbers-release.git
+    version: 0.1.1
+  robot_model:
+    url: git://github.com/wg-debs/robot_model-release.git
+    version: 1.9.6
+  robot_state_publisher:
+    url: git://github.com/wg-debs/robot_state_publisher-release.git
+    version: 1.9.1
+  ros:
+    url: git://github.com/wg-debs/ros-release.git
+    version: 1.9.6
+  ros_comm:
+    url: git://github.com/wg-debs/ros_comm-release.git
+    version: 1.9.6
+  ros_tutorials:
+    url: git://github.com/wg-debs/ros_tutorials-release.git
+    version: 0.3.2
+  rosconsole_bridge:
+    url: git://github.com/wg-debs/rosconsole_bridge-release.git
+    version: 0.2.0
+  roscpp_core:
+    url: git://github.com/wg-debs/roscpp_core-release.git
+    version: 0.3.3
+  rospack:
+    url: git://github.com/wg-debs/rospack-release.git
+    version: 2.1.3
+  rx:
+    url: git://github.com/wg-debs/rx-release.git
+    version: 1.9.2
+  sbpl:
+    url: git://github.com/wg-debs/sbpl.git
+    version: 1.1.2
+  shape_tools:
+    url: git://github.com/wg-debs/shape_tools-release.git
+    version: 0.1.8
+  srdfdom:
+    url: git://github.com/wg-debs/srdfdom-release.git
+    version: 0.1.1
+  std_msgs:
+    url: git://github.com/wg-debs/std_msgs-release.git
+    version: 0.5.2
+  swig-wx:
+    url: git://github.com/wg-debs/swig-wx.git
+    version: 1.3.29
+  urdfdom:
+    url: git://github.com/wg-debs/urdfdom.git
+    version: 0.2.2
+  urdfdom_headers:
+    url: git://github.com/wg-debs/urdfdom_headers-release.git
+    version: 0.2.0
+  usdfdom:
+    url: git://github.com/wg-debs/usdfdom-release.git
+    version: 0.1.3
+  vision_opencv:
+    url: git://github.com/wg-debs/vision_opencv-release.git
+    version: 1.9.2
+type: gbp
+variants:
+  moveit-full:
+  - actionlib
+  - common_msgs
+  - console_bridge
+  - octomap
+  - octomap_msgs
+  - ompl
+  - ros
+  - ros_comm
+  - roscpp_core
+  - rx
+  - std_msgs
+  - urdfdom
+  ros-base:
+  - actionlib
+  - catkin
+  - common_msgs
+  - gencpp
+  - genlisp
+  - genmsg
+  - genpy
+  - ros
+  - ros_comm
+  - roscpp_core
+  - rospack
+  - std_msgs
+  ros-full:
+  - actionlib
+  - catkin
+  - common_msgs
+  - gencpp
+  - genlisp
+  - genmsg
+  - genpy
+  - ros
+  - ros_comm
+  - ros_tutorials
+  - roscpp_core
+  - rospack
+  - rx
+  - std_msgs

--- a/releases/groovy-doc.yaml
+++ b/releases/groovy-doc.yaml
@@ -126,4 +126,4 @@ repositories:
     type: git
     url: git://github.com/wg-perception/vision_opencv.git
     version: master
-type: devel
+type: doc

--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -190,6 +190,9 @@ repositories:
   roscpp_core:
     url: git://github.com/wg-debs/roscpp_core-release.git
     version: 0.3.5
+  rosdoc_lite:
+    url: git://github.com/ros-gbp/rosdoc_lite-release.git
+    version: 0.1.0
   rospack:
     url: git://github.com/wg-debs/rospack-release.git
     version: 2.1.5-0


### PR DESCRIPTION
I threw the doc yaml files next to devel and pre-release since that seemed to make sense. The documentation work I've done is a bit different than the other tools in that it will work with both wet and dry stacks. So, these files should, eventually, be updated with everything that we are interested in documenting, even if the stacks are not catkinized. Right now, the only non-catkin stack is navigation which I threw in for testing purposes. This pull request also adds rosdoc_lite to groovy debs.
