### PR TITLE
rqt: 0.2.14-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3374,7 +3374,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.2.22-0
+      version: 0.2.20-0
     status: maintained
   qt_ros:
     doc:
@@ -4251,7 +4251,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rqt-release.git
-      version: 0.2.13-0
+      version: 0.2.14-0
     status: maintained
   rqt_common_plugins:
     doc:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3374,7 +3374,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.2.20-0
+      version: 0.2.22-0
     status: maintained
   qt_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `0.2.14-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.2.13-0`
## rqt_gui_cpp

```
* add ros spinner thread for cpp plugins (#95 <https://github.com/ros-visualization/rqt/issues/95>)
```
## rqt_gui
- No changes
## rqt_gui_py
- No changes
