### PR TITLE
pr2_common: 1.11.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3135,7 +3135,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/pr2_common-release.git
-      version: 1.11.3-0
+      version: 1.11.4-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_common.git
+      version: hydro-devel
     status: maintained
   pr2_controllers:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common` to `1.11.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.11.3-0`
