### PR TITLE
cob_driver: 0.5.2-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -459,7 +459,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.5.2-0
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.5.2-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.2-0`
## cob_base_drive_chain
- No changes
## cob_base_velocity_smoother
- No changes
## cob_cam3d_throttle
- No changes
## cob_camera_sensors
- No changes
## cob_canopen_motor
- No changes
## cob_collision_velocity_filter
- No changes
## cob_driver
- No changes
## cob_footprint_observer
- No changes
## cob_generic_can
- No changes
## cob_head_axis
- No changes
## cob_hokuyo
- No changes
## cob_hwboard
- No changes
## cob_light
- No changes
## cob_phidgets
- No changes
## cob_relayboard
- No changes
## cob_sick_lms1xx
- No changes
## cob_sick_s300
- No changes
## cob_sound
- No changes
## cob_trajectory_controller
- No changes
## cob_undercarriage_ctrl
- No changes
## cob_utilities
- No changes
## cob_voltage_control
- No changes
