### PR TITLE
rosjava_bootstrap: 0.1.19-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4105,7 +4105,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_bootstrap-release.git
-      version: 0.1.16-0
+      version: 0.1.19-0
     source:
       type: git
       url: https://github.com/rosjava/rosjava_bootstrap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_bootstrap` to `0.1.19-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.1.16-0`
## rosjava_bootstrap

```
* gradle 1.11, buildTools 19.0.3, gradle android plugin 0.9.+
* remove unused debugging variables
* Contributors: Daniel Stonier
```
