### PR TITLE
pluginlib: 1.9.21-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -893,7 +893,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/pluginlib-release.git
-    version: 1.9.20-0
+    version: 1.9.21-0
   pr2_mechanism_msgs:
     tags:
       release: release/{package}/{upstream_version}


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib`:
- previous version: `1.9.20-0`
- new version: `1.9.21-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
