### PR TITLE
industrial_core: 0.3.4-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -845,7 +845,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-industrial-release/industrial_core-release.git
-    version: 0.3.3-0
+    version: 0.3.4-0
   interactive_marker_proxy:
     status: maintained
     url: https://github.com/ros-gbp/interactive_marker_proxy-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_core`:
- previous version: `0.3.3-0`
- new version: `0.3.4-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
