### PR TITLE
Addition of RCPRG repos to documentation index.

### DIFF
--- a/doc/fuerte/RCPRG.rosinstall
+++ b/doc/fuerte/RCPRG.rosinstall
@@ -1,0 +1,38 @@
+- git:
+    local-name: orocos_controllers
+    uri: https://github.com/RCPRG-ros-pkg/orocos_controllers.git
+    version: electric
+- git: 
+    local-name: orocos_tools
+    uri:  https://github.com/RCPRG-ros-pkg/orocos_tools.git
+- git: 
+    local-name: lwr_hardware
+    uri:  https://github.com/RCPRG-ros-pkg/lwr_hardware.git
+- git: 
+    local-name: lwr_robot
+    uri:  https://github.com/RCPRG-ros-pkg/lwr_robot.git
+    version: electric
+- git: 
+    local-name: lwr_kinematics
+    uri:  https://github.com/RCPRG-ros-pkg/lwr_kinematics.git
+- git: 
+    local-name: lwr_gui
+    uri:  https://github.com/RCPRG-ros-pkg/lwr_gui.git
+- git: 
+    local-name: elektron_robot
+    uri:  https://github.com/RCPRG-ros-pkg/elektron_robot.git
+- git: 
+    local-name: elektron_kinectbot
+    uri:  https://github.com/RCPRG-ros-pkg/elektron_kinectbot.git
+- git: 
+    local-name: RCPRG_laser_drivers
+    uri:  https://github.com/RCPRG-ros-pkg/RCPRG_laser_drivers.git
+- git: 
+    local-name: elektron_gui
+    uri:  https://github.com/RCPRG-ros-pkg/elektron_gui.git
+- git: 
+    local-name: lwr_arm_navigation
+    uri:  https://github.com/RCPRG-ros-pkg/lwr_arm_navigation.git
+- git: 
+    local-name: two_lwr_robot
+    uri:  https://github.com/RCPRG-ros-pkg/two_lwr_robot.git

--- a/doc/groovy/RCPRG.rosinstall
+++ b/doc/groovy/RCPRG.rosinstall
@@ -1,0 +1,38 @@
+- git:
+    local-name: orocos_controllers
+    uri: https://github.com/RCPRG-ros-pkg/orocos_controllers.git
+    version: electric
+- git: 
+    local-name: orocos_tools
+    uri:  https://github.com/RCPRG-ros-pkg/orocos_tools.git
+- git: 
+    local-name: lwr_hardware
+    uri:  https://github.com/RCPRG-ros-pkg/lwr_hardware.git
+- git: 
+    local-name: lwr_robot
+    uri:  https://github.com/RCPRG-ros-pkg/lwr_robot.git
+    version: electric
+- git: 
+    local-name: lwr_kinematics
+    uri:  https://github.com/RCPRG-ros-pkg/lwr_kinematics.git
+- git: 
+    local-name: lwr_gui
+    uri:  https://github.com/RCPRG-ros-pkg/lwr_gui.git
+- git: 
+    local-name: elektron_robot
+    uri:  https://github.com/RCPRG-ros-pkg/elektron_robot.git
+- git: 
+    local-name: elektron_kinectbot
+    uri:  https://github.com/RCPRG-ros-pkg/elektron_kinectbot.git
+- git: 
+    local-name: RCPRG_laser_drivers
+    uri:  https://github.com/RCPRG-ros-pkg/RCPRG_laser_drivers.git
+- git: 
+    local-name: elektron_gui
+    uri:  https://github.com/RCPRG-ros-pkg/elektron_gui.git
+- git: 
+    local-name: lwr_arm_navigation
+    uri:  https://github.com/RCPRG-ros-pkg/lwr_arm_navigation.git
+- git: 
+    local-name: two_lwr_robot
+    uri:  https://github.com/RCPRG-ros-pkg/two_lwr_robot.git


### PR DESCRIPTION
I'd like RCPRG repos to be indexed on ros.org.
