### PR TITLE
gencpp: 0.4.16-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -971,7 +971,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/gencpp-release.git
-      version: 0.4.15-0
+      version: 0.4.16-0
     source:
       type: git
       url: https://github.com/ros/gencpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gencpp`:
- previous version: `0.4.15-0`
- new version: `0.4.16-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.7`
