### PR TITLE
universal_robot: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5619,6 +5619,7 @@ repositories:
     release:
       packages:
       - universal_robot
+      - ur10_moveit_config
       - ur5_moveit_config
       - ur_bringup
       - ur_description
@@ -5628,7 +5629,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-industrial-release/universal_robot-release.git
-      version: 1.0.0-3
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robot` to `1.0.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.0.0-3`
## universal_robot

```
* Added all packages in dependency list of metapackage.
* Updated to catkin.  ur_driver's files were added to nested Python directory for including in other packages.
* Contributors: IPR-SR2, Kelsey
```
## ur10_moveit_config

```
* changes due to file renaming
* update moveit_configs: include ee_link and handle limited robot
* new moveit_configs for ur5 and ur10
* Contributors: ipa-fxm
```
## ur5_moveit_config

```
* Merge branch 'hydro-devel' of github.com:ros-industrial/universal_robot into hydro
* changes due to file renaming
* update moveit_configs: include ee_link and handle limited robot
* new moveit_configs for ur5 and ur10
* remove old ur5_moveit_config
* Contributors: Florian Weisshardt, ipa-fxm
* ur5_moveit_cfg: add missing run_depend ind_rob_simulator. Fix #38 <https://github.com/ros-industrial/universal_robot/issues/38>.
* update moveit_configs to use moveit_simple_controller_manager
* Added config files missed on last commit
* Added launch/configuration files for using real robot.  Updated joint limits to velocity limits of the driver (all of which can be configured to make the robot move faster)
* Removed ur5_joint_limited_moveit_config.  ur5_moveit_config now has limited joint ranges to plus/minus 180 degrees.
* Added ur5 moveit library.  The Kinematics used by the ur5 move it library is unreliable and should be replaced with the ur_kinematics
* Contributors: Jeremy Zoss, Shaun Edwards, gavanderhoorn
```
## ur_bringup

```
* adapt launch files in order to be able to use normal/limited xacro
* Contributors: ipa-fxm
* Added definitions for adding tergets in install folder. Issue #10 <https://github.com/ros-industrial/universal_robot/issues/10>.
* Added definitions for adding tergets in install folder. Issue #10 <https://github.com/ros-industrial/universal_robot/issues/10>.
* Updated to catkin.  ur_driver's files were added to nested Python directory for including in other packages.
* Updated urdf files use collision/visual models.
* Added launch directory to bringup package.  Left the old launch files to be backwards compatable for now.  Updated driver with SwRI internal changes.  Changed driver to accept ip address to match ROS-Industrial standard.  IP addresses for industrial robots are typically fixed.  Hostnames are not typically used (this is what the driver expected)
* Removed extra stl files and fixed indentions
* Renamed packages and new groovy version
* Added ur10 and renamed packages
* Contributors: IPR-SR2, Kelsey, Shaun Edwards, ipa-nhg, robot
```
## ur_description

```
* changes due to file renaming
* generate urdfs from latest xacros
* file renaming
* adapt launch files in order to be able to use normal/limited xacro
* fixed typo in limits
* add joint_limited urdf.xacros for both robots
* (re-)add ee_link for both robots
* updates for latest gazebo under hydro
* remove ee_link - as in ur10
* use same xacro params as ur10
* use new transmission interfaces
* update xml namespaces for hydro
* remove obsolete urdf file
* remove obsolete urdf file
* Contributors: ipa-fxm
* Update ur10.urdf.xacro
  Corrected UR10's urdf to faithfully represent joint effort thresholds, velocity limits, and dynamics parameters.
* Update ur5.urdf.xacro
  Corrected effort thresholds and friction values for UR5 urdf.
* added corrected mesh file
* Added definitions for adding tergets in install folder. Issue #10 <https://github.com/ros-industrial/universal_robot/issues/10>.
* Corrected warning on xacro-files in hydro.
* Added definitions for adding tergets in install folder. Issue #10 <https://github.com/ros-industrial/universal_robot/issues/10>.
* Updated to catkin.  ur_driver's files were added to nested Python directory for including in other packages.
* fixed name of ur5 transmissions
* patched gazebo.urdf.xacro to be compatible with gazebo 1.5
* fixed copy&paste error (?)
* prefix versions of gazebo and transmission macros
* Added joint limited urdf and associated moveit package.  The joint limited package is friendlier to the default KLD IK solution
* Added ur5 moveit library.  The Kinematics used by the ur5 move it library is unreliable and should be replaced with the ur_kinematics
* Updated urdf files use collision/visual models.
* Reorganized meshes to include both collision and visual messhes (like other ROS-I robots).  Modified urdf xacro to include new models.  Removed extra robot pedestal link from urdf (urdfs should only include the robot itself).
* minor changes on ur5 xacro files
* Removed extra stl files and fixed indentions
* Renamed packages and new groovy version
* Added ur10 and renamed packages
* Contributors: Denis Štogl, IPR-SR2, Kelsey, Mathias Lüdtke, Shaun Edwards, ipa-nhg, jrgnicho, kphawkins, robot
```
## ur_driver

```
* Merge pull request #25 <https://github.com/ros-industrial/universal_robot/issues/25> from ros-industrial/groovy-devel
  Merging latest changed from groovy to hydro devel branch
