### PR TITLE
Rectified mistake in tango-icon-theme names

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1224,10 +1224,9 @@ sysstat:
   fedora: sysstat
 tango-icon-theme:
   arch: tango-icon-theme
-  cygwin: tango-icon-theme
   debian: tango-icon-theme
   fedora: tango-icon-theme
-  gentoo: tango-icon-theme
+  gentoo: gentoo x11-themes/tango-icon-theme
   macports: tango-icon-theme
   mandrake: tango-icon-theme
   opensuse: tango-icon-theme


### PR DESCRIPTION
cygwin name doesn't seem to exist
gentoo is x11-themes/tango-icon-theme
