### PR TITLE
grizzly: 0.1.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1261,11 +1261,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/grizzly-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/g/grizzly.git
       version: hydro-devel
+    status: maintained
   grizzly_desktop:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly` to `0.1.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.1.2-0`
## grizzly_motion

```
* Check absolute value of measured speed; fixes bug with spurious encoder faults when driving backwards.
* Contributors: Mike Purvis
```
## grizzly_teleop

```
* Add dependency on joy.
* Contributors: Mike Purvis
```
## grizzly_navigation
- No changes
## grizzly_description
- No changes
## grizzly_msgs
- No changes
