### PR TITLE
laser_geometry: 1.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -272,6 +272,12 @@ repositories:
       url: https://github.com/ros-perception/image_common.git
       version: hydro-devel
     status: maintained
+  laser_geometry:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/laser_geometry-release.git
+      version: 1.6.0-0
   libccd:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `1.6.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
- previous version for package: `null`
## laser_geometry -> 1.6.0

```
* Adding William Woodall as a co-maintainer
* Contributors: Vincent Rabaud, William Woodall
```
