### PR TITLE
re-adding joystick drivers to hydro

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -376,6 +376,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/joystick_drivers-release.git
+    version: 1.9.10-0
   kobuki:
     packages:
       kobuki:


### PR DESCRIPTION
I ran the release scripts, and they definitely created a ton of "hydro" branches on the gpb repository, I just ran them again, and pushed again.
