### PR TITLE
jsk_common: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1844,11 +1844,12 @@ repositories:
       - jsk_topic_tools
       - posedetection_msgs
       - pr2_groovy_patches
+      - rospatlite
       - rosping
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
   kinect_aux:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common`:
- previous version: `1.0.0-0`
- new version: `1.0.1-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
