### PR TITLE
geometry_experimental: 0.5.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -224,8 +224,11 @@ repositories:
       version: indigo-devel
     release:
       packages:
+      - geometry_experimental
       - tf2
       - tf2_bullet
+      - tf2_geometry_msgs
+      - tf2_kdl
       - tf2_msgs
       - tf2_py
       - tf2_ros
@@ -233,7 +236,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry_experimental-release.git
-      version: 0.5.1-0
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/ros/geometry_experimental.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_experimental` to `0.5.1-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
- previous version for package: `0.5.1-0`
## tf2_ros -> 0.5.1

```
* adding const to MessageEvent data
* Contributors: Tully Foote
```
