### PR TITLE
oculus_sdk: 0.2.3-7 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1051,7 +1051,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/OculusSDK-release.git
-    version: 0.2.3-6
+    version: 0.2.3-7
   ompl:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `oculus_sdk`:
- previous version: `0.2.3-6`
- new version: `0.2.3-7`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
