### PR TITLE
usb_cam: 0.1.3-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1415,7 +1415,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/bosch-ros-pkg-release/usb_cam-release.git
-    version: 0.1.2-0
+    version: 0.1.3-0
   uwsim_bullet:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam`:
- previous version: `0.1.2-0`
- new version: `0.1.3-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
