### PR TITLE
object_recognition_msgs: 0.4.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -506,7 +506,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_msgs-release.git
-      version: 0.4.0-0
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/wg-perception/object_recognition_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_msgs` to `0.4.0-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.4.0-0`
