### PR TITLE
bfl: 0.7.0-3 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -37,7 +37,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/bfl-release.git
-    version: 0.7.0-1
+    version: 0.7.0-3
   bond_core:
     packages:
       bond:


### PR DESCRIPTION
Increasing version of package(s) in repository `bfl`:
- previous version: `0.7.0-1`
- new version: `0.7.0-3`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
