### PR TITLE
humanoid_msgs: 0.2.0-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -424,6 +424,14 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/hrpsys-release.git
     version: 0.0.2-0
+  humanoid_msgs:
+    packages:
+      humanoid_msgs:
+      humanoid_nav_msgs:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/ros-gbp/humanoid_msgs-release
+    version: 0.2.0-0
   image_common:
     packages:
       camera_calibration_parsers:


### PR DESCRIPTION
Increasing version of package(s) in repository `humanoid_msgs`:
- previous version: `null`
- new version: `0.2.0-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
