### PR TITLE
openrtm_common: 3.1.5-5 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -876,7 +876,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/openrtm_common-release.git
-    version: 3.1.5-4
+    version: 3.1.5-5
   orocos_kdl:
     packages:
       kdl:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_common`:
- previous version: `3.1.5-4`
- new version: `3.1.5-5`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
