### PR TITLE
camera1394: 1.9.4-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -71,7 +71,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/camera1394-release.git
-    version: 1.9.3-0
+    version: 1.9.4-0
   camera_info_manager_py:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `camera1394`:
- previous version: `1.9.3-0`
- new version: `1.9.4-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
