### PR TITLE
urg_node: 0.1.6-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2348,7 +2348,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/urg_node-release.git
-    version: 0.1.5-0
+    version: 0.1.6-0
   usb_cam:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node`:
- previous version: `0.1.5-0`
- new version: `0.1.6-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
