### PR TITLE
um6: 0.0.1-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1937,6 +1937,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/turtlebot-release/turtlebot_viz-release.git
     version: 2.2.0-0
+  um6:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/um6-release.git
+    version: 0.0.1-1
   underwater_simulation:
     packages:
       underwater_sensor_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `um6`:
- previous version: `null`
- new version: `0.0.1-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
