### PR TITLE
catkin: 0.5.86-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -362,7 +362,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.5.82-0
+      version: 0.5.86-0
     status: maintained
   ccny_rgbd_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.5.86-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.5.82-0`
## catkin

```
* rewrite exported include dirs when pointing to absolute source / build / devel space (#600 <https://github.com/ros/catkin/issues/600>)
* improve error messages for wrong include dirs
```
