### PR TITLE
dynamixel_pro_moveit_controller: 0.8.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -233,6 +233,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/dynamixel_pro_driver-release.git
     version: 0.8.1-0
+  dynamixel_pro_moveit_controller:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/dynamixel_pro_moveit_controller-release.git
+    version: 0.8.1-0
   eband_local_planner:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_pro_moveit_controller`:
- previous version: `null`
- new version: `0.8.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
