### PR TITLE
perception_oru: 1.0.19-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2817,7 +2817,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tstoyanov/perception_oru-release.git
-      version: 1.0.13-0
+      version: 1.0.19-0
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_oru` to `1.0.19-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.1`
- previous version for package: `1.0.13-0`
## pointcloud_vrml
- No changes
## ndt_map
- No changes
## sdf_tracker

```
* fixes for backward compatibility to VTK5 and forward compatibility to new ubuntu releases
* Contributors: Todor Stoyanov
```
## ndt_mcl

```
* fixes for backward compatibility to VTK5 and forward compatibility to new ubuntu releases
* Contributors: Todor Stoyanov
```
## perception_oru
- No changes
## ndt_fuser
- No changes
## ndt_map_builder
- No changes
## ndt_visualisation
- No changes
## ndt_registration
- No changes
