### PR TITLE
Adding ueye_cam to documentation index for groovy+hydro distros

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -1612,6 +1612,10 @@ repositories:
     type: hg
     url: https://bitbucket.org/kmhallen/ueye
     version: default
+  ueye_cam:
+    type: git
+    url: https://github.com/anqixu/ueye_cam.git
+    version: master
   uncertain_tf:
     type: git
     url: https://github.com/ruehr/uncertain_tf.git

--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -834,6 +834,10 @@ repositories:
     type: git
     url: https://github.com/aswinthomas/udp-multicaster.git
     version: hydro-devel
+  ueye_cam:
+    type: git
+    url: https://github.com/anqixu/ueye_cam.git
+    version: master
   um6:
     type: git
     url: https://github.com/clearpathrobotics/um6.git


### PR DESCRIPTION
I'd like ueye_cam to be indexed and documented on ros.org.
