### PR TITLE
Adding navigation_2d to documentation index for fuerte

### DIFF
--- a/doc/fuerte/navigation_2d.rosinstall
+++ b/doc/fuerte/navigation_2d.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: navigation_2d
+    uri: https://github.com/skasperski/navigation_2d.git
+    version: master


### PR DESCRIPTION
I like to have my repo navigation_2d documented on ros.org.
