### PR TITLE
oculus_sdk: 0.2.3-7 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -845,7 +845,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/oculus_sdk-release.git
-    version: 0.2.3-2
+    version: 0.2.3-7
   ompl:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `oculus_sdk`:
- previous version: `0.2.3-2`
- new version: `0.2.3-7`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
