### PR TITLE
moveit_core: 0.5.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2139,7 +2139,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/moveit_core-release.git
-      version: 0.5.5-0
+      version: 0.5.6-0
     status: maintained
   moveit_ikfast:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_core`:
- previous version: `0.5.5-0`
- new version: `0.5.6-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
