### PR TITLE
octomap_rviz_plugins: 0.0.5-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1189,7 +1189,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/octomap_rviz_plugins-release.git
-    version: 0.0.4-0
+    version: 0.0.5-1
   oculus_rviz_plugins:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_rviz_plugins`:
- previous version: `0.0.4-0`
- new version: `0.0.5-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
