### PR TITLE
rqt_robot_plugins 0.2.13

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -753,6 +753,7 @@ repositories:
     version: 0.2.16-0
   rqt_robot_plugins:
     packages:
+      rqt_moveit: null
       rqt_nav_view: null
       rqt_pose_view: null
       rqt_robot_dashboard: null
@@ -761,8 +762,9 @@ repositories:
       rqt_robot_steering: null
       rqt_runtime_monitor: null
       rqt_rviz: null
+      rqt_tf_tree: null
     url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-    version: 0.2.9-0
+    version: 0.2.13-0
   rviz:
     url: https://github.com/ros-gbp/rviz-release.git
     version: 1.9.28-0


### PR DESCRIPTION
0.2.10 - 0.2.12 are skipped since they are used for solving issues regarding releasing (eg. http://answers.ros.org/question/60141/catkin_prepare_release-pushes-twice-wo-incrementing-tag/)
