### PR TITLE
ardrone_autonomy: 1.3.1-1 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -117,7 +117,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/AutonomyLab/ardrone_autonomy-release.git
-      version: 1.3.1-0
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/AutonomyLab/ardrone_autonomy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ardrone_autonomy`:
- previous version: `1.3.1-0`
- new version: `1.3.1-1`
- distro file: `groovy/distribution.yaml`
- bloom version: `0.4.9`
