### PR TITLE
interactive_markers: 1.10.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -286,6 +286,21 @@ repositories:
       url: https://github.com/ros-perception/image_common.git
       version: hydro-devel
     status: maintained
+  interactive_markers:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/interactive_markers-release.git
+      version: 1.10.2-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: hydro-devel
+    status: maintained
   laser_geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `1.10.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.0`
- previous version for package: `null`
## interactive_markers

```
* fix regression in menu_handler.py
  fixes #14 <https://github.com/ros-visualization/interactive_markers/issues/14>
* Contributors: William Woodall
```
