### PR TITLE
mr_teleoperator-release: 0.2.2-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1176,6 +1176,15 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
     version: 0.5.5-0
+  mr_teleoperator-release:
+    packages:
+      mr_rqt:
+      mr_teleoperator:
+      mr_tools:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/cogniteam/mr_teleoperator-release
+    version: 0.2.2-1
   multimaster_fkie:
     packages:
       default_cfg_fkie:


### PR DESCRIPTION
Increasing version of package(s) in repository `mr_teleoperator-release`:
- previous version: `null`
- new version: `0.2.2-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
