### PR TITLE
removes python-opencv from rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -171,8 +171,6 @@ python-omniorb:
     precise: [python-omniorb, omniidl-python]
     quantal: [python-omniorb, omniidl-python]
     raring: [python-omniorb, omniidl-python]
-python-opencv:
-  ubuntu: [python-opencv]
 python-opengl:
   debian: [python-opengl]
   fedora: [PyOpenGL]


### PR DESCRIPTION
Python opencv bindings come standard with ROS. 
Partially reverts 94258cedafbbe3a8e8b30c04b7f1d759cc9b5819
