### PR TITLE
densowave: 0.2.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -219,7 +219,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/start-jsk/densowave-release.git
-    version: 0.2.4-0
+    version: 0.2.5-0
   depthimage_to_laserscan:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `densowave`:
- previous version: `0.2.4-0`
- new version: `0.2.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
