### PR TITLE
cmake_modules: 0.1.0-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -91,6 +91,11 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/class_loader-release.git
     version: 0.1.30-0
+  cmake_modules:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/ros-gbp/cmake_modules-release.git
+    version: 0.1.0-0
   common_msgs:
     packages:
       actionlib_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
