### PR TITLE
hector_localization: 0.1.0-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -397,6 +397,17 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/gscam-release.git
     version: 0.1.1-0
+  hector_localization:
+    packages:
+      hector_localization:
+      hector_pose_estimation:
+      hector_pose_estimation_core:
+      message_to_tf:
+      world_magnetic_model:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
+    version: 0.1.0-0
   household_objects_database:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_localization`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
