### PR TITLE
rocon_msgs: 0.6.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1541,7 +1541,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-    version: 0.6.1-0
+    version: 0.6.2-0
   rocon_multimaster:
     packages:
       redis:


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs`:
- previous version: `0.6.1-0`
- new version: `0.6.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
