### PR TITLE
ax2550: 0.1.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -46,6 +46,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/audio_common-release.git
     version: 0.2.4-0
+  ax2550:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/wjwwood/ax2550-release.git
+    version: 0.1.0-0
   bfl:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `ax2550`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
