### PR TITLE
urg_c: 1.0.403-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1894,7 +1894,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/urg_c-release.git
-    version: 1.0.402-0
+    version: 1.0.403-0
   urg_node:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_c`:
- previous version: `1.0.402-0`
- new version: `1.0.403-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
