### PR TITLE
 Updated joystick dep for Fedora 

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -531,7 +531,9 @@ java:
 joystick:
   arch: [joyutils]
   debian: [joystick]
-  fedora: [joystick]
+  fedora:
+    beefy: [joystick]
+    spherical: [linuxconsoletools]
   gentoo: [games-util/joystick]
   rhel: [joystick]
   ubuntu: [joystick]


### PR DESCRIPTION
Looks like "joystick" is obsoleted by "linuxconsoletools" in F18+
