### PR TITLE
ocl: 2.7.0-rc1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1241,6 +1241,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/object_recognition_transparent_objects-release.git
     version: 0.3.18-0
+  ocl:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/orocos-gbp/ocl-release.git
+    version: 2.7.0-rc1-0
   octomap:
     packages:
       octomap:


### PR DESCRIPTION
Increasing version of package(s) in repository `ocl`:
- previous version: `null`
- new version: `2.7.0-rc1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
