### PR TITLE
Added tango-icon-theme

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1222,6 +1222,17 @@ sysstat:
   debian: sysstat
   ubuntu: sysstat
   fedora: sysstat
+tango-icon-theme:
+  arch: tango-icon-theme
+  cygwin: tango-icon-theme
+  debian: tango-icon-theme
+  fedora: tango-icon-theme
+  gentoo: tango-icon-theme
+  macports: tango-icon-theme
+  mandrake: tango-icon-theme
+  opensuse: tango-icon-theme
+  rhel: tango-icon-theme
+  ubuntu: tango-icon-theme
 tinyxml:
   arch: tinyxml
   debian: libtinyxml-dev


### PR DESCRIPTION
Needed as a default in rqt when the theme that is currently in use does not comply with the icon standard for themes.
