### PR TITLE
genpy: 0.5.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -207,7 +207,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.4.15-0
+      version: 0.5.0-0
     source:
       type: git
       url: https://github.com/ros/genpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.5.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.4.15-0`
## genpy

```
* use catkin_install_python() to install Python scripts (#25 <https://github.com/ros/genpy/issues/25>)
```
