### PR TITLE
genpy: 0.4.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -39,5 +39,11 @@ repositories:
       url: https://github.com/ros/genmsg.git
       version: hydro-devel
     status: maintained
+  genpy:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/genpy-release.git
+      version: 0.4.15-0
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy`:
- previous version: `null`
- new version: `0.4.15-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.7`
