### PR TITLE
new libusb package name on arch

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1088,7 +1088,7 @@ libunittest++:
     apt:
       packages: [libunittest++-dev]
 libusb-1.0-dev:
-  arch: [libusb]
+  arch: [libusbx]
   debian: [libusb-1.0-0-dev]
   fedora:
     beefy: [libusb1-devel]


### PR DESCRIPTION
ArchLinux no longer includes libusb; it has been replaced
with libusbx.
