### PR TITLE
srdfdom: 0.2.6-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1360,7 +1360,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/srdfdom-release.git
-    version: 0.2.5-1
+    version: 0.2.6-0
   std_msgs:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom`:
- previous version: `0.2.5-1`
- new version: `0.2.6-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
