### PR TITLE
typelib: 2.7.0-4 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4662,7 +4662,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/typelib-release.git
-      version: 2.7.0-3
+      version: 2.7.0-4
     source:
       type: git
       url: https://git.gitorious.org/orocos-toolchain/typelib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `typelib`:
- previous version: `2.7.0-3`
- new version: `2.7.0-4`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
