### PR TITLE
genrb: 0.1.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -490,6 +490,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/genpy-release.git
     version: 0.4.14-0
+  genrb:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/OTL/genrb-release
+    version: 0.1.0-0
   geographic_info:
     packages:
       geodesy:


### PR DESCRIPTION
Increasing version of package(s) in repository `genrb`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
