### PR TITLE
perception_oru: 1.0.18-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3644,7 +3644,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/tstoyanov/perception_oru-release.git
-      version: tag
+      version: release-hydro-source
     release:
       packages:
       - ndt_fuser

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3641,6 +3641,10 @@ repositories:
       version: hydro-devel
     status: maintained
   perception_oru:
+    doc:
+      type: git
+      url: https://github.com/tstoyanov/perception_oru-release.git
+      version: tag
     release:
       packages:
       - ndt_fuser
@@ -3655,7 +3659,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tstoyanov/perception_oru-release.git
-      version: 1.0.17-0
+      version: 1.0.18-0
+    source:
+      type: git
+      url: https://github.com/tstoyanov/perception_oru-release.git
+      version: release-hydro-source
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_oru` to `1.0.18-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.0.17-0`
## pointcloud_vrml
- No changes
## ndt_map
- No changes
## sdf_tracker

```
* fixes for backward support and compatibility on new ubuntu versions
* Contributors: Todor Stoyanov
```
## ndt_mcl

```
* fixes for backward support and compatibility on new ubuntu versions
* Contributors: Todor Stoyanov
```
## perception_oru
- No changes
## ndt_fuser
- No changes
## ndt_map_builder
- No changes
## ndt_visualisation
- No changes
## ndt_registration
- No changes
