### PR TITLE
Adding allegro_hand_ros to documentation index for fuerte.

### DIFF
--- a/doc/fuerte/allegro_hand_ros.rosinstall
+++ b/doc/fuerte/allegro_hand_ros.rosinstall
@@ -1,0 +1,3 @@
+- git:
+      local-name: allegro_hand_ros
+      uri: https://github.com/alexalspach/allegro_hand_ros.git


### PR DESCRIPTION
I would like allegro_hand_ros to be indexed and documented on ros.org. I have already made the stack wiki page.
