### PR TITLE
humanoid_msgs repositories actually remain at github.com/ahornung

### DIFF
--- a/doc/electric/alufr-humanoid_stacks.rosinstall
+++ b/doc/electric/alufr-humanoid_stacks.rosinstall
@@ -12,7 +12,7 @@
     version: master
 - git:
     local-name: humanoid_msgs
-    uri: https://github.com/ros-nao/humanoid_msgs.git
+    uri: https://github.com/ahornung/humanoid_msgs.git
     version: master
 - svn:
     local-name: humanoid_navigation

--- a/doc/fuerte/alufr-humanoid_stacks.rosinstall
+++ b/doc/fuerte/alufr-humanoid_stacks.rosinstall
@@ -12,7 +12,7 @@
     version: master
 - git:
     local-name: humanoid_msgs
-    uri: https://github.com/ros-nao/humanoid_msgs.git
+    uri: https://github.com/ahornung/humanoid_msgs.git
     version: master
 - git:
     local-name: humanoid_navigation

--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -634,7 +634,7 @@ repositories:
     version: HEAD
   humanoid_msgs:
     type: git
-    url: https://github.com/ros-nao/humanoid_msgs.git
+    url: https://github.com/ahornung/humanoid_msgs.git
     version: master
   humanoid_navigation:
     type: git

--- a/groovy/source.yaml
+++ b/groovy/source.yaml
@@ -145,7 +145,7 @@ repositories:
     version: master
   humanoid_msgs:
     type: git
-    url: https://github.com/ros-nao/humanoid_msgs
+    url: https://github.com/ahornung/humanoid_msgs
     version: devel
   image_common:
     type: git

--- a/hydro/doc.yaml
+++ b/hydro/doc.yaml
@@ -397,7 +397,7 @@ repositories:
     version: HEAD
   humanoid_msgs:
     type: git
-    url: https://github.com/ros-nao/humanoid_msgs.git
+    url: https://github.com/ahornung/humanoid_msgs.git
     version: master
   humanoid_navigation:
     type: git

--- a/hydro/source.yaml
+++ b/hydro/source.yaml
@@ -185,7 +185,7 @@ repositories:
     version: HEAD
   humanoid_msgs:
     type: git
-    url: https://github.com/ros-nao/humanoid_msgs
+    url: https://github.com/ahornung/humanoid_msgs
     version: devel
   image_common:
     type: git


### PR DESCRIPTION
This partially reverts commit 26c9bff
