### PR TITLE
console_bridge: 0.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13,5 +13,11 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
       version: 0.6.0-0
+  console_bridge:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/console_bridge-release.git
+      version: 0.2.4-0
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `console_bridge`:
- previous version: `null`
- new version: `0.2.4-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.7`
