### PR TITLE
imu_compass: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -733,6 +733,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/image_transport_plugins-release.git
     version: 1.8.21-0
+  imu_compass:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/imu_compass-release.git
+    version: 0.0.1-0
   imu_pipeline:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_compass`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
