### PR TITLE
urdfdom_headers: 0.2.3-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1678,7 +1678,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/urdfdom_headers-release.git
-    version: 0.2.3-0
+    version: 0.2.3-1
   urg_c:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_headers`:
- previous version: `0.2.3-0`
- new version: `0.2.3-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
