### PR TITLE
qt_gui_core: 0.2.22-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2980,7 +2980,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.2.18-0
+      version: 0.2.22-0
     status: maintained
   qt_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.2.22-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.2.18-0`
## qt_gui_app
- No changes
## qt_gui_py_common
- No changes
## qt_gui_cpp

```
* add shutdown notification for plugin providers (#39 <https://github.com/ros-visualization/qt_gui_core/issues/39>)
```
## qt_gui

```
* add shutdown notification for plugin providers (#39 <https://github.com/ros-visualization/qt_gui_core/issues/39>)
```
## qt_dotgraph
- No changes
