### PR TITLE
Adding kinect_aux to documentation index for Hydro

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -399,6 +399,10 @@ repositories:
     type: git
     url: https://github.com/maxipesfix/iwaki-ros-pkg.git
     version: master
+  kinect_aux:
+    type: git
+    url: https://github.com/muhrix/kinect_aux.git
+    version: hydro
   kobuki:
     type: git
     url: https://github.com/yujinrobot/kobuki.git


### PR DESCRIPTION
I'd like kinect_aux to be indexed and documented on ros.org.
