### PR TITLE
rqt_common_plugins: 0.3.4-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3600,7 +3600,6 @@ repositories:
       - rqt_bag_plugins
       - rqt_common_plugins
       - rqt_console
-      - rqt_cpp_common
       - rqt_dep
       - rqt_graph
       - rqt_image_view
@@ -3621,7 +3620,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.3.2-0
+      version: 0.3.4-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins`:
- previous version: `0.3.2-0`
- new version: `0.3.4-0`
- distro file: `groovy/distribution.yaml`
- bloom version: `0.4.9`
