### PR TITLE
opencv2: 2.4.6-2 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1313,7 +1313,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/opencv2-release.git
-    version: 2.4.6-1
+    version: 2.4.6-2
   opencv2_doc:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `opencv2`:
- previous version: `2.4.6-1`
- new version: `2.4.6-2`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
