### PR TITLE
ros_controllers: 0.5.1-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1347,7 +1347,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros_controllers-release.git
-    version: 0.5.1-0
+    version: 0.5.1-1
   ros_http_video_streamer:
     url: https://github.com/ros-gbp/ros_http_video_streamer-release.git
   ros_tutorials:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers`:
- previous version: `0.5.1-0`
- new version: `0.5.1-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
