### PR TITLE
pluginlib: 1.9.23-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -964,7 +964,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/pluginlib-release.git
-    version: 1.9.22-0
+    version: 1.9.23-0
   pocketsphinx:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib`:
- previous version: `1.9.22-0`
- new version: `1.9.23-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
