### PR TITLE
Adding uos-ros-pkg stacks to doc indexer for electric and fuerte

### DIFF
--- a/doc/electric/uos.rosinstall
+++ b/doc/electric/uos.rosinstall
@@ -1,0 +1,39 @@
+- git:
+    uri: http://kos.informatik.uni-osnabrueck.de/katana_driver.git
+    local-name: katana_driver
+    version: electric
+
+- git:
+    uri: http://kos.informatik.uni-osnabrueck.de/katana_manipulation.git
+    local-name: katana_manipulation
+    version: master
+
+- git:
+    uri: http://kos.informatik.uni-osnabrueck.de/kurtana_robot.git
+    local-name: kurtana_robot
+    version: master
+
+- git:
+    uri: http://kos.informatik.uni-osnabrueck.de/kurt_apps.git
+    local-name: kurt_apps
+    version: master
+
+- git:
+    uri: http://kos.informatik.uni-osnabrueck.de/kurt_driver.git
+    local-name: kurt_driver
+    version: electric
+
+- git:
+    uri: http://kos.informatik.uni-osnabrueck.de/uos_slam.git
+    local-name: uos_slam
+    version: master
+
+- git:
+    uri: http://kos.informatik.uni-osnabrueck.de/uos_tools.git
+    local-name: uos_tools
+    version: electric
+
+- git:
+    uri: http://kos.informatik.uni-osnabrueck.de/sick_tim3xx.git
+    local-name: sick_tim3xx
+    version: master

--- a/doc/fuerte/uos.rosinstall
+++ b/doc/fuerte/uos.rosinstall
@@ -1,0 +1,39 @@
+- git:
+    uri: http://kos.informatik.uni-osnabrueck.de/katana_driver.git
+    local-name: katana_driver
+    version: master
+
+- git:
+    uri: http://kos.informatik.uni-osnabrueck.de/katana_manipulation.git
+    local-name: katana_manipulation
+    version: master
+
+- git:
+    uri: http://kos.informatik.uni-osnabrueck.de/kurtana_robot.git
+    local-name: kurtana_robot
+    version: master
+
+- git:
+    uri: http://kos.informatik.uni-osnabrueck.de/kurt_apps.git
+    local-name: kurt_apps
+    version: master
+
+- git:
+    uri: http://kos.informatik.uni-osnabrueck.de/kurt_driver.git
+    local-name: kurt_driver
+    version: master
+
+- git:
+    uri: http://kos.informatik.uni-osnabrueck.de/uos_slam.git
+    local-name: uos_slam
+    version: master
+
+- git:
+    uri: http://kos.informatik.uni-osnabrueck.de/uos_tools.git
+    local-name: uos_tools
+    version: master
+
+- git:
+    uri: http://kos.informatik.uni-osnabrueck.de/sick_tim3xx.git
+    local-name: sick_tim3xx
+    version: master


### PR DESCRIPTION
Please add our [uos-ros-pkg](http://www.ros.org/wiki/uos-ros-pkg) stacks to the new indexer.
