### PR TITLE
actionlib: 1.11.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7,6 +7,12 @@ release_platforms:
   - saucy
   - trusty
 repositories:
+  actionlib:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/actionlib-release.git
+      version: 1.11.0-0
   bond_core:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8,11 +8,20 @@ release_platforms:
   - trusty
 repositories:
   actionlib:
+    doc:
+      type: git
+      url: https://github.com/ros/actionlib.git
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
       version: 1.11.0-0
+    source:
+      type: git
+      url: https://github.com/ros/actionlib.git
+      version: indigo-devel
+    status: maintained
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib`:
- previous version: `null`
- new version: `1.11.0-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
