### PR TITLE
typelib: 2.7.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2242,7 +2242,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/orocos-gbp/typelib-release.git
-    version: 2.7.0-0
+    version: 2.7.0-1
   um6:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `typelib`:
- previous version: `2.7.0-0`
- new version: `2.7.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
