### PR TITLE
genpy: 0.4.13-1 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -330,7 +330,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/genpy-release.git
-    version: 0.4.12-0
+    version: 0.4.13-1
   geometric_shapes:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy`:
- previous version: `0.4.12-0`
- new version: `0.4.13-1`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
