### PR TITLE
ros_control: 0.7.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4268,7 +4268,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.6.0-1
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros_control.git
+      version: hydro-devel
     status: developed
   ros_controllers:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.7.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.6.0-1`
## controller_interface
- No changes
## controller_manager

```
* Add --timeout option to controller spawner
* Use argparse instead of getopt
  It is a much nicer interface
* Contributors: Paul Mathieu
```
## controller_manager_msgs
- No changes
## controller_manager_tests
- No changes
## hardware_interface

```
* Add ResourceHandle typedef
* add name to anonymous objects to avoid cppcheck error
* Contributors: Daniel Pinyol, Igorec
```
## joint_limits_interface
- No changes
## ros_control
- No changes
## rqt_controller_manager
- No changes
## transmission_interface
- No changes
