### PR TITLE
universal_robot: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5634,7 +5634,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-industrial-release/universal_robot-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robot` to `1.0.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.0.1-0`
## universal_robot

```
* Merge branch 'hydro-devel' of github.com:ros-industrial/universal_robot into hydro
* added missing dependency
* Contributors: Florian Weisshardt, ipa-fxm
```
## ur10_moveit_config
- No changes
## ur5_moveit_config
- No changes
## ur_bringup
- No changes
## ur_description
- No changes
## ur_driver
- No changes
## ur_gazebo
- No changes
## ur_kinematics
- No changes
