### PR TITLE
openni2_launch: 0.1.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1250,6 +1250,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/openni2_camera-release.git
     version: 0.1.0-0
+  openni2_launch:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/openni2_launch.git
+    version: 0.1.0-0
   openni_camera:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_launch`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
