### PR TITLE
openni2_camera: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2751,7 +2751,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
   openni2_launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera`:
- previous version: `0.1.1-0`
- new version: `0.1.2-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
