### PR TITLE
gazebo_ros_pkgs: 2.1.1-2 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -344,12 +344,13 @@ repositories:
       gazebo_msgs:
       gazebo_plugins:
       gazebo_ros:
+      gazebo_ros_control:
       gazebo_ros_pkgs:
     status: developed
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-    version: 2.1.1-1
+    version: 2.1.1-2
   gencpp:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs`:
- previous version: `2.1.1-1`
- new version: `2.1.1-2`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
