### PR TITLE
microstrain_3dmgx2_imu: 1.5.9-0 in 'hydro.yaml' [bloom]

### DIFF
--- a/releases/hydro.yaml
+++ b/releases/hydro.yaml
@@ -330,7 +330,7 @@ repositories:
     version: 0.4.11-0
   microstrain_3dmgx2_imu:
     url: https://github.com/ros-gbp/microstrain_3dmgx2_imu-release.git
-    version: 1.5.8-0
+    version: 1.5.9-0
   moveit_commander:
     url: https://github.com/ros-gbp/moveit_commander-release.git
     version: null


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_3dmgx2_imu`:
- previous version: `1.5.8-0`
- new version: `1.5.9-0`
- distro file: `releases/hydro.yaml`
- bloom version: `0.3.4`
