### PR TITLE
sicktoolbox: 1.0.103-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1721,7 +1721,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/sicktoolbox-release.git
-    version: 1.0.102-0
+    version: 1.0.103-0
   sicktoolbox_wrapper:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sicktoolbox`:
- previous version: `1.0.102-0`
- new version: `1.0.103-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
