### PR TITLE
rosdep: add libusb-1.0

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1739,6 +1739,16 @@ libunittest++:
   ubuntu:
     apt:
       packages: [libunittest++-dev]
+libusb-1.0:
+  arch: [libusbx]
+  debian: [libusb-1.0-0]
+  fedora:
+    beefy: [libusb1]
+    heisenbug: [libusbx]
+    schrödinger’s: [libusbx]
+    spherical: [libusbx]
+  opensuse: [libusb-1_0-0]
+  ubuntu: [libusb-1.0-0]
 libusb-1.0-dev:
   arch: [libusbx]
   debian: [libusb-1.0-0-dev]


### PR DESCRIPTION
Packages that depend on libusb shouldn't use libusb-1.0-dev as a run_depends,
only as build_depends. That's why we need this new rosdep rule.
