### PR TITLE
people: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3016,6 +3016,25 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/pcl_msgs-release.git
       version: 0.1.0-0
+  people:
+    doc:
+      type: git
+      url: https://github.com/wg-perception/people.git
+      version: hydro-devel
+    release:
+      packages:
+      - face_detector
+      - people
+      - people_msgs
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/OSUrobotics/people-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/people.git
+      version: hydro-devel
+    status: maintained
   perception_oru:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `people` to `1.0.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `null`
## face_detector

```
* update some remappings to deal with the changed openni message api
* convert 16FC1 depth images to 32FC1 and scale to get meters
* switch constants to defines to get rid of linker issues for catkin switch
* catkinizing
* Contributors: Dan Lazewatsky
```
## people_msgs

```
* catkinizing
* Contributors: Dan Lazewatsky
```
## people

```
* catkinizing
* Contributors: Dan Lazewatsky
```
