### PR TITLE
baxter: 0.7.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -187,6 +187,23 @@ repositories:
       type: git
       url: https://github.com/clearpathrobotics/axis_camera.git
       version: master
+  baxter:
+    doc:
+      type: git
+      url: https://github.com/RethinkRobotics/baxter.git
+      version: master
+    release:
+      packages:
+      - baxter_sdk
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/RethinkRobotics-release/baxter-release.git
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/RethinkRobotics/baxter.git
+      version: master
+    status: developed
   baxter_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `baxter` to `0.7.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
