### PR TITLE
cob_common: 0.5.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -446,7 +446,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.5.2-2
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.5.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.2-2`
## brics_actuator
- No changes
## cob_common
- No changes
## cob_description

```
* reminder comment ;-)
* ee_link is now back in ur_description
* Contributors: ipa-fxm
```
## cob_srvs

```
* merge
* add new service
* Contributors: Florian Weisshardt
```
## desire_description
- No changes
## raw_description
- No changes
