### PR TITLE
adds tag to object_recognition_tabletop to allow pre-release

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1151,6 +1151,8 @@ repositories:
     version: 0.2.4-0
   object_recognition_tabletop:
     status: maintained
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/object_recognition_tabletop-release.git
   object_recognition_tod:
     status: maintained


### PR DESCRIPTION
Object_recognition_tabletop is already listed, but the web pre-release portal doesn't allow me to specify a version (i.e. latest). Also, I can't find a pre-release being triggered. Hence this PR with the hope of enabling buildfarm pre-releases.
