### PR TITLE
rocon_concert: 0.5.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1410,7 +1410,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_concert-release.git
-    version: 0.5.4-0
+    version: 0.5.5-0
   rocon_msgs:
     packages:
       concert_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_concert`:
- previous version: `0.5.4-0`
- new version: `0.5.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
