### PR TITLE
cob_driver: 0.5.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -405,6 +405,44 @@ repositories:
       url: https://github.com/ipa320/cob_common.git
       version: hydro_dev
     status: developed
+  cob_driver:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_driver.git
+      version: hydro_release_candidate
+    release:
+      packages:
+      - cob_base_drive_chain
+      - cob_base_velocity_smoother
+      - cob_cam3d_throttle
+      - cob_camera_sensors
+      - cob_canopen_motor
+      - cob_collision_velocity_filter
+      - cob_driver
+      - cob_footprint_observer
+      - cob_generic_can
+      - cob_head_axis
+      - cob_hokuyo
+      - cob_hwboard
+      - cob_light
+      - cob_phidgets
+      - cob_relayboard
+      - cob_sick_lms1xx
+      - cob_sick_s300
+      - cob_sound
+      - cob_trajectory_controller
+      - cob_undercarriage_ctrl
+      - cob_utilities
+      - cob_voltage_control
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ipa320/cob_driver-release.git
+      version: 0.5.2-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_driver.git
+      version: hydro_dev
+    status: developed
   cob_environments:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.5.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## cob_base_drive_chain
- No changes
## cob_base_velocity_smoother
- No changes
## cob_cam3d_throttle
- No changes
## cob_camera_sensors
- No changes
## cob_canopen_motor
- No changes
## cob_collision_velocity_filter
- No changes
## cob_driver
- No changes
## cob_footprint_observer
- No changes
## cob_generic_can
- No changes
## cob_head_axis
- No changes
## cob_hokuyo
- No changes
## cob_hwboard
- No changes
## cob_light
- No changes
## cob_phidgets
- No changes
## cob_relayboard
- No changes
## cob_sick_lms1xx
- No changes
## cob_sick_s300
- No changes
## cob_sound
- No changes
## cob_trajectory_controller
- No changes
## cob_undercarriage_ctrl
- No changes
## cob_utilities
- No changes
## cob_voltage_control
- No changes
