### PR TITLE
geometry_experimental: 0.3.7-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -386,7 +386,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/geometry_experimental-release.git
-    version: 0.3.6-0
+    version: 0.3.7-0
   glc:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_experimental`:
- previous version: `0.3.6-0`
- new version: `0.3.7-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
