### PR TITLE
ros_controllers: 0.7.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4302,7 +4302,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.7.0-0
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.7.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.7.0-0`
## diff_drive_controller

```
* Changed test-depend to build-depend for release jobs.
* Contributors: Bence Magyar
```
## effort_controllers
- No changes
## force_torque_sensor_controller
- No changes
## forward_command_controller
- No changes
## gripper_action_controller
- No changes
## imu_sensor_controller
- No changes
## joint_state_controller
- No changes
## joint_trajectory_controller
- No changes
## position_controllers
- No changes
## ros_controllers
- No changes
## velocity_controllers
- No changes
