### PR TITLE
Add arches.yaml

### DIFF
--- a/releases/arches.yaml
+++ b/releases/arches.yaml
@@ -1,0 +1,22 @@
+electric:
+  lucid: &pc ['amd64', 'i386']
+  maverick: *pc
+  natty: *pc
+  oneiric: *pc
+
+fuerte:
+  lucid: *pc
+  oneiric: *pc
+  precise: *pc
+
+groovy:
+  oneiric: *pc
+  precise: ['amd64', 'i386', 'armel']
+  quantal: *pc
+  wheezy: ['armhf']
+
+backports:
+  lucid: *pc
+  oneiric: *pc
+  precise: *pc
+  quantal: *pc


### PR DESCRIPTION
This file may (or may not) one day replace targets.yaml, as it contains the same information, but with available architectures.
It is kept as a separate file for now as to not conflict with existing scripts.

see https://github.com/po1/catkin-debs/commit/d8a0a4a1817f695069a168507b47d313ee7b8313
