### PR TITLE
moveit_planners: 0.5.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2185,7 +2185,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/moveit_planners-release.git
-      version: 0.5.3-0
+      version: 0.5.4-0
     status: maintained
   moveit_plugins:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_planners`:
- previous version: `0.5.3-0`
- new version: `0.5.4-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
