### PR TITLE
roboteq: 0.1.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1683,6 +1683,15 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/robot_upstart-release.git
     version: 0.0.5-0
+  roboteq:
+    packages:
+      roboteq_diagnostics:
+      roboteq_driver:
+      roboteq_msgs:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/roboteq-release
+    version: 0.1.0-0
   rocon:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `roboteq`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
