### PR TITLE
fcl: 0.3.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -119,6 +119,12 @@ repositories:
       type: git
       url: https://github.com/ros/dynamic_reconfigure.git
       version: master
+  fcl:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/fcl-release
+      version: 0.3.0-1
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fcl`:
- previous version: `null`
- new version: `0.3.0-1`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
