### PR TITLE
random_numbers: 0.2.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1083,7 +1083,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/random_numbers-release.git
-    version: 0.1.3-0
+    version: 0.2.0-0
   realtime_tools:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `random_numbers`:
- previous version: `0.1.3-0`
- new version: `0.2.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
