### PR TITLE
handle_detector-release: 1.0.4-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1341,7 +1341,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/atenpas/handle_detector-release.git
-      version: 1.0.3-0
+      version: 1.0.4-1
   hector_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `handle_detector-release` to `1.0.4-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.0.3-0`
## handle_detector

```
* added visualization_msgs to manifest and CMakeLists
* Contributors: Andreas
```
