### PR TITLE
ros_comm: 1.9.54-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3519,7 +3519,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.9.53-0
+      version: 1.9.54-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm`:
- previous version: `1.9.53-0`
- new version: `1.9.54-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.7`
