### PR TITLE
ros: 1.9.51-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1143,7 +1143,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/ros-release.git
-    version: 1.9.49-0
+    version: 1.9.51-0
   ros_comm:
     packages:
       message_filters:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros`:
- previous version: `1.9.49-0`
- new version: `1.9.51-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
