### PR TITLE
rtt_geometry: removed deleted packages rtt_kdl_conversions and kdl_lua

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4857,9 +4857,7 @@ repositories:
     release:
       packages:
       - eigen_typekit
-      - kdl_lua
       - kdl_typekit
-      - rtt_kdl_conversions
       - rtt_tf
       tags:
         release: release/hydro/{package}/{version}


### PR DESCRIPTION
...to prepare release of rtt_ros_integration
bloom otherwise refuses to create a pull request due to duplicate package names.
