### PR TITLE
urdf_tutorial: 0.2.2-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1573,7 +1573,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/urdf_tutorial-release.git
-    version: 0.2.1-0
+    version: 0.2.2-0
   urdfdom:
     tags:
       release: release/groovy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tutorial`:
- previous version: `0.2.1-0`
- new version: `0.2.2-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
