### PR TITLE
re-adding oculus_sdk

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -830,6 +830,11 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/oculus_rviz_plugins-release.git
     version: 0.0.5-0
+  oculus_sdk:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/ros-gbp/oculus_sdk-release.git
+    version: 0.2.3-0
   ompl:
     status: maintained
     tags:


### PR DESCRIPTION
The oculus_sdk entry got lost in the merge of oculus_rviz_plugins (see https://github.com/ros/rosdistro/pull/1729/files). Re-adding.
