### PR TITLE
openhrp3: 3.1.5-5 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2547,7 +2547,11 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/openhrp3-release.git
-      version: 3.1.5-3
+      version: 3.1.5-5
+    source:
+      type: git
+      url: https://github.com/start-jsk/openhrp3.git
+      version: master
     status: maintained
   openni2_camera:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `openhrp3` to `3.1.5-5`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `3.1.5-3`
## openhrp3

```
* Fix to an issue that caused https://github.com/start-jsk/hrpsys/issues/25
* Initial commit of CHANGELOG.rst
* Contributors: Kei Okada, chen.jsk, Ryohei Ueda, Isaac Isao Saito, Hiroyuki Mikita, Iori Kumagai, Takuya Nakaoka, Shunichi Nozawa, Rosen Diankov, Yohei Kakiuchi
```
