### PR TITLE
genmsg: 0.4.25-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1151,7 +1151,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/genmsg-release.git
-      version: 0.4.23-0
+      version: 0.4.25-0
     source:
       type: git
       url: https://github.com/ros/genmsg.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.4.25-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.4.23-0`
## genmsg

```
* remove usage of debug_message() (#40 <https://github.com/ros/genmsg/issues/40>)
* revert "python 3 compatibility" (introduced in 0.4.24)
```
