### PR TITLE
sr_ronex: 0.9.3-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2072,7 +2072,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/shadow-robot/sr-ronex-release.git
-    version: 0.9.3-0
+    version: 0.9.3-1
   srdfdom:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_ronex`:
- previous version: `0.9.3-0`
- new version: `0.9.3-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
