### PR TITLE
rosjava_bootstrap: 0.1.20-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4219,7 +4219,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_bootstrap-release.git
-      version: 0.1.19-0
+      version: 0.1.20-0
     source:
       type: git
       url: https://github.com/rosjava/rosjava_bootstrap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_bootstrap` to `0.1.20-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.1.19-0`
## rosjava_bootstrap

```
* Trim maven repository list and backup with maven central.
* Contributors: Daniel Stonier
```
