### PR TITLE
warehouse_ros: 0.8.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5295,7 +5295,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/warehouse_ros-release.git
-      version: 0.8.4-0
+      version: 0.8.6-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: master
     status: maintained
   wge100_driver:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `0.8.6-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.8.4-0`
