### PR TITLE
libuvc_ros: 0.0.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2124,7 +2124,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ktossell/libuvc_ros-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/ktossell/libuvc_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc_ros` to `0.0.7-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.0.6-0`
## libuvc_camera

```
* Removed dependency on the deprecated driver_base package.
* Added more informative error messages in the case of uvc_open() failure
```
## libuvc_ros
- No changes
