### PR TITLE
dynamixel_pro_driver: 0.8.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -223,6 +223,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/arebgun/dynamixel_motor-release.git
     version: 0.4.0-1
+  dynamixel_pro_driver:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: git@github.com:ros-gbp/dynamixel_pro_driver-release.git
+    version: 0.8.1-0
   eband_local_planner:
     status: developed
     tags:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -226,7 +226,7 @@ repositories:
   dynamixel_pro_driver:
     tags:
       release: release/hydro/{package}/{version}
-    url: git@github.com:ros-gbp/dynamixel_pro_driver-release.git
+    url: https://github.com/ros-gbp/dynamixel_pro_driver-release.git
     version: 0.8.1-0
   eband_local_planner:
     status: developed


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_pro_driver`:
- previous version: `null`
- new version: `0.8.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
