### PR TITLE
qt_gui_core: 0.2.20-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1718,7 +1718,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/qt_gui_core-release.git
-    version: 0.2.19-0
+    version: 0.2.20-0
   qt_ros:
     packages:
       qt_build:


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core`:
- previous version: `0.2.19-0`
- new version: `0.2.20-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
