### PR TITLE
moveit_commander: 0.5.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -466,6 +466,13 @@ repositories:
       url: https://github.com/ros-gbp/message_runtime-release.git
       version: 0.4.12-0
     status: maintained
+  moveit_commander:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_commander-release.git
+      version: 0.5.6-0
+    status: maintained
   moveit_core:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_commander` to `0.5.6-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## moveit_commander

```
* Added the calls necessary to manage path constraints.
* fix joint and link acces on __getattr__  when trying to acces a joint and its paramaters throught
* Contributors: Acorn, Emili Boronat, Sachin Chitta
```
