### PR TITLE
Adding mrpt-ros-pkg to documentation index for groovy & hydro

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -882,6 +882,18 @@ repositories:
     type: git
     url: https://github.com/ros-planning/moveit_setup_assistant.git
     version: groovy-devel
+  mrpt_common:
+    type: git
+    url: https://github.com/mrpt-ros-pkg/mrpt_common.git
+    version: master
+  mrpt_hwdrivers:
+    type: git
+    url: https://github.com/mrpt-ros-pkg/mrpt_hwdrivers.git
+    version: master
+  mrpt_slam:
+    type: git
+    url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
+    version: master
   multi_level_map:
     type: git
     url: https://github.com/utexas-bwi/multi_level_map.git

--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -427,6 +427,18 @@ repositories:
     type: git
     url: https://github.com/ros-planning/moveit_setup_assistant
     version: hydro-devel
+  mrpt_common:
+    type: git
+    url: https://github.com/mrpt-ros-pkg/mrpt_common.git
+    version: master
+  mrpt_hwdrivers:
+    type: git
+    url: https://github.com/mrpt-ros-pkg/mrpt_hwdrivers.git
+    version: master
+  mrpt_slam:
+    type: git
+    url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
+    version: master
   multi_level_map:
     type: git
     url: https://github.com/utexas-bwi/multi_level_map.git


### PR DESCRIPTION
I'd like to have these stacks' documentation included in ros.org. 

Cheers.
