### PR TITLE
kingfisher: 0.0.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -797,7 +797,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/kingfisher-release.git
-    version: 0.0.2-0
+    version: 0.0.3-0
   kingfisher_desktop:
     packages:
       kingfisher_desktop:


### PR DESCRIPTION
Increasing version of package(s) in repository `kingfisher`:
- previous version: `0.0.2-0`
- new version: `0.0.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
