### PR TITLE
Added roslisp to groovy-devel.yaml

### DIFF
--- a/releases/groovy-devel.yaml
+++ b/releases/groovy-devel.yaml
@@ -118,6 +118,10 @@ repositories:
     type: git
     url: git://github.com/ros/roscpp_core.git
     version: master
+  roslisp:
+    type: git
+    url: git://github.com/ros/roslisp.git
+    version: master
   rospack:
     type: hg
     url: https://kforge.ros.org/rosrelease/rospack


### PR DESCRIPTION
I would like to have the roslisp repo tested. Added it to groovy-devel.yaml.
