### PR TITLE
hrpsys: 315.0.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -681,7 +681,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/start-jsk/hrpsys-release.git
-    version: 3.1.4-0
+    version: 315.0.0-0
   humanoid_msgs:
     packages:
       humanoid_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys`:
- previous version: `3.1.4-0`
- new version: `315.0.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
