### PR TITLE
kobuki: 0.5.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1840,7 +1840,10 @@ repositories:
     url: https://github.com/ros-gbp/std_msgs-release.git
     version: 0.5.8-0
   tf2_web_republisher:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/tf2_web_republisher-release.git
+    version: 0.2.0-0
   topic_proxy:
     packages:
       blob:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -659,7 +659,6 @@ repositories:
   kobuki:
     packages:
       kobuki:
-      kobuki_arm:
       kobuki_auto_docking:
       kobuki_bumper2pc:
       kobuki_controller_tutorial:
@@ -673,7 +672,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/kobuki-release.git
-    version: 0.5.0-0
+    version: 0.5.2-0
   kobuki_core:
     packages:
       kobuki_core:
@@ -1841,10 +1840,7 @@ repositories:
     url: https://github.com/ros-gbp/std_msgs-release.git
     version: 0.5.8-0
   tf2_web_republisher:
-    tags:
-      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/tf2_web_republisher-release.git
-    version: 0.2.0-0
   topic_proxy:
     packages:
       blob:


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki`:
- previous version: `0.5.0-0`
- new version: `0.5.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
