### PR TITLE
household_objects_database: 0.1.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -505,6 +505,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/hokuyo_node-release.git
     version: 1.7.7-0
+  household_objects_database:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: git@github.com:ros-gbp/household_objects_database-release.git
+    version: 0.1.3-0
   household_objects_database_msgs:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `household_objects_database`:
- previous version: `null`
- new version: `0.1.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
