### PR TITLE
camera_umd: 0.2.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -78,6 +78,15 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/jack-oquin/camera_info_manager_py-release.git
     version: 0.2.2-0
+  camera_umd:
+    packages:
+      camera_umd:
+      jpeg_streamer:
+      uvc_camera:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ktossell/camera_umd-release.git
+    version: 0.2.0-0
   catkin:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_umd`:
- previous version: `null`
- new version: `0.2.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
