### PR TITLE
pcl_msgs: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1017,7 +1017,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/pcl_msgs-release.git
-      version: 0.1.0-1
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ros-perception/pcl_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_msgs` to `0.2.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.1.0-1`
## pcl_msgs

```
* clean up package.xml
* update maintainer info
* remove eigen dependency
* Merge pull request #1 <https://github.com/ros-perception/pcl_msgs/issues/1> from bulwahn/patch-1
* Contributors: Lukas Bulwahn, Paul Bovbel
```
