### PR TITLE
Add libopencv-dev key for OS X

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -185,6 +185,10 @@ libogre-dev:
   osx:
     homebrew:
       packages: [ogre]
+libopencv-dev:
+  osx:
+    homebrew:
+      packages: [opencv]
 libpcap:
   osx:
     homebrew:


### PR DESCRIPTION
Needed by image_geometry.
