### PR TITLE
razer_hydra: 0.0.11-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -997,7 +997,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/razer_hydra-release.git
-    version: 0.0.10-0
+    version: 0.0.11-0
   reflexxes_type2:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `razer_hydra`:
- previous version: `0.0.10-0`
- new version: `0.0.11-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
