### PR TITLE
rviz 1.9.27

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -736,7 +736,7 @@ repositories:
       rqt_rviz:
   rviz:
     url: https://github.com/ros-gbp/rviz-release.git
-    version: 1.9.25-0
+    version: 1.9.27-0
   rx:
     url: https://github.com/ros-gbp/rx-release.git
     version: 1.9.12-0


### PR DESCRIPTION
Fixes the broken build in 1.9.26
