### PR TITLE
libuvc: 0.0.3-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -391,6 +391,17 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/libccd-release.git
       version: 1.5.0-0
+  libuvc:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ktossell/libuvc-release.git
+      version: 0.0.3-2
+    source:
+      type: git
+      url: https://github.com/ktossell/libuvc.git
+      version: master
+    status: developed
   manipulation_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc` to `0.0.3-2`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
