### PR TITLE
roslisp: 1.9.13-2 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1016,7 +1016,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/roslisp-release.git
-    version: 1.9.12-0
+    version: 1.9.13-2
   rospack:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp`:
- previous version: `1.9.12-0`
- new version: `1.9.13-2`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.0`
