### PR TITLE
qt_ros: 0.2.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1533,6 +1533,16 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/qt_gui_core-release.git
     version: 0.2.18-0
+  qt_ros:
+    packages:
+      qt_build:
+      qt_create:
+      qt_ros:
+      qt_tutorials:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/yujinrobot-release/qt_ros-release.git
+    version: 0.2.1-0
   rail_maps:
     url: https://github.com/wpi-rail-release/rail_maps-release.git
   random_numbers:


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_ros`:
- previous version: `null`
- new version: `0.2.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
