### PR TITLE
Adding labust_ros_pkg to documentation index for groovy and hydro distros

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1686,6 +1686,11 @@ repositories:
       type: git
       url: https://github.com/uos/kurt_driver.git
       version: groovy
+  labust_ros_pkg:
+    doc:
+      type: git
+      url: https://github.com/labust/labust-ros-pkg.git
+      version: groovy-devel
   langs:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1868,6 +1868,11 @@ repositories:
       type: git
       url: https://github.com/uos/kurt_driver.git
       version: hydro
+  labust_ros_pkg:
+    doc:
+      type: git
+      url: https://github.com/labust/labust-ros-pkg.git
+      version: hydro-devel
   langs:
     source:
       type: git


### PR DESCRIPTION
I'd like labust_ros_pkg to be indexed and documented on ros.org.
