### PR TITLE
common_msgs: 1.11.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -113,7 +113,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.11.0-0
+      version: 1.11.0-1
     source:
       type: git
       url: https://github.com/ros/common_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.11.0-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.11.0-0`
## actionlib_msgs
- No changes
## common_msgs
- No changes
## diagnostic_msgs
- No changes
## geometry_msgs
- No changes
## nav_msgs
- No changes
## sensor_msgs

```
* add a PointCloud2 iterator and modifier
* Contributors: Tully Foote, Vincent Rabaud
```
## shape_msgs
- No changes
## stereo_msgs
- No changes
## trajectory_msgs
- No changes
## visualization_msgs
- No changes
