### PR TITLE
ardrone_autonomy: 1.3.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -120,11 +120,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/AutonomyLab/ardrone_autonomy-release.git
-      version: 1.3.1-2
+      version: 1.3.2-0
     source:
       type: git
       url: https://github.com/AutonomyLab/ardrone_autonomy.git
       version: hydro-devel
+    status: developed
   argos3d_p100:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ardrone_autonomy` to `1.3.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.3.1-2`
## ardrone_autonomy

```
* SDK related bug fixes for building binaries.
```
