### PR TITLE
Adding gazebo2rviz to documentation index for distro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -995,6 +995,12 @@ repositories:
       url: https://github.com/ros-drivers/freenect_stack.git
       version: master
     status: maintained
+  gazebo2rviz:
+    doc:
+      type: git
+      url: https://github.com/andreasBihlmaier/gazebo2rviz
+      version: hydro
+    status: developed
   gazebo_ros_pkgs:
     doc:
       type: git


### PR DESCRIPTION
Added initial documentation:
http://wiki.ros.org/gazebo2rviz
