### PR TITLE
rosconsole_bridge: 0.3.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -454,7 +454,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rosconsole_bridge-release.git
-      version: 0.3.3-0
+      version: 0.3.4-0
     source:
       type: git
       url: https://github.com/ros/rosconsole_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole_bridge`:
- previous version: `0.3.3-0`
- new version: `0.3.4-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
