### PR TITLE
rosjava_tools: 0.1.11-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1641,7 +1641,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rosjava_tools-release.git
-    version: 0.1.10-0
+    version: 0.1.11-0
   roslisp:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_tools`:
- previous version: `0.1.10-0`
- new version: `0.1.11-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
