### PR TITLE
jsk_common: 1.0.5-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1663,7 +1663,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.4-3
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.5-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.0.4-3`
## downward

```
* Added missing find_package to downward
* Contributors: Scott K Logan
```
## multi_map_server

```
* check if map_server exists under /opt/ros/{ROS_DISTRO}/stacks/navigation/map_server for groovy
* Contributors: Kei Okada
```
