### PR TITLE
Revert "add libeigen3-dev for debian:squeeze"

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -459,7 +459,6 @@ eigen:
   debian:
     jessie: [libeigen3-dev]
     sid: [libeigen3-dev]
-    squeeze: [libeigen3-dev]
     wheezy: [libeigen3-dev]
   fedora: [eigen3-devel]
   gentoo:


### PR DESCRIPTION
This reverts commit 8a386395e794d21d4534b3caf64470f5c853a755.

As commented in #3176 this is not available in the repositories.
