### PR TITLE
rail_maps: 0.2.1-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3134,9 +3134,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/{package}/{upstream_version}
+        release: release/groovy/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_maps-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_maps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_maps` to `0.2.1-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.2.0-0`
## rail_maps

```
* readme fix
* cleanup for release
* command_center added
* Contributors: Russell Toris
```
