### PR TITLE
oculus_rviz_plugins: 0.0.6-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -829,12 +829,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/oculus_rviz_plugins-release.git
-    version: 0.0.5-0
-  oculus_sdk:
-    tags:
-      release: release/groovy/{package}/{version}
-    url: https://github.com/ros-gbp/oculus_sdk-release.git
-    version: 0.2.3-0
+    version: 0.0.6-0
   ompl:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `oculus_rviz_plugins`:
- previous version: `0.0.5-0`
- new version: `0.0.6-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
