### PR TITLE
hector_worldmodel: 0.3.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -629,6 +629,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
+    version: 0.3.0-0
   hokuyo_node:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_worldmodel`:
- previous version: `null`
- new version: `0.3.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
