### PR TITLE
laser_filters: 1.6.10-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -498,7 +498,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/laser_filters-release.git
-    version: 1.6.9-0
+    version: 1.6.10-0
   laser_geometry:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters`:
- previous version: `1.6.9-0`
- new version: `1.6.10-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
