### PR TITLE
camera_info_manager_py: 0.2.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -73,7 +73,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/jack-oquin/camera_info_manager_py-release.git
-    version: 0.2.1-0
+    version: 0.2.2-0
   catkin:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_info_manager_py`:
- previous version: `0.2.1-0`
- new version: `0.2.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
