### PR TITLE
rocon_msgs: 0.6.7-1 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1833,13 +1833,14 @@ repositories:
       gateway_msgs:
       rocon_app_manager_msgs:
       rocon_msgs:
+      rocon_service_pair_msgs:
       rocon_std_msgs:
       scheduler_msgs:
     status: developed
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-    version: 0.6.6-0
+    version: 0.6.7-1
   rocon_multimaster:
     packages:
       redis:


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs`:
- previous version: `0.6.6-0`
- new version: `0.6.7-1`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
