### PR TITLE
rtmros_hironx: 1.0.5-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1422,7 +1422,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/rtmros_hironx-release.git
-    version: 1.0.4-0
+    version: 1.0.5-0
   rtmros_nextage:
     packages:
       nextage_description:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx`:
- previous version: `1.0.4-0`
- new version: `1.0.5-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
