### PR TITLE
visp: 2.8.0-4 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1635,7 +1635,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/laas/visp-release.git
-    version: 2.8.0-2
+    version: 2.8.0-4
   warehouse_ros:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `visp`:
- previous version: `2.8.0-2`
- new version: `2.8.0-4`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
