### PR TITLE
typelib: 2.7.0-3 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2546,7 +2546,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/orocos-gbp/typelib-release.git
-    version: 2.7.0-2
+    version: 2.7.0-3
   um6:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `typelib`:
- previous version: `2.7.0-2`
- new version: `2.7.0-3`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
