### PR TITLE
renaming depthcloudjs to depthcloud_encoder (release of this package has...

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -122,11 +122,11 @@ repositories:
       release: release/{package}/{upstream_version}
     url: https://github.com/ros-gbp/convex_decomposition-release.git
     version: 0.1.9-0
-  depthcloudjs:
+  depthcloud_encoder:
     status: maintained
     tags:
       release: release/groovy/{package}/{version}
-    url: https://github.com/ros-gbp/depthcloudjs-release.git
+    url: https://github.com/ros-gbp/depthcloud_encoder-release.git
     version: 0.0.2-0
   depthimage_to_laserscan:
     status: maintained


### PR DESCRIPTION
... not been announced so far)
