### PR TITLE
segbot: 0.1.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1379,7 +1379,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/utexas-bwi/segbot-release.git
-    version: 0.1.0-2
+    version: 0.1.3-0
   segbot_apps:
     packages:
       segbot_apps:


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot`:
- previous version: `0.1.0-2`
- new version: `0.1.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
