### PR TITLE
urdf_tutorial: 0.2.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2590,7 +2590,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/urdf_tutorial-release.git
-    version: 0.2.2-0
+    version: 0.2.3-0
   urdfdom:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tutorial`:
- previous version: `0.2.2-0`
- new version: `0.2.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
