### PR TITLE
ar_track_alvar: 0.4.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -21,7 +21,10 @@ repositories:
     url: https://github.com/ros-gbp/actionlib-release.git
     version: 1.10.3-0
   ar_track_alvar:
+    tags:
+      release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/ar_track_alvar-release.git
+    version: 0.4.1-0
   arbotix:
     packages:
       arbotix:


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar`:
- previous version: `null`
- new version: `0.4.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
