### PR TITLE
moveit_msgs: 0.5.4-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -483,7 +483,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_msgs-release.git
-      version: 0.5.3-0
+      version: 0.5.4-2
   moveit_resources:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `0.5.4-2`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.5.3-0`
## moveit_msgs

```
* update e-mail addresses
* Contributors: Ioan Sucan
```
