### PR TITLE
rosruby_common: 0.1.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1913,7 +1913,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/OTL/rosruby_common-release
-    version: 0.1.2-0
+    version: 0.1.3-0
   rosruby_messages:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `rosruby_common`:
- previous version: `0.1.2-0`
- new version: `0.1.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
