### PR TITLE
zeroconf_avahi_suite: 0.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1153,6 +1153,15 @@ repositories:
       type: git
       url: https://github.com/stonier/zeroconf_avahi_suite.git
       version: indigo
+    release:
+      packages:
+      - zeroconf_avahi
+      - zeroconf_avahi_demos
+      - zeroconf_avahi_suite
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/zeroconf_avahi_suite-release.git
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/stonier/zeroconf_avahi_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zeroconf_avahi_suite` to `0.2.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
