### PR TITLE
hector_gazebo: 0.3.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1636,15 +1636,16 @@ repositories:
       version: hydro-devel
     release:
       packages:
-      - gazebo_rtt_plugin
       - hector_gazebo
       - hector_gazebo_plugins
       - hector_gazebo_thermal_camera
       - hector_gazebo_worlds
+      - hector_sensors_gazebo
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
+    status: maintained
   hector_localization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_gazebo` to `0.3.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.3.1-0`
## hector_gazebo

```
* Made hector_gazebo and hector_sensors_gazebo true metapackages
* Contributors: Johannes Meyer
```
## hector_gazebo_plugins

```
* diffdrive_plugin_multi_wheel: Fix wrong whell rotation calculation (Was only half speed of desired)
* diffdrive_plugin_multi_wheel: Optionally do not publish odometry via tf or as msg
* Fixed boost 1.53 issues
  Replaced boost::shared_dynamic_cast with boost::dynamic_pointer_cast
* Add servo plugin (used for vision box currently)
* Add catkin_LIBRARIES to linking for multiwheel plugin
* Some fixes to make diffdrive_plugin_multi_wheel work properly
* Work in progress of a diffdrive plugin supporting multiple wheels per side
* used updated API to get rid of warnings
* added topicName parameter back to gazebo_ros_magnetic
* hector_gazebo: deleted deprecated export sections from package.xml files
* abort with a fatal error if ROS is not yet initialized + minor code cleanup
* Contributors: Christopher Hrabia, Johannes Meyer, Richard Williams, Stefan Kohlbrecher, richardw347
```
## hector_gazebo_thermal_camera

```
* added missing dependency to roscpp
* hector_gazebo: deleted deprecated export sections from package.xml files
* Contributors: Johannes Meyer
```
## hector_gazebo_worlds

```
* added missing install rule
* Contributors: Johannes Meyer
```
## hector_sensors_gazebo

```
* removed metapackage tag from hector_sensors_gazebo to not break packages depending on it
* hector_gazebo: Made hector_gazebo and hector_sensors_gazebo true metapackages
* Moved package from hector_models to hector_gazebo
* Contributors: Johannes Meyer
```
