### PR TITLE
moveit_core: 0.4.5-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -600,7 +600,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/moveit_core-release.git
-    version: 0.4.3-0
+    version: 0.4.5-0
   moveit_metapackages:
     packages:
       moveit_full:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_core`:
- previous version: `0.4.3-0`
- new version: `0.4.5-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.1`
