### PR TITLE
ros_control: 0.5.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1024,7 +1024,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pr2_mechanism-release.git
-    version: 1.8.6-0
+    version: 1.8.5-0
   pr2_mechanism_msgs:
     tags:
       release: release/hydro/{package}/{version}
@@ -1300,7 +1300,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros_control-release.git
-    version: 0.5.1-0
+    version: 0.5.2-0
   ros_controllers:
     packages:
       effort_controllers:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control`:
- previous version: `0.5.1-0`
- new version: `0.5.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.3`
