### PR TITLE
segbot_apps: 0.1.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1837,7 +1837,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/utexas-bwi-gbp/segbot_apps-release.git
-    version: 0.1.4-0
+    version: 0.1.5-0
   segbot_simulator:
     packages:
       segbot_gazebo:


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot_apps`:
- previous version: `0.1.4-0`
- new version: `0.1.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
