### PR TITLE
orocos_toolchain: 2.7.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1513,6 +1513,14 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/smits/orocos-kdl-release.git
     version: 1.2.1-0
+  orocos_toolchain:
+    packages:
+      orocos_toolchain:
+        subfolder: orocos_toolchain
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/orocos-gbp/orocos_toolchain-release.git
+    version: 2.7.0-0
   orogen:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_toolchain`:
- previous version: `null`
- new version: `2.7.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
