### PR TITLE
vision_visp: 0.7.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5364,7 +5364,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.7.0-0
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.7.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.7.0-0`
## visp_camera_calibration

```
* Fix errors detected with catkin_lint
* hydro-0.7.0
* Run catkin_generate_changelog, catkin_tag_changelog, bump version to 0.6.0
* Contributors: Fabien Spindler, Thomas Moulard
```
## visp_hand2eye_calibration

```
* Fix errors detected with catkin_lint
* hydro-0.7.0
* Run catkin_generate_changelog, catkin_tag_changelog, bump version to 0.6.0
* Contributors: Fabien Spindler, Thomas Moulard
```
## vision_visp

```
* hydro-0.7.0
* Run catkin_generate_changelog, catkin_tag_changelog, bump version to 0.6.0
* Contributors: Thomas Moulard
```
## visp_auto_tracker

```
* Fix errors detected with catkin_lint
* hydro-0.7.0
* Run catkin_generate_changelog, catkin_tag_changelog, bump version to 0.6.0
* Contributors: Fabien Spindler, Thomas Moulard
```
## visp_tracker

```
* Fix errors detected with catkin_lint
* hydro-0.7.0
* Run catkin_generate_changelog, catkin_tag_changelog, bump version to 0.6.0
* Contributors: Fabien Spindler, Thomas Moulard
```
## visp_bridge

```
* Fix errors detected with catkin_lint
* hydro-0.7.0
* Run catkin_generate_changelog, catkin_tag_changelog, bump version to 0.6.0
* Contributors: Fabien Spindler, Thomas Moulard
```
