### PR TITLE
moveit_commander: 0.5.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2128,7 +2128,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/moveit_commander-release.git
-      version: 0.5.3-0
+      version: 0.5.4-0
     status: maintained
   moveit_core:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_commander`:
- previous version: `0.5.3-0`
- new version: `0.5.4-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
