### PR TITLE
yujin_ocs: 0.2.3-1 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1601,7 +1601,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/yujinrobot-release/yujin_ocs-release.git
-    version: 0.2.3-0
+    version: 0.2.3-1
   zeroconf_avahi_suite:
     packages:
       zeroconf_avahi:


### PR DESCRIPTION
Increasing version of package(s) in repository `yujin_ocs`:
- previous version: `0.2.3-0`
- new version: `0.2.3-1`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
