### PR TITLE
Adding receive_xsens to index for fuerte

### DIFF
--- a/doc/fuerte/receive_xsens.rosinstall
+++ b/doc/fuerte/receive_xsens.rosinstall
@@ -1,0 +1,3 @@
+- hg:
+    local-name: receive_xsens
+    uri: https://github.com/jizhang-cmu/receive_xsens.git


### PR DESCRIPTION
I'd like my receive_xsens to be indexed and documented on ros.org.
