### PR TITLE
clearpath_base: 0.4.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -112,6 +112,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/class_loader-release.git
     version: 0.2.3-0
+  clearpath_base:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/clearpath_base-release.git
+    version: 0.4.0-1
   cmake_modules:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_base`:
- previous version: `null`
- new version: `0.4.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
