### PR TITLE
ecl_core: 0.60.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -211,6 +211,34 @@ repositories:
       type: git
       url: https://github.com/stonier/ecl_core.git
       version: indigo
+    release:
+      packages:
+      - ecl_command_line
+      - ecl_concepts
+      - ecl_containers
+      - ecl_converters
+      - ecl_core
+      - ecl_core_apps
+      - ecl_devices
+      - ecl_eigen
+      - ecl_exceptions
+      - ecl_formatters
+      - ecl_geometry
+      - ecl_ipc
+      - ecl_linear_algebra
+      - ecl_math
+      - ecl_mpl
+      - ecl_sigslots
+      - ecl_statistics
+      - ecl_streams
+      - ecl_threads
+      - ecl_time
+      - ecl_type_traits
+      - ecl_utilities
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_core-release.git
+      version: 0.60.8-0
     source:
       type: git
       url: https://github.com/stonier/ecl_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_core` to `0.60.8-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## ecl_command_line
- No changes
## ecl_concepts
- No changes
## ecl_containers
- No changes
## ecl_converters
- No changes
## ecl_core
- No changes
## ecl_core_apps
- No changes
## ecl_devices

```
* control new posix.1-2008 SIGPIPE signals, #34 <https://github.com/stonier/ecl_core/issues/34>
* Contributors: Daniel Stonier
```
## ecl_eigen
- No changes
## ecl_exceptions
- No changes
## ecl_formatters
- No changes
## ecl_geometry
- No changes
## ecl_ipc

```
* ecl_ipc requires ecl_build for cmake modules.
* make sure we detect threads in this module
* Contributors: Daniel Stonier
```
## ecl_linear_algebra
- No changes
## ecl_math
- No changes
## ecl_mpl
- No changes
## ecl_sigslots
- No changes
## ecl_statistics
- No changes
## ecl_streams
- No changes
## ecl_threads
- No changes
## ecl_time
- No changes
## ecl_type_traits
- No changes
## ecl_utilities
- No changes
