### PR TITLE
rtmros_common: 1.0.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1889,6 +1889,19 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
     version: 0.3.0-0
+  rtmros_common:
+    packages:
+      hrpsys_ros_bridge:
+      hrpsys_tools:
+      openrtm_ros_bridge:
+      openrtm_tools:
+      rosnode_rtc:
+      rtmbuild:
+      rtmros_common:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/start-jsk/rtmros_common-release.git
+    version: 1.0.0-0
   rtshell_core:
     packages:
       rtctree:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common`:
- previous version: `null`
- new version: `1.0.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
