### PR TITLE
kingfisher: 0.0.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -789,6 +789,15 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/joystick_drivers-release.git
     version: 1.9.10-0
+  kingfisher:
+    packages:
+      kingfisher_description:
+      kingfisher_msgs:
+      kingfisher_teleop:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/kingfisher-release.git
+    version: 0.0.2-0
   kobuki:
     packages:
       kobuki:


### PR DESCRIPTION
Increasing version of package(s) in repository `kingfisher`:
- previous version: `null`
- new version: `0.0.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
