### PR TITLE
added industrial_core dependency to hekateros package

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -547,6 +547,8 @@ repositories:
     url: https://github.com/tu-darmstadt-ros-pkg/hector_worldmodel.git
     version: master
   hekateros:
+    depends:
+    - industrial_core
     type: git
     url: https://github.com/roadnarrows-robotics/hekateros.git
   hlugv_common:


### PR DESCRIPTION
Hoping to fix http://jenkins.willowgarage.com:8080/job/doc-groovy-hekateros/ by specifying message dependencies: 

``` bash
    depends:
    - industrial_core
```
