### PR TITLE
rosjava_extras: 0.1.2-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1829,7 +1829,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/rosjava-release/rosjava_extras-release.git
-    version: 0.1.2-0
+    version: 0.1.2-1
   rosjava_messages:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_extras`:
- previous version: `0.1.2-0`
- new version: `0.1.2-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
