### PR TITLE
ecl_tools: 0.60.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -251,6 +251,15 @@ repositories:
       type: git
       url: https://github.com/stonier/ecl_tools.git
       version: indigo
+    release:
+      packages:
+      - ecl_build
+      - ecl_license
+      - ecl_tools
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_tools-release.git
+      version: 0.60.1-0
     source:
       type: git
       url: https://github.com/stonier/ecl_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_tools` to `0.60.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## ecl_build

```
* ecl_check_for->ecl_detect for consistency.
* use catkin exports for cmake modules, closes #2 <https://github.com/stonier/ecl_tools/issues/2>
* Contributors: Daniel Stonier
```
