### PR TITLE
urg_node: 0.1.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1944,7 +1944,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/urg_node-release.git
-    version: 0.1.4-0
+    version: 0.1.5-0
   uwsim_bullet:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node`:
- previous version: `0.1.4-0`
- new version: `0.1.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
