### PR TITLE
Adding my crsm_slam to documentation index for distro

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -115,6 +115,10 @@ repositories:
     type: git
     url: https://github.com/tu-darmstadt-ros-pkg/cpp_introspection.git
     version: master
+  crsm_slam:
+    type: git
+    url: https://github.com/etsardou/crsm-slam-ros-pkg.git
+    version: hydro-devel
   declination:
     type: git
     url: https://github.com/clearpathrobotics/declination.git


### PR DESCRIPTION
I'd like my crsm_slam to be indexed and documented on ros.org
