### PR TITLE
oculus_sdk: 0.2.3-2 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -834,7 +834,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/oculus_sdk-release.git
-    version: 0.2.3-0
+    version: 0.2.3-2
   ompl:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `oculus_sdk`:
- previous version: `0.2.3-0`
- new version: `0.2.3-2`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
