### PR TITLE
moveit_core: 0.5.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -410,7 +410,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_core-release.git
-      version: 0.5.6-0
+      version: 0.5.8-0
   moveit_ikfast:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_core` to `0.5.8-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.5.6-0`
## moveit_core

```
* Dix bad includes after upstream catkin fix
* update how we find eigen: this is needed for indigo
* Contributors: Ioan A Sucan, Dirk Thomas, Vincent Rabaud
```
