### PR TITLE
common_tutorials: 0.1.4-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -102,6 +102,19 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/common_msgs-release.git
     version: 1.9.16-0
+  common_tutorials:
+    packages:
+      common_tutorials:
+      learning_actionlib:
+        subfolder: actionlib_tutorials
+      nodelet_tutorial_math:
+      pluginlib_tutorials:
+      turtle_actionlib:
+    status: maintained
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/common_tutorials-release.git
+    version: 0.1.4-0
   console_bridge:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `common_tutorials`:
- previous version: `null`
- new version: `0.1.4-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
