### PR TITLE
kingfisher_robot: 0.0.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -806,6 +806,13 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/kingfisher_desktop-release.git
     version: 0.0.1-0
+  kingfisher_robot:
+    packages:
+      kingfisher_bringup:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/kingfisher_robot-release.git
+    version: 0.0.2-0
   kobuki:
     packages:
       kobuki:


### PR DESCRIPTION
Increasing version of package(s) in repository `kingfisher_robot`:
- previous version: `null`
- new version: `0.0.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
