### PR TITLE
husky_teleop: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -664,6 +664,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/husky_description-release.git
     version: 0.0.1-0
+  !!python/unicode 'husky_teleop':
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/husky_teleop-release.git
+    version: 0.0.1-0
   image_common:
     packages:
       camera_calibration_parsers:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -664,7 +664,7 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/husky_description-release.git
     version: 0.0.1-0
-  !!python/unicode 'husky_teleop':
+  husky_teleop:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/husky_teleop-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_teleop`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
