### PR TITLE
cob_robots: 0.5.1-4 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -593,7 +593,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.5.1-3
+      version: 0.5.1-4
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.5.1-4`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.1-3`
## cob_bringup

```
* fix for catkin_make_isolated
* some install tag updates
* merge
* merge with groovy_dev
* Fixed small typo
* setup tests
* move rviz config to robot folder
* changed ns
* renamed phidgets.lauch to tray_sensors.launch and added launch and config files for real phidget driver
* seperated gripper launch file
* New structure
* merge with groovy_dev_cob4 + use hydro configurations for controller
* updates for raw3-1
* renamed canopen files
* merge with ipa-nhg
* created driver generic launch files
* created driver generic launch files
* New cob_controller_configuration_gazebo structure
* New structure cob repositories (cob_controller_configuration_gazebo)
* New struture for cob repositories
* tested on robot
* cob4 integration
* added laserscanners to launch file and added frida to raw3-3 urdf
* readded frida urdf
* change install path for hydro
* removing cob3-5b
* Merge pull request #9 <https://github.com/ipa320/cob_robots/issues/9> from ipa-fxm/groovy_dev
  bring groovy updates to hydro
* Bugfix to pass missing pkg_hardware_config parameter to joy.launch file
* cob3-6 update
* update cob3-6 config
* Fix tray powerball positions
* fix diagnostics and cob3-5b launch
* delete vacuum cleaner
* deactivated wifi diagnosis
* added vacuum cleaner launch files
* setup for lwa4d arm on cob3-5b, correction of calibration entries in cob3-5
* Cepstral mode sound
* added cob3-5b and adjusted default calibration of cob3-5 to good values
* bring in groovy updates
* adjust config for cob3-7
* kinect with registration and z_offset
* merge with ipa320-groovy_dev
* depth offset in parameter -- not used right now
* add arg to ur.launch
* merge
* set localhost in ur_solo
* set localhost in robot.xml
* Renamed ur_connector
* update cob3-7
* ur_connector launch and yaml files
* canopen launch and yaml files for torso and tray
* Update cob3-7
* merge with uncommited local_robot
* Update cob3-7
* canopen launch file
* new torso and tray for cob3-3
* update cob3-7
* Changed package and node for LMS100 laser.
* Corrected launch file.
* start relayboard in simulation
* start relayboard in simulation
* relayboard needs to be started in sim mode
* added right camera and pc aggregators
* removed wifi monitor and mounted ur10 on robot again, not tested in gazebo yet
* changed ip and added tf2
* changed env config to work for hydro
* added remapping to /joint_states
* startup phidget board
* fixed tab and spaces inconsistency
* ur instead of ur10
* replaced ur5 and ur10 with ur
* Rename ur10.launch to ur.launch
* Delete ur5.launch
* Merge branch 'groovy_dev' of github.com:ipa320/cob_robots into review320_catkin
* add parameters timeout for undercarriage_ctrl and min_input_rate for cob_base_velocity_smoother
* added prace gripper launch file
* New launch files for PRL+ 80 , torso and tray
* Installation stuff
* extend tests to cob3-7, raw3-5 and raw3-6
* Merged with now rostest catkin looping, which Florian put upstream
* fix launch tests
* add roslaunch tests
* change way the env.sh is resolved for custom env.sh settings
* Initial catkinization.
* update on cob3-5
* update for cob3-4
* Parameters and launch files for cob3-7
* disabled failing tests
* Merge pull request #91 <https://github.com/ipa320/cob_robots/issues/91> from ipa-cob3-5/groovy_dev
  cob3-5 updates
* fix launch file
* Merge branch 'groovy_dev' of github.com:ipa-cob3-5/cob_robots into groovy_dev
* fix powerball launch file for tray
* add tray sensors to cob3-5 and rename phidgets.yaml to tray_sensors.yaml
* add voltage filter
* adapt sdh config to driver update
* Merge branch 'groovy_dev' of github.com:ipa-cob3-5/cob_robots into groovy_dev
* Added powerball tray
* Merge branch 'groovy_dev' of github.com:ipa-cob3-3/cob_robots into groovy_dev
* fixes for cob3-3
* fix
* correct launch of frida driver
* use full name for voltage filter
* change to festival due to installation problems with cepstral
* add respawn to sdh because it crashed when pressing emergency stop
* specify image and depth mode for kinect
* add voltage filter to each robot
* add cam3d throttle node to cob3-6
* separated sdh and dsa into two launch files
* add new voltage filter to cob3-6
* added launch file for frida
* adjust tray sensors for cob3-6
* Groovy- add rviz configuration
* fixed renaming bug for raw3-6
* cob needs the relayboard in normal mode
* mrege
* filename for uploading navigation goals is now taking into account update default_env_config structure in cob_environments
* fixed filename for uploading navigation_goals
* corrections due to 3 and not 2 pc in raw3-3
* modifications for icra2013
* fix in raw3-6 launch
* added new robot raw3-6
* using args instead of env variables in launch files
* Fixed simulation error for raw3-1
* changes for icra
* fixed cob_base_velocity_smoother params upload and namespace
* start relayboard in sim mode on raw3-5
* fixes for bringup raw3-5
* modified raw3-5 launch file
* added launch file for lms100 laser front
* groovy migration
* startup laserscanners on raw3-5
* added launch files for lms100
* added missing ur10.launch
* added raw3-5
* rename dependency to ur_
* Removing shutdown scripts
* Adjustments to the voltage filter
* ur5_driver -> ur_driver; ur5_description -> ur_description
* switched from ur5 to ur10
* Reverted some changes
* added missing parameter
* Updated .xml files in Groovy
* rename launch file in default_env_confg
* Updated machine tags in .xml files
* Merge pull request #63 <https://github.com/ipa320/cob_robots/issues/63> from ipa-nhg/groovy_dev
  New branch groovy_dev
* Merge branch 'groovy_dev' of github.com:ipa320/cob_robots into groovy_dev
* fixed light_controller bringup
* enable kinect depth registration by default
* separate sdh launch
* Revert "removed old packages"
  This reverts commit 23901cb1317a8ae8d477d22ad80f8efd986d9eae.
* removed old packages
* Groovy migration
* Groovy migration
* add cam3d_throttle to cob3-5
* update deps
* removed image_flip because it is not generic for all robots
* moved to cob_cam3d_throttle package in cob_perception_common
* add arg for nodelet manager
* set default val for data_skip to 2, added image flip
* fix launch syntax
* added data_skip with max value (10)
* adapted for new openni driver
* deavtivate launch tests for cob3-1.xml due to electric incompatible machine tag attribute 'env-loader'
* add launch arg sim to light controller
* add raw3-3 and raw3-4 to brinup tests
* added launch arg sim to relayboad instead of having two launch files
* add monitors and set sound to cepstral
* allow multiple teleop and joy nodes
* Merge branch 'master' of github.com:b-it-bots/cob_robots
* do not launch kinect
* reduce throttle frequency
* fixed remote launch of nodes for ros fuerte
* fixed launch file
* add default values to be able to launch the node in a standalone fashion
* fixes for cob3-1
* add second kinect launch file
* include cob_lbr  and pc monitor for pc2
* update right pike to use new calibration_data repo
* moved launch files of cameras to right folder
* update hardware parameters for cob3-1 and ros fuerte
* added service interface to lbr
* using cepstral by default for cob3-6
* add arguments to cam3d_throttle launch file
* Added kinect
* added additional topics
* added param, fixed syntax error
* Merge branch 'master' of github.com:ipa320/cob_robots
* added cam3d throttle
* hwboard updated
* comment ntp monitor
* add battery and emergency monitor for cob3-6
* Merge branch 'master' of github.com:ipa320/cob_robots
* comment out tray for cob3-6
* disabled wifi-monitor on cob3-6
* changes to include tray_powerball
* add hard disk monitor
* use cepstral by default for cob3-3
* update deps
* separate monitoring
* add monitoring to cob3-3
* pkg_env_config can be set in robot.launch
* hwboard updated
* Changed from reboot to halt
* Idea for the shutting down script
* hwboard added
* updated hwboard
* updated hwboard
* startup cpp light node instead of python node
* added hwboard
* raw3-4 settings
* startup lightnode with cob_bringup
* startup lightnode with cob_bringup
* added relayboard message based on phidget
* added cob_voltage_control to bringup
* added launch files for battery board
* settings for raw3-4
* move relayboard back to pc1
* xml mismatch for doubled laser_top include
* add arg to laser_top
* fixes for raw3-1 config
* remove env config reference
* merged with restructured launch files
* merge with ipa320
* add hokuyo config for scan filter
* support torso names in joystick, add prefix to ur5
* upload default robot config in solo launch files
* new pc names on raw3-1 and working torso config for new urdf
* testing of hardware_test on cob3-3
* missing conf files for raw3-1
* Moved light to pc3
* beautifying
* fix naming of ROBOT to ROBOT_ENV
* warning for no ROBOT or ROBOT_ENV set
* move light to pc1
* fix test definitions
* substitute env ROBOT with arg robot
* substitute env ROBOT with arg robot
* substitute env ROBOT with arg robot
* merged with new fxm version
* merged
* changes from automatica
* removed wifi monitor
* add pc monitor config for all robots
* adjust pc_monitor diagnostics for different cores
* merge
* config update for cob3-6
* Merge branch 'master' of github.com:ipa320/cob_robots
* launch files testing possible again
* move sound and light to pc3
* remove cwd=node
* Added kinect.launch in cob3-2.xml
* Merge branch 'master' of github.com:ipa320/cob_robots
* Merge branch 'master' of github.com:ipa320/cob_robots
* add tests for cob3-5
* added pkg_hardware_config, pkg_robot_config and pkg_env_config args to launch files in cob_robots
* merge with ipa-fxm-lc
* Merge branch 'master' of github.com:ipa-fmw/cob_robots
* added pkg_hardware_config, pkg_robot_config and pkg_env_config args to launch files in bringup
* updates for cob3-2
* add safe base controller to base_solo.launch
* fix paths to point to calibration_data
* move tests to hardware_test package
* Merge branch 'master' of github.com:ipa-fmw-ms/cob_robots into max
* cleanup bringup launch files
* allow individual buttons for command gui
* bringup test for desire
* tray test working on robot
* added simulated tray sensors to simulation
* New configuration parameters and calibration  for cob3-2
* Merge pull request #22 <https://github.com/ipa320/cob_robots/issues/22> from ipa-nhg/master
  Fixed some parameter mistakes and merge conflict
* Fixed errors in cob3-6.xml, the definition of the machine names were wrong
* Fixed errors in cob3-6.xml, the definition of the machine names were wrong
* Setup xml file for desire
* Update launch file of desire as launch+xml
* merge
* add basic config and tests for cob3-1
* beautify
* testing for ipa-apartment
* Merge branch 'master' of github.com:ipa-fmw/cob_robots
* do not load default configuration  in dashboard launch file but in bringup launch file
* use ROBOT environment variable for wifi monitor
* wifi diagnostics monitor
* Desire configuration parameters
* merge
* merge error
* merge
* cob3-6 bringup files
* cob3-6 calibration parameters
* cob3-6 bringup file update
* add default rviz config
* fix typo in machine tags
* rename safety topic to safe
* add tests for cob3-6
* remove empty line
* merged with 320
* Merge branch 'master' of github.com:ipa320/cob_robots
* Light config
* integration of base_velocity_smoother_param.yaml files and update of base.launch
* update deps
* apply bringup launch changes to all robots
* restructure bringup launch files tested on cob3-3
* restructure bringup launch files to use args --> better testing possible, needs to be tested on hardware
* changes before shipping raw3-1
* Fixed merge conflict
* add collision_observer
* move camera ip adresses to hardware config
* first version of raw3-2 config
* almost final raw3-1 hardware setup
* merge
* defaut arg to localhost
* add cpu diagnostics
* add cpu diagnostics
* add raw3-1 specific collision_velocity_filter_params, footprint_observer_params, local_costmap_params
* add missing dependencies and update stack.xml
* move launch and config files to cob_robots
* commit hardware configuration files for cob3-2
* config files for light in cob_hardware_config
* Included in the bringup light.launch on pc3
* Included in the bringup light.launch on pc3
* added hztest_all.test
* added right_prosilica.test
* added left_prosilica.test
* added laser_top.test
* added laser_rear.test
* added kinect.test
* added hztest_all.test
* added laser front test
* modifications on robot with ur5 arm
* configurations from raw3-1 robot
* add some configuration for cob3-1
* Merge remote branch 'origin-ipa320/master' into automerge
* adapt roslaunch checks
* Merge remote branch 'origin-ipa320/master' into automerge
* fix for raw
* manifest.xml
* filled manifest
* update stack
* teleop with safe base movements
* integrate safe velocity controller by default
* change kinect frame namespace
* fix cob3-2 commit
* fix cob3-2 mergerequest
* cob3-2 updates
* remap for usage of cob_collision_velocity_filter
* fixed laserscanner for icob
* add tests for cob3-4
* move sound to pc3
* fix laser
* fix laser remapping
* include upload_param for env_config (nav goals for base)
* moved camera calibration yaml files from config to calibration folder
* new launch file for rviz and config file
* remove dep to cob_lbr
* setup cob3-4
* cob_scan filter: using multiple scan_ranges given in RAD
* cob_scan_filter
* simplify launch file
* parameters for left and right prosilica camera separeted from intrinsics calibration
* made sdh respawn again
* added diagnostic aggregator for actuator monitoring
* sick_s300 yaml files to be used with new scan-filter
* changed name of cob_dashboard to cob_commmand_gui
* remove diagnostics test
* using hardware_config
* lbr working on robot again
* remove machine files
* update stack
* merge
* fix robot bringup
* lbr config
* added launch tests
* fix test
* Merge remote branch 'origin-ipa-goa/master' into automerge
* changed teleop launch location
* added stereo namespace
* move tools
* modifications for tray and torso config to support new powercube chain structure
* added lbr launch files
* add trajectory controller to torso
* base and teleop running
* added camera config
* add dependency to cob_default_env_config
* update stack
* deactivate robot test due to hostnames which can not be resolved
* added default_env_config
* added teleop and diagnostics
* launch file for cob3-3
* using inifiles from hardware_config
* update stack
* moved cob_config to cob_hardware_config
* added bringup for cob3-3
* bringup started
* moved bringup to robots stack
* Contributors: Alexander Bubeck, Denis Štogl, Florian Weisshardt, Florian Weißhardt, Jannik Abbenseth, Nadia Hammoudeh García, Richard Bormann, Thiago de Freitas, Your full name, abubeck, calibration, cob3-1-pc1, cob3-1-pc2, cob3-2 admin, cob3-5, cpc-pk, fmw-ms, ipa-bnm, ipa-cob3-3, ipa-cob3-4, ipa-cob3-5, ipa-cob3-6, ipa-cob3-7, ipa-fmw, ipa-fmw-ms, ipa-fmw-sh, ipa-frm, ipa-fxm, ipa-goa, ipa-jsf, ipa-mdl, ipa-mig, ipa-nhg, ipa-raw3-3, ipa-tys, ipa-uhr-eh, ipa-uhr-fm, ipa320, ipa320-cob3-6, raw3-1 administrator, robot, unhelkar
```
## cob_controller_configuration_gazebo

