### PR TITLE
Adding robot_face to documentation index for electric, groovy and fuerte

### DIFF
--- a/doc/electric/robot_face.rosinstall
+++ b/doc/electric/robot_face.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: robot_face
+    uri: http://agas-ros-pkg.googlecode.com/svn/trunk/robot_face

--- a/doc/fuerte/robot_face.rosinstall
+++ b/doc/fuerte/robot_face.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: robot_face
+    uri: http://agas-ros-pkg.googlecode.com/svn/trunk/robot_face

--- a/doc/groovy/robot_face.rosinstall
+++ b/doc/groovy/robot_face.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: robot_face
+    uri: http://agas-ros-pkg.googlecode.com/svn/trunk/robot_face


### PR DESCRIPTION
I'd like robot_face to be indexed and documented on ros.org.
