### PR TITLE
nodelet_core: 1.8.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -171,6 +171,16 @@ repositories:
       url: https://github.com/ros-gbp/message_runtime-release.git
       version: 0.4.12-0
     status: maintained
+  nodelet_core:
+    release:
+      packages:
+      - nodelet
+      - nodelet_core
+      - nodelet_topic_tools
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/nodelet_core-release.git
+      version: 1.8.2-0
   pluginlib:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -172,6 +172,10 @@ repositories:
       version: 0.4.12-0
     status: maintained
   nodelet_core:
+    doc:
+      type: git
+      url: https://github.com/ros/nodelet_core.git
+      version: hydro-devel
     release:
       packages:
       - nodelet
@@ -181,6 +185,10 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
       version: 1.8.2-0
+    source:
+      type: git
+      url: https://github.com/ros/nodelet_core.git
+      version: hydro-devel
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core`:
- previous version: `null`
- new version: `1.8.2-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
