### PR TITLE
hrpsys: 0.0.1-3 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -411,7 +411,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/hrpsys-release.git
-    version: 0.0.1-2
+    version: 0.0.1-3
   image_common:
     packages:
       camera_calibration_parsers:


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys`:
- previous version: `0.0.1-2`
- new version: `0.0.1-3`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
