### PR TITLE
arbotix: 0.9.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -21,6 +21,18 @@ repositories:
     version: 1.10.2-0
   ar_track_alvar:
     url: https://github.com/ros-gbp/ar_track_alvar-release.git
+  arbotix:
+    packages:
+      arbotix:
+      arbotix_controllers:
+      arbotix_firmware:
+      arbotix_msgs:
+      arbotix_python:
+      arbotix_sensors:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/vanadiumlabs/arbotix_ros-release.git
+    version: 0.9.0-0
   audio_common:
     packages:
       audio_capture:


### PR DESCRIPTION
Increasing version of package(s) in repository `arbotix`:
- previous version: `null`
- new version: `0.9.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
