### PR TITLE
shadow_robot: 1.3.0-4 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4372,7 +4372,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/shadow-robot/sr-ros-interface-release.git
-      version: 1.3.0-3
+      version: 1.3.0-4
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ros-interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `shadow_robot`:
- previous version: `1.3.0-3`
- new version: `1.3.0-4`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
