### PR TITLE
hrpsys: 315.1.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1442,7 +1442,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/start-jsk/hrpsys-release.git
-      version: 315.1.6-0
+      version: 315.1.7-0
     source:
       type: svn
       url: https://rtm-ros-robotics.googlecode.com/svn/trunk/openrtm_common/hrpsys


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys`:
- previous version: `315.1.6-0`
- new version: `315.1.7-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
