### PR TITLE
rosleapmotion: 0.0.3-1 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1274,7 +1274,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/rosleapmotion-release
-    version: 0.0.3-0
+    version: 0.0.3-1
   roslisp:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `rosleapmotion`:
- previous version: `0.0.3-0`
- new version: `0.0.3-1`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
