### PR TITLE
rosdoc_lite: 0.2.3-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1209,9 +1209,9 @@ repositories:
     version: 0.3.16-0
   rosdoc_lite:
     tags:
-      release: release/{package}/{upstream_version}
+      release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/rosdoc_lite-release.git
-    version: 0.2.2-0
+    version: 0.2.3-0
   roseus:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `rosdoc_lite`:
- previous version: `0.2.2-0`
- new version: `0.2.3-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
