### PR TITLE
cv_camera: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -195,6 +195,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/convex_decomposition-release.git
     version: 0.1.9-0
+  cv_camera:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/OTL/cv_camera-release
+    version: 0.0.1-0
   declination:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `cv_camera`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
