### PR TITLE
Addition of a rule for stack geographic_info

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -354,6 +354,10 @@ gccxml:
   ubuntu: gccxml
   fedora: gccxml
   debian: gccxml
+geographic_info: 
+  ubuntu: 
+    apt:
+      ros-fuerte-geographic-info
 gforth:
   debian: gforth
   ubuntu: gforth


### PR DESCRIPTION
I'm trying to resolve this question: http://answers.ros.org/question/52547/cannot-locate-rosdep-definition-for-geographicinfo/ . I don't know if the changes that I made will work, because of a bug in rosdep: http://answers.ros.org/question/50660/custom-rosdep-rules/ . I have never used rosdep either. Basically, I'm trying to get rosdep to download the stack geographicinfo when a ROS package depends on it.

P.S. I've never used git before and I don't understand clearly the concepts (forks, push, pull, etc.), so hopefully what I'm doing makes sense.
