### PR TITLE
rosserial: 0.5.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1396,6 +1396,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rosserial-release
+    version: 0.5.2-0
   rqt:
     packages:
       rqt:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial`:
- previous version: `null`
- new version: `0.5.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
