### PR TITLE
libfovis: 0.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1932,6 +1932,12 @@ repositories:
       url: https://github.com/ros-gbp/libccd-release.git
       version: 1.4.0-1
     status: maintained
+  libfovis:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/srv/libfovis-release.git
+      version: 0.0.4-0
   libfreenect:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libfovis`:
- previous version: `null`
- new version: `0.0.4-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
