### PR TITLE
turtlebot_apps: 2.2.3-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2149,7 +2149,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/turtlebot-release/turtlebot_apps-release.git
-    version: 2.2.2-0
+    version: 2.2.3-1
   turtlebot_create:
     packages:
       create_description:


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_apps`:
- previous version: `2.2.2-0`
- new version: `2.2.3-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
