### PR TITLE
mjpeg_server: 1.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -661,6 +661,21 @@ repositories:
       url: https://github.com/ros-gbp/message_runtime-release.git
       version: 0.4.12-0
     status: maintained
+  mjpeg_server:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/mjpeg_server.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotWebTools-release/mjpeg_server-release.git
+      version: 1.1.1-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/mjpeg_server.git
+      version: develop
+    status: maintained
   moveit_commander:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `mjpeg_server` to `1.1.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## mjpeg_server

```
* cleanup for indigo
* Merge pull request #6 <https://github.com/RobotWebTools/mjpeg_server/issues/6> from garaemon/unregister-nonused-topic
  Unregister non-used subscribers
* add documentation
* remove a subscriber in sendStream and sendSnapshot
* unregister Subscriber if the number of subscribers for the topic equals to 0
* Merge pull request #4 <https://github.com/RobotWebTools/mjpeg_server/issues/4> from nus/fixed-timestamp
  Fixed timestamp
* Fixed the streaming timestamp
* Fixed the snapshot timestamp
* Merge pull request #1 <https://github.com/RobotWebTools/mjpeg_server/issues/1> from rctoris/groovy-devel
  Cleanup/Travis Added
* Header files now installed
* minor cleanup and travis added
* Minor cleanup and change of READMEs and such
* Contributors: Brandon Alexander, Russell Toris, Ryohei Ueda, yota
```
