### PR TITLE
ROS nodes to wrap Optris thermal imager drivers

### DIFF
--- a/doc/fuerte/ohm.rosinstall
+++ b/doc/fuerte/ohm.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    uri: http://github.com/ohm-ros-pkg/optris_drivers.git
+    local-name: optris_drivers
+    version: master


### PR DESCRIPTION
There are two nodes available:
1) A wrapper for the Optris thermal imager driver for Ubuntu 12.04 32-bit
2) A color conversion module to convert raw thermal images to a "display-able" format
