### PR TITLE
image_transport_plugins: 1.8.21-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -482,7 +482,10 @@ repositories:
       compressed_image_transport:
       image_transport_plugins:
       theora_image_transport:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/image_transport_plugins-release.git
+    version: 1.8.21-0
   interactive_marker_proxy:
     status: maintained
     url: https://github.com/ros-gbp/interactive_marker_proxy-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins`:
- previous version: `null`
- new version: `1.8.21-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
