### PR TITLE
rosruby: 0.5.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1938,7 +1938,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/OTL/rosruby-release.git
-    version: 0.5.4-1
+    version: 0.5.5-0
   rosruby_common:
     packages:
       rosruby_actionlib:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosruby`:
- previous version: `0.5.4-1`
- new version: `0.5.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
