### PR TITLE
jsk_common: 1.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2186,7 +2186,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.4-2
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.5-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.0.4-2`
## downward

```
* Added missing find_package to downward
* Contributors: Scott K Logan
```
## multi_map_server

```
* check if map_server exists under /opt/ros/{ROS_DISTRO}/stacks/navigation/map_server for groovy
* Contributors: Kei Okada
```
