### PR TITLE
visualization_tutorials: 0.9.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1089,6 +1089,28 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: indigo
     status: maintained
+  visualization_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/visualization_tutorials.git
+      version: indigo-devel
+    release:
+      packages:
+      - interactive_marker_tutorials
+      - librviz_tutorial
+      - rviz_plugin_tutorials
+      - rviz_python_tutorial
+      - visualization_marker_tutorials
+      - visualization_tutorials
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/visualization_tutorials-release.git
+      version: 0.9.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/visualization_tutorials.git
+      version: indigo-devel
+    status: maintained
   warehouse_ros:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_tutorials` to `0.9.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## interactive_marker_tutorials

```
* set myself (william) as maintainer
* Contributors: William Woodall
```
## librviz_tutorial

```
* set myself (william) as maintainer
* Contributors: William Woodall
```
## rviz_plugin_tutorials

```
* set myself (william) as maintainer
* Contributors: William Woodall
```
## rviz_python_tutorial

```
* set myself (william) as maintainer
* Contributors: William Woodall
```
## visualization_marker_tutorials

```
* set myself (william) as maintainer
* Contributors: William Woodall
```
## visualization_tutorials

```
* set myself (william) as maintainer
* Contributors: William Woodall
```
