### PR TITLE
Update rosinstall file's git version to master

### DIFF
--- a/doc/electric/eddiebot.rosinstall
+++ b/doc/electric/eddiebot.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: eddiebot
     uri: https://github.com/robotictang/eddiebot.git
-    version: electric-devel
+    version: master

--- a/doc/electric/eddiebot_follower.rosinstall
+++ b/doc/electric/eddiebot_follower.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: eddiebot_follower
     uri: https://github.com/robotictang/eddiebot_follower.git
-    version: electric-devel
+    version: master

--- a/doc/electric/eddiebot_head_tracking.rosinstall
+++ b/doc/electric/eddiebot_head_tracking.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: eddiebot_head_tracking
     uri: https://github.com/robotictang/eddiebot_head_tracking.git
-    version: electric-devel
+    version: master

--- a/doc/electric/eddiebot_line_follower.rosinstall
+++ b/doc/electric/eddiebot_line_follower.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: eddiebot_line_follower
     uri: https://github.com/robotictang/eddiebot_line_follower.git
-    version: electric-devel
+    version: master

--- a/doc/electric/eddiebot_teleop.rosinstall
+++ b/doc/electric/eddiebot_teleop.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: eddiebot_teleop
     uri: https://github.com/robotictang/eddiebot_teleop.git
-    version: electric-devel
+    version: master

--- a/doc/fuerte/eddiebot.rosinstall
+++ b/doc/fuerte/eddiebot.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: eddiebot
     uri: https://github.com/robotictang/eddiebot.git
-    version: fuerte-devel
+    version: master

--- a/doc/fuerte/eddiebot_follower.rosinstall
+++ b/doc/fuerte/eddiebot_follower.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: eddiebot_follower
     uri: https://github.com/robotictang/eddiebot_follower.git
-    version: fuerte-devel
+    version: master

--- a/doc/fuerte/eddiebot_head_tracking.rosinstall
+++ b/doc/fuerte/eddiebot_head_tracking.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: eddiebot_head_tracking
     uri: https://github.com/robotictang/eddiebot_head_tracking.git
-    version: fuerte-devel
+    version: master

--- a/doc/fuerte/eddiebot_line_follower.rosinstall
+++ b/doc/fuerte/eddiebot_line_follower.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: eddiebot_line_follower
     uri: https://github.com/robotictang/eddiebot_line_follower.git
-    version: fuerte-devel
+    version: master

--- a/doc/fuerte/eddiebot_teleop.rosinstall
+++ b/doc/fuerte/eddiebot_teleop.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: eddiebot_teleop
     uri: https://github.com/robotictang/eddiebot_teleop.git
-    version: fuerte-devel
+    version: master

--- a/doc/groovy/eddiebot.rosinstall
+++ b/doc/groovy/eddiebot.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: eddiebot
     uri: https://github.com/robotictang/eddiebot.git
-    version: groovy-devel
+    version: master

--- a/doc/groovy/eddiebot_follower.rosinstall
+++ b/doc/groovy/eddiebot_follower.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: eddiebot_follower
     uri: https://github.com/robotictang/eddiebot_follower.git
-    version: groovy-devel
+    version: master

--- a/doc/groovy/eddiebot_head_tracking.rosinstall
+++ b/doc/groovy/eddiebot_head_tracking.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: eddiebot_head_tracking
     uri: https://github.com/robotictang/eddiebot_head_tracking.git
-    version: groovy-devel
+    version: master

--- a/doc/groovy/eddiebot_line_follower.rosinstall
+++ b/doc/groovy/eddiebot_line_follower.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: eddiebot_line_follower
     uri: https://github.com/robotictang/eddiebot_line_follower.git
-    version: groovy-devel
+    version: master

--- a/doc/groovy/eddiebot_teleop.rosinstall
+++ b/doc/groovy/eddiebot_teleop.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: eddiebot_teleop
     uri: https://github.com/robotictang/eddiebot_teleop.git
-    version: groovy-devel
+    version: master


### PR DESCRIPTION
I updated the rosinstall file version tag to 'master' to follow those successful doxygen package such as clearpath_husky. 
