### PR TITLE
laser_geometry: 1.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -287,11 +287,20 @@ repositories:
       version: hydro-devel
     status: maintained
   laser_geometry:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/laser_geometry-release.git
-      version: 1.6.0-0
+      version: 1.6.1-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: indigo-devel
+    status: maintained
   libccd:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `1.6.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
- previous version for package: `1.6.0-0`
## laser_geometry

```
* Added dependency on cmake_modules
* Contributors: William Woodall
```
