### PR TITLE
nao_robot: 0.2.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1128,6 +1128,18 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/fkie-release/multimaster_fkie-release.git
     version: 0.3.7-0
+  nao_robot:
+    packages:
+      nao_bringup:
+      nao_description:
+      nao_driver:
+      nao_msgs:
+      nao_pose:
+      nao_robot:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/nao_robot-release
+    version: 0.2.2-0
   navigation:
     packages:
       amcl:


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_robot`:
- previous version: `null`
- new version: `0.2.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
