### PR TITLE
bride: 0.3.0-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -205,7 +205,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/bride-release.git
-      version: 0.3.0-1
+      version: 0.3.0-2
   calibration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bride`:
- previous version: `0.3.0-1`
- new version: `0.3.0-2`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