* completed adding the workarounds from the original driver script
* ported modifications made to original driver script
* ur_driver: run_depend on trajectory_msgs.
* ur_driver: run_depend on beautifulsoup. Fix #29 <https://github.com/ros-industrial/universal_robot/issues/29>.
* Added keywords to arguments for new message instance of JointTrajectoryPoint().
  Arguments were previously "in order" but the keyword arguments are recommended as they are more resilient to msg changes.
* Add 1 sec throttle to unknown pkt warning.
* Fix formatting and sort list of unknown ptypes.
* Ignore unknown pkt types, instead of erroring out.
  This change modifies the behaviour of the driver in case an
  unknown packet type is encountered. Previously, the deserialisation
  routine would raise an exception, which would cause the driver
  to print an error and exit.
  In the current implementation the unknown packet type(s) are
  stored, their payload ignored, and the driver reports the fact that
  unknown type(s) was/were received (with a request to report the
  warning, ideally to the package maintainer).
  This is not a solution for #16 <https://github.com/ros-industrial/universal_robot/issues/16>, although that issue prompted this
  change.
* Added definitions for adding tergets in install folder. Issue #10 <https://github.com/ros-industrial/universal_robot/issues/10>.
* Merge branch 'groovy-devel' into groovy-dev
* Added definitions for adding tergets in install folder. Issue #10 <https://github.com/ros-industrial/universal_robot/issues/10>.
* Merge remote-tracking branch 'origin/master' into hydro-dev
* Fixed reference from ur5_driver to ur_driver in test_move.py
* patch for ur_driver/deserialize.py
* Updated to catkin.  ur_driver's files were added to nested Python directory for including in other packages.
* Added launch directory to bringup package.  Left the old launch files to be backwards compatable for now.  Updated driver with SwRI internal changes.  Changed driver to accept ip address to match ROS-Industrial standard.  IP addresses for industrial robots are typically fixed.  Hostnames are not typically used (this is what the driver expected)
* Renamed packages and new groovy version
* Added ur10 and renamed packages
* Contributors: Christina Gomez, Damien Smeets, IPR-SR2, Kelsey, ROS-Industrial, Shaun Edwards, gavanderhoorn, ipa-nhg, robot, ros-industrial
```
## ur_gazebo

```
* adapt launch files in order to be able to use normal/limited xacro
* updates for latest gazebo under hydro
* Contributors: ipa-fxm
* Added definitions for adding tergets in install folder. Issue #10 <https://github.com/ros-industrial/universal_robot/issues/10>.
* Added definitions for adding tergets in install folder. Issue #10 <https://github.com/ros-industrial/universal_robot/issues/10>.
* Updated to catkin.  ur_driver's files were added to nested Python directory for including in other packages.
* removed arm_ prefix from joint names in gazebo controller config
* Renamed packages and new groovy version
* Added ur10 and renamed packages
* Contributors: IPR-SR2, Kelsey, Mathias Lüdtke, ipa-nhg, robot
```
## ur_kinematics

```
* Added definitions for adding tergets in install folder. Issue #10 <https://github.com/ros-industrial/universal_robot/issues/10>.
* Added definitions for adding tergets in install folder. Issue #10 <https://github.com/ros-industrial/universal_robot/issues/10>.
* Updated to catkin.  ur_driver's files were added to nested Python directory for including in other packages.
* added IKfast compatibility functions
* Ported ur_kinematics package from Georgia Tech library.  Added ability to create ur5 & ur10 kinematics libraries.  Python libaries not untested.  Kinematics still needs to be wrapped within Kinematics plugin interface
* Contributors: IPR-SR2, Kelsey, Mathias Lüdtke, Shaun Edwards
```
