### PR TITLE
cob_substitute: 0.5.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -443,6 +443,28 @@ repositories:
       url: https://github.com/ipa320/cob_extern.git
       version: hydro_dev
     status: maintained
+  cob_substitute:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_substitute.git
+      version: hydro_release_candidate
+    release:
+      packages:
+      - cob_lbr
+      - cob_substitute
+      - frida_description
+      - frida_driver
+      - prace_gripper_description
+      - prace_gripper_driver
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ipa320/cob_substitute-release.git
+      version: 0.5.1-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_substitute.git
+      version: hydro_dev
+    status: developed
   cogniteam_models:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_substitute` to `0.5.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## cob_lbr

```
* remove pr2_controller_msgs
* Initial catkin version. Have to find away to fix the rosjava_jni dependency.
* added service_interface.py
* cob_substitute stack for internal packages. mostly used for testing
* Contributors: abubeck, ipa-fmw, ipa-fxm
```
## cob_substitute

```
* Initial catkin version. Have to find away to fix the rosjava_jni dependency.
* Contributors: abubeck
```
## frida_description

```
* update xacro file format
* update cob_substitute
* update cob_substitute
* update xmlns + beautifying
* Merged from groovy_dev and converted additional packages to catkin
* added virtual urdfs for raw3-3 manipulators that we can not share openly
* Contributors: abubeck, ipa-fxm
```
## frida_driver

```
* removed obsolete install tags
* added dummy launch files and removed dummy python driver
* fix type  in CMakeLists
* update cob_substitute
* update cob_substitute
* Contributors: ipa-fxm, ipa-raw3-3
```
## prace_gripper_description

```
* update xmlns + beautifying
* Merged from groovy_dev and converted additional packages to catkin
* added virtual urdfs for raw3-3 manipulators that we can not share openly
* Contributors: abubeck, ipa-fxm
```
## prace_gripper_driver

```
* removed obsolete install tags
* added dummy launch files and removed dummy python driver
* fix type  in CMakeLists
* update cob_substitute
* update cob_substitute
* Contributors: ipa-fxm, ipa-raw3-3
```
