### PR TITLE
pr2_mechanism: 1.8.9-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1379,7 +1379,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pr2_mechanism-release.git
-    version: 1.8.8-0
+    version: 1.8.9-0
   pr2_mechanism_msgs:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_mechanism`:
- previous version: `1.8.8-0`
- new version: `1.8.9-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
