### PR TITLE
perception_oru: 1.0.2-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -971,6 +971,20 @@ repositories:
       release: release/{package}/{upstream_version}
     url: https://github.com/ros-gbp/pcl_msgs-release.git
     version: 0.0.3-0
+  perception_oru:
+    packages:
+      ndt_fuser:
+      ndt_map:
+      ndt_map_builder:
+      ndt_mcl:
+      ndt_registration:
+      ndt_visualisation:
+      perception_oru:
+      pointcloud_vrml:
+    tags:
+      release: release/groovy/{package}/{version}
+    url: https://github.com/tstoyanov/perception_oru-release.git
+    version: 1.0.2-0
   perception_pcl:
     packages:
       pcl_ros:


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_oru`:
- previous version: `null`
- new version: `1.0.2-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
