### PR TITLE
Reindex roscorobot for documentation index for Fuert

### DIFF
--- a/doc/fuerte/roscorobot.rosinstall
+++ b/doc/fuerte/roscorobot.rosinstall
@@ -1,4 +1,4 @@
 - svn:
-    uri: svn://svn.code.sf.net/p/roscorobot/code/trunk/Electric/Corobot
+    uri: http://svn.code.sf.net/p/roscorobot/code/trunk/Electric/Corobot
     local-name: Corobot
 


### PR DESCRIPTION
Please reindex roscorobot as previous link in rosinstall file was in the svn:// form instead of http://
