### PR TITLE
class_loader: 0.2.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -97,7 +97,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/class_loader-release.git
-    version: 0.2.2-0
+    version: 0.2.3-0
   clearpath_common:
     packages:
       clearpath_base:


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader`:
- previous version: `0.2.2-0`
- new version: `0.2.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
