### PR TITLE
Adding thermalvis-ros-pkg repository to documentation index for fuerte

### DIFF
--- a/doc/fuerte/thermalvis.rosinstall
+++ b/doc/fuerte/thermalvis.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    uri: https://thermalvis-ros-pkg.googlecode.com/svn/trunk/
+    local-name: thermalvis-ros-pkg


### PR DESCRIPTION
Hi

You can find more details of this project at:

http://code.google.com/p/thermalvis-ros-pkg/

After I confirm that the Fuerte version is working, I will get it added to Electric.

Steve
