### PR TITLE
openhrp3: 0.0.1-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -863,6 +863,11 @@ repositories:
       release: release/{package}/{upstream_version}
     url: https://github.com/ros-gbp/opencv_candidate-release.git
     version: 0.1.8-0
+  openhrp3:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/start-jsk/openhrp3-release.git
+    version: 0.0.1-0
   openni_camera:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `openhrp3`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
