### PR TITLE
dynamic_reconfigure: 1.5.34-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -173,7 +173,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-    version: 1.5.33-0
+    version: 1.5.34-0
   ecl_core:
     packages:
       ecl_command_line:


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure`:
- previous version: `1.5.33-0`
- new version: `1.5.34-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
