### PR TITLE
Ecl branches switched to groovy-devel

### DIFF
--- a/releases/groovy-devel.yaml
+++ b/releases/groovy-devel.yaml
@@ -39,23 +39,23 @@ repositories:
   ecl_core:
     type: git
     url: https://github.com/stonier/ecl_core.git
-    version: master
+    version: groovy-devel
   ecl_lite:
     type: git
-    url: https://github.com/stonier/ecl_tools.git
-    version: master
+    url: https://github.com/stonier/ecl_lite.git
+    version: groovy-devel
   ecl_manipulation:
     type: git
     url: https://github.com/stonier/ecl_manipulation.git
-    version: master
+    version: groovy-devel
   ecl_navigation:
     type: git
     url: https://github.com/stonier/ecl_navigation.git
-    version: master
+    version: groovy-devel
   ecl_tools:
     type: git
     url: https://github.com/stonier/ecl_tools.git
-    version: master
+    version: groovy-devel
   ecto:
     type: git
     url: https://github.com/plasmodic/ecto.git


### PR DESCRIPTION
Also bugfix a name, no idea how that managed to release previously.
