### PR TITLE
Added definitions to osx-homebrew.yaml

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -308,6 +308,10 @@ python-numpy:
   osx:
     pip:
       packages: [numpy]
+python-opengl:
+  osx:
+    pip:
+      packages: [PyOpenGL]
 python-paramiko:
   osx:
     pip:
@@ -316,6 +320,10 @@ python-qt-bindings:
   osx:
     homebrew:
       packages: [pyside, shiboken, pyqt, sip]
+python-qt-bindings-gl:
+  osx:
+    homebrew:
+      packages: [pyqt]
 python-qt-bindings-qwt5:
   osx:
     homebrew:


### PR DESCRIPTION
Added definition of python-opengl and python-qt-bindings-gl rosdep keys for osx
they're needed in the rosdep install of the full package pack desktop-full
Hope i've put the right packages in there
