### PR TITLE
robot_model: 1.11.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -696,7 +696,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.11.0-0
+      version: 1.11.1-0
   robot_state_publisher:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.11.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.11.0-0`
## collada_parser

```
* remove visual and collision if there is no vertices
* do not use visual and collision group
* fix debug message
* fix problem of root coordinates
* Contributors: YoheiKakiuchi
```
## collada_urdf

```
* Use assimp-dev dep for building
* Contributors: Scott K Logan
```
## joint_state_publisher
- No changes
## kdl_parser
- No changes
## robot_model
- No changes
## urdf
- No changes
## urdf_parser_plugin
- No changes
