### PR TITLE
nodelet_core: 1.7.17-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -732,7 +732,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/nodelet_core-release.git
-    version: 1.7.16-0
+    version: 1.7.17-0
   object_recognition_capture:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core`:
- previous version: `1.7.16-0`
- new version: `1.7.17-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
