### PR TITLE
rqt_robot_plugins: 0.3.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2216,7 +2216,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-    version: 0.3.1-0
+    version: 0.3.2-0
   rtmros_common:
     packages:
       hrpsys_ros_bridge:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins`:
- previous version: `0.3.1-0`
- new version: `0.3.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
