### PR TITLE
ecl_core: 0.60.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -186,7 +186,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/ecl_core-release.git
-    version: 0.60.0-0
+    version: 0.60.1-0
   ecl_lite:
     packages:
       ecl_config:


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_core`:
- previous version: `0.60.0-0`
- new version: `0.60.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.1`
