### PR TITLE
ros_controllers: 0.6.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3591,7 +3591,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.5.4-0
+      version: 0.6.0-0
     status: developed
   ros_glass_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers`:
- previous version: `0.5.4-0`
- new version: `0.6.0-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
