### PR TITLE
ardrone_autonomy: 1.3.1-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -108,6 +108,12 @@ repositories:
       url: https://github.com/vanadiumlabs/arbotix_ros.git
       version: groovy-devel
     status: developed
+  ardrone_autonomy:
+    release:
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/AutonomyLab/ardrone_autonomy-release.git
+      version: 1.3.1-0
   argos3d_p100:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ardrone_autonomy`:
- previous version: `null`
- new version: `1.3.1-0`
- distro file: `groovy/distribution.yaml`
- bloom version: `0.4.9`
