### PR TITLE
razer_hydra: 0.0.1-1 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -933,6 +933,11 @@ repositories:
       release: release/{package}/{upstream_version}
     url: https://github.com/ros-gbp/random_numbers-release.git
     version: 0.1.3-0
+  razer_hydra:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/aleeper/razer_hydra-release.git
+    version: 0.0.1-1
   reflexxes_type2:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `razer_hydra`:
- previous version: `null`
- new version: `0.0.1-1`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
