### PR TITLE
Typo in texlive-fonts-extra for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1380,7 +1380,7 @@ texlive-fonts-extra:
   debian: texlive-fonts-extra
   ubuntu: texlive-fonts-extra
   fedora:
-    sperical: texlive-bbm texlive-bbm-macros
+    spherical: texlive-bbm texlive-bbm-macros
 texlive-fonts-recommended:
   debian: texlive-fonts-recommended
   ubuntu: texlive-fonts-recommended


### PR DESCRIPTION
Can't believe I missed that...

sperical =/= spherical
