### PR TITLE
Removed clearpath_turtlebot docs from Groovy.

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -196,10 +196,6 @@ repositories:
     type: svn
     url: https://clearpath-ros-pkg.googlecode.com/svn/trunk/clearpath_kingfisher
     version: HEAD
-  clearpath_turtlebot:
-    type: svn
-    url: https://clearpath-ros-pkg.googlecode.com/svn/trunk/clearpath_turtlebot
-    version: HEAD
   client_rosjava_jni:
     type: git
     url: https://github.com/gheorghelisca/rosjava_jni.git


### PR DESCRIPTION
This package does not support Groovy and should not have docs generated
in this release.
