### PR TITLE
python_qt_binding: 0.2.11-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -977,7 +977,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/python_qt_binding-release.git
-    version: 0.2.10-0
+    version: 0.2.11-0
   qt_gui_core:
     packages:
       qt_dotgraph:


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding`:
- previous version: `0.2.10-0`
- new version: `0.2.11-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
