### PR TITLE
husky_description: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -659,6 +659,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/husky_base-release.git
     version: 0.0.2-0
+  husky_description:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/husky_description-release.git
+    version: 0.0.1-0
   image_common:
     packages:
       camera_calibration_parsers:


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_description`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
