### PR TITLE
rosh_core: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3721,6 +3721,16 @@ repositories:
       url: https://github.com/ros-infrastructure/rosdoc_lite.git
       version: master
     status: maintained
+  rosh_core:
+    release:
+      packages:
+      - rosh
+      - rosh_core
+      - roshlaunch
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/OSUrobotics/rosh_core-release.git
+      version: 1.0.2-0
   rosjava:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_core`:
- previous version: `null`
- new version: `1.0.2-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
