### PR TITLE
Fix Gentoo rule for bullet dependency.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -300,10 +300,10 @@ bullet:
     jessie: [libbullet-dev]
     sid: [libbullet-dev]
   fedora: [bullet-devel]
-  opensuse: [libbullet]
   gentoo:
     portage:
       packages: [sci-physics/bullet]
+  opensuse: [libbullet]
   ubuntu:
     precise:
       apt:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -300,10 +300,10 @@ bullet:
     jessie: [libbullet-dev]
     sid: [libbullet-dev]
   fedora: [bullet-devel]
-  gentoo:
   opensuse: [libbullet]
-  portage:
-    packages: [sci-physics/bullet]
+  gentoo:
+    portage:
+      packages: [sci-physics/bullet]
   ubuntu:
     precise:
       apt:


### PR DESCRIPTION
A broken rule for the bullet rosdep on Gentoo does not appear to have been fixed (or was re-broken), this should correct it.

https://github.com/ros-infrastructure/rosdep/issues/278

`InvalidData: rosdep OS definition for [bullet:gentoo] must be a dictionary, string, or list: None`
