### PR TITLE
Update hokuyo_node and sicktoolbox for removal of REP 117 tick/tock

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -328,7 +328,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/hokuyo_node-release.git
-    version: 1.7.5-0
+    version: 1.7.6-0
   household_objects_database_msgs:
     tags:
       release: release/hydro/{package}/{version}
@@ -978,7 +978,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/sicktoolbox_wrapper-release.git
-    version: 2.5.1-0
+    version: 2.5.2-0
   sql_database:
     url: https://github.com/ros-gbp/sql_database-release.git
   srdfdom:


### PR DESCRIPTION
New versions of laser_drivers.
