### PR TITLE
kobuki: 0.5.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -672,7 +672,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/kobuki-release.git
-    version: 0.5.2-0
+    version: 0.5.3-0
   kobuki_core:
     packages:
       kobuki_core:


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki`:
- previous version: `0.5.2-0`
- new version: `0.5.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
