### PR TITLE
laser_geometry: 1.5.8-2 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -827,7 +827,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pr2_mechanism-release.git
-    version: 1.8.0-0
+    version: 1.8.1-0
   pr2_mechanism_msgs:
     tags:
       release: release/hydro/{package}/{version}

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -506,7 +506,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/laser_geometry-release.git
-    version: 1.5.8-0
+    version: 1.5.8-2
   laser_pipeline:
     tags:
       release: release/hydro/{package}/{version}
@@ -827,7 +827,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pr2_mechanism-release.git
-    version: 1.8.1-0
+    version: 1.8.0-0
   pr2_mechanism_msgs:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry`:
- previous version: `1.5.8-0`
- new version: `1.5.8-2`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.1`
