### PR TITLE
grizzly: 0.1.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -593,7 +593,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/grizzly-release
-    version: 0.1.0-0
+    version: 0.1.1-0
   gscam:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly`:
- previous version: `0.1.0-0`
- new version: `0.1.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
