### PR TITLE
hrpsys: 315.1.2-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -424,7 +424,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/start-jsk/hrpsys-release.git
-    version: 315.0.0-0
+    version: 315.1.2-0
   humanoid_msgs:
     packages:
       humanoid_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys`:
- previous version: `315.0.0-0`
- new version: `315.1.2-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
