### PR TITLE
rqt_robot_plugins: 0.3.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3999,7 +3999,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-      version: 0.3.2-0
+      version: 0.3.3-0
     status: maintained
   rtmros_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins`:
- previous version: `0.3.2-0`
- new version: `0.3.3-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.7`
