### PR TITLE
Adding mtconnect to documentation index for fuerte

### DIFF
--- a/doc/fuerte/mtconnect.rosinstall
+++ b/doc/fuerte/mtconnect.rosinstall
@@ -1,0 +1,3 @@
+- git:
+    local-name: mtconnect
+    uri: https://github.com/mtconnect/ros_bridge/mtconnect


### PR DESCRIPTION
I'd like to include the mtconnect repo in the index for fuerte.
