### PR TITLE
updated repo paths for released hector stacks in tu-darmstadt-ros-pkg

### DIFF
--- a/doc/fuerte/hector_common.rosinstall
+++ b/doc/fuerte/hector_common.rosinstall
@@ -1,3 +1,3 @@
 - svn:
     local-name: hector_common
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/branches/fuerte/hector_common
+    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_common

--- a/doc/fuerte/hector_gazebo.rosinstall
+++ b/doc/fuerte/hector_gazebo.rosinstall
@@ -1,3 +1,3 @@
 - svn:
     local-name: hector_gazebo
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/branches/fuerte/hector_gazebo
+    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_gazebo

--- a/doc/fuerte/hector_models.rosinstall
+++ b/doc/fuerte/hector_models.rosinstall
@@ -1,3 +1,3 @@
 - svn:
     local-name: hector_models
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/branches/fuerte/hector_models
+    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_models

--- a/doc/fuerte/hector_quadrotor.rosinstall
+++ b/doc/fuerte/hector_quadrotor.rosinstall
@@ -1,3 +1,3 @@
 - svn:
     local-name: hector_quadrotor
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/branches/fuerte/hector_quadrotor
+    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_quadrotor

--- a/doc/fuerte/hector_quadrotor_apps.rosinstall
+++ b/doc/fuerte/hector_quadrotor_apps.rosinstall
@@ -1,3 +1,3 @@
 - svn:
     local-name: hector_quadrotor_apps
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/branches/fuerte/hector_quadrotor_apps
+    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_quadrotor_apps

--- a/doc/fuerte/hector_slam.rosinstall
+++ b/doc/fuerte/hector_slam.rosinstall
@@ -1,3 +1,3 @@
 - svn:
     local-name: hector_slam
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/branches/fuerte/hector_slam
+    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_slam


### PR DESCRIPTION
Those released stacks are also contained in tu-darmstadt-ros-pkg.rosinstall. Do we need to have them twice in doc/fuerte? I was not aware of the additional files until I found them a couple of minutes ago.

The doc jobs for these jobs on Jenkins fail since 10 days ago as we deleted the old branch from the SVN.
