### PR TITLE
rail_maps: 0.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3933,7 +3933,10 @@ repositories:
       url: https://github.com/WPI-RAIL/rail_maps.git
       version: master
     release:
+      tags:
+        release: release/hydro/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_maps-release.git
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_maps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_maps` to `0.2.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## rail_maps

```
* readme fix
* cleanup for release
* command_center added
* Contributors: Russell Toris
```
