### PR TITLE
dynamixel_motor: 0.4.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -199,6 +199,17 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
     version: 1.5.32-0
+  dynamixel_motor:
+    packages:
+      dynamixel_controllers:
+      dynamixel_driver:
+      dynamixel_motor:
+      dynamixel_msgs:
+      dynamixel_tutorials:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/arebgun/dynamixel_motor-release.git
+    version: 0.4.0-1
   eband_local_planner:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_motor`:
- previous version: `null`
- new version: `0.4.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
