### PR TITLE
roswww_pkg: 0.1.1-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1339,7 +1339,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/tork-a/roswww_pkg-release.git
-    version: 0.1.0-0
+    version: 0.1.1-0
   rqt:
     packages:
       rqt:


### PR DESCRIPTION
Increasing version of package(s) in repository `roswww_pkg`:
- previous version: `0.1.0-0`
- new version: `0.1.1-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
