### PR TITLE
rosbag_migration_rule: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -69,6 +69,12 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/message_runtime-release.git
       version: 0.4.12-0
+  rosbag_migration_rule:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rosbag_migration_rule-release.git
+      version: 1.0.0-0
   roscpp_core:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_migration_rule`:
- previous version: `null`
- new version: `1.0.0-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.7`
