### PR TITLE
crsm_slam: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -519,7 +519,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/etsardou/crsm-slam-ros-pkg-release.git
-      version: 1.0.1-4
+      version: 1.0.2-0
     status: developed
   cv_camera:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `crsm_slam` to `1.0.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.0.1-4`
## crsm_slam

```
* fix cmake to export shared libraries
```
