### PR TITLE
Adding camera_aravis to documentation index for distro

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -75,6 +75,10 @@ repositories:
     type: git
     url: https://github.com/ros-drivers/camera1394.git
     version: master
+  camera_aravis:
+    type: git
+    url: https://github.com/ssafarik/camera_aravis.git
+    version: master
   camera_info_manager_py:
     type: git
     url: https://github.com/ros-perception/camera_info_manager_py.git


### PR DESCRIPTION
This is an ethernet camera driver for ROS, based on the Aravis library.
