### PR TITLE
visp: 2.9.0-3 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4367,7 +4367,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 2.9.0-2
+      version: 2.9.0-3
   visualization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visp`:
- previous version: `2.9.0-2`
- new version: `2.9.0-3`
- distro file: `groovy/distribution.yaml`
- bloom version: `0.4.9`
