### PR TITLE
Adding all-iri-ros to documentatin index for distro

### DIFF
--- a/doc/fuerte/all-iri-ros.pub.rosinstall
+++ b/doc/fuerte/all-iri-ros.pub.rosinstall
@@ -1,60 +1,57 @@
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_core/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_core/trunk
     local-name: iri_core
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_common_drivers/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_common_drivers/trunk
     local-name: iri_common_drivers
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_odometry_publisher/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_odometry_publisher/trunk
     local-name: iri_odometry_publisher
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_teleop/trunk
-    local-name: iri_teleop
-- svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_navigation/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_navigation/trunk
     local-name: iri_navigation
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_perception/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_perception/trunk
     local-name: iri_perception
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_perception_filters/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_perception_filters/trunk
     local-name: iri_perception_filters
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_planning/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_planning/trunk
     local-name: iri_planning
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_segway_rmp/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_segway_rmp/trunk
     local-name: iri_segway_rmp
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_smach/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_smach/trunk
     local-name: iri_smach
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_wam/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_wam/trunk
     local-name: iri_wam
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/estirabot_robot/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/estirabot_robot/trunk
     local-name: estirabot_robot
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/teo_robot/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/teo_robot/trunk
     local-name: teo_robot
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/tibi_dabo_robot/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/tibi_dabo_robot/trunk
     local-name: tibi_dabo_robot
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/zyonz_robot/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/zyonz_robot/trunk
     local-name: zyonz_robot
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_darwin/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_darwin/trunk
     local-name: iri_darwin
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/darwin_robot/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/darwin_robot/trunk
     local-name: darwin_robot
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_learning/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_learning/trunk
     local-name: iri_learning
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/kinton_robot/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/kinton_robot/trunk
     local-name: kinton_robot
 - svn:
-    uri: https://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_visual_servo/trunk
+    uri: http://devel.iri.upc.edu/pub/labrobotica/ros/iri-ros-pkg/stacks/iri_visual_servo/trunk
     local-name: iri_visual_servo


### PR DESCRIPTION
I'd like all-iri-ros to be indexed and documented on ros.org

The repository was already in the indexer before the change to rosdistro github project. It contains:

```
Several robots stacks
    wam
    segway
    darwin op
    others ...

Other useful robotics stacks related to perception, manipulation
and mobile robotics.
```

The first time we have had some problems with our ssl certificate. We have changed to simple http.
