### PR TITLE
pr2_ethercat_drivers: 1.8.8-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3180,7 +3180,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/pr2_ethercat_drivers-release.git
-      version: 1.8.7-0
+      version: 1.8.8-1
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_ethercat_drivers.git
+      version: hydro-devel
     status: maintained
   pr2_mechanism:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_ethercat_drivers` to `1.8.8-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.8.7-0`
