### PR TITLE
rosruby_messages: 0.1.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1914,6 +1914,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/OTL/rosruby_common-release
     version: 0.1.1-0
+  rosruby_messages:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/OTL/rosruby_messages-release
+    version: 0.1.1-0
   rosserial:
     packages:
       rosserial:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosruby_messages`:
- previous version: `null`
- new version: `0.1.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
