### PR TITLE
catkin: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16,7 +16,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     status: maintained
   console_bridge:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin`:
- previous version: `0.6.0-0`
- new version: `0.6.1-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.7`
