### PR TITLE
Release 1.10.7 of image_pipeline

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -248,7 +248,7 @@ repositories:
       polled_camera:
   image_pipeline:
     url: https://github.com/ros-gbp/image_pipeline-release.git
-    version: 1.10.6-0
+    version: 1.10.7-0
     packages:
       camera_calibration:
       depth_image_proc:


### PR DESCRIPTION
Fixes camera calibration bug. ros-perception/image_pipeline/issues/21
