### PR TITLE
catkin: 0.5.69-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -79,7 +79,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/catkin-release.git
-    version: 0.5.68-0
+    version: 0.5.69-0
   class_loader:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin`:
- previous version: `0.5.68-0`
- new version: `0.5.69-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
