### PR TITLE
control_msgs: 1.3.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -134,7 +134,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/control_msgs-release.git
-      version: 1.3.0-0
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `1.3.0-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.3.0-0`
## control_msgs

```
* Add error_string to action result.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
