### PR TITLE
qt_gui_core: 0.2.18-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -993,7 +993,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/qt_gui_core-release.git
-    version: 0.2.17-0
+    version: 0.2.18-0
   qt_ros:
     packages:
       qt_build:


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core`:
- previous version: `0.2.17-0`
- new version: `0.2.18-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
