### PR TITLE
geometry: 1.11.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -179,6 +179,10 @@ repositories:
       version: hydro-devel
     status: maintained
   geometry:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry.git
+      version: indigo-devel
     release:
       packages:
       - tf
@@ -186,6 +190,10 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry-release.git
       version: 1.11.0-0
+    source:
+      type: git
+      url: https://github.com/ros/geometry.git
+      version: indigo-devel
   geometry_experimental:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -178,6 +178,14 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: hydro-devel
     status: maintained
+  geometry:
+    release:
+      packages:
+      - tf
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/geometry-release.git
+      version: 1.11.0-0
   geometry_experimental:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry`:
- previous version: `null`
- new version: `1.11.0-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
