### PR TITLE
moveit_ros: 0.4.4-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -650,6 +650,8 @@ repositories:
       moveit_ros:
       moveit_ros_benchmarks:
         subfolder: benchmarks
+      moveit_ros_benchmarks_gui:
+        subfolder: benchmarks_gui
       moveit_ros_manipulation:
         subfolder: manipulation
       moveit_ros_move_group:
@@ -660,12 +662,17 @@ repositories:
         subfolder: planning
       moveit_ros_planning_interface:
         subfolder: planning_interface
+      moveit_ros_robot_interaction:
+        subfolder: robot_interaction
       moveit_ros_visualization:
         subfolder: visualization
       moveit_ros_warehouse:
         subfolder: warehouse
     status: maintained
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_ros-release.git
+    version: 0.4.4-0
   moveit_setup_assistant:
     status: maintained
     url: https://github.com/ros-gbp/moveit_setup_assistant-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ros`:
- previous version: `null`
- new version: `0.4.4-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
