### PR TITLE
eigen_stl_containers: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -119,6 +119,12 @@ repositories:
       type: git
       url: https://github.com/ros/dynamic_reconfigure.git
       version: master
+  eigen_stl_containers:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/eigen_stl_containers-release
+      version: 0.1.4-0
   fcl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `eigen_stl_containers`:
- previous version: `null`
- new version: `0.1.4-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
