### PR TITLE
Add libfreenect and libois to rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -570,6 +570,9 @@ libexpat1-dev:
 libfftw3:
   debian: libfftw3-3 libfftw3-dev
   ubuntu: libfftw3-3 libfftw3-dev
+libfreenect-dev:
+  debian: libfreenect-dev
+  ubuntu: libfreenect-dev
 libgfortran3:
   debian: libgfortran3
   ubuntu: libgfortran3

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -694,6 +694,9 @@ libnl-dev:
   arch: libnl
   debian: libnl-dev
   ubuntu: libnl-dev
+libois-dev:
+  debian: libois-dev
+  ubuntu: libois-dev
 libogg:
   arch: libogg
   ubuntu: libogg-dev


### PR DESCRIPTION
Hello,
this pull request adds two new entries to base.yaml.

These entries are required to port the vision_visp stack to catkin/bloom.

Thanks.
