### PR TITLE
schunk_modular_robotics: 0.5.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4989,7 +4989,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/schunk_modular_robotics-release.git
-      version: 0.5.3-0
+      version: 0.5.4-0
     source:
       type: git
       url: https://github.com/ipa320/schunk_modular_robotics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_modular_robotics` to `0.5.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.3-0`
## schunk_description
- No changes
## schunk_libm5api
- No changes
## schunk_modular_robotics
- No changes
## schunk_powercube_chain

```
* Merge branch 'hydro_dev' into hydro_release_candidate
* merge
* added missing dependency
* Contributors: Florian Weisshardt, ipa-fxm
```
## schunk_sdh
- No changes
## schunk_simulated_tactile_sensors
- No changes
