### PR TITLE
rosruby_common: 0.1.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1905,6 +1905,15 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/OTL/rosruby-release.git
     version: 0.5.2-0
+  rosruby_common:
+    packages:
+      rosruby_actionlib:
+      rosruby_common:
+      rosruby_tutorials:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/OTL/rosruby_common-release
+    version: 0.1.1-0
   rosserial:
     packages:
       rosserial:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosruby_common`:
- previous version: `null`
- new version: `0.1.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
