### PR TITLE
Adding p2os to documentation index for groovy

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -917,6 +917,9 @@ repositories:
   orocos_tools:
     type: git
     url: https://github.com/RCPRG-ros-pkg/orocos_tools.git
+  p2os:
+    type: git
+    url: https://github.com/allenh1/p2os.git
   pcl:
     type: git
     url: https://github.com/ros-gbp/pcl-release.git


### PR DESCRIPTION
I'd like to add a Groovy compatible p2os driver to groovy.
