### PR TITLE
eband_local_planner: 0.1.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -172,6 +172,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
     version: 1.5.32-0
+  eband_local_planner:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/utexas-bwi/eband_local_planner-release.git
+    version: 0.1.0-0
   ecl_core:
     packages:
       ecl_command_line:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -173,6 +173,7 @@ repositories:
     url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
     version: 1.5.32-0
   eband_local_planner:
+    status: developed
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/utexas-bwi/eband_local_planner-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `eband_local_planner`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
