### PR TITLE
rqt_pr2_dashboard: 0.2.4-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1316,7 +1316,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
-    version: 0.2.4-0
+    version: 0.2.4-1
   rqt_robot_plugins:
     packages:
       rqt_nav_view:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_pr2_dashboard`:
- previous version: `0.2.4-0`
- new version: `0.2.4-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
