### PR TITLE
re-release libfreenect version 0.1.2-1 to Groovy

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -481,6 +481,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-drivers-gbp/libfreenect-release.git
+    version: 0.1.2-1
   libg2o:
     tags:
       release: release/{package}/{upstream_version}


### PR DESCRIPTION
This release was formerly cancelled due to build issues.

It now passes pre-release tests, which had been broken before.
