### PR TITLE
ros: 1.10.7-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1686,7 +1686,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros-release.git
-    version: 1.10.6-0
+    version: 1.10.7-0
   ros_comm:
     packages:
       message_filters:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros`:
- previous version: `1.10.6-0`
- new version: `1.10.7-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
