### PR TITLE
geographic_info: 0.3.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -504,7 +504,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-geographic-info/geographic_info-release.git
-    version: 0.3.0-0
+    version: 0.3.1-0
   geometric_shapes:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `geographic_info`:
- previous version: `0.3.0-0`
- new version: `0.3.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
