### PR TITLE
rosjava_core: 0.1.6-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1921,7 +1921,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/rosjava-release/rosjava_core-release.git
-    version: 0.1.5-0
+    version: 0.1.6-0
   rosjava_extras:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_core`:
- previous version: `0.1.5-0`
- new version: `0.1.6-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
