### PR TITLE
adds robot_state_publisher to doc list

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -732,6 +732,10 @@ repositories:
     type: git
     url: https://github.com/ros/robot_model.git
     version: hydro-devel
+  robot_state_publisher:
+    type: git
+    url: https://github.com/ros/robot_state_publisher.git
+    version: hydro-devel
   robot_upstart:
     type: git
     url: https://github.com/clearpathrobotics/robot_upstart.git


### PR DESCRIPTION
Thereby fixing https://github.com/ros/robot_state_publisher/issues/9
