### PR TITLE
turtlebot_viz: 2.2.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5087,7 +5087,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_viz-release.git
-      version: 2.2.2-0
+      version: 2.2.3-0
     status: maintained
   typelib:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_viz` to `2.2.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `2.2.2-0`
## turtlebot_dashboard
- No changes
## turtlebot_interactive_markers
- fixes velocity smoother settings
## turtlebot_rviz_launchers
- No changes
## turtlebot_viz
- No changes
