### PR TITLE
zeroconf_jmdns_suite: 0.1.11-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2519,7 +2519,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/rosjava-release/zeroconf_jmdns_suite-release.git
-    version: 0.1.10-1
+    version: 0.1.11-0
   zeroconf_msgs:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `zeroconf_jmdns_suite`:
- previous version: `0.1.10-1`
- new version: `0.1.11-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
