### PR TITLE
message_generation: 0.2.10-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -616,9 +616,9 @@ repositories:
   message_generation:
     status: maintained
     tags:
-      release: release/{package}/{upstream_version}
+      release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/message_generation-release.git
-    version: 0.2.9-0
+    version: 0.2.10-0
   message_runtime:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `message_generation`:
- previous version: `0.2.9-0`
- new version: `0.2.10-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
