### PR TITLE
visp: 2.9.0-3 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5386,7 +5386,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 2.9.0-2
+      version: 2.9.0-3
   visualization_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visp`:
- previous version: `2.9.0-2`
- new version: `2.9.0-3`
- distro file: `hydro/distribution.yaml`
- bloom version: `0.4.9`
