### PR TITLE
people: 1.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3060,7 +3060,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/OSUrobotics/people-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/wg-perception/people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `people` to `1.0.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.0.2-0`
## face_detector

```
* fix message generation
* Contributors: Dan Lazewatsky
```
## people_msgs
- No changes
## people
- No changes
