### PR TITLE
openni_launch: 1.9.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -963,7 +963,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/openni_launch-release.git
-    version: 1.9.1-0
+    version: 1.9.2-0
   openni_tracker:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_launch`:
- previous version: `1.9.1-0`
- new version: `1.9.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
