### PR TITLE
Adding decision_making_robot_examples and cogniteam_models to documentation index for hydro

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -119,6 +119,10 @@ repositories:
     type: git
     url: https://github.com/ros/cmake_modules.git
     version: master
+  cogniteam_models:
+    type: git
+    url: https://github.com/cogniteam/cogniteam_models.git
+    version: master
   common_msgs:
     type: git
     url: https://github.com/ros/common_msgs.git
@@ -146,6 +150,10 @@ repositories:
   decision_making:
     type: git
     url: https://github.com/cogniteam/decision_making.git
+    version: master
+  decision_making_robot_examples:
+    type: git
+    url: https://github.com/cogniteam/decision_making_robot_examples.git
     version: master
   declination:
     type: git


### PR DESCRIPTION
I'd like decision_making_robot_examples and cogniteam_models to be indexed and documented on ros.org.
