### PR TITLE
moveit_ikfast: 3.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -375,6 +375,13 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_core-release.git
       version: 0.5.6-0
+  moveit_ikfast:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_ikfast-release.git
+      version: 3.0.7-0
+    status: maintained
   moveit_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ikfast` to `3.0.7-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `null`
## moveit_ikfast

```
* Fix issue #16 <https://github.com/ros-planning/moveit_ikfast/issues/16>: install 'templates' directory into pkg share directory
* Fix issue #21 <https://github.com/ros-planning/moveit_ikfast/issues/21>: move catkin pkgs to catkin_depends in generated CMakeLists
* Fix issue #18 <https://github.com/ros-planning/moveit_ikfast/issues/18>: remove install rule for ikfast.h from generated package CMakeLists.txt
* Contributors: Dave Coleman, gavanderhoorn
```
