### PR TITLE
stdr_simulator: 0.1.0-3 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3721,16 +3721,6 @@ repositories:
       url: https://github.com/ros-infrastructure/rosdoc_lite.git
       version: master
     status: maintained
-  rosh_core:
-    release:
-      packages:
-      - rosh
-      - rosh_core
-      - roshlaunch
-      tags:
-        release: release/hydro/{package}/{version}
-      url: https://github.com/OSUrobotics/rosh_core-release.git
-      version: 1.0.2-0
   rosjava:
     doc:
       type: git
@@ -4489,7 +4479,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator-release.git
-      version: 0.1.0-2
+      version: 0.1.0-3
     status: maintained
   steered_wheel_base_controller:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `stdr_simulator`:
- previous version: `0.1.0-2`
- new version: `0.1.0-3`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
