### PR TITLE
srdfdom: 0.2.5-1 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1353,9 +1353,9 @@ repositories:
     version: 0.4.7-0
   srdfdom:
     tags:
-      release: release/hydro/{package}/{version}
+      release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/srdfdom-release.git
-    version: 0.2.5-0
+    version: 0.2.5-1
   std_msgs:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom`:
- previous version: `0.2.5-0`
- new version: `0.2.5-1`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
