### PR TITLE
moveit_resources: 0.4.1-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -664,7 +664,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/moveit_resources-release.git
-    version: 0.4.0-0
+    version: 0.4.1-0
   moveit_ros:
     packages:
       moveit_ros:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources`:
- previous version: `0.4.0-0`
- new version: `0.4.1-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
