### PR TITLE
moveit_plugins: 0.5.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -495,6 +495,17 @@ repositories:
       url: https://github.com/ros-gbp/moveit_planners-release.git
       version: 0.5.5-0
     status: maintained
+  moveit_plugins:
+    release:
+      packages:
+      - moveit_fake_controller_manager
+      - moveit_plugins
+      - moveit_simple_controller_manager
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_plugins-release.git
+      version: 0.5.6-0
+    status: maintained
   moveit_resources:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_plugins` to `0.5.6-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## moveit_fake_controller_manager
- No changes
## moveit_plugins
- No changes
## moveit_simple_controller_manager

```
* Allow simple controller manager to ignore virtual joints without failing
* Contributors: Dave Coleman
```
