### PR TITLE
rovio: 0.2.1-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3764,6 +3764,26 @@ repositories:
     doc:
       type: git
       url: https://github.com/OSUrobotics/rostop_gui.git
+  rovio:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rovio.git
+      version: master
+    release:
+      packages:
+      - rovio
+      - rovio_av
+      - rovio_ctrl
+      - rovio_shared
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/wpi-rail-release/rovio-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rovio.git
+      version: develop
+    status: maintained
   rqt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rovio` to `0.2.1-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## rovio

```
* build errors fixed
* rovio_av catkinized
* rovio metapackage created
* Contributors: Russell Toris
```
## rovio_av

```
* launch bug fixed
* rovio_shared catkinized
* rovio_ctrl catkinized
* rovio_av catkinized
* initial import
* Contributors: Russell Toris
```
## rovio_ctrl

```
* launch bug fixed
* build errors fixed
* rovio_shared catkinized
* rovio_ctrl catkinized
* initial import
* Contributors: Russell Toris
```
## rovio_shared

```
* build errors fixed
* rovio_shared catkinized
* initial import
* Contributors: Russell Toris
```
