### PR TITLE
moveit_ikfast: 3.0.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -979,7 +979,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_ikfast-release.git
-    version: 3.0.4-0
+    version: 3.0.5-0
   moveit_metapackages:
     packages:
       moveit_full:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ikfast`:
- previous version: `3.0.4-0`
- new version: `3.0.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
