### PR TITLE
moveit_commander: 0.5.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2250,7 +2250,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/moveit_commander-release.git
-      version: 0.5.4-0
+      version: 0.5.5-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_commander.git
+      version: hydro-devel
     status: maintained
   moveit_core:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_commander` to `0.5.5-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.5.4-0`
## moveit_commander

```
* adding get for active joints
* Contributors: Acorn, Sachin Chitta
```
