### PR TITLE
Adding dri-ros-pkg to documentation index for fuerte

### DIFF
--- a/doc/fuerte/dri-ros-pkg.rosinstall
+++ b/doc/fuerte/dri-ros-pkg.rosinstall
@@ -1,0 +1,12 @@
+- svn:
+    local-name: extremum_seeking
+    uri: https://svn.3me.tudelft.nl/dri-ros-pkg/trunk/extremum_seeking
+- svn:
+    local-name: phidget_ik
+    uri: https://svn.3me.tudelft.nl/dri-ros-pkg/trunk/phidget_ik
+- svn:
+    local-name: saliency_detection
+    uri: https://svn.3me.tudelft.nl/dri-ros-pkg/trunk/saliency_detection
+- svn:
+    local-name: shared_serial
+    uri: https://svn.3me.tudelft.nl/dri-ros-pkg/trunk/shared_serial


### PR DESCRIPTION
I'd like dri-ros-pkg to be indexed and documented on ros.org.
