### PR TITLE
open_street_map: 0.2.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1272,7 +1272,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-geographic-info/open_street_map-release.git
-    version: 0.2.0-0
+    version: 0.2.1-0
   opencv2:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `open_street_map`:
- previous version: `0.2.0-0`
- new version: `0.2.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
