### PR TITLE
Adding my repo to doc index for distro

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -1184,6 +1184,10 @@ repositories:
     type: git
     url: https://github.com/ros/roscpp_core.git
     version: groovy-devel
+  rosdistro:
+  	type: git
+  	url: https://github.com/lionel67/rosdistro.git
+  	version: groovy-devel
   rosdoc_lite:
     type: git
     url: https://github.com/ros-infrastructure/rosdoc_lite.git


### PR DESCRIPTION
I'd like my repo to be indexed and documented on ros.org
