### PR TITLE
urdfdom: 0.3.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -536,6 +536,12 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  urdfdom:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/urdfdom-release
+      version: 0.3.0-1
   urdfdom_headers:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom`:
- previous version: `null`
- new version: `0.3.0-1`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
