### PR TITLE
Adding skeleton_markers to documentation index for groovy

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -1508,9 +1508,9 @@ repositories:
     type: hg
     url: https://bitbucket.org/osrf/simulator_gazebo
   skeleton_markers:
-    type: svn
-    url: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/skeleton_markers
-    version: HEAD
+    type: git
+    url: https://github.com/pirobot/skeleton_markers.git
+    version: groovy-devel
   slam_gmapping:
     type: git
     url: https://github.com/ros-perception/slam_gmapping.git


### PR DESCRIPTION
Adding skeleton_markers to documentation index for groovy
