### PR TITLE
Remove unused electric wiki doc indexer

### DIFF
--- a/doc/electric/zeroconf_implementations.rosinstall
+++ b/doc/electric/zeroconf_implementations.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: zeroconf_implementations
-    uri: https://github.com/stonier/zeroconf_implementations.git
-    version: master

--- a/doc/groovy/rocon_concert.rosinstall
+++ b/doc/groovy/rocon_concert.rosinstall
@@ -1,0 +1,5 @@
+- git:
+    uri: https://github.com/robotics-in-concert/rocon_concert.git
+    local-name: rocon_concert
+    version: groovy-devel
+

--- a/doc/groovy/rocon_orchestration.rosinstall
+++ b/doc/groovy/rocon_orchestration.rosinstall
@@ -1,5 +1,0 @@
-- git:
-    uri: https://github.com/robotics-in-concert/rocon_orchestration.git
-    local-name: rocon_orchestration
-    version: groovy-devel
-

--- a/releases/groovy-devel.yaml
+++ b/releases/groovy-devel.yaml
@@ -260,9 +260,9 @@ repositories:
     type: git
     url: https://github.com/robotics-in-concert/rocon_multimaster.git
     version: groovy-devel
-  rocon_orchestration:
+  rocon_concert:
     type: git
-    url: https://github.com/robotics-in-concert/rocon_orchestration.git
+    url: https://github.com/robotics-in-concert/rocon_concert.git
     version: groovy-devel
   rocon_rqt_plugins:
     type: git

--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -471,6 +471,55 @@ repositories:
   robot_state_publisher:
     url: git://github.com/ros-gbp/robot_state_publisher-release.git
     version: 1.9.9-0
+  rocon_msgs:
+    url: git://github.com/yujinrobot-release/rocon_msgs-release.git
+    version: 0.2.1-0
+    packages:
+      concert_msgs:
+      gateway_msgs:
+      rocon_app_manager_msgs:
+      rocon_demo_msgs:
+      rocon_msgs:
+  rocon_multimaster:
+    url: git://github.com/yujinrobot-release/rocon_multimaster-release.git
+    version: 0.2.2-0
+    packages:
+      rocon_unreliable_experiments:
+      redis:
+      rocon_gateway:
+      rocon_gateway_tests:
+      rocon_hub:
+      rocon_hub_client:
+      rocon_multimaster:
+      rocon_utilities:
+  rocon_app_platform:
+    url: git://github.com/yujinrobot-release/rocon_app_platform-release.git
+    version: 0.1.1-0
+    packages:
+      concert_client:
+      rocon_app_manager:
+      rocon_app_manager_www:
+      rocon_apps:
+      rocon_app_platform:
+  rocon_concert:
+    url: git://github.com/yujinrobot-release/rocon_concert-release.git
+    version: 0.1.1-0
+    packages:
+      concert_conductor:
+      concert_master:
+      rocon_orchestra:
+      rocon_concert:
+  rocon_tutorials:
+    url: git://github.com/yujinrobot-release/rocon_tutorials-release.git
+    version: 0.2.1-0
+    packages:
+      rocon_gateway_tutorials:
+      chatter_concert:
+      turtle_concert:
+      turtle_race_concert:
+      turtle_race_controllers:
+      turtle_stroll:
+      rocon_tutorials:
   ros:
     url: git://github.com/ros-gbp/ros-release.git
     version: 1.9.42-0


### PR DESCRIPTION
No longer used by anybody and confuses the wiki documentation with the renamed zeroconf_avahi_suite stack. Some additional commits followed also.
