### PR TITLE
Second attempt at adding skeleton_markers and pi_tracker to documentation index for Hydro

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -712,6 +712,10 @@ repositories:
     type: git
     url: https://github.com/ccny-ros-pkg/phidgets_drivers.git
     version: hydro
+  pi_tracker:
+    type: git
+    url: https://github.com/pirobot/pi_tracker.git
+    version: hydro-devel
   play_motion:
     type: git
     url: https://github.com/pal-robotics/play_motion.git
@@ -1035,6 +1039,10 @@ repositories:
   sicktoolbox_wrapper:
     type: git
     url: https://github.com/ros-drivers/sicktoolbox_wrapper
+    version: hydro-devel
+  skeleton_markers:
+    type: git
+    url: https://github.com/pirobot/skeleton_markers.git
     version: hydro-devel
   slam_gmapping:
     type: git


### PR DESCRIPTION
Second attempt at adding skeleton_markers and pi_tracker to documentation index for Hydro
