### PR TITLE
visp: 2.9.0-7 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1905,7 +1905,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 2.9.0-6
+      version: 2.9.0-7
     status: maintained
   visualization_tutorials:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `2.9.0-7`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `2.9.0-6`
