### PR TITLE
interactive_markers: 1.9.8-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -438,7 +438,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/interactive_markers-release.git
-    version: 1.9.7-0
+    version: 1.9.8-0
   ivcon:
     tags:
       release: release/{package}/{upstream_version}


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers`:
- previous version: `1.9.7-0`
- new version: `1.9.8-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.0`
