### PR TITLE
xv_11_laser_driver: 0.1.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2597,6 +2597,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/jbohren/xdot-release.git
     version: 1.10.0-0
+  xv_11_laser_driver:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: git@github.com:rohbotics/xv_11_laser_driver-release.git
+    version: 0.1.2-0
   yocs_msgs:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `xv_11_laser_driver`:
- previous version: `null`
- new version: `0.1.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
