### PR TITLE
ardrone_autonomy: 1.3.2-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -117,11 +117,12 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/AutonomyLab/ardrone_autonomy-release.git
-      version: 1.3.1-1
+      version: 1.3.2-0
     source:
       type: git
       url: https://github.com/AutonomyLab/ardrone_autonomy.git
       version: groovy-devel
+    status: developed
   argos3d_p100:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ardrone_autonomy` to `1.3.2-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.3.1-1`
## ardrone_autonomy

```
* SDK related bug fixes for building binaries.
```
