### PR TITLE
control_msgs: 1.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -117,6 +117,12 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/console_bridge-release.git
       version: 0.2.4-1
+  control_msgs:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/control_msgs-release.git
+      version: 1.3.0-0
   dynamic_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs`:
- previous version: `null`
- new version: `1.3.0-0`
- distro file: `indigo/distribution.yaml`
- bloom version: `0.4.8`
