### PR TITLE
bond_core: 1.7.13-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -46,7 +46,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/bond_core-release.git
-    version: 1.7.12-0
+    version: 1.7.13-0
   brics_actuator:
     status: maintained
     tags:
@@ -801,7 +801,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/object_recognition_ros-release.git
-    version: 0.2.4-0
+    version: 0.2.3-0
   object_recognition_tabletop:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core`:
- previous version: `1.7.12-0`
- new version: `1.7.13-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
