### PR TITLE
Adding drrobot_jaguar_ros_pkg to document index for distro

### DIFF
--- a/doc/fuerte/drrobot_jaguar_ros_pkg.rosinstall
+++ b/doc/fuerte/drrobot_jaguar_ros_pkg.rosinstall
@@ -1,0 +1,6 @@
+- git:
+	uri:https://github.com/gitdrrobot/dri_jaguar4X4_player.git
+	local-name: dri_jaguar4X4_player
+- git:
+	uri:https://github.com/gitdrrobot/drrobot_motionsensor_driver.git
+	local-name: drrobot_motionsensor_driver


### PR DESCRIPTION
I'd like drrobot_jaguar_ros_pkg to be indexed and documented on ros.org
