### PR TITLE
enu: 1.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -409,6 +409,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/eml-release.git
     version: 0.36.0-3
+  !!python/unicode 'enu':
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/enu-release.git
+    version: 1.0.1-0
   executive_smach:
     packages:
       executive_smach:


### PR DESCRIPTION
Increasing version of package(s) in repository `enu`:
- previous version: `null`
- new version: `1.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
