### PR TITLE
jsk_common: 1.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1846,6 +1846,10 @@ repositories:
       version: 1.9.10-0
     status: maintained
   jsk_common:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common.git
+      version: master
     release:
       packages:
       - collada_urdf_jsk_patch
@@ -1863,7 +1867,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common.git
+      version: master
+    status: developed
   kinect_aux:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.0.2-0`
## collada_urdf_jsk_patch
- No changes
## dynamic_tf_publisher
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_topic_tools
- No changes
## posedetection_msgs
- No changes
## pr2_groovy_patches
- No changes
## rospatlite
- No changes
## rosping

```
* display how to set uid for rosping
* use DISDIR in install(CODE) to make rosping work
* Contributors: Kei Okada
```
