### PR TITLE
yocs_msgs: 0.5.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2518,6 +2518,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/yocs_msgs-release.git
+    version: 0.5.2-0
   yujin_maps:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `yocs_msgs`:
- previous version: `null`
- new version: `0.5.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
