### PR TITLE
kingfisher: 0.0.4-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1875,7 +1875,7 @@ repositories:
       version: 0.0.4-1
     source:
       type: git
-      url: https://github.com/kf/kingfisher
+      url: https://github.com/kf/kingfisher.git
       version: hydro-devel
     status: maintained
   kingfisher_desktop:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1862,7 +1862,7 @@ repositories:
   kingfisher:
     doc:
       type: git
-      url: https://github.com/kf/kingfisher
+      url: https://github.com/kf/kingfisher.git
       version: hydro-devel
     release:
       packages:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1860,6 +1860,10 @@ repositories:
       url: https://github.com/muhrix/kinect_aux-release.git
       version: 0.0.1-1
   kingfisher:
+    doc:
+      type: git
+      url: https://github.com/kf/kingfisher
+      version: hydro-devel
     release:
       packages:
       - kingfisher_description
@@ -1868,7 +1872,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/kingfisher-release.git
-      version: 0.0.3-0
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://github.com/kf/kingfisher
+      version: hydro-devel
+    status: maintained
   kingfisher_desktop:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `kingfisher` to `0.0.4-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.0.3-0`
## kingfisher_msgs
- No changes
## kingfisher_description

```
* fix the launch arg name
* unnecessary xacro sonar xacro file
* adding sonar to a seperate urdf, and to description launch
* add gps to standard sensor suite
* Contributors: Yan Ma
```
## kingfisher_teleop
- No changes
