### PR TITLE
rqt_robot_plugins: 0.2.16-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1324,6 +1324,7 @@ repositories:
     version: 0.2.4-1
   rqt_robot_plugins:
     packages:
+      rqt_moveit:
       rqt_nav_view:
       rqt_pose_view:
       rqt_robot_dashboard:
@@ -1332,10 +1333,11 @@ repositories:
       rqt_robot_steering:
       rqt_runtime_monitor:
       rqt_rviz:
+      rqt_tf_tree:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-    version: 0.2.9-0
+    version: 0.2.16-0
   rviz:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins`:
- previous version: `0.2.9-0`
- new version: `0.2.16-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
