### PR TITLE
cmake_modules: 0.2.1-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -390,7 +390,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/cmake_modules-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
   cob_calibration_data:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules`:
- previous version: `0.2.0-0`
- new version: `0.2.1-0`
- distro file: `groovy/distribution.yaml`
- bloom version: `0.4.7`
