### PR TITLE
moveit_visual_tools: 0.2.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3005,7 +3005,7 @@ repositories:
       version: 0.2.0-0
     source:
       type: git
-      url: git@github.com:davetcoleman/moveit_visual_tools.git
+      url: https://github.com/davetcoleman/moveit_visual_tools.git
       version: hydro-devel
     status: developed
   mr_teleoperator:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3002,7 +3002,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 0.1.0-0
+      version: 0.2.0-0
+    source:
+      type: git
+      url: git@github.com:davetcoleman/moveit_visual_tools.git
+      version: hydro-devel
     status: developed
   mr_teleoperator:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `0.2.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.1.0-0`
## moveit_visual_tools

```
* Improved header comments are re-ordered functions into groups
* Started to create new trajectory point publisher
* Added getBaseLink function
* Added dependency on graph_msgs
* Added new collision cylinder functionality
* Created example code in README
* Renamed visualization to visual keyword
* Updated README
```
