### PR TITLE
care_o_bot: 0.5.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -320,6 +320,16 @@ repositories:
       type: git
       url: https://github.com/osrf/capabilities.git
       version: master
+  care_o_bot:
+    release:
+      packages:
+      - care_o_bot
+      - care_o_bot_robot
+      - care_o_bot_simulation
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ipa320/care-o-bot-release.git
+      version: 0.5.0-0
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `care_o_bot` to `0.5.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
