### PR TITLE
robot_model: 1.10.12-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -937,7 +937,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/robot_model-release.git
-    version: 1.10.11-0
+    version: 1.10.12-0
   robot_pose_publisher:
     url: https://github.com/wpi-rail-release/robot_pose_publisher-release.git
   robot_state_publisher:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model`:
- previous version: `1.10.11-0`
- new version: `1.10.12-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
