### PR TITLE
Adding ros_glass_tools to documentation index for distro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3562,6 +3562,10 @@ repositories:
       url: https://github.com/ros-gbp/ros_controllers-release.git
       version: 0.5.4-0
     status: developed
+  ros_glass_tools:
+    doc:
+      type: git
+      url: https://github.com/unl-nimbus-lab/ros_glass_tools.git
   ros_http_video_streamer:
     release:
       url: https://github.com/ros-gbp/ros_http_video_streamer-release.git


### PR DESCRIPTION
I'd like ros_glass_tools to be indexed and documented on ros.org. 
