### PR TITLE
navigation: 1.11.6-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2580,7 +2580,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.11.4-2
+      version: 1.11.6-1
     source:
       type: git
       url: https://github.com/ros-planning/navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation`:
- previous version: `1.11.4-2`
- new version: `1.11.6-1`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.7`
