### PR TITLE
Releasing roslisp in hydro.

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -989,7 +989,10 @@ repositories:
     url: https://github.com/yujinrobot-release/rosjava_tools-release.git
     version: 0.1.5-0
   roslisp:
+    tags:
+      release: release/hydro/{package}/{upstream_version}
     url: https://github.com/ros-gbp/roslisp-release.git
+    version: 1.9.12-0
   rospack:
     status: maintained
     tags:


### PR DESCRIPTION
Releasing current version of roslisp for hydro -- same version as released in groovy.
