### PR TITLE
gazebo_ros_pkgs: 2.3.4-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -471,7 +471,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-    version: 2.3.3-0
+    version: 2.3.4-0
   gencpp:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs`:
- previous version: `2.3.3-0`
- new version: `2.3.4-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
