### PR TITLE
Adding my_repo_name to documentation index for distro

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -19,6 +19,10 @@ repositories:
     type: git
     url: https://github.com/vanadiumlabs/arbotix_ros.git
     version: hydro-devel
+  aswin-ros-pkg:
+    type: git
+    url: https://github.com/vanadiumlabs/aswin_ros_pkg.git
+    version: hydro-devel
   axis_camera:
     type: git
     url: https://github.com/clearpathrobotics/axis_camera.git


### PR DESCRIPTION
I'd like aswin-ros-pkg to be indexed and documented on ros.org
