### PR TITLE
flir_ptu: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -472,7 +472,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_ptu-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/ros-drivers/flir_ptu.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_ptu` to `0.1.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.1.1-0`
## flir_ptu_description

```
* Remove $(find) macro referencing self, since this doesn't work on the first build.
* Contributors: Mike Purvis
```
## flir_ptu_driver
- No changes
## flir_ptu_viz
- No changes
