### PR TITLE
Rolling back recent releases due to build failure

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2569,7 +2569,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/ocl-release.git
-      version: 2.7.0-3
+      version: 2.7.0-2
     source:
       type: git
       url: https://git.gitorious.org/orocos-toolchain/ocl.git
@@ -4141,7 +4141,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/rtt-release.git
-      version: 2.7.0-4
+      version: 2.7.0-3
     source:
       type: git
       url: https://git.gitorious.org/orocos-toolchain/rtt.git
@@ -4662,7 +4662,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/typelib-release.git
-      version: 2.7.0-4
+      version: 2.7.0-3
     source:
       type: git
       url: https://git.gitorious.org/orocos-toolchain/typelib.git
@@ -4812,7 +4812,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/utilrb-release.git
-      version: 2.7.0-2
+      version: 2.7.0-1
     source:
       type: git
       url: https://git.gitorious.org/orocos-toolchain/utilrb.git


### PR DESCRIPTION
@smits

It looks like regressions in #3031 #3032 or #3034 I'm going to roll back #3033 since it was released at the same time, possibly in lockstep. 

Failures here: http://jenkins.ros.org/view/HbinP32/job/ros-hydro-rtt-typelib_binarydeb_precise_i386/10/console and http://jenkins.ros.org/view/HbinP32/job/ros-hydro-ocl_binarydeb_precise_i386/

I'm trying to do a sync and rolling these back to get a clean build quickly. @isucan @sachinchitta
