### PR TITLE
rosconsole_bridge: 0.3.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1549,7 +1549,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rosconsole_bridge-release.git
-    version: 0.3.2-0
+    version: 0.3.3-0
   roscpp_core:
     packages:
       cpp_common:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole_bridge`:
- previous version: `0.3.2-0`
- new version: `0.3.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
