### PR TITLE
libuvc-release: 0.0.1-3 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -578,6 +578,11 @@ repositories:
     version: 0.2.9-0
   libsiftfast:
     url: https://github.com/start-jsk/libsiftfast-release.git
+  libuvc-release:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ktossell/libuvc-release.git
+    version: 0.0.1-3
   manipulation_msgs:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc-release`:
- previous version: `null`
- new version: `0.0.1-3`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
