### PR TITLE
clearpath_base: 0.4.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -116,7 +116,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/clearpath_base-release.git
-    version: 0.4.2-0
+    version: 0.4.3-0
   cmake_modules:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_base`:
- previous version: `0.4.2-0`
- new version: `0.4.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
