### PR TITLE
openrtm_aist_core: 1.1.0-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -937,7 +937,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/openrtm_aist_core-release.git
-    version: 1.1.1-0
+    version: 1.1.0-0
   orocos_kdl:
     packages:
       kdl:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist_core`:
- previous version: `1.1.1-0`
- new version: `1.1.0-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
