### PR TITLE
octomap_rviz_plugins: 0.0.4-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -914,6 +914,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/octomap_ros-release.git
     version: 0.3.0-0
+  octomap_rviz_plugins:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/octomap_rviz_plugins-release
+    version: 0.0.4-0
   ompl:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_rviz_plugins`:
- previous version: `null`
- new version: `0.0.4-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
