### PR TITLE
New format for yaml files

### DIFF
--- a/releases/backports.yaml
+++ b/releases/backports.yaml
@@ -1,4 +1,10 @@
 release-name: backports
+targets:
+  lucid: &pc ['amd64', 'i386']
+  oneiric: *pc
+  precise: *pc
+  quantal: *pc
+
 repositories:
   rosemacs-el:
     url: https://github.com/moesenle/rosemacs-debs.git

--- a/releases/backports.yaml
+++ b/releases/backports.yaml
@@ -1,3 +1,4 @@
+version: 1.0
 release-name: backports
 targets:
   lucid: &pc ['amd64', 'i386']

--- a/releases/fuerte-devel.yaml
+++ b/releases/fuerte-devel.yaml
@@ -1,3 +1,4 @@
+version: 1.0
 release-name: fuerte
 targets:
   lucid: &pc ['amd64', 'i386']

--- a/releases/fuerte-devel.yaml
+++ b/releases/fuerte-devel.yaml
@@ -1,4 +1,9 @@
 release-name: fuerte
+targets:
+  lucid: &pc ['amd64', 'i386']
+  oneiric: *pc
+  precise: *pc
+
 repositories:
   actionlib:
     type: hg

--- a/releases/fuerte.yaml
+++ b/releases/fuerte.yaml
@@ -1,5 +1,10 @@
 gbp-repos: {You must update to a newer rosdep version by calling..sudo apt-get update && sudo apt-get install python-rosdep (make sure to uninstall the pip version on Ubuntu):}
 release-name: fuerte
+targets:
+  lucid: &pc ['amd64', 'i386']
+  oneiric: *pc
+  precise: *pc
+
 repositories:
   actionlib:
     url: git://github.com/ros-gbp/actionlib-release.git

--- a/releases/fuerte.yaml
+++ b/releases/fuerte.yaml
@@ -1,4 +1,4 @@
-gbp-repos: {You must update to a newer rosdep version by calling..sudo apt-get update && sudo apt-get install python-rosdep (make sure to uninstall the pip version on Ubuntu):}
+version: 1.0
 release-name: fuerte
 targets:
   lucid: &pc ['amd64', 'i386']

--- a/releases/groovy-devel.yaml
+++ b/releases/groovy-devel.yaml
@@ -1,4 +1,10 @@
 release-name: groovy
+targets:
+  oneiric: &pc ['amd64', 'i386']
+  precise: ['amd64', 'i386', 'armel', 'armhf']
+  quantal: *pc
+  wheezy: ['armhf']
+
 repositories:
   actionlib:
     type: hg

--- a/releases/groovy-devel.yaml
+++ b/releases/groovy-devel.yaml
@@ -1,3 +1,4 @@
+version: 1.0
 release-name: groovy
 targets:
   oneiric: &pc ['amd64', 'i386']

--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -1,4 +1,4 @@
-gbp-repos: {You must update to a newer rosdep version by calling..sudo apt-get update && sudo apt-get install python-rosdep (make sure to uninstall the pip version on Ubuntu):}
+version: 1.0
 release-name: groovy
 targets:
   oneiric: &pc ['amd64', 'i386']

--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -1,5 +1,11 @@
 gbp-repos: {You must update to a newer rosdep version by calling..sudo apt-get update && sudo apt-get install python-rosdep (make sure to uninstall the pip version on Ubuntu):}
 release-name: groovy
+targets:
+  oneiric: &pc ['amd64', 'i386']
+  precise: ['amd64', 'i386', 'armel', 'armhf']
+  quantal: *pc
+  wheezy: ['armhf']
+
 repositories:
   actionlib:
     url: git://github.com/ros-gbp/actionlib-release.git

--- a/releases/targets.yaml
+++ b/releases/targets.yaml
@@ -1,5 +1,0 @@
-# This file is a computer readable form of REP 3 http://www.ros.org/reps/rep-0003.html
-- electric: ['lucid', 'maverick', 'natty', 'oneiric']
-- fuerte: ['lucid', 'oneiric', 'precise']
-- groovy: ['oneiric', 'precise', 'quantal']
-- backports: ['lucid', 'oneiric', 'precise', 'quantal']

--- a/rosdistros.yaml
+++ b/rosdistros.yaml
@@ -1,3 +1,5 @@
+version: 1.0
+
 fuerte:
   release: releases/fuerte.yaml
   devel: releases/fuerte-devel.yaml

--- a/rosdistros.yaml
+++ b/rosdistros.yaml
@@ -6,5 +6,6 @@ groovy:
   release: releases/groovy.yaml
   devel: releases/groovy-devel.yaml
   doc: doc/groovy
+  deps_cache: http://www.ros.org/rosdistro/groovy-dependencies.tar.gz
 backports:
   release: releases/backports.yaml

--- a/rosdistros.yaml
+++ b/rosdistros.yaml
@@ -1,13 +1,13 @@
-version: 1.0
-
-fuerte:
-  release: releases/fuerte.yaml
-  devel: releases/fuerte-devel.yaml
-  doc: doc/fuerte
-groovy:
-  release: releases/groovy.yaml
-  devel: releases/groovy-devel.yaml
-  doc: doc/groovy
-  deps_cache: http://www.ros.org/rosdistro/groovy-dependencies.tar.gz
-backports:
-  release: releases/backports.yaml
+version: 2.0
+distros:
+  fuerte:
+    release: releases/fuerte.yaml
+    devel: releases/fuerte-devel.yaml
+    doc: doc/fuerte
+  groovy:
+    release: releases/groovy.yaml
+    devel: releases/groovy-devel.yaml
+    doc: doc/groovy
+    deps_cache: http://www.ros.org/rosdistro/groovy-dependencies.tar.gz
+  backports:
+    release: releases/backports.yaml

--- a/rosdistros.yaml
+++ b/rosdistros.yaml
@@ -1,0 +1,10 @@
+fuerte:
+  release: releases/fuerte.yaml
+  devel: releases/fuerte-devel.yaml
+  doc: doc/fuerte
+groovy:
+  release: releases/groovy.yaml
+  devel: releases/groovy-devel.yaml
+  doc: doc/groovy
+backports:
+  release: releases/backports.yaml


### PR DESCRIPTION
See https://github.com/po1/rep/blob/master/rep-0133.rst

/!\
Rosdep, catkin-debs and reprepro_updater will need to be updated as well. This pull request breaks them (deleted targets.yaml), and should only be merged once other tools are fixed.
