### PR TITLE
husky_metapackages: 0.0.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -691,7 +691,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/husky_metapackages-release.git
-    version: 0.0.1-0
+    version: 0.0.2-0
   husky_simulator:
     packages:
       husky_gazebo:


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_metapackages`:
- previous version: `0.0.1-0`
- new version: `0.0.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
