### PR TITLE
oculus_rviz_plugins: 0.0.5-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -825,11 +825,11 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/octomap_rviz_plugins-release.git
     version: 0.0.4-0
-  oculus_sdk:
+  oculus_rviz_plugins:
     tags:
       release: release/groovy/{package}/{version}
-    url: https://github.com/ros-gbp/oculus_sdk-release.git
-    version: 0.2.3-0
+    url: https://github.com/ros-gbp/oculus_rviz_plugins-release.git
+    version: 0.0.5-0
   ompl:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `oculus_rviz_plugins`:
- previous version: `null`
- new version: `0.0.5-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
