### PR TITLE
rqt_common_plugins: 0.3.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1681,7 +1681,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-    version: 0.2.17-1
+    version: 0.3.0-0
   rqt_pr2_dashboard:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins`:
- previous version: `0.2.17-1`
- new version: `0.3.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
