### PR TITLE
ros_control: 0.6.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3566,11 +3566,12 @@ repositories:
       - hardware_interface
       - joint_limits_interface
       - ros_control
+      - rqt_controller_manager
       - transmission_interface
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.5.8-0
+      version: 0.6.0-1
     status: developed
   ros_controllers:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control`:
- previous version: `0.5.8-0`
- new version: `0.6.0-1`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
