### PR TITLE
map_msgs: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -322,6 +322,20 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/libccd-release.git
       version: 1.5.0-0
+  map_msgs:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/map_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/map_msgs-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/ethz-asl/map_msgs.git
+      version: master
   message_generation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `map_msgs` to `0.0.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `null`
