### PR TITLE
pr2_ethercat_drivers: 1.8.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -940,6 +940,15 @@ repositories:
     version: 1.11.2-0
   pr2_controllers_msgs:
     url: https://github.com/ros-gbp/pr2_controllers_msgs-release.git
+  pr2_ethercat_drivers:
+    packages:
+      ethercat_hardware:
+      fingertip_pressure:
+      pr2_ethercat_drivers:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/pr2_ethercat_drivers-release.git
+    version: 1.8.0-0
   pr2_mechanism:
     packages:
       pr2_controller_interface:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_ethercat_drivers`:
- previous version: `null`
- new version: `1.8.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
