### PR TITLE
rosdep: libaria install script moved to github

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -775,9 +775,8 @@ libargtable2-dev:
 libaria:
   ubuntu:
     source:
-      alternate-uri: 'http://aus-www.rasip.fer.hr/libaria-2.8.0.rdmanifest'
       md5sum: 589c387995beb951edd9c77f33cb2286
-      uri: 'http://amor-ros-pkg.googlecode.com/files/libaria-2.8.0.rdmanifest'
+      uri: 'https://raw.github.com/amor-ros-pkg/rosaria/master/libaria.rdmanifest'
 libasound2-dev:
   arch: [alsa-lib]
   fedora: [alsa-lib]


### PR DESCRIPTION
The official repository location has changed to github.
