### PR TITLE
pcl: 1.7.0-6 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -878,7 +878,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pcl-release.git
-    version: 1.7.0-5
+    version: 1.7.0-6
   perception_pcl:
     packages:
       pcl_ros:


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl`:
- previous version: `1.7.0-5`
- new version: `1.7.0-6`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
