### PR TITLE
moveit_pr2: 0.5.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2341,7 +2341,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/moveit_pr2-release.git
-      version: 0.5.5-0
+      version: 0.5.6-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_pr2.git
+      version: hydro-devel
     status: maintained
   moveit_resources:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_pr2` to `0.5.6-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.5.5-0`
## pr2_moveit_plugins
- No changes
## pr2_moveit_config
- No changes
## pr2_moveit_tutorials

```
* Update controller_configuration.rst
  Fix cut and paste errors.
* fix topics to check for while debugging
* fixing
* added example for dual arm pose goals
* move_group tutorial: update expected output
* cleanup tutorial text (comments)
* move_group tutorial: fix timing & error checking
* move_group interface tutorial: plan around obstacle
  add code to generate a plan while a world box is in the way.
* improve move_group_interface tutorial
  Clarify use of display_publisher.
  Fix cartesian path request so it can succeed.
  Add path planning with obstacle.
* python tutorial: cleanup imports
* fix copyright and link
* python tutorial: update expected output description
* python tutorial: add cartesian paths
* python tutorial: add joint state plan
* python tutorial: fix display_trajectory_publisher
* python tutorial: fix title
* python tutorial: fix typo
* python tutorial: add go command
* python tutorial: add MoveGroupCommander interface
* add python move_group interface tutorial
* python interface tutorial
* Contributors: Acorn Pooley, Sachin Chitta
```
## moveit_pr2
- No changes
