### PR TITLE
Added mrpt libs as a system dependency into base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1815,9 +1815,9 @@ mpg123:
   fedora: [mpg123-devel]
   ubuntu: [mpg123]
 mrpt:
-  ubuntu: [libmrpt-dev]
   debian: [libmrpt-dev]
   fedora: [mrpt-devel]
+  ubuntu: [libmrpt-dev]
 muparser:
   ubuntu: [libmuparser-dev]
 netcdf:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1814,6 +1814,10 @@ mpg123:
   debian: [mpg123]
   fedora: [mpg123-devel]
   ubuntu: [mpg123]
+mrpt:
+  ubuntu: libmrpt-dev
+  debian: libmrpt-dev
+  fedora: mrpt-devel
 muparser:
   ubuntu: [libmuparser-dev]
 netcdf:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1815,9 +1815,9 @@ mpg123:
   fedora: [mpg123-devel]
   ubuntu: [mpg123]
 mrpt:
-  ubuntu: libmrpt-dev
-  debian: libmrpt-dev
-  fedora: mrpt-devel
+  ubuntu: [libmrpt-dev]
+  debian: [libmrpt-dev]
+  fedora: [mrpt-devel]
 muparser:
   ubuntu: [libmuparser-dev]
 netcdf:


### PR DESCRIPTION
Added the mrpt library to the list of system dependencies. The rosdep is taken from the mrpt git repo.
