### PR TITLE
schunk_modular_robotics: 0.5.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4799,7 +4799,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/schunk_modular_robotics-release.git
-      version: 0.5.1-0
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/ipa320/schunk_modular_robotics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_modular_robotics` to `0.5.1-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.1-0`
## schunk_description

```
* update xacro file format
* merge with groovy
* meshes files for lwa4p_extended
* added meshes files for lwa4p_extended
* tested on real arm
* 27.02. current status
* new meshes
* Tested on real arm
* Fixed arm_7_joint position
* bring in groovy updates
* Fix mesh files for lwa4d
* Added calibration arm_1_calibrationg_rising
* description for the a new lwa4p version
* Adjust lwa limits
* adapt limits for lwa and lwa_extended
* update lwa4d description
* fix arm_6_joint
* update transmission for schunk components
* update xmlns + beautifying
* transmission for new simulation controllers
* 2DOF Hack for finger
* fix fingers
* update pg70
* add pg70 gripper
* Corrected xacro files for hydro.
* Removed instalation of gazebo folder which doesn't exist.
* Updated lwa4d description
* Created lwa4d urdf model
* remove install command for gazebo subdirectory
* merge
* More changes from powerball to lwa4d
* Changed from powerball to lwa4p
* remove mesh file generation
* installation stuff
* remove generation of mesh files
* Initial catkinization. Still a linking error in sdh lib.
* some more fixes and cleaning up for gazebo simulation
* fix sdh description according to new gazebo format
* fix blue color
* Groovy migration
* adjust color settings
* change to light grey
* Reorganized list of colors
* Redefined colors
* Merge branch 'master' of github.com:ipa320/schunk_modular_robotics
* update limits for lwa
* Renamed the colors
* Redefined Schunk component colors for gazebo and rviz
* merge
* Fixed arm_0_link origin
* modified mesh files
* powerball stl changes
* Revised powerball  urdf and mesh files
* New meshes files for powerball
* fixes for powerball arm urdf
* New colors for powerball in simulation
* changed stl files not using solid
* changed stlb links to stl
* New model schunk powerball
* fix lwa
* renamed to schunk names
* renamed arm to lwa
* rename from arm to lwa
* renamed arm to lwa
* moved schunk desc
* Contributors: Alexander Bubeck, Denis Štogl, Frederik Hegger, IPR-SR2, Thiago de Freitas, abubeck, fmw, ipa-cob3-5, ipa-cob3-6, ipa-fmw, ipa-fxm, ipa-nhg, ipa-tys, rmb-om
```
## schunk_libm5api

```
* use const char* instead of char* to get rid of some compiler warnings
* output long unsigned correctly
* Initial catkinization. Still a linking error in sdh lib.
* Update CMakeList in schunk_libm5api for ESD
* add original link to sources on schunk site
* add libm5api as source code package
* Contributors: Frederik Hegger, abubeck, ipa-fmw, roboskin
```
## schunk_modular_robotics

```
* Initial catkinization. Still a linking error in sdh lib.
* Contributors: abubeck
```
## schunk_powercube_chain

```
* removed a lot of code related to packages not available in hydro anymore
* add definitions to get rid of some compiler warnings
* fixed linking error of SDH and CAN libraries
* Initial catkinization. Still a linking error in sdh lib.
* Offsets added in PowercubeChain
* merge conficts solved
* Recover function changed (syncmotion deleted)
* untested version that handels offsets inside ROS.
* IMPORTANT changes in init! No offset used anymore. No limits are set to the modules to avoid errors in the PRL-Modules
* Bug in reset during init fixed
* fix compile issue
* fix compile issue on natty
* remove c++0x
* Recover function improved
* remove std=c++0x
* spare includes deleted
* added little comments
* Restsequence in init() changed to avoid problems during 'init all' if there are more chains on one bus.
* changed error on com to debug message
* change to debug message
* -check of return values added in init() -aborting homing because of out of limits limited to only for PW-modules.
* Merge remote branch 'origin-ipa320/master' into automerge
* added effort to joint states message
* communication check for offset writing added
* communication check for setOffsets added.
* Too much output removed. Velocity smoothing reactivated.
* Init procedure improved in the case that 2 chains access the same bus.
* Check of joint position for limits during homing added to avoid fast movement if module is unreferenced.
* merge errors removed
* initalisation of m_position variable with true position from module added
* first draft of diagnostics class
* first draft of diagnostics class
* slightly changes. work in progress.
* Merge remote branch 'origin-ipa320/master' into automerge
* Merge branch 'master' of github.com:ipa-tif/schunk_modular_robotics
* little format changes
* movestep debuggin and adding force_movevel
* remove info output
* Bugfix in moveVel
* ResetAll replaced by resetModule, Diagnositcs output improved, changes in moveVel
* work in progress on limit handling
* Getting out of soft limits improved
* Output for diagnostics improved
* output for diagnostics improved
* selection of module type by encoder added, reading of module type parameter in .yaml removed
* firmware version dependend swichting between moveVelExt and moveStepExt for PRL-Modules
* automatic ModulType check removed, because Encoder Types are not provided. Info output on homing improved.
* improvments on ModuleType investigation
* merge
* Moduletype is read from module, comments added
* Moduletype is read from module
* Fixed stop of all motor on the bus in error case of one. Now only the motors in a kinematic chain are stopped.
* PW-Module homing tested, Rrecovering of only stall modules added, Stop command in global error case added, check for homing flag bevor homing added
* display version number on init added
* Switching of moveVel and moveStep depending on ModuleTypeadded.
* support for homing PRL and PW modules added
* ModuleType added for support of PW and PRL modules
* changed frequency again to avoid CAN bus crashes
* removed debug messages, changed frequency settings
* update stack description
* modified threading in powercube chain, added velocity calculation and fixed moveStep issues
* removed unused files
* add libm5api as source code package
* fill velocities in controller/state message
* fixed position value bug for stable movements
* remove newlines in diagnosticmsgs
* fixed error state bug
* added errorstring to diagnostic messages, has to be tested on real hardware
* added diagnotic topic for initialization states
* modifications for powercubechain to work with tray and torso
* added operation mode interface for general usage of trajectory controller
* fix move step
* using private namespace
* merge to working version of powercube_chain
* using private nodehandle
* moved powercube_chain to schunk repo
* moved to new repo
* Contributors: Alexander Bubeck, Frederik Hegger, abubeck, cob3-5, ipa-cob3-5, ipa-fmw, ipa-fxm, ipa-tif, ipa320, tif
```
## schunk_sdh

```
* removed a lot of code related to packages not available in hydro anymore
* fixed dependency
* added libusb dependency
* Merge branch 'groovy_dev' into feature/catkin
* overwrite link if exists
* changed custom_command to custom_target for dependencies
* Merge branch 'feature/catkin' of github.com:abubeck/schunk_modular_robotics into feature/catkin
* changed library to be an imported library
* cmake based shared library linking
* added genmsg
* deleted deprecated file
* fixed linking error of SDH and CAN libraries
* Initial catkinization. Still a linking error in sdh lib.
* Added mapping of joint_values to koint_names
* updated DSA polling policy
* updated SDHLibrary version 0.0.2.6 for i386
* Revert "removed ESD support flags"
  This reverts commit 34fb0db2b990423d7d0efc95602a1119835c8b53.
