### PR TITLE
rqt: 0.2.11-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1311,7 +1311,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/rqt-release.git
-    version: 0.2.9-0
+    version: 0.2.11-0
   rqt_common_plugins:
     packages:
       rqt_action:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt`:
- previous version: `0.2.9-0`
- new version: `0.2.11-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
