### PR TITLE
camera_info_manager_py: 0.2.2-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -79,7 +79,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/jack-oquin/camera_info_manager_py-release.git
-    version: 0.2.1-0
+    version: 0.2.2-0
   catkin:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_info_manager_py`:
- previous version: `0.2.1-0`
- new version: `0.2.2-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
