### PR TITLE
urdfdom_py: 0.2.9-9 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2114,7 +2114,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/urdfdom_py-release.git
-    version: 0.2.9-8
+    version: 0.2.9-9
   urg_c:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_py`:
- previous version: `0.2.9-8`
- new version: `0.2.9-9`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
