### PR TITLE
moveit_metapackages: 0.4.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -626,7 +626,10 @@ repositories:
       moveit_full:
       moveit_full_pr2:
     status: maintained
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_metapackages-release.git
+    version: 0.4.1-0
   moveit_msgs:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_metapackages`:
- previous version: `null`
- new version: `0.4.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
