### PR TITLE
metapackages: 1.0.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -960,7 +960,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/metapackages-release.git
-    version: 1.0.1-0
+    version: 1.0.2-0
   microstrain_3dmgx2_imu:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `metapackages`:
- previous version: `1.0.1-0`
- new version: `1.0.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
