### PR TITLE
Removing experimental groovy rosjava_tools support

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1261,12 +1261,6 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/roseus-release.git
     version: 0.1.0-0
-  rosjava_tools:
-    status: developed
-    tags:
-      release: release/groovy/{package}/{version}
-    url: https://github.com/yujinrobot-release/rosjava_tools-release.git
-    version: 0.1.5-0
   roslisp:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
This was just early experimentation. Everyone was just using sources directly, so dropping support for it in favour of a decent deb release in hydro is preferable.
