### PR TITLE
rtmros_common: 1.0.7-1 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3766,7 +3766,11 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.0.5-1
+      version: 1.0.7-1
+    source:
+      type: git
+      url: https://github.com/start-jsk/rtmros_common.git
+      version: master
     status: developed
   rtmros_hironx:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.0.7-1`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.0.5-1`
## hrpsys_ros_bridge

```
* hrpsys_ros_bridge: add test-compile-robot.sh test-compile-robot.xml  test-compile-robot.cmake
* check hrpsys_ros_bridge SOURCE_DIR for both SOURCE_DIR and PREFIX
* hrpsys_ros_bridge: use catkin package of pr2_controllers_msgs
* hrpsys_tools, hrpsys_ros_bridge: increase retly to 4 for test
* hrpsys_ros_bridge: install/lib/python2.7/dist-packages/hrpsys_ros_bridge/__init__.py disappeared somehow? this is  temprarily fix (FIXME)
* hrpsys_ros_bridge: fix compile_robot_model.cmkae, use find_package to set /lib/openrtm_aist/bin/rtm-naming /lib/openhrp3/export-collada
* collision_state.py: display with logwarn when CollisionDetector is not found
* hrpsys_ros_bridge, fix path for installed conf/dae/launch files
* compile_robot_model.cmake: add debug message in generate_default_launch_eusinterface_files
* hrpsys_ros_bridge: (test-samplerobot.py, test-p10.py), increase timeout of watForTransform() and catch exception if tf is not found
* collision_state, wait until co is found, if not found exit with 0, not 1
* hrpsys_profile.py add Exception
* hrpsys_ros_bridge: add collada_urdf to depends
* hrpsys_profile.py: run hrpsys_profile within try block
* hrpsys_profile.py: remove undefined variables
* hrpsys_ros_bridge: add visualization_msgs to depeds
* hrpsys_ros_bridge: fix ProjectGenerator location, see #353
* hrpsys_ros_bridge: add test code for samplerobot and pa10
* hrpsys_ros_bridge: add diagnostic_aggregator to depend (manifest.xml package.xml)
* hrpsys_ros_bridge: add more args to default_robot_*.in (GUI, SIMULATOR_NAME, corbaport)
* add comment on why we remove depend to pr2_controllers_msgs
* (package.xml) add angles to build_depend intentinally dut to build_depend to tf does ont install angles
* (manifest.xml) commented out depend package pr2_controllers_msgs for rosmake dependency graph generation, but comment in for rosmake build objects
* (manifest.xml) if you have both rosdep and depend, rosmake does not work well, see https://github.com/jsk-ros-pkg/jsk_common/issues/301
* (manifest.xml) users are expected to manually install ros-groovy-pr2-dashboard
* (CMakeLists.txt) download pr2_controllers_msgs for groovy/rosbuild
* fix typo ;; elif -> elseif
* add
* Wrong catkin macro (CATKIN-DEPENDS to CATKIN_DEPENDS).
* change destination of stdout of rtmlaunch.py by OUTPUT arg
* add CMAKE_PREFIX_PATH so that rosrun hrpsys ProjectGenerator works
* Merge pull request #334 from k-okada/master
* add openhrp3_PREFIX, more debug message
* add / after hrpsys_idl_DIR
* add hrpsys to find_package
* add more verbose log when error
* update PKG_CONFIG_PATH for hrpsys-base
* display error output
* add depend to pkg-config
* add depend to pkg-config
* added euslisp, srv, idl directories to install
* move to git repository
* add hrpsys to find_package
* add more verbose log when error
* Merge branch 'master' of http://github.com/k-okada/rtmros_common
* display error output
* add depend to pkg-config
* add depend to pkg-config
* update PKG_CONFIG_PATH for hrpsys-base
* Merge branch 'master' into garaemon-master
* not generating sh but running rostes directory to avoid escape problem
* Merge branch 'master' of http://github.com/k-okada/rtmros_common
* use pkg-config to find directories
* Merge branch 'master' of https://github.com/start-jsk/rtmros_common
* move to git repository
* added euslisp, srv, idl directories to install
* fixing list syntax
* force to set ROS_PACKAGE_PATH when calling euscollada for catkin build
* adding LD_LIBRARY_PATH
* remove depend to robot_monitor
* changing the working directory when call export-collada
* do not compile lisp code if euxport collada is not exists
* add diagnositcs_msgs to fake rosdep
* add dynamic_recofigure to fake rosdep
* add several rosdep names to fake rosdep
* add rosdep hrpsys/openrtm_aist to fake rosdep
* profibit to run rostest parallel
* installing src directory as python package
* (hrpsys_ros_bridge/package.xml) Partially revert r6936 where a dependency was removed by mistake.
```
## hrpsys_tools

