### PR TITLE
camera1394stereo: 1.0.1-1 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -73,7 +73,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/srv/camera1394stereo-release.git
-    version: 1.0.1-0
+    version: 1.0.1-1
   camera_info_manager_py:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `camera1394stereo`:
- previous version: `1.0.1-0`
- new version: `1.0.1-1`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
