### PR TITLE
Adding amor-ros-pkg to rosdistro documentation index for fuerte.

### DIFF
--- a/doc/fuerte/amor-ros-pkg.rosinstall
+++ b/doc/fuerte/amor-ros-pkg.rosinstall
@@ -1,0 +1,4 @@
+- hg:
+    local-name: amor-ros-pkg
+    uri: http://code.google.com/p/amor-ros-pkg/
+    version: fuerte


### PR DESCRIPTION
I'd like amor-ros-pkg to be indexed on ros.org.
