### PR TITLE
kobuki: 0.4.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -507,13 +507,17 @@ repositories:
       kobuki_auto_docking:
       kobuki_bumper2pc:
       kobuki_controller_tutorial:
+      kobuki_description:
       kobuki_driver:
       kobuki_ftdi:
       kobuki_keyop:
       kobuki_node:
       kobuki_safety_controller:
       kobuki_testsuite:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/kobuki-release.git
+    version: 0.4.0-0
   kobuki_msgs:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki`:
- previous version: `null`
- new version: `0.4.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
