### PR TITLE
catkin: 0.5.75-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -111,7 +111,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/catkin-release.git
-    version: 0.5.74-0
+    version: 0.5.75-0
   class_loader:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin`:
- previous version: `0.5.74-0`
- new version: `0.5.75-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
