### PR TITLE
Adding wifi_tools to documentation index for distro

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -1527,6 +1527,10 @@ repositories:
     type: svn
     url: https://code.ros.org/svn/wg-ros-pkg/stacks/wifi_drivers/trunk
     version: HEAD
+  wifi_tools:
+    type: svn
+    url: http://alufr-ros-pkg.googlecode.com/svn/trunk/wifi_tools
+    version: groovy
   win_ros:
     type: git
     url: https://github.com/yujinrobot/win_ros.git


### PR DESCRIPTION
I would like to wifi_tools to be indexed and documented on ros.org.
