### PR TITLE
cmake_modules: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -87,7 +87,12 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/cmake_modules-release.git
-      version: 0.2.1-0
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/ros/cmake_modules.git
+      version: 0.3-devel
+    status: maintained
   common_msgs:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules` to `0.3.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
- previous version for package: `0.2.1-0`
## cmake_modules

```
* Added Numpy CMake module
* Added Eigen CMake module
  closed #10 <https://github.com/ros/cmake_modules/issues/10>
* Removed use of absolute paths in extra files
  fixed #9 <https://github.com/ros/cmake_modules/issues/9>
* Contributors: Vincent Rabaud, William Woodall
```
