### PR TITLE
rocon_msgs: 0.7.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1184,12 +1184,12 @@ repositories:
     release:
       packages:
       - concert_msgs
+      - concert_service_msgs
       - gateway_msgs
       - rocon_annotation_msgs
       - rocon_app_manager_msgs
       - rocon_interaction_msgs
       - rocon_msgs
-      - rocon_service_msgs
       - rocon_service_pair_msgs
       - rocon_std_msgs
       - rocon_tutorial_msgs
@@ -1197,7 +1197,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-      version: 0.7.0-0
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs` to `0.7.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.7.0-0`
## concert_msgs

```
* Next iteration of role manager messages and services (#26 <https://github.com/robotics-in-concert/rocon_msgs/pull/26>).
```
## concert_service_msgs

```
* rocon_service -> concert_service
* Contributors: Daniel Stonier
```
## rocon_interaction_msgs

```
* get roles moved completely to a service.
* int32, not 8
* unlimited interactions constant.
```
## rocon_msgs

```
* rocon_service -> concert_service
* Contributors: Daniel Stonier
```
## rocon_std_msgs

```
* igloo -> indigo
* rocon_service -> concert_service
* Contributors: Daniel Stonier
```
## rocon_tutorial_msgs

```
* moved tutorial messages to service messages.
* turtlesim v2 messages.
* Contributors: Daniel Stonier
```
## scheduler_msgs

```
* updated invalid error code comment
* convenience string for introspecting on the reason errors.
* changelog entries fixed.
* Contributors: Daniel Stonier
```
