### PR TITLE
catkin: 0.5.82-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -350,7 +350,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.5.77-0
+      version: 0.5.82-0
     status: maintained
   ccny_rgbd_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.5.82-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.5.77-0`
## catkin

```
* fix detection of Python version for CMake 2.8.6 and older (regression from 0.5.78, #570 <https://github.com/ros/catkin/issues/570>)
```
