### PR TITLE
Adding eddiebot_teleop to documentation index for distro

### DIFF
--- a/doc/electric/eddiebot_line_follower.rosinstall
+++ b/doc/electric/eddiebot_line_follower.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: eddiebot_line_follower
+    uri: https://github.com/robotictang/eddiebot_line_follower.git
+    version: electric-devel

--- a/doc/electric/eddiebot_teleop.rosinstall
+++ b/doc/electric/eddiebot_teleop.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: eddiebot_teleop
+    uri: https://github.com/robotictang/eddiebot_teleop.git
+    version: electric-devel

--- a/doc/fuerte/eddiebot_line_follower.rosinstall
+++ b/doc/fuerte/eddiebot_line_follower.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: eddiebot_line_follower
+    uri: https://github.com/robotictang/eddiebot_line_follower.git
+    version: fuerte-devel

--- a/doc/fuerte/eddiebot_teleop.rosinstall
+++ b/doc/fuerte/eddiebot_teleop.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: eddiebot_teleop
+    uri: https://github.com/robotictang/eddiebot_teleop.git
+    version: fuerte-devel

--- a/doc/groovy/eddiebot_line_follower.rosinstall
+++ b/doc/groovy/eddiebot_line_follower.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: eddiebot_line_follower
+    uri: https://github.com/robotictang/eddiebot_line_follower.git
+    version: groovy-devel

--- a/doc/groovy/eddiebot_teleop.rosinstall
+++ b/doc/groovy/eddiebot_teleop.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: eddiebot_teleop
+    uri: https://github.com/robotictang/eddiebot_teleop.git
+    version: groovy-devel


### PR DESCRIPTION
I'd like eddiebot_teleop to be indexed and documented on ros.org.
