### PR TITLE
rviz: 1.9.33-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1477,7 +1477,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/rviz-release.git
-    version: 1.9.32-0
+    version: 1.9.33-0
   rx:
     packages:
       rx:


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz`:
- previous version: `1.9.32-0`
- new version: `1.9.33-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
