### PR TITLE
moveit_setup_assistant: 0.4.1-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -678,7 +678,10 @@ repositories:
     version: 0.4.4-0
   moveit_setup_assistant:
     status: maintained
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
+    version: 0.4.1-1
   nmea_gps_driver:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_setup_assistant`:
- previous version: `null`
- new version: `0.4.1-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
