### PR TITLE
rtshell_core: 1.0.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1675,6 +1675,16 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
     version: 0.2.16-0
+  rtshell_core:
+    packages:
+      rtctree:
+      rtshell:
+      rtshell_core:
+      rtsprofile:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/start-jsk/rtshell_core-release.git
+    version: 1.0.0-0
   rviz:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell_core`:
- previous version: `null`
- new version: `1.0.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
