### PR TITLE
octomap_rviz_plugins: 0.0.3-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -809,7 +809,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/octomap_rviz_plugins-release.git
-    version: 0.0.2-0
+    version: 0.0.3-0
   ompl:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_rviz_plugins`:
- previous version: `0.0.2-0`
- new version: `0.0.3-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.1`
