### PR TITLE
pluginlib: 1.9.24-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -627,7 +627,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.9.23-0
+      version: 1.9.24-0
     source:
       type: git
       url: https://github.com/ros/pluginlib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.9.24-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.9.23-0`
