### PR TITLE
rtmros_common: 1.0.0-7 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1356,7 +1356,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/rtmros_common-release.git
-    version: 1.0.0-6
+    version: 1.0.0-7
   rtmros_hironx:
     packages:
       hironx_moveit_config:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common`:
- previous version: `1.0.0-6`
- new version: `1.0.0-7`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
