### PR TITLE
Adding eddiebot to documentation index for distro

### DIFF
--- a/doc/electric/eddiebot.rosinstall
+++ b/doc/electric/eddiebot.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: eddiebot
+    uri: https://github.com/robotictang/eddiebot.git
+    version: electric-devel

--- a/doc/fuerte/eddiebot.rosinstall
+++ b/doc/fuerte/eddiebot.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: eddiebot
+    uri: https://github.com/robotictang/eddiebot.git
+    version: fuerte-devel

--- a/doc/groovy/eddiebot.rosinstall
+++ b/doc/groovy/eddiebot.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: eddiebot
+    uri: https://github.com/robotictang/eddiebot.git
+    version: groovy-devel


### PR DESCRIPTION
I'd like eddiebot to be indexed and documented on ros.org
