### PR TITLE
eigen_stl_containers: 0.1.4-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -279,7 +279,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/eigen_stl_containers-release.git
-    version: 0.1.3-0
+    version: 0.1.4-0
   euslisp:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `eigen_stl_containers`:
- previous version: `0.1.3-0`
- new version: `0.1.4-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.2`
