### PR TITLE
rqt: 0.2.14-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3648,7 +3648,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/rqt-release.git
-      version: 0.2.12-0
+      version: 0.2.14-0
     status: maintained
   rqt_common_plugins:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `0.2.14-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.2.12-0`
## rqt_gui_cpp

```
* add ros spinner thread for cpp plugins (#95 <https://github.com/ros-visualization/rqt/issues/95>)
```
## rqt_gui
- No changes
## rqt_gui_py
- No changes
