### PR TITLE
oculus_sdk: 0.2.3-6 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1001,7 +1001,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/OculusSDK-release.git
-    version: 0.2.3-4
+    version: 0.2.3-6
   ompl:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `oculus_sdk`:
- previous version: `0.2.3-4`
- new version: `0.2.3-6`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
