### PR TITLE
geometry: 1.10.4-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -390,7 +390,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/geometry-release.git
-    version: 1.10.3-0
+    version: 1.10.4-0
   geometry_angles_utils:
     packages:
       angles:


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry`:
- previous version: `1.10.3-0`
- new version: `1.10.4-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
