### PR TITLE
openhrp3: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1082,6 +1082,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/opencv_candidate-release.git
     version: 0.1.8-0
+  openhrp3:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/start-jsk/openhrp3-release.git
+    version: 0.0.1-0
   openni_camera:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `openhrp3`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
