### PR TITLE
std_msgs: 0.5.8-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1771,7 +1771,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/std_msgs-release.git
-    version: 0.5.7-0
+    version: 0.5.8-0
   tf2_web_republisher:
     url: https://github.com/ros-gbp/tf2_web_republisher-release.git
   topic_proxy:


### PR DESCRIPTION
Increasing version of package(s) in repository `std_msgs`:
- previous version: `0.5.7-0`
- new version: `0.5.8-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
