### PR TITLE
frontier_exploration: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1322,7 +1322,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/paulbovbel/frontier_exploration-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/paulbovbel/frontier_exploration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `frontier_exploration` to `0.1.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.1.1-0`
## frontier_exploration

```
* fix message dependencies
* fix goal aliasing corner case
* fix empty frame name
* Update README.md
* accomodate for empty boundaries
* parametrize goal aliasing for redundant move base goals
* Contributors: Paul Bovbel
```
