### PR TITLE
ardrone_autonomy: 1.3.1-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -120,7 +120,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/AutonomyLab/ardrone_autonomy-release.git
-      version: 1.3.1-0
+      version: 1.3.1-2
     source:
       type: git
       url: https://github.com/AutonomyLab/ardrone_autonomy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ardrone_autonomy`:
- previous version: `1.3.1-0`
- new version: `1.3.1-2`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
