### PR TITLE
cob_manipulation: 0.5.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -503,6 +503,31 @@ repositories:
       url: https://github.com/ipa320/cob_extern.git
       version: hydro_dev
     status: maintained
+  cob_manipulation:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_manipulation.git
+      version: hydro_release_candidate
+    release:
+      packages:
+      - cob_grasp_generation
+      - cob_kinematics
+      - cob_lookat_action
+      - cob_manipulation
+      - cob_moveit_config
+      - cob_moveit_interface
+      - cob_pick_place_action
+      - cob_tactiletools
+      - cob_tray_monitor
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ipa320/cob_manipulation-release.git
+      version: 0.5.1-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_manipulation.git
+      version: hydro_dev
+    status: developed
   cob_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_manipulation` to `0.5.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## cob_grasp_generation

```
* move cob_mmcontroller + groovy_updates
* fix deps
* pick_place now works with released version of moveit
* fixes for changed message types
* catkinized
* manually remove spreizgriffe
* removed bottom grasps from grasp tables
* generating new grasps
* better grasptable for instanttomatosoup
* better grasptable for hotpot2
* better grasptable for hotpot
* fixes after merge
* adaptions, fixes and new generation_strategy
* cleaning up
* restructuring folders
* new action_clients
* combined action_server
* new actions
* delete obsolete files
* new grasp_tables
* minor fixes
* additional params in action (threshold,grasp_id,num_grasps) + adaptions + some improvements
* close fingers a little more so that objects dont slip through
* fully implemented as class + improvements
* merge with ws
* Merge branch 'pick_n_place' of https://github.com/ipa-fmw-ws/cob_manipulation into pick_n_place
* remove obsolete sleep
* server now uses class from or_grasp_generation and a threshold
* added threshold, num_grasps and grasp_id for grasp database
* start implementation as class
* remove unused parameter
* improved show grasp
* removed some unfeasible grasps manually
* Removed Salt textures
* Added service server for showing grasps
* showgrasp functionality added
* sort call fixed, hardcoded paths fixed
* fixed sorting algorithm
* added hotpo2 to DB
* added hotpot to DB
* new DB for salt and tomatosoup
* pre_joint_config changed
* removed wrong DBs
* preshapes set to cylindric only
* fixing negative zero values
* Merge branch 'pick_n_place' of github.com:ipa-fxm/cob_manipulation into pick_n_place
* working on grasp view
* added grasptable for instanttomatosoup
* find package_paths using roslib
* Merge branch 'pick_n_place' of https://github.com/ipa-fmw-ws/cob_manipulation into pick_n_place
* add new db fruittea
* Todo added
* Merge remote-tracking branch 'origin-fxm/pick_n_place' into pick_n_place
* new structure
* objects now created dynamically from a mesh
* objects removed from scene
* fixed output for action server
* fixed naming of grasp_generation action
* removed tmp files
* added hotpot2
* new object hotpot and hotpot2
* saltcube with new preshapes
* db hotpot added, new preshapes
* first try with openrave
* first database for new meshes
* small changes
* kinbody for new meshfiles without scale
* modified to work with the new mesh files now
* database generated for transformed mesh file
* objects are now taken from cob_pick_place_action
* check if db exists for specific object before start planning with openrave
* output now a grasp list
* hardcoded paths fixed
* latest commit
* created with service call
* client can use object_id now for service calls
* moved to src
* service server call is working now
* salt xml for openrave
* salt mesh for testing
* added scene
* runs independently now
* clean up code
* README file added
* changed serice files from src to scripts
* new package for grasp_generation action
* Contributors: Jan Fischer, Witalij Siebert, ipa-fxm
```
## cob_kinematics

