### PR TITLE
robot_pose_publisher: 0.2.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3954,11 +3954,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/wpi-rail-release/robot_pose_publisher-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/robot_pose_publisher.git
       version: hydro-devel
+    status: maintained
   robot_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_pose_publisher` to `0.2.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.2.2-0`
## robot_pose_publisher

```
* cleanup for release
* travis fix
* travis test
* gitignore cleanup
* Dry branch cleanup
* Contributors: Russell Toris
```
