### PR TITLE
Cancel release of libfreenect to Groovy

### DIFF
--- a/releases/groovy.yaml
+++ b/releases/groovy.yaml
@@ -344,7 +344,7 @@ repositories:
     version: 0.0.1-0
   libfreenect:
     url: https://github.com/ros-drivers-gbp/libfreenect-release.git
-    version: 0.1.2-1
+    version: null
   libg2o:
     url: https://github.com/ros-gbp/libg2o-release.git
     version: 2012.11.09-1


### PR DESCRIPTION
There is a problem with the `libfreenect` install. We are waiting for the new rosdistro release before it will be fixed. So, the build farm should stop trying to create Debians.
