### PR TITLE
enu: 1.1.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -413,7 +413,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/enu-release.git
-    version: 1.0.3-0
+    version: 1.1.0-0
   executive_smach:
     packages:
       executive_smach:


### PR DESCRIPTION
Increasing version of package(s) in repository `enu`:
- previous version: `1.0.3-0`
- new version: `1.1.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
