### PR TITLE
new libfreenect patch release, 0.1.2-3

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -493,7 +493,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-drivers-gbp/libfreenect-release.git
-    version: 0.1.2-2
+    version: 0.1.2-3
   libg2o:
     tags:
       release: release/{package}/{upstream_version}


### PR DESCRIPTION
Fixes:
- ros-drivers-gbp/libfreenect-release#2 
- ros-drivers-gbp/libfreenect-release#3
- ros/rospkg#37
