### PR TITLE
Added orocos_toolchain documentation for hydro, groovy and fuerte

### DIFF
--- a/doc/fuerte/orocos_toolchain.rosinstall
+++ b/doc/fuerte/orocos_toolchain.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: orocos_toolchain
+    uri: https://git.gitorious.org/orocos-toolchain/orocos_toolchain.git
+    version: master

--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -1046,6 +1046,10 @@ repositories:
     type: git
     url: http://git.mech.kuleuven.be/robotics/orocos_kinematics_dynamics.git
     version: master
+  orocos_toolchain:
+    type: git
+    url: https://git.gitorious.org/orocos-toolchain/orocos_toolchain.git
+    version: master
   orocos_tools:
     type: git
     url: https://github.com/RCPRG-ros-pkg/orocos_tools.git

--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -543,6 +543,10 @@ repositories:
     type: svn
     url: https://rtm-ros-robotics.googlecode.com/svn/trunk/openrtm_common/openrtm_aist_core
     version: HEAD
+  orocos_toolchain:
+    type: git
+    url: https://git.gitorious.org/orocos-toolchain/orocos_toolchain.git
+    version: catkin
   pcl:
     type: git
     url: https://github.com/ros-gbp/pcl-release.git


### PR DESCRIPTION
I only added the orocos_toolchain repository that will hopefully clone and document all submodules as well (see #2347).

Not sure if there still will be doc jobs for ROS fuerte, just for completeness...
