### PR TITLE
enable devel builds for velodyne in Hydro

### DIFF
--- a/hydro/source.yaml
+++ b/hydro/source.yaml
@@ -268,6 +268,10 @@ repositories:
     type: git
     url: https://github.com/ros-geographic-info/unique_identifier.git
     version: master
+  velodyne:
+    type: git
+    url: https://github.com/ros-drivers/velodyne.git
+    version: master
   vision_opencv:
     type: git
     url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Sorry these requests have been coming in piecemeal. 

I keep remembering additional updates, belatedly.
