### PR TITLE
Adding phidgets_drivers to documentation index for groovy and hydro

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -1068,6 +1068,10 @@ repositories:
     type: git
     url: https://github.com/ros-perception/perception_pcl.git
     version: master
+  phidgets_drivers:
+    type: git
+    url: https://github.com/ccny-ros-pkg/phidgets_drivers.git
+    version: groovy
   physics_ode:
     type: svn
     url: https://code.ros.org/svn/ros-pkg/stacks/physics_ode/trunk

--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -563,6 +563,10 @@ repositories:
     type: git
     url: https://github.com/ros-perception/perception_pcl.git
     version: hydro-devel
+  phidgets_drivers:
+    type: git
+    url: https://github.com/ccny-ros-pkg/phidgets_drivers.git
+    version: hydro
   pluginlib:
     type: git
     url: https://github.com/ros/pluginlib.git


### PR DESCRIPTION
The metapackage phidgets_drivers has been catkinised and I'd like it to be indexed documented on ros.org.
