### PR TITLE
wu_ros_tools: 0.1.0-4 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1454,6 +1454,18 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/warehouse-release.git
     version: 0.7.12-0
+  wu_ros_tools:
+    packages:
+      catkinize_this:
+      easy_markers:
+      manifest_cleaner:
+      rosbaglive:
+      roswiki_node:
+      wu_ros_tools:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/wu-robotics/wu_ros_tools
+    version: 0.1.0-4
   youbot_driver:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `wu_ros_tools`:
- previous version: `null`
- new version: `0.1.0-4`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
