### PR TITLE
pr2_controllers: 1.10.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -976,7 +976,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pr2_controllers-release.git
-    version: 1.10.1-0
+    version: 1.10.2-0
   pr2_ethercat_drivers:
     packages:
       ethercat_hardware:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_controllers`:
- previous version: `1.10.1-0`
- new version: `1.10.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
