### PR TITLE
bfl: 0.7.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -35,9 +35,9 @@ repositories:
     version: 0.2.2-0
   bfl:
     tags:
-      release: release/groovy/{package}/{version}
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/bfl-release.git
-    version: 0.7.0-0
+    version: 0.7.0-1
   bond_core:
     packages:
       bond:


### PR DESCRIPTION
Increasing version of package(s) in repository `bfl`:
- previous version: `0.7.0-0`
- new version: `0.7.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
