### PR TITLE
octomap_ros: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1108,6 +1108,11 @@ repositories:
       type: git
       url: https://github.com/OctoMap/octomap_ros.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_ros-release.git
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/OctoMap/octomap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_ros` to `0.3.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
