### PR TITLE
openni2_camera: 0.1.0-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -879,6 +879,11 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/openhrp3-release.git
     version: 0.0.1-3
+  openni2_camera:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/ros-gbp/openni2_camera-release.git
+    version: 0.1.0-0
   openni_camera:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
