### PR TITLE
jsk_common: 1.0.4-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1640,21 +1640,30 @@ repositories:
     release:
       packages:
       - collada_urdf_jsk_patch
+      - depth_image_proc_jsk_patch
+      - downward
       - dynamic_tf_publisher
       - image_view2
+      - image_view_jsk_patch
       - jsk_common
       - jsk_footstep_msgs
       - jsk_gui_msgs
       - jsk_hark_msgs
+      - jsk_tools
       - jsk_topic_tools
+      - laser_filters_jsk_patch
+      - multi_map_server
+      - openni_tracker_jsk_patch
+      - opt_camera
       - posedetection_msgs
       - pr2_groovy_patches
       - rospatlite
       - rosping
+      - stereo_synchronizer
       tags:
-        release: release/hydro/{package}/{version}
+        release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.4-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.0.3-0`
## depth_image_proc_jsk_patch

```
* jsk_common: update revision number to 1.0.3
* depth_image_proc_jsk_patch: catkinize (dummy)
* Contributors: Kei Okada
```
## downward

```
* jsk_common: update revision number to 1.0.3
* downward: catkinize
* Contributors: Kei Okada
```
## image_view_jsk_patch

```
* jsk_common: update revision number to 1.0.3
* image_view_jsk_patch: catkinize (dummy)
* Contributors: Kei Okada
```
## jsk_tools

```
* stereo_synchronizer, jsk_tools: update to revision 1.0.3
* jsk_tools: catkinize, add cmake/download_package.cmake
* Contributors: Kei Okada
```
## laser_filters_jsk_patch

```
* jsk_common: update revision number to 1.0.3
* laser_filters_jsk_patch: download laser_filters, filters
* Contributors: Kei Okada
```
## multi_map_server

```
* jsk_common: update revision number to 1.0.3
* multi_map_server: catkinize
* Contributors: Kei Okada
```
## openni_tracker_jsk_patch

```
* jsk_common: update revision number to 1.0.3
* openni_tracker_jsk_patch: use upstream repository on github
* Contributors: Kei Okada
```
## opt_camera

```
* jsk_common: update revision number to 1.0.3
* opt_camera: catkinize
* Contributors: Kei Okada
```
## stereo_synchronizer

```
* stereo_synchronizer, jsk_tools: update to revision 1.0.3
* stereo_synchronizer: catkinize
* Contributors: Kei Okada
```
