### PR TITLE
hector_slam: 0.3.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1740,7 +1740,8 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
+    status: maintained
   hector_turtlebot:
     doc:
       type: svn


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_slam` to `0.3.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.3.1-0`
## hector_compressed_map_transport
- No changes
## hector_geotiff

```
* Add TrajectoryMapWriter to geotiff_mapper.launch per default
* Add arguments to launch files for specifying geotiff file path
* Contributors: Stefan Kohlbrecher
```
## hector_geotiff_plugins
- No changes
## hector_imu_attitude_to_tf
- No changes
## hector_map_server
- No changes
## hector_map_tools
- No changes
## hector_mapping
- No changes
## hector_marker_drawing
- No changes
## hector_nav_msgs
- No changes
## hector_slam
- No changes
## hector_slam_launch

```
* Add arguments to launch files for specifying geotiff file path
* Update rviz config to have proper default displays
* deleted quadrotor_uav.launch (moved to hector_quadrotor)
* Contributors: Johannes Meyer, Stefan Kohlbrecher
```
## hector_trajectory_server

```
* wait based on WallTime and check ros::ok() in waitForTf()
* Print out tf availability warning only once.
* Wait for tf become available to suppress warnings on startup
* Create a warning instead of an error for TransformExceptions
* Contributors: Johannes Meyer, Stefan Kohlbrecher, wachaja
```
