### PR TITLE
ipa_canopen: 0.5.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2106,7 +2106,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/ipa_canopen-release.git
-      version: 0.5.1-1
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/ipa320/ipa_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ipa_canopen` to `0.5.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.1-1`
## ipa_canopen
- No changes
## ipa_canopen_core

```
* merged
* revert pcan as external dependency
* merged
* Fixes schunk node
* Merge pull request #33 <https://github.com/ipa320/ipa_canopen/issues/33> from thiagodefreitas/hydro_dev
  Last day for syncs between groovy_dev and hydro_dev
* Fixes some installation problems acording to catkin_lint
* catkin_make_isolated is now working
* merge and smarter init
* Last day for syncs between groovy_dev and hydro_dev
* Syncs the hydro_dev to the groovy_dev
* transmit mode of operation SDO as uint8_t
* use int8_t for mode of operation
* allow motor state to be changed in both directions
* change mode of operation from uint8_t to int8_t
* function to set operation mode
* make pcan an external dependency
* overloaded init function to allow initialization with multiple modes
* setMotorState automatically goes through necessary states
* changed timing for change of operation mode
* Fixing author name
* Fixed delays when initializing
* Faster boot-up for Elmo
* small fixes for working with Schunk
* Restricted some calls to the core part
* Fixing the TPCanRdmsg
* Fixing syscall param print to uninitialised bytes
* Some beautifying
* Removed some unnecessary prints
* Missing files
* Fixing merge errors
* Tested on cob4 torso
* Fixed move device with mapped Schunk device
* Almost merged schunk and elmo
* Testing gtest for the ipa_canopen_core
* Update from the manual
* Modifying structure for 3 joints
* Position mode working at industrieStr
* Added swithces
* Changing Profiled Position Mode to a ROS Service
* Probably solves the errors from industrieStr
* Modifying the offsets and conversion factors
* Unit factor now comes from the yaml file
* Some cleaning
* Working for different ranges of baud rates
* Mapping is now independent of the canopen id
* Merged from changes at industrieStr
* Local changes
* elmo_pos worked for the first time
* Removing hard-coded baudrate from low-level Canopen
* Trying things
* fixes on cob3-7
* Std::couts out
* Removing some comments
* Definitions for the sendVel
* Functions separation between sendPos e sendVel
* Separating sendPos to sendVel
* Changes at sendPos
* No more fixed IDs for the Elmo Branch
* Correcting elmo endschalten
* Limits working properly, only the switch release needs some adjustment
* Hardware Limit Switches status
* Adjusting comments and license for the Elmo parts of the driver
* Recover works for the first time
* Elmo merging
* Contributors: Kai Franke, Thiago de Freitas, Thiago de Freitas Oliveira Araujo, cob4-1, ipa-cob3-7, thiagodefreitas
```
## ipa_canopen_ros

```
* Urgent Fix to ros pre-release build
* Missing a comment
* Changes the checks from the CMakeLists equal to ipa_canopen_ros
* Merge pull request #36 <https://github.com/ipa320/ipa_canopen/issues/36> from thiagodefreitas/hydro_dev
  Added diagnostic_msgs
* Added diagnostic_msgs
* Changes executable name to be compliant with catkin specs
* catkin_make_isolated is now working
* Last day for syncs between groovy_dev and hydro_dev
* Syncs the hydro_dev to the groovy_dev
* Fixing author name
* Fixes bug described by @kalectro
* Changed pr2 msgs to control_msgs
* Restricted some calls to the core part
* Fixing the TPCanRdmsg
* Removed some elmo trash
* Some beautifying
* Removed some unnecessary prints
* Ros Node Working for all the 3 devices
* Fixing the ros node
* Fixing merge errors
* Merge branch 'feature/simple_bride' of github.com:thiagodefreitas/ipa_canopen into almost_merged
  Conflicts:
  ipa_canopen_ros/CMakeLists.txt
  ipa_canopen_ros/src/canopen_ros.cpp
* integrate init, recover and moveVel. still not working yet
* add checks for ROS parameters
* add diagnostic_msgs to manifest and stack
* demo for torso
* Added PPMode service
* Modifying structure for 3 joints
* Position mode working at industrieStr
* Added swithces
* Removed sendPos
* devices
* Default positions for the request
* Changing Profiled Position Mode to a ROS Service
* Probably solves the errors from industrieStr
* Modifying the offsets and conversion factors
* Unit factor now comes from the yaml file
* Working for different ranges of baud rates
* Mapping is now independent of the canopen id
* Merged from changes at industrieStr
* Local changes
* elmo_pos worked for the first time
* Removing hard-coded baudrate from low-level Canopen
* Std::couts out
* Definitions for the sendVel
* Separating sendPos to sendVel
* Changed Handlers at ROS Level
* No more fixed IDs for the Elmo Branch
* Correcting elmo endschalten
* Limits working properly, only the switch release needs some adjustment
* Adjusting comments and license for the Elmo parts of the driver
* Recover works for the first time
* Changed elmo constraints
* Elmo merging
* Contributors: Thiago de Freitas, Thiago de Freitas Oliveira Araujo, ipa-fmw, thiagodefreitas
```
