### PR TITLE
rqt: 0.2.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -411,6 +411,17 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: indigo-devel
     status: maintained
+  rqt:
+    release:
+      packages:
+      - rqt
+      - rqt_gui
+      - rqt_gui_cpp
+      - rqt_gui_py
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rqt-release.git
+      version: 0.2.13-0
   std_msgs:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -412,6 +412,10 @@ repositories:
       version: indigo-devel
     status: maintained
   rqt:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt
+      version: groovy-devel
     release:
       packages:
       - rqt
@@ -422,6 +426,11 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt-release.git
       version: 0.2.13-0
+    source:
+      type: git
+      url: https://github.com/ros/rqt-release.git
+      version: groovy-devel
+    status: maintained
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt`:
- previous version: `null`
- new version: `0.2.13-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
