### PR TITLE
rtshell_core: 3.0.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4422,7 +4422,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtshell_core-release.git
-      version: 3.0.0-0
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/start-jsk/rtshell_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell_core`:
- previous version: `3.0.0-0`
- new version: `3.0.0-1`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
