### PR TITLE
pr2_mechanism: 1.8.11-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3190,7 +3190,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/pr2_mechanism-release.git
-      version: 1.8.9-0
+      version: 1.8.11-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_mechanism.git
+      version: hydro-devel
     status: maintained
   pr2_mechanism_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_mechanism` to `1.8.11-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.8.9-0`
