### PR TITLE
Added cyphy_vis_nav to cyphy_ros_pkg for fuerte

### DIFF
--- a/doc/fuerte/cyphy_ros_pkg.rosinstall
+++ b/doc/fuerte/cyphy_ros_pkg.rosinstall
@@ -4,6 +4,12 @@
   meta:
   repo_name: cyphy_ros_pkg
 - hg:
+  local-name: cyphy_vis_nav
+  uri: https://cyphy-vis-nav.googlecode.com/hg/cyphy_vis_nav
+  meta:
+  repo-name: cyphy_ros_pkg
+  version: default
+- hg:
   local-name: cyphy_vis_slam
   uri: https://cyphy-vis-slam.googlecode.com/hg/cyphy_vis_slam
   meta:


### PR DESCRIPTION
I'd like cyphy_vis_nav to be indexed and documented on ros.org
