### PR TITLE
moveit_pr2: 0.5.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -814,7 +814,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_pr2-release.git
-    version: 0.5.1-0
+    version: 0.5.2-0
   moveit_resources:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_pr2`:
- previous version: `0.5.1-0`
- new version: `0.5.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
