### PR TITLE
rtmros_hironx: 1.0.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2083,6 +2083,15 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/start-jsk/rtmros_common-release.git
     version: 1.0.5-0
+  rtmros_hironx:
+    packages:
+      hironx_moveit_config:
+      hironx_ros_bridge:
+      rtmros_hironx:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/start-jsk/rtmros_hironx-release.git
+    version: 1.0.5-0
   rtshell_core:
     packages:
       rtctree:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx`:
- previous version: `null`
- new version: `1.0.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
