### PR TITLE
flir_ptu: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1379,6 +1379,25 @@ repositories:
       url: https://github.com/ros/filters.git
       version: hydro-devel
     status: maintained
+  flir_ptu:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/flir_ptu.git
+      version: master
+    release:
+      packages:
+      - flir_ptu_description
+      - flir_ptu_driver
+      - flir_ptu_viz
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/flir_ptu-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/flir_ptu.git
+      version: master
+    status: developed
   flirtlib:
     release:
       url: https://github.com/ros-gbp/flirtlib-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_ptu` to `0.1.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## flir_ptu_description

```
* Completed basic tf tree and model of D46.
* Contributors: Mike Purvis
```
## flir_ptu_driver

```
* Parameterize the joint name.
* Add a new simple script for commanding the PTU.
* Remove package for actions; should use control_msgs instead.
* Remove Rate in favour of a Timer callback.
* Add roslint.
* Automatic astyle whitespace/padding fixes.
* Major refactoring.
* Contributors: Mike Purvis
```
## flir_ptu_viz

```
* Add stub package for viz launchers.
* Contributors: Mike Purvis
```
