### PR TITLE
rospack: 2.1.20-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1221,7 +1221,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rospack-release.git
-    version: 2.1.19-0
+    version: 2.1.20-0
   rqt:
     packages:
       rqt:


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack`:
- previous version: `2.1.19-0`
- new version: `2.1.20-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
