### PR TITLE
Adding webmap stack to dri-ros-pkg for fuerte

### DIFF
--- a/doc/fuerte/dri-ros-pkg.rosinstall
+++ b/doc/fuerte/dri-ros-pkg.rosinstall
@@ -10,3 +10,6 @@
 - svn:
     local-name: shared_serial
     uri: https://svn.3me.tudelft.nl/dri-ros-pkg/trunk/shared_serial
+- svn:
+    local-name: webmap
+    uri: https://svn.3me.tudelft.nl/dri-ros-pkg/trunk/webmap


### PR DESCRIPTION
Adding webmap stack to dri-ros-pkg for fuerte
