### PR TITLE
octomap: 1.5.7-0 in 'groovy/release.yaml' [bloom]

### DIFF
--- a/groovy/release.yaml
+++ b/groovy/release.yaml
@@ -853,7 +853,7 @@ repositories:
     tags:
       release: release/groovy/{package}/{version}
     url: https://github.com/ros-gbp/octomap-release.git
-    version: 1.5.6-0
+    version: 1.5.7-0
   octomap_msgs:
     status: maintained
     tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap`:
- previous version: `1.5.6-0`
- new version: `1.5.7-0`
- distro file: `groovy/release.yaml`
- bloom version: `0.4.4`
