### PR TITLE
ros_comm: 1.10.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3778,7 +3778,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.10.1-0
+      version: 1.10.2-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.10.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.10.1-0`
## message_filters
- No changes
## rosgraph
- No changes
## rosservice
- No changes
## rosout
- No changes
## roswtf
- No changes
## topic_tools
- No changes
## rosnode
- No changes
## rospy

```
* fix exception handling for queued connections (#369 <https://github.com/ros/ros_comm/issues/369>)
```
## roscpp
- No changes
## rosgraph_msgs
- No changes
## rostopic
- No changes
## ros_comm
- No changes
## rosbag
- No changes
## rosbag_storage
- No changes
## rosparam
- No changes
## std_srvs
- No changes
## rosmsg
- No changes
## xmlrpcpp

```
* output error message when hostname lookup fails (#364 <https://github.com/ros/ros_comm/issues/364>)
```
## rosmaster
- No changes
## roslaunch
- No changes
## rostest
- No changes
## rosconsole
- No changes
