### PR TITLE
kobuki: 0.4.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -596,7 +596,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/kobuki-release.git
-    version: 0.4.0-0
+    version: 0.4.0-1
   kobuki_desktop:
     packages:
       kobuki_dashboard:


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki`:
- previous version: `0.4.0-0`
- new version: `0.4.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
