### PR TITLE
pr2_mechanism: 1.8.12-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3899,7 +3899,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/pr2_mechanism-release.git
-      version: 1.8.11-0
+      version: 1.8.12-0
     source:
       type: git
       url: https://github.com/PR2/pr2_mechanism.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_mechanism` to `1.8.12-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.8.11-0`
