### PR TITLE
yujin_ocs: 0.5.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2397,7 +2397,7 @@ repositories:
     version: 0.1.0-0
   yujin_ocs:
     packages:
-      cmd_vel_mux:
+      yocs_cmd_vel_mux:
       yocs_controllers:
       yocs_diff_drive_pose_controller:
       yocs_math_toolkit:
@@ -2409,7 +2409,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/yujin_ocs-release.git
-    version: 0.4.1-0
+    version: 0.5.0-0
   zeroconf_avahi_suite:
     packages:
       zeroconf_avahi:


### PR DESCRIPTION
Increasing version of package(s) in repository `yujin_ocs`:
- previous version: `0.4.1-0`
- new version: `0.5.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
