### PR TITLE
qt_gui_core: 0.2.21-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -240,6 +240,10 @@ repositories:
       version: groovy-devel
     status: maintained
   qt_gui_core:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core
+      version: groovy-devel
     release:
       packages:
       - qt_dotgraph
@@ -252,6 +256,11 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
       version: 0.2.21-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core-release.git
+      version: groovy-devel
+    status: maintained
   ros:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -239,6 +239,19 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: groovy-devel
     status: maintained
+  qt_gui_core:
+    release:
+      packages:
+      - qt_dotgraph
+      - qt_gui
+      - qt_gui_app
+      - qt_gui_core
+      - qt_gui_cpp
+      - qt_gui_py_common
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/qt_gui_core-release.git
+      version: 0.2.21-0
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core`:
- previous version: `null`
- new version: `0.2.21-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
