### PR TITLE
Adding laser_tool to documentation index for distro

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -3,6 +3,10 @@
 # see REP 137: http://ros.org/reps/rep-0137.html
 ---
 repositories:
+  asd:
+   type: git
+    url: https://github.com/WuNL/asd.git
+    version: 1.00
   3d_interaction:
     type: git
     url: https://github.com/OSUrobotics/ros-3d-interaction.git

--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -3,10 +3,6 @@
 # see REP 137: http://ros.org/reps/rep-0137.html
 ---
 repositories:
-  asd:
-   type: git
-    url: https://github.com/WuNL/asd.git
-    version: 1.00
   3d_interaction:
     type: git
     url: https://github.com/OSUrobotics/ros-3d-interaction.git
@@ -706,6 +702,10 @@ repositories:
     type: git
     url: https://github.com/ros-perception/laser_pipeline.git
     version: groovy-devel
+  laser_tool:
+    type: git
+    url: https://github.com/WuNL/laser_tool.git
+    version: groovy
   libsegwayrmp:
     type: git
     url: https://github.com/segwayrmp/libsegwayrmp.git


### PR DESCRIPTION
It is a node used for laser hokuyo. 

Receive laserscan dates from hokuyo and quaternions form another device, then send out the pointcloud2 datas.
