### PR TITLE
pr2_ethercat_drivers: 1.8.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -151,11 +151,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.2.6-0
-    source:
-      type: git
-      url: https://github.com/ros-drivers/audio_common.git
-      version: hydro-devel
+      version: 0.2.5-0
     status: maintained
   ax2550:
     release:
@@ -3172,7 +3168,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/pr2_ethercat_drivers-release.git
-      version: 1.8.7-0
+      version: 1.8.8-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_ethercat_drivers.git
+      version: hydro-devel
     status: maintained
   pr2_mechanism:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_ethercat_drivers` to `1.8.8-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.8.7-0`
