### PR TITLE
Added roslisp-release to groovy.yaml

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -190,6 +190,9 @@ repositories:
   roscpp_core:
     url: git://github.com/wg-debs/roscpp_core-release.git
     version: 0.3.5
+  roslisp:
+    url: git://github.com/wg-debs/roslisp-release.git
+    version: 1.9.7
   rospack:
     url: git://github.com/wg-debs/rospack-release.git
     version: 2.1.5-0


### PR DESCRIPTION
Roslisp was moved into a separate repo. Added the bloom release repo to groovy.yaml.
