### PR TITLE
libaria: installing version 2.8.0 (Pioneer LX support).

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -762,9 +762,9 @@ libargtable2-dev:
 libaria:
   ubuntu:
     source:
-      alternate-uri: 'http://aus-www.rasip.fer.hr/libaria.rdmanifest'
-      md5sum: f00cf4b5496b085a6b8ef9ce0389ec0b
-      uri: 'http://amor-ros-pkg.googlecode.com/files/libaria.rdmanifest'
+      alternate-uri: 'http://aus-www.rasip.fer.hr/libaria-2.8.0.rdmanifest'
+      md5sum: 589c387995beb951edd9c77f33cb2286
+      uri: 'http://amor-ros-pkg.googlecode.com/files/libaria-2.8.0.rdmanifest'
 libasound2-dev:
   arch: [alsa-lib]
   fedora: [alsa-lib]


### PR DESCRIPTION
Updated libaria version for rosdep.
