### PR TITLE
ros_control: 0.4.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -988,6 +988,19 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros_comm-release.git
     version: 1.9.46-0
+  ros_control:
+    packages:
+      controller_interface:
+      controller_manager:
+      controller_manager_msgs:
+      controller_manager_tests:
+      hardware_interface:
+      ros_control:
+      transmission_interface:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/ros_control-release.git
+    version: 0.4.0-0
   ros_http_video_streamer:
     url: https://github.com/ros-gbp/ros_http_video_streamer-release.git
   ros_tutorials:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control`:
- previous version: `null`
- new version: `0.4.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.1`
