### PR TITLE
roslint: 0.9.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1118,11 +1118,20 @@ repositories:
       version: master
     status: maintained
   roslint:
+    doc:
+      type: git
+      url: https://github.com/ros/roslint.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/roslint-release.git
-      version: 0.9.1-0
+      version: 0.9.2-1
+    source:
+      type: git
+      url: https://github.com/ros/roslint.git
+      version: master
+    status: maintained
   roslisp:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `roslint` to `0.9.2-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.9.1-0`
## roslint

```
* Better implementation of roslint_add_test
* Simple implementation of XML results output
* roslint roslints itself
* Contributors: Mike Purvis
```
