### PR TITLE
adding shadow_robot stack to documentation index for both groovy and hydro

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3843,6 +3843,11 @@ repositories:
       type: svn
       url: http://pi-robot-ros-pkg.googlecode.com/svn/trunk/serializer
       version: HEAD
+  shadow_robot:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr-ros-interface.git
+      version: groovy-devel
   shape_tools:
     doc:
       type: git

--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3848,6 +3848,11 @@ repositories:
       type: git
       url: https://github.com/shadow-robot/sr-ros-interface.git
       version: groovy-devel
+  shadow_robot_ethercat:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr-ros-interface-ethercat.git
+      version: groovy-devel
   shape_tools:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4338,6 +4338,11 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/wjwwood/serial_utils-release.git
       version: 0.1.0-0
+  shadow_robot:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr-ros-interface.git
+      version: hydro-devel
   shape_tools:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4343,6 +4343,11 @@ repositories:
       type: git
       url: https://github.com/shadow-robot/sr-ros-interface.git
       version: hydro-devel
+  shadow_robot_ethercat:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr-ros-interface-ethercat.git
+      version: hydro-devel
   shape_tools:
     doc:
       type: git


### PR DESCRIPTION
By the way, it seems that this page is outdated:
http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation
