### PR TITLE
add libfreenect to hydro, but do not release yet

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -435,7 +435,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/libfreenect-release.git
-    version: 
+    version: null
   libg2o:
     tags:
       release: release/hydro/{package}/{version}

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -435,7 +435,6 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/libfreenect-release.git
-    version: null
   libg2o:
     tags:
       release: release/hydro/{package}/{version}

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -430,6 +430,12 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/libccd-release.git
     version: 1.4.0-1
+  libfreenect:
+    status: maintained
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-drivers-gbp/libfreenect-release.git
+    version: 
   libg2o:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
This has a blank `version:` field, for pre-release testing.
