### PR TITLE
roslint: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1878,6 +1878,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/rosjava-release/rosjava_messages-release.git
     version: 0.1.26-0
+  roslint:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/roslint-release.git
+    version: 0.0.1-0
   roslisp:
     tags:
       release: release/hydro/{package}/{version}

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1879,6 +1879,7 @@ repositories:
     url: https://github.com/rosjava-release/rosjava_messages-release.git
     version: 0.1.26-0
   roslint:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/roslint-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslint`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
