### PR TITLE
razer_hydra: 0.0.9-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1220,7 +1220,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/razer_hydra-release.git
-    version: 0.0.7-0
+    version: 0.0.9-1
   realtime_tools:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `razer_hydra`:
- previous version: `0.0.7-0`
- new version: `0.0.9-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
