### PR TITLE
genlisp: 0.4.12-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -332,9 +332,9 @@ repositories:
     version: 0.4.13-0
   genlisp:
     tags:
-      release: release/{package}/{upstream_version}
+      release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/genlisp-release.git
-    version: 0.4.10-0
+    version: 0.4.12-0
   genmsg:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `genlisp`:
- previous version: `0.4.10-0`
- new version: `0.4.12-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
