### PR TITLE
std_msgs: 0.5.8-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1457,9 +1457,9 @@ repositories:
   std_msgs:
     status: maintained
     tags:
-      release: release/{package}/{upstream_version}
+      release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/std_msgs-release.git
-    version: 0.5.7-0
+    version: 0.5.8-0
   swig-wx:
     status: end-of-life
     status_description: Obsolete in favor of Qt based tools


### PR DESCRIPTION
Increasing version of package(s) in repository `std_msgs`:
- previous version: `0.5.7-0`
- new version: `0.5.8-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
