### PR TITLE
pr2_mechanism: 1.8.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -810,6 +810,18 @@ repositories:
     version: 1.11.2-0
   pr2_controllers_msgs:
     url: https://github.com/ros-gbp/pr2_controllers_msgs-release.git
+  pr2_mechanism:
+    packages:
+      pr2_controller_interface:
+      pr2_controller_manager:
+      pr2_hardware_interface:
+      pr2_mechanism:
+      pr2_mechanism_diagnostics:
+      pr2_mechanism_model:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/pr2_mechanism-release.git
+    version: 1.8.0-0
   pr2_mechanism_msgs:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_mechanism`:
- previous version: `null`
- new version: `1.8.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
