### PR TITLE
control_toolbox: 1.10.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -117,7 +117,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/control_toolbox-release.git
-    version: 1.10.0-0
+    version: 1.10.1-0
   convex_decomposition:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox`:
- previous version: `1.10.0-0`
- new version: `1.10.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.1`
