### PR TITLE
Correct release tag for openhrp3 in G, H.

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2531,7 +2531,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/openhrp3-release.git
-      version: 3.1.5-2
+      version: 3.1.5-3
     status: maintained
   openni2_camera:
     doc:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2891,7 +2891,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/openhrp3-release.git
-      version: 3.1.5-2
+      version: 3.1.5-3
     source:
       type: git
       url: https://github.com/start-jsk/openhrp3.git


### PR DESCRIPTION
This corrects my mistake in this [manual operation](https://github.com/ros/rosdistro/commit/3bdb931dea41f8713ae946c0200d00eaf5b55948). Sorry for the mess.
