### PR TITLE
unique_identifier: 1.0.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1663,7 +1663,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-geographic-info/unique_identifier-release.git
-    version: 1.0.2-0
+    version: 1.0.3-0
   urdf_tutorial:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `unique_identifier`:
- previous version: `1.0.2-0`
- new version: `1.0.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
