### PR TITLE
interactive_markers: 1.9.8-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -402,7 +402,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/interactive_markers-release.git
-    version: 1.9.7-0
+    version: 1.9.8-0
   ivcon:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers`:
- previous version: `1.9.7-0`
- new version: `1.9.8-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.0`
