### PR TITLE
warehouse_ros: 0.8.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1448,7 +1448,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/warehouse-release.git
-    version: 0.8.0-0
+    version: 0.8.2-0
   wifi_ddwrt:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros`:
- previous version: `0.8.0-0`
- new version: `0.8.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
