### PR TITLE
Adding cn-alica-ros-pkg cn-util-ros-pkg cn-roscs-ros-pkg to documentation index for electric and fuerte

### DIFF
--- a/doc/electric/cn-alica-ros-pkg.rosinstall
+++ b/doc/electric/cn-alica-ros-pkg.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: cn-alica-ros-pkg
+    uri: https://code.google.com/p/cn-alica-ros-pkg/
+    version: release_electric

--- a/doc/electric/cn-alica-ros-pkg_depends.rosinstall
+++ b/doc/electric/cn-alica-ros-pkg_depends.rosinstall
@@ -1,0 +1,10 @@
+- git:
+    local-name: cn-roscs-ros-pkg
+    uri: https://code.google.com/p/cn-roscs-ros-pkg/ 
+    version: release_electric
+
+- git:
+    local-name: cn-util-ros-pkg
+    uri: https://code.google.com/p/cn-util-ros-pkg/ 
+    version: release_electric
+

--- a/doc/electric/cn-roscs-ros-pkg.rosinstall
+++ b/doc/electric/cn-roscs-ros-pkg.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: cn-roscs-ros-pkg
+    uri: https://code.google.com/p/cn-roscs-ros-pkg/ 
+    version: release_electric

--- a/doc/electric/cn-util-ros-pkg.rosinstall
+++ b/doc/electric/cn-util-ros-pkg.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: cn-util-ros-pkg
+    uri: https://code.google.com/p/cn-util-ros-pkg/ 
+    version: release_electric

--- a/doc/electric/cn-util-ros-pkg_depends.rosinstall
+++ b/doc/electric/cn-util-ros-pkg_depends.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: cn-roscs-ros-pkg
+    uri: https://code.google.com/p/cn-roscs-ros-pkg/ 
+    version: release_electric

--- a/doc/fuerte/cn-alica-ros-pkg.rosinstall
+++ b/doc/fuerte/cn-alica-ros-pkg.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: cn-alica-ros-pkg
+    uri: https://code.google.com/p/cn-alica-ros-pkg/
+    version: release_fuerte

--- a/doc/fuerte/cn-alica-ros-pkg_depends.rosinstall
+++ b/doc/fuerte/cn-alica-ros-pkg_depends.rosinstall
@@ -1,0 +1,10 @@
+- git:
+    local-name: cn-roscs-ros-pkg
+    uri: https://code.google.com/p/cn-roscs-ros-pkg/ 
+    version: release_fuerte
+
+- git:
+    local-name: cn-util-ros-pkg
+    uri: https://code.google.com/p/cn-util-ros-pkg/ 
+    version: release_fuerte
+

--- a/doc/fuerte/cn-roscs-ros-pkg.rosinstall
+++ b/doc/fuerte/cn-roscs-ros-pkg.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: cn-roscs-ros-pkg
+    uri: https://code.google.com/p/cn-roscs-ros-pkg/ 
+    version: release_fuerte

--- a/doc/fuerte/cn-util-ros-pkg.rosinstall
+++ b/doc/fuerte/cn-util-ros-pkg.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: cn-util-ros-pkg
+    uri: https://code.google.com/p/cn-util-ros-pkg/ 
+    version: release_fuerte

--- a/doc/fuerte/cn-util-ros-pkg_depends.rosinstall
+++ b/doc/fuerte/cn-util-ros-pkg_depends.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: cn-roscs-ros-pkg
+    uri: https://code.google.com/p/cn-roscs-ros-pkg/ 
+    version: release_fuerte


### PR DESCRIPTION
I'd like  cn-alica-ros-pkg cn-util-ros-pkg cn-roscs-ros-pkg to be indexed and documented on ros.org
