### PR TITLE
Adding various Pi Robot repos to documentation index for groovy

### DIFF
--- a/doc/electric/pi_robot_description.rosinstall
+++ b/doc/electric/pi_robot_description.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: pi_robot_description
+    uri: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/pi_robot_description

--- a/doc/fuerte/pi_robot_description.rosinstall
+++ b/doc/fuerte/pi_robot_description.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: pi_robot_description
+    uri: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/pi_robot_description

--- a/doc/groovy/element.rosinstall
+++ b/doc/groovy/element.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: element
+    uri: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/element

--- a/doc/groovy/pi_robot_description.rosinstall
+++ b/doc/groovy/pi_robot_description.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: pi_robot_description
+    uri: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/pi_robot_description

--- a/doc/groovy/pi_tracker.rosinstall
+++ b/doc/groovy/pi_tracker.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: pi_tracker
+    uri: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/pi_tracker

--- a/doc/groovy/pi_tutorials.rosinstall
+++ b/doc/groovy/pi_tutorials.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: pi_tutorials
+    uri: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/pi_tutorials

--- a/doc/groovy/pi_vision.rosinstall
+++ b/doc/groovy/pi_vision.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: pi_vision
+    uri: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/pi_vision

--- a/doc/groovy/serializer.rosinstall
+++ b/doc/groovy/serializer.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: serializer
+    uri: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/serializer

--- a/doc/groovy/skeleton_markers.rosinstall
+++ b/doc/groovy/skeleton_markers.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: skeleton_markers
+    uri: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/skeleton_markers


### PR DESCRIPTION
I'd like the following repos to be indexed for groovy: pi_robot_description pi_tracker pi_tutorials pi_vision serializer element skeleton_markers

as well as pi_robot_description to be indexed for electric and fuerte.
