### PR TITLE
depthimage_to_laserscan: 1.0.5-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -142,9 +142,9 @@ repositories:
   depthimage_to_laserscan:
     status: maintained
     tags:
-      release: release/{package}/{upstream_version}
+      release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/depthimage_to_laserscan-release.git
-    version: 1.0.4-0
+    version: 1.0.5-0
   diagnostics:
     packages:
       diagnostic_aggregator:


### PR DESCRIPTION
Increasing version of package(s) in repository `depthimage_to_laserscan`:
- previous version: `1.0.4-0`
- new version: `1.0.5-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
