### PR TITLE
Adding gazebo_ros_pkgs to build farm

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -289,8 +289,8 @@ repositories:
   gazebo_ros_pkgs:
     packages:
       gazebo_msgs:
-      gazebo_ros:
       gazebo_plugins:
+      gazebo_ros:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -286,6 +286,15 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/gazebo-release.git
     version: 1.5.0-3
+  gazebo_ros_pkgs:
+    packages:
+      gazebo_msgs:
+      gazebo_ros:
+      gazebo_plugins:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
+    version: 2.0.0-0
   gencpp:
     status: maintained
     tags:


### PR DESCRIPTION
I don't think we should include a deprecated `gazebo` package within `gazebo_ros_pkgs` since it is already a package in Hydro by itself (see the package in the release.yaml right before this addition). 
