### PR TITLE
shadow_robot: 1.3.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4347,6 +4347,25 @@ repositories:
       type: git
       url: https://github.com/shadow-robot/sr-ros-interface.git
       version: hydro-devel
+    release:
+      packages:
+      - shadow_robot
+      - sr_description
+      - sr_example
+      - sr_gazebo_plugins
+      - sr_hand
+      - sr_hardware_interface
+      - sr_mechanism_controllers
+      - sr_mechanism_model
+      - sr_movements
+      - sr_robot_msgs
+      - sr_self_test
+      - sr_tactile_sensors
+      - sr_utilities
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/shadow-robot/sr-ros-interface-release.git
+      version: 1.3.0-0
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ros-interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `shadow_robot`:
- previous version: `null`
- new version: `1.3.0-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
