### PR TITLE
pluginlib: 1.9.23-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1393,7 +1393,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pluginlib-release.git
-    version: 1.9.22-0
+    version: 1.9.23-0
   pocketsphinx:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib`:
- previous version: `1.9.22-0`
- new version: `1.9.23-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
