### PR TITLE
openni_launch: 1.9.4-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1113,7 +1113,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/openni_launch-release.git
-    version: 1.9.2-0
+    version: 1.9.4-0
   openni_tracker:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_launch`:
- previous version: `1.9.2-0`
- new version: `1.9.4-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
