### PR TITLE
jsk_roseus: 1.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2289,7 +2289,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.1-0
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.1.1-0`
## euslisp

```
* catkin.make : fix: use gcc dumpmachine to check archtecture
* test : add test code to test launch, test codes are already included in irteus/demo
* Contributors: Kei Okada, Shunnichi Nozawa
```
