### PR TITLE
Add docs for PR2 stacks.

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -391,6 +391,18 @@ repositories:
     type: git
     url: https://github.com/PR2/pr2_common.git
     version: hydro-devel
+  pr2_controllers:
+    type: git
+    url: https://github.com/PR2/pr2_controllers.git
+    version: hydro-devel
+  pr2_ethercat_drivers:
+    type: git
+    url: https://github.com/PR2/pr2_ethercat_drivers.git
+    version: hydro-devel
+  pr2_mechanism:
+    type: git
+    url: https://github.com/PR2/pr2_mechanism.git
+    version: hydro-devel
   pr2_mechanism_msgs:
     type: git
     url: https://github.com/PR2/pr2_mechanism_msgs.git
@@ -402,6 +414,10 @@ repositories:
   pr2_power_drivers:
     type: git
     url: https://github.com/PR2/pr2_power_drivers.git
+    version: hydro-devel
+  pr2_robot:
+    type: git
+    url: https://github.com/PR2/pr2_robot.git
     version: hydro-devel
   python_qt_binding:
     type: git


### PR DESCRIPTION
Add doc URLs for pr2_mechanism, pr2_ethercat_drivers, pr2_controllers and pr2_robot.
