### PR TITLE
crsm_slam: 1.0.1-3 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -456,7 +456,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/etsardou/crsm-slam-ros-pkg-release.git
-      version: 1.0.1-2
+      version: 1.0.1-3
     status: developed
   cv_camera:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `crsm_slam`:
- previous version: `1.0.1-2`
- new version: `1.0.1-3`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.7`
