### PR TITLE
added apt entries for ruby gems

### DIFF
--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -8,6 +8,7 @@ hoe:
     gem: hoe
 facets:
   ubuntu:
+    apt: libfacets-ruby
     gem: facets
 flexmock:
   ubuntu:

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -1,18 +1,23 @@
 nokogiri:
   ubuntu:
+    apt: ruby-nokogiri
     gem: nokogiri
 hoe:
   ubuntu:
+    apt: ruby-hoe
     gem: hoe
 facets:
   ubuntu:
     gem: facets
 flexmock:
   ubuntu:
+    apt: ruby-flexmock
     gem: flexmock
 rake:
   ubuntu:
+    apt: rake
     gem: rake
 rdoc:
   ubuntu:
+    apt: rdoc
     gem: rdoc

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -8,7 +8,7 @@ hoe:
     gem: hoe
 facets:
   ubuntu:
-    apt: libfacets-ruby
+    apt: ruby-facets
     gem: facets
 flexmock:
   ubuntu:


### PR DESCRIPTION
debian alternatives have been found for most of the gems enabling debian package creation of the orocos_toolchain

Except for ruby-facets which ATM is only available in ppa:smits-ruben/ppa and will soon be included in precise-backports.
