### PR TITLE
xv_11_laser_driver: 0.1.2-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5233,7 +5233,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/rohbotics/xv_11_laser_driver-release.git
-      version: 0.1.2-1
+      version: 0.1.2-2
   yocs_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xv_11_laser_driver`:
- previous version: `0.1.2-1`
- new version: `0.1.2-2`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
