### PR TITLE
cmake_modules: 0.2.0-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -96,7 +96,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/cmake_modules-release.git
-    version: 0.1.0-0
+    version: 0.2.0-0
   common_msgs:
     packages:
       actionlib_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules`:
- previous version: `0.1.0-0`
- new version: `0.2.0-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
