### PR TITLE
jsk_common: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1857,7 +1857,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
   kinect_aux:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common`:
- previous version: `1.0.1-0`
- new version: `1.0.2-0`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.8`
