### PR TITLE
ros_tutorials: 0.4.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -769,7 +769,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_tutorials-release.git
-      version: 0.4.3-0
+      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/ros/ros_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `0.4.3-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.4.3-0`
## ros_tutorials
- No changes
## roscpp_tutorials
- No changes
## rospy_tutorials

```
* python 3 compatibility (#13 <https://github.com/ros/ros_tutorials/issues/13>)
* remove load_manifest calls
```
## turtlesim
- No changes
