### PR TITLE
robot_model: 1.10.13-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1110,7 +1110,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/robot_model-release.git
-    version: 1.10.12-0
+    version: 1.10.13-0
   robot_pose_publisher:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model`:
- previous version: `1.10.12-0`
- new version: `1.10.13-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
