### PR TITLE
Adding kinect_aux to documentation index for groovy

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -667,6 +667,10 @@ repositories:
     type: git
     url: https://github.com/uos/katana_driver.git
     version: groovy
+  kinect_aux:
+    type: git
+    url: https://github.com/muhrix/kinect_aux.git
+    version: groovy
   knowrob:
     type: svn
     url: http://code.in.tum.de/pubsvn/knowrob/branches/release


### PR DESCRIPTION
Hello,

I would like my port of the kinect_aux package to be indexed and documented on ros.org.

I have catkinised the standalone kinect_aux package and tested under Precise + Groovy.
I will also be updating the corresponding wiki page once/if the package gets indexed.

Many thanks,

Murilo
