### PR TITLE
common_msgs: 1.10.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -385,7 +385,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.10.3-0
+      version: 1.10.4-0
     source:
       type: git
       url: https://github.com/ros/common_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs`:
- previous version: `1.10.3-0`
- new version: `1.10.4-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
