### PR TITLE
eml: 0.36.0-3 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -291,7 +291,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/eml-release.git
-    version: 0.36.0-2
+    version: 0.36.0-3
   executive_smach:
     packages:
       executive_smach:


### PR DESCRIPTION
Increasing version of package(s) in repository `eml`:
- previous version: `0.36.0-2`
- new version: `0.36.0-3`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
