### PR TITLE
handle_detector-release: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1341,7 +1341,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/atenpas/handle_detector-release.git
-      version: 1.0.0-2
+      version: 1.0.1-0
   hector_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `handle_detector-release` to `1.0.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.0.0-2`
## handle_detector

```
* adjusted manifest and CMakeList
* removed lapack rosdep rule to package.xml
* Updating README.md
* Updating release inc to: 2
* Modified tracks.yaml
* Modified tracks.yaml
* Updating README.md
* Updating release inc to: 1
* Modified tracks.yaml
* Modified tracks.yaml
* Updating README.md
* Updating release inc to: 0
* Modified tracks.yaml
* Modified tracks.yaml
* Initial tracks.yaml
* Contributors: Andreas
* added lapack rosdep rule to package.xml
* Updating README.md
* Updating release inc to: 2
* Modified tracks.yaml
* Modified tracks.yaml
* Updating README.md
* Updating release inc to: 1
* Modified tracks.yaml
* Modified tracks.yaml
* Updating README.md
* Updating release inc to: 0
* Modified tracks.yaml
* Modified tracks.yaml
* Initial tracks.yaml
* Contributors: Andreas
```