```
* Merge pull request #155 <https://github.com/ipa320/cob_robots/issues/155> from ipa-nhg/hydro_dev
  install tags
* install tags
* fix for catkin_make_isolated
* merge
* missing dependencies
* merge with groovy_dev
* setup tests
* fix desire dual sdh
* add tray sensors to simulation
* fix simulated cam3d topics
* fix rviz soft links
* fix diagnostics in simulation
* restructuring joint_state_controller and simulated tray_sensors
* Merge pull request #12 <https://github.com/ipa320/cob_robots/issues/12> from ipa-fxm/groovy_dev
  bring groovy updates to hydro
* added default value for arg robot for ros launch file checks
* fixed typo
* fixes while testing in simulation
* fix inclusion of joint_state_controller
* New structure
* merge with groovy_dev_cob4 + use hydro configurations for controller
* some more fixes due to restructuring
* update CMakeLists
* added fake topics for diagnostics
* removed obsolete file
* create a generic gazebo controller
* Tested on simulation
* New cob_controller_configuration_gazebo structure
* Added arm configuration for cob4
* gazebo controllers for cob4
* New structure cob repositories (cob_controller_configuration_gazebo)
* cob4 integration
* removed a lot of code related to packages not available in hydro anymore
* optimize torso controller
* better values for head_controller
* restructure and optimize gazebo controllers
* updating cob_controller_configuration_gazebo
* cleaning up
* bring in groovy updates
* merge with ipa320-groovy_dev
* changes for simulation
* launch file for lbr_solo
* gazebo controllers for cob3-7
* no more dependency to pr2_controller_manager
* update cob3-7
* Merge branch 'groovy_dev' of github.com:ipa320/cob_robots into review320_catkin
* modifications for new controller stucture, this is not working yet
* Installation stuff
* extend tests to cob3-7, raw3-5 and raw3-6
* Merged with now rostest catkin looping, which Florian put upstream
* fix launch tests
* add roslaunch tests
* use default robot arg
* separate sim launch files and enable diagnostics for sim
* Initial catkinization.
* readded prace gripper_controllers to launch file
* fixed faulty launch file argument 'sim'
* added launch for prace gripper controller
* removed gripper controller
* added new robot raw3-6
* Fixed simulation error for raw3-1
* added raw3-5
* added raw3-1 torso_controller configuration and launch files for gazebo simulation
* changed raw3-3 description and configs for abb frida
* Revert "removed old packages"
  This reverts commit 23901cb1317a8ae8d477d22ad80f8efd986d9eae.
* removed old packages
* add scan filter for hokuyo
* merge
* add tests for raw3-3 and raw3-4
* reorderd simulated sdh joints to match order on real robot
* fix gazebo controllers
* fixed trajectory controller for simulated cob3-6
* Urdf and parameter files for tray_powerball
* merge with ipa320
* fix launch arg handling
* substitute env ROBOT with arg robot
* add cob3-5 arm_controller
* add tests for cob3-5
* added pkg_hardware_config, pkg_robot_config and pkg_env_config args to launch files in cob_robots
* introducing raw3-3 with frida_arm
* add light by default
* added simulated tray sensors to simulation
* New sdh contoller parameters for desire gazebo model
* Desire configuration parameters
* move sound and collision observer
* add controllers for cob3-6
* add tests for cob3-6
* changed controller to support new follow joint trajectors action
* add raw3-2 test
* use relayboard_sim from cob_bringup
* cleanup manifest
* modifications for upstream ur5_description
* move launch and config files to cob_robots
* small tuning for gazebo
* modified joint names of controller configuration
* urdf structure change: tray can be calibrated now
* add some configuration for cob3-1
* moved simulated tactile sensors to schunk repository
* renamed icob to raw and merged and cleaned up lots of things
* preserve history for cob_controller_config_gazebot
* Contributors: Alexander Bubeck, Daniel Mäki, Florian Weisshardt, Florian Weißhardt, Jannik Abbenseth, Lucian Cucu, Mathias Lüdtke, abubeck, ipa-bnm, ipa-fmw, ipa-fmw-ms, ipa-fxm, ipa-mig, ipa-nhg
```
## cob_default_robot_config

