### PR TITLE
RobotWebTools broken

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -5,7 +5,7 @@ repositories:
     url: git://github.com/ros-gbp/actionlib-release.git
     version: 1.9.11-0
   actionlibjs:
-    url: git://github.com/RobotWebTools-release/actionlibjs.git
+    url: git://github.com/RobotWebTools-release/actionlibjs-release.git
     version: 0.2.0-0
   ar_track_alvar:
     url: https://github.com/ros-gbp/ar_track_alvar-release.git
@@ -250,7 +250,7 @@ repositories:
       spacenav_node:
       wiimote:
   keyboardteleopjs:
-    url: git://github.com/RobotWebTools-release/keyboardteleopjs.git
+    url: git://github.com/RobotWebTools-release/keyboardteleopjs-release.git
     version: 0.2.0-0
   korg_nanokontrol:
     url: git://github.com/ros-gbp/korg_nanokontrol-release.git
@@ -277,7 +277,7 @@ repositories:
     url: git://github.com/ros-gbp/manipulation_msgs-release.git
     version: 0.1.4-0
   map2djs:
-    url: git://github.com/RobotWebTools-release/map2djs.git
+    url: git://github.com/RobotWebTools-release/map2djs-release.git
     version: 0.2.0-0
   message_generation:
     url: git://github.com/ros-gbp/message_generation-release.git
@@ -286,7 +286,7 @@ repositories:
     url: git://github.com/ros-gbp/message_runtime-release.git
     version: 0.4.11-0
   mjpegcanvasjs:
-    url: git://github.com/RobotWebTools-release/mjpegcanvasjs.git
+    url: git://github.com/RobotWebTools-release/mjpegcanvasjs-release.git
     version: 0.2.0-0
   moveit_commander:
     url: git://github.com/ros-gbp/moveit_commander-release.git
@@ -338,7 +338,7 @@ repositories:
     url: git://github.com/ros-gbp/moveit_setup_assistant-release.git
     version: 0.3.2-0
   nav2djs:
-    url: git://github.com/RobotWebTools-release/nav2djs.git
+    url: git://github.com/RobotWebTools-release/nav2djs-release.git
     version: 0.2.0-0
   nodelet_core:
     url: git://github.com/ros-gbp/nodelet_core-release.git
@@ -538,7 +538,7 @@ repositories:
     url: git://github.com/ros-gbp/rosdoc_lite-release.git
     version: 0.2.1-0
   rosjs:
-    url: git://github.com/RobotWebTools-release/rosjs.git
+    url: git://github.com/RobotWebTools-release/rosjs-release.git
     version: 0.2.0-0
   roslisp:
     url: git://github.com/ros-gbp/roslisp-release.git


### PR DESCRIPTION
It appears that all of the RobotWebTools repos don't actually exist.  I think that the author intended to do git://github.com/RobotWebTools-release/*-release.git
