### PR TITLE
ros_controllers: 0.5.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1300,9 +1300,10 @@ repositories:
     version: 0.4.0-1
   ros_controllers:
     packages:
-      controllers_msgs:
       effort_controllers:
+      force_torque_sensor_controller:
       forward_command_controller:
+      imu_sensor_controller:
       joint_state_controller:
       position_controllers:
       ros_controllers:
@@ -1311,7 +1312,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros_controllers-release.git
-    version: 0.4.0-1
+    version: 0.5.0-0
   ros_http_video_streamer:
     url: https://github.com/ros-gbp/ros_http_video_streamer-release.git
   ros_tutorials:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers`:
- previous version: `0.4.0-1`
- new version: `0.5.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
