### PR TITLE
moveit_plugins: 0.4.2-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -653,7 +653,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/moveit_plugins-release.git
-    version: 0.4.0-0
+    version: 0.4.2-0
   moveit_pr2:
     packages:
       moveit_pr2:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_plugins`:
- previous version: `0.4.0-0`
- new version: `0.4.2-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
