### PR TITLE
Adding x52_joyext to documentation index for Groovy/Hydro

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -1806,6 +1806,10 @@ repositories:
     type: git
     url: https://github.com/WuNL/wlkeyctrl.git
     version: groovy-devel
+  x52_joyext:
+    type: git
+    url: https://github.com/cyborg-x1/x52_joyext
+    version: master
   xacro:
     type: git
     url: https://github.com/ros/xacro

--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -1195,6 +1195,10 @@ repositories:
     type: git
     url: https://github.com/ros-windows/win_ros.git
     version: hydro-devel
+  x52_joyext:
+    type: git
+    url: https://github.com/cyborg-x1/x52_joyext
+    version: master
   xacro:
     type: git
     url: https://github.com/ros/xacro


### PR DESCRIPTION
I'd like x52_joyext to be indexed and documented on ros.org.
