### PR TITLE
Adding sicks300 to documentation index for distro

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -1581,6 +1581,10 @@ repositories:
     type: git
     url: https://github.com/uos/sick_tim3xx.git
     version: groovy
+  sicks300:
+    type: git
+    url: https://github.com/bohlender/sicks300.git
+    version: groovy
   simple_arms:
     type: svn
     url: https://vanadium-ros-pkg.googlecode.com/svn/trunk/simple_arms


### PR DESCRIPTION
Updated the old sicks300 package to work under groovy and interpret both the old and the new protocol of the SICK S300 laserscanner. Original authors wanted me to create a new repository.
