### PR TITLE
MTConnect git repo updated

### DIFF
--- a/doc/fuerte/mtconnect.rosinstall
+++ b/doc/fuerte/mtconnect.rosinstall
@@ -1,3 +1,3 @@
 - git:
     local-name: mtconnect
-    uri: https://github.com/mtconnect/ros_bridge/mtconnect
+    uri: https://github.com/mtconnect/ros_bridge.git


### PR DESCRIPTION
Fixed uri for git repo.  Apparently the git syntax doesn't allow you to specify the path to a stack in the uri (like svn).  uri is now fixed and local name set correctly.
