### PR TITLE
jsk_roseus: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2177,6 +2177,24 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_common.git
       version: master
     status: developed
+  jsk_roseus:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_roseus.git
+      version: master
+    release:
+      packages:
+      - euslisp
+      - roseus
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/tork-a/jsk_roseus-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_roseus.git
+      version: master
+    status: developed
   kinect_aux:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.0.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## euslisp

```
* euslisp/roseus: add version numeber to 1.0.0
* Contributors: Kei Okada, Manabu saito, Masaki Murooka, Shunnichi Nozawa, Youhei Kakiuchi
```
## roseus

```
* roseus: add version numeber to 1.0.0
* Contributors: Kei Okada, Ryohei Ueda, Yohei Kakiuchi, Haseru Chen, Yuki Furuta, Yuto Inagaki, kazuto Murase, Eisoku Kuroiwa, Manabu Saito, Hiroyuki Mikita, Shunnich Nozawa
```
