### PR TITLE
pr2_robot: 1.6.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1042,7 +1042,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pr2_robot-release.git
-    version: 1.6.1-0
+    version: 1.6.2-0
   prosilica_driver:
     packages:
       prosilica_camera:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_robot`:
- previous version: `1.6.1-0`
- new version: `1.6.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
