### PR TITLE
diagnostics: 1.8.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -969,7 +969,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/diagnostics-release.git
-      version: 1.8.0-0
+      version: 1.8.1-0
+    source:
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: hydro-devel
+    status: maintained
   diffdrive_gazebo_plugin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `1.8.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.8.0-0`
