### PR TITLE
nodelet_core: 1.8.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -496,7 +496,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.8.2-0
+      version: 1.8.2-1
     source:
       type: git
       url: https://github.com/ros/nodelet_core.git
@@ -506,7 +506,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_msgs-release.git
-      version: 0.4.0-1
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/wg-perception/object_recognition_msgs.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -506,7 +506,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_msgs-release.git
-      version: 0.4.0-0
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/wg-perception/object_recognition_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.8.2-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.8.2-0`
## nodelet

```
* fix erasing bond when it breaks (#8 <https://github.com/ros/nodelet_core/issues/8>)
```
## nodelet_core
- No changes
## nodelet_topic_tools
- No changes
