### PR TITLE
random_numbers: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -364,6 +364,12 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: groovy-devel
     status: maintained
+  random_numbers:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/random_numbers-release
+      version: 0.2.0-0
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `random_numbers`:
- previous version: `null`
- new version: `0.2.0-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
