### PR TITLE
laser_pipeline: 1.6.1-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -504,6 +504,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/laser_geometry-release.git
     version: 1.5.8-0
+  laser_pipeline:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/laser_pipeline-release.git
+    version: 1.6.1-1
   laser_proc:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_pipeline`:
- previous version: `null`
- new version: `1.6.1-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.1`
