### PR TITLE
octomap_msgs: 0.3.1-4 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -554,7 +554,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/octomap_msgs-release.git
-      version: 0.3.1-1
+      version: 0.3.1-4
   ompl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_msgs` to `0.3.1-4`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.3.1-1`
## octomap_msgs

```
* Removed [binary|full]MsgDataToMap, created only incomplete OctoMap objects
  Replacement: use [binary|full]MsgToMap or msgToMap()
```
