### PR TITLE
hokuyo_node: 1.7.8-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -706,7 +706,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/hokuyo_node-release.git
-    version: 1.7.7-0
+    version: 1.7.8-0
   household_objects_database:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `hokuyo_node`:
- previous version: `1.7.7-0`
- new version: `1.7.8-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
