### PR TITLE
openrtm_aist_core: 1.1.0-7 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -892,13 +892,12 @@ repositories:
   openrtm_aist_core:
     packages:
       openrtm_aist:
+      openrtm_aist_core:
       openrtm_aist_python:
-      openrtm_common:
-        subfolder: openrtm_aist_core
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/openrtm_aist_core-release.git
-    version: 1.1.0-5
+    version: 1.1.0-7
   orocos_kdl:
     packages:
       kdl:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist_core`:
- previous version: `1.1.0-5`
- new version: `1.1.0-7`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
