### PR TITLE
openni_launch: 1.9.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -755,7 +755,10 @@ repositories:
     url: https://github.com/ros-gbp/openni_camera-release.git
     version: 1.9.0-0
   openni_launch:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/openni_launch-release.git
+    version: 1.9.0-0
   orocos_kdl:
     packages:
       orocos_kdl:


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_launch`:
- previous version: `null`
- new version: `1.9.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
