### PR TITLE
lms1xx: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2099,7 +2099,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/LMS1xx-release.git
-      version: 0.0.1-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/LMS1xx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lms1xx` to `0.1.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.0.1-0`
## lms1xx

```
* Fix example launch file and install it.
* Fix project name in CMakeLists.
* Adding original author, readme
* Contributors: Mike Purvis
```
