### PR TITLE
yujin_ocs: 0.5.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5966,7 +5966,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/yujinrobot-release/yujin_ocs-release.git
-      version: 0.5.2-1
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/yujinrobot/yujin_ocs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yujin_ocs` to `0.5.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.2-1`
## yocs_cmd_vel_mux

```
* Added support for YAML-CPP 0.5+.
  The new yaml-cpp API removes the "node >> outputvar;" operator, and
  it has a new way of loading documents. There's no version hint in the
  library's headers, so I'm getting the version number from pkg-config.
  This part of the patch is a port of the ones created by @ktossell for
  map_server and other packages.
  The new yaml-cpp also does not have FindValue.
* Contributors: Scott K Logan
```
## yocs_controllers
- No changes
## yocs_diff_drive_pose_controller
- No changes
## yocs_math_toolkit
- No changes
## yocs_velocity_smoother
- No changes
## yocs_virtual_sensor
- No changes
## yocs_waypoints_navi

```
* Added support for YAML-CPP 0.5+.
  The new yaml-cpp API removes the "node >> outputvar;" operator, and
  it has a new way of loading documents. There's no version hint in the
  library's headers, so I'm getting the version number from pkg-config.
  This part of the patch is a port of the ones created by @ktossell for
  map_server and other packages.
  The new yaml-cpp also does not have FindValue.
* Contributors: Scott K Logan
```
## yujin_ocs
- No changes
