### PR TITLE
realtime_tools: 1.8.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3194,7 +3194,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/realtime_tools-release.git
-      version: 1.8.2-0
+      version: 1.8.3-0
     status: maintained
   reemc_robot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools`:
- previous version: `1.8.2-0`
- new version: `1.8.3-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
