### PR TITLE
open_karto: 1.0.1-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -899,6 +899,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ompl-release.git
     version: 0.12.2002388-0
+  open_karto:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/open_karto-release.git
+    version: 1.0.1-1
   opencv2:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `open_karto`:
- previous version: `null`
- new version: `1.0.1-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
