### PR TITLE
calibration: 0.10.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -79,7 +79,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/calibration-release.git
-    version: 0.10.1-0
+    version: 0.10.2-0
   camera1394:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `calibration`:
- previous version: `0.10.1-0`
- new version: `0.10.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
