### PR TITLE
Added tu-darmstadt-ros-pkg release repositories to hydro/release.yaml

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -499,6 +499,52 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/gscam-release.git
     version: 0.1.1-0
+  hector_gazebo:
+    packages:
+      hector_gazebo:
+      hector_gazebo_plugins:
+      hector_gazebo_thermal_camera:
+      hector_gazebo_worlds:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
+  hector_localization:
+    packages:
+      hector_localization:
+      hector_pose_estimation:
+      hector_pose_estimation_core:
+      message_to_tf:
+      world_magnetic_model:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
+  hector_models:
+    packages:
+      hector_models:
+      hector_sensors_description:
+      hector_sensors_gazebo:
+      hector_xacro_tools:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
+  hector_quadrotor:
+    packages:
+      hector_quadrotor:
+      hector_quadrotor_controller:
+      hector_quadrotor_description:
+      hector_quadrotor_gazebo:
+      hector_quadrotor_gazebo_plugins:
+      hector_quadrotor_teleop:
+      hector_uav_msgs:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_quadrotor-release.git
+  hector_quadrotor_apps:
+    packages:
+      hector_quadrotor_demo:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_quadrotor_apps-release.git
   hector_slam:
     packages:
       hector_compressed_map_transport:
@@ -517,6 +563,15 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
     version: 0.3.0-1
+  hector_worldmodel:
+    packages:
+      hector_object_tracker:
+      hector_worldmodel:
+      hector_worldmodel_geotiff_plugins:
+      hector_worldmodel_msgs:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
   hokuyo_node:
     status: maintained
     tags:


### PR DESCRIPTION
I would like to use pre-release testing for these repositories by TU Darmstadt and added them without a version tag as explained in the new [Prerelease tutorial](http://wiki.ros.org/bloom/Tutorials/PrereleaseTest).

**Warning:** Most of the release repositories are still empty, but I will test and release all of them within the next days. Does this cause errors on the buildfarm in any way? Is it preferred to add the repositories one of another after having done the first release using bloom?
