### PR TITLE
segbot: 0.1.0-2 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1217,7 +1217,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/utexas-bwi/segbot-release.git
-    version: 0.1.0-1
+    version: 0.1.0-2
   segway_rmp:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot`:
- previous version: `0.1.0-1`
- new version: `0.1.0-2`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
