### PR TITLE
ros-controls updates

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -67,6 +67,10 @@ repositories:
     type: git
     url: https://github.com/ros/common_msgs.git
     version: groovy-devel
+  control_toolbox:
+    type: git
+    url: https://github.com/ros-controls/control_toolbox.git
+    version: hydro-devel
   ecl_core:
     type: git
     url: https://github.com/stonier/ecl_core.git
@@ -187,6 +191,10 @@ repositories:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core
     version: groovy-devel
+  realtime_tools:
+    type: git
+    url: https://github.com/ros-controls/realtime_tools.git
+    version: hydro-devel
   robot_model:
     type: git
     url: https://github.com/ros/robot_model.git
@@ -225,12 +233,12 @@ repositories:
     version: groovy-devel
   ros_control:
     type: git
-    url: https://github.com/willowgarage/ros_control
-    version: master
+    url: https://github.com/ros-controls/ros_control.git
+    version: hydro-devel
   ros_controllers:
     type: git
-    url: https://github.com/willowgarage/ros_controllers
-    version: master
+    url: https://github.com/ros-controls/ros_controllers.git
+    version: hydro-devel
   ros_tutorials:
     type: git
     url: https://github.com/ros/ros_tutorials.git

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -117,7 +117,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/control_toolbox-release.git
-    version: 1.10.0-0  
+    version: 1.10.0-0
   convex_decomposition:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Release control_toolbox 1.10.0
Release realtime_tools 1.8.0
Update doc URLs for repositories moved to ros-controls github org.
