### PR TITLE
pocketsphinx: 0.2.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1110,6 +1110,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pluginlib-release.git
     version: 1.9.21-0
+  pocketsphinx:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/pocketsphinx-release.git
+    version: 0.2.0-0
   pr2_common:
     packages:
       pr2_common:


### PR DESCRIPTION
Increasing version of package(s) in repository `pocketsphinx`:
- previous version: `null`
- new version: `0.2.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
