### PR TITLE
rosserial: 0.5.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2170,7 +2170,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/rosserial-release.git
-    version: 0.5.4-0
+    version: 0.5.5-0
   rqt:
     packages:
       rqt:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial`:
- previous version: `0.5.4-0`
- new version: `0.5.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
