### PR TITLE
Use devel package for SDL in Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2166,7 +2166,7 @@ sdformat:
 sdl:
   arch: [sdl]
   debian: [libsdl1.2-dev]
-  fedora: [SDL]
+  fedora: [SDL-devel]
   ubuntu: [libsdl1.2-dev]
 sdl-gfx:
   arch: [sdl_gfx]


### PR DESCRIPTION
Since there is no sdl-dev, sdl is used to reference the development package in most ROS packages.
