### PR TITLE
kingfisher_bringup: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -731,6 +731,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/joystick_drivers-release.git
     version: 1.9.10-0
+  kingfisher_bringup:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/kingfisher_bringup-release.git
+    version: 0.0.1-0
   kingfisher_msgs:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `kingfisher_bringup`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
