### PR TITLE
cmake_modules: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -82,6 +82,12 @@ repositories:
       type: git
       url: https://github.com/ros/class_loader
       version: hydro-devel
+  cmake_modules:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/cmake_modules-release.git
+      version: 0.2.1-0
   common_msgs:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules` to `0.2.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
- previous version for package: `null`
## cmake_modules -> 0.2.1

```
* Adding CMake module for finding Xenomai RT kernel patch build flags
* Contributors: Jonathan Bohren, William Woodall
```
