### PR TITLE
interactive_marker_twist_server: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -405,6 +405,21 @@ repositories:
       url: https://github.com/ros-perception/imu_pipeline.git
       version: indigo-devel
     status: maintained
+  interactive_marker_twist_server:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
+      version: indigo-devel
+    status: maintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_marker_twist_server` to `0.0.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## interactive_marker_twist_server

```
* Parameterize robot's name and the size of the resulting markers.
* Remove non-markers files from turtlebot_viz, Turtlebot-specific references.
* Starting point is https://github.com/turtlebot/turtlebot_viz
```
