### PR TITLE
common_msgs: 1.10.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -101,7 +101,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/common_msgs-release.git
-    version: 1.9.16-0
+    version: 1.10.0-0
   common_tutorials:
     packages:
       actionlib_tutorials:


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs`:
- previous version: `1.9.16-0`
- new version: `1.10.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
