### PR TITLE
moveit_setup_assistant: 0.4.1-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -689,7 +689,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
-    version: 0.4.0-0
+    version: 0.4.1-0
   multi_level_map:
     packages:
       multi_level_map:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_setup_assistant`:
- previous version: `0.4.0-0`
- new version: `0.4.1-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.1`
