### PR TITLE
rqt_pr2_dashboard: 0.2.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2199,7 +2199,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
-    version: 0.2.4-1
+    version: 0.2.5-0
   rqt_robot_plugins:
     packages:
       rqt_moveit:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_pr2_dashboard`:
- previous version: `0.2.4-1`
- new version: `0.2.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
