### PR TITLE
rocon_msgs: 0.6.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1792,11 +1792,13 @@ repositories:
       gateway_msgs:
       rocon_app_manager_msgs:
       rocon_msgs:
+      rocon_std_msgs:
+      scheduler_msgs:
     status: developed
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-    version: 0.6.4-0
+    version: 0.6.5-0
   rocon_multimaster:
     packages:
       redis:


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs`:
- previous version: `0.6.4-0`
- new version: `0.6.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
