### PR TITLE
serial: 1.1.4-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1301,9 +1301,9 @@ repositories:
   serial:
     status: maintained
     tags:
-      release: release/{package}/{upstream_version}
+      release: release/groovy/{package}/{version}
     url: https://github.com/wjwwood/serial-release.git
-    version: 1.1.3-0
+    version: 1.1.4-0
   shape_tools:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `serial`:
- previous version: `1.1.3-0`
- new version: `1.1.4-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.0`
