### PR TITLE
rosauth: 0.1.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1311,7 +1311,10 @@ repositories:
     url: https://github.com/ros-gbp/ros_tutorials-release.git
     version: 0.3.11-0
   rosauth:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/wpi-rail-release/rosauth-release.git
+    version: 0.1.3-0
   rosbridge_suite:
     packages:
       rosapi:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosauth`:
- previous version: `null`
- new version: `0.1.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
