### PR TITLE
ros_comm: 1.10.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -132,6 +132,33 @@ repositories:
       url: https://github.com/ros/ros.git
       version: indigo-devel
     status: maintained
+  ros_comm:
+    release:
+      packages:
+      - message_filters
+      - ros_comm
+      - rosbag
+      - rosbag_storage
+      - rosconsole
+      - roscpp
+      - rosgraph
+      - roslaunch
+      - rosmaster
+      - rosmsg
+      - rosnode
+      - rosout
+      - rosparam
+      - rospy
+      - rosservice
+      - rostest
+      - rostopic
+      - roswtf
+      - topic_tools
+      - xmlrpcpp
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/ros_comm-release.git
+      version: 1.10.0-0
   ros_comm_msgs:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm`:
- previous version: `null`
- new version: `1.10.0-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
