### PR TITLE
Adding sentis_tof_m100_ros_pkg to documentation index for distros hydro ...

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3814,6 +3814,11 @@ repositories:
       url: https://github.com/segwayrmp/segway_rmp-release.git
       version: 0.1.1-0
     status: maintained
+  sentis_tof_m100:
+    doc:
+      type: git
+      url: https://github.com/voxel-dot-at/sentis_tof_m100_pkg.git
+      version: master
   serial:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4289,6 +4289,11 @@ repositories:
       url: https://github.com/segwayrmp/segway_rmp-release.git
       version: 0.1.1-0
     status: maintained
+  sentis_tof_m100:
+    doc:
+      type: git
+      url: https://github.com/voxel-dot-at/sentis_tof_m100_pkg.git
+      version: master
   serial:
     release:
       tags:


### PR DESCRIPTION
...and groovy.
I'd like sentis_tof_m100_ros_pkg to be indexed and documented on ros.org
