### PR TITLE
Adding manus_arm to documentation index for fuerte

### DIFF
--- a/doc/fuerte/manus_arm.rosinstall
+++ b/doc/fuerte/manus_arm.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: manus_arm
+    uri: https://github.com/uml-robotics/manus_arm.git
+    version: master


### PR DESCRIPTION
Please index manus_arm for documentation on ros.org. Thank you
