### PR TITLE
rtshell_core: 1.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1891,7 +1891,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/start-jsk/rtshell_core-release.git
-    version: 1.0.0-0
+    version: 1.0.1-0
   rviz:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell_core`:
- previous version: `1.0.0-0`
- new version: `1.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
