### PR TITLE
resolve ambiguity for calibration repo which has a branch as well as a tag named groovy

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -266,7 +266,7 @@ repositories:
     source:
       type: git
       url: http://github.com/ros-perception/calibration.git
-      version: groovy
+      version: origin/groovy
   camera1394:
     doc:
       type: git


### PR DESCRIPTION
Jenkins "decided" that the repo had changes on every pull (once every hour). The patch clearly identifies the branch (over the tag) which makes Jenkins determine the changed status correctly.

It just started to happen since until yesterday the version was `master` which does not even exist. I fixed it to use groovy while doing the rep 141 migration.

@tfoote Please review.

@vrabaud FYI
