### PR TITLE
nasa_r2_common: 0.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1209,6 +1209,16 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/nao_robot-release
     version: 0.2.2-0
+  nasa_r2_common:
+    packages:
+      r2_description:
+      r2_dynamic_reconfigure:
+      r2_msgs:
+      r2_teleop:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: git@github.com:brown-release/nasa_r2_common_release.git
+    version: 0.0.1-0
   navigation:
     packages:
       amcl:

--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1217,7 +1217,7 @@ repositories:
       r2_teleop:
     tags:
       release: release/hydro/{package}/{version}
-    url: git@github.com:brown-release/nasa_r2_common_release.git
+    url: https://github.com/brown-release/nasa_r2_common_release.git
     version: 0.0.1-0
   navigation:
     packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `nasa_r2_common`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
