### PR TITLE
ardrone_autonomy: 1.3.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -111,6 +111,12 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/vanadiumlabs/arbotix_ros-release.git
       version: 0.9.2-0
+  ardrone_autonomy:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/AutonomyLab/ardrone_autonomy-release.git
+      version: 1.3.1-0
   argos3d_p100:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ardrone_autonomy`:
- previous version: `null`
- new version: `1.3.1-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
