### PR TITLE
industrial_core: 0.3.3-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -844,7 +844,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-industrial-release/industrial_core-release.git
-    version: 0.3.2-0
+    version: 0.3.3-0
   interactive_marker_proxy:
     status: maintained
     url: https://github.com/ros-gbp/interactive_marker_proxy-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_core`:
- previous version: `0.3.2-0`
- new version: `0.3.3-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
