### PR TITLE
gencpp: 0.5.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -163,7 +163,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/gencpp-release.git
-      version: 0.5.0-0
+      version: 0.5.1-0
     source:
       type: git
       url: https://github.com/ros/gencpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gencpp` to `0.5.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.5.0-0`
## gencpp

```
* use catkin_install_python() to install Python scripts (#18 <https://github.com/ros/gencpp/issues/18>)
* add 'u' suffix to unsigned enum values to avoid compiler warning (#16 <https://github.com/ros/gencpp/issues/16>)
```
