### PR TITLE
genmsg: 0.4.21-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -324,7 +324,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/genmsg-release.git
-    version: 0.4.20-0
+    version: 0.4.21-0
   genpy:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg`:
- previous version: `0.4.20-0`
- new version: `0.4.21-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
