### PR TITLE
common_msgs: 1.9.19-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -480,7 +480,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.9.18-0
+      version: 1.9.19-0
     source:
       type: git
       url: https://github.com/ros/common_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.9.19-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.9.18-0`