```
* fix for catkin_make_isolated
* merge with groovy_dev
* setup tests
* fix desire dual sdh
* fixes while testing in simulation
* updates for raw3-1
* Added arm configuration for cob4
* gazebo controllers for cob4
* New structure cob repositories (cob_controller_configuration_gazebo)
* cob4 integration
* removing cob3-5b
* adapt tray posiitons
* Fixed tray powerball
* Fix tray powerball positions
* added vacuum cleaner launch files
* added some arm and torso positions for cob3-5b, fixed upload script refernce error to cob3-5
* setup for lwa4d arm on cob3-5b, correction of calibration entries in cob3-5
* added cob3-5b and adjusted default calibration of cob3-5 to good values
* adjust config for cob3-7
* merge with ipa320-groovy_dev
* gazebo controllers for cob3-7
* Update cob3-7
* Update cob3-7
* yaml files for canopen components
* update cob3-7
* Merge branch 'groovy_dev' of github.com:ipa320/cob_robots into review320_catkin
* Installation stuff
* extend tests to cob3-7, raw3-5 and raw3-6
* Merged with now rostest catkin looping, which Florian put upstream
* update tray positions for cob3-5
* fix launch tests
* add roslaunch tests
* Initial catkinization.
* update on cob3-5
* deleted files
* Parameters and launch files for cob3-7
* Added powerball tray
* add new voltage filter to cob3-6
* new joint configurations for frida
* adapt tray configs to new tray_powerball urdf
* added joint configurations yaml for raw3-3
* added new robot raw3-6
* new arm configs
* added raw3-5
* new default arm configuration for ur10
* fix torso joint names
* Updated .xml files in Groovy
* better default arm joint configuration
* changed raw3-3 description and configs for abb frida
* Revert "removed old packages"
  This reverts commit 23901cb1317a8ae8d477d22ad80f8efd986d9eae.
* removed old packages
* add raw3-3 and raw3-4 to brinup tests
* adapt arm configurations for cob3-5
* changed back previous changes
* adapt head parameters for cob3-1
* opt env for ROBOT
* moved launch files of cameras to right folder
* update hardware parameters for cob3-1 and ros fuerte
* add arm settings to cob3-6
* inserted configuration for blue color
* Added init and recover buttons in command_gui for arm
* beautify
* new joint configs for cob3-6
* remove not readable tray positions
* reduced number of tray joint goals and button for cob3-6
* updated safe arm goal
* adapted tray positions
* changes to include tray_powerball
* removed comamnd gui buttons
* raw3-1 torso calibration
* fixed light configuration
* fixed typo
* settings for raw3-4
* Merge branch 'master' of github.com:ipa320/cob_robots
* rename eyes to head
* add sdhmount position for all lbr robots
* new sdh_mount arm_joint_configuration on dashboard
* some simple arm_joint_configs for testing
* merge with ipa320
* fix tray position for lbr
* missing conf files for raw3-1
* merged on raw3-1
* robot specific changes for raw3-1
* config for cob3-1 simulation
* change desire arm_left and arm_right
* substitute env ROBOT with arg robot
* modified joint_config for overtray so that they hold joint_limits (soft_limit)
* fix syntax
* unify robot configs
* cleanup robot config for cob3-2 and cob3-5
* remove arm settings
* removed wrong configurations
* fixed joint_names for raw3-1
* add tests for cob3-5
* add default robot config for cob3-5
* use robot name directly, not env  ROBOT
* adjust light parameters for all robots
* adjust light parameters
* Updated desire config files
* setup the default robot configuration for desire
* add basic config and tests for cob3-1
* add cob3-1 upload_param.launch
* Desire configuration parameters
* merge with ipa320
* add default_robot_config for cob3-6
* add tests for cob3-6
* add raw3-2 test
* apply bringup launch changes to all robots
* changes before shipping raw3-1
* Merge branch 'master' of https://github.com/abubeck/cob_robots into abubeck
* changed for cameras on raw3
* almost final raw3-1 hardware setup
* reduced teleop config
* fix for init_all and recover_all
* Merge branch 'master' of git://github.com/abubeck/cob_robots into review-aub
* modifications for new universal robot driver
* new nav_positions, new_arm_configurations
* fix base stop
* some new joint_poses for raw_exhibitioin
* corrected raw3-1s arm joint configurations, suffix arm was missing
* add raw3-1 specific collision_velocity_filter_params, footprint_observer_params, local_costmap_params
* stop for base working
* urdf structure change: tray can be calibrated now
* changes to work with raw3
* modifications on robot with ur5 arm
* add some configuration for cob3-1
* adapt roslaunch checks
* renamed icob to raw and merged and cleaned up lots of things
* update stack description
* cob3-2 with schunk lwa
* cob3-2 update, calibration and urdf file
* cob3-2 updates
* fixed laserscanner for icob
* add tests for cob3-4
* setup cob3-4
* changed name of cob_dashboard to cob_commmand_gui
* front_left, front_right, back_left, back_right fixed. right and left were interchanged...
* move default robot config
* Contributors: Alexander Bubeck, Daniel Mäki, Felix Messmer, Florian Weisshardt, Florian Weißhardt, Jannik Abbenseth, Mathias Lüdtke, Richard Bormann, abubeck, cob3-1-pc1, cob3-2 admin, cob3-5, cob_hardware_test, ipa-bnm, ipa-cob3-3, ipa-cob3-5, ipa-cob3-6, ipa-cob3-7, ipa-fmw, ipa-fmw-ms, ipa-fmw-sh, ipa-fxm, ipa-mdl, ipa-nhg, ipa-tys, robot
```
## cob_hardware_config

