### PR TITLE
common_msgs: 1.10.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -18,6 +18,23 @@ repositories:
       url: https://github.com/ros-gbp/catkin-release.git
       version: 0.6.1-0
     status: maintained
+  common_msgs:
+    release:
+      packages:
+      - actionlib_msgs
+      - common_msgs
+      - diagnostic_msgs
+      - geometry_msgs
+      - nav_msgs
+      - sensor_msgs
+      - shape_msgs
+      - stereo_msgs
+      - trajectory_msgs
+      - visualization_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/common_msgs-release.git
+      version: 1.10.3-0
   console_bridge:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs`:
- previous version: `null`
- new version: `1.10.3-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
