### PR TITLE
octomap_msgs: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -303,6 +303,12 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/octomap-release
       version: 1.6.4-0
+  octomap_msgs:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_msgs-release
+      version: 0.3.1-0
   ompl:
     release:
       tags:
@@ -603,7 +609,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git
-      version: indigo
+      version: groovy-devel
     release:
       packages:
       - cv_bridge
@@ -616,7 +622,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git
-      version: indigo
+      version: groovy-devel
     status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_msgs`:
- previous version: `null`
- new version: `0.3.1-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
