### PR TITLE
sr_ros_interface: 1.3.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4424,6 +4424,26 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/shadow-robot/sr-ronex-release.git
       version: 0.9.5-0
+  sr_ros_interface:
+    release:
+      packages:
+      - sr_description
+      - sr_example
+      - sr_gazebo_plugins
+      - sr_hand
+      - sr_hardware_interface
+      - sr_mechanism_controllers
+      - sr_mechanism_model
+      - sr_movements
+      - sr_robot_msgs
+      - sr_ros_interface
+      - sr_self_test
+      - sr_tactile_sensors
+      - sr_utilities
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/shadow-robot/sr-ros-interface-release.git
+      version: 1.3.0-0
   srdfdom:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_ros_interface`:
- previous version: `null`
- new version: `1.3.0-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
