### PR TITLE
rospack: 2.1.20-1 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1205,7 +1205,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/rospack-release.git
-    version: 2.1.19-0
+    version: 2.1.20-1
   rospy_message_converter:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack`:
- previous version: `2.1.19-0`
- new version: `2.1.20-1`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
