### PR TITLE
Bumped ros_controllers

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1314,7 +1314,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros_controllers-release.git
-    version: 0.5.0-0
+    version: 0.5.1-0
   ros_http_video_streamer:
     url: https://github.com/ros-gbp/ros_http_video_streamer-release.git
   ros_tutorials:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1281,7 +1281,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros_control-release.git
-    version: 0.4.0-2
+    version: 0.5.0-0
   ros_controllers:
     packages:
       effort_controllers:


### PR DESCRIPTION
For some reason the automatic version didn't work: @wjwwood

```
Open a pull request from 'davetcoleman/rosdistro:bloom-patch-3' into 'ros/rosdistro:master'?
Continue [Y/n]? Y
==> git checkout -b bloom-patch-3 bloom/master
Branch bloom-patch-3 set up to track remote branch master from bloom.
Switched to a new branch 'bloom-patch-3'
==> Writing new distribution file: hydro/release.yaml
==> git add hydro/release.yaml
==> git commit -m "ros_controllers: 0.5.1-0 in 'hydro/release.yaml' [bloom]"
[bloom-patch-3 20d85d7] ros_controllers: 0.5.1-0 in 'hydro/release.yaml' [bloom]
 1 file changed, 1 insertion(+), 1 deletion(-)
==> git push origin bloom-patch-3
To https://github.com/davetcoleman/rosdistro.git
 * [new branch]      bloom-patch-3 -> bloom-patch-3
Failed to create pull request: 401 Unauthorized
```
