### PR TITLE
common_tutorials: 0.1.7-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -134,7 +134,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/common_tutorials-release.git
-    version: 0.1.6-0
+    version: 0.1.7-0
   console_bridge:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `common_tutorials`:
- previous version: `0.1.6-0`
- new version: `0.1.7-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
