### PR TITLE
ompl: 0.13.0002516-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -974,7 +974,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ompl-release.git
-    version: 0.13.0002515-0
+    version: 0.13.0002516-0
   open_karto:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl`:
- previous version: `0.13.0002515-0`
- new version: `0.13.0002516-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
