### PR TITLE
Updating cram-core for groovy and hydro

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -661,7 +661,7 @@ repositories:
   cram_core:
     doc:
       type: git
-      url: https://github.com/moesenle/cram_core.git
+      url: https://github.com/cram-code/cram_core.git
       version: master
     release:
       packages:
@@ -678,7 +678,12 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/cram_core-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/cram-code/cram_core.git
+      version: master
+    status: maintained
   cram_highlevel:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -849,6 +849,10 @@ repositories:
       url: https://github.com/ros-gbp/cram_3rdparty-release.git
       version: 0.1.1-0
   cram_core:
+    doc:
+      type: git
+      url: https://github.com/cram-code/cram_core.git
+      version: master
     release:
       packages:
       - cram_core
@@ -864,7 +868,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/cram_core-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/cram-code/cram_core.git
+      version: master
+    status: maintained
   crsm_slam:
     doc:
       type: git


### PR DESCRIPTION
triggered because of cram-code/cram_core#23 and ros/rosdistro#3460
