### PR TITLE
oculus_rviz_plugins: 0.0.7-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1083,7 +1083,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/oculus_rviz_plugins-release.git
-    version: 0.0.6-0
+    version: 0.0.7-0
   oculus_sdk:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `oculus_rviz_plugins`:
- previous version: `0.0.6-0`
- new version: `0.0.7-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
