### PR TITLE
navigation: 1.11.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -792,7 +792,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/navigation-release.git
-    version: 1.11.2-0
+    version: 1.11.3-0
   nmea_gps_driver:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation`:
- previous version: `1.11.2-0`
- new version: `1.11.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.3`
