### PR TITLE
slam_gmapping: 1.3.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2427,7 +2427,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/slam_gmapping-release.git
-    version: 1.3.0-1
+    version: 1.3.1-0
   sql_database:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_gmapping`:
- previous version: `1.3.0-1`
- new version: `1.3.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
