### PR TITLE
updated repository URLs for tu-darmstadt-ros-pkg stacks

### DIFF
--- a/doc/electric/tu-darmstadt-ros-pkg.rosinstall
+++ b/doc/electric/tu-darmstadt-ros-pkg.rosinstall
@@ -1,39 +1,56 @@
 - svn: 
     local-name: biorob_common
     uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/biorob_common
-- svn: 
+- git: 
     local-name: hector_common
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_common
-- svn: 
+    uri: https://github.com/tu-darmstadt-ros-pkg/hector_common.git
+    version: master
+- git: 
     local-name: hector_gazebo
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/branches/electric/hector_gazebo
-- svn: 
+    uri: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
+    version: electric
+- git: 
     local-name: hector_localization
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_localization
-- svn: 
+    uri: https://github.com/tu-darmstadt-ros-pkg/hector_localization.git
+    version: master
+- git: 
     local-name: hector_models
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/branches/electric/hector_models
-- svn: 
+    uri: https://github.com/tu-darmstadt-ros-pkg/hector_models.git
+    version: electric
+- git: 
     local-name: hector_navigation
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_navigation
-- svn: 
+    uri: https://github.com/tu-darmstadt-ros-pkg/hector_navigation.git
+    version: master
+- git: 
     local-name: hector_nist_arenas_gazebo
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/branches/electric/hector_nist_arenas_gazebo
-- svn: 
+    uri: https://github.com/tu-darmstadt-ros-pkg/hector_nist_arenas_gazebo.git
+    version: electric
+- git: 
     local-name: hector_quadrotor
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/branches/electric/hector_quadrotor
-- svn: 
+    uri: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor.git
+    version: electric
+- git:
+    local-name: hector_quadrotor_apps
+    uri: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor_apps.git
+    version: master
+- git: 
+    local-name: hector_quadrotor_experimental
+    uri: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor_experimental.git
+    version: master
+- git: 
     local-name: hector_slam
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_slam
+    uri: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git
+    version: master
 - svn:
     local-name: hector_turtlebot
     uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_turtlebot
 - svn: 
     local-name: hector_ugv_common
     uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_ugv_common
-- svn: 
+- git: 
     local-name: hector_worldmodel
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_worldmodel
+    uri: https://github.com/tu-darmstadt-ros-pkg/hector_worldmodel.git
+    version: master
 - svn: 
     local-name: hlugv_common
     uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hlugv_common
@@ -42,7 +59,7 @@
     uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/vrmagic_camera
 - git:
     local-name: mapstitch
-    uri: https://github.com/tu-darmstadt-ros-pkg/mapstitch
+    uri: https://github.com/tu-darmstadt-ros-pkg/mapstitch.git
 - git:
     local-name: ublox
-    uri: https://github.com/tu-darmstadt-ros-pkg/ublox
+    uri: https://github.com/tu-darmstadt-ros-pkg/ublox.git

--- a/doc/fuerte/tu-darmstadt-ros-pkg.rosinstall
+++ b/doc/fuerte/tu-darmstadt-ros-pkg.rosinstall
@@ -1,23 +1,26 @@
 - svn: 
     local-name: biorob_common
     uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/biorob_common
-- svn: 
+- git: 
     local-name: hector_common
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_common
+    uri: https://github.com/tu-darmstadt-ros-pkg/hector_common.git
+    version: master
 - git: 
     local-name: hector_gazebo
     uri: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
     version: fuerte-devel
-- svn: 
+- git: 
     local-name: hector_localization
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_localization
+    uri: https://github.com/tu-darmstadt-ros-pkg/hector_localization.git
+    version: master
 - git: 
     local-name: hector_models
     uri: https://github.com/tu-darmstadt-ros-pkg/hector_models.git
     version: fuerte-devel
-- svn: 
+- git: 
     local-name: hector_navigation
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_navigation
+    uri: https://github.com/tu-darmstadt-ros-pkg/hector_navigation.git
+    version: master
 - git: 
     local-name: hector_nist_arenas_gazebo
     uri: https://github.com/tu-darmstadt-ros-pkg/hector_nist_arenas_gazebo.git
@@ -26,26 +29,28 @@
     local-name: hector_quadrotor
     uri: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor.git
     version: fuerte-devel
-- git: 
+- git:
     local-name: hector_quadrotor_apps
     uri: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor_apps.git
-    version: fuerte-devel
+    version: master
 - git: 
     local-name: hector_quadrotor_experimental
     uri: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor_experimental.git
-    version: fuerte-devel
-- svn: 
+    version: master
+- git: 
     local-name: hector_slam
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_slam
+    uri: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git
+    version: master
 - svn:
     local-name: hector_turtlebot
     uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_turtlebot
 - svn: 
     local-name: hector_ugv_common
     uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_ugv_common
-- svn: 
+- git: 
     local-name: hector_worldmodel
-    uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_worldmodel
+    uri: https://github.com/tu-darmstadt-ros-pkg/hector_worldmodel.git
+    version: master
 - svn: 
     local-name: hlugv_common
     uri: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hlugv_common

--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -495,25 +495,25 @@ repositories:
     url: https://github.com/OSUrobotics/ros-head-tracking.git
     version: groovy-devel
   hector_common:
-    type: svn
-    url: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_common
-    version: HEAD
+    type: git
+    url: https://github.com/tu-darmstadt-ros-pkg/hector_common.git
+    version: master
   hector_gazebo:
     type: git
     url: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
     version: groovy-devel
   hector_localization:
-    type: svn
-    url: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_localization
-    version: HEAD
+    type: git
+    url: https://github.com/tu-darmstadt-ros-pkg/hector_localization.git
+    version: master
   hector_models:
     type: git
     url: https://github.com/tu-darmstadt-ros-pkg/hector_models.git
     version: groovy-devel
   hector_navigation:
-    type: svn
-    url: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_navigation
-    version: HEAD
+    type: git
+    url: https://github.com/tu-darmstadt-ros-pkg/hector_navigation.git
+    version: master
   hector_nist_arenas_gazebo:
     type: git
     url: https://github.com/tu-darmstadt-ros-pkg/hector_nist_arenas_gazebo.git
@@ -525,15 +525,15 @@ repositories:
   hector_quadrotor_apps:
     type: git
     url: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor_apps.git
-    version: groovy-devel
+    version: master
   hector_quadrotor_experimental:
     type: git
     url: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor_experimental.git
-    version: groovy-devel
+    version: master
   hector_slam:
-    type: svn
-    url: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_slam
-    version: HEAD
+    type: git
+    url: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git
+    version: master
   hector_turtlebot:
     type: svn
     url: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_turtlebot
@@ -543,9 +543,9 @@ repositories:
     url: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_ugv_common
     version: HEAD
   hector_worldmodel:
-    type: svn
-    url: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hector_worldmodel
-    version: HEAD
+    type: git
+    url: https://github.com/tu-darmstadt-ros-pkg/hector_worldmodel.git
+    version: master
   hlugv_common:
     type: svn
     url: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hlugv_common


### PR DESCRIPTION
We moved some more stacks from Google Code to Github.
