### PR TITLE
rtt_geometry: 2.7.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4866,10 +4866,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_geometry-release.git
+      version: 2.7.0-1
     source:
       type: git
       url: https://github.com/orocos/rtt_geometry.git
       version: hydro-devel
+    status: developed
   rtt_ros_integration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_geometry` to `2.7.0-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
