### PR TITLE
Fix Arch Linux rosdep mappings.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -495,7 +495,7 @@ fcgi:
       packages: [dev-ruby/fcgi]
   ubuntu: [libfcgi-dev, libapache2-mod-fastcgi, spawn-fcgi]
 festival:
-  arch: [festival, festival-kallpc16k]
+  arch: [festival, festival-english]
   debian: [festival, festvox-kallpc16k]
   fedora: [festival, festvox-kal-diphone]
   gentoo:
@@ -550,7 +550,7 @@ g++-multilib:
 gawk:
   ubuntu: [gawk]
 gazebo:
-  arch: [gazebo-hg]
+  arch: [gazebo]
   ubuntu:
     precise: [gazebo]
     quantal: [gazebo]
@@ -1368,10 +1368,12 @@ libpcap:
     apt:
       packages: [libpcap0.8-dev]
 libpcl-all:
+  arch: [pcl]
   fedora: [pcl, pcl-tools]
   opensuse: [pcl]
   ubuntu: [libpcl-1.7-all]
 libpcl-all-dev:
+  arch: [pcl]
   fedora: [pcl-devel]
   opensuse: [pcl]
   ubuntu: [libpcl-1.7-all-dev]
@@ -1780,6 +1782,7 @@ libxi-dev:
   fedora: [libXi-devel]
   ubuntu: [libxi-dev]
 libxinerama-dev:
+  arch: [libxinerama]
   ubuntu: [libxinerama-dev]
 libxml++-2.6:
   arch: [libxml++]
@@ -1879,6 +1882,7 @@ mercurial:
   opensuse: [mercurial]
   ubuntu: [mercurial]
 mesa-common-dev:
+  arch: [mesa]
   ubuntu: [mesa-common-dev]
 meshlab:
   ubuntu: [meshlab]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -731,7 +731,7 @@ python-qt-bindings:
     raring: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
     saucy: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
     trusty: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
-    trusty_python3: [python3-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python3-sip-dev]
+    trusty_python3: [python3-pyside, libpyside-dev, libshiboken-dev, shiboken, python3-pyqt4, python3-sip-dev]
 python-qt-bindings-gl:
   debian: [python-qt4-gl]
   fedora: [PyQt4]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -13,7 +13,7 @@ ipython:
     trusty: [ipython]
     trusty_python3: [ipython3]
 paramiko:
-  arch: [python-paramiko]
+  arch: [python2-paramiko]
   debian: [python-paramiko]
   fedora: [python-paramiko]
   freebsd: [py27-paramiko]
@@ -65,6 +65,7 @@ python:
     trusty: [python-dev]
     trusty_python3: [python3-dev]
 python-argparse:
+  arch: [python2]
   debian:
     jessie: [libpython2.7-stdlib]
     sid: [libpython2.7-stdlib]
@@ -227,6 +228,7 @@ python-docutils:
     raring: [python-docutils]
     saucy: [python-docutils]
 python-empy:
+  arch: [python2-empy]
   debian: [python-empy]
   fedora: [python-empy]
   opensuse: [python-empy]
@@ -274,6 +276,7 @@ python-gridfs:
     raring: [python-gridfs]
     saucy: [python-gridfs]
 python-gst:
+  arch: [gstreamer0.10-python]
   debian: [python-gst0.10]
   ubuntu:
     lucid: [python-gst0.10]
@@ -350,6 +353,7 @@ python-impacket:
     raring: [python-impacket]
     saucy: [python-impacket]
 python-kitchen:
+  arch: [python-kitchen]
   debian: [python-kitchen]
   fedora: [python-kitchen]
   ubuntu:
@@ -393,6 +397,7 @@ python-matplotlib:
     trusty: [python-matplotlib]
     trusty_python3: [python3-matplotlib]
 python-mechanize:
+  arch: [python2-mechanize]
   debian: [python-mechanize]
   fedora: [python-mechanize]
   ubuntu:
@@ -512,7 +517,7 @@ python-opengl:
     raring: [python-opengl]
     saucy: [python-opengl]
 python-paramiko:
-  arch: [python-paramiko]
+  arch: [python2-paramiko]
   debian: [python-paramiko]
   fedora: [python-paramiko]
   freebsd: [py27-paramiko]
@@ -553,6 +558,7 @@ python-pexpect:
     raring: [python-pexpect]
     saucy: [python-pexpect]
 python-psutil:
+  arch: [python2-psutil]
   debian: [python-psutil]
   fedora: [python-psutil]
   opensuse: [python-psutil]
@@ -590,6 +596,7 @@ python-pyassimp:
     raring: [python-pyassimp]
     saucy: [python-pyassimp]
 python-pydot:
+  arch: [pydot]
   debian: [python-pydot]
   fedora: [pydot]
   opensuse: [python-pydot]
@@ -713,7 +720,7 @@ python-pyudev:
     raring: [python-pyudev]
     saucy: [python-pyudev]
 python-qt-bindings:
-  arch: [python2-pyqt]
+  arch: [python2-pyqt4]
   debian:
     jessie: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
     sid: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
@@ -733,6 +740,7 @@ python-qt-bindings:
     trusty: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
     trusty_python3: [python3-pyside, libpyside-dev, libshiboken-dev, shiboken, python3-pyqt4, python3-sip-dev]
 python-qt-bindings-gl:
+  arch: [python2-pyqt4]
   debian: [python-qt4-gl]
   fedora: [PyQt4]
   opensuse: [python-qt4-devel]
@@ -746,6 +754,7 @@ python-qt-bindings-gl:
     raring: [python-qt4-gl]
     saucy: [python-qt4-gl]
 python-qt-bindings-qwt5:
+  arch: [pyqwt]
   debian: [python-qwt5-qt4]
   fedora: [PyQwt-devel]
   ubuntu:
@@ -766,6 +775,7 @@ python-qt4-gl:
     apt:
       packages: [python-qt4-gl]
 python-qwt5-qt4:
+  arch: [pyqwt]
   debian: [python-qwt5-qt4]
   ubuntu:
     lucid: [python-qwt5-qt4]


### PR DESCRIPTION
## Fixed
- python2-argparse is now part of python2,
- fixing some python2/3 errors (lots of packages need to be checked and changed),
- using [`gazebo`](https://aur.archlinux.org/packages/gazebo/) (release package) rather than [`gazebo-hg`](https://aur.archlinux.org/packages/gazebo-hg/) (upstream package). Note that `gazebo-hg` does provide `gazebo` so users can still choose between these two options.
- `festival-kallpc16k` is now named [`festival-english`](https://www.archlinux.org/packages/community/any/festival-english/).
- `python-gst` is named `gstreamer0.10-python`
## Known remaining errors
- ~~compilation fails with yaml-cpp 0.5 so we stick with version 0.3~~ (cf. [discussion](https://github.com/ros/rosdistro/pull/2891#discussion-diff-8950120)) packages will still need [yaml-cpp0.3](https://aur.archlinux.org/packages/yaml-cpp0.3/) until everything is fixed in ROS packages,
- Ogre 1.9 is currently being fixed for gazebo/rviz so [ogre-1.8](https://aur.archlinux.org/packages/ogre-1.8/) is being used instead for now.
