### PR TITLE
ecl_lite: 0.60.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -688,7 +688,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_lite-release.git
-      version: 0.60.0-0
+      version: 0.60.1-0
     source:
       type: git
       url: https://github.com/stonier/ecl_lite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_lite`:
- previous version: `0.60.0-0`
- new version: `0.60.1-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.7`
