### PR TITLE
Adding eddiebot_follower to documentation index for distro

### DIFF
--- a/doc/electric/eddiebot_follower.rosinstall
+++ b/doc/electric/eddiebot_follower.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: eddiebot_follower
+    uri: https://github.com/robotictang/eddiebot_follower.git
+    version: electric-devel

--- a/doc/fuerte/eddiebot_follower.rosinstall
+++ b/doc/fuerte/eddiebot_follower.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: eddiebot_follower
+    uri: https://github.com/robotictang/eddiebot_follower.git
+    version: fuerte-devel

--- a/doc/groovy/eddiebot_follower.rosinstall
+++ b/doc/groovy/eddiebot_follower.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: eddiebot_follower
+    uri: https://github.com/robotictang/eddiebot_follower.git
+    version: groovy-devel


### PR DESCRIPTION
I'd like eddiebot_follower to be indexed and documented on ros.org.
