### PR TITLE
actionlib: 1.11.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16,7 +16,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.11.0-0
+      version: 1.11.0-1
     source:
       type: git
       url: https://github.com/ros/actionlib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.11.0-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.11.0-0`
## actionlib

```
* replace usage of __connection_header with MessageEvent (#20 <https://github.com/ros/actionlib/issues/20>)
```
