### PR TITLE
add python-omniorb-omg to python-omniorb

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -546,17 +546,17 @@ python-numpy:
     trusty_python3: [python3-numpy]
 python-omniorb:
   arch: [omniorbpy]
-  debian: [python-omniorb, omniidl-python]
+  debian: [python-omniorb, python-omniorb-omg, omniidl-python]
   ubuntu:
-    lucid: [python-omniorb2, omniidl4-python]
-    maverick: [python-omniorb, omniidl-python]
-    natty: [python-omniorb, omniidl-python]
-    oneiric: [python-omniorb, omniidl-python]
-    precise: [python-omniorb, omniidl-python]
-    quantal: [python-omniorb, omniidl-python]
-    raring: [python-omniorb, omniidl-python]
-    saucy: [python-omniorb, omniidl-python]
-    trusty: [python-omniorb, omniidl-python]
+    lucid: [python-omniorb2, python-omniorb2-omg, omniidl4-python]
+    maverick: [python-omniorb, python-omniorb-omg, omniidl-python]
+    natty: [python-omniorb, python-omniorb-omg, omniidl-python]
+    oneiric: [python-omniorb, python-omniorb-omg, omniidl-python]
+    precise: [python-omniorb, python-omniorb-omg, omniidl-python]
+    quantal: [python-omniorb, python-omniorb-omg, omniidl-python]
+    raring: [python-omniorb, python-omniorb-omg, omniidl-python]
+    saucy: [python-omniorb, python-omniorb-omg, omniidl-python]
+    trusty: [python-omniorb, python-omniorb-omg, omniidl-python]
 python-opencv:
   ubuntu:
     saucy: [python-opencv]


### PR DESCRIPTION
python-omniorb-omg is recommended package of python-omniorb and it is not installed jenkins.ros.org, just by setting depend to python-omniorb (http://jenkins.ros.org/job/devel-hydro-hrpsys/ARCH_PARAM=amd64,UBUNTU_PARAM=precise,label=devel/46/consoleFull)

```
Package: python-omniorb                  
State: installed
Automatically installed: yes
Version: 3.6-1
Priority: optional
Section: universe/python
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Architecture: amd64
Uncompressed Size: 2,828 k
Depends: python2.7, python (>= 2.7.1-0ubuntu2), python (< 2.8), libc6 (>= 2.4), libgcc1
         (>= 1:4.1.1), libomniorb4-1 (>= 4.1.5), libomnithread3c2 (>= 4.0.6),
         libstdc++6 (>= 4.1.1)
Recommends: python-omniorb-omg
Conflicts: python-omniorb

```
