### PR TITLE
rtmros_hironx: 1.0.10-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -2258,7 +2258,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/start-jsk/rtmros_hironx-release.git
-    version: 1.0.9-0
+    version: 1.0.10-0
   rtmros_nextage:
     packages:
       nextage_description:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx`:
- previous version: `1.0.9-0`
- new version: `1.0.10-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
