### PR TITLE
libsegwayrmp: 0.2.3-2 in 'hydro.yaml' [bloom]

### DIFF
--- a/releases/hydro.yaml
+++ b/releases/hydro.yaml
@@ -15,11 +15,11 @@ repositories:
     version: null
   audio_common:
     packages:
-      audio_capture:
-      audio_common:
-      audio_common_msgs:
-      audio_play:
-      sound_play:
+      audio_capture: null
+      audio_common: null
+      audio_common_msgs: null
+      audio_play: null
+      sound_play: null
     url: https://github.com/ros-gbp/audio_common-release.git
     version: 0.2.2-0
   bond_core:
@@ -315,7 +315,7 @@ repositories:
     version: 2013.03.21-1
   libsegwayrmp:
     url: https://github.com/segwayrmp/libsegwayrmp-release.git
-    version: null
+    version: 0.2.3-2
   libsiftfast:
     url: https://github.com/start-jsk/libsiftfast-release.git
     version: null


### PR DESCRIPTION
Increasing version of package(s) in repository `libsegwayrmp`:
- previous version: `null`
- new version: `0.2.3-2`
- distro file: `releases/hydro.yaml`
- bloom version: `0.3.4`
