### PR TITLE
youbot_driver_ros_interface: 1.0.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2766,6 +2766,11 @@ repositories:
       release: release/hydro/{package}/{version}
     url: https://github.com/youbot-release/youbot_driver-release.git
     version: 1.0.0-1
+  youbot_driver_ros_interface:
+    tags:
+      release: release/hydro/{package}/{version}
+    url: https://github.com/youbot-release/youbot_driver_ros_interface-release.git
+    version: 1.0.0-0
   yujin_maps:
     status: developed
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `youbot_driver_ros_interface`:
- previous version: `null`
- new version: `1.0.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
