### PR TITLE
precise has a different package name for flann library

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -656,7 +656,10 @@ libfftw3:
   ubuntu: [libfftw3-3, libfftw3-dev]
 libflann:
   debian: [libflann1.7]
-  ubuntu: [libflann1.7]
+  ubuntu:
+    precise:  [libflann1]
+    quantal:  [libflann1.7]
+    raring:  [libflann1.7]
 libflann-dev:
   debian: [libflann-dev]
   ubuntu: [libflann-dev]


### PR DESCRIPTION
This should fix hydro pcl on precise. 

Source http://packages.ubuntu.com/search?keywords=flann&searchon=names
