### PR TITLE
navigation: 1.11.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -705,6 +705,30 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
     version: 0.4.1-1
+  navigation:
+    packages:
+      amcl:
+      base_local_planner:
+      carrot_planner:
+      clear_costmap_recovery:
+      costmap_2d:
+      dwa_local_planner:
+      fake_localization:
+      global_planner:
+      map_server:
+      move_base:
+      move_base_msgs:
+      move_slow_and_clear:
+      nav_core:
+      navfn:
+      navigation:
+      robot_pose_ekf:
+      rotate_recovery:
+      voxel_grid:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/navigation-release.git
+    version: 1.11.0-0
   nmea_gps_driver:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation`:
- previous version: `null`
- new version: `1.11.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
