### PR TITLE
Fix pyqt4-dev-tools dep for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2174,7 +2174,7 @@ ps-engine:
 pyqt4-dev-tools:
   arch: [python2-pyqt4]
   debian: [pyqt4-dev-tools]
-  fedora: [PyQT4-devel]
+  fedora: [PyQt4-devel]
   gentoo:
     portage:
       packages: [dev-python/PyQt4]


### PR DESCRIPTION
Case mismatch caused installation failure

Thanks!
