### PR TITLE
Add dpkg deps

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -442,6 +442,11 @@ doxygen:
   macports: [doxygen]
   rhel: [doxygen]
   ubuntu: [doxygen]
+dpkg:
+  arch: [dpkg]
+  debian: [dpkg]
+  fedora: [dpkg]
+  ubuntu: [dpkg]
 eclipse:
   arch: [eclipse, eclipse-rcp, eclipse-emf, eclipse-pde]
   debian: [eclipse, eclipse-rcp, eclipse-xsd, eclipse-pde]


### PR DESCRIPTION
Obviously dpkg is installed on Ubuntu and Debian systems, but not always on others. Even if the system doesn't use dpkg for packages, other parts of dpkg can be useful, such as extracting deb contents.

Added initially only for Arch, Debian, Fedora and Ubuntu. Should probably be added to OSX if it has dpkg.

This will be part of a fix for https://github.com/ros-drivers/pointgrey_camera_driver/issues/3
