### PR TITLE
rosconsole_bridge: 0.3.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -394,6 +394,12 @@ repositories:
       url: https://github.com/ros-gbp/rosbag_migration_rule-release.git
       version: 1.0.0-0
     status: maintained
+  rosconsole_bridge:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rosconsole_bridge-release.git
+      version: 0.3.3-0
   roscpp_core:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -395,11 +395,19 @@ repositories:
       version: 1.0.0-0
     status: maintained
   rosconsole_bridge:
+    doc:
+      type: git
+      url: https://github.com/ros/rosconsole_bridge
+      version: hydro-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rosconsole_bridge-release.git
       version: 0.3.3-0
+    source:
+      type: git
+      url: https://github.com/ros/rosconsole_bridge.git
+      version: hydro-devel
   roscpp_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole_bridge`:
- previous version: `null`
- new version: `0.3.3-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
