### PR TITLE
Adding robot_capsule_urdf for fuerte and groovy

### DIFF
--- a/doc/fuerte/robot_capsule_urdf.rosinstall
+++ b/doc/fuerte/robot_capsule_urdf.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: robot_capsule_urdf
+    uri: https://github.com/laas/robot_capsule_urdf.git
+    version: master

--- a/doc/groovy/robot_capsule_urdf.rosinstall
+++ b/doc/groovy/robot_capsule_urdf.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: robot_capsule_urdf
+    uri: https://github.com/laas/robot_capsule_urdf.git
+    version: master


### PR DESCRIPTION
I'd like robot_capsule_urdf to be indexed and documented on ros.org.
