### PR TITLE
ros_control: 0.4.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1012,7 +1012,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros_control-release.git
-    version: 0.4.0-0
+    version: 0.4.0-1
   ros_controllers:
     packages:
       controllers_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control`:
- previous version: `0.4.0-0`
- new version: `0.4.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.1`
