### PR TITLE
sr_ros_interface: 1.3.0-9 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4473,7 +4473,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/shadow-robot/sr-ros-interface-release.git
-      version: 1.3.0-8
+      version: 1.3.0-9
   sr_ros_interface_ethercat:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_ros_interface`:
- previous version: `1.3.0-8`
- new version: `1.3.0-9`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
