### PR TITLE
removed rosmatlab stack from doc/fuerte/tu-darmstadt-ros-pkg.rosinstall

### DIFF
--- a/doc/fuerte/tu-darmstadt-ros-pkg.rosinstall
+++ b/doc/fuerte/tu-darmstadt-ros-pkg.rosinstall
@@ -50,9 +50,6 @@
     local-name: cpp_introspection
     uri: https://github.com/tu-darmstadt-ros-pkg/cpp_introspection
 - git:
-    local-name: rosmatlab
-    uri: https://github.com/tu-darmstadt-ros-pkg/rosmatlab
-- git:
     local-name: mapstitch
     uri: https://github.com/tu-darmstadt-ros-pkg/mapstitch
 - git:


### PR DESCRIPTION
...as it is not maintained anymore in fuerte

The missing `version: fuerte` tag could have caused the failure of the doc-fuerte-tu-darmstadt-ros-pkg job, see [#10](https://github.com/ros-infrastructure/jenkins_scripts/issues/10).
