### PR TITLE
wireless: 0.0.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2464,7 +2464,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/wireless-release.git
-    version: 0.0.1-0
+    version: 0.0.2-0
   xacro:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless`:
- previous version: `0.0.1-0`
- new version: `0.0.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
