### PR TITLE
rosdoc_lite: 0.2.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1428,9 +1428,9 @@ repositories:
     version: 0.3.16-0
   rosdoc_lite:
     tags:
-      release: release/{package}/{upstream_version}
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rosdoc_lite-release.git
-    version: 0.2.2-0
+    version: 0.2.3-0
   rosjava_tools:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosdoc_lite`:
- previous version: `0.2.2-0`
- new version: `0.2.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
