### PR TITLE
roscpp_core: 0.3.16-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1189,7 +1189,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/roscpp_core-release.git
-    version: 0.3.15-0
+    version: 0.3.16-0
   rosdoc_lite:
     tags:
       release: release/{package}/{upstream_version}


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core`:
- previous version: `0.3.15-0`
- new version: `0.3.16-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
