### PR TITLE
declination: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -195,6 +195,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/convex_decomposition-release.git
     version: 0.1.9-0
+  declination:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/declination-release
+    version: 0.0.1-0
   depthimage_to_laserscan:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `declination`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
