### PR TITLE
Added libdc1394-dev resolution on homebrew

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -137,6 +137,10 @@ jasper:
   osx:
     homebrew:
       packages: [jasper]
+libdc1394-dev:
+  osx:
+    homebrew:
+      packages: [libdc1394]
 libflann:
   osx:
     homebrew:


### PR DESCRIPTION
Tested on Mavericks. Needed for `camera1394` ROS package, which compiles with the homebrew installed dependecy.
