### PR TITLE
rosjava: 0.1.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1811,6 +1811,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/rosjava-release/rosjava-release.git
+    version: 0.1.1-0
   rosjava_bootstrap:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava`:
- previous version: `null`
- new version: `0.1.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
