### PR TITLE
rtmros_nextage: 0.2.7-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -1460,7 +1460,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/tork-a/rtmros_nextage-release.git
-    version: 0.2.6-0
+    version: 0.2.7-0
   rtshell_core:
     packages:
       rtctree:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage`:
- previous version: `0.2.6-0`
- new version: `0.2.7-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
