### PR TITLE
nodelet_core: 1.8.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -954,11 +954,13 @@ repositories:
       nodelet:
       nodelet_core:
       nodelet_topic_tools:
+      test_nodelet:
+      test_nodelet_topic_tools:
     status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/nodelet_core-release.git
-    version: 1.8.0-0
+    version: 1.8.1-0
   object_recognition_capture:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core`:
- previous version: `1.8.0-0`
- new version: `1.8.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
