### PR TITLE
humanoid_msgs: 0.3.0-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -432,7 +432,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/humanoid_msgs-release
-    version: 0.2.0-0
+    version: 0.3.0-0
   image_common:
     packages:
       camera_calibration_parsers:


### PR DESCRIPTION
Increasing version of package(s) in repository `humanoid_msgs`:
- previous version: `0.2.0-0`
- new version: `0.3.0-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
