### PR TITLE
baxter_common: 0.7.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -187,6 +187,26 @@ repositories:
       type: git
       url: https://github.com/clearpathrobotics/axis_camera.git
       version: master
+  baxter_common:
+    doc:
+      type: git
+      url: https://github.com/RethinkRobotics/baxter_common.git
+      version: master
+    release:
+      packages:
+      - baxter_common
+      - baxter_core_msgs
+      - baxter_description
+      - baxter_maintenance_msgs
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/RethinkRobotics-release/baxter_common-release.git
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/RethinkRobotics/baxter_common.git
+      version: master
+    status: developed
   bfl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `baxter_common` to `0.7.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
