### PR TITLE
rviz: 1.10.11-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4162,7 +4162,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.10.10-0
+      version: 1.10.11-0
     status: maintained
   sbpl:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz`:
- previous version: `1.10.10-0`
- new version: `1.10.11-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.7`
