### PR TITLE
rtshell_core: 3.0.0-2 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3800,7 +3800,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/rtshell_core-release.git
-      version: 3.0.0-0
+      version: 3.0.0-2
     status: maintained
   rtt_common_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell_core`:
- previous version: `3.0.0-0`
- new version: `3.0.0-2`
- distro file: `groovy/distribution.yaml`
- bloom version: `0.4.8`
