### PR TITLE
geometric_shapes: 0.3.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -214,11 +214,16 @@ repositories:
       version: hydro-devel
     status: maintained
   geometric_shapes:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.3.7-0
+      version: 0.3.8-0
+    status: maintained
   geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.3.8-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.3.7-0`
## geometric_shapes

```
* fix how we find eigen
* Contributors: Ioan Sucan
```
