### PR TITLE
imu_pipeline: 0.1.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -610,7 +610,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/imu_pipeline-release
-    version: 0.1.1-0
+    version: 0.1.2-0
   interactive_marker_proxy:
     status: maintained
     url: https://github.com/ros-gbp/interactive_marker_proxy-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_pipeline`:
- previous version: `0.1.1-0`
- new version: `0.1.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
