### PR TITLE
update doc branches for cob_*, schunk_modular_robotics and universal_robot

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -207,47 +207,43 @@ repositories:
   cob_calibration_data:
     type: git
     url: https://github.com/ipa320/cob_calibration_data.git
-    version: release_fuerte
+    version: groovy
   cob_command_tools:
     type: git
     url: https://github.com/ipa320/cob_command_tools.git
-    version: release_fuerte
+    version: groovy
   cob_common:
     type: git
     url: https://github.com/ipa320/cob_common.git
-    version: release_fuerte
+    version: groovy
   cob_driver:
     type: git
     url: https://github.com/ipa320/cob_driver.git
-    version: release_fuerte
+    version: groovy
   cob_environments:
     type: git
     url: https://github.com/ipa320/cob_environments.git
-    version: release_fuerte
+    version: groovy
   cob_extern:
     type: git
     url: https://github.com/ipa320/cob_extern.git
-    version: release_fuerte
+    version: groovy
   cob_navigation:
     type: git
     url: https://github.com/ipa320/cob_navigation.git
-    version: release_fuerte
-  cob_perception_common:
-    type: git
-    url: https://github.com/ipa320/cob_perception_common.git
-    version: release_fuerte
+    version: groovy
   cob_robots:
     type: git
     url: https://github.com/ipa320/cob_robots.git
-    version: release_fuerte
+    version: groovy
   cob_simulation:
     type: git
     url: https://github.com/ipa320/cob_simulation.git
-    version: release_fuerte
+    version: groovy
   cob_substitute:
     type: git
     url: https://github.com/ipa320/cob_substitute.git
-    version: release_fuerte
+    version: groovy
   common:
     type: hg
     url: https://kforge.ros.org/common/common
@@ -1510,11 +1506,7 @@ repositories:
   schunk_modular_robotics:
     type: git
     url: https://github.com/ipa320/schunk_modular_robotics.git
-    version: release_fuerte
-  schunk_robots:
-    type: git
-    url: https://github.com/ipa320/schunk_robots.git
-    version: release_fuerte
+    version: groovy
   scitos_metralabs:
     type: git
     url: https://github.com/felix-kolbe/scitos_metralabs.git
@@ -1577,10 +1569,6 @@ repositories:
     type: git
     url: https://github.com/ros-planning/srdfdom.git
     version: master
-  srs_common:
-    type: git
-    url: https://github.com/ipa320/srs_common.git
-    version: release_fuerte
   srs_public:
     type: git
     url: https://github.com/ipa320/srs_public.git
@@ -1679,9 +1667,9 @@ repositories:
     url: https://github.com/ros-geographic-info/unique_identifier.git
     version: groovy
   universal_robot:
-    type: hg
-    url: https://kforge.ros.org/ros_industrial/universal_robot
-    version: default
+    type: git
+    url: https://github.com/ros-industrial/universal_robot.git
+    version: groovy-devel
   unizar-ros-rt-wmp-pkg:
     type: git
     url: https://github.com/dantard/unizar-rt-wmp-ros-pkg.git


### PR DESCRIPTION
this should fix the failing doc jobs on jenkins
