### PR TITLE
genmsg: 0.4.22-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -340,7 +340,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/genmsg-release.git
-    version: 0.4.21-0
+    version: 0.4.22-0
   genpy:
     status: maintained
     tags:
@@ -801,7 +801,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/object_recognition_ros-release.git
-    version: 0.2.4-0
+    version: 0.2.3-0
   object_recognition_tabletop:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg`:
- previous version: `0.4.21-0`
- new version: `0.4.22-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
