### PR TITLE
rosbridge_suite: 0.5.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1682,7 +1682,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-    version: 0.6.2-0
+    version: 0.6.4-0
   rocon_multimaster:
     packages:
       redis:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1682,7 +1682,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-    version: 0.6.4-0
+    version: 0.6.2-0
   rocon_multimaster:
     packages:
       redis:
@@ -1868,7 +1868,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-    version: 0.5.0-0
+    version: 0.5.1-0
   rosconsole_bridge:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite`:
- previous version: `0.5.0-0`
- new version: `0.5.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
