### PR TITLE
hector_models: 0.3.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1668,14 +1668,15 @@ repositories:
       version: hydro-devel
     release:
       packages:
+      - hector_components_description
       - hector_models
       - hector_sensors_description
-      - hector_sensors_gazebo
       - hector_xacro_tools
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
+    status: maintained
   hector_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_models` to `0.3.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.3.0-0`
## hector_components_description

```
* Re-parent LIDAR and camera mount to top_box_link
* Add xacro macros for setting dimensions
* Remove obsolete files
* Add UTM-30LX macro to vision box xacro
* Add hector ugv vision box to hector_components_description package for better reusability
* Contributors: Stefan Kohlbrecher
```
## hector_models

```
* made hector_models a true metapackage
* Moved package hector_sensors_gazebo to ../hector_gazebo
* Contributors: Johannes Meyer
```
## hector_sensors_description

```
* added hokuyo_utm30lx_model and hokuyo_utm30lx_gpu macros and disabled gpu laser in default hokuyo_utm30lx macro
* use gpu_ray sensor in hydro
* Contributors: Johannes Meyer
```
## hector_xacro_tools
- No changes
