### PR TITLE
Updating roslisp

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1973,10 +1973,11 @@ repositories:
     url: https://github.com/ros-gbp/roslint-release.git
     version: 0.0.1-0
   roslisp:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/roslisp-release.git
-    version: 1.9.13-2
+    version: 1.9.14-0
   rospack:
     status: maintained
     tags:


### PR DESCRIPTION
- Bumped version to 1.9.14
- Incorporated bug-fix from Dirk Thomas
- updated status to 'maintained'
