### PR TITLE
stage: 4.1.1-4 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1212,7 +1212,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/stage-release.git
-    version: 4.1.1-3
+    version: 4.1.1-4
   std_msgs:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `stage`:
- previous version: `4.1.1-3`
- new version: `4.1.1-4`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
