### PR TITLE
geometric_shapes: 0.3.8-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -222,7 +222,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.3.8-0
+      version: 0.3.8-1
     status: maintained
   geometry:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.3.8-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.3.8-0`
## geometric_shapes

```
* fix how we find eigen
* Contributors: Ioan Sucan
```
