### PR TITLE
stage_ros: 1.7.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1261,6 +1261,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/stage-release.git
     version: 4.1.1-4
+  stage_ros:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/stage_ros-release.git
+    version: 1.7.0-0
   std_msgs:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `stage_ros`:
- previous version: `null`
- new version: `1.7.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
