### PR TITLE
libsegwayrmp: 0.2.10-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -610,7 +610,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/segwayrmp/libsegwayrmp-release.git
-    version: 0.2.9-0
+    version: 0.2.10-0
   libsiftfast:
     tags:
       release: release/{package}/{upstream_version}


### PR DESCRIPTION
Increasing version of package(s) in repository `libsegwayrmp`:
- previous version: `0.2.9-0`
- new version: `0.2.10-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
