### PR TITLE
urdfdom_headers: 0.3.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -536,6 +536,12 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  urdfdom_headers:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/urdfdom_headers-release
+      version: 0.3.0-1
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_headers`:
- previous version: `null`
- new version: `0.3.0-1`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
