### PR TITLE
catkin: 0.5.77-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -85,7 +85,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/catkin-release.git
-    version: 0.5.76-0
+    version: 0.5.77-0
   class_loader:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin`:
- previous version: `0.5.76-0`
- new version: `0.5.77-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
