### PR TITLE
Adding navigation to documentation index for groovy

### DIFF
--- a/doc/groovy/navigation.rosinstall
+++ b/doc/groovy/navigation.rosinstall
@@ -1,0 +1,4 @@
+- hg:
+    local-name: navigation
+    uri: https://kforge.ros.org/navigation/navigation
+    version: default


### PR DESCRIPTION
I'd like navigation to be indexed and documented on ros.org.
