### PR TITLE
robot_model: 1.10.18-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1723,7 +1723,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/robot_model-release.git
-    version: 1.10.17-0
+    version: 1.10.18-1
   robot_pose_publisher:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model`:
- previous version: `1.10.17-0`
- new version: `1.10.18-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
