### PR TITLE
Releasing v1.9.12 of roslisp.

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1169,9 +1169,9 @@ repositories:
     version: 0.1.5-0
   roslisp:
     tags:
-      release: release/{package}/{upstream_version}
+      release: release/groovy/{package}/{upstream_version}
     url: https://github.com/ros-gbp/roslisp-release.git
-    version: 1.9.11-0
+    version: 1.9.12-0
   rospack:
     status: maintained
     tags:


### PR DESCRIPTION
Up'ed version of roslisp. Also preparation for release in hydro: We would like to have groovy and hydro version of roslisp in sync and hydro shall get the new version...
