### PR TITLE
class_loader: 0.1.31-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -90,7 +90,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/class_loader-release.git
-    version: 0.1.30-0
+    version: 0.1.31-0
   cmake_modules:
     tags:
       release: release/groovy/{package}/{version}
@@ -801,7 +801,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/object_recognition_ros-release.git
-    version: 0.2.4-0
+    version: 0.2.3-0
   object_recognition_tabletop:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader`:
- previous version: `0.1.30-0`
- new version: `0.1.31-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
