### PR TITLE
sr_visualization: 1.3.0-4 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4821,11 +4821,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/shadow-robot/sr-visualization-release.git
-      version: 1.3.0-3
+      version: 1.3.0-4
     source:
       type: git
       url: https://github.com/shadow-robot/sr-visualization.git
       version: hydro-devel
+    status: maintained
   srdfdom:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_visualization` to `1.3.0-4`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.3.0-3`
## sr_gui_motor_resetter

```
* first hydro release
```
## sr_gui_muscle_driver_bootloader

```
* first hydro release
```
## sr_gui_bootloader

```
* first hydro release
```
## sr_gui_self_test

```
* first hydro release
```
## sr_gui_controller_tuner

```
* first hydro release
```
## sr_gui_change_controllers

```
* first hydro release
```
## sr_gui_movement_recorder

```
* first hydro release
```
## sr_gui_grasp_controller

```
* first hydro release
```
## sr_gui_change_muscle_controllers

```
* first hydro release
```
## sr_visualization_icons

```
* first hydro release
```
## sr_gui_joint_slider

```
* first hydro release
```
## sr_visualization

```
* first hydro release
```
## sr_gui_hand_calibration

```
* first hydro release
```
