### PR TITLE
ros_control: 0.5.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1275,13 +1275,14 @@ repositories:
       controller_manager_msgs:
       controller_manager_tests:
       hardware_interface:
+      joint_limits_interface:
       ros_control:
       transmission_interface:
     status: developed
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros_control-release.git
-    version: 0.4.0-2
+    version: 0.5.0-0
   ros_controllers:
     packages:
       effort_controllers:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control`:
- previous version: `0.4.0-2`
- new version: `0.5.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
