### PR TITLE
ipa_canopen: 0.5.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2106,7 +2106,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/ipa_canopen-release.git
-      version: 0.5.1-0
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/ipa320/ipa_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ipa_canopen` to `0.5.1-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.1-0`
## ipa_canopen

```
* Catkinized Version of the ipa_canopen package
* Contributors: thiago
```
## ipa_canopen_core

```
* This commit syncs the groovy_dev branch with the hydro_dev branch
* fix CMakeLists.txt
* Modifying Cmake
* Problem with library name
* Small mistake on the package.xml
* Changed CMakeLists to just one
* Modifications from cob3
* Catkinized Version of the ipa_canopen package
* Starting the catkinize process for the canopen stack
* Updating author and maintainer information
* Renamed function and services from stop to Halt
* Example of stop service
* Recover on movement now works
* Enhanced diagnostics version
* Pre initialization information
  New functions for getting the manufacturer erros
* Manufacturer information:
  * hardware version
  *firmware version
* Schunk errors description
* Some printout cleaning
* Velocity limit check for ROS
* Modified ROS part
* Pushing for saving
* Still only static recover
* FAULT_REACTION_ACTIVE
* Recover for static
* Deleted differente CMakeLists
* Florian modifications from Jenkins warnings
* Modifications tested with the LWA 4.10
* remove compiler warning
* Driver modifications
* Merge branch 'electric_dev' of github.com:uhr-eh/ipa_canopen into origin-thiago/electric_dev
  Conflicts:
  ipa_canopen_core/driver/canopen.cpp
* Implementing the diagnostics
* updated 64Bit version of ipa_canopen
* updated 64Bit version of ipa_canopen
* updated 64Bit version of canopen driver
* first version for 64Bit OS
* updated 64Bit version
* first test-version for ubuntu12 64bit
* first test-version for ubuntu12 64bit
* updated state machines
* updated state machines
* updated state machines
* updated state machines
* updated motor state machine
* updated NMT state machine and nodeguard handling
* updated NMT state machine and nodeguard handling
* updated NMT State machine and nodeguard handling
* updated NMT state machine & nodeguard handling
* updated NMT machine & nodeguarding function
* updated NWT state machine
* updated NWT state machine
* updated NWT state machine
* updated NWT state machine
* updated NWT state machine
* updated NMT state machine
* updated state NMW state machine
* added some docs on Schunk powerball arm
* added some documentation for Schunk Powerball arm
* updated stack and package info
* updated documentation
* small fixes
* updated documentation
* updated documentation
* moved documentation folder
* building for ros and non ros
* first step for building with rosmake
* added canopen core to repository
* Contributors: Thiago de Freitas, ipa-cob3-3, ipa-fmw, ipa-fxm, ipa-tys, ipa-uhr-eh, thiago, uhr-eh
```
## ipa_canopen_ros

```
* This commit syncs the groovy_dev branch with the hydro_dev branch
* Changed CMakeLists to just one
* Modifications from cob3
* Catkinized Version of the ipa_canopen package
* Merge pull request #21 <https://github.com/ipa320/ipa_canopen/issues/21> from thiagodefreitas/groovy_dev
  ROS node uses offsets for desired and actual positions
* Correction for the desired positions
* Modifying offsets
* fix recover and init behaviour
* Updating author and maintainer information
* Renamed function and services from stop to Halt
* Example of stop service
* Recover on movement now works
* Enhanced diagnostics version
* Pre initialization information
  New functions for getting the manufacturer erros
* Manufacturer information:
  * hardware version
  *firmware version
* Some printout cleaning
* Changing headers
* Velocity limit check for ROS
* Modified ROS part
* Pushing for saving
* Still only static recover
* remove yaml-cpp
* More jenkins changes
* Florian modifications from Jenkins warnings
* Modifications tested with the LWA 4.10
* add yaml-cpp dep
* Modified
* Deleted trash
* Driver modifications
* Implementing the diagnostics
* updated 64Bit version of ipa_canopen
* updated 64Bit version of ipa_canopen
* updated 64Bit version of canopen driver
* first version for 64Bit OS
* updated 64Bit version
* first test-version for ubuntu12 64bit
* updated stack and package info
* small fixes
* first step for building with rosmake
* added canopen_ros
* Contributors: Florian Weißhardt, Thiago de Freitas, ipa-cob3-3, ipa-cob3-5, ipa-fmw, ipa-tys, ipa-uhr-eh, thiago, uhr-eh
```
