### PR TITLE
velodyne release 1.1.0

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1704,7 +1704,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/velodyne-release.git
-    version: 1.0.1-0
+    version: 1.1.0-0
   vision_opencv:
     packages:
       cv_bridge:


### PR DESCRIPTION
- Fix build problems due to PCL 1.7 API incompatibilities (ros-drivers/velodyne#8). This version no longer works with earlier PCL releases.
- Fix errors with Mac OSX compiler (ros-drivers/velodyne#8).
- Install pluginlib XML files (ros-drivers/velodyne#9).
- Install some launch and parameter files.
- Enable unit tests when CATKIN_ENABLE_TESTING is set (ros-drivers/velodyne#10).
