### PR TITLE
ros: 1.9.48-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1077,7 +1077,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/ros-release.git
-    version: 1.9.47-0
+    version: 1.9.48-0
   ros_comm:
     packages:
       message_filters:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros`:
- previous version: `1.9.47-0`
- new version: `1.9.48-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
