### PR TITLE
cob_simulation: 0.5.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -614,7 +614,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/cob_simulation-release.git
-      version: 0.5.1-6
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/ipa320/cob_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.5.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.1-6`
## cob_bringup_sim
- No changes
## cob_gazebo

```
* no OpenCV required in cob_gazebo
* Contributors: ipa-fxm
```
## cob_gazebo_objects
- No changes
## cob_gazebo_worlds
- No changes
## cob_simulation
- No changes
