### PR TITLE
orocos_kdl: 1.2.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2873,7 +2873,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/smits/orocos-kdl-release.git
-      version: 1.2.1-0
+      version: 1.2.2-0
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kdl`:
- previous version: `1.2.1-0`
- new version: `1.2.2-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
