### PR TITLE
rosjava_build_tools: 0.1.32-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3827,7 +3827,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_build_tools-release.git
-      version: 0.1.31-0
+      version: 0.1.32-0
     source:
       type: git
       url: https://github.com/rosjava/rosjava_build_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_build_tools`:
- previous version: `0.1.31-0`
- new version: `0.1.32-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.7`
