### PR TITLE
Moving Groovy nmea_gps_driver to GitHub

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -914,8 +914,8 @@ repositories:
     version: HEAD
   nmea_gps_driver:
     type: git
-    url: https://kforge.ros.org/gpsdrivers/nmea_gps_driver
-    version: master
+    url: https://github.com/ros-drivers/nmea_gps_driver.git
+    version: groovy-devel
   nodelet_core:
     type: git
     url: https://github.com/ros/nodelet_core.git


### PR DESCRIPTION
Moving the source code link for nmea_gps_driver in Groovy to GitHub in preparation for deleting the kforge project.

This should update the source link on http://www.ros.org/wiki/nmea_gps_driver/ for Groovy.
