### PR TITLE
cob_robots: 0.5.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -593,7 +593,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.5.1-4
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.5.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.1-4`
## cob_bringup

```
* fix robot_ip address
* add parameter remapping for robot_description
* Contributors: Felix
```
## cob_controller_configuration_gazebo
- No changes
## cob_default_robot_config
- No changes
## cob_hardware_config
- No changes
## cob_monitoring
- No changes
## cob_robots
- No changes
