### PR TITLE
ecl_core: 0.60.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -645,7 +645,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_planners-release.git
-    version: 0.4.0-0
+    version: 0.4.1-0
   moveit_plugins:
     packages:
       moveit_plugins:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -199,7 +199,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/ecl_core-release.git
-    version: 0.60.4-0
+    version: 0.60.5-0
   ecl_lite:
     packages:
       ecl_config:
@@ -645,7 +645,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_planners-release.git
-    version: 0.4.1-0
+    version: 0.4.0-0
   moveit_plugins:
     packages:
       moveit_plugins:


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_core`:
- previous version: `0.60.4-0`
- new version: `0.60.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
