### PR TITLE
pr2_power_drivers: 1.1.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1670,7 +1670,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/pr2_power_drivers-release.git
-    version: 1.1.1-0
+    version: 1.1.2-0
   pr2_robot:
     packages:
       imu_monitor:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_power_drivers`:
- previous version: `1.1.1-0`
- new version: `1.1.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
