### PR TITLE
rtmros_common: 1.0.0-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1340,6 +1340,19 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
     version: 0.2.16-0
+  rtmros_common:
+    packages:
+      hrpsys_ros_bridge:
+      hrpsys_tools:
+      openrtm_ros_bridge:
+      openrtm_tools:
+      rosnode_rtc:
+      rtmbuild:
+      rtmros_common:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/start-jsk/rtmros_common-release.git
+    version: 1.0.0-0
   rtshell_core:
     packages:
       rtctree:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common`:
- previous version: `null`
- new version: `1.0.0-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
