### PR TITLE
rosjava_bootstrap: 0.1.7-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1805,7 +1805,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/rosjava-release/rosjava_bootstrap-release.git
-    version: 0.1.5-0
+    version: 0.1.7-0
   rosjava_build_tools:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_bootstrap`:
- previous version: `0.1.5-0`
- new version: `0.1.7-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
