### PR TITLE
moveit_planners: 0.4.1-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -627,10 +627,6 @@ repositories:
     version: 0.4.0-0
   moveit_planners:
     packages:
-      moveit_ompl_planners_core:
-        subfolder: remove_in_hydro/moveit_ompl_planners_core
-      moveit_ompl_planners_ros_plugin:
-        subfolder: remove_in_hydro/moveit_ompl_planners_ros_plugin
       moveit_planners:
       moveit_planners_ompl:
         subfolder: ompl
@@ -638,7 +634,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/moveit_planners-release.git
-    version: 0.4.0-0
+    version: 0.4.1-0
   moveit_plugins:
     packages:
       moveit_plugins:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_planners`:
- previous version: `0.4.0-0`
- new version: `0.4.1-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
