### PR TITLE
rocon_msgs: 0.6.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1277,7 +1277,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-    version: 0.5.2-0
+    version: 0.6.0-0
   rocon_multimaster:
     packages:
       redis:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -973,7 +973,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/OculusSDK-release.git
-    version: 0.2.3-2
+    version: 0.2.3-3
   ompl:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs`:
- previous version: `0.5.2-0`
- new version: `0.6.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
