### PR TITLE
Update base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -359,6 +359,8 @@ gforth:
   arch: gforth
   gentoo: gforth
   fedora: gforth
+gfortran:
+  ubuntu: gfortran
 gifsicle:
   debian: gifsicle
   ubuntu: gifsicle

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -993,6 +993,8 @@ libxaw:
   opensuse: xorg-x11-devel
   rhel: libXaw-devel
   ubuntu: libxaw7-dev
+libxenomai-dev:
+  ubuntu: libxenomai-dev
 libxext:
   arch: libxext
   debian: libxext-dev


### PR DESCRIPTION
base.yaml: Add libxenomai-dev and gfortran for Ubuntu
