### PR TITLE
turtlebot: 2.2.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5589,7 +5589,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot-release.git
-      version: 2.2.3-0
+      version: 2.2.4-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot` to `2.2.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `2.2.3-0`
## linux_hardware
- No changes
## turtlebot
- No changes
## turtlebot_bringup

```
* add depth argument to configure scan_processing. With this configuration scan works for both depth_regratation false and true
* Fixing "Error with diagnostics.yaml for roomba #110 <https://github.com/turtlebot/turtlebot/issues/110>"
* Contributors: Jihoon Lee, Luka Čehovin
```
## turtlebot_description
- No changes
