### PR TITLE
Add joystick rosdep for opensuse

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -764,6 +764,7 @@ joystick:
     schrödinger’s: [linuxconsoletools]
     spherical: [linuxconsoletools]
   gentoo: [games-util/joystick]
+  opensuse: [input-utils]
   rhel: [joystick]
   ubuntu: [joystick]
 jython:


### PR DESCRIPTION
Create a rule mapping joystick to input-utils for opensuse. Opensuse doesn't have a joystick package, but it places jstest, jscal, inputattach, and related programs into input-utils.
