### PR TITLE
Remove clearpath_common repo.

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -112,16 +112,6 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/class_loader-release.git
     version: 0.2.3-0
-  clearpath_common:
-    packages:
-      clearpath_base:
-      clearpath_bringup:
-      clearpath_common:
-      clearpath_teleop:
-    tags:
-      release: release/hydro/{package}/{version}
-    url: https://github.com/clearpathrobotics/clearpath_common-release.git
-    version: 0.3.1-0
   cmake_modules:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
We've eliminated this metapackage, and are now hoping to release clearpath_base separately (from its own repo, and a new release repo). When I try to do that with things in their current condition, bloom-release gives the following error:

```
Failed to open pull request: AssertionError - Duplicate package name 'clearpath_base' exists in repository 'clearpath_base' as well as in repository 'clearpath_common'
mikepurvis@testbox:~/husky_ws/src/clearpath_base
```

Is removing clearpath_common from the release.yaml all that's needed to fix it up, or will more surgery be required? Thanks.
