### PR TITLE
visp: 2.9.0-2 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4257,7 +4257,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/laas/visp-release.git
-      version: 2.8.0-4
+      version: 2.9.0-2
   visualization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visp`:
- previous version: `2.8.0-4`
- new version: `2.9.0-2`
- distro file: `groovy/distribution.yaml`
- bloom version: `0.4.9`
