### PR TITLE
pr2_robot: 1.6.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1031,13 +1031,13 @@ repositories:
       pr2_camera_synchronizer:
       pr2_computer_monitor:
       pr2_controller_configuration:
-      pr2_etherCAT:
+      pr2_ethercat:
       pr2_robot:
       pr2_run_stop_auto_restart:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pr2_robot-release.git
-    version: 1.6.0-0
+    version: 1.6.1-0
   prosilica_driver:
     packages:
       prosilica_camera:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_robot`:
- previous version: `1.6.0-0`
- new version: `1.6.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
