### PR TITLE
Adding socrob-ros-pkg to documentation index for distro

### DIFF
--- a/doc/fuerte/socrob-ros-pkg.rosinstall
+++ b/doc/fuerte/socrob-ros-pkg.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: socrob-ros-pkg
+    uri: https://github.com/larsys/socrob-ros-pkg.git
+    version: master


### PR DESCRIPTION
Hi! I'd like socrob-ros-pkg to be indexed and documented in ros.org. It contains software for the quadcopters and the RAPOSA-NG robot used by our team in RoboCup Rescue and a multicast multimaster communications library developed for RoboCup MSL.
