### PR TITLE
Add visp to releases/groovy.yaml

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -591,6 +591,9 @@ repositories:
       cv_bridge:
       image_geometry:
       vision_opencv:
+  visp:
+    url: git://github.com/laas/visp-release.git
+    version: 2.6.2-0
   warehouse_ros:
     url: git://github.com/ros-gbp/warehouse-release.git
     version: 0.7.12-0


### PR DESCRIPTION
Register ViSP 2.6.2 Bloom release (Groovy).
