### PR TITLE
pyqtgraph: 0.9.7-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1203,6 +1203,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/prosilica_gige_sdk-release.git
     version: 1.26.2-0
+  pyqtgraph:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/pyqtgraph-release.git
+    version: 0.9.7-0
   python_qt_binding:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pyqtgraph`:
- previous version: `null`
- new version: `0.9.7-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
