### PR TITLE
pcl_msgs: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -508,6 +508,21 @@ repositories:
       type: git
       url: https://github.com/orocos/orocos_kinematics_dynamics.git
       version: master
+  pcl_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/pcl_msgs.git
+      version: hydro-devel
+    release:
+      tags:
+        !!python/unicode 'release': release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/pcl_msgs-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/pcl_msgs.git
+      version: hydro-devel
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_msgs` to `0.1.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `null`
## pcl_msgs

```
* Generate messages into the pcl_msgs namespace rather than the pcl namespace
```
