### PR TITLE
adding iwaki-ros-pkg to documentation index for distro

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -618,6 +618,10 @@ repositories:
   ir_comm:
     type: git
     url: https://github.com/OSUrobotics/ros-phidgets-ir.git
+  iwaki:
+    type: git
+    url: https://github.com/maxipesfix/iwaki-ros-pkg.git
+    version: master
   joystick_drivers:
     type: git
     url: https://github.com/ros-drivers/joystick_drivers.git

--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -99,6 +99,10 @@ repositories:
     type: git
     url: https://github.com/ros-drivers/gscam.git
     version: master
+  iwaki:
+    type: git
+    url: https://github.com/maxipesfix/iwaki-ros-pkg.git
+    version: master
   maxwell:
     type: git
     url: https://github.com/mikeferguson/maxwell.git


### PR DESCRIPTION
I'd like iwaki-ros-pkg to be indexed on ros.org
