### PR TITLE
serial_utils: 0.1.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1989,6 +1989,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/wjwwood/serial-release.git
     version: 1.1.4-7
+  serial_utils:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/wjwwood/serial_utils-release.git
+    version: 0.1.0-0
   shape_tools:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `serial_utils`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
