### PR TITLE
Please merge to fixup ruby build environment on quantal.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1227,7 +1227,7 @@ redis-server:
   ubuntu: redis-server
 ruby:
   ubuntu:
-    quantal: ruby1.8-dev libruby1.8 rubygems1.8
+    quantal: ruby1.9.1-dev libruby1.9.1 rubygems
     precise: ruby1.8-dev libruby1.8 rubygems1.8
     oneiric: ruby1.8-dev libruby1.8 rubygems1.8
     natty: ruby1.8-dev libruby1.8 rubygems1.8


### PR DESCRIPTION
Ruby 1.9.x is the default and when installing ruby1.8-dev, one gets the error:

/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in 'require': cannot load such file -- mkmf (LoadError)
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in 'require'
    from extconf.rb:1:in '<main>'
  rake aborted!

So the ruby1.8-dev files are not picked up and useless for our case.

Signed-off-by: Peter Soetens peter@thesourceworks.com
