### PR TITLE
rtt: 2.6.9-2 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1983,6 +1983,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/start-jsk/rtshell_core-release.git
     version: 1.0.1-0
+  rtt:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/orocos-gbp/rtt-release.git
+    version: 2.6.9-1
   rviz:
     status: maintained
     tags:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1987,7 +1987,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/orocos-gbp/rtt-release.git
-    version: 2.6.9-1
+    version: 2.6.9-2
   rviz:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt`:
- previous version: `null`
- new version: `2.6.9-2`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
