### PR TITLE
turtlebot_apps: 2.1.0-2 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1577,7 +1577,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/turtlebot-release/turtlebot_apps-release.git
-    version: 2.1.0-1
+    version: 2.1.0-2
   turtlebot_create:
     packages:
       create_description:


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_apps`:
- previous version: `2.1.0-1`
- new version: `2.1.0-2`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
