### PR TITLE
Lots of Fedora key modifications

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1369,9 +1369,11 @@ tcsh:
 texlive-fonts-extra:
   debian: texlive-fonts-extra
   ubuntu: texlive-fonts-extra
+  fedora: texlive-bbm-macros
 texlive-fonts-recommended:
   debian: texlive-fonts-recommended
   ubuntu: texlive-fonts-recommended
+  fedora: texlive-times texlive-helvetic
 texlive-latex-base:
   arch: texlive-base
   debian: texlive-latex-base
@@ -1380,9 +1382,11 @@ texlive-latex-base:
 texlive-latex-extra:
   debian: texlive-latex-extra
   ubuntu: texlive-latex-extra
+  fedora: texlive-titlesec texlive-wrapfig texlive-multirow
 texlive-latex-recommended:
   debian: texlive-latex-recommended
   ubuntu: texlive-latex-recommended
+  fedora: texlive-framed texlive-threeparttable
 tix:
   debian: tix
   ubuntu: tix

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -953,7 +953,9 @@ libusb-1.0-dev:
   arch: libusb
   debian: libusb-1.0-0-dev
   ubuntu: libusb-1.0-0-dev
-  fedora: libusb1-devel
+  fedora:
+    beefy: libusb1-devel
+    spherical: libusbx-devel
 libusb-dev:
   arch: libusb-compat
   debian: libusb-dev

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -325,7 +325,7 @@ flex:
 fltk:
   arch: fltk
   debian: libfltk1.1-dev
-  fedora: fltk-devel
+  fedora: fltk-devel fltk-fluid
   freebsd: fltk
   gentoo: =x11-libs/fltk-1*
   macports: fltk

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -219,6 +219,7 @@ coinor-libipopt-dev:
   fedora: cmake
 collada-dom:
   ubuntu: collada-dom-dev
+  fedora: collada-dom-devel
 coreutils:
   arch: coreutils
   debian: coreutils
@@ -786,6 +787,7 @@ libpng12-dev:
 libpoco-dev:
   debian: libpoco-dev
   ubuntu: libpoco-dev
+  fedora: poco-devel
 libpocofoundation9:
   ubuntu: libpocofoundation9
 libpopt-dev:
@@ -1190,6 +1192,7 @@ protobuf:
   debian: libprotobuf7
 protobuf-dev:
   ubuntu: libprotobuf-dev protobuf-compiler libprotoc-dev
+  fedora: protobuf-devel protobuf-compiler
 ps-engine:
   arch: primesense-sensor
   ubuntu: ps-engine

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -662,7 +662,7 @@ libjpeg:
     'maverick': libjpeg62-dev
     'lucid': libjpeg62-dev
   debian: libjpeg8-dev
-  fedora: libjpeg-devel
+  fedora: libjpeg-turbo-devel
   macports: jpeg
   arch: libjpeg-turbo
   gentoo: libjpeg-turbo

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -146,6 +146,7 @@ python-omniorb:
    quantal: python-omniorb omniidl-python
 python-opengl: 
   ubuntu: python-opengl
+  fedora: PyOpenGL
 python-paramiko:
   ubuntu: python-paramiko
   debian: python-paramiko
@@ -165,6 +166,7 @@ python-pydot:
   osx:
     pip:
       packages: [ pydot ]
+  fedora: pydot
 python-pygame:
   ubuntu: python-pygame
 python-pygraphviz:
@@ -197,10 +199,13 @@ python-qt-bindings:
     wheezy: python-pyside libpyside-dev libshiboken-dev shiboken python-qt4 python-qt4-dev python-sip-dev
     sid: python-pyside libpyside-dev libshiboken-dev shiboken python-qt4 python-qt4-dev python-sip-dev
   gentoo: PyQt4
+  fedora: PyQt4 PyQt4-devel sip-devel
 python-qt-bindings-gl:
   ubuntu: python-qt4-gl
+  fedora: PyQt4
 python-qt-bindings-qwt5:
   ubuntu: python-qwt5-qt4
+  fedora: PyQwt-devel
 python-qt4-gl:
   ubuntu: 
     apt: 

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -225,7 +225,8 @@ python-rosdep:
       packages: [ rosdep ]
   ubuntu: python-rosdep
   fedora:
-    packages: [ rosdep ]
+    pip:
+      packages: [ rosdep ]
 python-rosinstall:
   fedora:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -221,6 +221,10 @@ python-rosdep:
   ubuntu: python-rosdep
   fedora:
     packages: [ rosdep ]
+python-rosinstall:
+  fedora:
+    pip:
+      packages: [ rosinstall ]
 python-rospkg:
   debian:
     pip:
@@ -276,6 +280,10 @@ python-tk:
   ubuntu: python-tk
 python-twisted-core:
   ubuntu: python-twisted-core
+python-wstool:
+  fedora:
+    pip:
+      packages: [ wstool ]
 python-yaml:
   ubuntu: python-yaml
   debian: python-yaml

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -33,7 +33,7 @@ python-argparse:
       packages: []
     quantal:
       packages: []
-  fedora: python-argparse
+  fedora: python
 python-avahi:
   ubuntu: python-avahi
   debian: python-avahi
@@ -263,7 +263,7 @@ python-sphinx:
   ubuntu: python-sphinx
 python-support:
   ubuntu: python-support
-  fedora: notneeded
+  fedora: python
 python-svn: 
   ubuntu: python-svn
 python-sympy: 

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -219,12 +219,16 @@ python-rosdep:
     pip:
       packages: [ rosdep ]
   ubuntu: python-rosdep
+  fedora:
+    packages: [ rosdep ]
 python-rospkg:
   debian:
     pip:
       packages: [ rospkg ]
   ubuntu: python-rospkg
-  fedora: python-rospkg
+  fedora:
+    pip:
+      packages: [ rospkg ]
 python-scapy:
   ubuntu: python-scapy
 python-scipy:
@@ -276,7 +280,9 @@ python-yaml:
   ubuntu: python-yaml
   debian: python-yaml
   opensuse: python-yaml
-  fedora: PyYAML
+  fedora:
+    pip:
+      packages: [ PyYAML ]
   rhel: PyYAML
   centos: PyYAML
   arch: python2-yaml


### PR DESCRIPTION
Keys SHOULD be compatible with both current versions of fedora, 17/18 beefy/spherical.
