### PR TITLE
shadow_robot_ethercat: 1.3.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4394,7 +4394,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/shadow-robot/sr-ros-interface-ethercat-release.git
-      version: 1.3.0-0
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ros-interface-ethercat.git


### PR DESCRIPTION
Increasing version of package(s) in repository `shadow_robot_ethercat`:
- previous version: `1.3.0-0`
- new version: `1.3.0-1`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
