### PR TITLE
Adding pose_ekf_slam to documentation index for distro

### DIFF
--- a/doc/fuerte/pose_ekf_slam.rosinstall
+++ b/doc/fuerte/pose_ekf_slam.rosinstall
@@ -1,0 +1,3 @@
+- git:
+    local-name: pose_ekf_slam
+    uri: https://github.com/narcispr/pose_ekf_slam


### PR DESCRIPTION
This package works on ROS Fuerte
