### PR TITLE
catkin: 0.5.80-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -292,7 +292,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.5.79-0
+      version: 0.5.80-0
     status: maintained
   class_loader:
     doc:
@@ -309,10 +309,6 @@ repositories:
       url: https://github.com/ros/class_loader
       version: hydro-devel
   clearpath_base:
-    doc:
-      type: git
-      url: https://github.com/clearpathrobotics/clearpath_base.git
-      version: hydro-devel
     release:
       tags:
         release: release/hydro/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin`:
- previous version: `0.5.79-0`
- new version: `0.5.80-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.7`
