### PR TITLE
rocon_multimaster: 0.6.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1803,7 +1803,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_multimaster-release.git
-    version: 0.6.1-0
+    version: 0.6.2-0
   rocon_rqt_plugins:
     packages:
       rocon_conductor_graph:


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_multimaster`:
- previous version: `0.6.1-0`
- new version: `0.6.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
