### PR TITLE
xacro: 1.9.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1280,6 +1280,21 @@ repositories:
       url: https://github.com/ros-gbp/warehouse_ros-release.git
       version: 0.8.6-0
     status: maintained
+  xacro:
+    doc:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/xacro-release.git
+      version: 1.9.0-0
+    source:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: indigo-devel
+    status: maintained
   zeroconf_avahi_suite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.9.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## xacro

```
* Remove the roslint_python glob, use the default one.
* Add roslint target to xacro; two whitespace fixes so that it passes.
* fix evaluation of integers in if statements
  also added a unit test, fixes #15 <https://github.com/ros/xacro/issues/15>
* fix setting of _xacro_py CMake var, fixes #16 <https://github.com/ros/xacro/issues/16>
* Add support for globbing multiple files in a single <xacro:include>
* code cleanup and python3 support
* check for CATKIN_ENABLE_TESTING
```
