### PR TITLE
household_objects_database_msgs: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -295,6 +295,13 @@ repositories:
       url: https://github.com/ros/geometry_experimental.git
       version: indigo-devel
     status: maintained
+  household_objects_database_msgs:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/household_objects_database_msgs-release.git
+      version: 0.1.1-0
+    status: maintained
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `household_objects_database_msgs` to `0.1.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `null`
