### PR TITLE
pr2_robot: 1.6.6-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1458,7 +1458,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pr2_robot-release.git
-    version: 1.6.5-0
+    version: 1.6.6-0
   prosilica_driver:
     packages:
       prosilica_camera:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_robot`:
- previous version: `1.6.5-0`
- new version: `1.6.6-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
