### PR TITLE
pr2_mechanism_msgs: 1.8.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -655,6 +655,13 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: groovy-devel
     status: maintained
+  pr2_mechanism_msgs:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
+      version: 1.8.0-0
+    status: maintained
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_mechanism_msgs` to `1.8.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
