### PR TITLE
serial: 1.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -637,11 +637,20 @@ repositories:
       version: groovy-devel
     status: maintained
   serial:
+    doc:
+      type: git
+      url: https://github.com/wjwwood/serial.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wjwwood/serial-release.git
       version: 1.1.7-0
+    source:
+      type: git
+      url: https://github.com/wjwwood/serial.git
+      version: master
+    status: maintained
   shape_tools:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `serial` to `1.1.7-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
- previous version for package: `1.1.7-0`
## serial

```
* Improved support for mingw (mxe.cc)
* Fix compilation warning
  See issue #53 <https://github.com/wjwwood/serial/issues/53>
* Improved timer handling in unix implementation
* fix broken ifdef _WIN32
* Fix broken ioctl calls, add exception handling.
* Code guards for platform-specific implementations. (when not using cmake / catkin)
* Contributors: Christopher Baker, Mike Purvis, Nicolas Bigaouette, William Woodall, dawid
```
