### PR TITLE
ros_comm: 1.9.48-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1191,7 +1191,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/ros_comm-release.git
-    version: 1.9.47-0
+    version: 1.9.48-0
   ros_http_video_streamer:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm`:
- previous version: `1.9.47-0`
- new version: `1.9.48-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
