### PR TITLE
open_street_map: 0.2.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1258,6 +1258,15 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/open_karto-release.git
     version: 1.0.1-0
+  open_street_map:
+    packages:
+      osm_cartography:
+      route_network:
+      test_osm:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-geographic-info/open_street_map-release.git
+    version: 0.2.0-0
   opencv2:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `open_street_map`:
- previous version: `null`
- new version: `0.2.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
