### PR TITLE
add check for valid url patterns of known hosting platforms

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -265,7 +265,7 @@ repositories:
       version: 0.9.29-0
     source:
       type: git
-      url: http://github.com/ros-perception/calibration.git
+      url: https://github.com/ros-perception/calibration.git
       version: groovy
   camera1394:
     doc:
@@ -2254,7 +2254,7 @@ repositories:
       version: 0.2.22-0
     source:
       type: git
-      url: http://github.com/wg-perception/capture.git
+      url: https://github.com/wg-perception/capture.git
       version: master
     status: maintained
   object_recognition_core:
@@ -2276,7 +2276,7 @@ repositories:
       version: 0.2.12-0
     source:
       type: git
-      url: http://github.com/wg-perception/linemod.git
+      url: https://github.com/wg-perception/linemod.git
       version: master
     status: maintained
   object_recognition_msgs:
@@ -2333,7 +2333,7 @@ repositories:
       version: 0.3.18-0
     source:
       type: git
-      url: http://github.com/wg-perception/transparent_objects.git
+      url: https://github.com/wg-perception/transparent_objects.git
       version: master
     status: maintained
   occupancy_grid_utils:
@@ -2577,7 +2577,7 @@ repositories:
       - p2os_urdf
       tags:
         release: release/groovy/{package}/{version}
-      url: http://github.com/allenh1/p2os-release.git
+      url: https://github.com/allenh1/p2os-release.git
       version: 1.0.9-0
   pcl:
     doc:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -212,7 +212,7 @@ repositories:
       version: 0.10.7-0
     source:
       type: git
-      url: http://github.com/ros-perception/calibration.git
+      url: https://github.com/ros-perception/calibration.git
       version: hydro
     status: maintained
   calvin_robot:
@@ -1946,7 +1946,7 @@ repositories:
   libuvc_ros:
     doc:
       type: git
-      url: http://github.com/ktossell/libuvc_ros.git
+      url: https://github.com/ktossell/libuvc_ros.git
       version: master
     release:
       packages:
@@ -2436,7 +2436,7 @@ repositories:
       version: 0.2.22-0
     source:
       type: git
-      url: http://github.com/wg-perception/capture.git
+      url: https://github.com/wg-perception/capture.git
       version: master
     status: maintained
   object_recognition_core:
@@ -2458,7 +2458,7 @@ repositories:
       version: 0.2.12-0
     source:
       type: git
-      url: http://github.com/wg-perception/linemod.git
+      url: https://github.com/wg-perception/linemod.git
       version: master
     status: maintained
   object_recognition_msgs:
@@ -2515,7 +2515,7 @@ repositories:
       version: 0.3.18-0
     source:
       type: git
-      url: http://github.com/wg-perception/transparent_objects.git
+      url: https://github.com/wg-perception/transparent_objects.git
       version: master
     status: maintained
   ocl:

--- a/scripts/check_rosdistro_urls.py
+++ b/scripts/check_rosdistro_urls.py
@@ -23,6 +23,10 @@ def main(index_url, rosdistro_name):
         repo = distribution_file.repositories[repo_name]
         repos = [repo.release_repository, repo.source_repository, repo.doc_repository]
         for repo in [r for r in repos if r]:
+            if repo.url.startswith('file://'):
+                print()
+                print("Repository '%s' with url '%s' must not be a local 'file://' url" % (repo_name, repo.url), file=sys.stderr)
+                success = False
             if repo.type == 'git':
                 prefixes = ['http://github.com/', 'git@github.com:']
                 for prefix in prefixes:

--- a/scripts/check_rosdistro_urls.py
+++ b/scripts/check_rosdistro_urls.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import argparse
+import sys
+
+from rosdistro import get_distribution_file, get_index
+
+
+def main(index_url, rosdistro_name):
+    index = get_index(index_url)
+    try:
+        distribution_file = get_distribution_file(index, rosdistro_name)
+    except RuntimeError as e:
+        print("Could not load distribution file for distro '%s': %s" % (rosdistro_name, e), file=sys.stderr)
+        return False
+
+    success = True
+    for repo_name in sorted(distribution_file.repositories.keys()):
+        sys.stdout.write('.')
+        sys.stdout.flush()
+        repo = distribution_file.repositories[repo_name]
+        repos = [repo.release_repository, repo.source_repository, repo.doc_repository]
+        for repo in [r for r in repos if r]:
+            if repo.type == 'git':
+                prefixes = ['http://github.com/', 'git@github.com:']
+                for prefix in prefixes:
+                    if repo.url.startswith(prefix):
+                        print()
+                        print("Repository '%s' with url '%s' must use 'https://github.com/%s' instead" % (repo_name, repo.url, repo.url[len(prefix):]), file=sys.stderr)
+                        success = False
+    print()
+
+    return success
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Checks whether the referenced URLs have the expected pattern for known hosts')
+    parser.add_argument('index_url', help='The url of the index.yaml file')
+    parser.add_argument('rosdistro_name', help='The ROS distro name')
+    args = parser.parse_args()
+
+    if not main(args.index_url, args.rosdistro_name):
+        sys.exit(1)

--- a/test/rosdistro_check_urls.py
+++ b/test/rosdistro_check_urls.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import os
+
+from rosdistro import get_index
+from scripts.check_rosdistro_urls import main as check_rosdistro_urls
+
+FILES_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
+
+def test_rosdistro_urls():
+    index_url = 'file://' + FILES_DIR + '/index.yaml'
+    index = get_index(index_url)
+    success = True
+    for distro_name in index.distributions.keys():
+        print("""
+Checking if distribution.yaml contains valid urls for known hosting services.
+If this fails you can run 'scripts/check_rosdistro_urls.py file://`pwd`/%s %s' to perform the same check locally.
+""" % ('index.yaml', distro_name))
+        success &= check_rosdistro_urls(index_url, distro_name)
+    assert success


### PR DESCRIPTION
To avoid adding `git@github.com:` and `http://github.com/` urls.
