### PR TITLE
rtmros_hironx: 1.0.11-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4121,7 +4121,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/start-jsk/rtmros_hironx-release.git
-      version: 1.0.10-0
+      version: 1.0.11-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git
@@ -4394,7 +4394,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/shadow-robot/sr-ros-interface-ethercat-release.git
-      version: 1.3.0-2
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ros-interface-ethercat.git
@@ -4516,10 +4516,6 @@ repositories:
       url: https://github.com/shadow-robot/sr-ronex-release.git
       version: 0.9.5-0
   sr_visualization:
-    doc:
-      type: git
-      url: https://github.com/shadow-robot/sr-visualization.git
-      version: hydro-devel
     release:
       packages:
       - sr_gui_bootloader


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx`:
- previous version: `1.0.10-0`
- new version: `1.0.11-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
