### PR TITLE
ros_comm: 1.10.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3699,7 +3699,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.9.54-0
+      version: 1.10.1-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.10.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.9.54-0`
## message_filters
- No changes
## rosgraph
- No changes
## rosservice
- No changes
## rosout
- No changes
## roswtf
- No changes
## topic_tools
- No changes
## rosnode
- No changes
## rospy
- No changes
## roscpp
- No changes
## rosgraph_msgs
- No changes
## rostopic
- No changes
## ros_comm
- No changes
## rosbag
- No changes
## rosbag_storage
- No changes
## rosparam
- No changes
## std_srvs
- No changes
## rosmsg
- No changes
## xmlrpcpp
- No changes
## rosmaster
- No changes
## roslaunch

```
* add optional DEPENDENCIES argument to roslaunch_add_file_check()
* add explicit run dependency (#347 <https://github.com/ros/ros_comm/issues/347>)
```
## rostest

```
* modify rostest to wait when other instances are running
```
## rosconsole
- No changes
