### PR TITLE
Add Fedora 20 to release_platforms for G, H, I

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3,6 +3,8 @@
 # see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
+  fedora:
+  - heisenbug
   ubuntu:
   - precise
   - oneiric

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3,6 +3,8 @@
 # see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
+  fedora:
+  - heisenbug
   ubuntu:
   - precise
   - quantal

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3,6 +3,8 @@
 # see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
+  fedora:
+  - heisenbug
   ubuntu:
   - saucy
   - trusty


### PR DESCRIPTION
This changed was discussed in https://github.com/ros-infrastructure/bloom/pull/228#issuecomment-35763315.

Initially, we'll work on Fedora 20 (heisenbug) only. As things progress, Fedora 19 support will be added.
