### PR TITLE
gps_umd: 0.1.6-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -465,6 +465,15 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/geometry_tutorials-release.git
     version: 0.2.0-0
+  gps_umd:
+    packages:
+      gps_common:
+      gps_umd:
+      gpsd_client:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ktossell/gps_umd-release.git
+    version: 0.1.6-0
   gscam:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd`:
- previous version: `null`
- new version: `0.1.6-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
