### PR TITLE
rviz_oculus: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1608,6 +1608,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rviz-release.git
     version: 1.10.2-0
+  rviz_oculus:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/rviz_oculus-release.git
+    version: 0.0.1-0
   sbpl:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_oculus`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
