### PR TITLE
pocketsphinx: 0.2.3-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1002,7 +1002,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/pocketsphinx-release.git
-    version: 0.2.1-0
+    version: 0.2.3-0
   pr2_mechanism_msgs:
     tags:
       release: release/{package}/{upstream_version}


### PR DESCRIPTION
Increasing version of package(s) in repository `pocketsphinx`:
- previous version: `0.2.1-0`
- new version: `0.2.3-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
