### PR TITLE
message_generation: 0.2.10-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -776,7 +776,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/message_generation-release.git
-    version: 0.2.9-0
+    version: 0.2.10-0
   message_runtime:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `message_generation`:
- previous version: `0.2.9-0`
- new version: `0.2.10-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
