### PR TITLE
Release prosilica_driver 1.9.1-0

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -852,15 +852,17 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pr2_power_drivers-release.git
     version: 1.1.0-0
-  prosilica-driver:
+  prosilica_driver:
     packages:
       prosilica_camera:
         subfolder: prosilica_camera
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/prosilica_driver-release.git
-    version: 1.9.0-0
+    version: 1.9.1-0
   prosilica_gige_sdk:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/prosilica_gige_sdk-release.git


### PR DESCRIPTION
Release prosilica_driver 1.9.1-0, fix name and add maintainer status.
