### PR TITLE
ros_comm: 1.11.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -731,7 +731,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.0-0
+      version: 1.11.0-1
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.0-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1` **with local mods...**
- previous version for package: `1.11.0-0`
## message_filters

```
* suppress boost::signals deprecation warning (#362 <https://github.com/ros/ros_comm/issues/362>)
```
## rosgraph

```
* use catkin_install_python() to install Python scripts (#361 <https://github.com/ros/ros_comm/issues/361>)
```
## rosservice

```
* use catkin_install_python() to install Python scripts (#361 <https://github.com/ros/ros_comm/issues/361>)
```
## rosout
- No changes
## roswtf

```
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
```
## topic_tools

```
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* use catkin_install_python() to install Python scripts (#361 <https://github.com/ros/ros_comm/issues/361>)
```
## rosnode

```
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
```
## rospy

```
* fix exception handling for queued connections (#369 <https://github.com/ros/ros_comm/issues/369>)
* use catkin_install_python() to install Python scripts (#361 <https://github.com/ros/ros_comm/issues/361>)
```
## roscpp

```
* allow getting parameters with name '/' (#313 <https://github.com/ros/ros_comm/issues/313>)
* support for /clock remapping (#359 <https://github.com/ros/ros_comm/issues/359>)
* suppress boost::signals deprecation warning (#362 <https://github.com/ros/ros_comm/issues/362>)
* use catkin_install_python() to install Python scripts (#361 <https://github.com/ros/ros_comm/issues/361>)
```
## rostopic

```
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* use catkin_install_python() to install Python scripts (#361 <https://github.com/ros/ros_comm/issues/361>)
```
## ros_comm
- No changes
## rosbag

```
* use catkin_install_python() to install Python scripts (#361 <https://github.com/ros/ros_comm/issues/361>)
```
## rosbag_storage
- No changes
## rosparam
- No changes
## rosmsg
- No changes
## xmlrpcpp

```
* output error message when hostname lookup fails (#364 <https://github.com/ros/ros_comm/issues/364>)
```
## rosmaster
- No changes
## roslaunch

```
* use catkin_install_python() to install Python scripts (#361 <https://github.com/ros/ros_comm/issues/361>)
```
## rostest

```
* use catkin_install_python() to install Python scripts (#361 <https://github.com/ros/ros_comm/issues/361>)
```
## rosconsole
- No changes
