### PR TITLE
audio_common: 0.2.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -32,7 +32,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/audio_common-release.git
-    version: 0.2.2-0
+    version: 0.2.3-0
   bfl:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common`:
- previous version: `0.2.2-0`
- new version: `0.2.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
