### PR TITLE
grizzly_desktop: 0.1.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -596,11 +596,12 @@ repositories:
     version: 0.1.1-0
   grizzly_desktop:
     packages:
+      grizzly_desktop:
       grizzly_viz:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/clearpath-gbp/grizzly_desktop-release
-    version: 0.1.0-0
+    version: 0.1.1-0
   grizzly_simulator:
     packages:
       grizzly_gazebo:


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly_desktop`:
- previous version: `0.1.0-0`
- new version: `0.1.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
