### PR TITLE
serial: 1.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -630,6 +630,12 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: groovy-devel
     status: maintained
+  serial:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wjwwood/serial-release.git
+      version: 1.1.7-0
   shape_tools:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `serial` to `1.1.7-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
- previous version for package: `null`
## serial -> 1.1.7

```
* Improved support for mingw (mxe.cc)
* Fix compilation warning
  See issue #53 <https://github.com/wjwwood/serial/issues/53>
* Improved timer handling in unix implementation
* fix broken ifdef _WIN32
* Fix broken ioctl calls, add exception handling.
* Code guards for platform-specific implementations. (when not using cmake / catkin)
* Contributors: Christopher Baker, Mike Purvis, Nicolas Bigaouette, William Woodall, dawid
```
