### PR TITLE
velodyne: 1.1.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2435,7 +2435,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/velodyne-release.git
-    version: 1.1.1-0
+    version: 1.1.2-0
   velodyne_height_map:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne`:
- previous version: `1.1.1-0`
- new version: `1.1.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
