### PR TITLE
Added rtt_ros_integration and rtt_geometry to hydro/release.yaml

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2231,6 +2231,56 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/orocos-gbp/rtt-release.git
     version: 2.7.0-2
+  rtt_geometry:
+    packages:
+      eigen_typekit:
+      kdl_lua:
+      kdl_typekit:
+      rtt_kdl_conversions:
+      rtt_tf:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/orocos-gbp/rtt_geometry-release.git
+  rtt_ros_integration:
+    packages:
+      rtt_actionlib:
+      rtt_actionlib_msgs:
+        subfolder: typekits/rtt_actionlib_msgs
+      rtt_common_msgs:
+        subfolder: typekits/rtt_common_msgs
+      rtt_diagnostic_msgs:
+        subfolder: typekits/rtt_diagnostic_msgs
+      rtt_geometry_msgs:
+        subfolder: typekits/rtt_geometry_msgs
+      rtt_nav_msgs:
+        subfolder: typekits/rtt_nav_msgs
+      rtt_ros:
+      rtt_ros_comm:
+        subfolder: typekits/rtt_ros_comm
+      rtt_ros_integration:
+      rtt_roscomm:
+      rtt_rosgraph_msgs:
+        subfolder: typekits/rtt_rosgraph_msgs
+      rtt_rosnode:
+      rtt_rospack:
+      rtt_rosparam:
+      rtt_sensor_msgs:
+        subfolder: typekits/rtt_sensor_msgs
+      rtt_shape_msgs:
+        subfolder: typekits/rtt_shape_msgs
+      rtt_std_msgs:
+        subfolder: typekits/rtt_std_msgs
+      rtt_std_srvs:
+        subfolder: typekits/rtt_std_srvs
+      rtt_stereo_msgs:
+        subfolder: typekits/rtt_stereo_msgs
+      rtt_trajectory_msgs:
+        subfolder: typekits/rtt_trajectory_msgs
+      rtt_visualization_msgs:
+        subfolder: typekits/rtt_visualization_msgs
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/orocos-gbp/rtt_ros_integration-release.git
   rtt_typelib:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Added [rtt_ros_integration](https://github.com/orocos/rtt_ros_integration.git) and [rtt_geometry](https://github.com/orocos/rtt_geometry.git) repositories to `hydro/release.yaml` without a version number for pre-release testing and to enable rosdep to resolve ROS package to binary package names.
