### PR TITLE
Added stacks maintained by Clearpath to the wiki index.

### DIFF
--- a/doc/fuerte/applanix_driver.rosinstall
+++ b/doc/fuerte/applanix_driver.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: applanix_driver
+    uri: https://github.com/clearpathrobotics/applanix_driver.git
+    version: master

--- a/doc/fuerte/husky_apps.rosinstall
+++ b/doc/fuerte/husky_apps.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: husky_apps
+    uri: https://github.com/clearpathrobotics/husky_apps.git
+    version: master

--- a/doc/fuerte/husky_simulator.rosinstall
+++ b/doc/fuerte/husky_simulator.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: husky_simulator
+    uri: https://github.com/clearpathrobotics/husky_simulator.git
+    version: master

--- a/doc/fuerte/mocap_optitrack.rosinstall
+++ b/doc/fuerte/mocap_optitrack.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: mocap_optitrack
+    uri: https://github.com/clearpathrobotics/mocap_optitrack.git
+    version: master


### PR DESCRIPTION
The husky_apps, husky_simulator, applanix_driver, and
mocap_optitrack stacks were added to the Fuerte index.
