### PR TITLE
Added missing package definition for Debian Jessie/Testing

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -68,6 +68,7 @@ armadillo:
 assimp:
   arch: [assimp]
   debian:
+    jessie: [libassimp-dev]
     sid: [libassimp-dev]
     wheezy: [libassimp-dev]
   fedora: [assimp]
@@ -235,6 +236,7 @@ boost:
   arch: [boost]
   cygwin: [libboost-devel, libboost1.40]
   debian:
+    jessie: [libboost-all-dev]
     sid: [libboost-all-dev]
     squeeze: [libboost1.42-all-dev]
     wheezy: [libboost-all-dev]
@@ -422,6 +424,7 @@ eclipse:
 eigen:
   arch: [eigen3]
   debian:
+    jessie: [libeigen3-dev]
     sid: [libeigen3-dev]
     wheezy: [libeigen3-dev]
   fedora: [eigen3-devel]
@@ -1231,7 +1234,10 @@ libogg:
   ubuntu: [libogg-dev]
 libogre-dev:
   arch: [ogre]
-  debian: [libogre-dev]
+  debian:
+  jessie: [libogre-1.9-dev]
+  sid: [libogre-1.9-dev]
+  wheezy: [libogre-dev]
   fedora: [ogre-devel]
   gentoo: [dev-games/ogre]
   macports: [ogre]
@@ -1578,6 +1584,7 @@ libtheora:
 libtiff-dev:
   arch: [libtiff]
   debian:
+    jessie: [libtiff5-dev]
     sid: [libtiff5-dev]
     wheezy: [libtiff5-alt-dev]
   fedora: [libtiff]
@@ -1606,6 +1613,7 @@ libtiff4-dev:
 libtool:
   arch: [libtool]
   debian:
+    jessie: [libtool, libltdl-dev]
     lenny: [libtool, libltdl3-dev]
     sid: [libtool, libltdl-dev]
     squeeze: [libtool, libltdl-dev]
@@ -1780,6 +1788,7 @@ log4cxx:
   arch: [log4cxx]
   cygwin: [liblog4cxx-devel]
   debian:
+    jessie: [liblog4cxx10-dev]
     sid: [liblog4cxx10-dev]
     squeeze: [liblog4cxx10-dev]
     wheezy: [liblog4cxx10-dev]
@@ -2448,6 +2457,9 @@ yaml:
 yaml-cpp:
   arch: [yaml-cpp]
   debian:
+    jessie:
+      apt:
+        packages: [libyaml-cpp-dev]
     sid:
       apt:
         packages: [libyaml-cpp-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1235,9 +1235,9 @@ libogg:
 libogre-dev:
   arch: [ogre]
   debian:
-  jessie: [libogre-1.9-dev]
-  sid: [libogre-1.9-dev]
-  wheezy: [libogre-dev]
+    jessie: [libogre-1.9-dev]
+    sid: [libogre-1.9-dev]
+    wheezy: [libogre-dev]
   fedora: [ogre-devel]
   gentoo: [dev-games/ogre]
   macports: [ogre]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -62,7 +62,10 @@ python:
     saucy: [python-dev]
     trusty: [python3-dev]
 python-argparse:
-  debian: [python-argparse]
+  debian:
+    jessie: [libpython2.7-stdlib]
+    sid: [libpython2.7-stdlib]
+    wheezy: [python-argparse]
   fedora: [python]
   opensuse: [python-argparse]
   ubuntu:
@@ -686,6 +689,7 @@ python-pyudev:
 python-qt-bindings:
   arch: [python2-pyqt]
   debian:
+    jessie: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
     sid: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
     squeeze: [python-qt4, python-qt4-dev, pyhton-sip-dev]
     wheezy: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]


### PR DESCRIPTION
Added Debian Jessie/Testing package definition so rosdep can search for the appropiate versions in te Debian repository
