### PR TITLE
laser_geometry: 1.5.10-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -518,7 +518,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/laser_geometry-release.git
-    version: 1.5.9-0
+    version: 1.5.10-0
   laser_proc:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry`:
- previous version: `1.5.9-0`
- new version: `1.5.10-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
