### PR TITLE
Rebase previous pull request to now have all in one

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -1406,6 +1406,10 @@ repositories:
     type: git
     url: https://github.com/ros/roslint.git
     version: master
+  roslisp:
+    type: git
+    url: https://github.com/ros/roslisp.git
+    version: master
   roslisp_common:
     type: svn
     url: https://code.ros.org/svn/ros-pkg/stacks/roslisp_common/trunk

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1973,10 +1973,11 @@ repositories:
     url: https://github.com/ros-gbp/roslint-release.git
     version: 0.0.1-0
   roslisp:
+    status: maintained
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/roslisp-release.git
-    version: 1.9.13-2
+    version: 1.9.14-0
   rospack:
     status: maintained
     tags:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1977,6 +1977,18 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/roslisp-release.git
     version: 1.9.13-2
+  roslisp_common:
+    packages:
+      actionlib_lisp:
+      cl_tf:
+      cl_transforms:
+      cl_utils:
+      roslisp_common:
+      roslisp_utilities:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/roslisp_common-release.git
+    version: 0.1.1-0
   rospack:
     status: maintained
     tags:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1990,6 +1990,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/roslisp_common-release.git
     version: 0.1.1-0
+  roslisp_repl:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/roslisp_repl-release.git
+    version: 0.3.3-0
   rospack:
     status: maintained
     tags:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1978,6 +1978,18 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/roslisp-release.git
     version: 1.9.14-0
+  roslisp_common:
+    packages:
+      actionlib_lisp:
+      cl_tf:
+      cl_transforms:
+      cl_utils:
+      roslisp_common:
+      roslisp_utilities:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/ros-gbp/roslisp_common-release.git
+    version: 0.1.1-0
   rospack:
     status: maintained
     tags:


### PR DESCRIPTION
- added rosdoc for roslisp under groovy
- added rosdoc for roslisp under hydro
- added rosdoc for roslisp_repl under hydro
- added rosdoc for roslisp_common under hydro
- released updated version of roslisp into hydro
- released roslisp_repl for the first time into hydro
- released roslisp_common for the first time into hydro
