### PR TITLE
threemxl: 0.1.6-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2128,7 +2128,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/wcaarls/threemxl-release
-    version: 0.1.4-0
+    version: 0.1.6-0
   topic_proxy:
     packages:
       blob:


### PR DESCRIPTION
Increasing version of package(s) in repository `threemxl`:
- previous version: `0.1.4-0`
- new version: `0.1.6-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
