### PR TITLE
stdr_simulator: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4896,7 +4896,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     status: maintained
   steered_wheel_base_controller:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `stdr_simulator` to `0.1.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.1.1-0`
## stdr_robot

```
* add collision checking
* fix minor issues with robot reposition
```
## stdr_server
- No changes
## stdr_msgs
- No changes
## stdr_resources
- No changes
## stdr_simulator
- No changes
## stdr_launchers
- No changes
## stdr_parser
- No changes
## stdr_gui

```
* Minor changes. Added message when relocation is not possible.
* Different labels for add and create robot
```
## stdr_samples
- No changes
