### PR TITLE
dynamic_reconfigure: 1.5.34-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -235,7 +235,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-    version: 1.5.33-0
+    version: 1.5.34-0
   dynamixel_motor:
     packages:
       dynamixel_controllers:


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure`:
- previous version: `1.5.33-0`
- new version: `1.5.34-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
