### PR TITLE
wge100_driver: 1.8.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1655,6 +1655,15 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/warehouse-release.git
     version: 0.8.4-0
+  wge100_driver:
+    packages:
+      wge100_camera:
+      wge100_camera_firmware:
+      wge100_driver:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-drivers-gbp/wge100_driver-release.git
+    version: 1.8.0-0
   wifi_ddwrt:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `wge100_driver`:
- previous version: `null`
- new version: `1.8.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
