### PR TITLE
hrpsys: 315.1.9-1 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1428,7 +1428,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/hrpsys-release.git
-      version: 315.1.8-1
+      version: 315.1.9-1
     source:
       type: git
       url: https://github.com/start-jsk/hrpsys.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys`:
- previous version: `315.1.8-1`
- new version: `315.1.9-1`
- distro file: `groovy/distribution.yaml`
- bloom version: `0.4.8`
