### PR TITLE
ccny-ros-pkg: fuerte stacks

### DIFF
--- a/doc/fuerte/asctec_drivers.rosinstall
+++ b/doc/fuerte/asctec_drivers.rosinstall
@@ -1,0 +1,7 @@
+- git:
+    local-name: asctec_drivers
+    uri: https://github.com/ccny-ros-pkg/asctec_drivers.git
+    version: fuerte
+    meta:
+        repo-name: ccny-ros-pkg
+        

--- a/doc/fuerte/imu_tools.rosinstall
+++ b/doc/fuerte/imu_tools.rosinstall
@@ -1,0 +1,6 @@
+- git:
+    local-name: imu_tools
+    uri: https://github.com/ccny-ros-pkg/imu_tools.git
+    version: fuerte
+    meta:
+        repo-name: ccny-ros-pkg

--- a/doc/fuerte/mav_tools.rosinstall
+++ b/doc/fuerte/mav_tools.rosinstall
@@ -1,0 +1,6 @@
+- git:
+    local-name: mav_tools
+    uri: https://github.com/ccny-ros-pkg/mav_tools.git
+    version: fuerte
+    meta:
+        repo-name: ccny-ros-pkg

--- a/doc/fuerte/scan_tools.rosinstall
+++ b/doc/fuerte/scan_tools.rosinstall
@@ -1,0 +1,6 @@
+- git:
+    local-name: scan_tools
+    uri: https://github.com/ccny-ros-pkg/scan_tools.git
+    version: fuerte
+    meta:
+        repo-name: ccny-ros-pkg

--- a/doc/phidgets_drivers.rosinstall
+++ b/doc/phidgets_drivers.rosinstall
@@ -1,0 +1,6 @@
+- git:
+    local-name: phidgets_drivers
+    uri: https://github.com/ccny-ros-pkg/phidgets_drivers.git
+    version: fuerte
+    meta:
+        repo-name: ccny-ros-pkg


### PR DESCRIPTION
Adding 5 stacks to fuerte from ccny-ros-pkg repo:
- asctec_drivers
- imu_tools
- mav_tools
- phidgets_drivers
- scan_tools
