### PR TITLE
roboteq: 0.1.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1702,7 +1702,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/roboteq-release
-    version: 0.1.0-0
+    version: 0.1.1-0
   rocon:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `roboteq`:
- previous version: `0.1.0-0`
- new version: `0.1.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
