### PR TITLE
rocon_multimaster: 0.6.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1432,12 +1432,13 @@ repositories:
       rocon_multimaster:
       rocon_test:
       rocon_unreliable_experiments:
+        subfolder: experiments/rocon_unreliable_experiments
       rocon_utilities:
     status: developed
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_multimaster-release.git
-    version: 0.5.5-0
+    version: 0.6.0-0
   rocon_rqt_plugins:
     packages:
       rocon_gateway_graph:


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_multimaster`:
- previous version: `0.5.5-0`
- new version: `0.6.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
