### PR TITLE
moveit_ros: 0.5.17-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -509,7 +509,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.5.16-0
+      version: 0.5.17-0
     status: maintained
   nodelet_core:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ros` to `0.5.17-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.16-0`
## moveit_ros
- No changes
## moveit_ros_benchmarks

```
* update build system for ROS indigo
* update maintainer e-mail
* Contributors: Ioan Sucan
```
## moveit_ros_benchmarks_gui

```
* update build system for ROS indigo
* Contributors: Ioan Sucan
```
## moveit_ros_manipulation

```
* update build system for ROS indigo
* fix merge
* refactor how we use params for pick&place
* set the pose frame so we don't get a crash in approach&translate
* Contributors: Ioan Sucan
```
## moveit_ros_move_group

```
* update maintainer e-mail
* Contributors: Ioan Sucan
```
## moveit_ros_perception

```
* update build system for ROS indigo
* update maintainer e-mail
* Contributors: Ioan Sucan
```
## moveit_ros_planning

```
* update build system for ROS indigo
* update maintainer e-mail
* Namespace a debug message
* Minor non-functional changes to KDL
* Contributors: Dave Coleman, Ioan Sucan
```
## moveit_ros_planning_interface

```
* update build system for ROS indigo
* added move_group python interface bindings to move group interface
  function:
  void setPathConstraints(const moveit_msgs::Constraint &constraint)
  in order to be able to set path constraints from python scripts
  directly and no need to use the DB.
* Use member NodeHandle in action clients.
  Currently services and topics are already using the member NodeHandle instance,
  but not the action clients.
  This is relevant for two reasons:
  - Consistency in the resulting ROS API namespace (everything in the same namespace).
  - Consistency in the spinning policy. All services, topics and actions will be spinned
  by the same NodeHandle, and whatever custom (or not) spinners and callback queues it
  has associated.
* adding error code returns to relevant functions
* Contributors: Adolfo Rodriguez Tsouroukdissian, Emili Boronat, Ioan A Sucan, Sachin Chitta
```
## moveit_ros_robot_interaction

```
* update maintainer e-mail
* Contributors: Ioan Sucan
```
## moveit_ros_visualization

```
* update build system for ROS indigo
* update maintainer e-mail
* Contributors: Ioan Sucan
```
## moveit_ros_warehouse

```
* update maintainer e-mail
* Contributors: Ioan Sucan
```
