### PR TITLE
moveit_plugins: 0.5.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1032,7 +1032,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_plugins-release.git
-    version: 0.5.4-0
+    version: 0.5.5-0
   moveit_pr2:
     packages:
       moveit_pr2:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_plugins`:
- previous version: `0.5.4-0`
- new version: `0.5.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
