### PR TITLE
ros_comm: 1.9.47-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1117,6 +1117,24 @@ repositories:
         subfolder: utilities/roswtf
       std_srvs:
         subfolder: messages/std_srvs
+      test_rosbag:
+        subfolder: test/test_rosbag
+      test_roscpp:
+        subfolder: test/test_roscpp
+      test_rosgraph:
+        subfolder: test/test_rosgraph
+      test_roslaunch:
+        subfolder: test/test_roslaunch
+      test_roslib_comm:
+        subfolder: test/test_roslib_comm
+      test_rosmaster:
+        subfolder: test/test_rosmaster
+      test_rosparam:
+        subfolder: test/test_rosparam
+      test_rospy:
+        subfolder: test/test_rospy
+      test_rosservice:
+        subfolder: test/test_rosservice
       topic_tools:
         subfolder: tools/topic_tools
       xmlrpcpp:
@@ -1125,7 +1143,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/ros_comm-release.git
-    version: 1.9.46-0
+    version: 1.9.47-0
   ros_http_video_streamer:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm`:
- previous version: `1.9.46-0`
- new version: `1.9.47-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
