### PR TITLE
rtshell_core: 1.0.0-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1314,6 +1314,16 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
     version: 0.2.16-0
+  rtshell_core:
+    packages:
+      rtctree:
+      rtshell:
+      rtshell_core:
+      rtsprofile:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/start-jsk/rtshell_core-release.git
+    version: 1.0.0-0
   rviz:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell_core`:
- previous version: `null`
- new version: `1.0.0-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
