### PR TITLE
turtlebot_simulator: 2.1.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2041,7 +2041,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/turtlebot-release/turtlebot_simulator-release.git
-    version: 2.1.0-0
+    version: 2.1.0-1
   turtlebot_viz:
     packages:
       turtlebot_dashboard:


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_simulator`:
- previous version: `2.1.0-0`
- new version: `2.1.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
