### PR TITLE
dynamixel_pro_controller: 0.8.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -963,7 +963,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/dynamixel_pro_controller-release.git
-      version: 0.8.3-0
+      version: 0.8.4-0
   dynamixel_pro_driver:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_pro_controller` to `0.8.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.8.3-0`
## dynamixel_pro_controller

```
* Added support for YAML-CPP 0.5+.
```
