### PR TITLE
bond_core: 1.7.13-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -51,7 +51,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/bond_core-release.git
-      version: 1.7.13-0
+      version: 1.7.13-1
     source:
       type: git
       url: https://github.com/ros/bond_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.7.13-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.7.13-0`
