### PR TITLE
bride: 0.3.0-5 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -224,7 +224,8 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/bride-release.git
-      version: 0.3.0-4
+      version: 0.3.0-5
+    status: developed
   calibration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bride` to `0.3.0-5`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.3.0-4`
