### PR TITLE
geometry: 1.11.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -283,7 +283,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry-release.git
-      version: 1.11.2-0
+      version: 1.11.2-1
     source:
       type: git
       url: https://github.com/ros/geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry` to `1.11.2-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.11.2-0`
## eigen_conversions

```
* alphabetization and updating cmake to find Eigen
* Contributors: Tully Foote
```
## geometry
- No changes
## kdl_conversions
- No changes
## tf

```
* fixing test linking
* Contributors: Tully Foote
```
## tf_conversions

```
* fixing eigen usage in tf_conversions
* Contributors: Tully Foote
```
