### PR TITLE
Adding scriptable_monitoring to documentation index for distro

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -936,6 +936,10 @@ repositories:
     type: git
     url: https://github.com/ros-visualization/rviz
     version: hydro-devel
+  scriptable_monitoring:
+    type: git
+    url: https://github.com/cogniteam/scriptable_monitoring.git
+    version: master
   segbot:
     type: git
     url: https://github.com/utexas-bwi/segbot.git


### PR DESCRIPTION
I'd like scriptable_monitoring to be indexed and documented on ros.org

thank you.
