### PR TITLE
Delete laser_tool and wlkeyctrl to documentation index for distro

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -706,10 +706,6 @@ repositories:
     type: git
     url: https://github.com/ros-perception/laser_pipeline.git
     version: groovy-devel
-  laser_tool:
-    type: git
-    url: https://github.com/WuNL/laser_tool.git
-    version: groovy
   libsegwayrmp:
     type: git
     url: https://github.com/segwayrmp/libsegwayrmp.git
@@ -1595,10 +1591,6 @@ repositories:
     type: git
     url: https://github.com/ros-windows/win_ros.git
     version: groovy-devel
-  wlkeyctrl:
-    type: git
-    url: https://github.com/WuNL/wlkeyctrl.git
-    version: groovy
   xacro:
     type: git
     url: https://github.com/ros/xacro


### PR DESCRIPTION
Because of documenting error .I cant create a ros wiki page now.
So ,I will edit them and pull requests again.

By the way, could you give me some suggestions about creating a wiki page? I use catkin_create_pkg to create a package but I can't find any file named manifest.xml,but your tutorials http://www.ros.org/wiki/PackageDocumentation need to ' Put the wiki page link in your manifest.xml file'.

Will you give me some help?
Thank you very much~
