### PR TITLE
sicktoolbox_wrapper: 2.5.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1727,7 +1727,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/sicktoolbox_wrapper-release.git
-    version: 2.5.2-0
+    version: 2.5.3-0
   slam_gmapping:
     packages:
       gmapping:


### PR DESCRIPTION
Increasing version of package(s) in repository `sicktoolbox_wrapper`:
- previous version: `2.5.2-0`
- new version: `2.5.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
