### PR TITLE
vision_visp: 0.7.2-1 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4355,7 +4355,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.7.1-0
+      version: 0.7.2-1
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.7.2-1`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `0.7.1-0`
## visp_camera_calibration

```
* Merge branch 'groovy-devel' into groovy
* Fix various dependency issues in the CMakeLists.txt and package.xml files
* Merge branch 'groovy-devel' into groovy
* lipstick

  Aesthetic changes
* Add missing dependency to ViSP
* groovy-0.7.1
* Prepare changelogs
* Contributors: Fabien Spindler, Thomas Moulard
```
## visp_hand2eye_calibration

```
* Fix various dependency issues in the CMakeLists.txt and package.xml files
* Merge branch 'groovy-devel' into groovy
* lipstick

  Aesthetic changes
* Add missing dependency to ViSP
* groovy-0.7.1
* Prepare changelogs
* Contributors: Fabien Spindler, Thomas Moulard
```
## vision_visp

```
* groovy-0.7.1
* Prepare changelogs
* Contributors: Thomas Moulard
```
## visp_auto_tracker

```
* Merge branch 'groovy-devel' into groovy
* Fix various dependency issues in the CMakeLists.txt and package.xml files
* Merge branch 'groovy-devel' into groovy
* lipstick

  Aesthetic changes
* [visp_auto_tracker] Add missing dependency
* Add missing dependency to ViSP
* groovy-0.7.1
* Prepare changelogs
* Contributors: Fabien Spindler, Thomas Moulard
```
## visp_tracker

```
* Remove bullet usage and dependency by using ViSP instead. This was done to avoid errors when releasing vision_visp on oneiric/groovy where bullet is not packaged.
* Reorganize launch files and fix since viewer and client nodes where renamed due to catkin_lint errors
* Merge branch 'groovy-devel' into groovy
* Fix various dependency issues in the CMakeLists.txt and package.xml files
* Use Boost Filesystem V3.
* [visp_tracker] package.xml: add back Bullet dependency
* Merge branch 'groovy-devel' into groovy
* Add missing dependency to ViSP
* groovy-0.7.1
* Prepare changelogs
* Contributors: Benjamin Chretien, Fabien Spindler, Thomas Moulard
```
## visp_bridge

```
* Fix various dependency issues in the CMakeLists.txt and package.xml files
* Merge branch 'groovy-devel' into groovy
* Add missing dependency to ViSP
* groovy-0.7.1
* Prepare changelogs
* Contributors: Fabien Spindler, Thomas Moulard
```
