### PR TITLE
geometry: 1.10.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1091,7 +1091,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/geometry-release.git
-      version: 1.10.7-0
+      version: 1.10.8-0
     source:
       type: git
       url: https://github.com/ros/geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry`:
- previous version: `1.10.7-0`
- new version: `1.10.8-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.6`
