### PR TITLE
Adding biotac_driver, force_torque_tools, kdl_wrapper and kdl_acc_solver to documentation index for distro

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -88,6 +88,10 @@ repositories:
     type: svn
     url: https://tu-darmstadt-ros-pkg.googlecode.com/svn/trunk/biorob_common
     version: HEAD
+  biotac_driver:
+    type: git
+    url: https://github.com/kth-ros-pkg/biotac_driver.git
+    version: groovy
   bond_core:
     type: git
     url: https://github.com/ros/bond_core
@@ -470,6 +474,10 @@ repositories:
     type: git
     url: https://kforge.ros.org/startuploc/git
     version: master
+  force_torque_tools:
+    type: git
+    url: https://github.com/kth-ros-pkg/force_torque_tools.git
+    version: groovy
   freenect_stack:
     type: git
     url: https://github.com/ros-drivers/freenect_stack.git
@@ -696,6 +704,14 @@ repositories:
   katana_driver:
     type: git
     url: https://github.com/uos/katana_driver.git
+    version: groovy
+  kdl_acc_solver:
+    type: git
+    url: https://github.com/kth-ros-pkg/kdl_acc_solver.git
+    version: groovy
+  kdl_wrapper:
+    type: git
+    url: https://github.com/kth-ros-pkg/kdl_wrapper.git
     version: groovy
   kinect_aux:
     type: git


### PR DESCRIPTION
I'd like to add the biotac_driver, force_torque_tools, kdl_wrapper and kdl_acc_solver to be indexed and documented on the ROS wiki.
