### PR TITLE
filters: 1.7.4-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -442,7 +442,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/filters-release.git
-    version: 1.7.4-0
+    version: 1.7.4-1
   flirtlib:
     url: https://github.com/ros-gbp/flirtlib-release.git
   freenect_stack:


### PR DESCRIPTION
Increasing version of package(s) in repository `filters`:
- previous version: `1.7.4-0`
- new version: `1.7.4-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
