### PR TITLE
media_export: 0.1.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -790,6 +790,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/map_store-release.git
     version: 0.3.1-0
+  media_export:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/media_export-release.git
+    version: 0.1.0-0
   message_generation:
     status: maintained
     tags:


### PR DESCRIPTION
replacement for invalid #1880
