### PR TITLE
Adding wifi_scan to documentation index for distro

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -906,6 +906,10 @@ repositories:
     type: git
     url: https://github.com/ros-drivers/wifi_ddwrt.git
     version: hydro-devel
+  wifi_scan:
+    type: git
+    url: https://github.com/RafBerkvens/wifi_scan.git
+    version: master
   win_ros:
     type: git
     url: https://github.com/ros-windows/win_ros.git


### PR DESCRIPTION
I'd like wifi_scan to be indexed and documented on ros.org.
