### PR TITLE
segbot: 0.1.4-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -176,7 +176,7 @@ repositories:
     status: developed
     tags:
       release: release/hydro/{package}/{version}
-    url: https://github.com/utexas-bwi/eband_local_planner-release.git
+    url: https://github.com/utexas-bwi-gbp/eband_local_planner-release.git
     version: 0.1.1-0
   ecl_core:
     packages:
@@ -1430,7 +1430,7 @@ repositories:
     status: developed
     tags:
       release: release/hydro/{package}/{version}
-    url: https://github.com/utexas-bwi/segbot-release.git
+    url: https://github.com/utexas-bwi-gbp/segbot-release.git
     version: 0.1.4-0
   segbot_apps:
     packages:
@@ -1439,7 +1439,7 @@ repositories:
     status: developed
     tags:
       release: release/hydro/{package}/{version}
-    url: https://github.com/utexas-bwi/segbot_apps-release.git
+    url: https://github.com/utexas-bwi-gbp/segbot_apps-release.git
     version: 0.1.1-0
   segbot_simulator:
     packages:
@@ -1449,7 +1449,7 @@ repositories:
     status: developed
     tags:
       release: release/hydro/{package}/{version}
-    url: https://github.com/utexas-bwi/segbot_simulator-release.git
+    url: https://github.com/utexas-bwi-gbp/segbot_simulator-release.git
     version: 0.1.0-0
   segway_rmp:
     status: maintained

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1431,7 +1431,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/utexas-bwi/segbot-release.git
-    version: 0.1.0-2
+    version: 0.1.4-0
   segbot_apps:
     packages:
       segbot_apps:


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot`:
- previous version: `0.1.0-2`
- new version: `0.1.4-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
