### PR TITLE
pocketsphinx: 0.3.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1484,7 +1484,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pocketsphinx-release.git
-    version: 0.2.2-0
+    version: 0.3.0-0
   pr2_common:
     packages:
       pr2_common:


### PR DESCRIPTION
Increasing version of package(s) in repository `pocketsphinx`:
- previous version: `0.2.2-0`
- new version: `0.3.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
