### PR TITLE
multimaster_fkie: 0.3.8-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -762,7 +762,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/fkie-release/multimaster_fkie-release.git
-    version: 0.3.7-0
+    version: 0.3.8-0
   nao_robot:
     packages:
       nao_bringup:


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie`:
- previous version: `0.3.7-0`
- new version: `0.3.8-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
