### PR TITLE
utilrb: 2.7.0-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2620,7 +2620,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/orocos-gbp/utilrb-release.git
-    version: 2.7.0-0
+    version: 2.7.0-1
   uwsim_bullet:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `utilrb`:
- previous version: `2.7.0-0`
- new version: `2.7.0-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
