### PR TITLE
rospack: 2.1.21-1 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1219,7 +1219,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/rospack-release.git
-    version: 2.1.20-1
+    version: 2.1.21-1
   rospy_message_converter:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack`:
- previous version: `2.1.20-1`
- new version: `2.1.21-1`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
