### PR TITLE
utilmm: 2.7.0-rc1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2285,6 +2285,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/bosch-ros-pkg-release/usb_cam-release.git
     version: 0.1.3-0
+  utilmm:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/orocos-gbp/utilmm-release.git
+    version: 2.7.0-rc1-0
   uwsim_bullet:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `utilmm`:
- previous version: `null`
- new version: `2.7.0-rc1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
