### PR TITLE
common_msgs: 1.11.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -94,6 +94,10 @@ repositories:
       version: 0.3-devel
     status: maintained
   common_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros/common_msgs.git
+      version: indigo-devel
     release:
       packages:
       - actionlib_msgs
@@ -109,7 +113,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.10.3-0
+      version: 1.11.0-0
+    source:
+      type: git
+      url: https://github.com/ros/common_msgs.git
+      version: indigo-devel
     status: maintained
   console_bridge:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.11.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.10.3-0`
## nav_msgs
- No changes
## shape_msgs
- No changes
## stereo_msgs
- No changes
## actionlib_msgs
- No changes
## trajectory_msgs
- No changes
## sensor_msgs

```
* add a PointCloud2 iterator and modifier
* Contributors: Tully Foote, Vincent Rabaud
```
## geometry_msgs
- No changes
## visualization_msgs
- No changes
## diagnostic_msgs
- No changes
## common_msgs
- No changes
