### PR TITLE
ros_controllers: 0.5.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1660,6 +1660,7 @@ repositories:
       forward_command_controller:
       imu_sensor_controller:
       joint_state_controller:
+      joint_trajectory_controller:
       position_controllers:
       ros_controllers:
       velocity_controllers:
@@ -1667,7 +1668,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros_controllers-release.git
-    version: 0.5.2-1
+    version: 0.5.3-0
   ros_http_video_streamer:
     url: https://github.com/ros-gbp/ros_http_video_streamer-release.git
   ros_tutorials:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers`:
- previous version: `0.5.2-1`
- new version: `0.5.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
