### PR TITLE
avt_vimba_camera: 0.0.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -157,6 +157,21 @@ repositories:
       url: https://github.com/ros-drivers/audio_common.git
       version: hydro-devel
     status: maintained
+  avt_vimba_camera:
+    doc:
+      type: git
+      url: https://github.com/srv/avt_vimba_camera.git
+      version: hydro
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/srv/avt_vimba_camera-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/srv/avt_vimba_camera.git
+      version: hydro
+    status: developed
   ax2550:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `avt_vimba_camera` to `0.0.1-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
