### PR TITLE
navigation_tutorials-release: 0.2.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -879,6 +879,20 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/navigation-release.git
     version: 1.11.3-0
+  navigation_tutorials-release:
+    packages:
+      laser_scan_publisher_tutorial:
+      navigation_stage:
+      navigation_tutorials:
+      odometry_publisher_tutorial:
+      point_cloud_publisher_tutorial:
+      robot_setup_tf_tutorial:
+      roomba_stage:
+      simple_navigation_goals_tutorial:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/navigation_tutorials-release.git
+    version: 0.2.0-0
   nmea_gps_driver:
     status: end-of-life
     status_description: Replaced by the nmea_navsat_driver package. Scheduled to be


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_tutorials-release`:
- previous version: `null`
- new version: `0.2.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
