### PR TITLE
oculus_sdk: 0.2.3-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -825,6 +825,11 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/octomap_rviz_plugins-release.git
     version: 0.0.4-0
+  oculus_sdk:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/ros-gbp/oculus_sdk-release.git
+    version: 0.2.3-0
   ompl:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `oculus_sdk`:
- previous version: `null`
- new version: `0.2.3-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
