### PR TITLE
jsk_recognition: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2296,6 +2296,28 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_common.git
       version: master
     status: developed
+  jsk_recognition:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_recognition.git
+      version: master
+    release:
+      packages:
+      - checkerboard_detector
+      - imagesift
+      - jsk_pcl_ros
+      - jsk_perception
+      - jsk_recognition
+      - resized_image_transport
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/tork-a/jsk_recognition-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_recognition.git
+      version: master
+    status: maintained
   jsk_roseus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.1.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## checkerboard_detector

```
* install programs
* fix depend package -> rosdep name
* adding rosconsole to its dependency
* add example : update tf position everytime he receves objectdetection msg
* update tf position everytime he receves objectdetection msg
* update objectdetection_tf_publisher by using tf msg directly
* update objectdetection_tf_publisher.py
* add python program for translating the result of checkerboard_detector to tf
* add_dependences to posedetection_msgs_gencpp
* use USE_ROSBUILD for catkin/rosbuild environment
* use ROS_Distributions instead of ROS_DISTRO for electric
* comment out : add catkin.cmake
* add catkin.cmake
* fixed the name bug
* forget to fix checkerboard_calibration [#154 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/154>]
* fix to compile with cv_bridge/cv_bridge, [#154 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/154>]
* enable to set display flag for cvNamedWindow
* add checkerboard_detector_single.launch for single checkerboard detection
* change: If there is no subscriber, node stop subscribing image / camera_info topics (shutdown subscriber)
* fix deperecated message asscessor see http://ros.org/wiki/fuerte/Migration#error:_XXX_has_no_member_named_.27set_YYY_size.27_.28or_.27get_YYY_size.27.29
* use rosdep opencv2 and pkg-config, as described in the wiki http://www.ros.org/wiki/opencv2
* use rosdep opencv2 and pkg-config, as described in the wiki http://www.ros.org/wiki/opencv2
* add maxboard param, use when you know how many checkerboards in the environment
* add code for detecting subpix position using geometry of detected points,this code came from checkerboard_pose
* moved jsk_vision to jsk_visioncommon
* moved vision packages to jsk_vision
* moved posedetection_msgs, sift processing, and other packages to jsk_common and jsk_perception
* Contributors: Kei Okada, k-okada, kazuto, nozawa, rosen, ueda, youhei
```
## imagesift

```
* catkinize imagesift
* catkinize imagesift
* update to use cv_bridge
* use rosdep opencv2 and pkg-config, as described in the wiki http://www.ros.org/wiki/opencv2
* use rosdep opencv2 and pkg-config, as described in the wiki http://www.ros.org/wiki/opencv2
* fix typo for opencv version check
* include nonfree/nonfree.hpp for OpenCV 2.4
* Switch to using the standard vector API: get_data_size() -> data.size()
* moved jsk_vision to jsk_visioncommon
* moved vision packages to jsk_vision
* moved posedetection_msgs, sift processing, and other packages to jsk_common and jsk_perception
* Contributors: Kei Okada, k-okada, rosen
```
## jsk_pcl_ros

