### PR TITLE
kinect_aux: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -852,6 +852,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/joystick_drivers-release.git
     version: 1.9.10-0
+  kinect_aux:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/muhrix/kinect_aux-release.git
+    version: 0.0.1-0
   kingfisher:
     packages:
       kingfisher_description:


### PR DESCRIPTION
Increasing version of package(s) in repository `kinect_aux`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
