### PR TITLE
moveit_msgs: 0.5.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -287,6 +287,12 @@ repositories:
       url: https://github.com/ros-gbp/message_runtime-release.git
       version: 0.4.12-0
     status: maintained
+  moveit_msgs:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_msgs-release
+      version: 0.5.3-0
   nodelet_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs`:
- previous version: `null`
- new version: `0.5.3-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
