### PR TITLE
orocos_kdl: new upstream and remove obsolete metapackages

### DIFF
--- a/releases/hydro.yaml
+++ b/releases/hydro.yaml
@@ -447,12 +447,10 @@ repositories:
     version: null
   orocos_kdl:
     packages:
-      kdl: null
       orocos_kdl: orocos_kdl
-      orocos_kinematics_dynamics: null
       python_orocos_kdl: python_orocos_kdl
     url: https://github.com/smits/orocos-kdl-release.git
-    version: 1.1.100-0
+    version: 1.1.101-0
   pcl:
     url: https://github.com/ros-gbp/pcl-release.git
     version: 1.6.0-0


### PR DESCRIPTION
Signed-off-by: Ruben Smits ruben.smits@intermodalics.eu
