### PR TITLE
vision_visp: 0.7.3-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4521,7 +4521,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.7.2-1
+      version: 0.7.3-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.7.3-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.7.2-1`
## vision_visp

```
* groovy-0.7.2
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_auto_tracker

```
* Install visp_auto_tracker/models folder
* groovy-0.7.2
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_bridge

```
* groovy-0.7.2
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_camera_calibration

```
* groovy-0.7.2
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_hand2eye_calibration

```
* groovy-0.7.2
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_tracker

```
* Remove unicode character that makes bloom-release failing
* Update changelog
* Contributors: Fabien Spindler
```
