### PR TITLE
wge100_driver: 1.8.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1742,7 +1742,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/wge100_driver-release.git
-    version: 1.8.1-0
+    version: 1.8.2-0
   wifi_ddwrt:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `wge100_driver`:
- previous version: `1.8.1-0`
- new version: `1.8.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
