### PR TITLE
hrpsys: 315.1.9-2 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1428,7 +1428,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/hrpsys-release.git
-      version: 315.1.9-1
+      version: 315.1.9-2
     source:
       type: git
       url: https://github.com/start-jsk/hrpsys.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys` to `315.1.9-2`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `315.1.9-1`
## hrpsys

```
* (hrpsys_config.py) wait (at most 10sec) if findComp found target component, check if  RobotHardware is active, see Issue #191
* (hrpsys_config.py) add max_timeout_count to findComps, if findComp could not find RTC  (for 10 seconds), successor RTC only check for 1 time
* Contributors: Kei Okada, Ryohei Ueda, Shunichi Nozawa
```
