### PR TITLE
rosleapmotion: 0.0.3-4 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1282,7 +1282,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/rosleapmotion-release
-    version: 0.0.3-3
+    version: 0.0.3-4
   roslisp:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `rosleapmotion`:
- previous version: `0.0.3-3`
- new version: `0.0.3-4`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
