### PR TITLE
oculus_sdk: 0.2.3-4 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -978,7 +978,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/OculusSDK-release.git
-    version: 0.2.3-3
+    version: 0.2.3-4
   ompl:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `oculus_sdk`:
- previous version: `0.2.3-3`
- new version: `0.2.3-4`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.2`
