### PR TITLE
robot_model: 1.11.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -458,6 +458,20 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/resource_retriever-release.git
       version: 1.11.0-2
+  robot_model:
+    release:
+      packages:
+      - collada_parser
+      - collada_urdf
+      - joint_state_publisher
+      - kdl_parser
+      - robot_model
+      - urdf
+      - urdf_parser_plugin
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/robot_model-release.git
+      version: 1.11.0-0
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model`:
- previous version: `null`
- new version: `1.11.0-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
