### PR TITLE
filters: 1.7.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -284,7 +284,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/filters-release.git
-    version: 1.7.1-0
+    version: 1.7.2-0
   flann:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `filters`:
- previous version: `1.7.1-0`
- new version: `1.7.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.1`
