### PR TITLE
openrtm_common: 3.1.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1025,7 +1025,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/start-jsk/openrtm_common-release.git
-    version: 3.1.4-0
+    version: 3.1.5-0
   openslam_gmapping:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_common`:
- previous version: `3.1.4-0`
- new version: `3.1.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
