### PR TITLE
baxter_tools: 0.7.0-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -192,6 +192,21 @@ repositories:
       url: https://github.com/RethinkRobotics/baxter_interface.git
       version: master
     status: developed
+  baxter_tools:
+    doc:
+      type: git
+      url: https://github.com/RethinkRobotics/baxter_tools.git
+      version: master
+    release:
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/RethinkRobotics-release/baxter_tools-release.git
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/RethinkRobotics/baxter_tools.git
+      version: master
+    status: developed
   bfl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `baxter_tools` to `0.7.0-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## baxter_tools

```
* Creation of baxter_tools repository from sdk-examples/tools.
* Package restructure in support of Catkin expected standards.
* Adds camera_control from previous location in baxter_examples.
* Adds check for grippers pre-tare/calibrate.
* Adds reset to camera_control tool. Useful when not all cameras enumerated at boot.
* Fixes tucks arms allowing for clean handling of interrupts and partial tucks.
```
