### PR TITLE
Robot Web Tools JavaScript projects removed from ROS build system

### DIFF
--- a/doc/fuerte/actionlibjs.rosinstall
+++ b/doc/fuerte/actionlibjs.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: actionlibjs
-    uri: https://github.com/RobotWebTools/actionlibjs.git
-    version: fuerte-devel

--- a/doc/fuerte/keyboardteleopjs.rosinstall
+++ b/doc/fuerte/keyboardteleopjs.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: keyboardteleopjs
-    uri: https://github.com/RobotWebTools/keyboardteleopjs.git
-    version: fuerte-devel

--- a/doc/fuerte/map2djs.rosinstall
+++ b/doc/fuerte/map2djs.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: map2djs
-    uri: https://github.com/RobotWebTools/map2djs.git
-    version: fuerte-devel

--- a/doc/fuerte/mjpegcanvasjs.rosinstall
+++ b/doc/fuerte/mjpegcanvasjs.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: mjpegcanvasjs
-    uri: https://github.com/RobotWebTools/mjpegcanvasjs.git
-    version: fuerte-devel

--- a/doc/fuerte/nav2djs.rosinstall
+++ b/doc/fuerte/nav2djs.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: nav2djs
-    uri: https://github.com/RobotWebTools/nav2djs.git
-    version: fuerte-devel

--- a/doc/fuerte/rms.rosinstall
+++ b/doc/fuerte/rms.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: rms
-    uri: https://github.com/WPI-RAIL/rms.git
-    version: fuerte-devel

--- a/doc/fuerte/rosjs.rosinstall
+++ b/doc/fuerte/rosjs.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: rosjs
-    uri: https://github.com/RobotWebTools/rosjs.git
-    version: fuerte-devel

--- a/doc/groovy/actionlibjs.rosinstall
+++ b/doc/groovy/actionlibjs.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: actionlibjs
-    uri: https://github.com/RobotWebTools/actionlibjs.git
-    version: groovy-devel

--- a/doc/groovy/keyboardteleopjs.rosinstall
+++ b/doc/groovy/keyboardteleopjs.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: keyboardteleopjs
-    uri: https://github.com/RobotWebTools/keyboardteleopjs.git
-    version: groovy-devel

--- a/doc/groovy/map2djs.rosinstall
+++ b/doc/groovy/map2djs.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: map2djs
-    uri: https://github.com/RobotWebTools/map2djs.git
-    version: groovy-devel

--- a/doc/groovy/mjpegcanvasjs.rosinstall
+++ b/doc/groovy/mjpegcanvasjs.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: mjpegcanvasjs
-    uri: https://github.com/RobotWebTools/mjpegcanvasjs.git
-    version: groovy-devel

--- a/doc/groovy/nav2djs.rosinstall
+++ b/doc/groovy/nav2djs.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: nav2djs
-    uri: https://github.com/RobotWebTools/nav2djs.git
-    version: groovy-devel

--- a/doc/groovy/rms.rosinstall
+++ b/doc/groovy/rms.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: rms
-    uri: https://github.com/WPI-RAIL/rms.git
-    version: groovy-devel

--- a/doc/groovy/rosjs.rosinstall
+++ b/doc/groovy/rosjs.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: rosjs
-    uri: https://github.com/RobotWebTools/rosjs.git
-    version: groovy-devel

--- a/releases/groovy-devel.yaml
+++ b/releases/groovy-devel.yaml
@@ -140,10 +140,6 @@ repositories:
     type: hg
     url: https://kforge.ros.org/robotmodel/ivcon
     version: default
-  keyboardteleopjs:
-    type: git
-    url: https://github.com/RobotWebTools/keyboardteleopjs.git
-    version: groovy-devel
   kobuki:
     type: git
     url: https://github.com/yujinrobot/kobuki.git
@@ -164,14 +160,6 @@ repositories:
 #    type: git
 #    url: https://github.com/ros-perception/laser_geometry.git
 #    version: groovy-devel
