### PR TITLE
baxter_examples: 0.7.0-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -177,6 +177,21 @@ repositories:
       url: https://github.com/RethinkRobotics/baxter_common.git
       version: master
     status: developed
+  baxter_examples:
+    doc:
+      type: git
+      url: https://github.com/RethinkRobotics/baxter_examples.git
+      version: master
+    release:
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/RethinkRobotics-release/baxter_examples-release.git
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/RethinkRobotics/baxter_examples.git
+      version: master
+    status: developed
   baxter_interface:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `baxter_examples` to `0.7.0-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## baxter_examples

```
* Creation of baxter_examples repository from sdk-examples/examples.
* Adds joint torque springs examples.
* Adds gripper cuff control example.
* Adds gripper action client example.
* Package restructure in support of Catkin expected standards.
* Adds launch files for examples using action servers or the joystick.
* Adds gripper position playback to joint trajectory file playback example.
* Removes camera_control example, now located in baxter_tools repository.
* Removes getch usage as means of exiting example programs (latency).
* Fixes joint position file playback looping. Loops now start at correct playback start.
* Fixes head movement during exit of wobbler example.
* Adds timeouts to action client's wait_for calls making sure the action servers are running.
* Fixes D-Pad mapping for ps3 joysticks.
* Adds success verification for result of joint trajectory file playback.
```
