### PR TITLE
octomap_msgs: 0.3.1-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -864,7 +864,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/octomap_msgs-release.git
-    version: 0.3.0-0
+    version: 0.3.1-1
   octomap_ros:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_msgs`:
- previous version: `0.3.0-0`
- new version: `0.3.1-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
