### PR TITLE
pcl: 1.7.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -881,7 +881,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pcl-release.git
-    version: 1.6.0-1
+    version: 1.7.0-1
   pcl_msgs:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl`:
- previous version: `1.6.0-1`
- new version: `1.7.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
