### PR TITLE
depthimage_to_laserscan: 1.0.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -194,7 +194,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/depthimage_to_laserscan-release.git
-    version: 1.0.4-2
+    version: 1.0.5-0
   diagnostics:
     packages:
       diagnostic_aggregator:


### PR DESCRIPTION
Increasing version of package(s) in repository `depthimage_to_laserscan`:
- previous version: `1.0.4-2`
- new version: `1.0.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
