### PR TITLE
rviz 1.10.0

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1182,7 +1182,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rviz-release.git
-    version: 1.9.30-0
+    version: 1.10.0-0
   sbpl:
     url: https://github.com/ros-gbp/sbpl-release.git
   segbot:


### PR DESCRIPTION
I did the normal bloom release process but when it was ready to push the updated hydro/release.yaml file, it showed that I was going to delete the entire "segbot" section from the file. I guess this must have resulted from a race condition where the segbot section was added after my version was pulled but before it was pushed.  Presumably this could be fixed or reduced by adding a separate pull step right before the push step.

Anyway, since I have push access to this repo if I click "edit" on this file it would actually push it immediately instead of making a pull request to you.  Therefore I made my edit on a branch I created and now I'm submitting it as a pull request manually.

Phew!

Hope you are doing well there!  Thanks for managing all this.  Latest bloom version is really slick. :)
