### PR TITLE
hector_localization: 0.1.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -579,6 +579,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
+    version: 0.1.0-0
   hector_models:
     packages:
       hector_models:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_localization`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
