### PR TITLE
jsk_roseus: 1.0.3-2 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1681,7 +1681,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.0.3-1
+      version: 1.0.3-2
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.0.3-2`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.0.3-1`
## euslisp

```
* euslisp: unittest.l, uses numnber of test, not number of assert
* euslisp: unittest.l, force error if signal or error
* euslisp: add build_depend to libpq-dev, see issue #8 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/8>
* Contributors: Kei Okada
```
## roseus

```
* catkin.cmake add rostest to find_package
* #14 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/14>: depend roseus message generation on python message generation.
  in roseus.cmake, do not take into account the dependencies between messages
  and packages and just depends roseus message generation on python message generation.
  The 1st reason is the difference between hydro and groovy. On groovy, genmsg
  does not craete the targets of foo_generate_messages_py
  which are already compiled, I mean the packages installed by apt.
  The 2nd reason is that roseus message generation utilizes rospy and it requires
  for rospy messages to be available. So this dependencies are required.
  Namely, the dependency will be like this:
  parent_pkg
  +-child_pkg+-grandchild_pkg

  +-grandchild_pkg_generate_messages_py

  +-euslip targets for grandchild_pkg
* Contributors: Ryohei Ueda
* roseus/test/test-tf.test: tf2_buffer_server output to screen
```
