### PR TITLE
audio_common: 0.2.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -151,7 +151,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.2.5-0
+      version: 0.2.6-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/audio_common.git
+      version: hydro-devel
     status: maintained
   ax2550:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.2.6-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.2.5-0`
