### PR TITLE
nmea_comms: 0.0.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1138,7 +1138,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/nmea_comms-release.git
-    version: 0.0.2-0
+    version: 0.0.3-0
   nmea_gps_driver:
     status: end-of-life
     status_description: Replaced by the nmea_navsat_driver package. Scheduled to be


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_comms`:
- previous version: `0.0.2-0`
- new version: `0.0.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
