### PR TITLE
driver_common: 1.6.7-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -206,7 +206,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/driver_common-release.git
-    version: 1.6.6-0
+    version: 1.6.7-0
   dynamic_reconfigure:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `driver_common`:
- previous version: `1.6.6-0`
- new version: `1.6.7-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
