### PR TITLE
console_bridge: 0.2.4-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -40,7 +40,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/console_bridge-release.git
-      version: 0.2.4-0
+      version: 0.2.4-1
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `console_bridge`:
- previous version: `0.2.4-0`
- new version: `0.2.4-1`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
