### PR TITLE
husky_viz: 0.0.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -710,7 +710,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/husky_viz-release.git
-    version: 0.0.2-0
+    version: 0.0.3-0
   image_common:
     packages:
       camera_calibration_parsers:


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_viz`:
- previous version: `0.0.2-0`
- new version: `0.0.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
