### PR TITLE
ecl_lite: 0.60.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -193,7 +193,10 @@ repositories:
       ecl_lite:
       ecl_sigslots_lite:
       ecl_time_lite:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/ecl_lite-release.git
+    version: 0.60.0-0
   ecl_manipulation:
     packages:
       ecl:


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_lite`:
- previous version: `null`
- new version: `0.60.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.1`
