### PR TITLE
openhrp3: 3.1.5-6 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3538,7 +3538,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/openhrp3-release.git
-      version: 3.1.5-5
+      version: 3.1.5-6
     source:
       type: git
       url: https://github.com/start-jsk/openhrp3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openhrp3` to `3.1.5-6`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `3.1.5-5`
