### PR TITLE
genmsg: 0.4.24-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -503,7 +503,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/genmsg-release.git
-    version: 0.4.23-0
+    version: 0.4.24-0
   genpy:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg`:
- previous version: `0.4.23-0`
- new version: `0.4.24-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
