### PR TITLE
occupancy_grid_utils: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2585,6 +2585,12 @@ repositories:
       url: https://github.com/wg-perception/transparent_objects.git
       version: master
     status: maintained
+  occupancy_grid_utils:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/clearpath-gbp/occupancy_grid_utils-release.git
+      version: 0.0.1-0
   ocl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `occupancy_grid_utils`:
- previous version: `null`
- new version: `0.0.1-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
