### PR TITLE
control_toolbox: 1.10.4-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -430,7 +430,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/control_toolbox-release.git
-      version: 1.10.3-0
+      version: 1.10.4-1
     status: maintained
   convex_decomposition:
     release:
@@ -3194,7 +3194,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/realtime_tools-release.git
-      version: 1.8.3-0
+      version: 1.8.2-0
     status: maintained
   reemc_robot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox`:
- previous version: `1.10.3-0`
- new version: `1.10.4-1`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
