### PR TITLE
rosleapmotion: 0.0.3-3 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1911,7 +1911,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rosleapmotion-release
-    version: 0.0.3-2
+    version: 0.0.3-3
   roslint:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosleapmotion`:
- previous version: `0.0.3-2`
- new version: `0.0.3-3`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
