### PR TITLE
added status for packages

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -441,13 +441,13 @@ repositories:
     status: maintained
     url: https://github.com/ros-gbp/moveit_msgs-release.git
   moveit_planners:
-    status: maintained
     packages:
       moveit_ompl_planners_core:
         subfolder: ompl/core
       moveit_ompl_planners_ros_plugin:
         subfolder: ompl/ros
       moveit_planners:
+    status: maintained
     url: https://github.com/ros-gbp/moveit_planners-release.git
   moveit_pr2:
     packages:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -94,6 +94,7 @@ repositories:
     url: https://github.com/ros-gbp/common_msgs-release.git
     version: 1.9.15-0
   console_bridge:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/console_bridge-release.git
@@ -226,11 +227,13 @@ repositories:
     url: https://github.com/ros-gbp/ecto_ros-release.git
     version: 0.3.23-0
   eigen_stl_containers:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/eigen_stl_containers-release.git
     version: 0.1.3-0
   fcl:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/fcl-release.git
@@ -271,6 +274,7 @@ repositories:
     url: https://github.com/ros-gbp/genpy-release.git
     version: 0.4.11-0
   geometric_shapes:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/geometric_shapes-release.git
@@ -382,6 +386,7 @@ repositories:
     url: https://github.com/ros-gbp/laser_proc-release.git
     version: 0.1.2-0
   libccd:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/libccd-release.git
@@ -421,18 +426,22 @@ repositories:
     url: https://github.com/ros-gbp/microstrain_3dmgx2_imu-release.git
     version: 1.5.9-0
   moveit_commander:
+    status: maintained
     url: https://github.com/ros-gbp/moveit_commander-release.git
   moveit_core:
+    status: maintained
     url: https://github.com/ros-gbp/moveit_core-release.git
   moveit_metapackages:
     packages:
       moveit_full:
       moveit_full_pr2:
-      moveit_source_build_deps:
+    status: maintained
     url: https://github.com/ros-gbp/moveit_metapackages-release.git
   moveit_msgs:
+    status: maintained
     url: https://github.com/ros-gbp/moveit_msgs-release.git
   moveit_planners:
+    status: maintained
     packages:
       moveit_ompl_planners_core:
         subfolder: ompl/core
@@ -446,8 +455,10 @@ repositories:
       pr2_moveit_config:
       pr2_moveit_plugins:
       pr2_moveit_tutorials:
+    status: maintained
     url: https://github.com/ros-gbp/moveit_pr2-release.git
   moveit_resources:
+    status: maintained
     url: https://github.com/ros-gbp/moveit_resources-release.git
   moveit_ros:
     packages:
@@ -468,8 +479,10 @@ repositories:
         subfolder: visualization
       moveit_ros_warehouse:
         subfolder: warehouse
+    status: maintained
     url: https://github.com/ros-gbp/moveit_ros-release.git
   moveit_setup_assistant:
+    status: maintained
     url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
   nodelet_core:
     packages:
@@ -541,6 +554,7 @@ repositories:
   octomap_ros:
     url: https://github.com/ros-gbp/octomap_ros-release.git
   ompl:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ompl-release.git
@@ -616,6 +630,7 @@ repositories:
   rail_maps:
     url: https://github.com/wpi-rail-release/rail_maps-release.git
   random_numbers:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/random_numbers-release.git
@@ -632,6 +647,7 @@ repositories:
       robot_model:
       urdf:
       urdf_parser:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/robot_model-release.git
@@ -639,6 +655,7 @@ repositories:
   robot_pose_publisher:
     url: https://github.com/wpi-rail-release/robot_pose_publisher-release.git
   robot_state_publisher:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/robot_state_publisher-release.git
@@ -784,6 +801,7 @@ repositories:
   rosauth:
     url: https://github.com/wpi-rail-release/rosauth-release.git
   rosconsole_bridge:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rosconsole_bridge-release.git
@@ -871,6 +889,7 @@ repositories:
     url: https://github.com/wjwwood/serial-release.git
     version: 1.1.3-28
   shape_tools:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/shape_tools-release.git
@@ -888,6 +907,7 @@ repositories:
   sql_database:
     url: https://github.com/ros-gbp/sql_database-release.git
   srdfdom:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/srdfdom-release.git
@@ -909,11 +929,13 @@ repositories:
     url: https://github.com/ros-geographic-info/unique_identifier-release.git
     version: 1.0.1-0
   urdfdom:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/urdfdom-release.git
     version: 0.2.7-1
   urdfdom_headers:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/urdfdom_headers-release.git
@@ -940,6 +962,7 @@ repositories:
   visp:
     url: https://github.com/laas/visp-release.git
   warehouse_ros:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/warehouse-release.git


### PR DESCRIPTION
question: some packages I do just release maintenance (3rd party ones) not active development. eg -- i probably will not fix bugs myself in libccd. is the correct status 'maintained' ? It seems to be the closest from the allowed list, but I figured I should check...
