### PR TITLE
xsens_driver: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5385,6 +5385,12 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/jbohren/xdot-release.git
       version: 1.10.0-0
+  xsens_driver:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ethz-asl/ethzasl_xsens_driver-release.git
+      version: 1.0.2-0
   xv_11_laser_driver:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `xsens_driver` to `1.0.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `null`
## xsens_driver

```
* catkinized
* experimental support of mark 4 IMUs
* fixed scaling in DOP values
* adding publisher for full data as a string
* relative topic names
```
