### PR TITLE
ros_comm: 1.9.50-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1734,7 +1734,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros_comm-release.git
-    version: 1.9.49-0
+    version: 1.9.50-0
   ros_control:
     packages:
       controller_interface:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm`:
- previous version: `1.9.49-0`
- new version: `1.9.50-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
