### PR TITLE
robot_upstart: 0.0.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3434,7 +3434,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/robot_upstart-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/robot_upstart.git
+      version: hydro_devel
+    status: maintained
   roboteq:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3438,7 +3438,7 @@ repositories:
     source:
       type: git
       url: https://github.com/clearpathrobotics/robot_upstart.git
-      version: hydro_devel
+      version: hydro-devel
     status: maintained
   roboteq:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart` to `0.0.6-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.0.5-0`
## robot_upstart

```
* Add capability to also generate amalgamated descriptions, similar to launch files.
* Update package.xml
* Contributors: Mike Purvis
```
