### PR TITLE
Revert "rqt_robot_plugins 0.2.10"

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -758,9 +758,8 @@ repositories:
       rqt_robot_steering: null
       rqt_runtime_monitor: null
       rqt_rviz: null
-      rqt_tf_tree: null
     url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-    version: 0.2.10-0
+    version: 0.2.9-0
   rviz:
     url: https://github.com/ros-gbp/rviz-release.git
     version: 1.9.28-0


### PR DESCRIPTION
This reverts commit ef1568a165ea3efb8b90d1d37d56925edad056ac, which tries to fetch the version that hasn't yet pushed into release repository.

This commit itself on rosdistro was my mistake (I committed before I tried to push into release repo). But after having committed, I'm having a problem to push into release repository (by [this issue](http://goo.gl/Q3jJP)).
