### PR TITLE
hector_gazebo: 0.3.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -574,7 +574,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
-    version: 0.3.0-2
+    version: 0.3.1-0
   hector_localization:
     packages:
       hector_localization:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_gazebo`:
- previous version: `0.3.0-2`
- new version: `0.3.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
