### PR TITLE
octomap_mapping: 0.5.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1262,6 +1262,14 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/octomap-release.git
     version: 1.6.1-0
+  octomap_mapping:
+    packages:
+      octomap_mapping:
+      octomap_server:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/octomap_mapping-release
+    version: 0.5.0-0
   octomap_msgs:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping`:
- previous version: `null`
- new version: `0.5.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
