### PR TITLE
octomap: 1.6.4-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -1399,7 +1399,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/octomap-release.git
-    version: 1.6.3-0
+    version: 1.6.4-0
   octomap_mapping:
     packages:
       octomap_mapping:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap`:
- previous version: `1.6.3-0`
- new version: `1.6.4-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
