### PR TITLE
rosauth: 0.1.4-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3487,7 +3487,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/wpi-rail-release/rosauth-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rosauth.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosauth` to `0.1.4-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.1.3-0`
## rosauth

```
* dox file fixed
* authors file added
* travis now runs tests
* cleanup for indigo
* Merge branch 'hydro-devel' of github.com:WPI-RAIL/rosauth into develop
* Merge pull request #4 <https://github.com/WPI-RAIL/rosauth/issues/4> from FriedCircuits/hydro-devel
  Add IF for rostest
* Add IF for rostest
* switched to sha512
* bug in rosauth fixed
* Contributors: Russell Toris, William
```
