### PR TITLE
image_transport_plugins: 1.8.21-1 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -426,7 +426,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/image_transport_plugins-release.git
-    version: 1.8.20-0
+    version: 1.8.21-1
   interactive_marker_proxy:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins`:
- previous version: `1.8.20-0`
- new version: `1.8.21-1`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.1`
