### PR TITLE
Document common_tutorials

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -392,6 +392,10 @@ repositories:
       version: hydro-devel
     status: maintained
   common_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/common_tutorials.git
+      version: hydro-devel
     release:
       packages:
       - actionlib_tutorials


### PR DESCRIPTION
Fixes http://answers.ros.org/question/128911/missing-file-in-the-actionlib-intermediate-tutorial/
