### PR TITLE
Adding point_cloud_filtering to documentation index for distro

### DIFF
--- a/doc/fuerte/point_cloud_filtering.rosinstall
+++ b/doc/fuerte/point_cloud_filtering.rosinstall
@@ -1,0 +1,3 @@
+- git:
+    local-name: point_cloud_filtering 
+    uri: git://github.com/srv/point_cloud_filtering.git

--- a/doc/fuerte/point_cloud_filtering.rosinstall
+++ b/doc/fuerte/point_cloud_filtering.rosinstall
@@ -1,3 +1,3 @@
 - git:
     local-name: point_cloud_filtering 
-    uri: git://github.com/srv/point_cloud_filtering.git
+    uri: https://github.com/srv/point_cloud_filtering.git


### PR DESCRIPTION
I'd like point_cloud_filtering to be indexed and documented on ros.org
