### PR TITLE
rtmros_common: 1.0.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3721,16 +3721,6 @@ repositories:
       url: https://github.com/ros-infrastructure/rosdoc_lite.git
       version: master
     status: maintained
-  rosh_core:
-    release:
-      packages:
-      - rosh
-      - rosh_core
-      - roshlaunch
-      tags:
-        release: release/hydro/{package}/{version}
-      url: https://github.com/OSUrobotics/rosh_core-release.git
-      version: 1.0.2-0
   rosjava:
     doc:
       type: git
@@ -4071,7 +4061,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/start-jsk/rtmros_common-release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     source:
       type: svn
       url: https://rtm-ros-robotics.googlecode.com/svn/trunk/rtmros_common


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common`:
- previous version: `1.0.5-0`
- new version: `1.0.6-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
