### PR TITLE
Added deps for Fedora 19 (Schrödinger’s Cat) 

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -710,6 +710,7 @@ joystick:
   debian: [joystick]
   fedora:
     beefy: [joystick]
+    schrödinger’s: [linuxconsoletools]
     spherical: [linuxconsoletools]
   gentoo: [games-util/joystick]
   rhel: [joystick]
@@ -1143,7 +1144,10 @@ libmp3lame-dev:
 libmysqlclient-dev:
   arch: [mariadb]
   debian: [libmysqlclient-dev]
-  fedora: [mysql]
+  fedora:
+    beefy: [mysql]
+    schrödinger’s: [mariadb]
+    spherical: [mysql]
   gentoo:
     portage:
       packages: [dev-db/mariadb]
@@ -2129,30 +2133,35 @@ texlive-fonts-extra:
   arch: [texlive-fontsextra]
   debian: [texlive-fonts-extra]
   fedora:
+    schrödinger’s: [texlive-bbm, texlive-bbm-macros]
     spherical: [texlive-bbm, texlive-bbm-macros]
   ubuntu: [texlive-fonts-extra]
 texlive-fonts-recommended:
   arch: [texlive-core]
   debian: [texlive-fonts-recommended]
   fedora:
+    schrödinger’s: [texlive-times, texlive-helvetic]
     spherical: [texlive-times, texlive-helvetic]
   ubuntu: [texlive-fonts-recommended]
 texlive-latex-base:
   arch: [texlive-core]
   debian: [texlive-latex-base]
   fedora:
+    schrödinger’s: [texlive-latex, texlive-parskip]
     spherical: [texlive-latex, texlive-parskip]
   ubuntu: [texlive-latex-base]
 texlive-latex-extra:
   arch: [texlive-latexextra]
   debian: [texlive-latex-extra]
   fedora:
+    schrödinger’s: [texlive-titlesec, texlive-wrapfig, texlive-multirow, texlive-fancybox]
     spherical: [texlive-titlesec, texlive-wrapfig, texlive-multirow, texlive-fancybox]
   ubuntu: [texlive-latex-extra]
 texlive-latex-recommended:
   arch: [texlive-core]
   debian: [texlive-latex-recommended]
   fedora:
+    schrödinger’s: [texlive-framed, texlive-threeparttable, texlive-ec, texlive-mdwtools]
     spherical: [texlive-framed, texlive-threeparttable, texlive-ec, texlive-mdwtools]
   ubuntu: [texlive-latex-recommended]
 tinyxml:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -135,7 +135,7 @@ python-imaging:
   debian: [python-imaging]
   fedora:
     beefy: [python-imaging]
-    schrödinger’s: [python-pillow] 
+    schrödinger’s: [python-pillow]
     spherical: [python-imaging]
   freebsd: [py27-imaging]
   gentoo: [dev-python/imaging]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -133,7 +133,10 @@ python-httplib2:
 python-imaging:
   arch: [python-imaging]
   debian: [python-imaging]
-  fedora: [python-imaging]
+  fedora:
+    beefy: [python-imaging]
+    schrödinger’s: [python-pillow] 
+    spherical: [python-imaging]
   freebsd: [py27-imaging]
   gentoo: [dev-python/imaging]
   macports: [py26-pil]


### PR DESCRIPTION
For those who are still having issues, rosdep has an encoding mismatch when comparing dict keys in lookup.py. Hopefully there will be a clean solution soon, these will work when it is resolved, and work if you hack around the encoding mismatch.
