### PR TITLE
ecl_core: 0.60.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -674,7 +674,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_core-release.git
-      version: 0.60.6-0
+      version: 0.60.7-0
     source:
       type: git
       url: https://github.com/stonier/ecl_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_core`:
- previous version: `0.60.6-0`
- new version: `0.60.7-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.7`
