### PR TITLE
Update audio_common to SSH URI

### DIFF
--- a/releases/hydro.yaml
+++ b/releases/hydro.yaml
@@ -23,7 +23,7 @@ repositories:
       audio_common_msgs:
       audio_play:
       sound_play:
-    url: https://github.com/ros-gbp/audio_common-release.git
+    url: git@github.com:ros-gbp/audio_common-release.git
     version: 0.2.2-0
   bond_core:
     packages:


### PR DESCRIPTION
Should cut down on password hassles during the release process.
