### PR TITLE
robot_model: 1.9.36-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -966,7 +966,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/robot_model-release.git
-    version: 1.9.35-0
+    version: 1.9.36-0
   robot_pose_publisher:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model`:
- previous version: `1.9.35-0`
- new version: `1.9.36-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.1`
