### PR TITLE
orocos_kdl: 1.2.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1478,7 +1478,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/smits/orocos-kdl-release.git
-    version: 1.1.102-0
+    version: 1.2.0-1
   orogen:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kdl`:
- previous version: `1.1.102-0`
- new version: `1.2.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
