### PR TITLE
dynamixel_pro_controller: 0.8.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -613,7 +613,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/dynamixel_pro_controller-release.git
-      version: 0.8.2-0
+      version: 0.8.3-0
   dynamixel_pro_driver:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_pro_controller`:
- previous version: `0.8.2-0`
- new version: `0.8.3-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.7`
