### PR TITLE
perception_pcl: 1.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1023,6 +1023,24 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: hydro-devel
     status: unmaintained
+  perception_pcl:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: indigo-devel
+    release:
+      packages:
+      - pcl_ros
+      - perception_pcl
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/perception_pcl-release.git
+      version: 1.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: indigo-devel
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.2.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## pcl_ros

```
* Updated maintainership
* Fix TF2 support for bag_to_pcd #46 <https://github.com/ros-perception/perception_pcl/issues/46>
* Use cmake_modules to find eigen on indigo #45 <https://github.com/ros-perception/perception_pcl/issues/45>
```
## perception_pcl

```
* Updated maintainership and added bugtracker/repository info to package.xml
```
