### PR TITLE
handle_detector: 1.0.5-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1579,11 +1579,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/atenpas/handle_detector-release.git
-      version: 1.0.5-0
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/atenpas/handle_detector.git
       version: master
+    status: maintained
   hector_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `handle_detector` to `1.0.5-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.0.5-0`
## handle_detector

```
* updated CMakeLists.txt and package.xml
* Contributors: atenpas
```
