### PR TITLE
rosleapmotion: 0.0.2-2 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1267,6 +1267,14 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/roseus-release.git
     version: 0.1.0-0
+  rosleapmotion:
+    packages:
+      leap_motion:
+        subfolder: .
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/ros-gbp/rosleapmotion-release
+    version: 0.0.2-2
   roslisp:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `rosleapmotion`:
- previous version: `null`
- new version: `0.0.2-2`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
