### PR TITLE
Kobuki version bumps to 0.3.9-2

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -483,13 +483,12 @@ repositories:
       kobuki_keyop:
       kobuki_node:
       kobuki_safety_controller:
-      kobuki_softnode:
       kobuki_testsuite:
     status: developed
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/yujinrobot-release/kobuki-release.git
-    version: 0.3.9-1
+    version: 0.3.9-2
   kobuki_msgs:
     status: developed
     tags:


### PR DESCRIPTION
We have removed kobuki_softnode, as we are experiencing many problems with it on goovy. I didn't make a bloom release; I assume that just removing from here is enough. If this is not the case, feel free to drop this pull request and I will make a normal release.
