### PR TITLE
rtmros_hironx: 1.0.11-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4121,7 +4121,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/start-jsk/rtmros_hironx-release.git
-      version: 1.0.10-0
+      version: 1.0.11-1
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx`:
- previous version: `1.0.10-0`
- new version: `1.0.11-1`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
