### PR TITLE
libuvc_ros: 0.0.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -926,7 +926,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ktossell/libuvc_ros-release.git
-    version: 0.0.4-0
+    version: 0.0.5-0
   manipulation_msgs:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc_ros`:
- previous version: `0.0.4-0`
- new version: `0.0.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
