### PR TITLE
nmea_comms: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1065,6 +1065,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/navigation_tutorials-release.git
     version: 0.2.0-0
+  nmea_comms:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/nmea_comms-release.git
+    version: 0.0.1-0
   nmea_gps_driver:
     status: end-of-life
     status_description: Replaced by the nmea_navsat_driver package. Scheduled to be


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_comms`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
