### PR TITLE
rtmros_hironx: 1.0.0-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1353,6 +1353,15 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/rtmros_common-release.git
     version: 1.0.0-3
+  rtmros_hironx:
+    packages:
+      hironx_moveit_config:
+      hironx_ros_bridge:
+      rtmros_hironx:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/start-jsk/rtmros_hironx-release.git
+    version: 1.0.0-0
   rtshell_core:
     packages:
       rtctree:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx`:
- previous version: `null`
- new version: `1.0.0-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
