### PR TITLE
serial: 1.1.3-28 in 'hydro.yaml' [bloom]

### DIFF
--- a/releases/hydro.yaml
+++ b/releases/hydro.yaml
@@ -709,7 +709,7 @@ repositories:
     version: null
   serial:
     url: https://github.com/wjwwood/serial-release.git
-    version: 1.1.3-26
+    version: 1.1.3-28
   shape_tools:
     url: https://github.com/ros-gbp/shape_tools-release.git
     version: null


### PR DESCRIPTION
Increasing version of package(s) in repository `serial`:
- previous version: `1.1.3-26`
- new version: `1.1.3-28`
- distro file: `releases/hydro.yaml`
- bloom version: `0.3.3-dev`
