### PR TITLE
rospack: 2.1.22-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2107,7 +2107,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rospack-release.git
-    version: 2.1.21-0
+    version: 2.1.22-0
   rospy_message_converter:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack`:
- previous version: `2.1.21-0`
- new version: `2.1.22-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
