### PR TITLE
perception_oru: 1.0.11-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -986,10 +986,11 @@ repositories:
       ndt_visualisation:
       perception_oru:
       pointcloud_vrml:
+      sdf_tracker:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/tstoyanov/perception_oru-release.git
-    version: 1.0.9-0
+    version: 1.0.11-0
   perception_pcl:
     packages:
       pcl_ros:


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_oru`:
- previous version: `1.0.9-0`
- new version: `1.0.11-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
