### PR TITLE
catkin: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7,5 +7,11 @@ release_platforms:
   - saucy
   - trusty
 repositories:
+  catkin:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/catkin-release.git
+      version: 0.6.0-0
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin`:
- previous version: `null`
- new version: `0.6.0-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.7`
