### PR TITLE
qt_ros: 0.2.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1543,7 +1543,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/qt_ros-release.git
-    version: 0.2.1-0
+    version: 0.2.2-0
   rail_maps:
     url: https://github.com/wpi-rail-release/rail_maps-release.git
   random_numbers:


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_ros`:
- previous version: `0.2.1-0`
- new version: `0.2.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
