### PR TITLE
robot_state_publisher: 1.10.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -585,6 +585,13 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
       version: 1.11.0-0
+  robot_state_publisher:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/robot_state_publisher-release.git
+      version: 1.10.2-0
+    status: maintained
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `1.10.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `null`
