### PR TITLE
libswiftnav to 0.0.4

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2113,7 +2113,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/libswiftnav-release.git
-    version: 0.0.2-1
+    version: 0.0.4-0
   tf2_web_republisher:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Trying again with this, if I could. Third party releases ftw.
