### PR TITLE
husky_navigation: 0.0.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -696,7 +696,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/husky_navigation-release.git
-    version: 0.0.4-0
+    version: 0.0.5-0
   husky_simulator:
     packages:
       husky_gazebo:


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_navigation`:
- previous version: `0.0.4-0`
- new version: `0.0.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
