### PR TITLE
openni_tracker: 0.2.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -873,7 +873,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/openni_tracker-release.git
-    version: 0.2.0-0
+    version: 0.2.0-1
   openslam_gmapping:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_tracker`:
- previous version: `0.2.0-0`
- new version: `0.2.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
