### PR TITLE
teleop_twist_keyboard: 0.5.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4549,11 +4549,16 @@ repositories:
       url: https://github.com/clearpath-gbp/libswiftnav-release.git
       version: 0.0.4-0
   teleop_twist_keyboard:
+    doc:
+      type: git
+      url: https://github.com/trainman419/teleop_twist_keyboard.git
+      version: master
     release:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/teleop_twist_keyboard-release.git
       version: 0.5.0-0
+    status: maintained
   tf2_web_republisher:
     release:
       tags:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4548,6 +4548,12 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/libswiftnav-release.git
       version: 0.0.4-0
+  teleop_twist_keyboard:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/teleop_twist_keyboard-release.git
+      version: 0.5.0-0
   tf2_web_republisher:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_keyboard`:
- previous version: `null`
- new version: `0.5.0-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
