### PR TITLE
Adding eddiebot_head_tracking to documentation index for distro

### DIFF
--- a/doc/electric/eddiebot_head_tracking.rosinstall
+++ b/doc/electric/eddiebot_head_tracking.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: eddiebot
+    uri: https://github.com/robotictang/eddiebot_head_tracking.git
+    version: electric-devel

--- a/doc/electric/eddiebot_head_tracking.rosinstall
+++ b/doc/electric/eddiebot_head_tracking.rosinstall
@@ -1,4 +1,4 @@
 - git:
-    local-name: eddiebot
+    local-name: eddiebot_head_tracking
     uri: https://github.com/robotictang/eddiebot_head_tracking.git
     version: electric-devel

--- a/doc/fuerte/eddiebot_head_tracking.rosinstall
+++ b/doc/fuerte/eddiebot_head_tracking.rosinstall
@@ -1,4 +1,4 @@
 - git:
-    local-name: eddiebot
+    local-name: eddiebot_head_tracking
     uri: https://github.com/robotictang/eddiebot_head_tracking.git
     version: fuerte-devel

--- a/doc/fuerte/eddiebot_head_tracking.rosinstall
+++ b/doc/fuerte/eddiebot_head_tracking.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: eddiebot
+    uri: https://github.com/robotictang/eddiebot_head_tracking.git
+    version: fuerte-devel

--- a/doc/groovy/eddiebot_head_tracking.rosinstall
+++ b/doc/groovy/eddiebot_head_tracking.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: eddiebot
+    uri: https://github.com/robotictang/eddiebot_head_tracking.git
+    version: groovy-devel

--- a/doc/groovy/eddiebot_head_tracking.rosinstall
+++ b/doc/groovy/eddiebot_head_tracking.rosinstall
@@ -1,4 +1,4 @@
 - git:
-    local-name: eddiebot
+    local-name: eddiebot_head_tracking
     uri: https://github.com/robotictang/eddiebot_head_tracking.git
     version: groovy-devel


### PR DESCRIPTION
I'd like eddiebot_head_tracking to be indexed and documented on ros.org.
