### PR TITLE
openslam_gmapping: 0.1.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -770,6 +770,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/openni_launch-release.git
     version: 1.9.0-0
+  openslam_gmapping:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/openslam_gmapping-release
+    version: 0.1.0-1
   orocos_kdl:
     packages:
       orocos_kdl:


### PR DESCRIPTION
Increasing version of package(s) in repository `openslam_gmapping`:
- previous version: `null`
- new version: `0.1.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
