### PR TITLE
vision_visp: 0.7.1-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4347,7 +4347,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.7.0-1
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.7.1-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.7.0-1`
## visp_camera_calibration

```
* Fix errors detected with catkin_lint
* groovy-0.7.0
* Run catkin_generate_changelog, catkin_tag_changelog, bump version to 0.7.0
* Fix package.xml version number (set to current version, i.e. 0.6.0)
* Merge visp_camera_calibration as our subdirectory
* Contributors: Fabien Spindler, Thomas Moulard
```
## visp_hand2eye_calibration

```
* Fix errors detected with catkin_lint
* groovy-0.7.0
* Run catkin_generate_changelog, catkin_tag_changelog, bump version to 0.7.0
* Fix package.xml version number (set to current version, i.e. 0.6.0)
* Merge visp_hand2eye_calibration as our subdirectory
* Contributors: Fabien Spindler, Thomas Moulard
```
## vision_visp

```
* groovy-0.7.0
* Run catkin_generate_changelog, catkin_tag_changelog, bump version to 0.7.0
* Fix package.xml version number (set to current version, i.e. 0.6.0)
* Add missing CMakeLists.txt to vision_visp metapackage
* Identify Fabien as the principal maintainer.
* Add vision_visp metapackage.
* Contributors: Thomas Moulard
```
## visp_auto_tracker

```
* Fix errors detected with catkin_lint
* groovy-0.7.0
* Run catkin_generate_changelog, catkin_tag_changelog, bump version to 0.7.0
* Fix package.xml version number (set to current version, i.e. 0.6.0)
* [visp_auto_tracker] Add flashcode_mbt as subdirectory.
* Merge visp_auto_tracker as our subdirectory
* Contributors: Fabien Spindler, Thomas Moulard
```
## visp_tracker

```
* Fix errors detected with catkin_lint
* groovy-0.7.0
* Run catkin_generate_changelog, catkin_tag_changelog, bump version to 0.7.0
* Fix package.xml version number (set to current version, i.e. 0.6.0)
* [visp_tracker] Remove unused bullet dependency
* [visp_tracker] Remove useless call to setup.py
* Identify Fabien as the principal maintainer.
* [visp_tracker] CMakeLists.txt: update bag file URL (use new GitHub Release API).
* Merge visp_tracker as our subdirectory
* Contributors: Fabien Spindler, Thomas Moulard
```
## visp_bridge

```
* Fix errors detected with catkin_lint
* groovy-0.7.0
* Run catkin_generate_changelog, catkin_tag_changelog, bump version to 0.7.0
* Fix package.xml version number (set to current version, i.e. 0.6.0)
* Merge visp_bridge as our subdirectory
* Contributors: Fabien Spindler, Thomas Moulard
```
