### PR TITLE
ros_comm: 1.9.47-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1130,6 +1130,24 @@ repositories:
         subfolder: utilities/roswtf
       std_srvs:
         subfolder: messages/std_srvs
+      test_rosbag:
+        subfolder: test/test_rosbag
+      test_roscpp:
+        subfolder: test/test_roscpp
+      test_rosgraph:
+        subfolder: test/test_rosgraph
+      test_roslaunch:
+        subfolder: test/test_roslaunch
+      test_roslib_comm:
+        subfolder: test/test_roslib_comm
+      test_rosmaster:
+        subfolder: test/test_rosmaster
+      test_rosparam:
+        subfolder: test/test_rosparam
+      test_rospy:
+        subfolder: test/test_rospy
+      test_rosservice:
+        subfolder: test/test_rosservice
       topic_tools:
         subfolder: tools/topic_tools
       xmlrpcpp:
@@ -1138,7 +1156,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros_comm-release.git
-    version: 1.9.46-0
+    version: 1.9.47-0
   ros_control:
     packages:
       controller_interface:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm`:
- previous version: `1.9.46-0`
- new version: `1.9.47-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
