### PR TITLE
rosruby: 0.3.0-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1283,6 +1283,11 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/baalexander/rospy_message_converter-release.git
     version: 0.1.4-0
+  rosruby:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/OTL/rosruby-release
+    version: 0.3.0-0
   rosserial:
     packages:
       rosserial:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosruby`:
- previous version: `null`
- new version: `0.3.0-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
