### PR TITLE
Release visp_2.6.2-1

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -593,7 +593,7 @@ repositories:
       vision_opencv:
   visp:
     url: git://github.com/laas/visp-release.git
-    version: 2.6.2-0
+    version: 2.6.2-1
   warehouse_ros:
     url: git://github.com/ros-gbp/warehouse-release.git
     version: 0.7.12-0


### PR DESCRIPTION
Previous release was missing building flags leading to only a static
library being built.
This new release has been used to compile the visp_tracker ROS package.
