### PR TITLE
Release pr2_ethercat_drivers 1.8.1-0

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -975,7 +975,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pr2_ethercat_drivers-release.git
-    version: 1.8.0-0
+    version: 1.8.1-0
   pr2_mechanism:
     packages:
       pr2_controller_interface:


### PR DESCRIPTION
Fixes deprecation warnings and compile warnings.
