### PR TITLE
Kobuki_softnode removed from Kobuki 0.3.9-1

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -483,7 +483,6 @@ repositories:
       kobuki_keyop:
       kobuki_node:
       kobuki_safety_controller:
-      kobuki_softnode:
       kobuki_testsuite:
     status: developed
     tags:


### PR DESCRIPTION
This time I don't touch the version number.
