### PR TITLE
Added java base_controller

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -67,7 +67,7 @@ repositories:
     type: git
     url: https://github.com/clearpathrobotics/axis_camera.git
     version: master
-  base_controller:
+  android_base_controller:
     type: git
     url: https://github.com/creativa77/base_controller.git
     version: master

--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -67,6 +67,10 @@ repositories:
     type: git
     url: https://github.com/clearpathrobotics/axis_camera.git
     version: master
+  base_controller:
+    type: git
+    url: https://github.com/creativa77/base_controller.git
+    version: master
   bfl:
     type: git
     url: https://github.com/ros-gbp/bfl-release


### PR DESCRIPTION
base_controller is a java implementation of the Husky and Kobuki base controller nodes. It subscribes to /cmd_vel, and sends the movement commands to the base via serial USB interfaces. It also reads odometry information from the bases and sensor information in the Kobuki.
