### PR TITLE
oculus_rviz_plugins: 0.0.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -992,6 +992,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/octomap_rviz_plugins-release
     version: 0.0.4-0
+  oculus_rviz_plugins:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/oculus_rviz_plugins-release.git
+    version: 0.0.2-0
   oculus_sdk:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `oculus_rviz_plugins`:
- previous version: `null`
- new version: `0.0.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
