### PR TITLE
moveit_ros: 0.5.16-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2376,7 +2376,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.5.15-0
+      version: 0.5.16-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_ros.git
+      version: hydro-devel
     status: maintained
   moveit_setup_assistant:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ros` to `0.5.16-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.5.15-0`
## moveit_ros_visualization

```
* back out problematic ogre fixes
* robot_interaction: split InteractionHandler into its own file
* Switched from isStateColliding to isStateValid
* Changed per PR review
* Clean up debug output
* Added ability to set a random <collision free> start/goal position
* Merge branch 'hydro-devel' of https://github.com/ros-planning/moveit_ros into acorn_rviz_stereo
* rviz: prepare for Ogre1.10
* Contributors: Acorn Pooley, Dave Coleman
```
## moveit_ros_perception
- No changes
## moveit_ros
- No changes
## moveit_ros_move_group

```
* empty state should be a diff state, otherwise attached objects are deleted
* Contributors: sachinc
```
## moveit_ros_warehouse
- No changes
## moveit_ros_benchmarks_gui

```
* back out problematic ogre fixes
* robot_interaction: split InteractionHandler into its own file
* rviz: prepare for Ogre1.10
* Contributors: Acorn Pooley
```
## moveit_ros_planning

```
* Copy paste error fix
* Contributors: fivef
```
## moveit_ros_benchmarks
- No changes
## moveit_ros_manipulation
- No changes
## moveit_ros_robot_interaction

```
* fix test
  This was testing functionality that got removed.  Removed that part of the
  test.
* robot_interaction: add comments
  Comment cryptic public function behavior.
* robot_interaction: fix formatting
  remove tabs and whitespace at the end of lines.
* robot_interaction: fix comment formatting
  Limit lines to 120 chars max (80 preferred in headers).
* robot_interaction: fix setStateFromIK prototypes
  use references instead of pointers.
* robot_interaction: fix header problems
  fix getRobotModel() bug
  make internal functions private.
* remove extraneous code
* add missing headers
* robot_interaction: Fix issues raised by Ioan
* robot_interaction: use LockedRobotState
  Fix a number of thread safety violations.
* robot_interaction: add LockedRobotState and tests
* robot_interaction: use KinematicOptionsMap
  Fixes threading issues.
  Separate the handling of kinematics options into a separate object which
  enforces thread safe access.
* robot_interaction: add KinematicOptions
  KinematicOptions contains the parameters needed to call RobotState::setFromIK.
  KinematicOptionsMap contains a map of string->KinematicOptions a default KinematicOptions.
  These are useful in RobotInteraction with the group name as the key.
* pull RobotInteraction structures out of class
  The Generic, EndEffector, and Joint structures complicate the core of
  RobotInteraction.  Pull them out to simplify the code.  This will also
  help with future plans to make the core of RobotInteraction more
  generic and flexible.
* fix include guards to match moveit conventions
* robot_interaction: include interaction_handler.h from robot_interaction.h
  This is for backwards compatibility with code that only includes
  robot_interaction.h
* robot_interaction: split handler into own file
* robot_interaction: split InteractionHandler into its own file
* robot_interaction: make lock-protected members private
  Since the lock is needed to access these and the lock is private it makes no
  sense for them to be protected.
* robot_interaction: add locking comments
* robot_interaction: simplify code
* robot_interaction: fix comments
* Contributors: Acorn Pooley
```
## moveit_ros_planning_interface

```
* adding node handle to options in move_group_interface
* adding get for active joints
* Contributors: Sachin Chitta
* adding node handle to options in move_group_interface
* adding get for active joints
* Contributors: Sachin Chitta
```
