### PR TITLE
laser_assembler: 1.7.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -465,6 +465,7 @@ repositories:
     url: https://github.com/ros-gbp/korg_nanokontrol-release.git
     version: 0.1.1-0
   laser_assembler:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/laser_assembler-release.git

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -464,6 +464,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/korg_nanokontrol-release.git
     version: 0.1.1-0
+  laser_assembler:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/laser_assembler-release.git
+    version: 1.7.1-0
   laser_filters:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_assembler`:
- previous version: `null`
- new version: `1.7.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.1`
