### PR TITLE
laser_filters: 1.6.14-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -368,7 +368,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/laser_filters-release.git
-      version: 1.6.14-0
+      version: 1.6.14-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_filters.git
+      version: indigo-devel
     status: maintained
   laser_geometry:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `1.6.14-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.6.14-0`
## laser_filters

```
* fix compilation on some platforms
* Contributors: Vincent Rabaud
```
