### PR TITLE
hector_worldmodel: 0.3.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1775,7 +1775,8 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
+    status: maintained
   hlugv_common:
     doc:
       type: svn


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_worldmodel` to `0.3.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.3.0-0`
## hector_object_tracker

```
* changed distance for negative update
* renamed hector_object_tracker::param() method to hector_object_tracker::parameter()
  This will hopefully fix the build failures on Jenkins for lucid binaries.
  See http://jenkins.ros.org/job/ros-fuerte-hector-worldmodel_binarydeb_lucid_amd64/132/console
* added missing target dependency to hector_nav_msgs_generate_messages_cpp
* Contributors: Johannes Meyer
```
## hector_worldmodel

```
* added missing <metapackage/> tag in package.xml
* Contributors: Johannes Meyer
```
## hector_worldmodel_geotiff_plugins

```
* Updated to new format 2014
* add missing "lib" prefix in library path
* Contributors: Alexander Stumpf, Thorsten Graber
```
## hector_worldmodel_msgs
- No changes
