### PR TITLE
rtt: 2.7.0-2 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2230,7 +2230,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/orocos-gbp/rtt-release.git
-    version: 2.7.0-1
+    version: 2.7.0-2
   rtt_typelib:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt`:
- previous version: `2.7.0-1`
- new version: `2.7.0-2`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
