### PR TITLE
robot_state_publisher: 1.9.10-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1734,7 +1734,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/robot_state_publisher-release.git
-    version: 1.9.9-0
+    version: 1.9.10-0
   robot_upstart:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher`:
- previous version: `1.9.9-0`
- new version: `1.9.10-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
