### PR TITLE
arbotix: 0.9.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -110,7 +110,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/vanadiumlabs/arbotix_ros-release.git
-      version: 0.9.1-0
+      version: 0.9.2-0
   argos3d_p100:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `arbotix`:
- previous version: `0.9.1-0`
- new version: `0.9.2-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
