### PR TITLE
stage: 4.1.1-6 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4872,7 +4872,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/stage-release.git
-      version: 4.1.1-5
+      version: 4.1.1-6
   stage_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stage` to `4.1.1-6`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `4.1.1-5`
