### PR TITLE
octomap_rviz_plugins: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1118,6 +1118,11 @@ repositories:
       type: git
       url: https://github.com/OctoMap/octomap_rviz_plugins.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_rviz_plugins-release.git
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/OctoMap/octomap_rviz_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_rviz_plugins` to `0.0.5-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## octomap_rviz_plugins

```
* fix a crash when the destructor is called before onInitialize
* Fix descriptions, limit octree depth range
* Porting fixes from groovy branch (QT4_WRAP macro, OCTOMAP_INCLUDE_DIRS)
```
