### PR TITLE
multimaster_fkie: 0.3.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1031,7 +1031,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/fkie-release/multimaster_fkie-release.git
-    version: 0.3.4-0
+    version: 0.3.5-0
   navigation:
     packages:
       amcl:


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie`:
- previous version: `0.3.4-0`
- new version: `0.3.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4
