### PR TITLE
manipulation_msgs: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -370,6 +370,13 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/libccd-release.git
       version: 1.5.0-0
+  manipulation_msgs:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/manipulation_msgs-release.git
+      version: 0.2.0-0
+    status: maintained
   map_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `manipulation_msgs` to `0.2.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `null`
