### PR TITLE
adding roscorobot to documentation index for fuerte

### DIFF
--- a/doc/fuerte/roscorobot.rosinstall
+++ b/doc/fuerte/roscorobot.rosinstall
@@ -1,0 +1,4 @@
+- svn:
+    uri: svn://svn.code.sf.net/p/roscorobot/code/trunk/Electric/Corobot
+    local-name: Corobot
+


### PR DESCRIPTION
I'd like roscorobot to be indexed and documented on ros.org
