### PR TITLE
realtime_tools: 1.8.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1337,7 +1337,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/realtime_tools-release.git
-    version: 1.8.1-0
+    version: 1.8.2-0
   reflexxes_type2:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools`:
- previous version: `1.8.1-0`
- new version: `1.8.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
