### PR TITLE
Add python-catkin_pkg to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -55,7 +55,7 @@ python-bluez:
   ubuntu: [python-bluez]
 python-catkin-pkg:
   debian: [python-catkin-pkg]
-  fedora: [python-catkin-pkg]
+  fedora: [python-catkin_pkg]
   osx:
     pip:
       packages: [catkin-pkg]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -55,9 +55,7 @@ python-bluez:
   ubuntu: [python-bluez]
 python-catkin-pkg:
   debian: [python-catkin-pkg]
-  fedora:
-    pip:
-      packages: [catkin-pkg]
+  fedora: [python-catkin-pkg]
   osx:
     pip:
       packages: [catkin-pkg]


### PR DESCRIPTION
The package is now available for installation using yum.

```
[asinha@localhost  ~]$ sudo yum info python-catkin_pkg
[sudo] password for asinha:
Loaded plugins: fastestmirror, langpacks, refresh-packagekit, remove-with-leaves
Loading mirror speeds from cached hostfile
 * fedora: fedora.mirror.uber.com.au
 * livna: rpm.livna.org
 * rpmfusion-free: ucmirror.canterbury.ac.nz
 * rpmfusion-free-updates: ucmirror.canterbury.ac.nz
 * rpmfusion-nonfree: ucmirror.canterbury.ac.nz
 * rpmfusion-nonfree-updates: ucmirror.canterbury.ac.nz
 * updates: fedora.mirror.uber.com.au
 * updates-testing: fedora.mirror.uber.com.au
Installed Packages
Name        : python-catkin_pkg
Arch        : noarch
Version     : 0.1.18
Release     : 1.fc19
Size        : 253 k
Repo        : installed
From repo   : updates-testing
Summary     : Library for retrieving information about catkin packages
URL         : https://github.com/ros-infrastructure/catkin_pkg
Licence     : BSD
Description : Library for retrieving information about catkin packages

[asinha@localhost  ~]$
```
