### PR TITLE
Adding mr_teleoperator to documentation index for distro

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -499,6 +499,10 @@ repositories:
     type: git
     url: https://github.com/ros-planning/moveit_setup_assistant
     version: hydro-devel
+  mr_teleoperator:
+    type: git
+    url: https://github.com/cogniteam/mr_teleoperator.git
+    version: master
   mrpt_common:
     type: git
     url: https://github.com/mrpt-ros-pkg/mrpt_common.git


### PR DESCRIPTION
I'd Like mr_teleoperator to be indexed and documented on www.ros.org.
