### PR TITLE
update some ecto packages

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -934,7 +934,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/ecto-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto.git
@@ -967,7 +967,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/ecto_openni-release.git
-      version: 0.3.9-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto_openni.git
@@ -978,7 +978,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/ecto_pcl-release.git
-      version: 0.3.14-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto_pcl.git
@@ -989,7 +989,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/ecto_ros-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto_ros.git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1171,7 +1171,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ecto-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto.git
@@ -1204,7 +1204,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ecto_openni-release.git
-      version: 0.3.9-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto_openni.git
@@ -1215,7 +1215,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ecto_pcl-release.git
-      version: 0.3.14-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto_pcl.git
@@ -1226,7 +1226,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ecto_ros-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto_ros.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -201,10 +201,32 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ecto-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto.git
+      version: master
+    status: maintained
+  ecto_openni:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/ecto_openni-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/plasmodic/ecto_openni.git
+      version: master
+    status: maintained
+  ecto_pcl:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/ecto_pcl-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/plasmodic/ecto_pcl.git
       version: master
     status: maintained
   ecto_ros:


### PR DESCRIPTION
ecto and ecto_ros actually have broken compilations for some configurations on hydro and need to be released: your call on whether you want to do it before the sync.
