### PR TITLE
add some saucy keys

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -213,6 +213,7 @@ python-omniorb:
     precise: [python-omniorb, omniidl-python]
     quantal: [python-omniorb, omniidl-python]
     raring: [python-omniorb, omniidl-python]
+    saucy: [python-omniorb, omniidl-python]
 python-opengl:
   debian: [python-opengl]
   fedora: [PyOpenGL]
@@ -252,6 +253,7 @@ python-pyassimp:
     precise: [python-pyassimp]
     quantal: [python-pyassimp]
     raring: [python-pyassimp]
+    saucy: [python-pyassimp]
 python-pydot:
   debian: [python-pydot]
   fedora: [pydot]


### PR DESCRIPTION
trying to get things going on ubuntu 13.10 . appears to be a problem with python-qt-bindings. These tweaks don't fix that, but i think they need to be done regardless (just copying things in from the raring keys).
