### PR TITLE
cob_extern: 0.5.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -381,6 +381,26 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
       version: 0.5.0-1
+  cob_extern:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_extern.git
+      version: hydro_release_candidate
+    release:
+      packages:
+      - cob_extern
+      - libntcan
+      - libpcan
+      - libphidgets
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ipa320/cob_extern-release.git
+      version: 0.5.1-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_extern.git
+      version: hydro_dev
+    status: maintained
   cogniteam_models:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_extern` to `0.5.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## cob_extern

```
* add changelogs
* Update package.xml
* Catkinized version of stack.
  Needs checking of build flags in cob_drivers.
  Also includes updating of libphidgets to 2.1.8 for newer boards.
* Contributors: Alexander Bubeck, abubeck, ipa-fmw
```
## libntcan

```
* add changelogs
* added install flags for libntcan
* gefrickel ported to cmake
* some more cmake stuff
* small change in include files
* fixing runtime linking errors by introducing library versions
* cob_extern is now cob_gefrickel :) did some cmake foo to be compatible to catkin
* Catkinized version of stack.
  Needs checking of build flags in cob_drivers.
  Also includes updating of libphidgets to 2.1.8 for newer boards.
* add CMakeLists.txt
* beautify manifest
* update manifests
* fixed make clean bug
* fixed make clean bug
* new package libmesasr
* cleanup in cob_extern
* renamed camera_axis to head_axis and platform to base
* update urdf to be compatible with ctrutle, add 64bit support for libntcan
* update documentation
* added esd_make_devices
* changed sdh to esd support
* renamed to general cob packages
* Contributors: Alexander Bubeck, abubeck, ipa-fmw
```
## libpcan

```
* add changelogs
* Updatad libcan-7.9 installation and cleand some files.
* missing builddep
* added missing builddep
* changed copy deps
* Added another include and some more gefrickel
* Added include files for cmake.
* gefrickel ported to cmake
* added patch for libpcan to compile with Linux kernel >=3.4
* fixing runtime linking errors by introducing library versions
* cob_extern is now cob_gefrickel :) did some cmake foo to be compatible to catkin
* Catkinized version of stack.
  Needs checking of build flags in cob_drivers.
  Also includes updating of libphidgets to 2.1.8 for newer boards.
* using tarball from willow server
* Merge branch 'master' of github.com:ipa-nhg/cob_extern
* Updated libpcan to driver 7.6
* add CMakeLists.txt
* Fixed errors in installation script
* Modification in pcan installation script
* add libpopt to rosdep
* fuerte migration
* activated dongle support for peaksys driver
* update manifests
* added md5sum file
* changed . to -
* updated to pcan 6.24 on wg servers
* updated pcan version to 6.24
* using wg tarballs
* using tarball from wg for peak
* cleanup in cob_extern
* update documentation
* libpcan install now with insmod, modprobe and NO_NETDEV_SUPPORT
* additional include export
* IniFiles are passed via arguments in base_drive_chain
* restructure from cob3 to cob
* Merge branch 'master' of mailto:git@github.com:ipa320/care-o-bot into review
* renamed to general cob packages
* Contributors: Alexander Bubeck, Denis Štogl, Tobias Fromm, abubeck, cob, ipa, ipa-fmw, ipa-nhg, ipa320-cob3-6
```
## libphidgets

```
* add changelogs
* gone back in phidget version and fixed hydro build
* merge
* add dep to libusb
* Updated version of libphidgets to 2.1.8.20130618.
* version bump
* missing builddep
* added missing builddep
* updated md5sum
* add another lib version
* fixed order of dependency
* Added another include and some more gefrickel
* gefrickel ported to cmake
* updated phidgetversion
* cob_extern is now cob_gefrickel :) did some cmake foo to be compatible to catkin
* Catkinized version of stack.
  Needs checking of build flags in cob_drivers.
  Also includes updating of libphidgets to 2.1.8 for newer boards.
* updated to new version, have to upload to wg server
* add CMakeLists.txt
* fuerte migration
* update manifests
* copy right lib files for phidget
* changes for compiling tray_sensors
* fix
* fix
* using wg tarballs
* added deps to libusb
* cleanup in cob_extern
* update documentation
* update license information
* bugfix in libphidgets
* libphidget package
* Contributors: Alexander Bubeck, Denis Štogl, abubeck, ipa-bnm, ipa-fmw, uh
```
