### PR TITLE
roscpp_core: 0.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -154,7 +154,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/ros/roscpp_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core`:
- previous version: `0.4.0-0`
- new version: `0.4.1-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
