### PR TITLE
Adding rosruby repos to documentation index for hydro

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -788,6 +788,18 @@ repositories:
     type: git
     url: https://github.com/ros/rospack.git
     version: groovy-devel
+  rosruby:
+    type: git
+    url: https://github.com/OTL/rosruby.git
+    version: master
+  rosruby_common:
+    type: git
+    url: https://github.com/OTL/rosruby_common.git
+    version: hydro-devel
+  rosruby_messages:
+    type: git
+    url: https://github.com/OTL/rosruby_messages.git
+    version: master
   rosserial:
     type: git
     url: https://github.com/ros-drivers/rosserial.git


### PR DESCRIPTION
I want to add rosruby for wiki.ros.org!
