### PR TITLE
geometry_experimental: 0.5.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -165,7 +165,7 @@ repositories:
       version: hydro-devel
     status: maintained
   geometry_experimental:
-  doc:
+    doc:
       type: git
       url: https://github.com/ros/geometry_experimental.git
       version: indigo-devel
@@ -181,7 +181,7 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry_experimental-release.git
       version: 0.5.0-0
-  source:
+    source:
       type: git
       url: https://github.com/ros/geometry_experimental.git
       version: indigo-devel

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -164,6 +164,19 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: hydro-devel
     status: maintained
+  geometry_experimental:
+    release:
+      packages:
+      - tf2
+      - tf2_bullet
+      - tf2_msgs
+      - tf2_py
+      - tf2_ros
+      - tf2_tools
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/geometry_experimental-release.git
+      version: 0.5.0-0
   image_common:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -165,6 +165,10 @@ repositories:
       version: hydro-devel
     status: maintained
   geometry_experimental:
+  doc:
+      type: git
+      url: https://github.com/ros/geometry_experimental.git
+      version: indigo-devel
     release:
       packages:
       - tf2
@@ -177,6 +181,10 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry_experimental-release.git
       version: 0.5.0-0
+  source:
+      type: git
+      url: https://github.com/ros/geometry_experimental.git
+      version: indigo-devel
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_experimental`:
- previous version: `null`
- new version: `0.5.0-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
