### PR TITLE
sbpl: 1.1.4-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1506,7 +1506,10 @@ repositories:
     url: https://github.com/ros-gbp/rviz-release.git
     version: 1.10.2-0
   sbpl:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/sbpl-release.git
+    version: 1.1.4-1
   segbot:
     packages:
       segbot:


### PR DESCRIPTION
Increasing version of package(s) in repository `sbpl`:
- previous version: `null`
- new version: `1.1.4-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
