### PR TITLE
Adapted documentation links for optris_drivers in order to support ROS versions

### DIFF
--- a/doc/electric/ohm.rosinstall
+++ b/doc/electric/ohm.rosinstall
@@ -1,4 +1,4 @@
 - git:
-    uri: http://github.com/ohm-ros-pkg/optris_drivers.git
+    uri: https://github.com/ohm-ros-pkg/optris_drivers.git
     local-name: optris_drivers
-    version: master
+    version: fuerte-devel

--- a/doc/fuerte/ohm.rosinstall
+++ b/doc/fuerte/ohm.rosinstall
@@ -1,4 +1,4 @@
 - git:
-    uri: http://github.com/ohm-ros-pkg/optris_drivers.git
+    uri: https://github.com/ohm-ros-pkg/optris_drivers.git
     local-name: optris_drivers
-    version: master
+    version: fuerte-devel

--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -989,7 +989,7 @@ repositories:
   optris_drivers:
     type: git
     url: https://github.com/ohm-ros-pkg/optris_drivers.git
-    version: master
+    version: groovy-devel
   orocos_controllers:
     type: git
     url: https://github.com/RCPRG-ros-pkg/orocos_controllers.git


### PR DESCRIPTION
electric and fuerte are pointing to fuerte-devel branch
groovy points to groovy-devel
