### PR TITLE
rqt_robot_plugins: 0.2.16-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1265,7 +1265,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-    version: 0.2.15-0
+    version: 0.2.16-0
   rviz:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins`:
- previous version: `0.2.15-0`
- new version: `0.2.16-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
