### PR TITLE
laser_geometry: 1.5.10-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -514,7 +514,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/laser_geometry-release.git
-    version: 1.5.9-0
+    version: 1.5.10-0
   laser_pipeline:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry`:
- previous version: `1.5.9-0`
- new version: `1.5.10-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
