### PR TITLE
moveit_resources: 0.4.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -644,7 +644,10 @@ repositories:
     url: https://github.com/ros-gbp/moveit_pr2-release.git
   moveit_resources:
     status: maintained
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_resources-release.git
+    version: 0.4.1-0
   moveit_ros:
     packages:
       moveit_ros:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources`:
- previous version: `null`
- new version: `0.4.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
