### PR TITLE
moveit_ros: 0.5.15-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2250,7 +2250,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.5.12-0
+      version: 0.5.15-0
     status: maintained
   moveit_setup_assistant:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ros`:
- previous version: `0.5.12-0`
- new version: `0.5.15-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
