### PR TITLE
orogen: 2.7.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1393,6 +1393,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/smits/orocos-kdl-release.git
     version: 1.1.102-0
+  orogen:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/orocos-gbp/orogen-release.git
+    version: 2.7.0-0
   p2os:
     packages:
       p2os_driver:


### PR DESCRIPTION
Increasing version of package(s) in repository `orogen`:
- previous version: `null`
- new version: `2.7.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
