### PR TITLE
catkin: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -66,7 +66,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     status: maintained
   class_loader:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.6.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.6.1-0`
## catkin

```
* use underlay workspaces when calculating topological order (#590 <https://github.com/ros/catkin/issues/590>)
* remove restriction to run unit test single threaded (#597 <https://github.com/ros/catkin/issues/597>)
* support using nosetests with Python3 (#593 <https://github.com/ros/catkin/issues/593>)
* remove invalid symbolic links of workspace level CMakeLists.txt file (#591 <https://github.com/ros/catkin/issues/591>)
* remove debug_message usage from generated pkgConfig.cmake files (#583 <https://github.com/ros/catkin/issues/583>)
* use catkin_install_python() to install Python scripts (#596 <https://github.com/ros/catkin/issues/596>)
* fix unicode error with japanese LANG (#578 <https://github.com/ros/catkin/issues/578>)
* fix gtest include dir when using gtest inside the workspace (#585 <https://github.com/ros/catkin/issues/585>)
```
