### PR TITLE
pcl_msgs: 0.1.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -587,7 +587,7 @@ repositories:
       tags:
         !!python/unicode 'release': release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/pcl_msgs-release.git
-      version: 0.1.0-0
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/ros-perception/pcl_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_msgs` to `0.1.0-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.1.0-0`
## pcl_msgs

```
* Generate messages into the pcl_msgs namespace rather than the pcl namespace
```
