### PR TITLE
roswww_pkg: 0.1.0-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1331,6 +1331,15 @@ repositories:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/rosserial-release.git
     version: 0.4.4-0
+  roswww_pkg:
+    packages:
+      roswww:
+      roswww_pack:
+      roswww_pkg:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/tork-a/roswww_pkg-release.git
+    version: 0.1.0-0
   rqt:
     packages:
       rqt:


### PR DESCRIPTION
Increasing version of package(s) in repository `roswww_pkg`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
