### PR TITLE
cmake_modules: 0.1.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -95,6 +95,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpathrobotics/clearpath_common-release.git
     version: 0.3.1-0
+  cmake_modules:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/cmake_modules-release.git
+    version: 0.1.0-0
   cob_common:
     packages:
       brics_actuator:


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
