### PR TITLE
Adding roscorobot to documentation index for groovy

### DIFF
--- a/doc/groovy/roscorobot.rosinstall
+++ b/doc/groovy/roscorobot.rosinstall
@@ -1,0 +1,4 @@
+- svn:
+    uri: http://svn.code.sf.net/p/roscorobot/code/trunk/Electric/Corobot
+    local-name: Corobot
+


### PR DESCRIPTION
I'd like roscorobot to be indexed and documented on ros.org for groovy. 
