### PR TITLE
turtlebot: 2.1.0-2 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1535,6 +1535,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/turtlebot-release/turtlebot-release.git
+    version: 2.1.0-2
   turtlebot_create:
     packages:
       create_description:


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot`:
- previous version: `null`
- new version: `2.1.0-2`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
