### PR TITLE
rtshell_core: 3.0.0-3 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3821,7 +3821,11 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/rtshell_core-release.git
-      version: 3.0.0-2
+      version: 3.0.0-3
+    source:
+      type: git
+      url: https://github.com/start-jsk/rtshell_core
+      version: master
     status: maintained
   rtt_common_msgs:
     doc:

--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3824,8 +3824,8 @@ repositories:
       version: 3.0.0-3
     source:
       type: git
-      url: https://github.com/start-jsk/rtshell_core
-      version: master
+      url: https://github.com/start-jsk/rtshell_core.git
+      version: groovy-devel
     status: maintained
   rtt_common_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell_core` to `3.0.0-3`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `3.0.0-2`
