### PR TITLE
topic_proxy: 0.1.0-1 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1413,7 +1413,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/tu-darmstadt-ros-pkg-gbp/topic_proxy-release.git
-    version: 0.1.0-0
+    version: 0.1.0-1
   underwater_simulation:
     packages:
       underwater_sensor_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_proxy`:
- previous version: `0.1.0-0`
- new version: `0.1.0-1`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
