### PR TITLE
rosh_core: 1.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3880,7 +3880,8 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/OSUrobotics/rosh_core-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
+    status: maintained
   rosjava:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_core` to `1.0.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.0.2-0`
## roshlaunch
- No changes
## rosh_core
- No changes
## rosh

```
* make sure shell.py gets put somewhere importable
* Contributors: Dan Lazewatsky
```
