### PR TITLE
python_qt_binding: 0.2.12-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2958,7 +2958,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/python_qt_binding-release.git
-      version: 0.2.11-0
+      version: 0.2.12-0
     source:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `0.2.12-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.2.11-0`
## python_qt_binding

```
* python 3 compatibility
* fix sip bindings when paths contain spaces (#9 <https://github.com/ros-visualization/python_qt_binding/issues/9>)
```
