### PR TITLE
ros_comm_msgs: 1.10.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -749,7 +749,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm_msgs-release.git
-      version: 1.10.1-0
+      version: 1.10.1-1
     source:
       type: git
       url: https://github.com/ros/ros_comm_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm_msgs` to `1.10.1-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1` **with local mods...**
- previous version for package: `1.10.1-0`
## rosgraph_msgs

```
* move from ros_comm to separate repository (#355 <https://github.com/ros/ros_comm/issues/355>)
```
## std_srvs

```
* move from ros_comm to separate repository (#355 <https://github.com/ros/ros_comm/issues/355>)
```
