### PR TITLE
navigation: 1.11.4-2 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1105,7 +1105,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/navigation-release.git
-    version: 1.11.3-1
+    version: 1.11.4-2
   navigation_tutorials:
     packages:
       laser_scan_publisher_tutorial:


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation`:
- previous version: `1.11.3-1`
- new version: `1.11.4-2`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