```
* fix desire dual sdh
* set fixed frame to base_link
* fix rviz soft links
* move rviz config to robot folder
* adjust rviz config
* renamed phidgets.lauch to tray_sensors.launch and added launch and config files for real phidget driver
* base is at pcan0 connected
* fixes while testing in simulation
* update xacro file format
* merge with groovy_dev_cob4 + use hydro configurations for controller
* updates for raw3-1
* addedd missing light parameters
* added missing epsilon parameter
* renamed canopen files
* Tested on simulation
* New cob_controller_configuration_gazebo structure
* Merge pull request #141 <https://github.com/ipa320/cob_robots/issues/141> from ipa-bnm/fix/raw3-3_bringup
  raw3-3 bringup fixes
* Rename scanners rules
* gazebo controllers for cob4
* New structure cob repositories (cob_controller_configuration_gazebo)
* type error fixed
* New struture for cob repositories
* tested on robot
* cob4 integration
* Merge branch 'groovy_dev' of https://github.com/ipa320/cob_robots into fix/raw3-3_bringup
* removed unused file
* changed encoder counts
* added laserscanners to launch file and added frida to raw3-3 urdf
* added camera holder
* removed a lot of code related to packages not available in hydro anymore
* New cob3-3 calibration
* remove offsets for torso
* removing cob3-5b
* Merge pull request #9 <https://github.com/ipa320/cob_robots/issues/9> from ipa-fxm/groovy_dev
  bring groovy updates to hydro
* Updated urdf of raw3-1 in cob_hardware_config regarding latest IMU-brick mount on raw3-1
* setup tray configutarion
* Fixed tray powerball
* cob3-6 update
* update cob3-6 config
* adapt calibration
* Fix tray powerball positions
* fix diagnostics and cob3-5b launch
* fixed little number mistake
* added vacuum cleaner launch files
* setup for lwa4d arm on cob3-5b, correction of calibration entries in cob3-5
* copied cob3-5 default config to cob3-5b
* added cob3-5b and adjusted default calibration of cob3-5 to good values
* added teachin handle link
* fix default ref vaues for cob3-5
* update xmlns + beautifying
* bring in groovy updates
* beautifying + slight changes in lookat component
* harmonize with cob structure
* add lookat to all cobs + some fixes in calibration values
* fixing names for cob3-5
* adjust config for cob3-7
* fixed naming error + update structure for all raw's
* 3DOF Tray for cob3-5
* Merge branch 'stable' of github.com:ipa-fmw-ja/cob_robots into lookat
* add lookat component to cob3-3
* cob3-7 new structure with new values
* updated values for cob3-7
* merge with ipa320-groovy_dev
* changes for simulation
* merge 320 with ja
* cam_reference and cam_l differ
* component macro deleted. not supported by xacro
* new better default calibration
* merge
* Renamed ur_connector
* ur_connector launch and yaml files
* canopen launch and yaml files for torso and tray
* Update cob3-7
* merge with uncommited local_robot
* Update cob3-7
* offset of lbr in calibration
* had to flip the laser scans for new udev script
* merge with canopen
* yaml files for canopen components
* merge ipa320/groovy_dev
* Merge branch 'groovy_dev' of https://github.com/ipa-cob3-7/cob_robots into groovy_dev
* Merge branch 'groovy_dev' of https://github.com/ipa-cob3-7/cob_robots into groovy_dev
* update cob3-7
* update cob3-7
* Updated Can configuration for raw3-5.
* Updated lasers configuration for raw3-5.
* move raw calibration
* moved default calibration
* Solved xacro warning in hydro.
* consider left and right arm inside dynamic footprint
* changed homeing switch port for one elmo
* base is connected on pcan0
* attached boxgripper to ee_link
* prosilica config
* added right camera and pc aggregators
* removed wifi monitor and mounted ur10 on robot again, not tested in gazebo yet
* changed prosilica parameters for faster image processing
* Merge branch 'groovy_dev' of github.com:ipa-bnm/cob_robots into groovy_dev
* encoder offsets
* changed homeingdigin port for steer3 because default port on elmo is broken
* fixed yaml file syntax error
* changed urdfs to new base_long and base_short structure, cleaned up all raw's
* change to ur_description
* Merge branch 'review320_catkin' into hydro_dev
* Merge branch 'groovy_dev' of github.com:ipa320/cob_robots into review320_catkin
* modifications for new controller stucture, this is not working yet
* add parameters timeout for undercarriage_ctrl and min_input_rate for cob_base_velocity_smoother
* cleanup
* New launch files for PRL+ 80 , torso and tray
* cleaup
* Installation stuff
* extend tests to cob3-7, raw3-5 and raw3-6
* Merged with now rostest catkin looping, which Florian put upstream
* fix launch tests
* add roslaunch tests
* separate sim launch files and enable diagnostics for sim
* remove deprecated relayboard parameters
* Initial catkinization.
* update voltage foilters
* update rviz config
* update on cob3-5
* update for cob3-4
* flipped directories
* temporary fix for calibration_data
* moved default calibration to cob_hardware_config for cob3-3
* deleted files
* Parameters and launch files for cob3-7
* New platform dimensions
* New offsets
* disabled failing tests
* New diagnostics analyzers parameters for desire
* fix cob3-5 urdf for head
* fix powerball launch file for tray
* add tray sensors to cob3-5 and rename phidgets.yaml to tray_sensors.yaml
* remove deprecated rviz config
* fix frame_ids for cameras
* adapt sdh config to driver update
* added canopenmaster config file
* Merge branch 'groovy_dev' of github.com:ipa-cob3-5/cob_robots into groovy_dev
* Added powerball tray
* fixes for cob3-3
* add voltage filter to each robot
* Yaml file for the voltage filter
* merge origin320
* laser configs
* platform ctrl offset
* remove tray and dsa from diagnostics
* adjust tray sensors for cob3-6
* Update rviz config
* Groovy- add rviz configuration
* added adapter plate for frida
* Merge branch 'automerge' into electric_dev
* replace all hardcoded mounting values with respective macros in cob_calibration_data
* replace all hardcoded mounting values with respective macros in cob_calibration_data
* mrege
* new tower description
* new tower description
* some fixes in urdf.xacro for raw3-1
* adapted platform dimensions
* removed gripper
* clean up code
* Merge branch 'groovy_dev' of git://github.com/ipa-raw3-1/cob_robots into groovy_dev
* modifications for icra2013
* encoder offsets for raw3-6
* fixed number of pc cores
* added new robot raw3-6
* added pc_monitor yaml for raw3-5
* Merge pull request #73 <https://github.com/ipa320/cob_robots/issues/73> from ipa-nhg/groovy_dev
  Added ur10 to raw3-1 urdf model
* changes for icra
* adapted raw3-5s platform ctrl ini
* modified footprint dimensions
* use urdf from short base
* modified footprint observer params for raw3-5
* proper laserscanner configuration for lms100
* adapted diagnostics_analyzers config
* torso mount position can now be parameterized within calibration_data
* added raw3-5
* rename dependency to ur_
* fixed gripper position
* Merge branch 'groovy_dev' of https://github.com/ipa-bnm/cob_robots into groovy_dev
* calibration data for arm mount position
* Adjustments to the voltage filter
* ur5_driver -> ur_driver; ur5_description -> ur_description
* fixed raw3-1s teleop config
* fixed raw3-1s teleop config
* Merge branch 'groovy_dev' of github.com:ipa320/cob_robots
* Analyzer mods
* merge
* switched from ur5 to ur10
* Added ur10 from univeral_robot package to raw3-1 description
* add parameter publish_frequency to scanner yaml files; remove swp file
* new parameters for light configuration
* Updated .xml files in Groovy
* Merge pull request #67 <https://github.com/ipa320/cob_robots/issues/67> from ipa-fmw/master
  add diagnostics to sound and rename launch files
* Merge pull request #69 <https://github.com/ipa320/cob_robots/issues/69> from ipa-fmw/master
  add diagnostics to sound and rename launch files
* add sound to diagnostics
* no arm_ee_link in frida_description
* Merge branch 'master' into merge
* remove --cov
* Added ur10 to raw3-1 urdf model
* parameter updates for all robots after velocity_smoother-rework
* modified raw3-3s light paramas
* increase circumscribed_threshold for collision velocity filter
* add dsa diagnostics
* separate sdh launch
* changed diagnostic analyzers config, so that diagnostics work together with abb frida on raw3-3
* readded boxgripper on raw3-1 description
* changed raw3-3 description and configs for abb frida
* Revert "removed old packages"
  This reverts commit 23901cb1317a8ae8d477d22ad80f8efd986d9eae.
* removed old packages
* Merge branch 'stable'
* new reference for head due to change in cob_common
* merge
* Included Schunk colors in robot descriptions
* LWA in movevel mode
* head mount calibration
* set horizon of tray back to default
* force velocity mode to have a smooth motion
* change port of led board
* add raw3-3 and raw3-4 to brinup tests
* update cob3-1 urdf
* adapt arm configurations for cob3-5
* fixed order of sdh joint names
* fixed shaky tray movement by reducing the horizon parameter
* changed back previous changes
* adapt head parameters for cob3-1
* Merge remote branch 'origin-ipa320/master' into automerge
* fixed direction of translation for head link. due to last commit
* update horizon parameter of the tray
* using powerball tray for cob3-6
* update hardware parameters for cob3-1 and ros fuerte
* add collision marker and interactive teleop
* using movestep for lwa
* remove swap file
* fix raw urdf
* use ttyTact for cob3-6
* changed reference for "head"
  from "torso_upper_neck_tilt_link"
  to "head_cover_link" for cob3-3 and cob3-6 only
* added inversion flag to raw3-1s light hardware configuration
* Revert "added inversion flag to light hardware configuration"
  This reverts commit f65c326ed3e1bcec9a2f310e0d6bfe6de0ee8fda.
* assigned ttyScanX to scanners
* added raw3-3 to urdf tests
* added inversion flag to light hardware configuration
* Added kinect
* prepared DSA config for cob3-6
* added canopenmaster.yaml
* changes to include tray_powerball
* enable tactile sensors for cob3-3-
* add config for emergency and battery monitor
* remove test file
* separate monitoring
* use move_vel for torso
* comment out wifi monitor
* add monitoring to cob3-3
* hwboard updated
* updated hwboard
* raw3-1 base calibrated
* added hwboard
* raw3-4 settings
* Updated urdf file for cob3-6
* Urdf and parameter files for tray_powerball
* modified/corrected raw3-1 urdf description
* added amadeus box gripper to raw3-1 urdf description
* added cob_voltage_control to bringup
* added launch files for battery board
* settings for raw3-4
* add config for raw3-1 pc monitors
* fixes for raw3-1 config
* changed position of manipulator from back to front
* changed LED device
* changed torso naming to raw
* merge with ipa320
* add hokuyo config for scan filter
* support torso names in joystick, add prefix to ur5
* new pc names on raw3-1 and working torso config for new urdf
* robot specific changes for raw3-1
* config for cob3-1 simulation
* change desire arm_left and arm_right
* Deleted tactile sensor port parameter in the configuration cob3-6
* update to corei7 cob3-3-pc1
* warning for no ROBOT or ROBOT_ENV set
* move light to pc1
* light config for cob3-3
* substitute env ROBOT with arg robot
* harmonize schunk configuration
* New calibration data for torso and tray cob3-4
* adapt laser range
* added torso
* fixed name of xacro macro for raw base
* extend error_range
* removed old arm_ur model
* extend error range
* config for torso and tray on cob3-2
* extend error range for tray
* use movevel for lwa
* force using moveVel
* base calibration for cob3-6
* adapted raw_torso files
* final raw-model V2
* add pc monitor config for all robots
* adjust pc_monitor diagnostics for different cores
* base calibration copied from cob3-5
* config update for cob3-6
* changed can slots on cob3-2
* working parameters for powercube_chain on cob3-5
* added dummy phidgets config
* update config
* config for cob3-5
* Added kinect.launch in cob3-2.xml
* removed wrong launch file
* config for torso, head and lwa
* base calibration
* removed tray, head, sdh config for raw3-1
* removed tray, head, sdh config for raw3-3
* updated base_velocity_smoother_params.yaml files for cob3-1 to cob3-6, desire and raw3-1 and raw3-2
* Merge branch 'review-ipa320'
* updated camera parameter files for cob3-4
* updated camera parameter files for cob3-5
* updated camera parameter files for cob3-2 and cob3-6
* remove calibration files
* camera settings for cob3-2, cob3-4, cob3-5 and cob3-6
* decreased the target frame rate of camera pair to reduce warnings caused by dropped frames
* add tests for cob3-5
* add hardware config for cob3-5
* added pkg_hardware_config, pkg_robot_config and pkg_env_config args to launch files in cob_robots
* added pkg_hardware_config, pkg_robot_config and pkg_env_config args to launch files in bringup
* introducing raw3-3 with frida_arm
* introducing raw3-3 with frida_arm
* clean raw3-1 hardware_config
* final raw-model
* ModuleTypes parameter removed, because not used anymore.
* updates for cob3-2
* adjust tests for cob32
* lights for cob3-6
* adjust diagnostics parameters
* fix desire arm joint names
* add tray links to footprint observer
* remove param farthest_frame from footprint_observer
* add tray links
* Merge branch 'master' of github.com:ipa-fmw/cob_robots
* update manifest
* update stack
* move calibration data to new cob_calibration_data stack
* new torso ref position
* add light by default
* urdf test for desire
* New configuration parameters and calibration  for cob3-2
* new calibration for cob3-3
* Fixed merge conflict
* Setup cob3-6 calibration
* Updated desire config files
* Setup xml file for desire
* Desire config files
* add basic config and tests for cob3-1
* sdh hardware configuration parameters
* lwa configuration parameters for cob3-6
* wifi diagnostics monitor
* Desire configuration parameters
* rename torso joints of raw3-1
* merge
* Merge branch 'master' of github.com:ipa-fmw/cob_robots
* cob3-6 calibration parameters
* cob3-6 bringup file update
* cob3-6 cob_hardware_config update
* add default rviz config
* add controllers for cob3-6
* add config for vel smoother for cob3-6
* add config for vel smoother for cob3-6
* add config for vel smoother for cob3-6
* add tests for cob3-6
* MErge conflict
* Light config
* integration of base_velocity_smoother_param.yaml files and update of base.launch
* Hardware config files for cob3-6
* finished raw3-1 model --- V1
* update deps
* apply bringup launch changes to all robots
* urdf test file for raw3-2
* restructure bringup launch files to use args --> better testing possible, needs to be tested on hardware
* changes before shipping raw3-1
* add ur5_description dep
* move camera ip adresses to hardware config
* merged with ipa320
* first version of raw3-2 config
* calibration by richard
* use old arm model
* Merge branch 'master' of git://github.com/abubeck/cob_robots into review-abubeck
* small modifications for raw
* merge with abubeck
* modifications for raw3-1
* changed for cameras on raw3
* almost final raw3-1 hardware setup
* reduced teleop config
* modifications for new universal robot driver
* add cpu diagnostics
* modifications for upstream ur5_description
* add raw3-1 specific collision_velocity_filter_params, footprint_observer_params, local_costmap_params
* add missing dependencies and update stack.xml
* move launch and config files to cob_robots
* new torso calibration
* commit hardware configuration files for cob3-2
* add empty light.yaml for cbo3-4 to fulffill tests
* fix typo
* fix urdf
* small tuning for gazebo
* urdf structure change: tray can be calibrated now
* config files for light in cob_hardware_config
* changed direction of urdf model to new convention
* Merge branch 'master' of github.com:ipa320/cob_robots
* new torso calibration
* modifications on robot with ur5 arm
* configurations from raw3-1 robot
* add some configuration for cob3-1
* add test for cob3-2
* adapt roslaunch checks
* add calibration for base lasers
* fix for raw
* Merge branch 'master' of github.com:ipa-fmw/cob_robots
* new calibration
* Merge branch 'master' of github.com:ipa-fmw/cob_robots
* using calibration for laser scanners
* new calibration
* renamed icob to raw and merged and cleaned up lots of things
* remove swp file
* again new calibration and moved frequency paramter to controller parameters
* Merge branch 'master' of github.com:ipa320/cob_robots
* chancge speed paraemters
* new calibration for torso
* updated tray config for smoother movements
* new calibration for cameras
* teleop with safe base movements
* load new calibration structure for cob3-4
* cob3-2 with schunk lwa
* cob3-2 update, calibration and urdf file
* cob3-2 updates
* merged with upstream version, deleted a lot of unnecessary stuff
* changed robot/name from cob3-3 to cob3_3 due to cob3_3_arm_navigation requirements
* fixed false macro name
* example config for lwa
* fixed laserscanner for icob
* add calibration files to cob3-4, still uncalibrated
* add laser config for icob
* fix icob urdf
* add tests for cob3-4
* new calibration
* missing files
* restructured icob_description
* icob robot config
* calibrated and verified
* moved camera calibration yaml files from config to calibration folder
* moved sdh up by 1.2cm to correct mount position
* default robot calibration added
* new files for icob for new repository structure
* tosro urdf change: moved head axis up (as in cad)
* torso and arm origins are calibratable in calibration.urdf.xacro
* torso calibrated straight with all zero joint angles
* camera handyed/stereo calibration adjusted to zero offset in head_v3 change
* setup cob3-4
* cob_scan filter: using multiple scan_ranges given in RAD
* cob_scan_filter
* changed default trigger freq for left camera again
* calibrated for experimentation days
* stereo calibration of left and right prosilica
* parameters for left and right prosilica camera separeted from intrinsics calibration
* added lbr stuff to diagnostics
* sick_s300: introduced scan_cycle_time
* changed default trigger freq for left camera, added sensor information to dashboard
* Merge remote branch 'origin/master'
* changed lbr config
* sick_s300: changed laser_frequency to scan_duration
* sick_s300: added laser frequency in yaml
* sick_s300 yaml files to be used with new scan-filter
* changed name of cob_dashboard to cob_commmand_gui
* commented out some not working diagnostics and modified the Actuator analyzers
* change to python test
* lbr working on robot again
* add dep
* added launch tests
* updated calibration
* modifications for tray and torso config to support new powercube chain structure
* added lbr launch files
* base and teleop running
* added camera config
* fix rostest
* added teleop and diagnostics
* launch file for cob3-3
* remove deprecated launch file
* update stack
* moved cob_config to cob_hardware_config
* update hardware config
* Contributors: Alexander Bubeck, Denis Štogl, Felipe Garcia Lopez, Florian Weißhardt, Jannik Abbenseth, Joshua Hampp, Lucian Cucu, Nadia Hammoudeh García, Richard Bormann, SimonEbner, Thiago de Freitas, abubeck, calibration, cob3-1-pc1, cob3-2 admin, cob3-5, cpc-pk, ipa-bnm, ipa-cob3-3, ipa-cob3-4, ipa-cob3-5, ipa-cob3-6, ipa-cob3-7, ipa-fmw, ipa-fmw-ms, ipa-fmw-sh, ipa-frm, ipa-fxm, ipa-goa, ipa-mdl, ipa-mig, ipa-nhg, ipa-raw3-3, ipa-tys, ipa-uhr-eh, ipa-uhr-fm, ipa320, ipa320-cob3-6, mig, nhg-ipa, raw3-1 administrator, robot
```
## cob_monitoring

```
* Initial catkinization.
* no speach output for first emergency change
* enhanced battery monitoring
* separate monitoring
* add todos to monitoring
* add sound to em monitoring
* monitoring package
* Contributors: abubeck, ipa-fmw
```
## cob_robots

```
* Initial catkinization.
* Contributors: abubeck
```
