### PR TITLE
moveit_ikfast: 3.0.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2253,7 +2253,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ikfast-release.git
-      version: 3.0.6-0
+      version: 3.0.7-0
     status: developed
   moveit_metapackages:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ikfast` to `3.0.7-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `3.0.6-0`
## moveit_ikfast

```
* Fix issue #16 <https://github.com/ros-planning/moveit_ikfast/issues/16>: install 'templates' directory into pkg share directory
* Fix issue #21 <https://github.com/ros-planning/moveit_ikfast/issues/21>: move catkin pkgs to catkin_depends in generated CMakeLists
* Fix issue #18 <https://github.com/ros-planning/moveit_ikfast/issues/18>: remove install rule for ikfast.h from generated package CMakeLists.txt
* Contributors: Dave Coleman, gavanderhoorn
```
