### PR TITLE
rtmros_common: 1.0.0-3 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1352,7 +1352,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/rtmros_common-release.git
-    version: 1.0.0-2
+    version: 1.0.0-3
   rtshell_core:
     packages:
       rtctree:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common`:
- previous version: `1.0.0-2`
- new version: `1.0.0-3`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
