### PR TITLE
hector_quadrotor: 0.3.1-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -665,7 +665,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_quadrotor-release.git
-    version: 0.3.1-0
+    version: 0.3.1-1
   hector_slam:
     packages:
       hector_compressed_map_transport:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_quadrotor`:
- previous version: `0.3.1-0`
- new version: `0.3.1-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
