### PR TITLE
typelib: 2.7.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2238,6 +2238,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/turtlebot-release/turtlebot_viz-release.git
     version: 2.2.1-0
+  typelib:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/orocos-gbp/typelib-release.git
+    version: 2.7.0-0
   um6:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `typelib`:
- previous version: `null`
- new version: `2.7.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
