### PR TITLE
point libogre-dev to libogre-1.8-dev for Saucy

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1221,7 +1221,15 @@ libogre-dev:
   macports: [ogre]
   opensuse: [ogre-devel]
   rhel: [ogre-devel]
-  ubuntu: [libogre-dev]
+  ubuntu:
+    lucid: [libogre-dev]
+    maverick: [libogre-dev]
+    natty: [libogre-dev]
+    oneiric: [libogre-dev]
+    precise: [libogre-dev]
+    quantal: [libogre-dev]
+    raring: [libogre-dev]
+    saucy: [libogre-1.8-dev]
 libois-dev:
   arch: [ois]
   debian: [libois-dev]


### PR DESCRIPTION
it appears that libogre-dev on Saucy points to libogre-1.7.4 which needs boost 1.49, which doesn't work with the many other packages we have which use boost 1.53
