### PR TITLE
octomap_mapping: 0.5.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1390,7 +1390,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/octomap_mapping-release
-    version: 0.5.2-0
+    version: 0.5.3-0
   octomap_msgs:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping`:
- previous version: `0.5.2-0`
- new version: `0.5.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
