### PR TITLE
rFSM: 1.0.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3374,6 +3374,23 @@ repositories:
       url: https://github.com/stonier/qt_ros.git
       version: hydro
     status: maintained
+  rFSM:
+    doc:
+      type: git
+      url: https://github.com/orocos/rFSM.git
+      version: master
+    release:
+      packages:
+      - rfsm
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/orocos-gbp/rfsm-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/orocos/rFSM.git
+      version: master
+    status: developed
   rail_maps:
     release:
       url: https://github.com/wpi-rail-release/rail_maps-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rFSM` to `1.0.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `null`
