### PR TITLE
Adding thermalvis-ros-pkg to documentation index for electric

### DIFF
--- a/doc/electric/thermalvis.rosinstall
+++ b/doc/electric/thermalvis.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    uri: https://thermalvis-ros-pkg.googlecode.com/svn/trunk/
+    local-name: thermalvis-ros-pkg


### PR DESCRIPTION
I have already got my thermalvis repo documented for Fuerte and have verified that it still works in Electric, so would like to have it documented for this distro as well.
