### PR TITLE
geometry: 1.9.31-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -364,7 +364,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/geometry-release.git
-    version: 1.9.30-0
+    version: 1.9.31-0
   geometry_angles_utils:
     packages:
       angles:


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry`:
- previous version: `1.9.30-0`
- new version: `1.9.31-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
