### PR TITLE
class_loader: 0.1.30-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -85,7 +85,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/class_loader-release.git
-    version: 0.1.29-0
+    version: 0.1.30-0
   common_msgs:
     packages:
       actionlib_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader`:
- previous version: `0.1.29-0`
- new version: `0.1.30-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
