### PR TITLE
velodyne_height_map: 0.4.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2003,7 +2003,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/jack-oquin-ros-releases/velodyne_height_map-release.git
-    version: 0.4.0-0
+    version: 0.4.1-0
   velodyne_utils:
     status: end-of-life
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_height_map`:
- previous version: `0.4.0-0`
- new version: `0.4.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
