### PR TITLE
moveit_msgs: 0.5.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1105,7 +1105,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_msgs-release.git
-    version: 0.5.2-0
+    version: 0.5.3-0
   moveit_planners:
     packages:
       moveit_planners:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs`:
- previous version: `0.5.2-0`
- new version: `0.5.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
