### PR TITLE
motoman: 0.3.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2102,7 +2102,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-industrial-release/motoman-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/ros-industrial/motoman


### PR DESCRIPTION
Increasing version of package(s) in repository `motoman`:
- previous version: `0.3.1-0`
- new version: `0.3.2-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
