### PR TITLE
cram_core: 0.1.1-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -568,6 +568,22 @@ repositories:
       type: git
       url: https://github.com/moesenle/cram_core.git
       version: master
+    release:
+      packages:
+      - cram_core
+      - cram_designators
+      - cram_execution_trace
+      - cram_language
+      - cram_math
+      - cram_process_modules
+      - cram_projection
+      - cram_reasoning
+      - cram_test_utilities
+      - cram_utilities
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/ros-gbp/cram_core-release.git
+      version: 0.1.1-0
   cram_highlevel:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cram_core` to `0.1.1-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `null`