* updated to SDHLibrary version 0.0.2.6, currenty only for x86_64!
* dsa: added push stop on start
* removed ESD support flags
* dsa: proper shutdown
* dsa: fixed frequency setting
* init topic in contructor
* dsa: added push mode frequency
* dsa: implemented polling mode
* dsa: debug output, logic fixes
* dsa: error counter decrement logic
* dsa: clean-up
* dsa: added reorder parameter
* dsa: added various parameters, auto-publish feature
* dsa: switched to timer callbacks
* dsa: error count in diagnostics msg
* dsa: node handle passing in constructor
* dsa_only compiles
* dsa_only: 60 Hz loop
* dsa_only: removed services
* schunk_sdh: added error counter in dsa_only
* splitted version of sdh/dsa driver
* add effort to joint_states
* added brics velocity interface to schunk_sdh
* fixed warning
* whitespace
* schunk_sdh: stop hand on mode change
* schunk_sdh: read operation mode from paramter server
* schunk_sdh: reordered tactile data to match joint state order
* schunk_sdh: added some more sanity checks
* schunk_sdh: renamed set_velocities to set_velocities_raw
* schunk_sdh: fixed joint order
* schunk_sdh: fixed mode switching
* schunk_sdh: init with position mode as default
* call to MoveHand is not needed because SetAxisTargetVelocity takes effect immediately
* schunk_sdh: added set_velocities topic and velocity control mode
* schunk_sdh: set_operation_mode switches the SDH controller as well
* schunk_sdh: operation mode is a member variable now
* Merge pull request #2 <https://github.com/ipa320/schunk_modular_robotics/issues/2> from ipa-fxm/master
  JointTrajectoryAction -> FollowJointTrajectoryAction
* Addapted the sdh driver for sdh without sensors
* switched from pr2_controllers_msgs::JointTrajectoryAction to control_msgs::FollowJointTrajectory
* remap recover service to init
* Merge pull request #3 <https://github.com/ipa320/schunk_modular_robotics/issues/3> from abubeck/master
  fuerte support, compatible with electric
* fuerte migration
* removed unused files
* sdh library version 0.0.2.18 for 32-bit
* setup cob3-4
* added diagnotic topic for initialization states for sdh
* chancged action to private namespace
* using private namespace
* using private namespace
* renamed to schunk
* moved sdh to schunk repository
* Contributors: Alexander Bubeck, Felix Messmer, Florian Weißhardt, Jan Fischer, Mathias Lüdtke, abubeck, ipa-fmw, ipa-fxm, ipa-mdl, robot
```
## schunk_simulated_tactile_sensors

```
* Adapted topics for simulated tactile sensors.
* installation stuff
* changed to new gazebo_msgs
* Initial catkinization. Still a linking error in sdh lib.
* switched namespace for simulated tactile sensors to dsa_controller (the same as on the robots)
* switched namespace for simulated tactile sensors to dsa_controller (the same as on the robots)
* updated documentation
* schunk_simulated_tactile_sensors: reordered pads to match joint state order
* moved simulated tactile sensors to schunk repository
* Contributors: Mathias Lüdtke, abubeck, ipa-fmw, ipa-mdl, jsanch2s
```
