### PR TITLE
freenect_stack: 0.2.2-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -307,7 +307,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-drivers-gbp/freenect_stack-release.git
-    version: 0.2.1-0
+    version: 0.2.2-0
   gencpp:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `freenect_stack`:
- previous version: `0.2.1-0`
- new version: `0.2.2-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.1`
