### PR TITLE
class_loader: 0.2.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -340,11 +340,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/class_loader-release.git
-      version: 0.2.3-0
+      version: 0.2.5-0
     source:
       type: git
       url: https://github.com/ros/class_loader.git
       version: hydro-devel
+    status: maintained
   clearpath_base:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `0.2.5-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.2.3-0`
## class_loader

```
* Changed format of debug messages so that rosconsole_bridge can correctly parse the prefix
* Improved debug output
```
