### PR TITLE
stage: 4.1.1-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1180,6 +1180,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/srdfdom-release.git
     version: 0.2.5-0
+  stage:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/stage-release.git
+    version: 4.1.1-1
   std_msgs:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `stage`:
- previous version: `null`
- new version: `4.1.1-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.1`
