### PR TITLE
More Fedora deps for texlive (so opencv2 compiles)

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1372,7 +1372,7 @@ tcsh:
 texlive-fonts-extra:
   debian: texlive-fonts-extra
   ubuntu: texlive-fonts-extra
-  fedora: texlive-bbm-macros
+  fedora: texlive-bbm texlive-bbm-macros
 texlive-fonts-recommended:
   debian: texlive-fonts-recommended
   ubuntu: texlive-fonts-recommended
@@ -1381,15 +1381,15 @@ texlive-latex-base:
   arch: texlive-base
   debian: texlive-latex-base
   ubuntu: texlive-latex-base
-  fedora: texlive-latex
+  fedora: texlive-latex texlive-parskip
 texlive-latex-extra:
   debian: texlive-latex-extra
   ubuntu: texlive-latex-extra
-  fedora: texlive-titlesec texlive-wrapfig texlive-multirow
+  fedora: texlive-titlesec texlive-wrapfig texlive-multirow texlive-fancybox
 texlive-latex-recommended:
   debian: texlive-latex-recommended
   ubuntu: texlive-latex-recommended
-  fedora: texlive-framed texlive-threeparttable
+  fedora: texlive-framed texlive-threeparttable texlive-ec texlive-mdwtools
 tix:
   debian: tix
   ubuntu: tix


### PR DESCRIPTION
Again, the Fedora texlive deps are not exhaustive. They will need to be appended as the need arises.
