### PR TITLE
utilrb: 2.7.0-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4802,7 +4802,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/utilrb-release.git
-      version: 2.7.0-1
+      version: 2.7.0-2
     source:
       type: git
       url: https://git.gitorious.org/orocos-toolchain/utilrb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `utilrb`:
- previous version: `2.7.0-1`
- new version: `2.7.0-2`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
