### PR TITLE
cmvision: 0.4.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -131,7 +131,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/utexas-bwi-gbp/cmvision-release.git
-    version: 0.4.0-0
+    version: 0.4.1-0
   cob_common:
     packages:
       brics_actuator:


### PR DESCRIPTION
Increasing version of package(s) in repository `cmvision`:
- previous version: `0.4.0-0`
- new version: `0.4.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
