### PR TITLE
Adding corobot to documentation index for Hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -442,6 +442,11 @@ repositories:
       type: git
       url: https://github.com/ros/convex_decomposition.git
       version: master
+  corobot:
+    doc:
+      type: git
+      url: https://github.com/morgancormier/corobot.git
+      version: master
   cpp_introspection:
     doc:
       type: git


### PR DESCRIPTION
I'd like corobot for Hydro to be indexed and documented on ros.org.
Thank you.
