### PR TITLE
camera1394stereo: 1.0.0-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -69,6 +69,11 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/calibration-release.git
     version: 0.9.28-0
+  camera1394stereo:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: git@github.com:srv/camera1394stereo-release.git
+    version: 1.0.0-0
   camera_info_manager_py:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `camera1394stereo`:
- previous version: `null`
- new version: `1.0.0-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.3`
