### PR TITLE
ros_tutorials: 0.4.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -185,6 +185,17 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm_msgs-release.git
       version: 1.10.1-0
+  ros_tutorials:
+    release:
+      packages:
+      - ros_tutorials
+      - roscpp_tutorials
+      - rospy_tutorials
+      - turtlesim
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/ros_tutorials-release.git
+      version: 0.4.3-0
   rosbag_migration_rule:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials`:
- previous version: `null`
- new version: `0.4.3-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
