### PR TITLE
rosleapmotion: 0.0.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1889,6 +1889,14 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/rosjava-release/rosjava_messages-release.git
     version: 0.1.26-0
+  rosleapmotion:
+    packages:
+      leap_motion:
+        subfolder: .
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/rosleapmotion-release
+    version: 0.0.2-0
   roslint:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosleapmotion`:
- previous version: `null`
- new version: `0.0.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
