### PR TITLE
cob_extern: 0.5.2-3 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -497,7 +497,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/cob_extern-release.git
-      version: 0.5.2-2
+      version: 0.5.2-3
     source:
       type: git
       url: https://github.com/ipa320/cob_extern.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_extern` to `0.5.2-3`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.2-2`
## cob_extern

```
* Merge branch 'hydro_dev' into hydro_release_candidate
* Update package.xml
* Contributors: Florian Weißhardt, ipa-fmw
```
## libntcan

```
* Add missing find_package calls
* Contributors: Scott K Logan
```
## libpcan

```
* Add missing rospack depends
* Add missing find_package calls
* Contributors: Scott K Logan
```
## libphidgets

```
* Add missing rospack depends
* Add missing find_package calls
* Contributors: Scott K Logan
```
