### PR TITLE
pr2_controllers: 1.10.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -948,6 +948,22 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pr2_common-release.git
     version: 1.11.2-0
+  pr2_controllers:
+    packages:
+      ethercat_trigger_controllers:
+      joint_trajectory_action:
+      pr2_calibration_controllers:
+      pr2_controllers:
+      pr2_controllers_msgs:
+      pr2_gripper_action:
+      pr2_head_action:
+      pr2_mechanism_controllers:
+      robot_mechanism_controllers:
+      single_joint_position_action:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/pr2_controllers-release.git
+    version: 1.10.1-0
   pr2_ethercat_drivers:
     packages:
       ethercat_hardware:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_controllers`:
- previous version: `null`
- new version: `1.10.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
