### PR TITLE
rosauth: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1102,6 +1102,21 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: hydro-devel
     status: maintained
+  rosauth:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rosauth.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/rosauth-release.git
+      version: 0.1.4-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rosauth.git
+      version: develop
+    status: maintained
   rosbag_migration_rule:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosauth` to `0.1.4-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## rosauth

```
* dox file fixed
* authors file added
* travis now runs tests
* cleanup for indigo
* Merge branch 'hydro-devel' of github.com:WPI-RAIL/rosauth into develop
* Merge pull request #4 <https://github.com/WPI-RAIL/rosauth/issues/4> from FriedCircuits/hydro-devel
  Add IF for rostest
* Add IF for rostest
* switched to sha512
* bug in rosauth fixed
* Contributors: Russell Toris, William
```
