### PR TITLE
rtmros_common: 1.0.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4071,7 +4071,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/start-jsk/rtmros_common-release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     source:
       type: svn
       url: https://rtm-ros-robotics.googlecode.com/svn/trunk/rtmros_common


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common`:
- previous version: `1.0.5-0`
- new version: `1.0.6-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
