### PR TITLE
gencpp: 0.4.15-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -492,7 +492,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/gencpp-release.git
-    version: 0.4.14-0
+    version: 0.4.15-0
   genlisp:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `gencpp`:
- previous version: `0.4.14-0`
- new version: `0.4.15-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
