### PR TITLE
bugfix release for filters

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -267,7 +267,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/filters-release.git
-    version: 1.7.0-0
+    version: 1.7.1-0
   flann:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
adds install rule for headers, which was breaking laser_filters
