### PR TITLE
rgbd_launch: 2.0.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1247,6 +1247,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/reflexxes_type2-release.git
     version: 1.2.4-0
+  rgbd_launch:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/rgbd_launch-release.git
+    version: 2.0.0-0
   robot_model:
     packages:
       collada_parser:


### PR DESCRIPTION
Increasing version of package(s) in repository `rgbd_launch`:
- previous version: `null`
- new version: `2.0.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
