### PR TITLE
openni_tracker: 0.2.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -859,6 +859,7 @@ repositories:
     url: https://github.com/ros-gbp/openni_launch-release.git
     version: 1.9.0-0
   openni_tracker:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/openni_tracker-release.git

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -858,6 +858,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/openni_launch-release.git
     version: 1.9.0-0
+  openni_tracker:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/openni_tracker-release.git
+    version: 0.2.0-0
   openslam_gmapping:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_tracker`:
- previous version: `null`
- new version: `0.2.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
