### PR TITLE
rtmros_nextage: no-version in 'groovy/release.yaml' for pre-release test

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1414,6 +1414,16 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/rtmros_hironx-release.git
     version: 1.0.2-0
+  rtmros_nextage:
+    packages:
+      nextage_description:
+      nextage_moveit_config:
+      nextage_ros_bridge:
+      rtmros_nextage:
+    status: developed
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/tork-a/rtmros_nextage-release.git
   rtshell_core:
     packages:
       rtctree:


### PR DESCRIPTION
Since this package hasn't been released yet, I hope this is the right way to register first so that I can pre-release test on buildfarm.
