### PR TITLE
pr2_ethercat_drivers: 1.8.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1012,7 +1012,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pr2_ethercat_drivers-release.git
-    version: 1.8.1-0
+    version: 1.8.2-0
   pr2_mechanism:
     packages:
       pr2_controller_interface:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_ethercat_drivers`:
- previous version: `1.8.1-0`
- new version: `1.8.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.3`
