### PR TITLE
tf2_web_republisher removed in pre of re-release

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -706,11 +706,6 @@ repositories:
       url: https://github.com/ros-gbp/depthcloud_encoder-release.git
       version: 0.0.3-0
     status: maintained
-  depthcloudjs:
-    doc:
-      type: git
-      url: https://github.com/RobotWebTools/depthcloudjs.git
-      version: groovy-devel
   depthimage_to_laserscan:
     doc:
       type: git

--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4223,16 +4223,6 @@ repositories:
       type: git
       url: https://github.com/vonovak/text_locator.git
       version: master
-  tf2_web_republisher:
-    doc:
-      type: git
-      url: https://github.com/RobotWebTools/tf2_web_republisher.git
-      version: groovy-devel
-    release:
-      tags:
-        release: release/{package}/{upstream_version}
-      url: https://github.com/ros-gbp/tf2_web_republisher-release.git
-      version: 0.1.0-0
   topic_proxy:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5563,12 +5563,6 @@ repositories:
       url: https://github.com/ros-gbp/teleop_twist_keyboard-release.git
       version: 0.5.0-0
     status: maintained
-  tf2_web_republisher:
-    release:
-      tags:
-        release: release/hydro/{package}/{version}
-      url: https://github.com/ros-gbp/tf2_web_republisher-release.git
-      version: 0.2.0-0
   threemxl:
     doc:
       type: git


### PR DESCRIPTION
tf2_web_republisher entries removed in order to re-release them into the proper Robot Web Tools release repository (https://github.com/RobotWebTools-release/tf2_web_republisher-release). Will re-run bloom-release once updated.
