### PR TITLE
freenect_stack: 0.3.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -481,7 +481,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-drivers-gbp/freenect_stack-release.git
-    version: 0.3.0-0
+    version: 0.3.1-0
   gazebo_ros_pkgs:
     packages:
       gazebo_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `freenect_stack`:
- previous version: `0.3.0-0`
- new version: `0.3.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
