### PR TITLE
Adding roboearth to the documentation index for fuerte

### DIFF
--- a/doc/fuerte/roboearth.rosinstall
+++ b/doc/fuerte/roboearth.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: roboearth
+    uri: https://ipvs.informatik.uni-stuttgart.de/roboearth/repos/public/tags/latest


### PR DESCRIPTION
Hi, I'd like to have the roboearth stuff added to the new indexer.
