### PR TITLE
geometry_experimental: 0.4.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -388,7 +388,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/geometry_experimental-release.git
-    version: 0.4.0-0
+    version: 0.4.0-1
   gscam:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_experimental`:
- previous version: `0.4.0-0`
- new version: `0.4.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.1`
