### PR TITLE
rgbd_launch: 2.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1454,7 +1454,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rgbd_launch-release.git
-    version: 2.0.0-0
+    version: 2.0.1-0
   robot_model:
     packages:
       collada_parser:


### PR DESCRIPTION
Increasing version of package(s) in repository `rgbd_launch`:
- previous version: `2.0.0-0`
- new version: `2.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
