### PR TITLE
hector_slam: 0.3.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -499,6 +499,24 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/gscam-release.git
     version: 0.1.1-0
+  hector_slam:
+    packages:
+      hector_compressed_map_transport:
+      hector_geotiff:
+      hector_geotiff_plugins:
+      hector_imu_attitude_to_tf:
+      hector_map_server:
+      hector_map_tools:
+      hector_mapping:
+      hector_marker_drawing:
+      hector_nav_msgs:
+      hector_slam:
+      hector_slam_launch:
+      hector_trajectory_server:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
+    version: 0.3.0-0
   hokuyo_node:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_slam`:
- previous version: `null`
- new version: `0.3.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
