### PR TITLE
rospack: 2.1.23-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4036,7 +4036,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
-      version: 2.1.22-0
+      version: 2.1.23-0
     source:
       type: git
       url: https://github.com/ros/rospack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.1.23-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `2.1.22-0`
## rospack

```
* only perform backquote substitution when needed (#34 <https://github.com/ros/rospack/issues/34>)
```
