### PR TITLE
rocon_tutorials: 0.5.6-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1421,7 +1421,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-    version: 0.6.1-0
+    version: 0.6.0-0
   rocon_multimaster:
     packages:
       redis:
@@ -1440,27 +1440,30 @@ repositories:
     version: 0.5.5-0
   rocon_rqt_plugins:
     packages:
-      rocon_conductor_graph:
       rocon_gateway_graph:
       rocon_rqt_plugins:
     status: developed
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_rqt_plugins-release.git
-    version: 0.5.3-0
+    version: 0.5.2-0
   rocon_tutorials:
     packages:
       chatter_concert:
+        subfolder: concert_tutorials/chatter_concert
       multinav_concert:
+        subfolder: concert_tutorials/multinav_concert
       rocon_gateway_tutorials:
       rocon_tutorials:
       turtle_concert:
+        subfolder: concert_tutorials/turtle_concert
       turtle_stroll:
+        subfolder: concert_tutorials/software/turtle_stroll
     status: developed
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_tutorials-release.git
-    version: 0.5.5-0
+    version: 0.5.6-0
   ros:
     packages:
       mk:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1421,7 +1421,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-    version: 0.6.0-0
+    version: 0.6.1-0
   rocon_multimaster:
     packages:
       redis:
@@ -1440,13 +1440,14 @@ repositories:
     version: 0.5.5-0
   rocon_rqt_plugins:
     packages:
+      rocon_conductor_graph:
       rocon_gateway_graph:
       rocon_rqt_plugins:
     status: developed
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_rqt_plugins-release.git
-    version: 0.5.2-0
+    version: 0.5.3-0
   rocon_tutorials:
     packages:
       chatter_concert:


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_tutorials`:
- previous version: `0.5.5-0`
- new version: `0.5.6-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
