### PR TITLE
open-industrial-ros-controllers: 0.1.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1342,7 +1342,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/start-jsk/open_industrial_ros_controllers-release.git
-    version: 0.1.0-0
+    version: 0.1.1-0
   open_karto:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `open-industrial-ros-controllers`:
- previous version: `0.1.0-0`
- new version: `0.1.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
