### PR TITLE
rocon_app_platform: 0.6.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1399,7 +1399,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_app_platform-release.git
-    version: 0.5.4-0
+    version: 0.6.0-0
   rocon_concert:
     packages:
       concert_conductor:


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_app_platform`:
- previous version: `0.5.4-0`
- new version: `0.6.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
