### PR TITLE
roscpp_core: 0.3.17-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2020,7 +2020,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/roscpp_core-release.git
-    version: 0.3.16-0
+    version: 0.3.17-0
   rosdoc_lite:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core`:
- previous version: `0.3.16-0`
- new version: `0.3.17-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
