### PR TITLE
moveit_setup_assistant: 0.5.4-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1088,7 +1088,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
-    version: 0.5.3-0
+    version: 0.5.4-0
   multimaster_fkie:
     packages:
       default_cfg_fkie:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_setup_assistant`:
- previous version: `0.5.3-0`
- new version: `0.5.4-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
