### PR TITLE
hector_quadrotor: 0.3.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1707,7 +1707,8 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_quadrotor-release.git
-      version: 0.3.1-1
+      version: 0.3.2-0
+    status: maintained
   hector_quadrotor_apps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_quadrotor` to `0.3.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.3.1-1`
## hector_quadrotor

```
* added packages hector_quadrotor_controller and hector_quadrotor_controller_gazebo to meta-package
* Contributors: Johannes Meyer
```
## hector_quadrotor_controller

```
* Fix boost 1.53 issues
  changed boost::shared_dynamic_cast to boost::dynamic_pointer_cast and
  boost::shared_static_cast to boost::static_pointer_cast
* use a separate callback queue thread for the TwistController
* added optional twist limit in pose controller
* Contributors: Christopher Hrabia, Johannes Meyer
```
## hector_quadrotor_controller_gazebo
- No changes
## hector_quadrotor_demo
- No changes
## hector_quadrotor_description
- No changes
## hector_quadrotor_gazebo
- No changes
## hector_quadrotor_gazebo_plugins
- No changes
## hector_quadrotor_model
- No changes
## hector_quadrotor_pose_estimation
- No changes
## hector_quadrotor_teleop
- No changes
## hector_uav_msgs
- No changes
