### PR TITLE
Remove version number from rtmros_common for pre-release test on buildfarm.

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1941,7 +1941,6 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/start-jsk/rtmros_common-release.git
-    version: 1.0.0-0
   rtshell_core:
     packages:
       rtctree:


### PR DESCRIPTION
Hope I'm doing pre-release right (first time for me to do so, looking at [tutorial](http://wiki.ros.org/bloom/Tutorials/PrereleaseTest)). Update is already pushed to Release repo.

@k-okada