```
* removed a lot of code related to packages not available in hydro anymore
* added lapack to deps
* move cob_mmcontroller + groovy_updates
* fix ikfast + cleanup
* reduce solver_iterations for faster IK calculation
* update package.xml
* catkinize cob_kinematics + use kdl instead of lookat-IK + update moveit_configs
* update CMakeLists
* faster lookat_ik solver
* speedup ik by reducing solver_iterations
* lookat_ik_plugin
* NO BUILD of kinematics
* tweaked harmonization
* added bound checking to harmonization
* IK solver based on GT code
* fixed linker problems
* added ik10 ikfast plugin
* added lock_redundant_joints argument to api functions
* merge with mdl
* ikfast plugin works now
* added missing return statement
  fixed return value
* fixed init
* merge with ipa-mdl
* removed outdated components that have moveit substitutes
* export to moveit_core
* adapted ikfast_plugin to moveit interface
* switched to moveit dependencies
* cob_kinematics: remove everything from CMakeLists that won't build properly (TODOs)
* ikfast pluging are now included in cob_kinematics again
  Conflicts:
  cob_kinematics/manifest.xml
* cob_kinematics: fixed plugin path
* ikfast pluging are now included in cob_kinematics again
* cob_kinematics: fixed plugin path
* disabled IKfast plugins
* added rosdep on liblapack-dev
* temporarily not using ik-fast plugins - ToBeFixed
* disabled kinematics_node, must be upated for fuerte
* Merge remote-tracking branch 'origin-ipa-fxm/fuerte_dev' into fuerte_dev
  Conflicts: (solved)
  cob_manipulator/CMakeLists.txt
  cob_manipulator/manifest.xml
  lwa_arm_navigation/manifest.xml
* moved kinematics_node from cob_manipulator to cob_kinematics
* moved KDL plugin overlay from cob_manipulator to cob_kinematics
* ikfast: debug options
* ikfast: bug fixes
* small changes
* implemented generic searchPositionIK
* introduced auto-magic IkSolutionListFiltered..
* added JointSpaceStepper
* support for consistency limits
* desired_pose_callback checks
* implemented getPositionFK
* added URDF parsing, included IK header/ properties
* auto-format
* added license headers
* lwa solver name fixed
* fixed ikfast CMake chain
* simplified electric to fuerte wrapper
* added missing file
* little parsing bug fix
* adapted skeleton to work on electric and fuerte (hopefully)
* added skeleton for the IKfast solver plugins
* changed ur5 tip link to arm_wrist_3_link, since arm_ee_link is fixed
* added configurations and soures for lbr,lwa and ur5
* added ikfast build pipeline
* added simple urdf to openrave xml converter
* cob_ik_wapper now uses robot_state from planning_scene if available
* prepared ik_wrapper for multiple joint state sources
* enhanced IK wrapper
* FK/IK/FK test for solving to tip link at pregrasp
* fixed names parsing
* fixed IK handling
* added IK wrapper
* new kinematics package
* Contributors: Mathias Lüdtke, Witalij Siebert, ipa-fxm
```
## cob_lookat_action

```
* backup from cob3-3
* update deps
* catkinized
* generalize cob_lookat_action for various torso dofs + w/o head
* tweaking lookat_monitor
* added some output
* minor mods in cob_lookat_action + new example clients
* initial commit for cob_lookat_action - this is just conceptual at the moment
* Contributors: ipa-fxm
```
## cob_manipulation

```
* move cob_mmcontroller + groovy_updates
* preliminary catkinization mmcontroller
* catkinize cob_kinematics + use kdl instead of lookat-IK + update moveit_configs
* catkinized
* update package.xml
* started catkinizing
* Contributors: ipa-fxm
```
## cob_moveit_config

```
* fix launch files
* backup from cob3-3
* use sensor info with moveit
* next try
* next try
* fix dependencies
* update package.xml
* catkinize cob_kinematics + use kdl instead of lookat-IK + update moveit_configs
* fix parameter namespace
* started catkinizing
* update moveit_config
* update cob_moveit_configs for all cobs
* lookat_ik_plugin
* updated moveit_config for lookat
* update moveit_config
* back to pick_config
* merge with fmw-ja
* Merge branch 'groovy_dev' of https://github.com/ipa-fmw-ja/cob_manipulation into combine
* started to merge pick-n-place with lookat
* commit before getting nasty
* backup
* merge
* different robot_description for moveit
* fixed namespaces for some parameters
* integration of openrave
* test sensor input for planning_scene
* merge
* introducing cob_moveit_interface, making cob_object_handler obsolete
* new moveit config with base_placement and lookat group
* JSF: Added collision object action to add/remove from remote code
* able to plan for group base again - needs moveit_ros 0.4.4 - still missing controller for execution
* adding launchfile parameter for debugging
* using IKFast plugin - fixing pick() with grasp_list
* added controller for sdh to moveit_config
* updated launch files
* add endeffector for lookat to get interactive marker
* modified moveit_config for cob3-3 to include lookat component
* fixed controller setttings
* loaf rviz config in demo
* moved rviz launch file
* added rviz config
* moveit config for cob3-6 updated
* moveit config for cob3-3 updated
* updated srdf
* updated srdf after upper/lower arm fixup
* updated srdf
* updated SRDF
* switched to IKfast
* rviz demo with debug flag
* updated raw3-1 config
* updated groups
* updated to latest URDF changes
* fixed controller naming
* fixed controller_manager parameters
* added namespace for controller parameters
* new config for raw3-1 using universal_robot ur_description
* added initial version of plan/execute launch file
* updated launch files according to template
* added missing arg
* updated raw3-1 config
* added controller settings
* added first versions of generic launch files
* added projection evaluators
* switched back to kdl solver for raw3-1
* setup assistant launch file
* added cob_moveit_config
* Contributors: Jan Fischer, Jannik Abbenseth, Mathias Lüdtke, Witalij Siebert, ipa-fxm, rohit chandra
```
## cob_moveit_interface

