### PR TITLE
rtt_typelib: 2.7.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2059,6 +2059,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/orocos-gbp/rtt-release.git
     version: 2.7.0-0
+  rtt_typelib:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/orocos-gbp/rtt_typelib-release.git
+    version: 2.7.0-0
   rviz:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_typelib`:
- previous version: `null`
- new version: `2.7.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
