### PR TITLE
prosilica-driver: 1.9.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -841,6 +841,14 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pr2_power_drivers-release.git
     version: 1.1.0-0
+  prosilica-driver:
+    packages:
+      prosilica_camera:
+        subfolder: prosilica_camera
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-drivers-gbp/prosilica_driver-release.git
+    version: 1.9.0-0
   prosilica_gige_sdk:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `prosilica-driver`:
- previous version: `null`
- new version: `1.9.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
