### PR TITLE
frontier_exploration: 0.2.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1405,7 +1405,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/paulbovbel/frontier_exploration-release.git
-      version: 0.1.9-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/paulbovbel/frontier_exploration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `frontier_exploration` to `0.2.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.1.9-0`
## frontier_exploration

```
* rename test file
* add more costmap_tools tests
* refactor with frontier_search strategy object
* remove calls to parent costmap instance
* refactored to raii
* fix gmapping compatibility using new "explore_clear_space" parameter
* Contributors: Paul Bovbel
```
