### PR TITLE
libsegwayrmp: 0.2.10-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -993,7 +993,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/segwayrmp/libsegwayrmp-release.git
-    version: 0.2.9-0
+    version: 0.2.10-0
   libsiftfast:
     url: https://github.com/start-jsk/libsiftfast-release.git
   libuvc:


### PR DESCRIPTION
Increasing version of package(s) in repository `libsegwayrmp`:
- previous version: `0.2.9-0`
- new version: `0.2.10-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
