### PR TITLE
segbot_simulator: 0.1.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1476,7 +1476,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/utexas-bwi-gbp/segbot_apps-release.git
-    version: 0.1.3-0
+    version: 0.1.2-0
   segbot_simulator:
     packages:
       segbot_gazebo:
@@ -1486,7 +1486,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/utexas-bwi-gbp/segbot_simulator-release.git
-    version: 0.1.1-0
+    version: 0.1.2-0
   segway_rmp:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot_simulator`:
- previous version: `0.1.1-0`
- new version: `0.1.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
