### PR TITLE
rosserial: 0.5.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1359,6 +1359,19 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rospack-release.git
     version: 2.1.21-0
+  rosserial:
+    packages:
+      rosserial:
+      rosserial_arduino:
+      rosserial_client:
+      rosserial_embeddedlinux:
+      rosserial_msgs:
+      rosserial_python:
+      rosserial_xbee:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: ' https://github.com/ros-gbp/rosserial-release'
+    version: 0.5.1-0
   rqt:
     packages:
       rqt:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1370,7 +1370,7 @@ repositories:
       rosserial_xbee:
     tags:
       release: release/hydro/{package}/{version}
-    url: ' https://github.com/ros-gbp/rosserial-release'
+    url: https://github.com/ros-gbp/rosserial-release
     version: 0.5.1-0
   rqt:
     packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial`:
- previous version: `null`
- new version: `0.5.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
