### PR TITLE
ros_control: 0.5.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1300,7 +1300,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros_control-release.git
-    version: 0.5.2-1
+    version: 0.5.3-0
   ros_controllers:
     packages:
       effort_controllers:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control`:
- previous version: `0.5.2-1`
- new version: `0.5.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.3`
