### PR TITLE
Adding "loam_back_and_forth" to documentation index for both Fuerte and Groovy, to replace "loam_backAndForth"

### DIFF
--- a/doc/fuerte/loam_backAndForth.rosinstall
+++ b/doc/fuerte/loam_backAndForth.rosinstall
@@ -1,3 +1,0 @@
-- git:
-    local-name: loam_backAndForth
-    uri: https://github.com/jizhang-cmu/loam_backAndForth.git

--- a/doc/fuerte/loam_back_and_forth.rosinstall
+++ b/doc/fuerte/loam_back_and_forth.rosinstall
@@ -1,0 +1,3 @@
+- git:
+    local-name: loam_back_and_forth
+    uri: https://github.com/jizhang-cmu/loam_back_and_forth.git

--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -766,9 +766,9 @@ repositories:
     type: svn
     url: https://code.ros.org/svn/ros-pkg/stacks/linux_networking/trunk
     version: HEAD
-  loam_backAndForth:
+  loam_back_and_forth:
     type: git
-    url: https://github.com/jizhang-cmu/loam_backAndForth.git
+    url: https://github.com/jizhang-cmu/loam_back_and_forth.git
   loam_continuous:
     type: git
     url: https://github.com/jizhang-cmu/loam_continuous.git


### PR DESCRIPTION
Could you please add "loam_back_and_forth" to documentation index for both Fuerte and Groovy, and remove "loam_backAndForth". I changed the name because the old is not a compliant package name of ROS. Thanks!
