### PR TITLE
class_loader: 0.2.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -84,7 +84,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/class_loader-release.git
-    version: 0.2.1-0
+    version: 0.2.2-0
   common_msgs:
     packages:
       actionlib_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader`:
- previous version: `0.2.1-0`
- new version: `0.2.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
