### PR TITLE
nasa_r2_simulator: 0.5.3-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1232,7 +1232,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/brown-release/nasa_r2_simulator_release
-    version: 0.5.1-0
+    version: 0.5.3-1
   navigation:
     packages:
       amcl:


### PR DESCRIPTION
Increasing version of package(s) in repository `nasa_r2_simulator`:
- previous version: `0.5.1-0`
- new version: `0.5.3-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
