### PR TITLE
geometry: 1.11.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -208,11 +208,15 @@ repositories:
       version: indigo-devel
     release:
       packages:
+      - eigen_conversions
+      - geometry
+      - kdl_conversions
       - tf
+      - tf_conversions
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry-release.git
-      version: 1.11.0-0
+      version: 1.11.0-1
     source:
       type: git
       url: https://github.com/ros/geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry` to `1.11.0-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
- previous version for package: `1.11.0-0`
## tf -> 1.11.0

```
* TF uses ros::MessageEvent to get connection information
* Contributors: Kevin Watts, Tully Foote
```
## eigen_conversions -> 1.11.0

```
* fixed Eigen-KDL 3D Vector conversion functions
* Contributors: fevb
```
