### PR TITLE
OculusSDK-release: 0.2.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -8,6 +8,14 @@ platforms:
   - quantal
   - raring
 repositories:
+  OculusSDK-release:
+    packages:
+      oculus_sdk:
+        subfolder: .
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/OculusSDK-release.git
+    version: 0.2.3-0
   ackermann_msgs:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `OculusSDK-release`:
- previous version: `null`
- new version: `0.2.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
