### PR TITLE
kingfisher_desktop: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -798,6 +798,14 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/kingfisher-release.git
     version: 0.0.2-0
+  kingfisher_desktop:
+    packages:
+      kingfisher_desktop:
+      kingfisher_viz:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/kingfisher_desktop-release.git
+    version: 0.0.1-0
   kobuki:
     packages:
       kobuki:


### PR DESCRIPTION
Increasing version of package(s) in repository `kingfisher_desktop`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
