### PR TITLE
Fix libpq-dev dep for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1476,7 +1476,7 @@ libpopt-dev:
 libpq-dev:
   arch: [postgresql-libs]
   debian: [libpq-dev]
-  fedora: [derelict-pq-devel]
+  fedora: [derelict-postgresql-devel, postgresql-devel]
   gentoo:
     portage:
       packages: [dev-libs/libpqxx]


### PR DESCRIPTION
In F19+, derelict-pq-devel is called derelict-postgresql-devel. Also, postgresql-devel was missing.
