### PR TITLE
cram_core: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -493,6 +493,23 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/cram_3rdparty-release.git
       version: 0.1.1-0
+  cram_core:
+    release:
+      packages:
+      - cram_core
+      - cram_designators
+      - cram_execution_trace
+      - cram_language
+      - cram_math
+      - cram_process_modules
+      - cram_projection
+      - cram_reasoning
+      - cram_test_utilities
+      - cram_utilities
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/cram_core-release.git
+      version: 0.1.1-0
   crsm_slam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cram_core` to `0.1.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `null`
