### PR TITLE
vision_visp: 0.7.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6077,7 +6077,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.7.2-0
+      version: 0.7.3-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.7.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.7.2-0`
## vision_visp

```
* hydro-0.7.2
* Contributors: Thomas Moulard
```
## visp_auto_tracker

```
* Fix to install model folder
* hydro-0.7.2
* Contributors: Fabien Spindler
```
## visp_bridge

```
* hydro-0.7.2
* Prepare changelogs
* Fix various dependency issues in the CMakeLists.txt and package.xml files
* Merge branch 'hydro-devel' into hydro
* Add missing dependency to ViSP
* hydro-0.7.1
* Prepare changelogs
* Fix errors detected with catkin_lint
* hydro-0.7.0
* Run catkin_generate_changelog, catkin_tag_changelog, bump version to 0.6.0
* Contributors: Fabien Spindler, Thomas Moulard
```
## visp_camera_calibration

```
* hydro-0.7.2
* Contributors: Fabien Spindler
```
## visp_hand2eye_calibration

```
* hydro-0.7.2
* Prepare changelogs
* Contributors: Fabien Spindler, Thomas Moulard
```
## visp_tracker

```
* hydro-0.7.2
* Prepare changelogs
* Reorganize launch files and fix since viewer and client nodes where renamed due to catkin_lint errors
* Contributors: Fabien Spindler
```
