### PR TITLE
ros_controllers: 0.7.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4277,9 +4277,11 @@ repositories:
       version: hydro-devel
     release:
       packages:
+      - diff_drive_controller
       - effort_controllers
       - force_torque_sensor_controller
       - forward_command_controller
+      - gripper_action_controller
       - imu_sensor_controller
       - joint_state_controller
       - joint_trajectory_controller
@@ -4289,7 +4291,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.6.0-0
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros_controllers.git
+      version: hydro-devel
     status: developed
   ros_glass_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.7.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.6.0-0`
## diff_drive_controller

```
* diff_drive_controller: New controller for differential drive wheel systems.
* Control is in the form of a velocity command, that is split then sent on the two wheels of a differential drive
wheel base.
* Odometry is published to tf and to a dedicated nav__msgs/Odometry topic.
* Realtime-safe implementation.
* Implements task-space velocity and acceleration limits.
* Automatic stop after command time-out.
* Contributors: Bence Magyar, Paul Mathieu, Enrique Fernandez.
```
## effort_controllers
- No changes
## force_torque_sensor_controller
- No changes
## forward_command_controller
- No changes
## gripper_action_controller

```
* gripper_action_controller: New controller for single dof grippers.
* Contributors: Sachin Chitta.
```
## imu_sensor_controller
- No changes
## joint_state_controller
- No changes
## joint_trajectory_controller

```
* Add support for an joint interfaces are not inherited from JointHandle.
* Contributors: Igorec
```
## position_controllers
- No changes
## ros_controllers

```
* Add diff_drive_controller and gripper_action_controller dependencies.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## velocity_controllers
- No changes
