### PR TITLE
serial: 1.1.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4349,7 +4349,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/wjwwood/serial-release.git
-      version: 1.1.5-0
+      version: 1.1.6-0
     status: maintained
   serial_utils:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `serial` to `1.1.5-0` from `1.1.6-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`

```
Changes for serial 1.1.6:
* Move stopbits_one_point_five to the end of the enum, so that it doesn't alias with stopbits_two.
```
