### PR TITLE
gencpp: 0.5.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -24,6 +24,12 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/console_bridge-release.git
       version: 0.2.4-0
+  gencpp:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/gencpp-release.git
+      version: 0.5.0-0
   genmsg:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gencpp`:
- previous version: `null`
- new version: `0.5.0-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.7`
