### PR TITLE
sql_database: 0.4.7-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1649,7 +1649,10 @@ repositories:
     url: https://github.com/ros-gbp/slam_gmapping-release.git
     version: 1.3.0-1
   sql_database:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/sql_database-release.git
+    version: 0.4.7-0
   srdfdom:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sql_database`:
- previous version: `null`
- new version: `0.4.7-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
