### PR TITLE
rosdep: fixed rubygems version for quantal and raring

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1991,8 +1991,8 @@ ruby:
     natty: [ruby1.8-dev, libruby1.8, rubygems1.8]
     oneiric: [ruby1.8-dev, libruby1.8, rubygems1.8]
     precise: [ruby1.8-dev, libruby1.8, rubygems1.8]
-    quantal: [ruby1.9.1-dev, libruby1.9.1, rubygems]
-    raring: [ruby1.9.1-dev, libruby1.9.1, rubygems]
+    quantal: [ruby1.9.1-dev, libruby1.9.1, ruby1.9.1]
+    raring: [ruby1.9.1-dev, libruby1.9.1, ruby1.9.1]
 sbcl:
   arch: [sbcl]
   debian: [sbcl]


### PR DESCRIPTION
Replaced `rubygems` entries in for rosdep key `ruby` by `rubygems1.9.1` for Ubuntu quantal and raring.

`rubygems` without a version depends on `ruby1.8`, which does not match the installed dev package (http://packages.ubuntu.com/search?keywords=rubygems).

I guess this could be the reason why [orogen builds currently fail](http://jenkins.ros.org/view/HbinQ32/job/ros-hydro-orogen_binarydeb_quantal_i386/26/console) on Jenkins (@smits).
