### PR TITLE
humanoid_msgs: 0.3.0-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -731,7 +731,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/humanoid_msgs-release
-    version: 0.2.0-1
+    version: 0.3.0-0
   husky_base:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `humanoid_msgs`:
- previous version: `0.2.0-1`
- new version: `0.3.0-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
