### PR TITLE
ecl_tools: 0.60.0-2 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -213,7 +213,10 @@ repositories:
       ecl_build:
       ecl_license:
       ecl_tools:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/ecl_tools-release.git
+    version: 0.60.0-2
   ecto:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_tools`:
- previous version: `null`
- new version: `0.60.0-2`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.1`
