### PR TITLE
Adding motoman to documentation index for hydro

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -351,6 +351,10 @@ repositories:
     type: git
     url: https://github.com/ros-drivers/microstrain_3dmgx2_imu
     version: hydro-devel
+  motoman:
+    type: git
+    url: https://github.com/ros-industrial/motoman
+    version: groovy-devel
   moveit_commander:
     type: git
     url: https://github.com/ros-planning/moveit_commander


### PR DESCRIPTION
I'd like to add the motoman repo to the hydro doc index.
