### PR TITLE
perception_oru: 1.0.11-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1504,6 +1504,20 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pcl_msgs-release.git
     version: 0.1.0-0
+  perception_oru:
+    packages:
+      ndt_fuser:
+      ndt_map:
+      ndt_map_builder:
+      ndt_mcl:
+      ndt_registration:
+      ndt_visualisation:
+      perception_oru:
+      pointcloud_vrml:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/tstoyanov/perception_oru-release.git
+    version: 1.0.11-0
   perception_pcl:
     packages:
       pcl_ros:


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_oru`:
- previous version: `null`
- new version: `1.0.11-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
