### PR TITLE
Updates rospy_message_converter to v0.1.1

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -613,7 +613,7 @@ repositories:
       xmlrpcpp: utilities/xmlrpcpp
   rospy_message_converter:
     url: https://github.com/baalexander/rospy_message_converter-release.git
-    version: 0.1.0-0
+    version: 0.1.1-0
   ros_tutorials:
     url: git://github.com/ros-gbp/ros_tutorials-release.git
     version: 0.3.9-0


### PR DESCRIPTION
Should fix a broken a build from 0.1.0.
