### PR TITLE
prosilica_driver: 1.9.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1014,7 +1014,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/prosilica_driver-release.git
-    version: 1.9.1-0
+    version: 1.9.3-0
   prosilica_gige_sdk:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `prosilica_driver`:
- previous version: `1.9.1-0`
- new version: `1.9.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
