### PR TITLE
rtmros_common: 1.0.8-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3932,7 +3932,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.0.7-6
+      version: 1.0.8-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.0.8-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.0.7-6`
## hrpsys_ros_bridge

```
* use git:// for download pr2_controllers (potential fix for #410 <https://github.com/start-jsk/rtmros_common/issues/410>)
* add rosdnode to depends(see https://github.com/jsk-ros-pkg/jsk_roseus/pull/65, #411 <https://github.com/start-jsk/rtmros_common/issues/411>)
* add euscollada_SOURCE_PREFIX and euscollada_PREFIX
* use start_omninames.sh for rosdevel build environment, see #400 <https://github.com/start-jsk/rtmros_common/issues/400>
* remove deprecate function to generate conf parameter
* Added procps, hostname, net-tools build_depends. These tools are used during building and testing
* Contributors: Kei Okada, Scott K Logan, Shunichi Nozawa
```
## hrpsys_tools

```
* use start_omninames.sh for rosdevel build environment, see #400 <https://github.com/start-jsk/rtmros_common/issues/400>
* add_py_launch_prefix
* Contributors: Kei Okada, Yohei Kakiuchi, Isaac Isao Saito
```
## openrtm_ros_bridge

```
* use start_omninames.sh for rosdevel build environment, see #400 <https://github.com/start-jsk/rtmros_common/issues/400>
* Contributors: Kei Okada
```
## openrtm_tools

```
* use start_omninames.sh for rosdevel build environment, see #400 <https://github.com/start-jsk/rtmros_common/issues/400>
* Contributors: Kei Okada
```
## rosnode_rtc
- No changes
## rtmbuild

```
* fix to work on rosbuild
* fix for installed test, use rtmbuild_SOURCE_PREFIX to check if devel/src environment
* rtmbuild: install test directory so that others can uses this
* rtmbuild: rewrite rtmbulid.cmake
* rtmbuild: cleanup catkin.cmake and put everything into CMakeLists.txt
* Contributors: Kei Okada
```
## rtmros_common

```
* (See each contained package for the changelog)
```
