### PR TITLE
Removing cram-rosie, roll, mapping stacks

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -288,9 +288,6 @@ repositories:
   cram_pr2:
     type: git
     url: https://github.com/cram-code/cram_pr2.git
-  cram_rosie:
-    type: git
-    url: http://code.in.tum.de/git/cram-rosie.git
   depthcloudjs:
     type: git
     url: https://github.com/RobotWebTools/depthcloudjs.git
@@ -803,9 +800,6 @@ repositories:
     type: git
     url: https://github.com/ros-planning/map_store.git
     version: groovy-devel
-  mapping:
-    type: git
-    url: http://code.in.tum.de/git/mapping.git
   mapstitch:
     type: git
     url: https://github.com/tu-darmstadt-ros-pkg/mapstitch.git
@@ -1328,9 +1322,6 @@ repositories:
     type: git
     url: https://github.com/robotics-in-concert/rocon_tutorials.git
     version: groovy-devel
-  roll:
-    type: git
-    url: http://code.in.tum.de/git/roll.git
   ros:
     type: git
     url: https://github.com/ros/ros.git


### PR DESCRIPTION
They are unmaintained or have been ported somewhere else by their authors

code.in.tum.de is not mentioned anymore in groovy and the server can be stopped now.

I will contact the authors to get them to put their packages in the hydro doc.yaml if they work there too.
