### PR TITLE
Adding differential_drive documentation index for fuerte.

### DIFF
--- a/doc/fuerte/differential_drive.rosinstall
+++ b/doc/fuerte/differential_drive.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: differential_drive
+    uri: https://jfstepha@code.google.com/p/differential-drive/ 
+


### PR DESCRIPTION
I would like differential_drive to be indexed and documented on ros.org.
