### PR TITLE
rosjava_build_tools: 0.1.15-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1778,6 +1778,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/rosjava-release/rosjava_build_tools-release.git
+    version: 0.1.15-0
   rosjava_messages:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_build_tools`:
- previous version: `null`
- new version: `0.1.15-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
