### PR TITLE
shared_serial: 0.2.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2030,6 +2030,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/wcaarls/shared_serial-release
+    version: 0.2.0-1
   sicktoolbox:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `shared_serial`:
- previous version: `null`
- new version: `0.2.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
