### PR TITLE
moveit_core: 0.4.7-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -652,7 +652,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_core-release.git
-    version: 0.4.6-1
+    version: 0.4.7-0
   moveit_ikfast:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_core`:
- previous version: `0.4.6-1`
- new version: `0.4.7-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
