### PR TITLE
laser_assembler: 1.7.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2483,7 +2483,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/laser_assembler-release.git
-      version: 1.7.1-0
+      version: 1.7.2-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_assembler.git
+      version: hydro-devel
     status: maintained
   laser_filters:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_assembler` to `1.7.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.7.1-0`
