### PR TITLE
humanoid_msgs: 0.2.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -664,6 +664,14 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/start-jsk/hrpsys-release.git
     version: 0.0.2-0
+  humanoid_msgs:
+    packages:
+      humanoid_msgs:
+      humanoid_nav_msgs:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/humanoid_msgs-release
+    version: 0.2.0-1
   husky_base:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `humanoid_msgs`:
- previous version: `null`
- new version: `0.2.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
