### PR TITLE
libuvc_ros: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -661,6 +661,14 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ktossell/libuvc-release.git
     version: 0.0.1-4
+  libuvc_ros:
+    packages:
+      libuvc_camera:
+      libuvc_ros:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ktossell/libuvc_ros-release.git
+    version: 0.0.1-0
   manipulation_msgs:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc_ros`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
