### PR TITLE
Increased version number of roslisp again after re-release.

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -365,7 +365,7 @@ repositories:
     version: 0.2.1-0
   roslisp:
     url: git://github.com/wg-debs/roslisp-release.git
-    version: 1.9.8-0
+    version: 1.9.9-0
   rospack:
     url: git://github.com/ros-gbp/rospack-release.git
     version: 2.1.11-0


### PR DESCRIPTION
This time, it should be working. At least a pre-relase test didn't fail.
