### PR TITLE
sr_config: 1.3.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5180,11 +5180,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/shadow-robot/sr-config-release.git
-      version: 1.3.0-1
+      version: 1.3.3-0
     source:
       type: git
       url: https://github.com/shadow-robot/sr-config.git
       version: hydro-devel
+    status: maintained
   sr_ronex:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_config` to `1.3.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.3.0-1`
