### PR TITLE
kinect_aux: 0.0.1-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -856,7 +856,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/muhrix/kinect_aux-release.git
-    version: 0.0.1-0
+    version: 0.0.1-1
   kingfisher:
     packages:
       kingfisher_description:


### PR DESCRIPTION
Increasing version of package(s) in repository `kinect_aux`:
- previous version: `0.0.1-0`
- new version: `0.0.1-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
