### PR TITLE
std_msgs: 0.5.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -81,5 +81,11 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
       version: 0.4.0-0
+  std_msgs:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/std_msgs-release.git
+      version: 0.5.8-0
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `std_msgs`:
- previous version: `null`
- new version: `0.5.8-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.7`
