### PR TITLE
rospack: 2.1.23-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3582,7 +3582,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
-      version: 2.1.21-1
+      version: 2.1.23-0
     source:
       type: git
       url: https://github.com/ros/rospack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.1.23-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `2.1.21-1`
## rospack

```
* only perform backquote substitution when needed (#34 <https://github.com/ros/rospack/issues/34>)
```
