### PR TITLE
visp: 2.8.0-5 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2540,7 +2540,10 @@ repositories:
     url: https://github.com/ros-gbp/vision_opencv-release.git
     version: 1.10.11-0
   visp:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/laas/visp-release.git
+    version: 2.8.0-5
   visualization_tutorials:
     packages:
       interactive_marker_tutorials:


### PR DESCRIPTION
Increasing version of package(s) in repository `visp`:
- previous version: `null`
- new version: `2.8.0-5`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
