### PR TITLE
freenect_stack: 0.3.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -389,7 +389,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/freenect_stack-release.git
-    version: 0.2.2-1
+    version: 0.3.0-0
   gazebo_ros_pkgs:
     packages:
       gazebo_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `freenect_stack`:
- previous version: `0.2.2-1`
- new version: `0.3.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
