### PR TITLE
moveit_planners: 0.5.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -693,7 +693,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_planners-release.git
-    version: 0.4.2-0
+    version: 0.5.0-0
   moveit_plugins:
     packages:
       moveit_plugins:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_planners`:
- previous version: `0.4.2-0`
- new version: `0.5.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
