### PR TITLE
rtt: 2.7.0-rc1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1992,7 +1992,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/orocos-gbp/rtt-release.git
-    version: 2.6.9-2
+    version: 2.7.0-rc1-0
   rviz:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt`:
- previous version: `2.6.9-2`
- new version: `2.7.0-rc1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
