### PR TITLE
rosbridge_suite: 0.5.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4354,7 +4354,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.5.2-1
+      version: 0.5.3-0
     status: maintained
   rosconsole_bridge:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.5.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.2-1`
## rosapi
- No changes
## rosbridge_library

```
* use queue_size for publishers
* Contributors: Jon Binney
```
## rosbridge_server

```
* rosbridge_server: add install tag for python files, not just symlinks, to make them executable
* Contributors: ipa-mig
```
## rosbridge_suite
- No changes
