### PR TITLE
Add psutil to rosdep/osx-homebrew

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -364,6 +364,10 @@ python-paramiko:
   osx:
     pip:
       packages: [paramiko]
+python-psutil:
+  osx:
+    pip:
+      packages: [psutil]
 python-qt-bindings:
   osx:
     homebrew:


### PR DESCRIPTION
Problem reported [here](http://answers.ros.org/question/80446/osx-install-problem-rqt_top-no-definition-of-python-psutil-for-os-osx/?answer=80541#post-id-80541).
