### PR TITLE
handle_detector-release: 1.0.0-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1334,6 +1334,14 @@ repositories:
       url: https://github.com/ros-drivers/gscam.git
       version: master
     status: maintained
+  handle_detector-release:
+    release:
+      packages:
+      - handle_detector
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/atenpas/handle_detector-release.git
+      version: 1.0.0-2
   hector_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `handle_detector-release` to `1.0.0-2`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `null`
## handle_detector

```
* moved from bitbucket to github
* Initial commit
* Contributors: atenpas
```
