### PR TITLE
genpy: 0.4.16-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1166,7 +1166,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.4.14-0
+      version: 0.4.16-0
     source:
       type: git
       url: https://github.com/ros/genpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.4.16-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.4.14-0`
## genpy

```
* revert "python 3 compatibility" (introduced in 0.4.15)
```
