### PR TITLE
added python-simplejson dependency

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -228,6 +228,10 @@ python-setuptools:
   arch: python2-distribute
   ubuntu: python-setuptools
   fedora: python-setuptools
+python-simplejson:
+  ubuntu: python-simplejson
+  debian: python-simplejson
+  fedora: python-simplejson
 python-sip:
   ubuntu: python-sip-dev
   debian: python-sip-dev


### PR DESCRIPTION
Hi,

please include the new rosdep rule for the python-simplejson package required by the KnowRob stack.

Thanks!
Moritz (tenorth@cs.uni-bremen.de)
