### PR TITLE
visualization-tutorials: 0.8.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1418,6 +1418,18 @@ repositories:
     version: 1.10.6-0
   visp:
     url: https://github.com/laas/visp-release.git
+  visualization-tutorials:
+    packages:
+      interactive_marker_tutorials:
+      librviz_tutorial:
+      rviz_plugin_tutorials:
+      rviz_python_tutorial:
+      visualization_marker_tutorials:
+      visualization_tutorials:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/visualization_tutorials-release.git
+    version: 0.8.0-0
   warehouse_ros:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization-tutorials`:
- previous version: `null`
- new version: `0.8.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
