### PR TITLE
rosbag_migration_rule: 1.0.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1459,6 +1459,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/wpi-rail-release/rosauth-release.git
     version: 0.1.3-0
+  rosbag_migration_rule:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/rosbag_migration_rule-release
+    version: 1.0.0-0
   rosbridge_suite:
     packages:
       rosapi:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_migration_rule`:
- previous version: `null`
- new version: `1.0.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
