### PR TITLE
hrpsys: 0.0.1-8 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -422,7 +422,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/hrpsys-release.git
-    version: 0.0.1-7
+    version: 0.0.1-8
   image_common:
     packages:
       camera_calibration_parsers:


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys`:
- previous version: `0.0.1-7`
- new version: `0.0.1-8`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
