### PR TITLE
nasa_r2_simulator: 0.5.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1219,6 +1219,17 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/brown-release/nasa_r2_common_release.git
     version: 0.0.1-0
+  nasa_r2_simulator:
+    packages:
+      gazebo_gripper:
+      gazebo_interface:
+      gazebo_taskboard:
+      r2_controllers_gazebo:
+      r2_gazebo:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/brown-release/nasa_r2_simulator_release
+    version: 0.5.1-0
   navigation:
     packages:
       amcl:


### PR DESCRIPTION
Increasing version of package(s) in repository `nasa_r2_simulator`:
- previous version: `null`
- new version: `0.5.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
