### PR TITLE
razer_hydra: 0.0.6-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1225,6 +1225,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/random_numbers-release.git
     version: 0.2.0-0
+  razer_hydra:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/dgossow/razer_hydra-release.git
+    version: 0.0.6-0
   realtime_tools:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `razer_hydra`:
- previous version: `null`
- new version: `0.0.6-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
