### PR TITLE
yujin_ocs: 0.3.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1469,9 +1469,13 @@ repositories:
     packages:
       cmd_vel_mux:
       yocs_controllers:
+      yocs_diff_drive_pose_controller:
       yocs_velocity_smoother:
       yujin_ocs:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/yujin_ocs-release.git
+    version: 0.3.0-0
   zeroconf_avahi_suite:
     packages:
       zeroconf_avahi:


### PR DESCRIPTION
Increasing version of package(s) in repository `yujin_ocs`:
- previous version: `null`
- new version: `0.3.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
