### PR TITLE
geometric_shapes: 0.3.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -505,7 +505,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/geometric_shapes-release.git
-    version: 0.3.4-0
+    version: 0.3.5-0
   geometry:
     packages:
       eigen_conversions:


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes`:
- previous version: `0.3.4-0`
- new version: `0.3.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
