### PR TITLE
rqt: 0.2.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -847,7 +847,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt-release.git
-      version: 0.2.13-0
+      version: 0.2.14-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `0.2.14-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.2.13-0`
## rqt_gui_cpp

```
* add ros spinner thread for cpp plugins (#95 <https://github.com/ros-visualization/rqt/issues/95>)
```
## rqt_gui
- No changes
## rqt_gui_py
- No changes
