### PR TITLE
Quick fix for kobuki

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -266,7 +266,6 @@ repositories:
       kobuki_auto_docking:
       kobuki_bumper2pc:
       kobuki_controller_tutorial:
-      kobuki_description:
       kobuki_driver:
       kobuki_ftdi:
       kobuki_keyop:


### PR DESCRIPTION
Remove the non-catkinizable kobuki_description from this list (it's pushed to a unary stack in dry land). Sorry for the extra pull request - have to kick the lads to pre-release, even when they think its only a minor change! 
