### PR TITLE
release libfreenect version 0.1.2-1 to Groovy

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -342,6 +342,9 @@ repositories:
   libfovis:
     url: https://github.com/srv/libfovis-release.git
     version: 0.0.1-0
+  libfreenect:
+    url: https://github.com/ros-drivers-gbp/libfreenect-release.git
+    version: 0.1.2-1
   libg2o:
     url: https://github.com/ros-gbp/libg2o-release.git
     version: 2012.11.09-1


### PR DESCRIPTION
This is a 3rd party release of libfreenect 0.1.2 with additional commits.

This version is considerably ahead of the Universe Debian release.
