### PR TITLE
Adding infinisoleil to documentation index for groovy

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -651,6 +651,10 @@ repositories:
     type: svn
     url: https://swri-ros-pkg.googlecode.com/svn/branches/groovy/industrial_experimental
     version: HEAD
+  infinisoleil:
+    type: git
+    url: https://github.com/ncs-3d-sensing/infinisoleil.git
+    version: master
   interactive_markers:
     type: git
     url: https://github.com/ros-visualization/interactive_markers.git


### PR DESCRIPTION
I'd like infinisoleil to be indexed and documented on ros.org.
