### PR TITLE
stdr_simulator: 0.1.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5258,7 +5258,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     status: maintained
   steered_wheel_base_controller:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `stdr_simulator` to `0.1.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.1.2-0`
## stdr_gui

```
* fixed #143 <https://github.com/stdr-simulator-ros-pkg/stdr_simulator/issues/143>
* fixed #142 <https://github.com/stdr-simulator-ros-pkg/stdr_simulator/issues/142>
* fixed #125 <https://github.com/stdr-simulator-ros-pkg/stdr_simulator/issues/125>
* fixed #141 <https://github.com/stdr-simulator-ros-pkg/stdr_simulator/issues/141>
* Fixed glob in CMakeLists.txt
* Load and save robot in robot creator works
* Robot creator works with footprint points
* Zoom in GUI is now performed with mouse wheel
* Added antialiasing to robot draw in gui
* Polygon robots appear in gui as they should.
```
## stdr_launchers
- No changes
## stdr_msgs
- No changes
## stdr_parser

```
* Load and save robot in robot creator works
* Add points parsing for footprints
  This adds support for parsing a list of points for footprints:
  * Allow multiple copies of the point tag ( only used in footprints )
  * Add a parser specialization for geometry_msgs::Point
  * Parse points if they appear in a footprint
```
## stdr_resources

```
* Add more footprint files.
```
## stdr_robot

```
* Publish odometry
* Collision detection works decently with random shaped robots
* Fixed bug preventing robot from turning after collision with obstacle
* Removed robot's erroneous random collisions in obstacle-free space. #133 <https://github.com/stdr-simulator-ros-pkg/stdr_simulator/issues/133>
* Use footprint points if available.
```
## stdr_samples
- No changes
## stdr_server
- No changes
## stdr_simulator
- No changes
