### PR TITLE
stdr_simulator: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4459,7 +4459,23 @@ repositories:
     doc:
       type: git
       url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator.git
-      version: develop
+      version: hydro-devel
+    release:
+      packages:
+      - stdr_gui
+      - stdr_launchers
+      - stdr_msgs
+      - stdr_parser
+      - stdr_resources
+      - stdr_robot
+      - stdr_samples
+      - stdr_server
+      - stdr_simulator
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator-release.git
+      version: 0.1.0-0
+    status: maintained
   steered_wheel_base_controller:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stdr_simulator`:
- previous version: `null`
- new version: `0.1.0-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
