### PR TITLE
rtt_ros_integration: 2.7.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4882,29 +4882,37 @@ repositories:
       - rtt_common_msgs
       - rtt_diagnostic_msgs
       - rtt_geometry_msgs
+      - rtt_kdl_conversions
       - rtt_nav_msgs
       - rtt_ros
       - rtt_ros_comm
       - rtt_ros_integration
+      - rtt_ros_tests
+      - rtt_rosclock
       - rtt_roscomm
+      - rtt_roscomm_tests
       - rtt_rosgraph_msgs
       - rtt_rosnode
       - rtt_rospack
+      - rtt_rospack_tests
       - rtt_rosparam
       - rtt_sensor_msgs
       - rtt_shape_msgs
       - rtt_std_msgs
       - rtt_std_srvs
       - rtt_stereo_msgs
+      - rtt_tf
       - rtt_trajectory_msgs
       - rtt_visualization_msgs
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_ros_integration-release.git
+      version: 2.7.0-1
     source:
       type: git
       url: https://github.com/orocos/rtt_ros_integration.git
       version: hydro-devel
+    status: developed
   rtt_typelib:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_ros_integration` to `2.7.0-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
