### PR TITLE
Adding cra-ros-pkg to documentation index for hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -820,6 +820,11 @@ repositories:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/cpp_introspection.git
       version: master
+  cra-ros-pkg:
+    doc:
+      type: git
+      url: https://github.com/CharlesRiverAnalytics/cra-ros-pkg.git
+      version: hydro-devel
   cram_3rdparty:
     release:
       packages:


### PR DESCRIPTION
I'd like to add cra-ros-pkg to the ros.org index.
