### PR TITLE
catkin: 0.5.83-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -328,7 +328,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.5.81-0
+      version: 0.5.83-0
     status: maintained
   class_loader:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.5.83-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.5.81-0`
## catkin

```
* allow passing absolute INCLUDE_DIRS via catkin_package() into CMake config file in install space (#600 <https://github.com/ros/catkin/issues/600>)
```
