### PR TITLE
merged crsm_slam with crsm-slam-ros-pkg, they refer to the same repo

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -435,20 +435,17 @@ repositories:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/cpp_introspection.git
       version: master
-  crsm-slam-ros-pkg:
-    release:
-      packages:
-      - crsm_slam
-      tags:
-        release: release/hydro/{package}/{version}
-      url: https://github.com/etsardou/crsm-slam-ros-pkg-release.git
-      version: 1.0.1-2
-    status: developed
   crsm_slam:
     doc:
       type: git
       url: https://github.com/etsardou/crsm-slam-ros-pkg.git
       version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/etsardou/crsm-slam-ros-pkg-release.git
+      version: 1.0.1-2
+    status: developed
   cv_camera:
     doc:
       type: git


### PR DESCRIPTION
I think that this change should not affect bloom. In the release repository all tags/branches are being referenced with their package name and not the repo name. So i think, it should work..
