### PR TITLE
Adding handle_detector to documentation index for distro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1342,8 +1342,8 @@ repositories:
     release:
       tags:
         release: release/hydro/{package}/{version}
-      url: https://github.com/atenpas/handle_detector.git
-      version: 1.0.0
+      url: https://github.com/atenpas/handle_detector-release.git
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/atenpas/handle_detector.git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1334,6 +1334,20 @@ repositories:
       url: https://github.com/ros-drivers/gscam.git
       version: master
     status: maintained
+  handle_detector:
+    doc:
+      type: git
+      url: https://github.com/atenpas/handle_detector.git
+      version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/atenpas/handle_detector.git
+      version: 1.0.0
+    source:
+      type: git
+      url: https://github.com/atenpas/handle_detector.git
+      version: master
   hector_gazebo:
     doc:
       type: git


### PR DESCRIPTION
I'd like my repository to be indexed and documented at ros.org.
