### PR TITLE
stdr_simulator: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4489,7 +4489,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator-release.git
-      version: 0.1.0-4
+      version: 0.1.1-0
     status: maintained
   steered_wheel_base_controller:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `stdr_simulator`:
- previous version: `0.1.0-4`
- new version: `0.1.1-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
