### PR TITLE
Adding argos3d_p100 to documentation index for groovy and hydro

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -57,6 +57,10 @@ repositories:
     type: git
     url: https://github.com/vanadiumlabs/arbotix_ros.git
     version: groovy-devel
+  argos3d_p100:
+    type: git
+    url: https://github.com/voxel-dot-at/argos3d_p100_ros_pkg.git
+    version: master
   arm_navigation:
     type: hg
     url: https://kforge.ros.org/armnavigation/armnavigation

--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -51,6 +51,10 @@ repositories:
     type: git
     url: https://github.com/vanadiumlabs/arbotix_ros.git
     version: hydro-devel
+  argos3d_p100:
+    type: git
+    url: https://github.com/voxel-dot-at/argos3d_p100_ros_pkg.git
+    version: master
   audio_common:
     type: git
     url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
I'd like argos3d_p100 to be indexed and documented in ros.org
