### PR TITLE
Fixed source URL for ros_arduino_bridge package in Electric/Fuerte/Groovy and added to Hydro index

### DIFF
--- a/doc/electric/ros_arduino_bridge.rosinstall
+++ b/doc/electric/ros_arduino_bridge.rosinstall
@@ -1,3 +1,3 @@
 - git:
     local-name: ros_arduino_bridge
-    uri: git://github.com/hbrobotics/ros_arduino_bridge.git
+    uri: https://github.com/hbrobotics/ros_arduino_bridge.git

--- a/doc/fuerte/ros_arduino_bridge.rosinstall
+++ b/doc/fuerte/ros_arduino_bridge.rosinstall
@@ -1,3 +1,3 @@
 - git:
     local-name: ros_arduino_bridge
-    uri: git://github.com/hbrobotics/ros_arduino_bridge.git
+    uri: https://github.com/hbrobotics/ros_arduino_bridge.git

--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -1328,7 +1328,7 @@ repositories:
     version: HEAD
   ros_arduino_bridge:
     type: git
-    url: git://github.com/hbrobotics/ros_arduino_bridge.git
+    url: https://github.com/hbrobotics/ros_arduino_bridge.git
   ros_comm:
     type: git
     url: https://github.com/ros/ros_comm.git

--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -635,6 +635,9 @@ repositories:
     type: git
     url: https://github.com/ros/ros.git
     version: hydro-devel
+  ros_arduino_bridge:
+    type: git
+    url: https://github.com/hbrobotics/ros_arduino_bridge.git
   ros_comm:
     type: git
     url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Fixed source URL for ros_arduino_bridge package in Electric/Fuerte/Groovy and added to Hydro index
