### PR TITLE
bond_core: 1.7.13-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -45,10 +45,11 @@ repositories:
       bondcpp:
       bondpy:
       smclib:
+      test_bond:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/bond_core-release.git
-    version: 1.7.12-0
+    version: 1.7.13-0
   calibration:
     packages:
       calibration:


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core`:
- previous version: `1.7.12-0`
- new version: `1.7.13-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
