### PR TITLE
handle_detector: 1.0.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1604,7 +1604,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/atenpas/handle_detector-release.git
-      version: 1.0.5-1
+      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/atenpas/handle_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `handle_detector` to `1.0.6-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.0.5-1`
## handle_detector

```
* Merge pull request #1 <https://github.com/atenpas/handle_detector/issues/1> from cottsay/master
  Fix Fedora build errors
* Move default affordances values into source file
  I really couldn't tell you exactly why this was failing builds on 32-bit Fedora, but in any case this fixes it.
* Build message_lib only after message generation
  On faster machines, the makefile generated by cmake will thread quite a lot, and will attempt to compile messages_lib before the header files have been generated, failing the build.
  This will force make to wait for the message generation to complete.
* Contributors: Scott K Logan, atenpas
```
