### PR TITLE
Adding markov_decision_making to documentation index for hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2029,6 +2029,11 @@ repositories:
       type: git
       url: https://github.com/TobiasBaer/marble_plugin.git
       version: master
+  markov_decision_making:
+    doc:
+      type: git
+      url: https://github.com/larsys/markov_decision_making.git
+      version: master
   maxwell:
     doc:
       type: git


### PR DESCRIPTION
I'd like markov_decision_making to be indexed and documented on ros.org. Thanks.
