### PR TITLE
message_runtime: 0.4.12-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -622,9 +622,9 @@ repositories:
   message_runtime:
     status: maintained
     tags:
-      release: release/{package}/{upstream_version}
+      release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/message_runtime-release.git
-    version: 0.4.11-0
+    version: 0.4.12-0
   mjpeg_server:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `message_runtime`:
- previous version: `0.4.11-0`
- new version: `0.4.12-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
