### PR TITLE
orocos_toolchain repositories in hydro source file

### DIFF
--- a/hydro/source.yaml
+++ b/hydro/source.yaml
@@ -164,10 +164,6 @@ repositories:
     type: git
     url: https://github.com/ktossell/libuvc_ros.git
     version: master
-  log4cpp:
-    type: git
-    url: https://git.gitorious.org/orocos-toolchain/log4cpp.git
-    version: master
   multi_level_map:
     type: git
     url: https://github.com/utexas-bwi/multi_level_map.git
@@ -196,10 +192,6 @@ repositories:
     type: git
     url: http://github.com/wg-perception/transparent_objects.git
     version: master
-  ocl:
-    type: git
-    url: https://git.gitorious.org/orocos-toolchain/ocl.git
-    version: master
   octomap_msgs:
     type: git
     url: https://github.com/OctoMap/octomap_msgs.git
@@ -217,10 +209,6 @@ repositories:
   orocos_toolchain:
     type: git
     url: https://git.gitorious.org/orocos-toolchain/orocos_toolchain.git
-    version: catkin
-  orogen:
-    type: git
-    url: https://git.gitorious.org/orocos-toolchain/orogen.git
     version: catkin
   pcl_conversions:
     type: git
@@ -302,14 +290,6 @@ repositories:
   rospack:
     type: git
     url: https://github.com/ros/rospack.git
-  rtt:
-    type: git
-    url: https://git.gitorious.org/orocos-toolchain/rtt.git
-    version: catkin
-  rtt_typelib:
-    type: git
-    url: https://git.gitorious.org/orocos-toolchain/rtt_typelib.git
-    version: master
   rx:
     type: git
     url: https://github.com/ros-visualization/rx.git
@@ -337,22 +317,10 @@ repositories:
   std_msgs:
     type: git
     url: https://github.com/ros/std_msgs.git
-  typelib:
-    type: git
-    url: https://git.gitorious.org/orocos-toolchain/typelib.git
-    version: catkin
   unique_identifier:
     type: git
     url: https://github.com/ros-geographic-info/unique_identifier.git
     version: master
-  utilmm:
-    type: git
-    url: https://git.gitorious.org/orocos-toolchain/utilmm.git
-    version: master
-  utilrb:
-    type: git
-    url: https://git.gitorious.org/orocos-toolchain/utilrb.git
-    version: catkin
   velodyne:
     type: git
     url: https://github.com/ros-drivers/velodyne.git


### PR DESCRIPTION
I added the orocos_toolchain repositories to hydro's source.yaml last week in order to do prerelease tests on the source repositories (see #2332). This pull request partially reverts that commit.

orocos_toolchain consists of the main repository and eight sub-repositories (rtt, ocl, log4cpp, ...) which are usually pulled in as git submodules. The prerelease test for orocos_toolchain was successful and orocos_toolchain will be released to hydro soon.

It seems that the [devel-hydro-orocos_toolchain](http://jenkins.ros.org/job/devel-hydro-orocos_toolchain/) job already includes all the submodules. All other jobs in Hdev related to the orocos_toolchain are therefore somehow redundant. Is there any advantage to keep them in source.yaml or should they be removed to save computation time? Currently some of them fail because rosdep keys of dependencies are not yet available (e.g. [devel-hydro-ocl](http://jenkins.ros.org/job/devel-hydro-ocl/)).

Releases will probably also happen separately as the version numbers of packages currently differ and [bloom cannot handle submodules](http://answers.ros.org/question/76732/build-failure-after-moving-submodule/).

Please merge this pull request or not, whatever makes more sense.
CC to @smits
