### PR TITLE
genmsg: 0.4.25-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1096,7 +1096,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/genmsg-release.git
-      version: 0.4.24-0
+      version: 0.4.25-0
     source:
       type: git
       url: https://github.com/ros/genmsg.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.4.25-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.4.24-0`
## genmsg

```
* remove usage of debug_message() (#40 <https://github.com/ros/genmsg/issues/40>)
* revert "python 3 compatibility" (introduced in 0.4.24)
```
