### PR TITLE
pointgrey_camera_driver: 0.9.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3110,11 +3110,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
-      version: 0.0.1-0
+      version: 0.9.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/pointgrey_camera_driver.git
       version: master
+    status: maintained
   pr2_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointgrey_camera_driver` to `0.9.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.0.1-0`
## image_exposure_msgs
- No changes
## pointgrey_camera_driver

```
* Remove pgrimaging from all USB devices.
* Rename standalone executables, fix priority of udev rules for USB cameras, parameterize example launchfiles better.
* Contributors: Mike Purvis
```
## wfov_camera_msgs
- No changes
## statistics_msgs
- No changes
