### PR TITLE
openrtm_common: 3.1.5-11 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -876,7 +876,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/openrtm_common-release.git
-    version: 3.1.5-10
+    version: 3.1.5-11
   orocos_kdl:
     packages:
       kdl:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_common`:
- previous version: `3.1.5-10`
- new version: `3.1.5-11`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
