### PR TITLE
pcl: 1.7.0-9 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -925,7 +925,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pcl-release.git
-    version: 1.7.0-8
+    version: 1.7.0-9
   pcl_conversions:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl`:
- previous version: `1.7.0-8`
- new version: `1.7.0-9`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
