### PR TITLE
eigen_utils: 1.0.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -392,7 +392,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/marioprats/eigen_utils-release.git
-    version: 1.0.1-1
+    version: 1.0.2-0
   eml:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `eigen_utils`:
- previous version: `1.0.1-1`
- new version: `1.0.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
