### PR TITLE
rtmros_hironx: 1.0.2-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1383,7 +1383,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/rtmros_hironx-release.git
-    version: 1.0.1-0
+    version: 1.0.2-0
   rtshell_core:
     packages:
       rtctree:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx`:
- previous version: `1.0.1-0`
- new version: `1.0.2-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
