### PR TITLE
slam_gmapping: 1.3.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1277,6 +1277,14 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/sicktoolbox_wrapper-release.git
     version: 2.5.2-0
+  slam_gmapping:
+    packages:
+      gmapping:
+      slam_gmapping:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/slam_gmapping-release.git
+    version: 1.3.0-1
   sql_database:
     url: https://github.com/ros-gbp/sql_database-release.git
   srdfdom:


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_gmapping`:
- previous version: `null`
- new version: `1.3.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
