### PR TITLE
handle_detector: 1.0.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1731,7 +1731,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/atenpas/handle_detector-release.git
-      version: 1.0.6-0
+      version: 1.0.7-0
     source:
       type: git
       url: https://github.com/atenpas/handle_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `handle_detector` to `1.0.7-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.0.6-0`
## handle_detector

```
* removed LIBRARIES from catkin_package(...) call in CMakeLists.txt
* changed naming of libraries and executable in CMakeLists.txt so that it contains the project name
* added libs to install targets in CMakeLists
* Contributors: atenpas
```
