### PR TITLE
um6: 0.0.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2294,7 +2294,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/um6-release.git
-    version: 0.0.1-1
+    version: 0.0.2-0
   underwater_simulation:
     packages:
       underwater_sensor_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `um6`:
- previous version: `0.0.1-1`
- new version: `0.0.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
