### PR TITLE
driver_common updates, move to github, catkinized

### DIFF
--- a/doc/electric/driver_common.rosinstall
+++ b/doc/electric/driver_common.rosinstall
@@ -1,3 +1,4 @@
-- svn:
+- git:
     local-name: driver_common
-    uri: https://code.ros.org/svn/ros-pkg/stacks/driver_common/trunk
+    uri: https://github.com/ros-drivers/driver_common.git
+    version: electric-devel

--- a/doc/fuerte/driver_common.rosinstall
+++ b/doc/fuerte/driver_common.rosinstall
@@ -1,3 +1,4 @@
-- svn:
+- git:
     local-name: driver_common
-    uri: https://code.ros.org/svn/ros-pkg/stacks/driver_common/trunk
+    uri: https://github.com/ros-drivers/driver_common.git
+    version: fuerte-devel

--- a/doc/groovy/driver_common.rosinstall
+++ b/doc/groovy/driver_common.rosinstall
@@ -1,3 +1,4 @@
-- svn:
+- git:
     local-name: driver_common
-    uri: https://code.ros.org/svn/ros-pkg/stacks/driver_common/trunk
+    uri: https://github.com/ros-drivers/driver_common.git
+    version: groovy-devel

--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -69,6 +69,12 @@ repositories:
       diagnostic_updater:
       diagnostics:
       self_test:
+  driver_common:
+    url: git://github.com/ros-drivers/driver_common.git
+    version: 1.6.0-0
+    packages:
+      driver_base:
+      timestamp_tools:
   dynamic_reconfigure:
     url: git://github.com/ros-gbp/dynamic_reconfigure-release.git
     version: 1.5.23-0


### PR DESCRIPTION
Driver common msgs were used a lot in dynamic_reconfigure tutorials, so they may be dependencies in many stacks.
