### PR TITLE
Add android_base_controller

### DIFF
--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -27,6 +27,10 @@ repositories:
     type: git
     url: https://github.com/rosjava/android_apps.git
     version: hydro
+  android_base_controller:
+    type: git
+    url: https://github.com/creativa77/base_controller
+    version: master
   android_core:
     type: git
     url: https://github.com/rosjava/android_core.git


### PR DESCRIPTION
This package implements Android base controllers for different robotic bases. Currently it supports the Kobuki and the Husky.
