### PR TITLE
image_transport_plugins: 1.8.21-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -320,8 +320,6 @@ repositories:
     url: https://github.com/ros-gbp/executive_smach-release.git
     version: 1.3.0-0
   executive_smach_visualization:
-    packages:
-      smach_viewer:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/jbohren/executive_smach_visualization-release.git
@@ -403,8 +401,6 @@ repositories:
     url: https://github.com/ros-gbp/geometry-release.git
     version: 1.10.4-0
   geometry_angles_utils:
-    packages:
-      angles:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/geometry_angles_utils-release.git
@@ -482,7 +478,10 @@ repositories:
       compressed_image_transport:
       image_transport_plugins:
       theora_image_transport:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/image_transport_plugins-release.git
+    version: 1.8.21-0
   interactive_marker_proxy:
     status: maintained
     url: https://github.com/ros-gbp/interactive_marker_proxy-release.git
@@ -547,8 +546,6 @@ repositories:
     url: https://github.com/yujinrobot-release/kobuki_msgs-release.git
     version: 0.4.0-0
   kobuki_soft:
-    packages:
-      kobuki_softnode:
     status: developed
     tags:
       release: release/hydro/{package}/{version}
@@ -1039,8 +1036,6 @@ repositories:
     url: https://github.com/ros-gbp/pr2_robot-release.git
     version: 1.6.1-0
   prosilica_driver:
-    packages:
-      prosilica_camera:
     status: maintained
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins`:
- previous version: `null`
- new version: `1.8.21-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
