### PR TITLE
jsk_roseus: 1.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -732,6 +732,25 @@ repositories:
       url: https://github.com/ipa320/ipa_canopen.git
       version: indigo_dev
     status: maintained
+  jsk_roseus:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_roseus.git
+      version: master
+    release:
+      packages:
+      - euslisp
+      - geneus
+      - roseus
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/jsk_roseus-release.git
+      version: 1.1.3-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_roseus.git
+      version: master
+    status: maintained
   laser_filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## euslisp
- No changes
## geneus

```
* fix for roseus message generation (#51 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/51>)
* Contributors: Kei Okada, Ryohei Ueda
```
## roseus

```
* add rosdnoe to depends(#64)
* Contributors: Kei Okada
```
