### PR TITLE
schunk_modular_robotics: 0.5.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4980,7 +4980,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/schunk_modular_robotics-release.git
-      version: 0.5.1-2
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/ipa320/schunk_modular_robotics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_modular_robotics` to `0.5.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.1-2`
## schunk_description

```
* Merge branch 'hydro_dev' into hydro_release_candidate
* install tags
* Merge branch 'hydro_dev' of github.com:ipa320/schunk_modular_robotics into hydro_dev
* some catkin_lint
* Contributors: Florian Weisshardt, ipa-fxm
```
## schunk_libm5api

```
* install tags for header files
* install tags
* Contributors: ipa-fxm
```
## schunk_modular_robotics
- No changes
## schunk_powercube_chain

```
* install tags
* merge with ipa320
* merge with ipa320
* some catkin_lint
* Contributors: Felix, ipa-fxm
```
## schunk_sdh

```
* Merge branch 'hydro_dev' into hydro_release_candidate
* Update package.xml
* Merge branch 'hydro_dev' into hydro_release_candidate
* Merge pull request #74 <https://github.com/ipa320/schunk_modular_robotics/issues/74> from ipa-fxm/hydro_dev
  install_tags
* find architecture using dpkg
* Update package.xml
* install tags
* Merge branch 'hydro_dev' of github.com:ipa320/schunk_modular_robotics into hydro_dev
* some catkin_lint
* Contributors: Florian Weisshardt, ipa-fxm
```
## schunk_simulated_tactile_sensors

```
* install tags
* some catkin_lint
* Contributors: ipa-fxm
```
