### PR TITLE
common_msgs: 1.9.17-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -112,7 +112,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/common_msgs-release.git
-    version: 1.9.16-0
+    version: 1.9.17-0
   console_bridge:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs`:
- previous version: `1.9.16-0`
- new version: `1.9.17-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
