### PR TITLE
Adding razor_imu_9dof to documentation index for distro

### DIFF
--- a/doc/electric/razor_imu_9dof.rosinstall
+++ b/doc/electric/razor_imu_9dof.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: razor_imu_9dof
+    uri: https://github.com/robotictang/razor_imu_9dof.git
+    version: master

--- a/doc/fuerte/razor_imu_9dof.rosinstall
+++ b/doc/fuerte/razor_imu_9dof.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: razor_imu_9dof
+    uri: https://github.com/robotictang/razor_imu_9dof.git
+    version: master

--- a/doc/groovy/razor_imu_9dof.rosinstall
+++ b/doc/groovy/razor_imu_9dof.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: razor_imu_9dof
+    uri: https://github.com/robotictang/razor_imu_9dof.git
+    version: master


### PR DESCRIPTION
I'd like razor_imu_9dof to be indexed and documented on ros.org.
