### PR TITLE
moveit_ros: 0.4.5-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -692,7 +692,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/moveit_ros-release.git
-    version: 0.4.4-0
+    version: 0.4.5-0
   moveit_setup_assistant:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ros`:
- previous version: `0.4.4-0`
- new version: `0.4.5-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
