### PR TITLE
handle_detector: 1.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1343,7 +1343,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/atenpas/handle_detector-release.git
-      version: 1.0.4-1
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/atenpas/handle_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `handle_detector` to `1.0.5-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.0.4-1`
## handle_detector

```
* updated CMakeLists.txt and package.xml
* Contributors: atenpas
```
