### PR TITLE
moveit_visual_tools: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2924,6 +2924,13 @@ repositories:
       url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
       version: 0.5.8-0
     status: maintained
+  moveit_visual_tools:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/davetcoleman/moveit_visual_tools-release.git
+      version: 0.1.0-0
+    status: developed
   mr_teleoperator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `0.1.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## moveit_visual_tools

```
* Split moveit_visual_tools from its original usage within block_grasp_generator package
```
