### PR TITLE
rosconsole_bridge: 0.3.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3944,7 +3944,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rosconsole_bridge-release.git
-      version: 0.3.3-0
+      version: 0.3.4-0
     source:
       type: git
       url: https://github.com/ros/rosconsole_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole_bridge` to `0.3.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.3.3-0`
## rosconsole_bridge

```
* Allows non-ros components to utilize the prefix functionality of log4j
* Contributors: Dave Coleman, Ioan A Sucan
```
