### PR TITLE
turtlebot: 2.1.1-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -596,7 +596,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/kobuki-release.git
-    version: 0.4.0-1
+    version: 0.4.0-0
   kobuki_desktop:
     packages:
       kobuki_dashboard:
@@ -608,7 +608,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/kobuki_desktop-release.git
-    version: 0.2.0-2
+    version: 0.2.0-1
   kobuki_msgs:
     status: developed
     tags:
@@ -1416,7 +1416,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros_controllers-release.git
-    version: 0.5.2-1
+    version: 0.5.1-1
   ros_http_video_streamer:
     url: https://github.com/ros-gbp/ros_http_video_streamer-release.git
   ros_tutorials:
@@ -1687,7 +1687,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/turtlebot-release/turtlebot-release.git
-    version: 2.1.1-0
+    version: 2.1.1-1
   turtlebot_apps:
     packages:
       pano_core:
@@ -1730,7 +1730,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/turtlebot-release/turtlebot_create_desktop-release.git
-    version: 2.1.0-2
+    version: 2.1.0-1
   turtlebot_simulator:
     packages:
       turtlebot_gazebo:


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot`:
- previous version: `2.1.1-0`
- new version: `2.1.1-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
