### PR TITLE
topic_proxy: 0.1.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1687,6 +1687,14 @@ repositories:
     version: 0.5.7-0
   tf2_web_republisher:
     url: https://github.com/ros-gbp/tf2_web_republisher-release.git
+  topic_proxy:
+    packages:
+      blob:
+      topic_proxy:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/tu-darmstadt-ros-pkg-gbp/topic_proxy-release.git
+    version: 0.1.0-0
   turtlebot:
     packages:
       linux_hardware:


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_proxy`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
