### PR TITLE
visp: 2.8.0-8 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2610,7 +2610,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/laas/visp-release.git
-    version: 2.8.0-5
+    version: 2.8.0-8
   visualization_tutorials:
     packages:
       interactive_marker_tutorials:


### PR DESCRIPTION
Increasing version of package(s) in repository `visp`:
- previous version: `2.8.0-5`
- new version: `2.8.0-8`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
