### PR TITLE
nmea_gps_driver: 0.3.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -863,7 +863,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/nmea_gps_driver-release.git
-    version: 0.3.1-0
+    version: 0.3.2-0
   nmea_msgs:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_gps_driver`:
- previous version: `0.3.1-0`
- new version: `0.3.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
