### PR TITLE
libuvc: 0.0.1-6 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -711,7 +711,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ktossell/libuvc-release.git
-    version: 0.0.1-4
+    version: 0.0.1-6
   libuvc_ros:
     packages:
       libuvc_camera:


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc`:
- previous version: `0.0.1-4`
- new version: `0.0.1-6`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
