### PR TITLE
update glc 0.5.8-2 -> 0.5.8-3

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -239,7 +239,7 @@ repositories:
     version: 0.3.6-0
   glc:
     url: https://github.com/start-jsk/glc-release.git
-    version: 0.5.8-2
+    version: 0.5.8-3
   household_objects_database:
     url: https://github.com/ros-gbp/household_objects_database-release.git
     version: 0.1.2-0

--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -292,6 +292,9 @@ repositories:
       wiimote: null
     url: https://github.com/ros-gbp/joystick_drivers-release.git
     version: 1.9.9-0
+  jsk_openni_kinect:
+    url: https://github.com/start-jsk/jsk_openni_kinect-release.git
+    version: 0.1.0-0
   jsk_rviz_plugins:
     url: https://github.com/start-jsk/jsk_rviz_plugins-release.git
     version: 0.0.9-0


### PR DESCRIPTION
Sorry to bother you, I tried to pass buildfirm but still find missing libraries so that  add new line to build_depend tag of package.xml file and git-bloom-generate again. As far as I understand, we need to increment debian  version number in order to execute source.deb that triggers binary.deb. If there are another way to add new build dependency to package.xml and run binary.deb, I'd like to know.
