### PR TITLE
husky_simulator: 0.0.2-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -700,7 +700,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/husky_simulator-release.git
-    version: 0.0.1-0
+    version: 0.0.2-1
   husky_teleop:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_simulator`:
- previous version: `0.0.1-0`
- new version: `0.0.2-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
