### PR TITLE
cob_environments: 0.5.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -405,6 +405,24 @@ repositories:
       url: https://github.com/ipa320/cob_common.git
       version: hydro_dev
     status: developed
+  cob_environments:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_environments.git
+      version: hydro_release_candidate
+    release:
+      packages:
+      - cob_default_env_config
+      - cob_environments
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ipa320/cob_environments-release.git
+      version: 0.5.1-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_environments.git
+      version: hydro_dev
+    status: developed
   cob_extern:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_environments` to `0.5.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## cob_default_env_config

```
* avoid error message
* enable paused mode again
* enable paused mode again
* full map  for ipa-apartment
* full map  for ipa-apartment
* add checkerboard again
* add checkerboard again
* cb_9x6 fixed
* cb_9x6 fixed
* Changed name medication_prospan to medicine_prospan and moved the default camera position
* Changed name medication_prospan to medicine_prospan and moved the default camera position
* Created new objects
* Created new objects
* New wall textures and floor for ipa-apartment environment
* New wall textures and floor for ipa-apartment environment
* remove unsupported environment ipa-maze
* remove unsupported environment ipa-maze
* remove not supported environment ipa-maze
* remove not supported environment ipa-maze
* installation stuff
* installation stuff
* add object locations for empty world
* add object locations for empty world
* Initial catkinization without rostest stuff
* Initial catkinization without rostest stuff
* added dummy yaml file for enabling use of empty environment
* added dummy yaml file for enabling use of empty environment
* fixing and cleaning up files
* fixing and cleaning up files
* removing ipa-maze
* removing ipa-maze
* move object locations to cob_default_env_config- groovy branch
* move object locations to cob_default_env_config- groovy branch
* move object locations to cob_default_env_config
* move object locations to cob_default_env_config
* all env working except ipa-factory
* all env working except ipa-factory
* modified map raw-industriestrasse
* modified map raw-industriestrasse
* now using English names
* now using English names
* updated map
* updated map
* warning for no ROBOT or ROBOT_ENV set
* warning for no ROBOT or ROBOT_ENV set
* use optenv for testing
* use optenv for testing
* fix tests
* fix tests
* substitute env ROBOT with arg robot
* substitute env ROBOT with arg robot
* added default environment config for raw3-1 at industriestrasse
* added default environment config for raw3-1 at industriestrasse
* fix bookcase position
* fix bookcase position
* new slammed map
* new slammed map
* removed script specific settings from default env config
* removed script specific settings from default env config
* new nav_positions, new_arm_configurations
* new nav_positions, new_arm_configurations
* new nav goals for raw_exhibiton
* new nav goals for raw_exhibiton
* add new map for raw-exhibition
* add new map for raw-exhibition
* added exhibition environment
* added exhibition environment
* Added ipa-apartment in CMakeLists.txt
* Added ipa-apartment in CMakeLists.txt
* new ipa-apartment environment
* new ipa-apartment environment
* change manifest description
* change manifest description
* new map for ipa-apartment
* new map for ipa-apartment
* changed name of cob_dashboard to cob_command_gui
* changed name of cob_dashboard to cob_command_gui
* add rostest
* add rostest
* moved cob_default_env_config
* moved cob_default_env_config
* Contributors: Alexander Bubeck, Jannik Abbenseth, abubeck, ipa-bnm, ipa-fmw, ipa-fxm, ipa-nhg
```
## cob_environments

```
* moved gazebo simulation environments to cob_simulation to cleanup dependencies. Discussed with fmw
* metapackage for cob_environments
* metapackage for cob_environments
* add CMakeLists to cob_environments
* add CMakeLists to cob_environments
* Initial catkinization without rostest stuff
* Initial catkinization without rostest stuff
* Contributors: abubeck, ipa-fmw
```
