### PR TITLE
sr_ronex: 0.9.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2060,7 +2060,7 @@ repositories:
   sr_ronex:
     tags:
       release: release/hydro/{package}/{version}
-    url: git@github.com:shadow-robot/sr-ronex-release.git
+    url: https://github.com/shadow-robot/sr-ronex-release.git
     version: 0.9.2-0
   srdfdom:
     status: maintained

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2057,6 +2057,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/sql_database-release.git
     version: 0.4.7-0
+  sr_ronex:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: git@github.com:shadow-robot/sr-ronex-release.git
+    version: 0.9.2-0
   srdfdom:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_ronex`:
- previous version: `null`
- new version: `0.9.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
