### PR TITLE
husky_simulator: 0.0.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -713,7 +713,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/husky_simulator-release.git
-    version: 0.0.2-1
+    version: 0.0.3-0
   husky_teleop:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_simulator`:
- previous version: `0.0.2-1`
- new version: `0.0.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
