### PR TITLE
ecl_manipulation: 0.60.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -272,6 +272,15 @@ repositories:
       type: git
       url: https://github.com/stonier/ecl_manipulation.git
       version: indigo
+    release:
+      packages:
+      - ecl
+      - ecl_manipulation
+      - ecl_manipulators
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_manipulation-release.git
+      version: 0.60.0-0
     source:
       type: git
       url: https://github.com/stonier/ecl_manipulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_manipulation` to `0.60.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
