### PR TITLE
rqt_pr2_dashboard: 0.2.4-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1185,6 +1185,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rqt_common_plugins-release.git
     version: 0.2.16-0
+  rqt_pr2_dashboard:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/130s/rqt_pr2_dashboard-release.git
+    version: 0.2.4-0
   rqt_robot_plugins:
     packages:
       rqt_nav_view:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1188,7 +1188,7 @@ repositories:
   rqt_pr2_dashboard:
     tags:
       release: release/hydro/{package}/{version}
-    url: https://github.com/130s/rqt_pr2_dashboard-release.git
+    url: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
     version: 0.2.4-0
   rqt_robot_plugins:
     packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_pr2_dashboard`:
- previous version: `null`
- new version: `0.2.4-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