-  map2djs:
-    type: git
-    url: https://github.com/RobotWebTools/map2djs.git
-    version: groovy-devel
-  mjpegcanvasjs:
-    type: git
-    url: https://github.com/RobotWebTools/mjpegcanvasjs.git
-    version: groovy-devel
 #  moveit_core:
 #    type: git
 #    url: https://github.com/ros-planning/moveit-core.git
@@ -193,10 +181,6 @@ repositories:
     type: git
     url: https://github.com/fkie/multimaster_fkie.git
     version: 0.2.0-0
-  nav2djs:
-    type: git
-    url: https://github.com/RobotWebTools/nav2djs.git
-    version: groovy-devel
   nodelet_core:
     type: git
     url: https://github.com/ros/nodelet_core.git
@@ -336,10 +320,6 @@ repositories:
   roscpp_core:
     type: git
     url: https://github.com/ros/roscpp_core.git
-    version: groovy-devel
-  rosjs:
-    type: git
-    url: https://github.com/RobotWebTools/rosjs.git
     version: groovy-devel
   rospack:
     type: git

--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -7,9 +7,6 @@ repositories:
   actionlib:
     url: https://github.com/ros-gbp/actionlib-release.git
     version: 1.9.11-0
-  actionlibjs:
-    url: https://github.com/RobotWebTools-release/actionlibjs-release.git
-    version: 0.2.0-0
   ar_track_alvar:
     url: https://github.com/ros-gbp/ar_track_alvar-release.git
     version: 0.3.3-0
@@ -298,9 +295,6 @@ repositories:
   jsk_rviz_plugins:
     url: https://github.com/start-jsk/jsk_rviz_plugins-release.git
     version: 0.0.9-0
-  keyboardteleopjs:
-    url: https://github.com/RobotWebTools-release/keyboardteleopjs-release.git
-    version: 0.2.0-0
   kobuki:
     packages:
       kobuki: null
@@ -357,18 +351,12 @@ repositories:
   manipulation_msgs:
     url: https://github.com/ros-gbp/manipulation_msgs-release.git
     version: 0.1.8-0
-  map2djs:
-    url: https://github.com/RobotWebTools-release/map2djs-release.git
-    version: 0.2.0-0
   message_generation:
     url: https://github.com/ros-gbp/message_generation-release.git
     version: 0.2.9-0
   message_runtime:
     url: https://github.com/ros-gbp/message_runtime-release.git
     version: 0.4.11-0
-  mjpegcanvasjs:
-    url: https://github.com/RobotWebTools-release/mjpegcanvasjs-release.git
-    version: 0.2.0-0
   moveit_commander:
     url: https://github.com/ros-gbp/moveit_commander-release.git
     version: 0.3.2-0
@@ -427,9 +415,6 @@ repositories:
       multi_level_map_utils:
     url: https://github.com/utexas-bwi-gbp/multi_level_map-release.git
     version: 0.0.1-0
-  nav2djs:
-    url: https://github.com/RobotWebTools-release/nav2djs-release.git
-    version: 0.2.0-0
   nodelet_core:
     packages:
       nodelet: null
@@ -704,9 +689,6 @@ repositories:
   rosdoc_lite:
     url: https://github.com/ros-gbp/rosdoc_lite-release.git
     version: 0.2.2-0
-  rosjs:
-    url: https://github.com/RobotWebTools-release/rosjs-release.git
-    version: 0.2.0-0
   roslisp:
     url: https://github.com/ros-gbp/roslisp-release.git
     version: 1.9.11-0

--- a/releases/hydro-devel.yaml
+++ b/releases/hydro-devel.yaml
@@ -8,10 +8,6 @@ repositories:
     type: git
     url: https://github.com/ros/actionlib.git
     version: hydro-devel
-  actionlibjs:
-    type: git
-    url: https://github.com/RobotWebTools/actionlibjs.git
-    version: null
   axis_camera:
     type: git
     url: https://github.com/clearpathrobotics/axis_camera.git
@@ -148,10 +144,6 @@ repositories:
     type: hg
     url: https://kforge.ros.org/robotmodel/ivcon
     version: default
-  keyboardteleopjs:
-    type: git
-    url: https://github.com/RobotWebTools/keyboardteleopjs.git
-    version: null
   kobuki:
     type: git
     url: https://github.com/yujinrobot/kobuki.git
