### PR TITLE
rviz: 1.11.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -868,7 +868,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rviz.git
-      version: hydro-devel
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -877,7 +877,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git
-      version: hydro-devel
+      version: indigo-devel
     status: maintained
   serial:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -873,7 +873,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.10.12-0
+      version: 1.11.0-0
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.11.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.10.12-0`
## rviz

```
* fixing problems with urdfdom_headers 0.3.0
* Contributors: William Woodall
```
