### PR TITLE
kobuki: 0.3.7-0 in 'groovy.yaml' [bloom]

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -312,7 +312,7 @@ repositories:
       kobuki_safety_controller: null
       kobuki_testsuite: null
     url: https://github.com/yujinrobot-release/kobuki-release.git
-    version: 0.3.5-0
+    version: 0.3.7-0
   kobuki_msgs:
     packages:
       kobuki_msgs: null


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki`:
- previous version: `0.3.5-0`
- new version: `0.3.7-0`
- distro file: `releases/groovy.yaml`
- bloom version: `0.3.4`
