### PR TITLE
mr_teleoperator: 0.2.6-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1184,7 +1184,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/cogniteam/mr_teleoperator-release
-    version: 0.2.5-0
+    version: 0.2.6-0
   multimaster_fkie:
     packages:
       default_cfg_fkie:


### PR DESCRIPTION
Increasing version of package(s) in repository `mr_teleoperator`:
- previous version: `0.2.5-0`
- new version: `0.2.6-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
