### PR TITLE
ackermann_msgs: 0.9.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12,6 +12,11 @@ repositories:
       type: git
       url: https://github.com/jack-oquin/ackermann_msgs.git
       version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/jack-oquin/ackermann_msgs-release.git
+      version: 0.9.0-0
     source:
       type: git
       url: https://github.com/jack-oquin/ackermann_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ackermann_msgs` to `0.9.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
