### PR TITLE
rtmros_hironx: 1.0.12-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4238,7 +4238,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/start-jsk/rtmros_hironx-release.git
-      version: 1.0.11-1
+      version: 1.0.12-1
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.12-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.0.11-1`
## hironx_ros_bridge

```
* Adding and improving unit test files.
* Adding travis conf files.
* Adding more checker programs for robot's internal os.
* Contributors: Isaac Isao Saito, Kei Okada
```
## hironx_moveit_config

```
* (moveit_rviz.launch) Enable to respawn rviz
* Contributors: Isaac Isao Saito
```
## rtmros_hironx

```
* Adding and improving unit test files.
* Adding travis conf files.
* Adding more checker programs for robot's internal os.
* Contributors: Isaac Isao Saito, Kei Okada
```
