### PR TITLE
moveit_core: 0.5.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -315,6 +315,12 @@ repositories:
       url: https://github.com/ros-gbp/message_runtime-release.git
       version: 0.4.12-0
     status: maintained
+  moveit_core:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_core-release.git
+      version: 0.5.6-0
   moveit_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_core`:
- previous version: `null`
- new version: `0.5.6-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
