### PR TITLE
Point Hydro NMEA GPS Driver doc job at the correct branch for Hydro

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -90,7 +90,7 @@ repositories:
   nmea_gps_driver:
     type: git
     url: https://github.com/ros-drivers/nmea_gps_driver.git
-    version: master
+    version: hydro-devel
   nodelet_core:
     type: git
     url: https://github.com/ros/nodelet_core.git


### PR DESCRIPTION
nmea_gps_driver is on the hydro-devel branch, not a master branch.
