### PR TITLE
robot_upstart: 0.0.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1499,7 +1499,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/robot_upstart-release.git
-    version: 0.0.2-0
+    version: 0.0.3-0
   rocon:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart`:
- previous version: `0.0.2-0`
- new version: `0.0.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
