### PR TITLE
ros: 1.9.53-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1146,7 +1146,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/ros-release.git
-    version: 1.9.52-0
+    version: 1.9.53-0
   ros_comm:
     packages:
       message_filters:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros`:
- previous version: `1.9.52-0`
- new version: `1.9.53-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
