### PR TITLE
kobuki_msgs: 0.4.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -504,7 +504,10 @@ repositories:
       kobuki_testsuite:
     url: https://github.com/yujinrobot-release/kobuki-release.git
   kobuki_msgs:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/kobuki_msgs-release.git
+    version: 0.4.0-0
   korg_nanokontrol:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_msgs`:
- previous version: `null`
- new version: `0.4.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
