### PR TITLE
Unify texlive deps for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2462,40 +2462,30 @@ tcsh:
 texlive-fonts-extra:
   arch: [texlive-fontsextra]
   debian: [texlive-fonts-extra]
-  fedora:
-    schrödinger’s: [texlive-bbm, texlive-bbm-macros]
-    spherical: [texlive-bbm, texlive-bbm-macros]
+  fedora: [texlive-bbm, texlive-bbm-macros]
   macports: [texlive-fonts-extra]
   ubuntu: [texlive-fonts-extra]
 texlive-fonts-recommended:
   arch: [texlive-core]
   debian: [texlive-fonts-recommended]
-  fedora:
-    schrödinger’s: [texlive-times, texlive-helvetic]
-    spherical: [texlive-times, texlive-helvetic]
+  fedora: [texlive-times, texlive-helvetic]
   macports: [texlive-fonts-recommended]
   ubuntu: [texlive-fonts-recommended]
 texlive-latex-base:
   arch: [texlive-core]
   debian: [texlive-latex-base]
-  fedora:
-    schrödinger’s: [texlive-latex, texlive-parskip]
-    spherical: [texlive-latex, texlive-parskip]
+  fedora: [texlive-latex, texlive-parskip]
   macports: [texlive]
   ubuntu: [texlive-latex-base]
 texlive-latex-extra:
   arch: [texlive-latexextra]
   debian: [texlive-latex-extra]
-  fedora:
-    schrödinger’s: [texlive-titlesec, texlive-wrapfig, texlive-multirow, texlive-fancybox]
-    spherical: [texlive-titlesec, texlive-wrapfig, texlive-multirow, texlive-fancybox]
+  fedora: [texlive-titlesec, texlive-wrapfig, texlive-multirow, texlive-fancybox]
   ubuntu: [texlive-latex-extra]
 texlive-latex-recommended:
   arch: [texlive-core]
   debian: [texlive-latex-recommended]
-  fedora:
-    schrödinger’s: [texlive-framed, texlive-threeparttable, texlive-ec, texlive-mdwtools]
-    spherical: [texlive-framed, texlive-threeparttable, texlive-ec, texlive-mdwtools]
+  fedora: [texlive-framed, texlive-threeparttable, texlive-ec, texlive-mdwtools]
   macports: [texlive-latex-recommended]
   ubuntu: [texlive-latex-recommended]
 tinyxml:


### PR DESCRIPTION
These deps are the same for `f20`+, `f19` and `f18`, which is EOL. It is surely safe to unify them now.
