### PR TITLE
rviz: 1.9.35-2 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3777,7 +3777,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.9.34-0
+      version: 1.9.35-2
     status: maintained
   rx:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.9.35-2`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.0`
- previous version for package: `1.9.34-0`
## rviz

```
* point_cloud: back ported changes to pc iteration
  fixes #715 <https://github.com/ros-visualization/rviz/issues/715> for me
* Contributors: William Woodall
```
