### PR TITLE
srdfdom: 0.2.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -701,6 +701,12 @@ repositories:
       url: https://github.com/ros-perception/slam_gmapping.git
       version: hydro-devel
     status: maintained
+  srdfdom:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/srdfdom-release.git
+      version: 0.2.6-0
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom`:
- previous version: `null`
- new version: `0.2.6-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
