### PR TITLE
imu_compass: 0.0.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -756,7 +756,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/imu_compass-release.git
-    version: 0.0.2-0
+    version: 0.0.3-0
   imu_pipeline:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_compass`:
- previous version: `0.0.2-0`
- new version: `0.0.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
