### PR TITLE
visp: 2.9.0-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5075,7 +5075,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/laas/visp-release.git
-      version: 2.8.0-8
+      version: 2.9.0-2
   visualization_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visp`:
- previous version: `2.8.0-8`
- new version: `2.9.0-2`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
