### PR TITLE
pcl_msgs: 0.1.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -909,7 +909,7 @@ repositories:
   pcl_msgs:
     tags:
       release: release/hydro/{package}/{version}
-    url: https://github.com/ros-gbp/pcl_msgs-release
+    url: https://github.com/ros-gbp/pcl_msgs-release.git
     version: 0.1.0-0
   perception_pcl:
     packages:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -906,6 +906,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pcl_conversions-release.git
     version: 0.1.0-0
+  pcl_msgs:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/pcl_msgs-release
+    version: 0.1.0-0
   perception_pcl:
     packages:
       pcl_ros:


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_msgs`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
