### PR TITLE
openhrp3: 0.0.1-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1255,7 +1255,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/start-jsk/openhrp3-release.git
-    version: 0.0.1-0
+    version: 0.0.1-1
   openni2_camera:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `openhrp3`:
- previous version: `0.0.1-0`
- new version: `0.0.1-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
