### PR TITLE
catkin: 0.5.69-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -80,7 +80,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/catkin-release.git
-    version: 0.5.68-0
+    version: 0.5.69-0
   class_loader:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin`:
- previous version: `0.5.68-0`
- new version: `0.5.69-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
