### PR TITLE
turtlebot_viz: 2.2.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1930,7 +1930,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/turtlebot-release/turtlebot_viz-release.git
-    version: 2.1.1-0
+    version: 2.2.0-0
   underwater_simulation:
     packages:
       underwater_sensor_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_viz`:
- previous version: `2.1.1-0`
- new version: `2.2.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
