### PR TITLE
hector_slam: 0.3.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -632,7 +632,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
-    version: 0.3.0-1
+    version: 0.3.1-0
   hector_worldmodel:
     packages:
       hector_object_tracker:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_slam`:
- previous version: `0.3.0-1`
- new version: `0.3.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
