### PR TITLE
Resolved 'rosgraph' dependency issue by adding python-netifaces pip

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -239,6 +239,10 @@ netpbm:
   osx:
     homebrew:
       packages: [netpbm]
+netifaces:
+  osx:
+    pip:
+      packages: [netifaces]      
 nvidia-cg:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -238,11 +238,7 @@ mercurial:
 netpbm:
   osx:
     homebrew:
-      packages: [netpbm]
-netifaces:
-  osx:
-    pip:
-      packages: [netifaces]      
+      packages: [netpbm]     
 nvidia-cg:
   osx:
     homebrew:
@@ -300,6 +296,10 @@ python-matplotlib:
     pip:
       depends: [pkg-config]
       packages: [matplotlib]
+python-netifaces:
+  osx:
+    pip:
+      packages: [netifaces]       
 python-nose:
   osx:
     pip:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -238,7 +238,7 @@ mercurial:
 netpbm:
   osx:
     homebrew:
-      packages: [netpbm]     
+      packages: [netpbm]
 nvidia-cg:
   osx:
     homebrew:
@@ -299,7 +299,7 @@ python-matplotlib:
 python-netifaces:
   osx:
     pip:
-      packages: [netifaces]       
+      packages: [netifaces]
 python-nose:
   osx:
     pip:


### PR DESCRIPTION
While trying to do a brew install of groovy, I kept encountering the following error:

> ERROR: the following packages/stacks could not have their rosdep keys resolved
> to system dependencies:
> rosgraph: No definition of [python-netifaces] for OS [osx]

I went ahead and added the definition for python-netifaces.  It exists as a pip called 'netifaces'.
