### PR TITLE
dynamixel_pro_arm_description: 0.8.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -223,10 +223,10 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/arebgun/dynamixel_motor-release.git
     version: 0.4.0-1
-  dynamixel_pro_controller:
+  dynamixel_pro_arm_description:
     tags:
       release: release/hydro/{package}/{version}
-    url: https://github.com/ros-gbp/dynamixel_pro_controller-release.git
+    url: https://github.com/ros-gbp/dynamixel_pro_arm_description-release.git
     version: 0.8.1-0
   dynamixel_pro_driver:
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_pro_arm_description`:
- previous version: `null`
- new version: `0.8.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
