### PR TITLE
oculus_rviz_plugins: 0.0.6-2 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -840,7 +840,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/oculus_rviz_plugins-release.git
-    version: 0.0.6-1
+    version: 0.0.6-2
   oculus_sdk:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `oculus_rviz_plugins`:
- previous version: `0.0.6-1`
- new version: `0.0.6-2`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
