### PR TITLE
moveit_planners: 0.4.2-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -633,7 +633,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/moveit_planners-release.git
-    version: 0.4.1-0
+    version: 0.4.2-0
   moveit_plugins:
     packages:
       moveit_plugins:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_planners`:
- previous version: `0.4.1-0`
- new version: `0.4.2-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
