### PR TITLE
fix syntax for yaml-cpp on debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1525,13 +1525,14 @@ yaml:
 yaml-cpp:
   arch: yaml-cpp
   debian:
+    squeeze:
+      source: {md5sum: f7fb81fd4a2fbd5022daa7686e816359, uri: 'https://kforge.ros.org/rosrelease/viewvc/sourcedeps/yaml-cpp/yaml-cpp-0.2.5.rdmanifest'}
     wheezy:
       apt:
         packages: [libyaml-cpp-dev]
     sid:
       apt:
         packages: [libyaml-cpp-dev]
-    source: {md5sum: f7fb81fd4a2fbd5022daa7686e816359, uri: 'https://kforge.ros.org/rosrelease/viewvc/sourcedeps/yaml-cpp/yaml-cpp-0.2.5.rdmanifest'}
   ubuntu:
     quantal: libyaml-cpp-dev
     precise: yaml-cpp

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1525,9 +1525,12 @@ yaml:
 yaml-cpp:
   arch: yaml-cpp
   debian:
-    apt:
-      wheezy: libyaml-cpp-dev
-      sid: libyaml-cpp-dev
+    wheezy:
+      apt:
+        packages: [libyaml-cpp-dev]
+    sid:
+      apt:
+        packages: [libyaml-cpp-dev]
     source: {md5sum: f7fb81fd4a2fbd5022daa7686e816359, uri: 'https://kforge.ros.org/rosrelease/viewvc/sourcedeps/yaml-cpp/yaml-cpp-0.2.5.rdmanifest'}
   ubuntu:
     quantal: libyaml-cpp-dev


### PR DESCRIPTION
The definitions in base.yaml for yaml-cpp and os debian were wrong: the package manager was specified before the os version (wheezy, sid).
Corrected that and added the source "package manager" to squeeze only.