```
* add depend_tag for pcl_conversions and not needed tags
  delete not needed tags
* #31 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/31>: catch runtime error in order to ignore error from tf and so on
* #31 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/31>: use SlicedPointCloud in VoxelGridDownsampleDecoder and use NODELET_** macros
  instead of ROS_** macros
* #31 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/31>:  use SlicedPointCloud in VoxelGridDownsampleManager
* #31 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/31>: add new message for VoxelGrid{Manager,Decoder}: SlicedPointCloud.msg
* replacing image_rotate namespace with jsk_pcl_ros because of porting
* fix package name of dynamic reconfigure setting file
* use ROS_VERSION_MINIMUM
* use TF2_ROS_VERSION instead of ROS_MINIMUM_VERSION macro
* use tf2::BufferClient on groovy
* add cfg file for image_rotate dynamic reconfigure
* porting image_rotate_nodelet from image_pipeline garamon's fork.
  this version of image_rotate supports tf2 and nodelet.
* add rosdepend to prevent pointcloud_screenpoint_nodelet error
* use jsk nodelet mux for pcl roi
* add arg to set nodelet manager name
* use the same nodelet manager as openni
* #20 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/20>: implement PointCloudThrottle and ImageMUX, ImageDEMUX and ImageThrotle
* add sensor_msgs dependency to message generation
* Merge remote-tracking branch 'refs/remotes/garaemon/add-message-dependency-to-jsk-pcl-ros' into garaemon-avoid-roseus-catkin-bug
  Conflicts:
  jsk_pcl_ros/catkin.cmake
* change the location of generate_messages and catkin_package of jsk_pcl_ros
* add sensor_msgs depdendency to jsk_pcl_ros's message generation
* #8 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/8>: remove delay pointcloud nodelet
* #15 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/15>: remove unused comment
* #15 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/15>: remove unused cpp source codes, now they are automatically generated from single_nodelet_exec.cpp.in
* #15 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/15>: automatically generate the single nodelet programs on rosbuild
* #15 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/15>: rename resize_points_publisher to resize_points_publisher_nodelet according to naming convention
* #15 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/15>: fix endmacro syntax
* #15 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/15>: automatically generate cpp codes in catkin build
* #15 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/15>: add quotes to the template file
* #15 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/15>: add a template file to run single nodelet
* add pcl_conversions to jsk_pcl_ros
* add eigen_conversions to jsk_pcl_ros dependency
* #11 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/11>: specify package.xml by fullpath
* #11 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/11>: add pcl to dependency if distro is groovy
* #11 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/11>: pcl is not a catkin package
* #11 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/11>: fix if sentence order
* #11 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/11>: depend pcl catkin package in groovy
* listed up nodelets provided by jsk_pcl_ros
* #4 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/4>: removed icp_server, it's just a sample program
* #4 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/4>: remove LazyConcatenater and PointcloudFlowrate from CMakeLists.txt
* #4 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/4>: remove LazyConcatenater and PointcloudFlowrate from jsk_pcl_nodelets.xml
* #4 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/4>: removed LazyConcatenater and PointcloudFlowrate
* fix depend package -> rosdep name
* add keypoints publisher; first supported only nerf
* add code for using GICP if using hydro
* add PolygonArray.msg for catkin build system
* adding header
* adding more nodelet modules for catkin
* adding CallSnapIt.srv
* add tf topic name parameter
* add pcl roi launch files
* add base_frame parameter in voxel_grid_downsample
* adding special message for polygon array
* adding hinted plane detector to xml nodelet list
* enable use_point_array of screenpoint
* add include <pcl_conversions/pcl_conversions.h> for groovy
* use pcl_conversions for hydro, see http://wiki.ros.org/hydro/Migration#PCL
* fix wrong commit on
* forget to commit, sorry
* add SnapItRequest to add_message_files
* adding sample for hinted plane detector
* adding HintedPlaneDetector and pointcloudScreenpoint supports converting array of 2d points into 3d
* adding HintedPlaneDetector and pointcloudScreenpoint supports converting array of 2d points into 3d
* publishing marker as recognition result
* implemented snapit for cylinder model
* adding height field
* adding cylinder parameters
* supporting cylinder model fitting
* fix for groovy with catkin
* setting axis when snap to the plane
* fixing transformation concatenation
* adding new module: SnapIt
* fix issue #268 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/268>, run sed only when needed
* does not publish if the grid is empty
* change the default value
* change the default value
* adding initial ROI
* adding initial ROI
* not cahing old points
* supporting the change of the voxel num
* supporting the change of the voxel num
* supporting the change of the voxel num
* supporting the change of the voxel num
* not remove previous pointcloud as long as possible
* change the default value to 300
* supporting frame_id
* using tf
* adding decoder for voxel grid downsample manager
* adding message
* adding voxel grid downsample manager
* adding voxel_grid_downsample_manager
* supporting dynamic reconfigure
* adding lazy concatenater
* adding lazy concatenate sample
* adding lazy_concatenater
* debug RGBColorFilter and HSVColorFIlter for hydro
* adding pointcloud_flowrate nodelet skelton
* adding pointcloud_flowrate nodelet skelton
* compile pointcloud_flowrate executable
* executable to run pointcloud_flowrate
* tracking.launch change to tracking_hydro.launch and tracking_groovy.launch
* add load_manifest for rosbuild
* fix filtering range when min value is grater than max value
* fix filter name
* add rgb filter
* add mutex::scoped_lock in particle_filter_tracking
* debug in renew_tracking.py ROS_INFO -> rospy.loginfo
* add scripts/renew_trakcing.py launch/tracking.launch
* use SetPointCloud2
* add particle filter trackig node/nodelt with SetPointCloud2.srv
* fix pointcloud_scrennpoint.cpp to use jsk_pcl_ros -> jsk_pcl, by k-okada
* enable respawning
* add depends to pcl_msgs
* adding icp server
* adding TOWER_LOWEST2
* support both catkin/rosbuild
* update catkin makefile, add _gencpp, _gencfg
* support both catkin/rosbuild
* add_dependences to jsk_pcl_ros_gencpp
* pcl -> pcl_msgs for pcl-1.7 (hydro), but use sed to force change pcl/ namespace for groovy
* hydro migration, pcl 1.7 is independent from ros, see http://wiki.ros.org/hydro/Migration
* use USE_ROSBUILD for catkin/rosbuild environment
* starting with the middle tower
* fixing typo
* fixing typo
* using positoin from /origin, instead of from robot frame id
* added code for running centroid_publishers to publish segmented point cloud centroids
* update the position parameter for the demo
* fixing the rotatio of camera
* update the index of tower, plate, using enum in srv
* adding service to move robot with just index
* update the parameter and the axis
* fix to move robot to the goal tower
* update to run with eus ik server
* resolve position of each tf
* set the quality of the mjpeg server 100
* fixing message of the modal of alert
* block the tower already having plates
* adding debug message
* adding empty function to move robot
* adding graph
* adding service type to move robot
* smaller fonts
* adding cluster num on debug layer
* adding the number of the clusters
* update
* update the message
* adding more states for hanoi-tower
* small fixes
* adding service to pickup tower
* adding text shadow
* click detection by service call
* cenrerize button
* adding help modal
* track the window size
* adding html to redirect to tower_detecct_viewer
* centerize the image
* centerize the image
* adding state
* introducing state machine
* detecting clicked cluster
* using tower_detect_viewer_server
* providing a class
* adding some web related files
* using filled flag
* update params for lab room
* specifying tf_timeout of image_view2
* not subscribing topic to refer timestamp
* fixing header timestamp
* using some topic to refer timestamp
* supporting marker id
* update
* update topic to use image_view2's image
* fixing draw_3d_circle
* add script to draw circle on image_view2
* using location.hostname for the IP address
* adding www directory for tower_detect brawser viewer
* adding a launch file to launch mjpeg_server
* adding CentroidPublisher
* empty CentroidPublisher class
* implementing z axis sorting
* more effective implementation
* more information about resetting tracking
* fixing registration parameter
* adding nodelet skelton cpp
* adding cluster_point_indices_decomposer_z_axis.cpp
* adding sortIndicesOrder as preparation to customize ordering technique
* adding new nodelet ClusterPointIndicesDecomposer
* adding more methods
* adding skelton class to decompose ClusterPointIndices
* adding license declaration
* adding launch file to examin euclidean segmentation
* fixing label tracking
* refactoring
* refactoring
* refactoring
* supporting label_tracking_tolerance
* refactoring
* implementing labeling tracking
* calculate distance matrix
* adding one more color
* refactoring
* fixing compilation warning
* calculate centroids at the first frame
* fixing indentation
* using static colors to colorize clustered pointclouds
* removing noisy output
* removing invalid comments
* supporting dynamic reconfigure for euclidean clustering
* fixing rotation
* adding /origin and /table_center
* adding two lanch files
* adding top level launch
* openni.launch with depth_registered=true
* fix missing dependancy
* update hsv_color_filter.launch
* add USE_REGISTERER_DEPTH argument to pointcloud_screenpoint.launch
* remove env-loader (localhost do not need env-loader)
* update parameter use_point false -> true
* add same parameters to not USE_VIEW
* fix strequal ROS_DISTRO env
* use ROS_Distributions instead of ROS_DISTRO for electric
* fix for electric
* add USE_SYNC parameter to pointcloud_screenpoint.launch
* update pointcloud_screnpoint.launch
* merged image_view2/points_rectangle_extractor.cpp to pointcloud_screenpoint
* add EuclideanClustering [#119 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/119>]
* copy pcl_ros/filters/filter to jsk_pcl_ros directory due to https://github.com/ros-perception/perception_pcl/issues/9, [#119 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/119>]
* add catkin.cmake, package.xml for groovy, remove nodelt depends on pcl_ros::Filter https://github.com/ros-perception/perception_pcl/issues/9
* fix description comment
* remove cv_bridge
* add sample code for using
* add lisp code for using pointcloud in roseus
* use tf::Quaternion instead of btQuaternion
* comment out pcl_ros/features/features.cpp
* libtbb -> tbb , see rosdep/base.yaml
* change rodep name:libtbb to tbb
* update index.rst,conf.py by Jenkins
* fix: high load of screenpoint
* fix: change dynamic config
* fix: variable range of hue
* delete obsolated files
* rewrite color_filter and color_filter_nodelet for PCL 1.5 and later
* update sample for color_filter
* update index.rst,conf.py by Jenkins
* changed arg setting for launch from pr2.launch using mux
* update index.rst,conf.py by Jenkins
* fix: for using pcl_ros/feature class
* changed kinect's name from camera to openni
* fix: depth_image_creator added to nodelet
* use machine tag with env-loader
* comment out old pcl modules
* remove machine tag, which is not used
* fix for compiling fuerte and electric
* fix row_step and is_dense variables for resized point cloud
* added service of switching topic for depth_image_creator
* update index.rst,conf.py by Jenkins
* outout launchdoc-generator to build directry to avoid svn confrict
* remove jskpointcloud dependency from jsk_pcl_ros
* copy depth_image_creator from unreleased
* add jsk_pcl_ros (copy from unreleased repository)
* Contributors: JSK applications, Kei Okada, Ryohei Ueda, aginika, chen, furushchev, furuta, inagaki, k-okada, kazuto, roseus, ueda, wesley, youhei
```
## jsk_perception

