### PR TITLE
libuvc: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1942,7 +1942,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ktossell/libuvc-release.git
-      version: 0.0.2-1
+      version: 0.0.3-0
   libuvc_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc`:
- previous version: `0.0.2-1`
- new version: `0.0.3-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.7`
