### PR TITLE
rviz: 1.9.29-2 in 'groovy.yaml' [bloom]

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -419,14 +419,6 @@ repositories:
       multi_level_map_utils: null
     url: https://github.com/utexas-bwi-gbp/multi_level_map-release.git
     version: 0.0.1-0
-  multimaster_fkie:
-    packages:
-      default_cfg_fkie: default_cfg_fkie
-      master_discovery_fkie: master_discovery_fkie
-      master_sync_fkie: master_sync_fkie
-      node_manager_fkie: node_manager_fkie
-    url: https://github.com/fkie-release/multimaster_fkie-release.git
-    version: 0.2.0-0
   nodelet_core:
     packages:
       nodelet: null
@@ -769,7 +761,7 @@ repositories:
     version: 0.2.13-1
   rviz:
     url: https://github.com/ros-gbp/rviz-release.git
-    version: 1.9.28-0
+    version: 1.9.29-2
   rx:
     packages:
       rx: null


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz`:
- previous version: `1.9.28-0`
- new version: `1.9.29-2`
- distro file: `releases/groovy.yaml`
- bloom version: `0.3.4`
