### PR TITLE
executive_smach: 1.3.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -329,7 +329,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/executive_smach-release.git
-    version: 1.3.0-0
+    version: 1.3.1-0
   executive_smach_visualization:
     packages:
       smach_viewer:


### PR DESCRIPTION
Increasing version of package(s) in repository `executive_smach`:
- previous version: `1.3.0-0`
- new version: `1.3.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.3`
