### PR TITLE
audio_common: 0.2.5-0 in 'hydro/release.yaml' [bloom]

### DIFF
--- a/hydro/release.yaml
+++ b/hydro/release.yaml
@@ -48,7 +48,7 @@ repositories:
     tags:
       release: release/hydro/{package}/{version}
     url: https://github.com/ros-gbp/audio_common-release.git
-    version: 0.2.4-0
+    version: 0.2.5-0
   ax2550:
     tags:
       release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common`:
- previous version: `0.2.4-0`
- new version: `0.2.5-0`
- distro file: `hydro/release.yaml`
- bloom version: `0.4.4`
