### PR TITLE
rqt_common_plugins: 0.2.17-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1228,11 +1228,13 @@ repositories:
       rqt_bag_plugins:
       rqt_common_plugins:
       rqt_console:
+      rqt_cpp_common:
       rqt_dep:
       rqt_graph:
       rqt_image_view:
       rqt_launch:
       rqt_logger_level:
+      rqt_marble:
       rqt_msg:
       rqt_plot:
       rqt_publisher:
@@ -1242,13 +1244,14 @@ repositories:
       rqt_service_caller:
       rqt_shell:
       rqt_srv:
+      rqt_top:
       rqt_topic:
       rqt_web:
     status: developed
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-    version: 0.2.16-0
+    version: 0.2.17-0
   rqt_robot_plugins:
     packages:
       rqt_moveit:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins`:
- previous version: `0.2.16-0`
- new version: `0.2.17-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
