### PR TITLE
Updating groovy release of roslisp to v1.9.12

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1169,9 +1169,9 @@ repositories:
     version: 0.1.5-0
   roslisp:
     tags:
-      release: release/{package}/{upstream_version}
+      release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/roslisp-release.git
-    version: 1.9.11-0
+    version: 1.9.12-0
   rospack:
     status: maintained
     tags:


### PR DESCRIPTION
New try: corrected pattern of release tag.
