### PR TITLE
crsm-slam-ros-pkg: 1.0.1-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -442,7 +442,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/etsardou/crsm-slam-ros-pkg-release.git
-      version: 1.0.1-1
+      version: 1.0.1-2
     status: developed
   crsm_slam:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `crsm-slam-ros-pkg`:
- previous version: `1.0.1-1`
- new version: `1.0.1-2`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.7`
