### PR TITLE
ecl_lite: 0.60.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -221,6 +221,19 @@ repositories:
       type: git
       url: https://github.com/stonier/ecl_lite.git
       version: indigo
+    release:
+      packages:
+      - ecl_config
+      - ecl_converters_lite
+      - ecl_errors
+      - ecl_io
+      - ecl_lite
+      - ecl_sigslots_lite
+      - ecl_time_lite
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_lite-release.git
+      version: 0.60.1-0
     source:
       type: git
       url: https://github.com/stonier/ecl_lite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_lite` to `0.60.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## ecl_config

```
* update to catkin's CFG_EXTRAS for easy to find cmake modules.
* Contributors: Daniel Stonier
```
## ecl_time_lite

```
* update to catkin's CFG_EXTRAS for easy to find cmake modules.
* Contributors: Daniel Stonier
```
