### PR TITLE
p2os: 1.0.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -947,7 +947,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/allenh1/p2os-release.git
-    version: 1.0.1-0
+    version: 1.0.2-0
   pcl:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os`:
- previous version: `1.0.1-0`
- new version: `1.0.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.3`
