### PR TITLE
rviz: 1.9.31-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1299,7 +1299,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/rviz-release.git
-    version: 1.9.30-0
+    version: 1.9.31-0
   rx:
     packages:
       rx:


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz`:
- previous version: `1.9.30-0`
- new version: `1.9.31-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
