### PR TITLE
tf2_web_republisher: 0.2.1-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4218,6 +4218,21 @@ repositories:
       type: git
       url: https://github.com/vonovak/text_locator.git
       version: master
+  tf2_web_republisher:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/tf2_web_republisher.git
+      version: master
+    release:
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/RobotWebTools-release/tf2_web_republisher-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/tf2_web_republisher.git
+      version: develop
+    status: maintained
   topic_proxy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_web_republisher` to `0.2.1-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## tf2_web_republisher

```
* cleanup
* ROS version checked for tf2 API namespace
* Contributors: Russell Toris
```
