### PR TITLE
Adding dlut-ros-pkg to documentation index for distro

### DIFF
--- a/doc/fuerte/dlut-ros-pkg.rosinstall
+++ b/doc/fuerte/dlut-ros-pkg.rosinstall
@@ -1,5 +1,5 @@
 - git:
-    local-name: ~/stacks_to_index
+    local-name: dlut-ros-pkg
     uri: https://github.com/ZhuangYanDLUT/dlut-ros-pkg.git
     version: fuerte
 

--- a/doc/fuerte/dlut-ros-pkg.rosinstall
+++ b/doc/fuerte/dlut-ros-pkg.rosinstall
@@ -1,2 +1,5 @@
-- git: {local-name: ~/stacks_to_index, uri: https://github.com/ZhuangYanDLUT/dlut-ros-pkg.git, version: fuerte}
+- git:
+    local-name: ~/stacks_to_index
+    uri: https://github.com/ZhuangYanDLUT/dlut-ros-pkg.git
+    version: fuerte
 

--- a/doc/fuerte/dlut-ros-pkg.rosinstall
+++ b/doc/fuerte/dlut-ros-pkg.rosinstall
@@ -1,0 +1,2 @@
+- git: {local-name: ~/stacks_to_index, uri: https://github.com/ZhuangYanDLUT/dlut-ros-pkg.git, version: fuerte}
+


### PR DESCRIPTION
I'd like dlut-ros-pkg to be indexed and documented on ros.org.
