### PR TITLE
Catkin bugfixes for kobuki

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -259,10 +259,9 @@ repositories:
       kobuki_msgs:
   kobuki:
     url: git://github.com/yujinrobot-release/kobuki-release.git
-    version: 0.3.1-0
+    version: 0.3.3-0
     packages:
       kobuki:
-      kobuki_arm:
       kobuki_auto_docking:
       kobuki_bumper2pc:
       kobuki_controller_tutorial:
@@ -726,7 +725,7 @@ repositories:
     version: 0.7.12-0
   yujin_ocs:
     url: git://github.com/yujinrobot-release/yujin_ocs-release.git
-    version: 0.2.1-0
+    version: 0.2.2-0
     packages:
       yujin_ocs:
       cmd_vel_mux:


### PR DESCRIPTION
I don't think prereleases are catching all the dependency bugs. 
Prereleases compile and build all your stack's packages together,
whereas the individual build farm builds packages in an isolated 
fashion (I think). This means that the former can have an 
unrelated package in your stack install the dependency for another 
package, so it hides a missing dependancy error until you get 
to the build farm and your package has to do it on its own.
