### PR TITLE
microstrain_3dmgx2_imu: 1.5.12-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1092,7 +1092,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/microstrain_3dmgx2_imu-release.git
-    version: 1.5.11-0
+    version: 1.5.12-0
   mjpeg_server:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_3dmgx2_imu`:
- previous version: `1.5.11-0`
- new version: `1.5.12-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
