### PR TITLE
Adding 2 packages loam_backAndForth and loam_continuous to documentation index for both Fuerte and Groovy

### DIFF
--- a/doc/fuerte/loam_backAndForth.rosinstall
+++ b/doc/fuerte/loam_backAndForth.rosinstall
@@ -1,0 +1,3 @@
+- git:
+    local-name: loam_backAndForth
+    uri: https://github.com/jizhang-cmu/loam_backAndForth.git

--- a/doc/fuerte/loam_continuous.rosinstall
+++ b/doc/fuerte/loam_continuous.rosinstall
@@ -1,0 +1,3 @@
+- git:
+    local-name: loam_continuous
+    uri: https://github.com/jizhang-cmu/loam_continuous.git

--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -766,6 +766,12 @@ repositories:
     type: svn
     url: https://code.ros.org/svn/ros-pkg/stacks/linux_networking/trunk
     version: HEAD
+  loam_backAndForth:
+    type: git
+    url: https://github.com/jizhang-cmu/loam_backAndForth.git
+  loam_continuous:
+    type: git
+    url: https://github.com/jizhang-cmu/loam_continuous.git
   lwr_arm_navigation:
     type: git
     url: https://github.com/RCPRG-ros-pkg/lwr_arm_navigation.git


### PR DESCRIPTION
Hello, could you add 2 packages, loam_backAndForth and loam_continuous, to documentation index for both Fuerte and Groovy. Thanks!
