### PR TITLE
urdfdom_py: 0.2.9-2 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2076,6 +2076,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/urdfdom_headers-release.git
     version: 0.2.3-1
+  urdfdom_py:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/urdfdom_py-release
+    version: 0.2.9-2
   urg_c:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_py`:
- previous version: `null`
- new version: `0.2.9-2`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
