### PR TITLE
youbot_driver_ros_interface: 1.0.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5074,7 +5074,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/youbot-release/youbot_driver_ros_interface-release.git
-      version: 1.0.0-0
+      version: 1.0.0-1
   yujin_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `youbot_driver_ros_interface`:
- previous version: `1.0.0-0`
- new version: `1.0.0-1`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
