### PR TITLE
orocos_kinematics_dynamics: 1.2.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -365,6 +365,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/smits/orocos-kdl-release.git
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/orocos/orocos_kinematics_dynamics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kinematics_dynamics`:
- previous version: `null`
- new version: `1.2.2-1`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
