### PR TITLE
husky_simulator: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -692,6 +692,15 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/husky_metapackages-release.git
     version: 0.0.1-0
+  husky_simulator:
+    packages:
+      husky_gazebo:
+      husky_gazebo_plugins:
+      husky_simulator:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/husky_simulator-release.git
+    version: 0.0.1-0
   husky_teleop:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_simulator`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
