### PR TITLE
Adding bipedRobin to documentation index for fuerte

### DIFF
--- a/doc/fuerte/bipedRobin.rosinstall
+++ b/doc/fuerte/bipedRobin.rosinstall
@@ -1,0 +1,3 @@
+- svn:
+    local-name: bipedRobin
+    uri: http://robin-jku-linz-ros-pkg.googlecode.com/svn/trunk/bipedRobin/


### PR DESCRIPTION
I'd like bipedRobin to be indexed and documented on ros.org.
