### PR TITLE
rtt: 2.7.0-7 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4172,7 +4172,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/rtt-release.git
-      version: 2.7.0-6
+      version: 2.7.0-7
     source:
       type: git
       url: https://git.gitorious.org/orocos-toolchain/rtt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt`:
- previous version: `2.7.0-6`
- new version: `2.7.0-7`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
