### PR TITLE
stage_ros: 1.7.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2054,7 +2054,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/stage_ros-release.git
-    version: 1.7.1-0
+    version: 1.7.2-0
   std_msgs:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `stage_ros`:
- previous version: `1.7.1-0`
- new version: `1.7.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
