### PR TITLE
serial: 1.1.7-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3850,7 +3850,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/wjwwood/serial-release.git
-      version: 1.1.4-0
+      version: 1.1.7-0
     source:
       type: git
       url: https://github.com/wjwwood/serial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `serial` to `1.1.7-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.4.9`
- previous version for package: `1.1.4-0`
## serial -> 1.1.7

```
* Improved support for mingw (mxe.cc)
* Fix compilation warning
  See issue #53 <https://github.com/wjwwood/serial/issues/53>
* Improved timer handling in unix implementation
* fix broken ifdef _WIN32
* Fix broken ioctl calls, add exception handling.
* Code guards for platform-specific implementations. (when not using cmake / catkin)
* Contributors: Christopher Baker, Mike Purvis, Nicolas Bigaouette, William Woodall, dawid
```
