### PR TITLE
rtshell_core: 1.0.0-3 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1391,7 +1391,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/rtshell_core-release.git
-    version: 1.0.0-2
+    version: 1.0.0-3
   rviz:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell_core`:
- previous version: `1.0.0-2`
- new version: `1.0.0-3`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
