### PR TITLE
husky_bringup: 0.0.1-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -659,6 +659,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/husky_base-release.git
     version: 0.0.2-0
+  husky_bringup:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/husky_bringup-release.git
+    version: 0.0.1-1
   husky_description:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_bringup`:
- previous version: `null`
- new version: `0.0.1-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
