### PR TITLE
rtmros_nextage: 0.2.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2237,7 +2237,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/tork-a/rtmros_nextage-release.git
-    version: 0.2.4-0
+    version: 0.2.5-0
   rtshell_core:
     packages:
       rtctree:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage`:
- previous version: `0.2.4-0`
- new version: `0.2.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
