### PR TITLE
sr_ros_interface: 1.3.0-8 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4459,7 +4459,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/shadow-robot/sr-ros-interface-release.git
-      version: 1.3.0-0
+      version: 1.3.0-8
   srdfdom:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_ros_interface`:
- previous version: `1.3.0-0`
- new version: `1.3.0-8`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
