### PR TITLE
grizzly_simulator: 0.1.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -601,6 +601,15 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/grizzly_desktop-release
     version: 0.1.0-0
+  grizzly_simulator:
+    packages:
+      grizzly_gazebo:
+      grizzly_gazebo_plugins:
+      grizzly_simulator:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/grizzly_simulator-release
+    version: 0.1.0-0
   gscam:
     status: maintained
     tags:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -594,6 +594,13 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/grizzly-release
     version: 0.1.1-0
+  grizzly_desktop:
+    packages:
+      grizzly_viz:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/clearpath-gbp/grizzly_desktop-release
+    version: 0.1.0-0
   gscam:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly_simulator`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
