### PR TITLE
Adding omniidl-python to python-omniorb

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -687,8 +687,8 @@ libsimage-dev:
   ubuntu: libsimage-dev
 omniorb:
   ubuntu:
-    quantal: omniorb omniidl omniidl-python omniorb-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
-    precise: omniorb omniidl omniidl-python omniorb-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
+    quantal: omniorb omniidl omniorb-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
+    precise: omniorb omniidl omniorb-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
     oneiric: omniorb omniidl omniorb-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
     natty: omniorb4 omniidl4 omniorb4-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2
     maverick: omniorb4 omniidl4 omniorb4-nameserver libomniorb4-1 libomniorb4-dev libomnithread3-dev libomnithread3c2

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -110,12 +110,13 @@ python-opengl:
   ubuntu: python-opengl
 python-omniorb:
   ubuntu:
-   kermic: python-omniorb2
-   lucid: python-omniorb2
-   maverick: python-omniorb
-   natty: python-omniorb
-   oneiric: python-omniorb
-   precise: python-omniorb
+   kermic: python-omniorb2 omniidl4-python
+   lucid: python-omniorb2 omniidl4-python
+   maverick: python-omniorb omniidl-python
+   natty: python-omniorb omniidl-python
+   oneiric: python-omniorb omniidl-python
+   precise: python-omniorb omniidl-python
+   quantal: python-omniorb omniidl-python
 python-paramiko:
   ubuntu: python-paramiko
   debian: python-paramiko


### PR DESCRIPTION
replacing omniidl-python from omniorb to python-omniorb and adding omniidl-python to python-omniorb for other ubuntu versions
