### PR TITLE
kobuki: 0.5.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -668,13 +668,14 @@ repositories:
       kobuki_ftdi:
       kobuki_keyop:
       kobuki_node:
+      kobuki_random_walker:
       kobuki_safety_controller:
       kobuki_testsuite:
     status: developed
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/kobuki-release.git
-    version: 0.4.0-2
+    version: 0.5.0-0
   kobuki_desktop:
     packages:
       kobuki_dashboard:


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki`:
- previous version: `0.4.0-2`
- new version: `0.5.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
