### PR TITLE
angles: 1.9.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -22,6 +22,12 @@ repositories:
       url: https://github.com/ros/actionlib.git
       version: indigo-devel
     status: maintained
+  angles:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/geometry_angles_utils-release.git
+      version: 1.9.9-0
   bond_core:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -23,11 +23,19 @@ repositories:
       version: indigo-devel
     status: maintained
   angles:
+    doc:
+      type: git
+      url: https://github.com/ros/angles.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry_angles_utils-release.git
       version: 1.9.9-0
+    source:
+      type: git
+      url: https://github.com/ros/angles.git
+      version: master
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `angles`:
- previous version: `null`
- new version: `1.9.9-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
