### PR TITLE
moveit_planners: 0.5.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -485,6 +485,16 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_msgs-release.git
       version: 0.5.4-2
+  moveit_planners:
+    release:
+      packages:
+      - moveit_planners
+      - moveit_planners_ompl
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_planners-release.git
+      version: 0.5.5-0
+    status: maintained
   moveit_resources:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_planners` to `0.5.5-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## moveit_planners
- No changes
## moveit_planners_ompl

```
* update build system for ROS indigo
* Removed duplicate call to setPlanningScene(), added various comments
* Contributors: Dave Coleman, Ioan Sucan
```
