### PR TITLE
rosjava_core: 0.1.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1905,7 +1905,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/rosjava-release/rosjava_bootstrap-release.git
-    version: 0.1.8-0
+    version: 0.1.9-0
   rosjava_build_tools:
     status: developed
     tags:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1905,7 +1905,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/rosjava-release/rosjava_bootstrap-release.git
-    version: 0.1.9-0
+    version: 0.1.8-0
   rosjava_build_tools:
     status: developed
     tags:
@@ -1917,7 +1917,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/rosjava-release/rosjava_core-release.git
-    version: 0.1.4-0
+    version: 0.1.5-0
   rosjava_extras:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_core`:
- previous version: `0.1.4-0`
- new version: `0.1.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
