### PR TITLE
open_industrial_ros_controllers: 0.1.4-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1407,7 +1407,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/start-jsk/open_industrial_ros_controllers-release.git
-    version: 0.1.3-0
+    version: 0.1.4-0
   open_karto:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `open_industrial_ros_controllers`:
- previous version: `0.1.3-0`
- new version: `0.1.4-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
