### PR TITLE
openrtm_aist_core: 1.1.1-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -873,6 +873,16 @@ repositories:
       release: release/{package}/{upstream_version}
     url: https://github.com/ros-gbp/openni_launch-release.git
     version: 1.8.3-0
+  openrtm_aist_core:
+    packages:
+      openrtm_aist:
+      openrtm_aist_python:
+      openrtm_common:
+        subfolder: openrtm_aist_core
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/start-jsk/openrtm_aist_core-release.git
+    version: 1.1.1-0
   orocos_kdl:
     packages:
       kdl:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist_core`:
- previous version: `null`
- new version: `1.1.1-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
