### PR TITLE
Moves rosbridge_suite to GitHub

### DIFF
--- a/doc/fuerte/rosbridge_suite.rosinstall
+++ b/doc/fuerte/rosbridge_suite.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: rosbridge_suite
-    uri: http://kforge.ros.org/rosbridge/git
-    version: master
+    uri: git://github.com/RobotWebTools/rosbridge_suite.git
+    version: fuerte-devel


### PR DESCRIPTION
Rosbridge 2.0 has been moved from KForge to GitHub. Thanks!
