### PR TITLE
perception_oru: 1.0.12-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1514,10 +1514,11 @@ repositories:
       ndt_visualisation:
       perception_oru:
       pointcloud_vrml:
+      sdf_tracker:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/tstoyanov/perception_oru-release.git
-    version: 1.0.11-0
+    version: 1.0.12-0
   perception_pcl:
     packages:
       pcl_ros:


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_oru`:
- previous version: `1.0.11-0`
- new version: `1.0.12-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
