### PR TITLE
rocon_msgs: 0.6.9-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3886,7 +3886,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-      version: 0.6.8-0
+      version: 0.6.9-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs` to `0.6.9-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.6.8-0`
## rocon_service_pair_msgs

```
* bugfix location of install space genpair script.
```
