### PR TITLE
rqt: 0.2.12-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1906,7 +1906,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rqt-release.git
-    version: 0.2.11-0
+    version: 0.2.12-0
   rqt_common_plugins:
     packages:
       rqt_action:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt`:
- previous version: `0.2.11-0`
- new version: `0.2.12-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
