### PR TITLE
hrpsys: 3.1.3-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -423,7 +423,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/hrpsys-release.git
-    version: 0.0.2-0
+    version: 3.1.3-0
   humanoid_msgs:
     packages:
       humanoid_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys`:
- previous version: `0.0.2-0`
- new version: `3.1.3-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
