### PR TITLE
libfovis: 0.0.4-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1783,7 +1783,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/srv/libfovis-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
   libfreenect:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libfovis`:
- previous version: `0.0.3-0`
- new version: `0.0.4-0`
- distro file: `groovy/distribution.yaml`
- bloom version: `0.4.8`
