### PR TITLE
visp: 2.8.0-2 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1606,9 +1606,9 @@ repositories:
     version: 1.10.11-0
   visp:
     tags:
-      release: release/{package}/{upstream_version}
+      release: release/groovy/{package}/{version}
     url: https://github.com/laas/visp-release.git
-    version: 2.6.2-1
+    version: 2.8.0-2
   warehouse_ros:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `visp`:
- previous version: `2.6.2-1`
- new version: `2.8.0-2`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
