### PR TITLE
pcl_conversions: 0.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -508,6 +508,21 @@ repositories:
       type: git
       url: https://github.com/orocos/orocos_kinematics_dynamics.git
       version: master
+  pcl_conversions:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/pcl_conversions.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/pcl_conversions-release.git
+      version: 0.1.5-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/pcl_conversions.git
+      version: hydro-devel
+    status: maintained
   pcl_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_conversions` to `0.1.5-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `null`
## pcl_conversions

```
* Use new pcl rosdep keys (libpcl-all and libpcl-all-dev)
```
