### PR TITLE
rtmros_nextage: 0.2.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2092,6 +2092,16 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/start-jsk/rtmros_hironx-release.git
     version: 1.0.5-0
+  rtmros_nextage:
+    packages:
+      nextage_description:
+      nextage_moveit_config:
+      nextage_ros_bridge:
+      rtmros_nextage:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/tork-a/rtmros_nextage-release.git
+    version: 0.2.3-0
   rtshell_core:
     packages:
       rtctree:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage`:
- previous version: `null`
- new version: `0.2.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
