### PR TITLE
household_objects_database: 0.1.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1499,7 +1499,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/household_objects_database-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
   household_objects_database_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `household_objects_database` to `0.1.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.1.3-0`
