### PR TITLE
kingfisher_msgs: 0.0.1-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -731,6 +731,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/joystick_drivers-release.git
     version: 1.9.10-0
+  !!python/unicode 'kingfisher_msgs':
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/kingfisher_msgs-release.git
+    version: 0.0.1-1
   kobuki:
     packages:
       kobuki:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -731,7 +731,7 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/joystick_drivers-release.git
     version: 1.9.10-0
-  !!python/unicode 'kingfisher_msgs':
+  kingfisher_msgs:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/kingfisher_msgs-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kingfisher_msgs`:
- previous version: `null`
- new version: `0.0.1-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
