### PR TITLE
ipa_canopen: 0.5.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2220,7 +2220,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/ipa_canopen-release.git
-      version: 0.5.3-0
+      version: 0.5.4-0
     source:
       type: git
       url: https://github.com/ipa320/ipa_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ipa_canopen` to `0.5.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.5.3-0`
## ipa_canopen
- No changes
## ipa_canopen_core

```
* Fixes the move_device and homing tools for the multiple chains version
* Small clean
* Seeing EMCY
* Seeing EMCY
* Some init chains
* First functional and hardware tested version of the multiple_chains node, fixes ipa320/ipa_canopen#57 <https://github.com/ipa320/ipa_canopen/issues/57>
* Fixes ipa320/ipa_canopen#48 <https://github.com/ipa320/ipa_canopen/issues/48>
* Show devices on bus for get_error
* Incredible boost to initialization speed
* Contributors: thiagodefreitas
```
## ipa_canopen_ros

```
* Small clean
* Some init chains
* Changes on diagnostics
* fixes ipa320/cob4#58 <https://github.com/ipa320/cob4/issues/58>
* First functional and hardware tested version of the multiple_chains node, fixes ipa320/ipa_canopen#57 <https://github.com/ipa320/ipa_canopen/issues/57>
* still fixes ipa320/cob4#58 <https://github.com/ipa320/cob4/issues/58>
* fixes ipa320/cob4#58 <https://github.com/ipa320/cob4/issues/58>
* fixes ipa320/cob4#58 <https://github.com/ipa320/cob4/issues/58>
* fixes ipa320/ipa_canopen#45 <https://github.com/ipa320/ipa_canopen/issues/45>
* Contributors: thiagodefreitas
```
