### PR TITLE
Adding structure_coloring_fkie to documentation index for fuerte

### DIFF
--- a/doc/fuerte/structure_coloring_fkie.rosinstall
+++ b/doc/fuerte/structure_coloring_fkie.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: structure_coloring_fkie
+    uri: https://github.com/fkie/structure_coloring_fkie.git
+    version: master


### PR DESCRIPTION
I'd like structure_coloring_fkie to be indexed and documented on ros.org.
