### PR TITLE
clearpath_common: 0.3.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -94,7 +94,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpathrobotics/clearpath_common-release.git
-    version: 0.3.0-0
+    version: 0.3.1-0
   cob_common:
     packages:
       brics_actuator:


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common`:
- previous version: `0.3.0-0`
- new version: `0.3.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
