### PR TITLE
ros_tutorials: 0.3.13-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1207,7 +1207,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/ros_tutorials-release.git
-    version: 0.3.12-0
+    version: 0.3.13-0
   ros_web_video:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials`:
- previous version: `0.3.12-0`
- new version: `0.3.13-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
