### PR TITLE
p2os: 1.0.2-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -872,6 +872,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/allenh1/p2os-release.git
+    version: 1.0.2-0
   pcl:
     tags:
       release: release/{package}/{upstream_version}


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os`:
- previous version: `null`
- new version: `1.0.2-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.3`
