### PR TITLE
hrpsys: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -570,6 +570,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/household_objects_database_msgs-release.git
     version: 0.1.1-0
+  hrpsys:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/start-jsk/hrpsys-release.git
+    version: 0.0.1-0
   image_common:
     packages:
       camera_calibration_parsers:


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
