### PR TITLE
Define a few python rules for the "debian testing" distro

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -210,6 +210,7 @@ python-qt-bindings-gl:
   debian: python-qt4-gl
 python-qt-bindings-qwt5:
   ubuntu: python-qwt5-qt4
+  debian: python-qwt5-qt4
   fedora: PyQwt-devel
 python-qt4-gl:
   ubuntu: 

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -220,6 +220,7 @@ python-qt4-gl:
       packages: [python-qt4-gl]
 python-qwt5-qt4:
   ubuntu: python-qwt5-qt4
+  debian: python-qwt5-qt4
 python-rdflib:
   ubuntu: python-rdflib
 python-redis:
@@ -285,6 +286,7 @@ python-sphinx:
   ubuntu: python-sphinx
 python-support:
   ubuntu: python-support
+  debian: python-support
   fedora: python
 python-svn: 
   ubuntu: python-svn


### PR DESCRIPTION
After adding these defines, when installing Desktop-Full I can almost pass all tests for except collada-dom. This doesn't appear in the debian repo, nor I can build it from source (same error as http://sourceforge.net/tracker/index.php?func=detail&aid=3589620&group_id=157838&atid=805424).
