### PR TITLE
rosjava_messages: 0.1.38-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1928,7 +1928,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/rosjava-release/rosjava_messages-release.git
-    version: 0.1.36-0
+    version: 0.1.38-0
   rosleapmotion:
     packages:
       leap_motion:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_messages`:
- previous version: `0.1.36-0`
- new version: `0.1.38-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
