### PR TITLE
rosjava: 0.1.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -668,7 +668,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/husky_bringup-release.git
-    version: 0.0.2-0
+    version: 0.0.1-1
   husky_description:
     tags:
       release: release/hydro/{package}/{version}
@@ -907,7 +907,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ktossell/libuvc_ros-release.git
-    version: 0.0.3-0
+    version: 0.0.2-2
   manipulation_msgs:
     tags:
       release: release/hydro/{package}/{version}
@@ -1124,7 +1124,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/nmea_comms-release.git
-    version: 0.0.2-0
+    version: 0.0.1-0
   nmea_gps_driver:
     status: end-of-life
     status_description: Replaced by the nmea_navsat_driver package. Scheduled to be
@@ -1811,6 +1811,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/rosjava-release/rosjava-release.git
+    version: 0.1.1-0
   rosjava_bootstrap:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava`:
- previous version: `null`
- new version: `0.1.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
