### PR TITLE
nasa_r2_common: 0.1.2-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1237,6 +1237,7 @@ repositories:
     version: 0.2.2-0
   nasa_r2_common:
     packages:
+      nasa_r2_common:
       r2_description:
       r2_dynamic_reconfigure:
       r2_msgs:
@@ -1244,7 +1245,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/brown-release/nasa_r2_common_release.git
-    version: 0.0.2-0
+    version: 0.1.2-0
   nasa_r2_simulator:
     packages:
       r2_gazebo:


### PR DESCRIPTION
Increasing version of package(s) in repository `nasa_r2_common`:
- previous version: `0.0.2-0`
- new version: `0.1.2-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
