### PR TITLE
cob_common: 0.5.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -124,7 +124,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ipa320/cob_common-release.git
-    version: 0.5.0-0
+    version: 0.5.0-1
   common_msgs:
     packages:
       actionlib_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common`:
- previous version: `0.5.0-0`
- new version: `0.5.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
