### PR TITLE
imu_pipeline: 0.1.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -518,6 +518,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/image_transport_plugins-release.git
     version: 1.8.21-0
+  imu_pipeline:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/imu_pipeline-release
+    version: 0.1.1-0
   interactive_marker_proxy:
     status: maintained
     url: https://github.com/ros-gbp/interactive_marker_proxy-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_pipeline`:
- previous version: `null`
- new version: `0.1.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
