### PR TITLE
rtmros_hironx: 1.0.13-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4382,7 +4382,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.12-1
+      version: 1.0.13-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.13-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.0.12-1`
## hironx_moveit_config

```
* Applying an important change suggest by moveit developers (same as https://github.com/tork-a/rtmros_nextage/issues/46).
* (hironx_moveit_config) Add run_depend on moveit_planners to avoid the error happens on RViz Moveit plugin without.
* Contributors: Isaac Isao Saito
```
## hironx_ros_bridge

```
* Add comment to clarify necessary build_depend.
* quick hack for missing python-tk on hrpsys/waitInput.py
* disable test-hironx-ros-bridge for now
* Comform to python file naming scheme so that test files run from travis
* use pkg-config --variable=idl_dir openhrp3.1 to specify openhrp3 directory
* support corbaport arguments
* Enable rostest
* Contributors: Isaac Isao Saito, Kei Okada
```
## rtmros_hironx

```
* Applying an important change suggest by moveit developers (same as https://github.com/tork-a/rtmros_nextage/issues/46).
* (hironx_moveit_config) Add run_depend on moveit_planners to avoid the error happens on RViz Moveit plugin without.
* Add comment to clarify necessary build_depend.
* Enable rostest
* disable test-hironx-ros-bridge for now
* Comform to python file naming scheme so that test files run from travis
* Contributors: Kei Okada, Isaac Isao Saito
```
