### PR TITLE
eband_local_planner: 0.1.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -228,7 +228,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/utexas-bwi-gbp/eband_local_planner-release.git
-    version: 0.1.1-0
+    version: 0.1.2-0
   ecl_core:
     packages:
       ecl_command_line:


### PR DESCRIPTION
Increasing version of package(s) in repository `eband_local_planner`:
- previous version: `0.1.1-0`
- new version: `0.1.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
