### PR TITLE
Update base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1555,7 +1555,7 @@ libtiff-dev:
   arch: [libtiff]
   debian:
     sid: [libtiff5-dev]
-    wheezy: [libtiff5-dev]
+    wheezy: [libtiff5-alt-dev]
   fedora: [libtiff]
   gentoo:
     portage:


### PR DESCRIPTION
resolve libsdl-image1.2-dev and libtiff5 conflict in debian wheezy
