### PR TITLE
moveit_setup_assistant: 0.5.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -643,6 +643,13 @@ repositories:
       url: https://github.com/ros-gbp/moveit_ros-release.git
       version: 0.5.18-0
     status: maintained
+  moveit_setup_assistant:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
+      version: 0.5.9-0
+    status: maintained
   nodelet_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_setup_assistant` to `0.5.9-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## moveit_setup_assistant

```
* Fixed bug 82 in a quick way by reducing min size.
* Fix for issue #70 <https://github.com/ros-planning/moveit_setup_assistant/issues/70>: support yaml-cpp 0.5+ (new api).
* Generate joint_limits.yaml using ordered joints
* Ensures that group name changes are reflected in the end effectors and robot poses screens as well
* Prevent dirty transforms warning
* Cleaned up stray cout's
* Contributors: Benjamin Chretien, Dave Coleman, Dave Hershberger, Sachin Chitta
```
