### PR TITLE
message_runtime: None-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -63,6 +63,12 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/message_generation-release.git
       version: 0.2.10-0
+  message_runtime:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/message_runtime-release.git
+      version: None-0
   roscpp_core:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `message_runtime`:
- previous version: `null`
- new version: `None-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.7`
