### PR TITLE
moveit_setup_assistant: 0.5.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2261,7 +2261,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
-      version: 0.5.7-0
+      version: 0.5.8-0
     status: maintained
   mr_teleoperator:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_setup_assistant`:
- previous version: `0.5.7-0`
- new version: `0.5.8-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
