### PR TITLE
Contributing libaria rosdep rule

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -562,6 +562,12 @@ libargtable2-dev:
   debian: [libargtable2-dev]
   fedora: [argtable2-devel]
   ubuntu: [libargtable2-dev]
+libaria:
+  ubuntu:
+    source:
+      alternate-uri: 'http://aus-www.rasip.fer.hr/libaria.rdmanifest'
+      md5sum: f00cf4b5496b085a6b8ef9ce0389ec0b
+      uri: 'http://amor-ros-pkg.googlecode.com/files/libaria.rdmanifest'
 libavahi-client-dev:
   debian: [libavahi-client-dev]
   ubuntu: [libavahi-client-dev]


### PR DESCRIPTION
Before requesting documentation generation/indexing of ROSARIA for Groovy,
need to add libaria rosdep rule, since wrapping external libraries is not
supported by catkin (Aria package).

However, this won't be enough for the catkinized version of ROSARIA to compile on the build farm, due to following issues:
- rosdep_source script was removed from python-rosdep package (https://github.com/ros/rosdep/issues/210)
- it seem that rosdep ignores the dependencies stated in .rdmanifest files. I haven't found an open issue on this. Should I open one? As a temporary solution, I could list those dependencies in package.xml.
