### PR TITLE
rocon_tools: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1237,7 +1237,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_tools-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_tools` to `0.1.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.1.2-0`
## rocon_interactions

```
* rocon_uri variable name clashes with module name, fixed.
* get roles moved to a service.
* more precise rocon uri os fields for pc interactions, also added trusty to the os rules.
* catch invalid uri's when filtering.
* bugfix the request interactions hash handling, had legacy msg code still being used.
* Contributors: Daniel Stonier
```
## rocon_launch

```
* default arg for when higher level users don't need it.
* Contributors: Daniel Stonier
```
## rocon_master_info

```
* a globally visible 'ping' parameter for rocon
* Contributors: Daniel Stonier
```
## rocon_uri

```
* more precise rocon uri os fields for pc interactions, also added trusty to the os rules.
* Contributors: Daniel Stonier
```
