### PR TITLE
jsk_roseus: 1.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2283,11 +2283,12 @@ repositories:
     release:
       packages:
       - euslisp
+      - geneus
       - roseus
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.0.4-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.0.4-0`
## euslisp

```
* Merge pull request #49 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/49> from cottsay/master
  Fix permissions on installed libraries
* (#41 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/41>) check if installed binary inlcude old rpath with file(STRING,
* check gcc -dumpmachine for deb build
* Contributors: Kei Okada
* Fix permissions on installed libraries
  All shared-object libraries should have execute permissions.
* Contributors: Scott K Logan
```
## geneus

```
* roseus.cmake: add depend to message_generation_py, use same code for both msg/srv generation
* generated_eus: do not write generated file if manifest.l is not exists
* add geneus package that generate ros message for euslisp
* Contributors: Kei Okada
```
## roseus

```
* add geneus package that generate ros message for euslisp
* (#32 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/32>) copy jsk_roseus for one workspace and remove build on rosbuild
* (#32 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/32>) add rich test for euslisp message generation, remove scripts and generate them from one shell script.
  * one workspace/separated workspace
  * add several dependency
  * action messages generation
* (#32 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/32>) add scripts to test geneus more
* (#32 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/32>) check if test the message has created or not by simple roseus program, add euslisp test rather than cpp test code
* (#32 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/32>) add test-genmsg, test message generation on catkin and rosbuild
* add check delay of lookuptransform
* add checking delay of tf return
* Contributors: Kei Okada, Ryohei Ueda, YoheiKakiuchi
```
