### PR TITLE
openni-dev and libopenni-dev rosdep keys conflict

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1842,9 +1842,9 @@ openmpi:
   ubuntu: []
 openni-dev:
   arch: [openni]
-  debian: [openni-dev]
+  debian: [libopenni-dev]
   fedora: [openni-devel]
-  ubuntu: [openni-dev]
+  ubuntu: [libopenni-dev]
 pcre:
   arch: [pcre]
   debian: [libpcre3-dev]


### PR DESCRIPTION
This is breaking here: http://jenkins.ros.org/job/ros-hydro-turtlebot-navigation_binarydeb_quantal_i386/26/console

It looks like openni-dev is out of date. 
