### PR TITLE
swiftnav: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1948,6 +1948,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/std_msgs-release.git
     version: 0.5.8-0
+  swiftnav:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/libswiftnav-release.git
+    version: 0.0.1-0
   tf2_web_republisher:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `swiftnav`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
