### PR TITLE
rosh_desktop_plugins: 1.0.1-0 in 'hydro/distribution.yaml'

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4260,6 +4260,24 @@ repositories:
       url: https://github.com/OSUrobotics/rosh_robot_plugins.git
       version: master
     status: maintained
+  rosh_desktop_plugins:
+    doc:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_desktop_plugins.git
+      version: master
+    release:
+      packages:
+      - rosh_desktop
+      - rosh_desktop_plugins
+      - rosh_visualization
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/OSUrobotics/rosh_desktop_plugins-release.git
+    source:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_desktop_plugins.git
+      version: master
+    status: maintained
   rosjava:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4240,6 +4240,24 @@ repositories:
       url: https://github.com/OSUrobotics/rosh_core-release.git
       version: 1.0.3-0
     status: maintained
+  rosh_desktop_plugins:
+    doc:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_desktop_plugins.git
+      version: master
+    release:
+      packages:
+      - rosh_desktop
+      - rosh_desktop_plugins
+      - rosh_visualization
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/OSUrobotics/rosh_desktop_plugins-release.git
+    source:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_desktop_plugins.git
+      version: master
+    status: maintained
   rosh_robot_plugins:
     doc:
       type: git
@@ -4258,24 +4276,6 @@ repositories:
     source:
       type: git
       url: https://github.com/OSUrobotics/rosh_robot_plugins.git
-      version: master
-    status: maintained
-  rosh_desktop_plugins:
-    doc:
-      type: git
-      url: https://github.com/OSUrobotics/rosh_desktop_plugins.git
-      version: master
-    release:
-      packages:
-      - rosh_desktop
-      - rosh_desktop_plugins
-      - rosh_visualization
-      tags:
-        release: release/hydro/{package}/{version}
-      url: https://github.com/OSUrobotics/rosh_desktop_plugins-release.git
-    source:
-      type: git
-      url: https://github.com/OSUrobotics/rosh_desktop_plugins.git
       version: master
     status: maintained
   rosjava:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_desktop_plugins` to `1.0.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## rosh_desktop

```
* catkinizing
```
## rosh_desktop_plugins

```
* catkinizing
```
## rosh_visualization

```
* rosh_visualization) switch from rviz/image_view to image_view/image_view to fix #1 <https://github.com/OSUrobotics/rosh_desktop_plugins/issues/1>
* catkinizing
```
