### PR TITLE
rolling back segbot to 0.1.0-2

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1417,7 +1417,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/utexas-bwi/segbot-release.git
-    version: 0.1.3-0
+    version: 0.1.0-2
   segbot_apps:
     packages:
       segbot_apps:


### PR DESCRIPTION
It has 0.1.3-0 in the package.xml but 0.1.0-2 in the debian changelog which means that it retriggers continuously. 

For example: https://github.com/utexas-bwi/segbot-release/tree/debian/ros-hydro-segbot_0.1.3-0_precise

rollback of #1293 
