### PR TITLE
Adding my wheeled_robin_* to documentation index for hydro

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -918,6 +918,18 @@ repositories:
     type: git
     url: https://github.com/ros-planning/warehouse_ros.git
     version: master
+  wheeled_robin:
+    type: git
+    url: https://github.com/robinJKU/wheeled_robin.git
+    version: hydro-devel
+  wheeled_robin_apps:
+    type: git
+    url: https://github.com/robinJKU/wheeled_robin_apps.git
+    version: hydro-devel
+  wheeled_robin_simulator:
+    type: git
+    url: https://github.com/robinJKU/wheeled_robin_simulator.git
+    version: hydro-devel
   wifi_ddwrt:
     type: git
     url: https://github.com/ros-drivers/wifi_ddwrt.git


### PR DESCRIPTION
I'd like wheeled_robin_\* to be indexed and documented on ros.org.
