### PR TITLE
Adding ros_arduino_bridge to documentation index for Electric

### DIFF
--- a/doc/electric/ros_arduino_bridge.rosinstall
+++ b/doc/electric/ros_arduino_bridge.rosinstall
@@ -1,0 +1,3 @@
+- git:
+    local-name: ros_arduino_bridge
+    uri: git://github.com/hbrobotics/ros_arduino_bridge.git

--- a/doc/fuerte/ros_arduino_bridge.rosinstall
+++ b/doc/fuerte/ros_arduino_bridge.rosinstall
@@ -1,0 +1,3 @@
+- git:
+    local-name: ros_arduino_bridge
+    uri: git://github.com/hbrobotics/ros_arduino_bridge.git


### PR DESCRIPTION
I'd like ros_arduino_bridge to be indexed on ros.org.
