### PR TITLE
openni_camera: 1.9.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1501,7 +1501,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/openni_camera-release.git
-    version: 1.9.1-0
+    version: 1.9.2-0
   openni_launch:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_camera`:
- previous version: `1.9.1-0`
- new version: `1.9.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
