### PR TITLE
openni_camera: 1.8.9-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -840,9 +840,9 @@ repositories:
     version: 0.1.8-0
   openni_camera:
     tags:
-      release: release/{package}/{upstream_version}
+      release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/openni_camera-release.git
-    version: 1.8.8-0
+    version: 1.8.9-0
   openni_launch:
     tags:
       release: release/{package}/{upstream_version}


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_camera`:
- previous version: `1.8.8-0`
- new version: `1.8.9-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
