### PR TITLE
jsk_common: 1.0.7-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1741,7 +1741,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.6-0
+      version: 1.0.7-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.7-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.0.6-0`
## jsk_topic_tools

```
* add documentation on nodelet xml
* Contributors: Ryohei Ueda
```
## libsiftfast

```
* Added missing build_depend on rospack and roslib
* Handle case where ROS_DISTRO is not set
* Contributors: Scott K Logan
```
