### PR TITLE
geometry: 1.11.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -234,7 +234,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry-release.git
-      version: 1.11.0-1
+      version: 1.11.1-0
     source:
       type: git
       url: https://github.com/ros/geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry`:
- previous version: `1.11.0-1`
- new version: `1.11.1-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.9`
