### PR TITLE
frontier_exploration: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1314,11 +1314,15 @@ repositories:
       version: master
     status: maintained
   frontier_exploration:
+    doc:
+      type: git
+      url: https://github.com/paulbovbel/frontier_exploration.git
+      version: hydro-devel
     release:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/paulbovbel/frontier_exploration-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/paulbovbel/frontier_exploration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `frontier_exploration` to `0.1.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.1.0-0`
## frontier_exploration

```
* fix build dependency
* eliminate redundant move_base goal updates, fix locking
* externalize static for geometric calculations
* refactor action server with callbacks
* fix pre-emption with continuous goal updating
* implement continuous frontier/goal updating
* Contributors: Paul Bovbel
```
