### PR TITLE
openhrp3: 3.1.5-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -912,7 +912,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/openhrp3-release.git
-    version: 3.1.3-0
+    version: 3.1.5-0
   openni2_camera:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `openhrp3`:
- previous version: `3.1.3-0`
- new version: `3.1.5-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
