### PR TITLE
add libeigen3-dev for debian:squeeze

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -459,6 +459,7 @@ eigen:
   debian:
     jessie: [libeigen3-dev]
     sid: [libeigen3-dev]
+    squeeze: [libeigen3-dev]
     wheezy: [libeigen3-dev]
   fedora: [eigen3-devel]
   gentoo:


### PR DESCRIPTION
libeigen3-dev isn't officially supported for squeeze, but manually installing this package from the .deb proceeds without issue with a pretty stock squeeze. Including it in the base.yaml means that squeeze users can use eigen stack.

See my 'answers' post at http://answers.ros.org/question/130726/rosdep-fails-to-find-libeigen3-dev-on-debiansqueeze/
