### PR TITLE
robot_pose_publisher: 0.2.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1112,7 +1112,10 @@ repositories:
     url: https://github.com/ros-gbp/robot_model-release.git
     version: 1.10.12-0
   robot_pose_publisher:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/wpi-rail-release/robot_pose_publisher-release.git
+    version: 0.2.2-0
   robot_state_publisher:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_pose_publisher`:
- previous version: `null`
- new version: `0.2.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
