### PR TITLE
rosruby: 0.3.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1750,6 +1750,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/baalexander/rospy_message_converter-release.git
     version: 0.2.0-2
+  rosruby:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/OTL/rosruby-release
+    version: 0.3.0-0
   rosserial:
     packages:
       rosserial:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosruby`:
- previous version: `null`
- new version: `0.3.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
