### PR TITLE
moveit_commander: 0.4.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -600,7 +600,10 @@ repositories:
     version: 1.5.9-0
   moveit_commander:
     status: maintained
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_commander-release.git
+    version: 0.4.2-0
   moveit_core:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_commander`:
- previous version: `null`
- new version: `0.4.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
