### PR TITLE
Add SDL, SDL-TTF, and SDL-GFX development libraries

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1143,6 +1143,12 @@ scons:
   macports: scons
   opensuse: scons
   ubuntu: scons
+sdl:
+  debian: libsdl1.2-dev
+  ubuntu: libsdl1.2-dev
+sdl-gfx:
+  debian: libsdl-gfx1.2-dev
+  ubuntu: libsdl-gfx1.2-dev
 sdl-image:
   ubuntu: libsdl-image1.2-dev
   debian: libsdl-image1.2-dev
@@ -1151,6 +1157,9 @@ sdl-image:
   macports: libsdl_image
   gentoo: sdl-image
   freebsd: sdl_image
+sdl-ttf:
+  debian: libsdl-ttf2.0-dev
+  ubuntu: libsdl-ttf2.0-dev
 sqlite3:
   debian: sqlite3
   ubuntu: sqlite3


### PR DESCRIPTION
Added rosdep definitions for SDL, SDL-TTF, and SDL-GFX development libraries for Ubuntu and Debian.
