### PR TITLE
bride: 0.3.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -194,6 +194,18 @@ repositories:
       type: git
       url: https://github.com/gt-ros-pkg/Boost.NumPy.git
       version: hydro-devel
+  bride:
+    release:
+      packages:
+      - bride
+      - bride_compilers
+      - bride_plugin_source
+      - bride_templates
+      - bride_tutorials
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ipa320/bride-release.git
+      version: 0.3.0-1
   calibration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bride`:
- previous version: `null`
- new version: `0.3.0-1`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
