### PR TITLE
ipa_canopen: 0.5.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2106,7 +2106,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/ipa_canopen-release.git
-      version: 0.5.1-1
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/ipa320/ipa_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ipa_canopen` to `0.5.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.1-1`
## ipa_canopen
- No changes
## ipa_canopen_core

```
* Lint Fixes for ipa_canopen_core
* Catkin_lint modifications
  *Init bug fix
  *Schunk bug fix
* Contributors: thiagodefreitas
```
## ipa_canopen_ros

```
* Merge branch 'hydro_dev' of github.com:ipa320/ipa_canopen into hydro_release_candidate
* Catkin_lint modifications
  *Init bug fix
  *Schunk bug fix
* Contributors: thiagodefreitas
```
