### PR TITLE
rospack: 2.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -699,7 +699,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
-      version: 2.2.1-0
+      version: 2.2.2-0
     source:
       type: git
       url: https://github.com/ros/rospack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.2.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `2.2.1-0`
## rospack

```
* python 3 compatibility (#35 <https://github.com/ros/rospack/issues/35>)
```
