### PR TITLE
Add appl to documentation index for distro

### DIFF
--- a/doc/electric/appl.rosinstall
+++ b/doc/electric/appl.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: appl
+    uri: https://github.com/petercaiyoyo/appl.git
+    version: master

--- a/doc/fuerte/appl.rosinstall
+++ b/doc/fuerte/appl.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: appl
+    uri: https://github.com/petercaiyoyo/appl.git
+    version: master


### PR DESCRIPTION
I'd like my appl repository to be indexed and documented on ros.org
