### PR TITLE
rtmros_common: 1.0.0-13 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1372,7 +1372,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/rtmros_common-release.git
-    version: 1.0.0-12
+    version: 1.0.0-13
   rtmros_hironx:
     packages:
       hironx_moveit_config:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common`:
- previous version: `1.0.0-12`
- new version: `1.0.0-13`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
