### PR TITLE
visualization_tutorials: 0.8.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1749,7 +1749,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/visualization_tutorials-release.git
-    version: 0.8.0-0
+    version: 0.8.1-0
   warehouse_ros:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_tutorials`:
- previous version: `0.8.0-0`
- new version: `0.8.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.3`
