### PR TITLE
Adding skeleton_markers and pi_tracker to documentation index for Hydro

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -680,6 +680,10 @@ repositories:
     type: git
     url: https://github.com/ccny-ros-pkg/phidgets_drivers.git
     version: hydro
+  pi_tracker:
+    type: git
+    url: https://github.com/pirobot/pi_tracker.git
+    version: hydro-devel
   play_motion:
     type: git
     url: https://github.com/pal-robotics/play_motion.git
@@ -1003,6 +1007,10 @@ repositories:
   sicktoolbox_wrapper:
     type: git
     url: https://github.com/ros-drivers/sicktoolbox_wrapper
+    version: hydro-devel
+  skeleton_markers:
+    type: git
+    url: https://github.com/pirobot/skeleton_markers.git
     version: hydro-devel
   stage:
     type: git


### PR DESCRIPTION
Adding skeleton_markers and pi_tracker to documentation index for Hydro
