### PR TITLE
hello_bloom: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -648,6 +648,14 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
     version: 0.3.0-0
+  hello_bloom:
+    packages:
+      hello_bloom:
+        subfolder: hello_bloom
+    tags:
+      release: release/hydro/{package}/{version}
+    url: git@github.com:xuyuan/hello_bloom-release.git
+    version: 0.0.1-0
   hokuyo_node:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `hello_bloom`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
