### PR TITLE
pr2_common: 1.11.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1342,7 +1342,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pr2_common-release.git
-    version: 1.11.2-0
+    version: 1.11.3-0
   pr2_controllers:
     packages:
       ethercat_trigger_controllers:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common`:
- previous version: `1.11.2-0`
- new version: `1.11.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
