### PR TITLE
Adding tue-ros-pkg to documentation index for electric and fuerte

### DIFF
--- a/doc/electric/tue.rosinstall
+++ b/doc/electric/tue.rosinstall
@@ -1,0 +1,9 @@
+- svn:
+    local-name: tulip_simulator
+    uri: https://robotics.wtb.tue.nl/svn/ros/release/electric/tulip_simulator
+- svn:
+    local-name: amigo_common
+    uri: https://robotics.wtb.tue.nl/svn/ros/release/amigo_common
+- svn:
+    local-name: amigo_simulator
+    uri: https://robotics.wtb.tue.nl/svn/ros/release/amigo_simulator  

--- a/doc/fuerte/tue.rosinstall
+++ b/doc/fuerte/tue.rosinstall
@@ -1,0 +1,9 @@
+- svn:
+    local-name: tulip_simulator
+    uri: https://robotics.wtb.tue.nl/svn/ros/release/fuerte/tulip_simulator
+- svn:
+    local-name: amigo_common
+    uri: https://robotics.wtb.tue.nl/svn/ros/release/amigo_common
+- svn:
+    local-name: amigo_simulator
+    uri: https://robotics.wtb.tue.nl/svn/ros/release/amigo_simulator  


### PR DESCRIPTION
I'd like tue-ros-pkg to be indexed and documented on ros.org.
