### PR TITLE
Add kyb-mpg-ros-pkg to the documentation indexer

### DIFF
--- a/doc/fuerte/kyb-mpg-ros-pkg.rosinstall
+++ b/doc/fuerte/kyb-mpg-ros-pkg.rosinstall
@@ -1,0 +1,29 @@
+- svn: 
+    local-name: telekyb_algo
+    uri: https://svn.tuebingen.mpg.de/kyb-robotics/TeleKyb/trunk/stacks/telekyb_algo
+- svn: 
+    local-name: telekyb_behaviors
+    uri: https://svn.tuebingen.mpg.de/kyb-robotics/TeleKyb/trunk/stacks/telekyb_behaviors
+- svn: 
+    local-name: telekyb_common
+    uri: https://svn.tuebingen.mpg.de/kyb-robotics/TeleKyb/trunk/stacks/telekyb_common
+- svn: 
+    local-name: telekyb_drivers
+    uri: https://svn.tuebingen.mpg.de/kyb-robotics/TeleKyb/trunk/stacks/telekyb_drivers
+- svn: 
+    local-name: telekyb_haptics
+    uri: https://svn.tuebingen.mpg.de/kyb-robotics/TeleKyb/trunk/stacks/telekyb_haptics
+- svn: 
+    local-name: telekyb_main
+    uri: https://svn.tuebingen.mpg.de/kyb-robotics/TeleKyb/trunk/stacks/telekyb_main
+- svn: 
+    local-name: telekyb_sensors
+    uri: https://svn.tuebingen.mpg.de/kyb-robotics/TeleKyb/trunk/stacks/telekyb_sensors
+- svn: 
+    local-name: telekyb_swarm
+    uri: https://svn.tuebingen.mpg.de/kyb-robotics/TeleKyb/trunk/stacks/telekyb_swarm
+- svn: 
+    local-name: telekyb_utils
+    uri: https://svn.tuebingen.mpg.de/kyb-robotics/TeleKyb/trunk/stacks/telekyb_utils
+
+

--- a/doc/fuerte/kyb-mpg-ros-pkg_depends.rosinstall
+++ b/doc/fuerte/kyb-mpg-ros-pkg_depends.rosinstall
@@ -1,0 +1,9 @@
+- svn: 
+    local-name: telekyb_deps
+    uri: https://svn.tuebingen.mpg.de/kyb-robotics/TeleKyb/trunk/stacks/telekyb_deps
+- svn: 
+    local-name: telekyb_exp
+    uri: https://svn.tuebingen.mpg.de/kyb-robotics/TeleKyb/trunk/stacks/telekyb_exp
+
+
+


### PR DESCRIPTION
Hi, could you please add the repository kyb-mpg-ros-pkg to the documentation indexer? It's contains ROS stacks generated at the Max-Planck-Institute for Biological Cybernetics in Tuebingen. More specifically the Human-Robot-Interaction group.

Thanks!
Martin
