### PR TITLE
densowave: 0.2.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -205,6 +205,17 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/declination-release.git
     version: 0.0.2-0
+  densowave:
+    packages:
+      denso_controller:
+      denso_launch:
+      densowave:
+      vs060:
+      vs060_moveit_config:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/start-jsk/densowave-release.git
+    version: 0.2.0-0
   depthimage_to_laserscan:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `densowave`:
- previous version: `null`
- new version: `0.2.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
