### PR TITLE
Revert "rqt_common_plugins: 0.2.17-0 in 'hydro/release.yaml' [bloom]"

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1192,13 +1192,11 @@ repositories:
       rqt_bag_plugins:
       rqt_common_plugins:
       rqt_console:
-      rqt_cpp_common:
       rqt_dep:
       rqt_graph:
       rqt_image_view:
       rqt_launch:
       rqt_logger_level:
-      rqt_marble:
       rqt_msg:
       rqt_plot:
       rqt_publisher:
@@ -1208,14 +1206,13 @@ repositories:
       rqt_service_caller:
       rqt_shell:
       rqt_srv:
-      rqt_top:
       rqt_topic:
       rqt_web:
     status: developed
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-    version: 0.2.17-0
+    version: 0.2.16-0
   rqt_pr2_dashboard:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
This reverts commit 3c15215e1d3643fc2bc277148261125638769a68.

Reversing #1160 as it has the same problem as #1146
