### PR TITLE
octomap: 1.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -282,6 +282,15 @@ repositories:
       type: git
       url: https://github.com/ros/nodelet_core.git
       version: hydro-devel
+  octomap:
+    release:
+      packages:
+      - octomap
+      - octovis
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/octomap-release
+      version: 1.6.4-0
   ompl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap`:
- previous version: `null`
- new version: `1.6.4-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
