### PR TITLE
qt_ros: 0.1.5-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1000,7 +1000,10 @@ repositories:
       qt_create:
       qt_ros:
       qt_tutorials:
+    tags:
+      release: release/groovy/{package}/{version}
     url: https://github.com/yujinrobot-release/qt_ros-release.git
+    version: 0.1.5-0
   rail_maps:
     tags:
       release: release/{package}/{upstream_version}


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_ros`:
- previous version: `null`
- new version: `0.1.5-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
