### PR TITLE
rtt: 2.7.0-6 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4162,7 +4162,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/rtt-release.git
-      version: 2.7.0-5
+      version: 2.7.0-6
     source:
       type: git
       url: https://git.gitorious.org/orocos-toolchain/rtt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt`:
- previous version: `2.7.0-5`
- new version: `2.7.0-6`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
