### PR TITLE
household_objects_database_msgs: 0.1.1-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -321,7 +321,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/household_objects_database_msgs-release.git
-      version: 0.1.1-0
+      version: 0.1.1-2
     status: maintained
   image_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `household_objects_database_msgs` to `0.1.1-2`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.1.1-0`
