### PR TITLE
removing rosserial due to changelog mismatch causing constant triggering

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1396,7 +1396,6 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rosserial-release
-    version: 0.5.1-0
   rqt:
     packages:
       rqt:


### PR DESCRIPTION
See #1395 for more discussion
