### PR TITLE
eigen_utils: 1.0.2-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -295,7 +295,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/marioprats/eigen_utils-release.git
-    version: 1.0.1-0
+    version: 1.0.2-0
   euslisp:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `eigen_utils`:
- previous version: `1.0.1-0`
- new version: `1.0.2-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
