### PR TITLE
zeroconf_msgs: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1163,6 +1163,11 @@ repositories:
       type: git
       url: https://github.com/stonier/zeroconf_msgs.git
       version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/zeroconf_msgs-release.git
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/stonier/zeroconf_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zeroconf_msgs` to `0.2.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
