### PR TITLE
Remove kingfisher packages

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -789,16 +789,6 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/joystick_drivers-release.git
     version: 1.9.10-0
-  kingfisher_bringup:
-    tags:
-      release: release/hydro/{package}/{version}
-    url: https://github.com/clearpath-gbp/kingfisher_bringup-release.git
-    version: 0.0.1-0
-  kingfisher_msgs:
-    tags:
-      release: release/hydro/{package}/{version}
-    url: https://github.com/clearpath-gbp/kingfisher_msgs-release.git
-    version: 0.0.1-1
   kobuki:
     packages:
       kobuki:


### PR DESCRIPTION
We reorganized the KF software into a smaller number of repos and will redo these from new release repos.
