### PR TITLE
avt_vimba_camera: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -166,7 +166,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/srv/avt_vimba_camera-release.git
-      version: 0.0.1-1
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/srv/avt_vimba_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `avt_vimba_camera` to `0.0.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.0.1-1`
## avt_vimba_camera

```
* test on polled camera
* formatting
* added packages
* added GPIO params
* added params and launchfile
* added launchfile
* added camera calibration and fixed reconfiguration issues
* first images in ROS
* first tests with Manta G-504C
* added tags to gitignore
* develop in progress
* added gitignore
* changed package name and pushed some devel
* added config file
* prepared and tested Vimba library
* first commit
* Contributors: Miquel Massot
```
