### PR TITLE
Make texlive deps specific to Fedora 18

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1379,24 +1379,29 @@ tcsh:
 texlive-fonts-extra:
   debian: texlive-fonts-extra
   ubuntu: texlive-fonts-extra
-  fedora: texlive-bbm texlive-bbm-macros
+  fedora:
+    sperical: texlive-bbm texlive-bbm-macros
 texlive-fonts-recommended:
   debian: texlive-fonts-recommended
   ubuntu: texlive-fonts-recommended
-  fedora: texlive-times texlive-helvetic
+  fedora:
+    spherical: texlive-times texlive-helvetic
 texlive-latex-base:
   arch: texlive-base
   debian: texlive-latex-base
   ubuntu: texlive-latex-base
-  fedora: texlive-latex texlive-parskip
+  fedora:
+    spherical: texlive-latex texlive-parskip
 texlive-latex-extra:
   debian: texlive-latex-extra
   ubuntu: texlive-latex-extra
-  fedora: texlive-titlesec texlive-wrapfig texlive-multirow texlive-fancybox
+  fedora:
+    spherical: texlive-titlesec texlive-wrapfig texlive-multirow texlive-fancybox
 texlive-latex-recommended:
   debian: texlive-latex-recommended
   ubuntu: texlive-latex-recommended
-  fedora: texlive-framed texlive-threeparttable texlive-ec texlive-mdwtools
+  fedora:
+    spherical: texlive-framed texlive-threeparttable texlive-ec texlive-mdwtools
 tix:
   debian: tix
   ubuntu: tix


### PR DESCRIPTION
Those texlive packages don't exist in Fedora < 18, so we should not attempt to install them. A missing key error is more appropriate than a package not found error in this case. Fedora 17 actually doesn't HAVE some of the necessary fonts available, even under different package names.
