### PR TITLE
Update entries for sdformat and gazebo

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -504,10 +504,12 @@ ftdi-eeprom:
   ubuntu: [ftdi-eeprom]
 gazebo:
   arch: [gazebo-hg]
-  gentoo:
-    portage:
-      packages: [sci-electronics/gazebo]
-  ubuntu: [gazebo]
+  ubuntu:
+    precise: [gazebo]
+    quantal: [gazebo]
+    raring: [gazebo]
+    saucy: [gazebo2]
+    trusty: [gazebo2]
 gcc-avr:
   arch: [avr-gcc]
   debian: [gcc-avr]
@@ -1972,6 +1974,17 @@ screen:
     portage:
       packages: [app-misc/screen]
   ubuntu: [screen]
+sdformat:
+  arch: [sdformat-hg]
+  debian:
+    sid: [libsdformat-dev]
+  fedora: [sdformat-devel]
+  ubuntu:
+    precise: [sdformat]
+    quantal: [sdformat]
+    raring: [sdformat]
+    saucy: [libsdformat-dev]
+    trusty: [libsdformat-dev]
 sdl:
   arch: [sdl]
   debian: [libsdl1.2-dev]


### PR DESCRIPTION
The update for gazebo and sdformat packages. Some details:
- I did not see any entry using Trusty or Saucy. Should I leave them out?
- I included the sdformat package in debian SID. It is in [debian NEW queue right now](https://ftp-master.debian.org/new.html) and I hope to get it in before the end of sync in Trusty.
- In sdformat for fedora, I did not see entries for 19 or 20. 19 is specially fun since it is called "Schrödinger's Cat", I don't know if the funky chars or spaces will work fine for rosdep.
- I removed gentoo for gazebo. Too out of date.

/cc @DLu. @nkoenig, @scpeters
