### PR TITLE
pr2_controllers: 1.10.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3157,7 +3157,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/pr2_controllers-release.git
-      version: 1.10.7-0
+      version: 1.10.8-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_controllers.git
+      version: hydro-devel
     status: maintained
   pr2_ethercat_drivers:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_controllers` to `1.10.8-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.10.7-0`