```
* add respawn to rtcd/hrpsys-simulator, RESPAWN_MODELLOADER, RESPAWN_SIMULATOR, RESPAWN_RTCD, see Issue #380
* hrpsys_tools: (test-pa10.test) run unittest first, then test hcf
* hrpsys_tools, hrpsys_ros_bridge: increase retly to 4 for test
* hrpsys_tools: add rosbuild_add_rostest to CMakeList.txt and fix test-hrpsys-config.py to load_mafest for rosbuild environment
* add retry=2 tag, since we staill have trouble on connection sometimes (https://code.google.com/p/hrpsys-base/issues/detail?id=192)
* add launch-prefix argument for hrpsys_py node
* add samples direcotry to install
* add -c option to specify commands to execute
* set RobotHardware name due to api change of hrpsys_tools_config.py
* add samples direcotry to install
* use -c to specify commands
* add -c option to specify commands to execute
* forge to add
* set RobotHardware name due to api change of hrpsys_tools_config.py
* add test code that uses hrpsys.launch
* add waitForRTCManagerAndRobotHardware for interactive mode
* remove openrtm_aist_python from find_package
* add interactive mode, invoke with ipython ... or -i option
* add sample code of interactive mode of hrpsys_tools_config.py in test-hrpsys-config-test
* fix test code to work with clean environment
* fix python code syntax error
* fix typo
* write contents of test-hrpsys.test
* Update test-hrpsys-config.py
  rename testHrpsysConfigurator -> TestHrpsysConfigurator
* add test/test-hrpsys-config.test
* add depend hrpsys to fke rosdep install
```
## openrtm_ros_bridge

```
* openrtm_ros_bridge: (test_myservice_rosbridge.test) add retry=4
* openrtm_ros_bridge: mv samples/test_myservice_rosbridge.* -> test/test_myservice_rosbridge.* and add test to CMakeLists.txt/catkin.cmake
* disable openrtm_ros_bridge/rosbuil test for now
* Wrong catkin macro (CATKIN-DEPENDS to CATKIN_DEPENDS).
* use pkg-config to find directories
* disable test_myservice_rosbridge.launch, is is not working right now
```
## openrtm_tools

```
* (rtmlaunch.py) trap SIGINT and exits with 0
* openrtm_tools: add rosbash to depends
* openrtm_tools : add test code to check if rtmlaunch works
* comment out import OpenRTM_aist.RTM_IDL # for catkin, see #375
* openrtm_tools: add rosbash to depends
* openrtm_tools : add test code to check if rtmlaunch works test-rtmlaunch.{py,test}
* comment out import OpenRTM_aist.RTM_IDL # for catkin, see #375
* display output when test fails
* fix PATH/PYTHONPATH for rosbuild/catkin
* add test code for openrtm_tools (rtshell-setup.sh)
* fix rtshell-setup.sh to support catkin environment
* add link to more useful information, suggested by Isaac
* remove debug code
* display more verbose information of weird connection error
* add rosdep hrpsys/openrtm_aist to fake rosdep
```
## rosnode_rtc

```
* (package.xml) move rostopic from test_depend to build_depend
* add rosdep roscpp_tutorials
```
## rtmbuild

```
* (rtmbuild.cmake, idl2srv.py) fix for rtmbuild/deb environment
* (rtmbuild.cmake) display variables on both rtmbuild and cmake
* (rtmbuild.cmake) add find_package(PkgConfig)
* Wrong catkin macro (CATKIN-DEPENDS to CATKIN_DEPENDS).
```
## rtmros_common
- No changes
