### PR TITLE
common_msgs: 1.9.18-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -472,7 +472,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.9.17-0
+      version: 1.9.18-0
     source:
       type: git
       url: https://github.com/ros/common_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs`:
- previous version: `1.9.17-0`
- new version: `1.9.18-0`
- distro file: `groovy/distribution.yaml`
- bloom version: `0.4.9`
