### PR TITLE
perception_pcl: 1.1.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3703,11 +3703,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/perception_pcl-release.git
-      version: 1.1.7-0
+      version: 1.1.8-0
     source:
       type: git
       url: https://github.com/ros-perception/perception_pcl.git
       version: hydro-devel
+    status: maintained
   phidgets_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.1.8-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.1.7-0`
## pcl_ros

```
* Update to support TF2
  Fixes #46 <https://github.com/ros-perception/perception_pcl/issues/46>
* pcl_ros: also run_depend on libpcl-all
* Make pcl_ros run_depend on libpcl-all-dev
  When downstream projects build against pcl_ros, they need the pcl headers provided by libpcl-all-dev.
* Contributors: Lucid One, Scott K Logan, William Woodall
```
## perception_pcl
- No changes
