### PR TITLE
openrtm_aist_core: 1.1.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1290,7 +1290,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/start-jsk/openrtm_aist_core-release.git
-    version: 1.1.0-0
+    version: 1.1.0-1
   openslam_gmapping:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist_core`:
- previous version: `1.1.0-0`
- new version: `1.1.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
