### PR TITLE
oculus_rviz_plugins: 0.0.8-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -851,7 +851,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/oculus_rviz_plugins-release.git
-    version: 0.0.7-0
+    version: 0.0.8-0
   oculus_sdk:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `oculus_rviz_plugins`:
- previous version: `0.0.7-0`
- new version: `0.0.8-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
