### PR TITLE
crsm-slam-ros-pkg: 1.0.1-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -201,10 +201,11 @@ repositories:
   crsm-slam-ros-pkg:
     packages:
       crsm_slam:
+    status: developed
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/etsardou/crsm-slam-ros-pkg-release.git
-    version: 1.0.0-0
+    version: 1.0.1-0
   cv_camera:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `crsm-slam-ros-pkg`:
- previous version: `1.0.0-0`
- new version: `1.0.1-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
