### PR TITLE
geometric_shapes: 0.3.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -207,6 +207,12 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: hydro-devel
     status: maintained
+  geometric_shapes:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/geometric_shapes-release.git
+      version: 0.3.6-0
   geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes`:
- previous version: `null`
- new version: `0.3.6-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
