### PR TITLE
resource_retriever: 1.11.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -446,6 +446,12 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/random_numbers-release.git
       version: 0.2.0-0
+  resource_retriever:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/resource_retriever-release
+      version: 1.11.0-1
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever`:
- previous version: `null`
- new version: `1.11.0-1`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
