### PR TITLE
ecl_navigation: 0.60.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -282,6 +282,14 @@ repositories:
       type: git
       url: https://github.com/stonier/ecl_navigation.git
       version: indigo
+    release:
+      packages:
+      - ecl_mobile_robot
+      - ecl_navigation
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_navigation-release.git
+      version: 0.60.0-0
     source:
       type: git
       url: https://github.com/stonier/ecl_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_navigation` to `0.60.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
