### PR TITLE
universal_robot: 1.0.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5407,6 +5407,29 @@ repositories:
       url: https://github.com/ros-geographic-info/unique_identifier.git
       version: master
     status: maintained
+  universal_robot:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/universal_robot.git
+      version: hydro_release_candidate
+    release:
+      packages:
+      - universal_robot
+      - ur5_moveit_config
+      - ur_bringup
+      - ur_description
+      - ur_driver
+      - ur_gazebo
+      - ur_kinematics
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-industrial-release/universal_robot-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-industrial/universal_robot.git
+      version: hydro-devel
+    status: developed
   uos_slam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robot` to `1.0.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
