### PR TITLE
ros_tutorials: 0.4.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1687,7 +1687,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros_tutorials-release.git
-    version: 0.3.13-0
+    version: 0.4.0-0
   rosauth:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials`:
- previous version: `0.3.13-0`
- new version: `0.4.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
