### PR TITLE
robot_pose_publisher: 0.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -853,6 +853,21 @@ repositories:
       url: https://github.com/ros-gbp/robot_model-release.git
       version: 1.11.2-0
     status: maintained
+  robot_pose_publisher:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/robot_pose_publisher.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/robot_pose_publisher-release.git
+      version: 0.2.3-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/robot_pose_publisher.git
+      version: develop
+    status: maintained
   robot_state_publisher:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_pose_publisher` to `0.2.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## robot_pose_publisher

```
* cleanup for release
* travis fix
* travis test
* gitignore cleanup
* Dry branch cleanup
* Contributors: Russell Toris
```
