### PR TITLE
geometry_experimental: 0.4.9-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -545,7 +545,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/geometry_experimental-release.git
-    version: 0.4.8-0
+    version: 0.4.9-0
   geometry_tutorials:
     packages:
       geometry_tutorials:


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_experimental`:
- previous version: `0.4.8-0`
- new version: `0.4.9-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
