### PR TITLE
yujin_ocs: 0.4.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2344,7 +2344,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/yujin_ocs-release.git
-    version: 0.4.0-0
+    version: 0.4.0-1
   zeroconf_avahi_suite:
     packages:
       zeroconf_avahi:


### PR DESCRIPTION
Increasing version of package(s) in repository `yujin_ocs`:
- previous version: `0.4.0-0`
- new version: `0.4.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
