### PR TITLE
youbot_driver_ros_interface: 1.0.0-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5285,7 +5285,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/youbot-release/youbot_driver_ros_interface-release.git
-      version: 1.0.0-1
+      version: 1.0.0-2
   youbot_simulation:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `youbot_driver_ros_interface` to `1.0.0-2`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.0.0-1`
