### PR TITLE
ros_controllers: 0.4.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1013,6 +1013,19 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros_control-release.git
     version: 0.4.0-0
+  ros_controllers:
+    packages:
+      controllers_msgs:
+      effort_controllers:
+      forward_command_controller:
+      joint_state_controller:
+      position_controllers:
+      ros_controllers:
+      velocity_controllers:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/ros_controllers-release.git
+    version: 0.4.0-0
   ros_http_video_streamer:
     url: https://github.com/ros-gbp/ros_http_video_streamer-release.git
   ros_tutorials:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers`:
- previous version: `null`
- new version: `0.4.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.1`
