### PR TITLE
orogen: 2.7.0-2 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1517,7 +1517,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/orocos-gbp/orogen-release.git
-    version: 2.7.0-1
+    version: 2.7.0-2
   p2os:
     packages:
       p2os_driver:


### PR DESCRIPTION
Increasing version of package(s) in repository `orogen`:
- previous version: `2.7.0-1`
- new version: `2.7.0-2`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
