### PR TITLE
image_pipeline: 1.11.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -613,7 +613,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/image_pipeline-release.git
-    version: 1.11.1-0
+    version: 1.11.2-0
   image_transport_plugins:
     packages:
       compressed_depth_image_transport:


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline`:
- previous version: `1.11.1-0`
- new version: `1.11.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
