### PR TITLE
rosruby: 0.4.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1783,7 +1783,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/OTL/rosruby-release.git
-    version: 0.4.2-0
+    version: 0.4.3-0
   rosserial:
     packages:
       rosserial:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosruby`:
- previous version: `0.4.2-0`
- new version: `0.4.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
