### PR TITLE
Withdraw kingfisher_robot repo from hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1749,14 +1749,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/kingfisher_desktop-release.git
       version: 0.0.1-0
-  kingfisher_robot:
-    release:
-      packages:
-      - kingfisher_bringup
-      tags:
-        release: release/hydro/{package}/{version}
-      url: https://github.com/clearpath-gbp/kingfisher_robot-release.git
-      version: 0.0.2-0
   kobuki:
     doc:
       type: git


### PR DESCRIPTION
Switching to a private build for this one since it's going to depend on proprietary firmware and controller packages.
