### PR TITLE
play_motion: 0.3.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3025,7 +3025,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/pal-gbp/play_motion-release.git
-      version: 0.3.3-0
+      version: 0.3.5-0
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion`:
- previous version: `0.3.3-0`
- new version: `0.3.5-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
