### PR TITLE
Correct branch for git indexing

### DIFF
--- a/doc/groovy/turtlebot.rosinstall
+++ b/doc/groovy/turtlebot.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: turtlebot
     uri: https://github.com/turtlebot/turtlebot.git
-    version: default
+    version: groovy

--- a/doc/groovy/turtlebot_apps.rosinstall
+++ b/doc/groovy/turtlebot_apps.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: turtlebot_apps
     uri: https://github.com/turtlebot/turtlebot_apps.git
-    version: default
+    version: groovy

--- a/doc/groovy/turtlebot_arm.rosinstall
+++ b/doc/groovy/turtlebot_arm.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: turtlebot_arm
     uri: https://github.com/turtlebot/turtlebot_arm.git
-    version: default
+    version: groovy

--- a/doc/groovy/turtlebot_create.rosinstall
+++ b/doc/groovy/turtlebot_create.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: turtlebot_create
     uri: https://github.com/turtlebot/turtlebot_create.git
-    version: default
+    version: groovy

--- a/doc/groovy/turtlebot_simulator.rosinstall
+++ b/doc/groovy/turtlebot_simulator.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: turtlebot_simulator
     uri: https://github.com/turtlebot/turtlebot_simulator.git
-    version: default
+    version: groovy

--- a/doc/groovy/turtlebot_viz.rosinstall
+++ b/doc/groovy/turtlebot_viz.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: turtlebot_viz
     uri: https://github.com/turtlebot/turtlebot_viz.git
-    version: default
+    version: groovy

--- a/doc/groovy/yujin_ocs.rosinstall
+++ b/doc/groovy/yujin_ocs.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    uri: https://github.com/yujinrobot/yujin_ocs.git
+    local-name: yujin_ocs
+    version: groovy-devel


### PR DESCRIPTION
Git doesn't use default.

Set these to use groovy branch - if not already there, they will soon be there.
