### PR TITLE
Pull request for additional OpenSUSE bindings

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -311,6 +311,7 @@ cmake:
   debian: [cmake]
   fedora: [cmake]
   gentoo: [dev-util/cmake]
+  opensuse: [cmake]
   ubuntu: [cmake]
 coinor-libipopt-dev:
   arch: [coinor-all]
@@ -407,12 +408,14 @@ eigen:
   gentoo:
     portage:
       packages: [dev-cpp/eigen]
+  opensuse: [libeigen3-devel]
   rhel: [eigen3-devel]
   ubuntu:
     apt:
       packages: [libeigen3-dev]
 eigen2:
   arch: [eigen2]
+  opensuse: [libeigen2-devel]
   ubuntu:
     apt:
       packages: [libeigen2-dev]
@@ -697,6 +700,7 @@ jasper:
   fedora: [jasper-devel]
   gentoo: [jasper]
   macports: [jasper]
+  opensuse: [libjasper-devel]
   ubuntu: [libjasper-dev]
 java:
   arch: [openjdk6]
@@ -1068,6 +1072,7 @@ libjpeg:
   fedora: [libjpeg-turbo-devel]
   gentoo: [libjpeg-turbo]
   macports: [jpeg]
+  opensuse: [libjpeg62-devel]
   ubuntu:
     lucid: [libjpeg62-dev]
     maverick: [libjpeg62-dev]
@@ -1153,6 +1158,7 @@ libmysqlclient-dev:
   gentoo:
     portage:
       packages: [dev-db/mariadb]
+  opensuse: [libmysqlclient-devel]
   ubuntu: [libmysqlclient-dev]
 libncurses-dev:
   arch: [ncurses]
@@ -1190,6 +1196,7 @@ libogg:
   fedora: [libogg-devel]
   gentoo: [media-libs/libogg]
   macports: [libogg]
+  opensuse: [libogg-devel]
   ubuntu: [libogg-dev]
 libogre-dev:
   arch: [ogre]
@@ -1295,6 +1302,7 @@ libpng12-dev:
   gentoo:
     portage:
       packages: [media-libs/libpng]
+  opensuse: [libpng12-devel]
   ubuntu: [libpng12-dev]
 libpoco-dev:
   arch: [poco]
@@ -1340,6 +1348,7 @@ libqhull:
   fedora: [qhull-devel]
   gentoo: [media-libs/qhull]
   macports: [qhull]
+  opensuse: [qhull-devel]
   ubuntu: [libqhull-dev]
 libqt4:
   arch: [qt4]
@@ -1381,6 +1390,7 @@ libqt4-opengl-dev:
   gentoo:
     portage:
       packages: [dev-qt/qtopengl]
+  opensuse: [libqt4-devel]
   rhel: [qt-devel]
   ubuntu: [libqt4-opengl-dev]
 libqt4-sql-psql:
@@ -1522,6 +1532,7 @@ libtheora:
   fedora: [libtheora-devel]
   gentoo: [media-libs/libtheora]
   macports: [libtheora]
+  opensuse: [libtheora-devel]
   ubuntu: [libtheora-dev]
 libtiff-dev:
   arch: [libtiff]
@@ -1532,6 +1543,7 @@ libtiff-dev:
   gentoo:
     portage:
       packages: [media-libs/tiff]
+  opensuse: [libtiff-devel]
   ubuntu:
     lucid: [libtiff4-dev]
     maverick: [libtiff4-dev]
@@ -1588,6 +1600,7 @@ libusb-1.0-dev:
     beefy: [libusb1-devel]
     schrödinger’s: [libusbx-devel]
     spherical: [libusbx-devel]
+  opensuse: [libusb-1_0-devel]
   ubuntu: [libusb-1.0-0-dev]
 libusb-dev:
   arch: [libusb-compat]
@@ -1598,6 +1611,7 @@ libv4l-dev:
   arch: [v4l-utils]
   debian: [libv4l-dev]
   fedora: [libv4l-devel]
+  opensuse: [libv4l-devel]
   ubuntu: [libv4l-dev]
 libvtk:
   arch: [vtk]
@@ -1605,6 +1619,7 @@ libvtk:
   fedora: [vtk-devel]
   gentoo: [sci-libs/vtk]
   macports: [vtk-devel]
+  opensuse: [vtk-devel]
   ubuntu:
     lucid: [libvtk5-dev]
     maverick: [libvtk5-dev]
@@ -1729,7 +1744,7 @@ log4cxx:
   freebsd: [log4cxx]
   gentoo: [dev-libs/log4cxx]
   macports: [log4cxx]
-  opensuse: [log4cxx-devel]
+  opensuse: [liblog4cxx-devel]
   rhel: [log4cxx-devel]
   ubuntu: [liblog4cxx10-dev]
 lua-dev:
