### PR TITLE
urdfdom_py: 0.2.9-7 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2099,7 +2099,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/urdfdom_py-release.git
-    version: 0.2.9-5
+    version: 0.2.9-7
   urg_c:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_py`:
- previous version: `0.2.9-5`
- new version: `0.2.9-7`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
