### PR TITLE
Adding vrep_ros_bridge to documentation index for distro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5747,6 +5747,11 @@ repositories:
       type: git
       url: https://github.com/uos/volksbot_driver.git
       version: hydro
+  vrep_ros_bridge:
+    doc:
+      type: git
+      url: https://github.com/lagadic/vrep_ros_bridge.git
+      version: master
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
I would like vrep_ros_bridge to be indexed and documented on wiki.ros.org
