### PR TITLE
Rolling back rtmros_common

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4071,7 +4071,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/start-jsk/rtmros_common-release.git
-      version: 1.0.6-0
+      version: 1.0.5-0
     source:
       type: svn
       url: https://rtm-ros-robotics.googlecode.com/svn/trunk/rtmros_common


### PR DESCRIPTION
From https://github.com/ros/rosdistro/pull/3043 due to build failures. 

```
[ 42%] Building CXX object CMakeFiles/HrpsysJointTrajectoryBridge.dir/src/HrpsysJointTrajectoryBridge.cpp.o
/usr/lib/ccache/c++   -DROS_PACKAGE_NAME=\"hrpsys_ros_bridge\" -DROSCONSOLE_BACKEND_LOG4CXX -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security  -I/tmp/buildd/ros-hydro-hrpsys-ros-bridge-1.0.6-0precise-20140210-0942/obj-x86_64-linux-gnu/devel/include -I/opt/ros/hydro/include -I/usr/include/eigen3 -I/tmp/buildd/ros-hydro-hrpsys-ros-bridge-1.0.6-0precise-20140210-0942/idl_gen/cpp -I/opt/ros/hydro/include/openrtm_aist/include/coil-1.1 -I/opt/ros/hydro/include/openrtm_aist/include/openrtm-1.1 -I/opt/ros/hydro/include/openrtm_aist/include/openrtm-1.1/rtm/idl -I/opt/ros/hydro/include/openhrp3/include/OpenHRP-3.1    -o CMakeFiles/HrpsysJointTrajectoryBridge.dir/src/HrpsysJointTrajectoryBridge.cpp.o -c /tmp/buildd/ros-hydro-hrpsys-ros-bridge-1.0.6-0precise-20140210-0942/src/HrpsysJointTrajectoryBridge.cpp
In file included from /tmp/buildd/ros-hydro-hrpsys-ros-bridge-1.0.6-0precise-20140210-0942/src/HrpsysJointTrajectoryBridge.cpp:7:0:
/tmp/buildd/ros-hydro-hrpsys-ros-bridge-1.0.6-0precise-20140210-0942/src/HrpsysJointTrajectoryBridge.h:32:56: fatal error: pr2_controllers_msgs/JointTrajectoryAction.h: No such file or directory
compilation terminated.
make[4]: *** [CMakeFiles/HrpsysJointTrajectoryBridge.dir/src/HrpsysJointTrajectoryBridge.cpp.o] Error 1
```

http://jenkins.ros.org/view/HbinP64/job/ros-hydro-hrpsys-ros-bridge_binarydeb_precise_amd64/119/console
