### PR TITLE
husky_base: 0.0.4-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -668,7 +668,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/husky_base-release.git
-    version: 0.0.3-0
+    version: 0.0.4-0
   husky_bringup:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_base`:
- previous version: `0.0.3-0`
- new version: `0.0.4-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
