### PR TITLE
mjpeg_server: 1.1.1-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2115,7 +2115,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/RobotWebTools-release/mjpeg_server-release.git
-      version: 1.1.0-0
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/RobotWebTools/mjpeg_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mjpeg_server` to `1.1.1-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.1.0-0`
## mjpeg_server

```
* cleanup for indigo
* Merge pull request #6 <https://github.com/RobotWebTools/mjpeg_server/issues/6> from garaemon/unregister-nonused-topic
  Unregister non-used subscribers
* add documentation
* remove a subscriber in sendStream and sendSnapshot
* unregister Subscriber if the number of subscribers for the topic equals to 0
* Merge pull request #4 <https://github.com/RobotWebTools/mjpeg_server/issues/4> from nus/fixed-timestamp
  Fixed timestamp
* Fixed the streaming timestamp
* Fixed the snapshot timestamp
* Merge pull request #1 <https://github.com/RobotWebTools/mjpeg_server/issues/1> from rctoris/groovy-devel
  Cleanup/Travis Added
* Header files now installed
* minor cleanup and travis added
* Minor cleanup and change of READMEs and such
* Contributors: Brandon Alexander, Russell Toris, Ryohei Ueda, yota
```
