### PR TITLE
kobuki_core: 0.5.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -758,7 +758,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/kobuki_core-release.git
-    version: 0.5.2-0
+    version: 0.5.3-0
   kobuki_desktop:
     packages:
       kobuki_dashboard:


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core`:
- previous version: `0.5.2-0`
- new version: `0.5.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
