### PR TITLE
python_qt_binding: 0.2.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -224,6 +224,12 @@ repositories:
       type: git
       url: https://github.com/ros/pluginlib.git
       version: groovy-devel
+  python_qt_binding:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/python_qt_binding-release.git
+      version: 0.2.12-0
   ros:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -225,11 +225,20 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: groovy-devel
   python_qt_binding:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding
+      version: groovy-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/python_qt_binding-release.git
       version: 0.2.12-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: groovy-devel
+    status: maintained
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding`:
- previous version: `null`
- new version: `0.2.12-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
