### PR TITLE
Adding ros_dds_proxies to documentation index for groovy

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3368,6 +3368,11 @@ repositories:
       url: https://github.com/ros/ros_comm.git
       version: groovy-devel
     status: maintained
+  ros_dds_proxies:
+    doc:
+      type: git
+      url: https://github.com/ronnyh/ros_dds_proxies.git
+      version: master
   ros_http_video_streamer:
     release:
       tags:


### PR DESCRIPTION
I would like to add ros_dds_proxies to be indexed and documented. 
