### PR TITLE
xacro: 1.8.4-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1897,7 +1897,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/xacro-release.git
-    version: 1.8.3-2
+    version: 1.8.4-0
   xdot:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro`:
- previous version: `1.8.3-2`
- new version: `1.8.4-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
