### PR TITLE
serial: 1.1.3-43 in 'release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1085,7 +1085,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/wjwwood/serial-release.git
-    version: 1.1.3-28
+    version: 1.1.3-43
   shape_tools:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `serial`:
- previous version: `1.1.3-28`
- new version: `1.1.3-43`
- distro file: `hydro/release.yaml`
- bloom version: `0.3.5`
