### PR TITLE
Moved the 'people' repo to github, updating the location for the docs in groovy.

### DIFF
--- a/doc/groovy/people.rosinstall
+++ b/doc/groovy/people.rosinstall
@@ -1,3 +1,4 @@
-- svn:
+- git:
     local-name: people
-    uri: https://code.ros.org/svn/wg-ros-pkg/stacks/people/branches/fuerte_trunk
+    uri: https://github.com/wg-perception/people.git
+    version: groovy-devel


### PR DESCRIPTION
Moved the 'people' repo to github, updating the location for the docs in groovy.
