### PR TITLE
dynamixel_pro_controller: 0.8.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -255,7 +255,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/dynamixel_pro_controller-release.git
-    version: 0.8.1-0
+    version: 0.8.2-0
   dynamixel_pro_driver:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_pro_controller`:
- previous version: `0.8.1-0`
- new version: `0.8.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
