### PR TITLE
perception_oru: 1.0.7-2 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -989,7 +989,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/tstoyanov/perception_oru-release.git
-    version: 1.0.6-0
+    version: 1.0.7-2
   perception_pcl:
     packages:
       pcl_ros:


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_oru`:
- previous version: `1.0.6-0`
- new version: `1.0.7-2`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
