### PR TITLE
openrtm_aist_core: 1.1.0-8 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -897,7 +897,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/openrtm_aist_core-release.git
-    version: 1.1.0-7
+    version: 1.1.0-8
   orocos_kdl:
     packages:
       kdl:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist_core`:
- previous version: `1.1.0-7`
- new version: `1.1.0-8`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
