### PR TITLE
roslisp: 1.9.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -169,6 +169,12 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: indigo-devel
     status: maintained
+  roslisp:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/roslisp-release.git
+      version: 1.9.15-0
   rospack:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp`:
- previous version: `null`
- new version: `1.9.15-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
