### PR TITLE
jsk_roseus: 1.1.3-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1782,7 +1782,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.2-0
+      version: 1.1.3-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.3-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.1.2-0`
## euslisp
- No changes
## geneus

```
* fix for roseus message generation (#51 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/51>)
* Contributors: Kei Okada, Ryohei Ueda
```
## roseus

```
* add rosdnoe to depends(#64)
* Contributors: Kei Okada
```
