### PR TITLE
Add deps for hostname, net-tools and procps

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -758,6 +758,11 @@ hostapd:
     portage:
       packages: [net-wireless/hostapd]
   ubuntu: [hostapd]
+hostname:
+  arch: [inetutils]
+  debian: [hostname]
+  fedora: [hostname]
+  ubuntu: [hostname]
 i2c-tools:
   opensuse: [i2c-tools]
 imagemagick:
@@ -1992,6 +1997,11 @@ mrpt:
     raring: [libmrpt-dev, mrpt-apps]
 muparser:
   ubuntu: [libmuparser-dev]
+net-tools:
+  arch: [net-tools]
+  debian: [net-tools]
+  fedora: [net-tools]
+  ubuntu: [net-tools]
 netcdf:
   debian: [libnetcdf-dev]
   fedora: [netcdf]
@@ -2121,6 +2131,11 @@ pkg-config:
   opensuse: [pkg-config]
   rhel: [pkgconfig]
   ubuntu: [pkg-config]
+procps:
+  arch: [procps-ng]
+  debian: [procps]
+  fedora: [procps-ng]
+  ubuntu: [procps]
 protobuf:
   arch: [protobuf]
   debian: [libprotobuf7]


### PR DESCRIPTION
Initially added only for Arch, Debian, Fedora and Ubuntu. Someone should probably add macports...

It looks like these tools are pretty much always installed on Ubuntu, but this is not true on Fedora systems. Packages using these tools will need to add a dependency.