```
* backup from cob3-3
* next try
* next try
* next try
* update package.xml
* catkinized
* minor changes
* example for reactive planning
* backup
* adding clear_attached_object function
* added file for testing simple_moveit_interface
* clear objects attached to arm_7_link
* merge
* introducing cob_moveit_interface, making cob_object_handler obsolete
* Contributors: Jan Fischer, ipa-fxm
```
## cob_pick_place_action

```
* Merge pull request #11 <https://github.com/ipa320/cob_manipulation/issues/11> from ipa-fxm/groovy_dev
  bring groovy updates to hydro
* use object_class to determine mesh_file in insertObject
* backup from cob3-3
* move cob_mmcontroller + groovy_updates
* pick_place now works with released version of moveit
* next try
* catkinized + fixes for changed message types
* changes in action definition + according changes in code
* multi-place upright example
* changes for multi-pick-multi-place + example
* changes for multi-pick-multi-place + example
* test place
* fixes after merge
* minor
* adapt to new action in grasp_generation
* delete obsolete files
* approach and retreat is now wrt arm_7_link
* use random in pick_client
* additional params in action (threshold,grasp_id,num_grasps) + adaptions + some improvements
* backup
* introducing ALL grasps, some debug output
* merge with ws
* show output only in debug mode
* latest r3cop status
* testing
* better approach retreat
* object position changed
* Merge branch 'pick_n_place' of https://github.com/ipa-fmw-ws/cob_manipulation into pick_n_place
* Merge remote-tracking branch 'origin-fxm/pick_n_place' into pick_n_place
* small changes in parameters
* grasp hotpot
* fixed grasp_generation action client
* added launch file for pick-n-place with grasp_generation
* Merge branch 'pick_n_place' of https://github.com/ipa-fmw-ws/cob_manipulation into pick_n_place
* db hotpot added, new preshapes
* Merge branch 'pick_n_place' of https://github.com/ipa-fmw-ws/cob_manipulation into pick_n_place
* first try with openrave
* integration of openrave
* integration of openrave
* better approach and retreat strategy
* all meshes have translation, rotation and scale applied + new objects for r3cop
* remove all setupEnvironment stuff from pick_place
* mesh with applied translation, rotation and scale
* fixed yellowsaltcube
* fixed rotation of meshes
* Merge branch 'r3_cop_pick-n-place' of github.com:ipa-fxm/cob_manipulation into pick_n_place
* fixed lookupTransform problems with tf_listener
* integration of OpenRAVE-grasp-generation + beautifying
* added missing action description
* better retreat + beautifying
* transform sdh_palm-arm7 added - still problems with lookupTransform
* fixed mergeconficts
* merge
* using cob_moveit_interface within pick-n-place
* merge
* added destination pose
* added many more objects
* pick and place python client
* use last grasp from pick within place
* implementation of place action and transform pose
* fixing insertObject using meshes
* adding new grasptables
* cleaning up
* added grasp_id field to action description
* adding meshes and grasptables for new objects
* fixing meshes scale
* introducing relative paths for grasptables - modifications in setup environment
* relative path for .xml's
* fix typo, increase planning time, use fillAllGrasps()
* RELATIVE PATH TO GRASPTABLE(XML)
* calculate approach direction wrt footprint
* find GraspTable.txt in package instead of hardcoded absolute path
* beautifying and minor improvements
* minor changes
* minor changes
* added class GraspTable for parsing GraspTables from KIT database
* adding mesh for objects from KIT database
* adding GraspTables from KIT database
* added pick action_client
* added pick action_server
* define action
* initial commit of cob_pick_place_action
* Contributors: Jan Fischer, Witalij Siebert, ipa-fxm, rohit chandra
```
## cob_tactiletools

```
* update package.xml
* catkinized
* fixed tactile filters due to message movement to schunk repository
* changed to schunk_sdh
* moved to new stack
* Contributors: LucaLattanzi, ipa-fmw, ipa-fxm
```
## cob_tray_monitor

```
* update package.xml
* catkinized
* fixed tray_monitor and added filter to it (tys)
* add missing parameter file
* add launch test
* add tray monitor package
* Contributors: ipa-fmw, ipa-fxm, ipa-mdl
```
