### PR TITLE
moveit_metapackages: 0.5.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -720,7 +720,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_metapackages-release.git
-    version: 0.4.1-0
+    version: 0.5.0-0
   moveit_msgs:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_metapackages`:
- previous version: `0.4.1-0`
- new version: `0.5.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
