### PR TITLE
dynamic_reconfigure: 1.5.35-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -77,11 +77,19 @@ repositories:
       url: https://github.com/ros-gbp/console_bridge-release.git
       version: 0.2.4-1
   dynamic_reconfigure:
+    doc:
+      type: git
+      url: https://github.com/ros/dynamic_reconfigure
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
       version: 1.5.35-0
+    source:
+      type: git
+      url: https://github.com/ros/dynamic_reconfigure.git
+      version: master
   gencpp:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -76,6 +76,12 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/console_bridge-release.git
       version: 0.2.4-1
+  dynamic_reconfigure:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
+      version: 1.5.35-0
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure`:
- previous version: `null`
- new version: `1.5.35-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
