### PR TITLE
ros: 1.10.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1090,7 +1090,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros-release.git
-    version: 1.10.2-0
+    version: 1.10.3-0
   ros_comm:
     packages:
       message_filters:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros`:
- previous version: `1.10.2-0`
- new version: `1.10.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
