### PR TITLE
Add declination, enu, um6, upstart to doc generation

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -706,10 +706,18 @@ repositories:
     type: git
     url: https://github.com/aswinthomas/udp-multicaster.git
     version: hydro-devel
+  um6:
+    type: git
+    url: https://github.com/clearpathrobotics/um6.git
+    version: master
   unique_identifier:
     type: git
     url: https://github.com/ros-geographic-info/unique_identifier.git
     version: master
+  upstart:
+    type: git
+    url: https://github.com/clearpathrobotics/upstart.git
+    version: hydro-devel
   urdf_tutorial:
     type: git
     url: https://github.com/ros/urdf_tutorial.git
@@ -721,14 +729,6 @@ repositories:
   urg_node:
     type: git
     url: https://github.com/ros-drivers/urg_node
-    version: hydro-devel
-  um6:
-    type: git
-    url: https://github.com/clearpathrobotics/um6.git
-    version: master
-  upstart:
-    type: git
-    url: https://github.com/clearpathrobotics/upstart.git
     version: hydro-devel
   velodyne:
     type: git

--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -714,6 +714,10 @@ repositories:
     type: git
     url: https://github.com/ros-drivers/urg_node
     version: hydro-devel
+  upstart:
+    type: git
+    url: https://github.com/clearpathrobotics/upstart.git
+    version: hydro-devel
   velodyne:
     type: git
     url: https://github.com/ros-drivers/velodyne.git

--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -99,6 +99,10 @@ repositories:
     type: git
     url: https://github.com/tu-darmstadt-ros-pkg/cpp_introspection.git
     version: master
+  declination:
+    type: git
+    url: https://github.com/clearpathrobotics/declination.git
+    version: master
   depthimage_to_laserscan:
     type: git
     url: https://github.com/ros-perception/depthimage_to_laserscan.git
@@ -147,6 +151,10 @@ repositories:
     type: git
     url: https://github.com/marioprats/eigen_utils
     version: groovy-devel
+  enu:
+    type: git
+    url: https://github.com/clearpathrobotics/enu.git
+    version: master
   erratic_robot:
     type: git
     url: https://github.com/arebgun/erratic_robot.git
@@ -714,6 +722,10 @@ repositories:
     type: git
     url: https://github.com/ros-drivers/urg_node
     version: hydro-devel
+  um6:
+    type: git
+    url: https://github.com/clearpathrobotics/um6.git
+    version: master
   upstart:
     type: git
     url: https://github.com/clearpathrobotics/upstart.git

--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -519,6 +519,10 @@ repositories:
     type: git
     url: https://github.com/ros/robot_model.git
     version: hydro-devel
+  robot_upstart:
+    type: git
+    url: https://github.com/clearpathrobotics/robot_upstart.git
+    version: hydro-devel
   rocon:
     type: git
     url: https://github.com/robotics-in-concert/rocon.git
@@ -714,10 +718,6 @@ repositories:
     type: git
     url: https://github.com/ros-geographic-info/unique_identifier.git
     version: master
-  upstart:
-    type: git
-    url: https://github.com/clearpathrobotics/upstart.git
-    version: hydro-devel
   urdf_tutorial:
     type: git
     url: https://github.com/ros/urdf_tutorial.git


### PR DESCRIPTION
enu— already in groovy docs, just adding to hydro
um6— a rewritten driver for the CHRobotics UM6
declination— provides a simple node which computes compass magnetic declination from a NavSatFix and can then transform an IMU message accordingly.
robot_upstart— tools for launching ROS from upstart.

(For others tuning in, [discussion on upstart name here](https://github.com/clearpathrobotics/upstart/issues/1).)
