### PR TITLE
genmsg: 0.4.24-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -19,5 +19,11 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/console_bridge-release.git
       version: 0.2.4-0
+  genmsg:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/genmsg-release.git
+      version: 0.4.24-0
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg`:
- previous version: `null`
- new version: `0.4.24-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.7`
