### PR TITLE
catkin: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -66,7 +66,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     status: maintained
   class_loader:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.6.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.6.2-0`
## catkin

```
* allow passing absolute INCLUDE_DIRS via catkin_package() into CMake config file in install space (#600 <https://github.com/ros/catkin/issues/600>, #601 <https://github.com/ros/catkin/issues/601>)
* improve error messages for wrong include dirs
```
