### PR TITLE
add some hydro-devel branches to hydro/doc.yaml

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -227,6 +227,18 @@ repositories:
     type: svn
     url: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/hlugv_common
     version: HEAD
+  image_common:
+    type: git
+    url: https://github.com/ros-perception/image_common.git
+    version: hydro-devel
+  image_pipeline:
+    type: git
+    url: https://github.com/ros-perception/image_pipeline.git
+    version: hydro-devel
+  image_transport_plugins:
+    type: git
+    url: https://github.com/ros-perception/image_transport_plugins.git
+    version: hydro-devel
   iwaki:
     type: git
     url: https://github.com/maxipesfix/iwaki-ros-pkg.git


### PR DESCRIPTION
Provide missing doc entries for image_common, image_pipeline and image_transport_plugins
