### PR TITLE
rocon_rqt_plugins: 0.5.4-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1568,7 +1568,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_rqt_plugins-release.git
-    version: 0.5.3-0
+    version: 0.5.4-0
   rocon_tutorials:
     packages:
       chatter_concert:


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_rqt_plugins`:
- previous version: `0.5.3-0`
- new version: `0.5.4-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
