### PR TITLE
husky_navigation: 0.0.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -692,6 +692,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/husky_metapackages-release.git
     version: 0.0.2-0
+  husky_navigation:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/husky_navigation-release.git
+    version: 0.0.3-0
   husky_simulator:
     packages:
       husky_gazebo:


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_navigation`:
- previous version: `null`
- new version: `0.0.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
