### PR TITLE
Remove duplicate entry: doc/fuerte/symbolic_planning.rosinstall

### DIFF
--- a/doc/fuerte/symbolic_planning.rosinstall
+++ b/doc/fuerte/symbolic_planning.rosinstall
@@ -1,3 +1,0 @@
-- svn:
-    local-name: symbolic_planning
-    uri: https://alufr-ros-pkg.googlecode.com/svn/trunk/symbolic_planning


### PR DESCRIPTION
removed symbolic_planning as duplicate entry already exists in alufr-ros-pkg.rosinstall
