### PR TITLE
rocon_msgs: 0.6.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3878,6 +3878,7 @@ repositories:
       - concert_msgs
       - gateway_msgs
       - rocon_app_manager_msgs
+      - rocon_interaction_msgs
       - rocon_msgs
       - rocon_service_pair_msgs
       - rocon_std_msgs
@@ -3885,7 +3886,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-      version: 0.6.7-1
+      version: 0.6.8-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs` to `0.6.8-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.6.7-1`
## scheduler_msgs
- No changes
## rocon_msgs

```
* adding interaction messages and updated scheduler_msgs.
* Contributors: Daniel Stonier
```
## rocon_std_msgs

```
* some string type messages and service pairs.
* Contributors: Daniel Stonier
```
