### PR TITLE
media_export: 0.1.0-2 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -794,7 +794,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/media_export-release.git
-    version: 0.1.0-0
+    version: 0.1.0-2
   message_generation:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `media_export`:
- previous version: `0.1.0-0`
- new version: `0.1.0-2`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
