### PR TITLE
frontier_exploration: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1313,6 +1313,17 @@ repositories:
       url: https://github.com/ros-drivers/freenect_stack.git
       version: master
     status: maintained
+  frontier_exploration:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/paulbovbel/frontier_exploration-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/paulbovbel/frontier_exploration.git
+      version: hydro-devel
+    status: developed
   gazebo2rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `frontier_exploration` to `0.1.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## frontier_exploration

```
* added install target for client
* Contributors: Paul Bovbel
```
