### PR TITLE
freenect_stack: 0.2.2-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -305,9 +305,9 @@ repositories:
       freenect_stack:
     status: maintained
     tags:
-      release: release/groovy/{package}/{version}
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/freenect_stack-release.git
-    version: 0.2.2-0
+    version: 0.2.2-1
   gazebo:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `freenect_stack`:
- previous version: `0.2.2-0`
- new version: `0.2.2-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.1`
