### PR TITLE
underwater_simulation: 1.2.0-4 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1332,7 +1332,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/uji-ros-pkg/underwater_simulation-release.git
-    version: 1.2.0-3
+    version: 1.2.0-4
   unique_identifier:
     packages:
       unique_id:


### PR DESCRIPTION
Increasing version of package(s) in repository `underwater_simulation`:
- previous version: `1.2.0-3`
- new version: `1.2.0-4`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
