### PR TITLE
shape_tools: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -548,6 +548,12 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: groovy-devel
     status: maintained
+  shape_tools:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/shape_tools-release
+      version: 0.2.1-0
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `shape_tools`:
- previous version: `null`
- new version: `0.2.1-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
