### PR TITLE
pluginlib: 1.9.24-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3197,11 +3197,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.9.23-0
+      version: 1.9.24-0
     source:
       type: git
       url: https://github.com/ros/pluginlib.git
       version: groovy-devel
+    status: maintained
   pocketsphinx:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.9.24-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.9.23-0`
