### PR TITLE
rocon: 0.6.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1389,7 +1389,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon-release.git
-    version: 0.5.3-0
+    version: 0.6.0-0
   rocon_app_platform:
     packages:
       rocon_app_manager:


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon`:
- previous version: `0.5.3-0`
- new version: `0.6.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
