### PR TITLE
groovy/doc: add pr2_controllers dependency to katana_driver

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -655,6 +655,8 @@ repositories:
     url: https://jsk-ros-pkg.svn.sourceforge.net/svnroot/jsk-ros-pkg/trunk
     version: HEAD
   katana_driver:
+    depends:
+    - pr2_controllers
     type: git
     url: https://github.com/uos/katana_driver.git
     version: groovy


### PR DESCRIPTION
The indexer gets confused while trying to guess what debs I would like to
have installed; it thinks I want
`ros-groovy-pr2-controllers-msgs` and freaks out because that deb doesn't 
exist, refusing to even generate a groovy link for the documentation (so 
there even isn't any link to the error output on the wiki). Maybe we can work
around that bug by adding the dependency to the correct stack manually, let's
wait and see in a few days.

See https://github.com/ros/rosdistro/issues/1235
