### PR TITLE
rospy_message_converter: 0.2.0-2 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1367,6 +1367,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rospack-release.git
     version: 2.1.21-0
+  rospy_message_converter:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/baalexander/rospy_message_converter-release.git
+    version: 0.2.0-2
   rosserial:
     packages:
       rosserial:


### PR DESCRIPTION
Increasing version of package(s) in repository `rospy_message_converter`:
- previous version: `null`
- new version: `0.2.0-2`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
