### PR TITLE
qt_ros: 0.1.6-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1003,7 +1003,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/yujinrobot-release/qt_ros-release.git
-    version: 0.1.5-0
+    version: 0.1.6-0
   rail_maps:
     tags:
       release: release/{package}/{upstream_version}


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_ros`:
- previous version: `0.1.5-0`
- new version: `0.1.6-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
