### PR TITLE
media_export: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -336,6 +336,12 @@ repositories:
       type: git
       url: https://github.com/ethz-asl/map_msgs.git
       version: master
+  media_export:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/media_export-release.git
+      version: 0.1.0-0
   message_generation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `media_export` to `0.1.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `null`
