### PR TITLE
octomap: 1.6.4-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -330,7 +330,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/octomap-release
-      version: 1.6.4-0
+      version: 1.6.4-1
   octomap_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap`:
- previous version: `1.6.4-0`
- new version: `1.6.4-1`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
