### PR TITLE
robot_upstart: 0.0.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1481,6 +1481,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/robot_state_publisher-release.git
     version: 1.9.9-0
+  !!python/unicode 'robot_upstart':
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/robot_upstart-release.git
+    version: 0.0.2-0
   rocon:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart`:
- previous version: `null`
- new version: `0.0.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
