### PR TITLE
pcl_msgs: 0.0.4-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2788,11 +2788,19 @@ repositories:
       url: https://github.com/ros-perception/pcl_conversions.git
       version: groovy-devel
   pcl_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/pcl_msgs.git
+      version: groovy-devel
     release:
       tags:
-        release: release/{package}/{upstream_version}
+        release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/pcl_msgs-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/pcl_msgs.git
+      version: groovy-devel
   people:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_msgs` to `0.0.4-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.0.3-0`
## pcl_msgs

```
* install messages into both pcl and pcl_msgs namespace for transition
* package.xml: tuned whitespaces from bulwahn
* Contributors: Lukas Bulwahn, Paul Bovbel
```
