### PR TITLE
Switch yujin release repos from git:// to https://

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -92,14 +92,14 @@ repositories:
     url: git://github.com/ros-gbp/dynamic_reconfigure-release.git
     version: 1.5.31-0
   ecl_tools:
-    url: git://github.com/yujinrobot-release/ecl_tools-release.git
+    url: https://github.com/yujinrobot-release/ecl_tools-release.git
     version: 0.50.2-0
     packages:
       ecl_license:
       ecl_tools:
       ecl_build:
   ecl_lite:
-    url: git://github.com/yujinrobot-release/ecl_lite-release.git
+    url: https://github.com/yujinrobot-release/ecl_lite-release.git
     version: 0.50.5-0
     packages:
       ecl_config:
@@ -110,7 +110,7 @@ repositories:
       ecl_sigslots_lite:
       ecl_time_lite:
   ecl_core:
-    url: git://github.com/yujinrobot-release/ecl_core-release.git
+    url: https://github.com/yujinrobot-release/ecl_core-release.git
     version: 0.50.5-0
     packages:
       ecl_command_line:
@@ -136,7 +136,7 @@ repositories:
       ecl_type_traits:
       ecl_utilities:
   ecl_navigation:
-    url: git://github.com/yujinrobot-release/ecl_navigation-release.git
+    url: https://github.com/yujinrobot-release/ecl_navigation-release.git
     version: 0.50.3-0
     packages:
       ecl_maps:
@@ -145,7 +145,7 @@ repositories:
       ecl_navigation_apps:
       ecl_slam:
   ecl_manipulation:
-    url: git://github.com/yujinrobot-release/ecl_manipulation-release.git
+    url: https://github.com/yujinrobot-release/ecl_manipulation-release.git
     version: 0.50.2-0
     packages:
       ecl_manipulation:
@@ -271,12 +271,12 @@ repositories:
     url: git://github.com/RobotWebTools-release/keyboardteleopjs-release.git
     version: 0.2.0-0
   kobuki_msgs:
-    url: git://github.com/yujinrobot-release/kobuki_msgs-release.git
+    url: https://github.com/yujinrobot-release/kobuki_msgs-release.git
     version: 0.3.1-0
     packages:
       kobuki_msgs:
   kobuki:
-    url: git://github.com/yujinrobot-release/kobuki-release.git
+    url: https://github.com/yujinrobot-release/kobuki-release.git
     version: 0.3.5-0
     packages:
       kobuki:
@@ -517,7 +517,7 @@ repositories:
     url: git://github.com/ros-gbp/robot_state_publisher-release.git
     version: 1.9.9-0
   rocon_msgs:
-    url: git://github.com/yujinrobot-release/rocon_msgs-release.git
+    url: https://github.com/yujinrobot-release/rocon_msgs-release.git
     version: 0.3.0-0
     packages:
       concert_msgs:
@@ -526,7 +526,7 @@ repositories:
       rocon_demo_msgs:
       rocon_msgs:
   rocon_multimaster:
-    url: git://github.com/yujinrobot-release/rocon_multimaster-release.git
+    url: https://github.com/yujinrobot-release/rocon_multimaster-release.git
     version: 0.3.0-0
     packages:
       rocon_unreliable_experiments:
@@ -538,7 +538,7 @@ repositories:
       rocon_multimaster:
       rocon_utilities:
   rocon_app_platform:
-    url: git://github.com/yujinrobot-release/rocon_app_platform-release.git
+    url: https://github.com/yujinrobot-release/rocon_app_platform-release.git
     version: 0.3.0-0
     packages:
       rocon_app_manager:
@@ -546,7 +546,7 @@ repositories:
       rocon_apps:
       rocon_app_platform:
   rocon_concert:
-    url: git://github.com/yujinrobot-release/rocon_concert-release.git
+    url: https://github.com/yujinrobot-release/rocon_concert-release.git
     version: 0.3.0-0
     packages:
       concert_conductor:
@@ -554,13 +554,13 @@ repositories:
       rocon_orchestra:
       rocon_concert:
   rocon_rqt_plugins:
-    url: git://github.com/yujinrobot-release/rocon_rqt_plugins-release.git
+    url: https://github.com/yujinrobot-release/rocon_rqt_plugins-release.git
     version: 0.3.0-0
     packages:
       rocon_gateway_graph:
       rocon_rqt_plugins:
   rocon_tutorials:
-    url: git://github.com/yujinrobot-release/rocon_tutorials-release.git
+    url: https://github.com/yujinrobot-release/rocon_tutorials-release.git
     version: null
     packages:
       rocon_gateway_tutorials:
@@ -755,7 +755,7 @@ repositories:
     url: git://github.com/ros-gbp/xacro-release.git
     version: 1.7.1-0
   yujin_ocs:
-    url: git://github.com/yujinrobot-release/yujin_ocs-release.git
+    url: https://github.com/yujinrobot-release/yujin_ocs-release.git
     version: 0.2.2-0
     packages:
       yujin_ocs:
@@ -763,13 +763,13 @@ repositories:
       yocs_velocity_smoother:
       yocs_controllers:
   zeroconf_avahi_suite:
-    url: git://github.com/yujinrobot-release/zeroconf_avahi_suite-release.git
+    url: https://github.com/yujinrobot-release/zeroconf_avahi_suite-release.git
     version: 0.2.2-0
     packages:
       zeroconf_avahi_suite:
       zeroconf_avahi:
       zeroconf_avahi_demos:
   zeroconf_msgs:
-    url: git://github.com/yujinrobot-release/zeroconf_msgs-release.git
+    url: https://github.com/yujinrobot-release/zeroconf_msgs-release.git
     version: 0.2.1-0
 type: gbp


### PR DESCRIPTION
We typically tend to use https with .netrc instead of git + ssh keys. Need to take care of that here now since the new bloom is using it.

I noticed no-one else is using https yet - is there a reason not to do so or is this acceptable?
