### PR TITLE
warehouse_ros: 0.8.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -827,5 +827,12 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: indigo
     status: maintained
+  warehouse_ros:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/warehouse_ros-release.git
+      version: 0.8.5-1
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `0.8.5-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `null`
## warehouse_ros

```
* Fixed malloc.h inclusion on Mac OS X
* Rename README.rst to README.md
* added travis support
* Contributors: Acorn, Dave Hershberger, Ioan A Sucan, Marco Esposito
```
