### PR TITLE
metapackages: 1.0.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -801,6 +801,21 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/message_runtime-release.git
     version: 0.4.12-0
+  metapackages:
+    packages:
+      desktop:
+      desktop_full:
+      mobile:
+      perception:
+      robot:
+      ros_base:
+      ros_full:
+      simulators:
+      viz:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/metapackages-release.git
+    version: 1.0.0-0
   microstrain_3dmgx2_imu:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `metapackages`:
- previous version: `null`
- new version: `1.0.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
