### PR TITLE
manipulation_msgs: 0.2.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -421,7 +421,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/manipulation_msgs-release.git
-      version: 0.2.0-0
+      version: 0.2.0-2
     status: maintained
   map_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `manipulation_msgs` to `0.2.0-2`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.2.0-0`
