### PR TITLE
open-industrial-ros-controllers: 0.1.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1335,6 +1335,14 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ompl-release.git
     version: 0.13.0002516-0
+  open-industrial-ros-controllers:
+    packages:
+      open_controllers_interface:
+      open_industrial_ros_controllers:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/start-jsk/open_industrial_ros_controllers-release.git
+    version: 0.1.0-0
   open_karto:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `open-industrial-ros-controllers`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
