### PR TITLE
libsegwayrmp: 0.2.6-0 in 'hydro.yaml' [bloom]

### DIFF
--- a/releases/hydro.yaml
+++ b/releases/hydro.yaml
@@ -315,7 +315,7 @@ repositories:
     version: 2013.03.21-1
   libsegwayrmp:
     url: https://github.com/segwayrmp/libsegwayrmp-release.git
-    version: 0.2.5-0
+    version: 0.2.6-0
   libsiftfast:
     url: https://github.com/start-jsk/libsiftfast-release.git
     version: null


### PR DESCRIPTION
Increasing version of package(s) in repository `libsegwayrmp`:
- previous version: `0.2.5-0`
- new version: `0.2.6-0`
- distro file: `releases/hydro.yaml`
- bloom version: `0.3.4`
