### PR TITLE
hector_gazebo: 0.3.0-2 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -561,6 +561,7 @@ repositories:
     version: 0.1.1-0
   hector_gazebo:
     packages:
+      gazebo_rtt_plugin:
       hector_gazebo:
       hector_gazebo_plugins:
       hector_gazebo_thermal_camera:
@@ -568,7 +569,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
-    version: 0.3.0-0
+    version: 0.3.0-2
   hector_localization:
     packages:
       hector_localization:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_gazebo`:
- previous version: `0.3.0-0`
- new version: `0.3.0-2`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
