### PR TITLE
openni_camera: 1.9.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -750,7 +750,10 @@ repositories:
     url: https://github.com/ros-gbp/opencv_candidate-release.git
     version: 0.1.8-0
   openni_camera:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/openni_camera-release.git
+    version: 1.9.0-0
   openni_launch:
     url: https://github.com/ros-gbp/openni_launch-release.git
   orocos_kdl:


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_camera`:
- previous version: `null`
- new version: `1.9.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
