### PR TITLE
segbot_apps: 0.1.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1222,6 +1222,7 @@ repositories:
     packages:
       segbot_apps:
       segbot_navigation:
+    status: developed
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/utexas-bwi/segbot_apps-release.git

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1218,6 +1218,14 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/utexas-bwi/segbot-release.git
     version: 0.1.0-2
+  segbot_apps:
+    packages:
+      segbot_apps:
+      segbot_navigation:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/utexas-bwi/segbot_apps-release.git
+    version: 0.1.0-0
   segway_rmp:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot_apps`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