@@ -172,14 +164,6 @@ repositories:
 #    type: git
 #    url: https://github.com/ros-perception/laser_geometry.git
 #    version: null
-  map2djs:
-    type: git
-    url: https://github.com/RobotWebTools/map2djs.git
-    version: null
-  mjpegcanvasjs:
-    type: git
-    url: https://github.com/RobotWebTools/mjpegcanvasjs.git
-    version: null
 #  moveit_core:
 #    type: git
 #    url: https://github.com/ros-planning/moveit-core.git
@@ -192,10 +176,6 @@ repositories:
     type: git
     url: https://github.com/utexas-bwi/multi_level_map.git
     version: master
-  nav2djs:
-    type: git
-    url: https://github.com/RobotWebTools/nav2djs.git
-    version: null
   nodelet_core:
     type: git
     url: https://github.com/ros/nodelet_core.git
@@ -327,10 +307,6 @@ repositories:
   roscpp_core:
     type: git
     url: https://github.com/ros/roscpp_core.git
-    version: null
-  rosjs:
-    type: git
-    url: https://github.com/RobotWebTools/rosjs.git
     version: null
   rospack:
     type: git

--- a/releases/hydro.yaml
+++ b/releases/hydro.yaml
@@ -10,9 +10,6 @@ repositories:
   actionlib:
     url: https://github.com/ros-gbp/actionlib-release.git
     version: 1.10.0-0
-  actionlibjs:
-    url: https://github.com/RobotWebTools-release/actionlibjs-release.git
-    version: null
   ar_track_alvar:
     url: https://github.com/ros-gbp/ar_track_alvar-release.git
     version: null
@@ -281,9 +278,6 @@ repositories:
       wiimote: null
     url: https://github.com/ros-gbp/joystick_drivers-release.git
     version: null
-  keyboardteleopjs:
-    url: https://github.com/RobotWebTools-release/keyboardteleopjs-release.git
-    version: null
   kobuki:
     packages:
       kobuki: null
@@ -328,9 +322,6 @@ repositories:
   manipulation_msgs:
     url: https://github.com/ros-gbp/manipulation_msgs-release.git
     version: null
-  map2djs:
-    url: https://github.com/RobotWebTools-release/map2djs-release.git
-    version: null
   message_generation:
     url: https://github.com/ros-gbp/message_generation-release.git
     version: 0.2.9-0
@@ -340,9 +331,6 @@ repositories:
   microstrain_3dmgx2_imu:
     url: https://github.com/ros-gbp/microstrain_3dmgx2_imu-release.git
     version: 1.5.7-0
-  mjpegcanvasjs:
-    url: https://github.com/RobotWebTools-release/mjpegcanvasjs-release.git
-    version: null
   moveit_commander:
     url: https://github.com/ros-gbp/moveit_commander-release.git
     version: null
@@ -392,9 +380,6 @@ repositories:
     version: null
   moveit_setup_assistant:
     url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
-    version: null
-  nav2djs:
-    url: https://github.com/RobotWebTools-release/nav2djs-release.git
     version: null
   nodelet_core:
     packages:
@@ -652,9 +637,6 @@ repositories:
     version: 0.3.14-0
   rosdoc_lite:
     url: https://github.com/ros-gbp/rosdoc_lite-release.git
-    version: null
-  rosjs:
-    url: https://github.com/RobotWebTools-release/rosjs-release.git
     version: null
   roslisp:
     url: https://github.com/ros-gbp/roslisp-release.git


### PR DESCRIPTION
Old JavaScript projects from the Robot Web Tools project are now deprecated for new standardized libraries like [roslibjs](https://github.com/robotwebtools/roslibjs). The old repositories will be removed and, as such, they have been removed from the ROS build files.

Robot Web Tools will now be validated and tested using [Travis CI](https://travis-ci.org/RobotWebTools/roslibjs) and distributed in a manner more appropriate for JavaScript project using the Robot Web Tools CDN service (http:cdn.robotwebtools.org). E.g., http://cdn.robotwebtools.org/roslibjs/current/roslib.min.js

@baalexander
