### PR TITLE
turtlebot_create_desktop: 2.2.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5301,7 +5301,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_create_desktop-release.git
-      version: 2.2.0-0
+      version: 2.2.2-0
     status: maintained
   turtlebot_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_create_desktop` to `2.2.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `2.2.0-0`
## create_dashboard

```
* create_dashboard: Fix some python syntax errors
  Even if this file isn't used, it will be bytecompiled when packaged for Fedora. This will fail if there are   syntax errors in the file, so even if it is not used or has functi
* Contributors: Scott K Logan
```
## create_gazebo_plugins

```
* boost::shared_*_cast are deprecated, removed in boost 1.53
* fixes gazebo header paths (refs `#7 <https://github.com/turtlebot/turtlebot_create_desktop/issues/7>`_)
* Contributors: Scott K Logan, Marcus Liebhardt
```
## turtlebot_create_desktop
- No changes
