### PR TITLE
Moving some TUM repositories from our old hosting at code.in.tum.de to g...

### DIFF
--- a/doc/fuerte/knowrob.rosinstall
+++ b/doc/fuerte/knowrob.rosinstall
@@ -1,3 +1,3 @@
-- svn:
+- git:
     local-name: knowrob
-    uri: http://code.in.tum.de/pubsvn/knowrob/branches/release
+    uri: https://github.com/knowrob/knowrob.git

--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -618,11 +618,11 @@ repositories:
     version: master
   ias_common:
     type: git
-    url: git://code.in.tum.de/git/ias-common.git
+    url: https://github.com/code-iai/ias_common.git
     version: master
   ias_perception:
     type: git
-    url: http://code.in.tum.de/git/ias-perception.git
+    url: https://github.com/code-iai/ias_perception.git
   image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
@@ -695,8 +695,8 @@ repositories:
     url: https://github.com/muhrix/kinect_aux.git
     version: groovy
   knowrob:
-    type: svn
-    url: http://code.in.tum.de/pubsvn/knowrob/branches/release
+    type: git
+    url: https://github.com/knowrob/knowrob.git
     version: HEAD
   kobuki:
     type: git


### PR DESCRIPTION
...ithub

Our team at the Technische Universitaet Muenchen (TUM) moved with the professor (Michael Beetz) to the University of Bremen about a year ago.

We are migrating away all the services hosted at TUM to either github or things hosted locally in Bremen.

Before we bring down the 'code.in.tum.de' server, we would like to update the documentation on the ros wiki.

Please accept this patch changing some of the repositories to their new places. About 3-4 are still missing, and will come soon.

Alexis Maldonado
amaldo@cs.uni-bremen.de
Universitaet Bremen
http://www.ai.uni-bremen.de/team/alexis_maldonado
