### PR TITLE
orogen: 2.7.0-3 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3028,7 +3028,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/orogen-release.git
-      version: 2.7.0-2
+      version: 2.7.0-3
     source:
       type: git
       url: https://git.gitorious.org/orocos-toolchain/orogen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `orogen` to `2.7.0-3`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `2.7.0-2`
## orogen

```
* catkin: added run_depend on catkin to package.xml for released packages
  Signed-off-by: Johannes Meyer <mailto:johannes@intermodalics.eu>
* cmake: prevent duplicate targets in catkin workspaces
  Signed-off-by: Ruben Smits <mailto:ruben.smits@intermodalics.eu>
* adding minimum required cmake version
* templates: add correct rpath settings for OSX
  Signed-off-by: Ruben Smits <mailto:ruben.smits@mech.kuleuven.be>
* add package.xml template to support catkin builds
  Signed-off-by: Ruben Smits <mailto:ruben@intermodalics.eu>
* catkin: add CMakeLists.txt to install parts in the right directory and add package.xml to make it buildable with catkin
  Signed-off-by: Ruben Smits <mailto:ruben.smits@mech.kuleuven.be>
```
