### PR TITLE
catkin: 0.5.81-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -349,7 +349,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.5.77-0
+      version: 0.5.81-0
     status: maintained
   ccny_rgbd_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.5.81-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.5.77-0`
## catkin

```
* fix generated find_package() logic when used from dry packages: remove debug_message usage from generated pkgConfig.cmake files (#583 <https://github.com/ros/catkin/issues/583>)
* fix EXPORTED_TARGETS argument for catkin_package() (#581 <https://github.com/ros/catkin/issues/581>)
```
