### PR TITLE
libccd: 1.5.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -236,6 +236,12 @@ repositories:
       url: https://github.com/ros-perception/image_common.git
       version: hydro-devel
     status: maintained
+  libccd:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/libccd-release
+      version: 1.5.0-0
   message_generation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libccd`:
- previous version: `null`
- new version: `1.5.0-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
