### PR TITLE
yujin_ocs: 0.5.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2525,15 +2525,15 @@ repositories:
       yocs_controllers:
       yocs_diff_drive_pose_controller:
       yocs_math_toolkit:
-      yocs_msgs:
       yocs_velocity_smoother:
       yocs_virtual_sensor:
+      yocs_waypoints_navi:
       yujin_ocs:
     status: developed
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/yujin_ocs-release.git
-    version: 0.5.1-0
+    version: 0.5.2-0
   zeroconf_avahi_suite:
     packages:
       zeroconf_avahi:


### PR DESCRIPTION
Increasing version of package(s) in repository `yujin_ocs`:
- previous version: `0.5.1-0`
- new version: `0.5.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
