### PR TITLE
genlisp: 0.4.12-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -448,7 +448,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/genlisp-release.git
-    version: 0.4.11-0
+    version: 0.4.12-0
   genmsg:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `genlisp`:
- previous version: `0.4.11-0`
- new version: `0.4.12-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
