### PR TITLE
camera_umd: 0.2.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -108,7 +108,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ktossell/camera_umd-release.git
-    version: 0.2.0-0
+    version: 0.2.1-0
   catkin:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_umd`:
- previous version: `0.2.0-0`
- new version: `0.2.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
