### PR TITLE
ocl: 2.7.0-3 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2569,7 +2569,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/ocl-release.git
-      version: 2.7.0-2
+      version: 2.7.0-3
     source:
       type: git
       url: https://git.gitorious.org/orocos-toolchain/ocl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ocl`:
- previous version: `2.7.0-2`
- new version: `2.7.0-3`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
