### PR TITLE
log4cpp: v2.7.0-rc1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -927,6 +927,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ktossell/libuvc_ros-release.git
     version: 0.0.5-0
+  log4cpp:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/orocos-gbp/log4cpp-release.git
+    version: v2.7.0-rc1-0
   manipulation_msgs:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `log4cpp`:
- previous version: `null`
- new version: `v2.7.0-rc1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
