### PR TITLE
serial: 1.1.4-7 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1986,7 +1986,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/wjwwood/serial-release.git
-    version: 1.1.4-0
+    version: 1.1.4-7
   shape_tools:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `serial`:
- previous version: `1.1.4-0`
- new version: `1.1.4-7`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
