### PR TITLE
urdfdom_py: 0.2.9-4 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1750,11 +1750,6 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/baalexander/rospy_message_converter-release.git
     version: 0.2.0-2
-  rosruby:
-    tags:
-      release: release/hydro/{package}/{version}
-    url: https://github.com/OTL/rosruby-release
-    version: 0.3.0-0
   rosserial:
     packages:
       rosserial:
@@ -2085,7 +2080,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/urdfdom_py-release
-    version: 0.2.9-2
+    version: 0.2.9-4
   urg_c:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_py`:
- previous version: `0.2.9-2`
- new version: `0.2.9-4`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
