### PR TITLE
ros_comm: 1.9.55-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3343,7 +3343,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.9.50-0
+      version: 1.9.55-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.9.55-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.9.50-0`
## message_filters
- No changes
## rosgraph
- No changes
## rosservice
- No changes
## rosout
- No changes
## roswtf
- No changes
## topic_tools
- No changes
## rosnode
- No changes
## rospy
- No changes
## roscpp

```
* fix compile problem with gcc 4.4 (#302 <https://github.com/ros/ros_comm/issues/302>)
```
## rosgraph_msgs
- No changes
## rostopic
- No changes
## ros_comm
- No changes
## rosbag

```
* fix return value on platforms where char is unsigned (#311 <https://github.com/ros/ros_comm/issues/311>)
```
## rosparam
- No changes
## std_srvs
- No changes
## rosmsg
- No changes
## xmlrpcpp

```
* fix compilation with clang (#291 <https://github.com/ros/ros_comm/issues/291>)
```
## rosmaster
- No changes
## roslaunch
- No changes
## rostest

```
* add missing boost component
```
## rosconsole
- No changes
