### PR TITLE
libuvc_ros: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -402,6 +402,20 @@ repositories:
       url: https://github.com/ktossell/libuvc.git
       version: master
     status: developed
+  libuvc_ros:
+    release:
+      packages:
+      - libuvc_camera
+      - libuvc_ros
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ktossell/libuvc_ros-release.git
+      version: 0.0.7-0
+    source:
+      type: git
+      url: https://github.com/ktossell/libuvc_ros.git
+      version: master
+    status: developed
   manipulation_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc_ros` to `0.0.7-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## libuvc_camera

```
* Removed dependency on the deprecated driver_base package.
* Added more informative error messages in the case of uvc_open() failure
```
## libuvc_ros
- No changes
