### PR TITLE
rocon_msgs: 0.7.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -847,6 +847,23 @@ repositories:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git
       version: indigo
+    release:
+      packages:
+      - concert_msgs
+      - gateway_msgs
+      - rocon_annotation_msgs
+      - rocon_app_manager_msgs
+      - rocon_interaction_msgs
+      - rocon_msgs
+      - rocon_service_msgs
+      - rocon_service_pair_msgs
+      - rocon_std_msgs
+      - rocon_tutorial_msgs
+      - scheduler_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/rocon_msgs-release.git
+      version: 0.7.0-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs` to `0.7.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## concert_msgs
- No changes
## gateway_msgs

```
* Changes supporting connectivity and disconnection handling.
```
## rocon_annotation_msgs
- No changes
## rocon_app_manager_msgs
- No changes
## rocon_interaction_msgs
- No changes
## rocon_msgs

```
* Major redesign focusing on the orchestration platform prototype.
```
## rocon_service_msgs

```
* First release
```
## rocon_service_pair_msgs

```
* First release of th service pair message generation infrastructure
```
## rocon_std_msgs

```
* major redesign focusing on the orchestration platform prototype.
```
## rocon_tutorial_msgs

```
* first release of the rocon tutorial messages into their own package
```
## scheduler_msgs
- No changes
