### PR TITLE
add python-argparse for squeeze

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -71,6 +71,7 @@ python-argparse:
     jessie: [libpython2.7-stdlib]
     sid: [libpython2.7-stdlib]
     wheezy: [python-argparse]
+    squeeze: [python-argparse]
   fedora: [python]
   opensuse: [python-argparse]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -70,8 +70,8 @@ python-argparse:
   debian:
     jessie: [libpython2.7-stdlib]
     sid: [libpython2.7-stdlib]
-    wheezy: [python-argparse]
     squeeze: [python-argparse]
+    wheezy: [python-argparse]
   fedora: [python]
   opensuse: [python-argparse]
   ubuntu:


### PR DESCRIPTION
Simple change, as suggested at
http://answers.ros.org/question/78231/rosdep-failed-to-detect-argparse-debian/
(i'll comment on the answer there)

nosetests pass
