### PR TITLE
serial: 1.1.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2014,7 +2014,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/wjwwood/serial-release.git
-    version: 1.1.4-7
+    version: 1.1.5-0
   serial_utils:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `serial`:
- previous version: `1.1.4-7`
- new version: `1.1.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
