### PR TITLE
Adding pi_tracker, skeleton_markers, pi_tutorials, element to documentation index for distro

### DIFF
--- a/doc/electric/element.rosinstall
+++ b/doc/electric/element.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: element
+    uri: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/element

--- a/doc/electric/pi_tracker.rosinstall
+++ b/doc/electric/pi_tracker.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: pi_tracker
+    uri: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/pi_tracker

--- a/doc/electric/pi_tutorials.rosinstall
+++ b/doc/electric/pi_tutorials.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: pi_tutorials
+    uri: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/pi_tutorials

--- a/doc/electric/skeleton_markers.rosinstall
+++ b/doc/electric/skeleton_markers.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: skeleton_markers
+    uri: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/skeleton_markers

--- a/doc/fuerte/element.rosinstall
+++ b/doc/fuerte/element.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: element
+    uri: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/element

--- a/doc/fuerte/pi_tracker.rosinstall
+++ b/doc/fuerte/pi_tracker.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: pi_tracker
+    uri: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/pi_tracker

--- a/doc/fuerte/pi_tutorials.rosinstall
+++ b/doc/fuerte/pi_tutorials.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: pi_tutorials
+    uri: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/pi_tutorials

--- a/doc/fuerte/skeleton_markers.rosinstall
+++ b/doc/fuerte/skeleton_markers.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: skeleton_markers
+    uri: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/skeleton_markers


### PR DESCRIPTION
Please add pi_tracker, skeleton_markers, pi_tutorials, element to documentation index on ros.org.
