### PR TITLE
moveit_plugins: 0.4.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -649,7 +649,7 @@ repositories:
       moveit_simple_controller_manager:
     tags:
       release: release/hydro/{package}/{version}
-    url: https://github.com/ros-gbp/moveit_plugins-release
+    url: https://github.com/ros-gbp/moveit_plugins-release.git
     version: 0.4.1-0
   moveit_pr2:
     packages:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -643,6 +643,14 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_planners-release.git
     version: 0.4.0-0
+  moveit_plugins:
+    packages:
+      moveit_plugins:
+      moveit_simple_controller_manager:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/moveit_plugins-release
+    version: 0.4.1-0
   moveit_pr2:
     packages:
       moveit_pr2:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_plugins`:
- previous version: `null`
- new version: `0.4.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
