### PR TITLE
media_export: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -439,11 +439,20 @@ repositories:
       url: https://github.com/ethz-asl/map_msgs.git
       version: master
   media_export:
+    doc:
+      type: git
+      url: https://github.com/ros/media_export.git
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/media_export-release.git
-      version: 0.1.0-0
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros/media_export.git
+      version: indigo-devel
+    status: maintained
   message_generation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `media_export` to `0.2.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.1.0-0`
## media_export

```
* set myself (william) as maintainer
* Contributors: William Woodall
```
