### PR TITLE
genlisp: 0.4.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -30,6 +30,12 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/gencpp-release.git
       version: 0.5.0-0
+  genlisp:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/genlisp-release.git
+      version: 0.4.12-0
   genmsg:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genlisp`:
- previous version: `null`
- new version: `0.4.12-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.7`
