### PR TITLE
octomap_msgs: 0.3.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -303,6 +303,12 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/octomap-release
       version: 1.6.4-0
+  octomap_msgs:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_msgs-release
+      version: 0.3.1-1
   ompl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_msgs`:
- previous version: `null`
- new version: `0.3.1-1`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
