### PR TITLE
rosjava_build_tools: 0.1.28-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1910,7 +1910,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/rosjava-release/rosjava_build_tools-release.git
-    version: 0.1.27-0
+    version: 0.1.28-0
   rosjava_core:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_build_tools`:
- previous version: `0.1.27-0`
- new version: `0.1.28-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
