### PR TITLE
segbot_simulator: 0.1.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1399,6 +1399,15 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/utexas-bwi/segbot_apps-release.git
     version: 0.1.1-0
+  segbot_simulator:
+    packages:
+      segbot_gazebo:
+      segbot_gazebo_plugins:
+      segbot_simulator:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/utexas-bwi/segbot_simulator-release.git
+    version: 0.1.0-0
   segway_rmp:
     status: maintained
     tags:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1404,6 +1404,7 @@ repositories:
       segbot_gazebo:
       segbot_gazebo_plugins:
       segbot_simulator:
+    status: developed
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/utexas-bwi/segbot_simulator-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot_simulator`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
