### PR TITLE
cram_3rdparty: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -470,6 +470,29 @@ repositories:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/cpp_introspection.git
       version: master
+  cram_3rdparty:
+    release:
+      packages:
+      - alexandria
+      - babel
+      - cffi
+      - cl_store
+      - cl_utilities
+      - cram_3rdparty
+      - fiveam
+      - gsd
+      - gsll
+      - lisp_unit
+      - split_sequence
+      - synchronization_tools
+      - trivial_features
+      - trivial_garbage
+      - trivial_gray_streams
+      - yason
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/cram_3rdparty-release.git
+      version: 0.1.1-0
   crsm_slam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cram_3rdparty` to `0.1.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `null`
