### PR TITLE
rviz: 1.9.34-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3742,7 +3742,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.9.33-0
+      version: 1.9.34-0
     status: maintained
   rx:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz`:
- previous version: `1.9.33-0`
- new version: `1.9.34-0`
- distro file: `groovy/distribution.yaml`
- bloom version: `0.4.7`
