### PR TITLE
openhrp3: 0.0.1-2 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -867,7 +867,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/openhrp3-release.git
-    version: 0.0.1-1
+    version: 0.0.1-2
   openni_camera:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `openhrp3`:
- previous version: `0.0.1-1`
- new version: `0.0.1-2`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
