### PR TITLE
tf2_web_republisher: 0.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5551,6 +5551,21 @@ repositories:
       url: https://github.com/ros-gbp/teleop_twist_keyboard-release.git
       version: 0.5.0-0
     status: maintained
+  tf2_web_republisher:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools-release/tf2_web_republisher.git
+      version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/RobotWebTools-release/tf2_web_republisher-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools-release/tf2_web_republisher.git
+      version: develop
+    status: maintained
   threemxl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_web_republisher` to `0.2.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## tf2_web_republisher

```
* cleanup
* ROS version checked for tf2 API namespace
* Contributors: Russell Toris
```
