### PR TITLE
rqt_common_plugins: 0.3.1-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1339,7 +1339,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-    version: 0.3.0-0
+    version: 0.3.1-0
   rqt_robot_plugins:
     packages:
       rqt_moveit:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins`:
- previous version: `0.3.0-0`
- new version: `0.3.1-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
