### PR TITLE
rosruby: 0.5.4-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1904,7 +1904,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/OTL/rosruby-release.git
-    version: 0.5.3-0
+    version: 0.5.4-1
   rosruby_common:
     packages:
       rosruby_actionlib:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosruby`:
- previous version: `0.5.3-0`
- new version: `0.5.4-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
