### PR TITLE
rosh_robot_plugins: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4240,6 +4240,26 @@ repositories:
       url: https://github.com/OSUrobotics/rosh_core-release.git
       version: 1.0.3-0
     status: maintained
+  rosh_robot_plugins:
+    doc:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_robot_plugins.git
+      version: master
+    release:
+      packages:
+      - rosh_common
+      - rosh_geometry
+      - rosh_robot
+      - rosh_robot_plugins
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/OSUrobotics/rosh_robot_plugins-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_robot_plugins.git
+      version: master
+    status: maintained
   rosjava:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_robot_plugins` to `1.0.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## rosh_common

```
* catkinizing
```
## rosh_geometry

```
* Print a message when trying to load rosh_geometry if roscore isn't running
* catkinizing
```
## rosh_robot

```
* catkinizing
```
## rosh_robot_plugins

```
* catkinizing
```
