### PR TITLE
Adding xsens_reader to documentation index for distro hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5506,6 +5506,16 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/ethz-asl/ethzasl_xsens_driver-release.git
       version: 1.0.2-0
+  xsens_reader:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/JJJJJJJack/xsens_reader.git
+      version: 1.0.0
+    source:
+      type: git
+      url: https://github.com/JJJJJJJack/xsens_reader.git
+      version: hydro
   xv_11_laser_driver:
     release:
       tags:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5507,11 +5507,6 @@ repositories:
       url: https://github.com/ethz-asl/ethzasl_xsens_driver-release.git
       version: 1.0.2-0
   xsens_reader:
-    release:
-      tags:
-        release: release/hydro/{package}/{version}
-      url: https://github.com/JJJJJJJack/xsens_reader.git
-      version: 1.0.0
     source:
       type: git
       url: https://github.com/JJJJJJJack/xsens_reader.git


### PR DESCRIPTION
Dear Sir,

I'd like my xsens_reader to be indexed and documented on ros.org.
Comparing to xsens_driver and receive_xsens, the xsens_reader is  a simple but useful node of publishing imu data from 3rd product Xsens Mti.

JJJJJJJack.HeXiang
