### PR TITLE
cob_driver: 0.5.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -484,7 +484,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.5.2-1
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.5.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.2-1`
## cob_base_drive_chain

```
* install tags
* Contributors: ipa-fxm
```
## cob_base_velocity_smoother

```
* install tags
* Contributors: ipa-fxm
```
## cob_cam3d_throttle

```
* install tags
* Contributors: ipa-fxm
```
## cob_camera_sensors

```
* removed obsolete files
* install tags
* Contributors: ipa-fxm
```
## cob_canopen_motor

```
* install tags
* Contributors: ipa-fxm
```
## cob_collision_velocity_filter

```
* install tags
* Contributors: ipa-fxm
```
## cob_driver
- No changes
## cob_footprint_observer

```
* install tags
* Contributors: ipa-fxm
```
## cob_generic_can

```
* install tags
* Contributors: ipa-fxm
```
## cob_head_axis

```
* install tags
* cob_head_axis: tabs to spaces
* cob_head_axis: fix deprecated API in constructor
* Contributors: ipa-fxm, ipa-mig
```
## cob_hokuyo
- No changes
## cob_hwboard

```
* install tags
* Contributors: ipa-fxm
```
## cob_light

```
* install tags
* Contributors: ipa-fxm
```
## cob_phidgets

```
* install tags
* Contributors: ipa-fxm
```
## cob_relayboard

```
* install tags
* Contributors: ipa-fxm
```
## cob_sick_lms1xx

```
* install tags
* Contributors: ipa-fxm
```
## cob_sick_s300

```
* install tags
* Contributors: ipa-fxm
```
## cob_sound

```
* install tags
* Contributors: ipa-fxm
```
## cob_trajectory_controller

```
* install tags
* Contributors: ipa-fxm
```
## cob_undercarriage_ctrl

```
* removed obsoledte OpenCV reference
* install tags
* Contributors: ipa-fxm
```
## cob_utilities

```
* install tags
* Contributors: ipa-fxm
```
## cob_voltage_control

```
* install tags
* Contributors: ipa-fxm
```
