### PR TITLE
Moving Fuerte nmea_gps_driver to GitHub

### DIFF
--- a/doc/fuerte/nmea_gps_driver.rosinstall
+++ b/doc/fuerte/nmea_gps_driver.rosinstall
@@ -1,4 +1,6 @@
 - git:
     local-name: nmea_gps_driver
-    uri: https://kforge.ros.org/gpsdrivers/nmea_gps_driver
-    version: master
+    uri: https://github.com/ros-drivers/nmea_gps_driver.git
+    version: fuerte-devel
+    meta:
+        repo-name: ros-drivers


### PR DESCRIPTION
Moving the source code link for nmea_gps_driver in Fuerte to GitHub in preparation for deleting the kforge project.

This should update the source link on http://www.ros.org/wiki/nmea_gps_driver/ for Fuerte.
