### PR TITLE
nmea_navsat_driver: 0.3.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1163,7 +1163,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/nmea_navsat_driver-release.git
-    version: 0.3.2-0
+    version: 0.3.3-0
   nodelet_core:
     packages:
       nodelet:


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_navsat_driver`:
- previous version: `0.3.2-0`
- new version: `0.3.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
