### PR TITLE
Adding stdr_simulator to documentation index for hydro

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -1076,6 +1076,10 @@ repositories:
     type: git
     url: https://github.com/ros/std_msgs.git
     version: groovy-devel
+  stdr_simulator:
+    type: git
+    url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator.git
+    version: develop
   steered_wheel_base_controller:
     type: git
     url: https://github.com/wunderkammer-laboratory/steered_wheel_base_controller.git


### PR DESCRIPTION
I'd like stdr_simulator to be indexed and documented on ros.org.
