### PR TITLE
Adding vanderbit_ros to documentation index for groovy

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -1469,6 +1469,10 @@ repositories:
     type: git
     url: https://github.com/bosch-ros-pkg/usb_cam.git
     version: groovy-devel
+  vanderbilt_ros:
+    type: git
+    url: https://github.com/allenh1/vanderbit-ros-pkg.git
+    version: master
   velodyne:
     type: git
     url: https://github.com/ros-drivers/velodyne.git


### PR DESCRIPTION
I'd like vanderbilt_ros to be indexed and documented on ros.org.
