### PR TITLE
hector_quadrotor: 0.3.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -653,16 +653,19 @@ repositories:
     packages:
       hector_quadrotor:
       hector_quadrotor_controller:
+      hector_quadrotor_controller_gazebo:
       hector_quadrotor_demo:
       hector_quadrotor_description:
       hector_quadrotor_gazebo:
       hector_quadrotor_gazebo_plugins:
       hector_quadrotor_model:
+      hector_quadrotor_pose_estimation:
       hector_quadrotor_teleop:
       hector_uav_msgs:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_quadrotor-release.git
+    version: 0.3.1-0
   hector_slam:
     packages:
       hector_compressed_map_transport:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_quadrotor`:
- previous version: `null`
- new version: `0.3.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
