### PR TITLE
nasa_r2_common: 0.0.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1218,7 +1218,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/brown-release/nasa_r2_common_release.git
-    version: 0.0.1-0
+    version: 0.0.2-0
   navigation:
     packages:
       amcl:


### PR DESCRIPTION
Increasing version of package(s) in repository `nasa_r2_common`:
- previous version: `0.0.1-0`
- new version: `0.0.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
