### PR TITLE
interaction_cursor_3d: 0.0.1-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -427,6 +427,15 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/image_transport_plugins-release.git
     version: 1.8.21-1
+  interaction_cursor_3d:
+    packages:
+      interaction_cursor_demo:
+      interaction_cursor_msgs:
+      interaction_cursor_rviz:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/aleeper/interaction_cursor_3d-release.git
+    version: 0.0.1-0
   interactive_marker_proxy:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `interaction_cursor_3d`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
