### PR TITLE
Release audio_common 0.2.2 into Hydro.

### DIFF
--- a/releases/hydro.yaml
+++ b/releases/hydro.yaml
@@ -24,7 +24,7 @@ repositories:
       audio_play:
       sound_play:
     url: https://github.com/ros-gbp/audio_common-release.git
-    version: 0.2.1-0
+    version: 0.2.2-0
   bond_core:
     packages:
       bond: bond


### PR DESCRIPTION
Fix build dependency problem.
