### PR TITLE
pr2_simulator: 2.0.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3952,6 +3952,25 @@ repositories:
       url: https://github.com/ros-gbp/pr2_robot-release.git
       version: 1.6.6-0
     status: maintained
+  pr2_simulator:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_simulator.git
+      version: hydro-devel
+    release:
+      packages:
+      - pr2_controller_configuration_gazebo
+      - pr2_gazebo
+      - pr2_gazebo_plugins
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/pr2_simulator-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_simulator.git
+      version: hydro-devel
+    status: maintained
   prosilica_driver:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_simulator` to `2.0.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
