### PR TITLE
wireless: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2056,7 +2056,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/wjwwood/serial-release.git
-    version: 1.1.6-0
+    version: 1.1.5-0
   serial_utils:
     tags:
       release: release/hydro/{package}/{version}
@@ -2410,6 +2410,14 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/wifi_ddwrt-release.git
     version: 0.2.0-0
+  wireless:
+    packages:
+      wireless_msgs:
+      wireless_watcher:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/wireless-release.git
+    version: 0.0.1-0
   xacro:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
