### PR TITLE
utilrb: 2.7.0-rc1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -927,11 +927,6 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ktossell/libuvc_ros-release.git
     version: 0.0.5-0
-  log4cpp:
-    tags:
-      release: release/hydro/{package}/{version}
-    url: https://github.com/orocos-gbp/log4cpp-release.git
-    version: 2.7.0-0
   manipulation_msgs:
     tags:
       release: release/hydro/{package}/{version}
@@ -2290,6 +2285,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/bosch-ros-pkg-release/usb_cam-release.git
     version: 0.1.3-0
+  utilrb:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/orocos-gbp/utilrb-release.git
+    version: 2.7.0-rc1-0
   uwsim_bullet:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `utilrb`:
- previous version: `null`
- new version: `2.7.0-rc1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
