### PR TITLE
turtlebot: 2.1.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1578,7 +1578,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/turtlebot-release/turtlebot-release.git
-    version: 2.1.0-2
+    version: 2.1.1-0
   turtlebot_apps:
     packages:
       pano_core:


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot`:
- previous version: `2.1.0-2`
- new version: `2.1.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.3`
