### PR TITLE
Add python-pexpect rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -153,6 +153,8 @@ python-paramiko:
   gentoo: dev-python/paramiko
   freebsd: py27-paramiko
   arch: python-paramiko
+python-pexpect:
+  ubuntu: python-pexpect
 python-pydot:
   ubuntu: python-pydot
   osx:


### PR DESCRIPTION
Add a rosdep for python-pexpect for the pending release of pr2_app_manager.
