### PR TITLE
robot_localization: 0.1.0-3 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4067,7 +4067,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 0.1.0-1
+      version: 0.1.0-3
     source:
       type: git
       url: https://github.com/cra-ros-pkg/robot_localization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `0.1.0-3`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.1.0-1`
