### PR TITLE
catkin: 0.5.86-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -328,7 +328,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.5.85-0
+      version: 0.5.86-0
     status: maintained
   class_loader:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.5.86-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.5.85-0`
## catkin

```
* rewrite exported include dirs when pointing to absolute source / build / devel space (#600 <https://github.com/ros/catkin/issues/600>)
* improve error messages for wrong include dirs
```
