### PR TITLE
turtlebot_create: 2.1.0-4 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1496,7 +1496,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/turtlebot-release/turtlebot_create-release.git
-    version: 2.1.0-3
+    version: 2.1.0-4
   underwater_simulation:
     packages:
       underwater_sensor_msgs:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1493,6 +1493,7 @@ repositories:
       create_driver:
       create_node:
       turtlebot_create:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/turtlebot-release/turtlebot_create-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_create`:
- previous version: `2.1.0-3`
- new version: `2.1.0-4`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
