### PR TITLE
pocketsphinx: 0.2.0-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -936,6 +936,11 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/pluginlib-release.git
     version: 1.9.21-0
+  pocketsphinx:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/ros-gbp/pocketsphinx-release.git
+    version: 0.2.0-0
   pr2_mechanism_msgs:
     tags:
       release: release/{package}/{upstream_version}


### PR DESCRIPTION
Increasing version of package(s) in repository `pocketsphinx`:
- previous version: `null`
- new version: `0.2.0-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
