### PR TITLE
rtmros_nextage: 0.2.11-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4384,7 +4384,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.2.10-0
+      version: 0.2.11-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.2.11-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.2.10-0`
## nextage_description
- No changes
## nextage_moveit_config

```
* Fix to #23 <https://github.com/tork-a/rtmros_nextage/issues/23>, #46 <https://github.com/tork-a/rtmros_nextage/issues/46>
* Contributors: Isaac Isao Saito
```
## rtmros_nextage

```
* fix to https://github.com/tork-a/rtmros_nextage/issues/53
* Add the source text files of tutorials on ROS wiki. These are just a backup and not intended to be updated per every change made on ROS wiki. The location of the source of ROS wiki doc needs to be figured out (discussed in https://github.com/tork-a/rtmros_nextage/issues/12).
* Fix to #23 <https://github.com/tork-a/rtmros_nextage/issues/23>, #46 <https://github.com/tork-a/rtmros_nextage/issues/46>
* Contributors: Isaac Isao Saito
```
## nextage_ros_bridge

```
* fix to https://github.com/tork-a/rtmros_nextage/issues/53
* Add the source text files of tutorials on ROS wiki. These are just a backup and not intended to be updated per every change made on ROS wiki. The location of the source of ROS wiki doc needs to be figured out (discussed in https://github.com/tork-a/rtmros_nextage/issues/12).
* Contributors: Isaac Isao Saito
```
