### PR TITLE
sr_ronex: 0.9.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2058,10 +2058,21 @@ repositories:
     url: https://github.com/ros-gbp/sql_database-release.git
     version: 0.4.7-0
   sr_ronex:
+    packages:
+      sr_ronex:
+      sr_ronex_controllers:
+      sr_ronex_drivers:
+      sr_ronex_examples:
+      sr_ronex_external_protocol:
+      sr_ronex_hardware_interface:
+      sr_ronex_launch:
+      sr_ronex_msgs:
+      sr_ronex_transmissions:
+      sr_ronex_utilities:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/shadow-robot/sr-ronex-release.git
-    version: 0.9.2-0
+    version: 0.9.3-0
   srdfdom:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_ronex`:
- previous version: `0.9.2-0`
- new version: `0.9.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
