### PR TITLE
sr_ronex: 0.9.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5202,7 +5202,8 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/shadow-robot/sr-ronex-release.git
-      version: 0.9.5-0
+      version: 0.9.6-0
+    status: developed
   sr_visualization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_ronex` to `0.9.6-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.9.5-0`
## sr_ronex
- No changes
## sr_ronex_controllers
- No changes
## sr_ronex_drivers
- No changes
## sr_ronex_examples
- No changes
## sr_ronex_external_protocol
- No changes
## sr_ronex_hardware_interface
- No changes
## sr_ronex_launch
- No changes
## sr_ronex_msgs
- No changes
## sr_ronex_test

```
* Call catkin_package in sr_ronex_test by default
```
## sr_ronex_transmissions
- No changes
## sr_ronex_utilities
- No changes
