### PR TITLE
Releasing roslisp for hydro (v1.9.12)

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -989,7 +989,10 @@ repositories:
     url: https://github.com/yujinrobot-release/rosjava_tools-release.git
     version: 0.1.5-0
   roslisp:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/roslisp-release.git
+    version: 1.9.12-0
   rospack:
     status: maintained
     tags:


### PR DESCRIPTION
Also here: Corrected pattern for release tag.
