### PR TITLE
Kobuki version bumps to 0.38. Yujin repos status set as developed

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -187,6 +187,7 @@ repositories:
       ecl_time:
       ecl_type_traits:
       ecl_utilities:
+    status: developed
     tags:
       release: release/{package}/{upstream_version}
     url: https://github.com/yujinrobot-release/ecl_core-release.git
@@ -200,6 +201,7 @@ repositories:
       ecl_lite:
       ecl_sigslots_lite:
       ecl_time_lite:
+    status: developed
     tags:
       release: release/{package}/{upstream_version}
     url: https://github.com/yujinrobot-release/ecl_lite-release.git
@@ -209,6 +211,7 @@ repositories:
       ecl:
       ecl_manipulation:
       ecl_manipulators:
+    status: developed
     tags:
       release: release/{package}/{upstream_version}
     url: https://github.com/yujinrobot-release/ecl_manipulation-release.git
@@ -220,6 +223,7 @@ repositories:
       ecl_navigation:
       ecl_navigation_apps:
       ecl_slam:
+    status: developed
     tags:
       release: release/{package}/{upstream_version}
     url: https://github.com/yujinrobot-release/ecl_navigation-release.git
@@ -229,6 +233,7 @@ repositories:
       ecl_build:
       ecl_license:
       ecl_tools:
+    status: developed
     tags:
       release: release/{package}/{upstream_version}
     url: https://github.com/yujinrobot-release/ecl_tools-release.git
@@ -462,11 +467,13 @@ repositories:
       kobuki_node:
       kobuki_safety_controller:
       kobuki_testsuite:
+    status: developed
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/yujinrobot-release/kobuki-release.git
-    version: 0.3.7-0
+    version: 0.3.8-0
   kobuki_msgs:
+    status: developed
     tags:
       release: release/{package}/{upstream_version}
     url: https://github.com/yujinrobot-release/kobuki_msgs-release.git
@@ -901,6 +908,7 @@ repositories:
       rocon_app_manager_www:
       rocon_app_platform:
       rocon_apps:
+    status: developed
     tags:
       release: release/{package}/{upstream_version}
     url: https://github.com/yujinrobot-release/rocon_app_platform-release.git
@@ -911,6 +919,7 @@ repositories:
       concert_master:
       rocon_concert:
       rocon_orchestra:
+    status: developed
     tags:
       release: release/{package}/{upstream_version}
     url: https://github.com/yujinrobot-release/rocon_concert-release.git
@@ -922,6 +931,7 @@ repositories:
       rocon_app_manager_msgs:
       rocon_demo_msgs:
       rocon_msgs:
+    status: developed
     tags:
       release: release/{package}/{upstream_version}
     url: https://github.com/yujinrobot-release/rocon_msgs-release.git
@@ -936,6 +946,7 @@ repositories:
       rocon_multimaster:
       rocon_unreliable_experiments:
       rocon_utilities:
+    status: developed
     tags:
       release: release/{package}/{upstream_version}
     url: https://github.com/yujinrobot-release/rocon_multimaster-release.git
@@ -944,6 +955,7 @@ repositories:
     packages:
       rocon_gateway_graph:
       rocon_rqt_plugins:
+    status: developed
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_rqt_plugins-release.git
@@ -963,6 +975,7 @@ repositories:
         subfolder: concert_tutorials/software/turtle_race_controllers
       turtle_stroll:
         subfolder: concert_tutorials/software/turtle_stroll
+    status: developed
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_tutorials-release.git
@@ -1343,6 +1356,7 @@ repositories:
     url: https://github.com/wpi-rail-release/youbot_teleop-release.git
     version: 0.1.1-0
   yujin_maps:
+    status: developed
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/yujinrobot-release/yujin_maps-release.git
@@ -1353,6 +1367,7 @@ repositories:
       yocs_controllers:
       yocs_velocity_smoother:
       yujin_ocs:
+    status: developed
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/yujinrobot-release/yujin_ocs-release.git
@@ -1362,11 +1377,13 @@ repositories:
       zeroconf_avahi:
       zeroconf_avahi_demos:
       zeroconf_avahi_suite:
+    status: developed
     tags:
       release: release/{package}/{upstream_version}
     url: https://github.com/yujinrobot-release/zeroconf_avahi_suite-release.git
     version: 0.2.2-0
   zeroconf_msgs:
+    status: developed
     tags:
       release: release/{package}/{upstream_version}
     url: https://github.com/yujinrobot-release/zeroconf_msgs-release.git


### PR DESCRIPTION
Affected packages:
kobuki_xxx
ecl_xxx
rocon_xxx
zeroconf
yujin_ocs
yujin_maps
