### PR TITLE
youbot_driver: 1.0.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2761,6 +2761,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/yocs_msgs-release.git
     version: 0.5.2-0
+  youbot_driver:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/youbot-release/youbot_driver-release.git
+    version: 1.0.0-0
   yujin_maps:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `youbot_driver`:
- previous version: `null`
- new version: `1.0.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
