### PR TITLE
velodyne_utils: 0.4.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1738,6 +1738,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/jack-oquin-ros-releases/velodyne_height_map-release.git
     version: 0.4.0-0
+  velodyne_utils:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/jack-oquin-ros-releases/velodyne_utils-release.git
+    version: 0.4.0-0
   vision_opencv:
     packages:
       cv_bridge:


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_utils`:
- previous version: `null`
- new version: `0.4.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
