### PR TITLE
vision_opencv: 1.11.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -549,7 +549,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.10.15-2
+      version: 1.11.0-0
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv`:
- previous version: `1.10.15-2`
- new version: `1.11.0-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
