### PR TITLE
rviz: 1.10.12-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4367,7 +4367,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.10.11-0
+      version: 1.10.12-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rviz.git
+      version: hydro-devel
     status: maintained
   sbpl:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.10.12-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.10.11-0`
## rviz

```
* Shiboken is now disabled when a version which would segfault is detected (fix #728 <https://github.com/ros-visualization/rviz/issues/728>)
* Eigen is now found using the FindEigen.cmake from the cmake_modules package.
* Added support for rendering rviz in stereo.
  For more information see this commit: https://github.com/ros-visualization/rviz/commit/9cfaf78e2ae8d34e4481de19568b353964846842
* Added a "Queue Size" option for the Range display type.
* Added Ogre-1.10 compatibility
  This allows rviz to compile (and work) against Ogre 1.10 (currently
  the latest version of ogre).
  It also still works with earlier versions of Ogre (tested with Ogre
  1.7.4 as installed via debs on Ubuntu 12.04).
* Now includes ogre without OGRE prefix
  This is necessary to find Ogre files in the right place with
  compatibility between Ogre < 1.9 and Ogre >= 1.9.
  This is also necessary when 2 versions of Ogre are installed on the
  build machine.
* RVIZ doesn't use __connection_header from incoming messages, but only uses ros::MessageEvent's
* Better feature detection for assimp version
  The unified headers were introduced in Assimp 2.0.1150, so checking for Assimp 3.0.0 is not quite the best solution.
  See https://github.com/assimp/assimp/commit/6fa251c2f2e7a142bb861227dce0c26362927fbc
* Contributors: Acorn Pooley, Benjamin Chrétien, Dave Hershberger, Kevin Watts, Scott K Logan, Siegfried-A. Gevatter Pujals, Tully Foote, William Woodall, hersh
```
