### PR TITLE
rospack: 2.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -87,6 +87,12 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
       version: 0.4.0-0
+  rospack:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rospack-release.git
+      version: 2.2.0-0
   std_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack`:
- previous version: `null`
- new version: `2.2.0-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.7`
