### PR TITLE
ecl_tools: 0.60.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -744,7 +744,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_tools-release.git
-      version: 0.60.0-2
+      version: 0.60.1-0
     source:
       type: git
       url: https://github.com/stonier/ecl_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_tools`:
- previous version: `0.60.0-2`
- new version: `0.60.1-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.7`
