### PR TITLE
moveit_ros: 0.5.18-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -519,7 +519,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.5.17-0
+      version: 0.5.18-0
     status: maintained
   nodelet_core:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ros` to `0.5.18-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.17-0`
## moveit_ros
- No changes
## moveit_ros_benchmarks
- No changes
## moveit_ros_benchmarks_gui

```
* add pkg-config as dep
* find PkgConfig before using pkg_check_modules
  PC specific functions mustn't be used before including PkgConfig
* Contributors: Ioan Sucan, v4hn
```
## moveit_ros_manipulation
- No changes
## moveit_ros_move_group
- No changes
## moveit_ros_perception
- No changes
## moveit_ros_planning
- No changes
## moveit_ros_planning_interface
- No changes
## moveit_ros_robot_interaction
- No changes
## moveit_ros_visualization

```
* add pkg-config as dep
* find PkgConfig before using pkg_check_modules
  PC specific functions mustn't be used before including PkgConfig
* Contributors: Ioan Sucan, v4hn
```
## moveit_ros_warehouse
- No changes
