### PR TITLE
srdfdom: 0.2.6-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1549,7 +1549,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/srdfdom-release.git
-    version: 0.2.5-0
+    version: 0.2.6-0
   stage:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom`:
- previous version: `0.2.5-0`
- new version: `0.2.6-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
