### PR TITLE
octomap_msgs: 0.3.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -303,6 +303,12 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/octomap-release
       version: 1.6.4-0
+  octomap_msgs:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_msgs-release
+      version: 0.3.1-1
   ompl:
     release:
       tags:
@@ -566,24 +572,6 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/shape_tools-release
       version: 0.2.1-0
-  slam_gmapping:
-    doc:
-      type: git
-      url: https://github.com/ros-perception/slam_gmapping.git
-      version: hydro-devel
-    release:
-      packages:
-      - gmapping
-      - slam_gmapping
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/slam_gmapping-release.git
-      version: 1.3.2-0
-    source:
-      type: git
-      url: https://github.com/ros-perception/slam_gmapping.git
-      version: hydro-devl=el
-    status: maintained
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_msgs`:
- previous version: `null`
- new version: `0.3.1-1`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
