### PR TITLE
microstrain_3dmgx2_imu: 1.5.11-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -788,7 +788,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/microstrain_3dmgx2_imu-release.git
-    version: 1.5.10-0
+    version: 1.5.11-0
   moveit_commander:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_3dmgx2_imu`:
- previous version: `1.5.10-0`
- new version: `1.5.11-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
