### PR TITLE
Manual update-release of ecl_navigation

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -211,12 +211,12 @@ repositories:
     version: 0.60.0-0
   ecl_navigation:
     packages:
-      ecl_maps:
       ecl_mobile_robot:
       ecl_navigation:
-      ecl_navigation_apps:
-      ecl_slam:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/ecl_navigation-release.git
+    version: 0.60.0-2
   ecl_tools:
     packages:
       ecl_build:


### PR DESCRIPTION
Failed to pull request by bloom since some packages were removed. Rather obscure bloom error (can bloom intelligently work this out easily?)

```
Failed to open pull request: RuntimeError - dictionary changed size during iteration
```
