### PR TITLE
rtmros_nextage: 0.2.1-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1424,6 +1424,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/tork-a/rtmros_nextage-release.git
+    version: 0.2.1-0
   rtshell_core:
     packages:
       rtctree:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage`:
- previous version: `null`
- new version: `0.2.1-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
