### PR TITLE
Adding pr2_ft_moveit_config to documentation index for distro

### DIFF
--- a/groovy/doc.yaml
+++ b/groovy/doc.yaml
@@ -1176,6 +1176,10 @@ repositories:
     type: svn
     url: http://svn.code.sf.net/p/bosch-ros-pkg/code/trunk/stacks/pr2_exploration
     version: HEAD
+  pr2_ft_moveit_config:
+    type: git
+    url: https://github.com/kth-ros-pkg/pr2_ft_moveit_config.git
+    version: groovy
   pr2_gui:
     type: svn
     url: https://code.ros.org/svn/wg-ros-pkg/stacks/pr2_gui/trunk


### PR DESCRIPTION
I'd like pr2_ft_moveit_config to be documented and indexed in wiki.ros.org. 

This config package for Moveit is intended for PR2 robots that have force-torque sensors.
