### PR TITLE
stage: 4.1.1-5 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4382,7 +4382,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/stage-release.git
-      version: 4.1.1-4
+      version: 4.1.1-5
   stage_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stage`:
- previous version: `4.1.1-4`
- new version: `4.1.1-5`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.7`
