### PR TITLE
velodyne_height_map: 0.4.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1733,6 +1733,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/velodyne-release.git
     version: 1.1.0-0
+  velodyne_height_map:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/jack-oquin-ros-releases/velodyne_height_map-release.git
+    version: 0.4.0-0
   vision_opencv:
     packages:
       cv_bridge:


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_height_map`:
- previous version: `null`
- new version: `0.4.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
