### PR TITLE
Add (gcc,g++)-multilib deps for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -571,6 +571,7 @@ ftdi-eeprom:
   fedora: [libftdi-devel, libftdi-c++-devel]
   ubuntu: [ftdi-eeprom]
 g++-multilib:
+  fedora: [gcc-c++, glibc-devel, glibc-devel(x86-32), glibc-static, glibc-static(x86-32), libstdc++-devel, libstdc++-devel(x86-32), libstdc++-static, libstdc++-static(x86-32)]
   ubuntu: [g++-multilib]
 gawk:
   ubuntu: [gawk]
@@ -589,6 +590,7 @@ gcc-avr:
   gentoo: [cross-avr/gcc]
   ubuntu: [gcc-avr]
 gcc-multilib:
+  fedora: [gcc, glibc-devel, glibc-devel(x86-32), glibc-static, glibc-static(x86-32)]
   ubuntu: [gcc-multilib]
 gccxml:
   arch: [gccxml-git]


### PR DESCRIPTION
This will only work for `x86` machines because Fedora doesn't currently have a package which installs these libraries for the _other_ sub-architectures that are available on the current arch. A better solution should eventually be found, but as of now, I know of no such solution.

These packages will install without https://github.com/ros-infrastructure/rosdep/pull/315, but rosdep will not detect the successful installation without it.
