### PR TITLE
openrtm_common: 3.1.4-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -863,6 +863,20 @@ repositories:
       release: release/{package}/{upstream_version}
     url: https://github.com/ros-gbp/openni_launch-release.git
     version: 1.8.3-0
+  openrtm_common:
+    packages:
+      hrpsys:
+      openhrp3:
+      openrtm_aist:
+      openrtm_aist_python:
+      openrtm_common:
+      rtctree:
+      rtshell:
+      rtsprofile:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/start-jsk/openrtm_common-release.git
+    version: 3.1.4-0
   orocos_kdl:
     packages:
       kdl:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_common`:
- previous version: `null`
- new version: `3.1.4-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
