### PR TITLE
perception_pcl: 1.1.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -969,7 +969,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/perception_pcl-release.git
-    version: 1.1.2-0
+    version: 1.1.3-0
   pluginlib:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl`:
- previous version: `1.1.2-0`
- new version: `1.1.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.3`
