### PR TITLE
Bumping version of swiftnav

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2113,7 +2113,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/libswiftnav-release.git
-    version: 0.0.1-0
+    version: 0.0.2-1
   tf2_web_republisher:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Mostly to add a new patch turning off CPU optimizations, as that's causing some trouble for us.
