### PR TITLE
ecl_manipulation: 0.60.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -202,7 +202,10 @@ repositories:
       ecl:
       ecl_manipulation:
       ecl_manipulators:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/ecl_manipulation-release.git
+    version: 0.60.0-0
   ecl_navigation:
     packages:
       ecl_maps:


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_manipulation`:
- previous version: `null`
- new version: `0.60.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.1`
