### PR TITLE
prosilica_gige_sdk: 1.26.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -864,7 +864,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/prosilica_gige_sdk-release.git
-    version: 1.26.0-0
+    version: 1.26.1-0
   python_qt_binding:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `prosilica_gige_sdk`:
- previous version: `1.26.0-0`
- new version: `1.26.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
