### PR TITLE
turtlebot_create: 2.1.0-6 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1720,7 +1720,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/turtlebot-release/turtlebot_create-release.git
-    version: 2.1.0-5
+    version: 2.1.0-6
   turtlebot_create_desktop:
     packages:
       create_dashboard:


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_create`:
- previous version: `2.1.0-5`
- new version: `2.1.0-6`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
