### PR TITLE
catkin: 0.5.81-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -297,7 +297,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.5.80-0
+      version: 0.5.81-0
     status: maintained
   class_loader:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin`:
- previous version: `0.5.80-0`
- new version: `0.5.81-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.7`
