### PR TITLE
jsk_common: 1.0.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1831,6 +1831,24 @@ repositories:
       url: https://github.com/ros-gbp/joystick_drivers-release.git
       version: 1.9.10-0
     status: maintained
+  jsk_common:
+    release:
+      packages:
+      - collada_urdf_jsk_patch
+      - dynamic_tf_publisher
+      - image_view2
+      - jsk_common
+      - jsk_footstep_msgs
+      - jsk_gui_msgs
+      - jsk_hark_msgs
+      - jsk_topic_tools
+      - posedetection_msgs
+      - pr2_groovy_patches
+      - rosping
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/tork-a/jsk_common-release.git
+      version: 1.0.0-0
   kinect_aux:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common`:
- previous version: `null`
- new version: `1.0.0-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
