### PR TITLE
Adding pi_tracker to documentation index for groovy

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -1069,9 +1069,9 @@ repositories:
     url: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/pi_robot_description
     version: HEAD
   pi_tracker:
-    type: svn
-    url: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/pi_tracker
-    version: HEAD
+    type: git
+    url: https://github.com/pirobot/pi_tracker.git
+    version: groovy-devel
   pi_tutorials:
     type: svn
     url: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/pi_tutorials


### PR DESCRIPTION
Adding pi_tracker to documentation index for groovy
