### PR TITLE
geometric_shapes: 0.3.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -218,7 +218,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.3.6-0
+      version: 0.3.7-0
   geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes`:
- previous version: `0.3.6-0`
- new version: `0.3.7-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
