### PR TITLE
vision_visp: 0.7.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1582,6 +1582,28 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: indigo
     status: maintained
+  vision_visp:
+    doc:
+      type: git
+      url: https://github.com/lagadic/vision_visp.git
+      version: indigo
+    release:
+      packages:
+      - vision_visp
+      - visp_auto_tracker
+      - visp_bridge
+      - visp_camera_calibration
+      - visp_hand2eye_calibration
+      - visp_tracker
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/lagadic/vision_visp.git
+      version: 0.7.2-0
+    source:
+      type: git
+      url: https://github.com/lagadic/vision_visp.git
+      version: indigo-devel
+    status: maintained
   visp:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.7.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## vision_visp
- No changes
## visp_auto_tracker

```
* Fix various dependency issues in the CMakeLists.txt and package.xml files
* lipstick

  Aesthetic changes
* [visp_auto_tracker] Add missing dependency
* Add missing dependency to ViSP
* Fix errors detected with catkin_lint
* Contributors: Fabien Spindler, Thomas Moulard
```
## visp_bridge

```
* Fix various dependency issues in the CMakeLists.txt and package.xml files
* Add missing dependency to ViSP
* Fix errors detected with catkin_lint
* Contributors: Fabien Spindler, Thomas Moulard
```
## visp_camera_calibration

```
* Fix various dependency issues in the CMakeLists.txt and package.xml files
* lipstick

  Aesthetic changes
* Add missing dependency to ViSP
* Fix errors detected with catkin_lint
* Contributors: Fabien Spindler, Thomas Moulard
```
## visp_hand2eye_calibration

```
* Fix various dependency issues in the CMakeLists.txt and package.xml files
* lipstick

  Aesthetic changes
* Add missing dependency to ViSP
* Fix errors detected with catkin_lint
* Contributors: Fabien Spindler, Thomas Moulard
```
## visp_tracker

```
* Remove bullet usage and dependency by using ViSP instead. This was done to avoid errors when releasing vision_visp on oneiric/groovy where bullet is not packaged.
* Reorganize launch files and fix since viewer and client nodes where renamed due to catkin_lint errors
* Fix various dependency issues in the CMakeLists.txt and package.xml files
* Use Boost Filesystem V3.
* [visp_tracker] package.xml: add back Bullet dependency
* Add missing dependency to ViSP
* Fix errors detected with catkin_lint
* Contributors: Benjamin Chrétien, Fabien Spindler, Thomas Moulard
```
