### PR TITLE
crsm-slam-ros-pkg: hydro-devel-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -198,6 +198,13 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/convex_decomposition-release.git
     version: 0.1.9-0
+  crsm-slam-ros-pkg:
+    packages:
+      crsm_slam:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/etsardou/crsm-slam-ros-pkg-release.git
+    version: hydro-devel-0
   cv_camera:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `crsm-slam-ros-pkg`:
- previous version: `null`
- new version: `hydro-devel-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
