### PR TITLE
rosdep: update pydot to python2-pydot on Arch.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -669,7 +669,7 @@ python-pyassimp:
     saucy: [python-pyassimp]
     trusty: [python-pyassimp]
 python-pydot:
-  arch: [pydot]
+  arch: [python2-pydot]
   debian: [python-pydot]
   fedora: [pydot]
   gentoo:


### PR DESCRIPTION
pydot is now officially supported on Arch Linux and available in `[community]`.
