### PR TITLE
roscpp_core: 0.4.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3761,7 +3761,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.3.17-0
+      version: 0.4.3-0
     source:
       type: git
       url: https://github.com/ros/roscpp_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core`:
- previous version: `0.3.17-0`
- new version: `0.4.3-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
