### PR TITLE
gscam: 0.1.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -616,7 +616,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/gscam-release.git
-    version: 0.1.1-0
+    version: 0.1.3-0
   hector_gazebo:
     packages:
       gazebo_rtt_plugin:


### PR DESCRIPTION
Increasing version of package(s) in repository `gscam`:
- previous version: `0.1.1-0`
- new version: `0.1.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
