### PR TITLE
kobuki_desktop: 0.3.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -695,7 +695,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/kobuki_desktop-release.git
-    version: 0.2.0-3
+    version: 0.3.0-0
   kobuki_msgs:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_desktop`:
- previous version: `0.2.0-3`
- new version: `0.3.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
