### PR TITLE
interactive_marker_twist_server: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -408,7 +408,7 @@ repositories:
   interactive_marker_twist_server:
     doc:
       type: git
-      url: https://github.com/ros-visualization/interactive_marker_twist_server
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
       version: indigo-devel
     release:
       tags:
@@ -417,7 +417,7 @@ repositories:
       version: 1.0.0-0
     source:
       type: git
-      url: https://github.com/ros-visualization/interactive_marker_twist_server
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
       version: indigo-devel
     status: maintained
   interactive_markers:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -405,6 +405,21 @@ repositories:
       url: https://github.com/ros-perception/imu_pipeline.git
       version: indigo-devel
     status: maintained
+  interactive_marker_twist_server:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server
+      version: indigo-devel
+    status: maintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_marker_twist_server` to `1.0.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## interactive_marker_twist_server

```
* Add roslaunch file check, roslint
* Make cmd_vel topic relative; fixes #3 <https://github.com/ros-visualization/interactive_marker_twist_server/issues/3>.
* Max speed control, fixes #1 <https://github.com/ros-visualization/interactive_marker_twist_server/issues/1>
* Update copyright.
* Contributors: Mike Purvis
```
