### PR TITLE
Fix a libcurl conflict on debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -349,7 +349,7 @@ cppunit:
   ubuntu: [libcppunit-dev]
 curl:
   arch: [curl]
-  debian: [libcurl4-openssl-dev]
+  debian: [libcurl-ssl-dev]
   fedora: [libcurl-devel]
   freebsd: [curl]
   gentoo:


### PR DESCRIPTION
... was preventing to install GDAL (libgdal1-dev)

fix https://github.com/ros/robot_model/issues/37

"The .deb should depend on `libcurl-ssl-dev` and not `libcurl4-openssl-dev`,
that conflicts with `libcurl4-gnutls-dev` which GDAL-dev depends on."

EDIT: libgdal1 -> libgdal1-dev
