### PR TITLE
revert sdl entry which is removed in  787cd0b

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1670,6 +1670,10 @@ screen:
     portage:
       packages: [app-misc/screen]
   ubuntu: [screen]
+sdl:
+  arch: [sdl]
+  debian: [libsdl1.2-dev]
+  ubuntu: [libsdl1.2-dev]
 sdl-gfx:
   arch: [sdl_gfx]
   debian: [libsdl-gfx1.2-dev]


### PR DESCRIPTION
787cd0b [1] remove sdl entrly from the list, it also breaks ubuntu section of atlas-oss, atlas-utils??

[1] https://github.com/ros/rosdistro/commit/787cd0b8f9d5712bd7d59d15469fc28ebf992476#rosdep/base.yaml
