### PR TITLE
rail_maps: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -826,6 +826,21 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: groovy-devel
     status: maintained
+  rail_maps:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_maps.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/rail_maps-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_maps.git
+      version: develop
+    status: maintained
   random_numbers:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_maps` to `0.2.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## rail_maps

```
* readme fix
* cleanup for release
* command_center added
* Contributors: Russell Toris
```
