### PR TITLE
gazebo_ros_pkgs: 2.3.5-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1349,7 +1349,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.3.5-0
+      version: 2.3.5-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.3.5-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `2.3.5-0`
## gazebo_msgs
- No changes
## gazebo_plugins

```
* update test world for block laser
* this corrects the right orientation of the laser scan and improves on comparison between 2 double numbers
* Initialize ``depth_image_connect_count_`` in openni_kinect plugin
* multicamera bad namespace. Fixes #161 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/161>
  There was a race condition between GazeboRosCameraUtils::LoadThread
  creating the ros::NodeHandle and GazeboRosCameraUtils::Load
  suffixing the camera name in the namespace
* Use function for accessing scene node in gazebo_ros_video
* readded the trailing whitespace for cleaner diff
* the parent sensor in gazebo seems not to be active
* Contributors: Dejan Pangercic, Ian Chen, John Hsu, Jordi Pages, Toni Oliver, Ugo Cupcic
```
## gazebo_ros

```
* gazebo_ros: [less-than-minor] fix newlines
* gazebo_ros: remove assignment to self
  If this is needed for any twisted reason, it should be made clear
  anyway. Assuming this line is harmless and removing it because it
  generates cppcheck warnings.
* Contributors: Paul Mathieu
```
## gazebo_ros_control

```
* Removed some debugging code.
* joint->SetAngle() and joint->SetVelocity() are now used to control
  position-controlled joints and velocity-controlled joints that do not
  have PID gain values stored on the Parameter Server.
* Position-controlled and velocity-controlled joints now use PID controllers
  instead of calling SetAngle() or SetVelocity(). readSim() now longer calls
  angles::shortest_angular_distance() when a joint is prismatic.
  PLUGINLIB_EXPORT_CLASS is now used to register the plugin.
* gazebo_ros_control now depends on control_toolbox.
* Added support for the position hardware interface. Completed support for the
  velocity hardware interface.
* Removed the "support more hardware interfaces" line.
* Contributors: Jim Rothrock
```
## gazebo_ros_pkgs
- No changes
