### PR TITLE
urdfdom: 0.2.10-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2510,7 +2510,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/urdfdom-release.git
-    version: 0.2.10-0
+    version: 0.2.10-1
   urdfdom_headers:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom`:
- previous version: `0.2.10-0`
- new version: `0.2.10-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
