### PR TITLE
Switched control_msgs to ROS distro-specific branches

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -503,7 +503,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
-      version: master
+      version: groovy-devel
     release:
       packages:
       - control

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -425,7 +425,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
-      version: master
+      version: groovy-devel
     release:
       tags:
         release: release/hydro/{package}/{version}


### PR DESCRIPTION
In preparation for a change in the `indigo-branch`, we've renamed the control_msgs branch from `master` to `groovy-devel` (no changes were made for Hydro so we don't need a branch for that).

Is this the right way to specify this change, or do we also need to re-release to GBP in some way?
