### PR TITLE
grizzly: 0.2.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1266,7 +1266,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/grizzly-release.git
-      version: 0.1.3-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/g/grizzly.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly` to `0.2.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.1.3-0`
## grizzly_motion

```
* Change max acceleration from 0.5 to 1.5.
* Contributors: Mike Purvis
```
## grizzly_teleop
- No changes
## grizzly_navigation
- No changes
## grizzly_description
- No changes
## grizzly_msgs
- No changes
