### PR TITLE
rtmros_nextage: 0.2.10-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4141,7 +4141,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.2.9-0
+      version: 0.2.10-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage`:
- previous version: `0.2.9-0`
- new version: `0.2.10-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
