### PR TITLE
rosserial: 0.5.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1859,11 +1859,12 @@ repositories:
       rosserial_embeddedlinux:
       rosserial_msgs:
       rosserial_python:
+      rosserial_server:
       rosserial_xbee:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rosserial-release.git
-    version: 0.5.2-0
+    version: 0.5.3-0
   rqt:
     packages:
       rqt:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial`:
- previous version: `0.5.2-0`
- new version: `0.5.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
