### PR TITLE
Bump nmea_gps_driver to 0.3.1 in Hydro

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -524,7 +524,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/nmea_gps_driver-release.git
-    version: 0.3.0-0
+    version: 0.3.1-0
   nodelet_core:
     packages:
       nodelet:


### PR DESCRIPTION
Fixed build dependency issues. Passed pre-release test.
