### PR TITLE
Revert "rqt_robot_plugins: 0.2.16-0 in 'groovy/release.yaml' [bloom]"

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1265,7 +1265,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-    version: 0.2.16-0
+    version: 0.2.15-0
   rviz:
     status: maintained
     tags:


### PR DESCRIPTION
This reverts commit a4440df70babd3631a96000fc613ea5507d7910e.

The versions are not tagged correctly inside the repo.

Same issue as with hydro: a19c251fba9a5eca2cc4a90fbc1401cf4413c475