```
* catkinize jsk_perception
* check initialization in check_subscribers function
* change callback function names for avoiding the same name functions
* add edge_detector.launch
* change debug message
* rename type -> atype
* fix minor bug
* change for treating multiple objects in one ObjectDetection.msg
* add test programs
* add rosbuild_link_boost for compile on fuerte/12.04 , see Issue #224 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/224>, thanks tnakaoka
* add rectangle_detector, based on http://opencv-code.com/tutorials/automatic-perspective-correction-for-quadrilateral-objects/
* update hoguh_lines
* use blur before canny
* add image_proc modules from opencv samples
* change error_threshold max 200 -> 2000
* add :detection-topic keyword to (check-detection)
* replace sleep to :ros-wait for making interruptible
* add scripts for speaking english
* speak before sleep
* add to spek we're looking for...
* print out debug info
* turtlebot/ros pdf
* add ros/turtlebot-logo images #173 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/173>
* update japanese speaking
* modify parameter definition. parameter should not be overwritten.
* add option publish-objectdetection-marker
* add slot :diff-rotation in detection_interface.l
* do not create ros::roseus object by load detection_interface.l
* publish tf from sensor frame to detected object pose
* update objectdetection-marker program for new detection_interface
* publish tf and markers, add messages
* print out error value
* fix segfault
* suppor rpy style in relative_pose, status:closed #139 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/139>
* add :target-object keyword to check-detection
* fix : project3dToPixel was removed in groovy
* update to use cv_bridge
* fix for groovy, use cv_bridge not CvBridge
* fix: speak content
* fix: speak-jp
* fix template location
* add microwave detection sample
* add speak-name for speaking japanease object name
* add speak words
* update detction_interface.l for single detection and speak flag
* add solve-tf parameter for not using tf
* add frame_id for coordinates
* add detection_interface.l for using point_pose_extractor
* remove euclidean_cluster,plane_detector and color_extractor from jsk_perception, they are supported in tabletop and pcl apps should go into jsk_pcl_ros
* add max_output
* add opencv2 to rosdep.yaml for compatibility
* update to fit opencv2 electric/fuerte convention
* fix for fuerte see https://code.ros.org/trac/ros/ticket/3955
* add size check
* fix btVector3 -> tf::Vector3
* fix remove define KdTreePtr
* fix style: support ROSPACK_API_V2 (fuerte)
* support ROSPACK_API_V2 (fuerte)
* fix for pcl > 1.3.0, pcl::KdTree -> pcl::search::KdTree, pcl::KdTreeFLANN -> pcl::search::KdTree
* remove explicit dependency to eigen from jsk_perception
* add whilte_balance_param.yaml
* add publish_array for publishing pointsarray
* move posedetectiondb/SetTemplate -> jsk_perception/SetTemplate
* add color_extractor, plane_detector, euclidean_clustering for jsk_perception
* fixed the package name of WhiteBalance.srv
* add eigen to dependency
* add white_balance_converter to jsk_perception
* change msg from face_detector_mono/Rect -> jsk_perception/Rect. I couldn't find set_serch_rect string under jsk-ros-pkg
* node moved from virtual_camera
* check if the matched region does not too big or too small
* add dynamic reconfigure for point_pose_extractor
* split launch for elevator_navigation, to test modules
* fix for oneiric
* fix for users who does not have roseus in their PATH
* ns can't be empty string in launch xml syntax
* commit updates for demo
* added tv-controller with ut logo
* added tv-controller with ut logo
* fixed the size of wrap image, which is calcurated from input (width/height)
* add to write wrapped image
* add error handling and output template file
* add opencv-logo2.png
* add lipton milktea model, auto generated file prefix .launch -> .xml to avoid listed by auto complete
* add sharp rimokon with ist logo
* changed variable name client -> clients
* add sharp tv controller to sample
* add sample for detection launcher generator
* use try to catch assertions
* set Zero as distortionMatrix, because ImageFeature0D.image is rectified
* fixed the box pose in debug image
* changed code for generate SIFT template info
* use projectionMatrix instead of intrinsicMatrix in solvePnP, remove CvBridge -> cv_bridge
* fix to work without roseus path in PATH
* fix relative pose, object coords to texture coords
* update generation script of SIFT pose estimation launcher, relative pose is not correct
* update eusmodel->sift_perception script
* change detection launch generation script to use jsk_perception/point_pose_extractor
* add std namespace appropriately
* update initialize template method
* publish the debug_image of point_pose_extractor
* chnage the output frame id when using only one template
* change threashold for detectiong object
* use /ObjectDetection_agg instead of /ObjectDetection
* add _agg output topic for debug and logging
* add debug message, set lifetime to 1 sec
* add objectdetection-marker.l
* add relative pose parameter to point_pose_extractor.cpp
* change the PutText region
* update sample launch file, point pose extractor do not subscribe input topics when output is not subscribed
* add viewer_window option to disable the OpenCV window
* empty window name to disable window, point_pose_extractor
* move posedetectiondb to jsk_visioncommon
* moved jsk_vision to jsk_visioncommon
* Contributors: HiroyukiMikita, Kei Okada, Haseru Chen, Yuki Furuta, Yuto Inagaki, Kazuto Murai, Manabu Saito, Rosen Dinakov, Youhei Kakiuchi
```
## jsk_recognition

```
* Initial commit
```
## resized_image_transport

```
* #11 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/11>: add depend tags
* add depend to driver_base
* add update with message
* simplify example and rename to example.launch
* fix bugs whcn resize paramater is 0, see issue #252 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/252>
* use Kbps not kB, issue #253 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/253>
* updating for catkin
* add option to change fps, rename image_type->image, see Issue 248
* mv resized_imagetransport resized_image_transport
* Contributors: Kei Okada, Ryohei Ueda, Youhei Kakiuchi
```
