### PR TITLE
rosjava_core: 0.1.2-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1803,6 +1803,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/rosjava-release/rosjava_core-release.git
+    version: 0.1.2-1
   rosjava_extras:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_core`:
- previous version: `null`
- new version: `0.1.2-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
