### PR TITLE
dynamixel_pro_driver: 0.8.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -271,7 +271,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/dynamixel_pro_driver-release.git
-    version: 0.8.2-0
+    version: 0.8.3-0
   dynamixel_pro_moveit_controller:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_pro_driver`:
- previous version: `0.8.2-0`
- new version: `0.8.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
