### PR TITLE
rqt_common_plugins: 0.3.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3966,7 +3966,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.3.3-0
+      version: 0.3.4-0
     status: developed
   rqt_pr2_dashboard:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins`:
- previous version: `0.3.3-0`
- new version: `0.3.4-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.7`
