### PR TITLE
diagnostics: 1.8.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -191,6 +191,29 @@ repositories:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
       version: indigo-devel
+  diagnostics:
+    doc:
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: indigo-devel
+    release:
+      packages:
+      - diagnostic_aggregator
+      - diagnostic_analysis
+      - diagnostic_common_diagnostics
+      - diagnostic_updater
+      - diagnostics
+      - self_test
+      - test_diagnostic_aggregator
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/diagnostics-release.git
+      version: 1.8.1-0
+    source:
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: indigo-devel
+    status: maintained
   dynamic_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `1.8.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
