### PR TITLE
rqt_robot_common is actually rqt_robot_plugins

### DIFF
--- a/doc/groovy/rqt.rosinstall
+++ b/doc/groovy/rqt.rosinstall
@@ -11,6 +11,6 @@
     uri: https://github.com/ros-visualization/rqt_pr2_dashboard
     version: groovy-devel
 - git:
-    local-name: rqt_robot_common
-    uri: https://github.com/ros-visualization/rqt_robot_common
+    local-name: rqt_robot_plugins
+    uri: https://github.com/ros-visualization/rqt_robot_plugins
     version: groovy-devel


### PR DESCRIPTION
The repository rqt_robot_common doesn't exist and is causing the doc job to fail.
