### PR TITLE
Updating version of octomap to 1.5.4-2

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -682,7 +682,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/octomap-release.git
-    version: 1.5.4-1
+    version: 1.5.4-2
   octomap_msgs:
     tags:
       release: release/{package}/{upstream_version}


### PR DESCRIPTION
This is to fix a bug where octovis was installing
its package.xml into octomap's share directory.