@@ -1916,6 +1931,7 @@ qt4-qmake:
   debian: [qt4-qmake]
   fedora: [qt-devel]
   gentoo: [qt-core]
+  opensuse: [libqt4-devel]
   rhel: [qt-devel]
   ubuntu: [qt4-qmake]
 readline-dev:
@@ -2127,6 +2143,7 @@ tbb:
   debian: [libtbb-dev]
   fedora: [tbb-devel]
   gentoo: [tbb]
+  opensuse: [tbb-devel]
   ubuntu: [libtbb-dev]
 tcsh:
   arch: [tcsh]
@@ -2173,6 +2190,7 @@ tinyxml:
   debian: [libtinyxml-dev]
   fedora: [tinyxml-devel]
   gentoo: [tinyxml]
+  opensuse: [tinyxml-devel]
   rhel: [tinyxml-devel]
   ubuntu: [libtinyxml-dev]
 tix:
@@ -2240,6 +2258,7 @@ uuid:
   freebsd: [e2fsprogs-libuuid]
   gentoo: [util-linux]
   macports: [ossp-uuid]
+  opensuse: [libuuid-devel]
   rhel: [libuuid-devel]
   ubuntu: [uuid-dev]
 vlc:
@@ -2379,6 +2398,7 @@ yaml-cpp:
         packages: [libyaml-cpp-dev]
   fedora: [yaml-cpp-devel]
   gentoo: [yaml-cpp]
+  opensuse: [yaml-cpp-devel]
   rhel: [yaml-cpp-devel]
   ubuntu:
     lucid: [yaml-cpp0.2.6-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -305,8 +305,8 @@ python-qt-bindings:
     squeeze: [python-qt4, python-qt4-dev, pyhton-sip-dev]
     wheezy: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
   fedora: [PyQt4, PyQt4-devel, sip-devel]
-  opensuse: [python-qt4-devel]
   gentoo: [PyQt4]
+  opensuse: [python-qt4-devel]
   rhel: [PyQt4, PyQt4-devel, sip-devel]
   ubuntu:
     lucid: [python-qt4, python-qt4-dev, python-sip-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -30,6 +30,7 @@ python:
 python-argparse:
   debian: [python-argparse]
   fedora: [python]
+  opensuse: [python-argparse]
   ubuntu:
     lucid: [python-argparse]
     maverick: [python-argparse]
@@ -106,6 +107,7 @@ python-docutils:
 python-empy:
   debian: [python-empy]
   fedora: [python-empy]
+  opensuse: [python-empy]
   ubuntu: [python-empy]
 python-espeak:
   debian: [python-espeak]
@@ -182,6 +184,7 @@ python-nose:
   arch: [python2-nose]
   debian: [python-nose]
   fedora: [python-nose]
+  opensuse: [python-nose]
   ubuntu: [python-nose]
 python-numpy:
   arch: [python2-numpy]
@@ -206,6 +209,7 @@ python-omniorb:
 python-opengl:
   debian: [python-opengl]
   fedora: [PyOpenGL]
+  opensuse: [python-opengl]
   ubuntu: [python-opengl]
 python-paramiko:
   arch: [python-paramiko]
@@ -301,6 +305,7 @@ python-qt-bindings:
     squeeze: [python-qt4, python-qt4-dev, pyhton-sip-dev]
     wheezy: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
   fedora: [PyQt4, PyQt4-devel, sip-devel]
+  opensuse: [python-qt4-devel]
   gentoo: [PyQt4]
   rhel: [PyQt4, PyQt4-devel, sip-devel]
   ubuntu:
@@ -312,6 +317,7 @@ python-qt-bindings:
 python-qt-bindings-gl:
   debian: [python-qt4-gl]
   fedora: [PyQt4]
+  opensuse: [python-qt4-devel]
   ubuntu: [python-qt4-gl]
 python-qt-bindings-qwt5:
   debian: [python-qwt5-qt4]
@@ -377,6 +383,7 @@ python-sip:
   freebsd: [py26-sip]
   gentoo: [dev-python/sip]
   macports: [py26-sip]
+  opensuse: [python-sip-devel]
   osxbrew:
     homebrew:
       packages: [sip]
@@ -388,6 +395,7 @@ python-sphinx:
   fedora: [python-sphinx]
   freebsd: [py27-sphinx]
   macports: [py26-sphinx]
+  opensuse: [python-Sphinx]
   ubuntu: [python-sphinx]
 python-support:
   debian: [python-support]


### PR DESCRIPTION
I've added several bindings in rosdep/base.yaml and rosdep/python.yaml for OpenSUSE. I also corrected what I presume to be an error with the opensuse binding of log4cxx, renaming it to liblog4cxx-devel. I've run the nosetests and they passed. If you could merge these changes in, that would be splendid.
