### PR TITLE
roslisp: 1.9.13-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1186,7 +1186,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/roslisp-release.git
-    version: 1.9.12-0
+    version: 1.9.13-0
   rospack:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp`:
- previous version: `1.9.12-0`
- new version: `1.9.13-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.0`
