### PR TITLE
resource_retriever: 1.11.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5253,7 +5253,7 @@ repositories:
     release:
       tags:
         release: release/hydro/{package}/{version}
-      url: https://github.com/youbot-release/youbot_description-release
+      url: https://github.com/youbot-release/youbot_description-release.git
       version: 0.8.0-0
   youbot_driver:
     release:
@@ -5276,7 +5276,7 @@ repositories:
       - youbot_simulation
       tags:
         release: release/hydro/{package}/{version}
-      url: https://github.com/youbot-release/youbot_simulation-release
+      url: https://github.com/youbot-release/youbot_simulation-release.git
       version: 0.8.0-0
   yujin_maps:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -446,6 +446,12 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/random_numbers-release.git
       version: 0.2.0-0
+  resource_retriever:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/resource_retriever-release.git
+      version: 1.11.0-2
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever`:
- previous version: `null`
- new version: `1.11.0-2`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
