### PR TITLE
bride: 0.3.0-2 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -237,6 +237,18 @@ repositories:
       type: git
       url: https://github.com/ipa320/bride.git
       version: groovy
+    release:
+      packages:
+      - bride
+      - bride_compilers
+      - bride_plugin_source
+      - bride_templates
+      - bride_tutorials
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/ipa320/bride-release.git
+      version: 0.3.0-2
+    status: developed
   brown_drivers:
     doc:
       type: svn


### PR DESCRIPTION
Increasing version of package(s) in repository `bride` to `0.3.0-2`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `null`
