### PR TITLE
hector_slam: 0.3.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -516,7 +516,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
-    version: 0.3.0-0
+    version: 0.3.0-1
   hokuyo_node:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_slam`:
- previous version: `0.3.0-0`
- new version: `0.3.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
