### PR TITLE
gencpp: 0.4.17-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1122,7 +1122,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/gencpp-release.git
-      version: 0.4.14-0
+      version: 0.4.17-0
     source:
       type: git
       url: https://github.com/ros/gencpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gencpp` to `0.4.17-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.4.14-0`
## gencpp

```
* revert "python 3 compatibility" (introduced in 0.4.15)
```
