### PR TITLE
ros_control: 0.5.8-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1749,7 +1749,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ros_control-release.git
-    version: 0.5.7-0
+    version: 0.5.8-0
   ros_controllers:
     packages:
       effort_controllers:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control`:
- previous version: `0.5.7-0`
- new version: `0.5.8-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
