### PR TITLE
segbot: 0.1.7-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1828,7 +1828,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/utexas-bwi-gbp/segbot-release.git
-    version: 0.1.6-0
+    version: 0.1.7-0
   segbot_apps:
     packages:
       segbot_apps:


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot`:
- previous version: `0.1.6-0`
- new version: `0.1.7-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
