### PR TITLE
pr2_ethercat_drivers: 1.8.4-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1044,7 +1044,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pr2_ethercat_drivers-release.git
-    version: 1.8.3-0
+    version: 1.8.4-0
   pr2_mechanism:
     packages:
       pr2_controller_interface:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_ethercat_drivers`:
- previous version: `1.8.3-0`
- new version: `1.8.4-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
