### PR TITLE
rqt_robot_plugins: 0.3.3-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3652,7 +3652,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-      version: 0.3.1-0
+      version: 0.3.3-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins`:
- previous version: `0.3.1-0`
- new version: `0.3.3-0`
- distro file: `groovy/distribution.yaml`
- bloom version: `0.4.9`
