### PR TITLE
shadow_robot_ethercat: 1.3.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4382,6 +4382,19 @@ repositories:
       type: git
       url: https://github.com/shadow-robot/sr-ros-interface-ethercat.git
       version: hydro-devel
+    release:
+      packages:
+      - shadow_robot_ethercat
+      - sr_edc_controller_configuration
+      - sr_edc_ethercat_drivers
+      - sr_edc_launch
+      - sr_edc_muscle_tools
+      - sr_external_dependencies
+      - sr_robot_lib
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/shadow-robot/sr-ros-interface-ethercat-release.git
+      version: 1.3.0-0
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ros-interface-ethercat.git


### PR DESCRIPTION
Increasing version of package(s) in repository `shadow_robot_ethercat`:
- previous version: `null`
- new version: `1.3.0-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
