### PR TITLE
Release play_motion (0.3.2)

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2983,6 +2983,15 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/play_motion.git
       version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/pal-gbp/play_motion-release.git
+      version: 0.3.2-0
+    source:
+      type: git
+      url: https://github.com/pal-robotics/play_motion.git
+      version: hydro-devel
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
A tool to play pre-recorded motions through `ros_control` 's `joint_trajectory_controller`
