### PR TITLE
common_msgs: 1.10.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -404,7 +404,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.10.5-0
+      version: 1.10.6-0
     source:
       type: git
       url: https://github.com/ros/common_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.10.6-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.10.5-0`
## nav_msgs
- No changes
## shape_msgs
- No changes
## stereo_msgs
- No changes
## actionlib_msgs

```
* fix actionlib_msgs for dry
* use catkin_install_python() to install Python scripts #29 <https://github.com/ros/common_msgs/issues/29>
* Contributors: Dirk Thomas
```
## trajectory_msgs
- No changes
## sensor_msgs
- No changes
## geometry_msgs
- No changes
## visualization_msgs
- No changes
## diagnostic_msgs
- No changes
## common_msgs
- No changes
