### PR TITLE
rosjava_extras: 0.1.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1897,7 +1897,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/rosjava-release/rosjava_extras-release.git
-    version: 0.1.2-1
+    version: 0.1.3-0
   rosjava_messages:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_extras`:
- previous version: `0.1.2-1`
- new version: `0.1.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
