### PR TITLE
Add python-mock and python-coverage for osx.

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -371,6 +371,10 @@ python-argparse:
   osx:
     pip:
       packages: [argparse]
+python-coverage:
+  osx:
+    pip:
+      packages: [coverage]
 python-empy:
   osx:
     pip:
@@ -392,6 +396,10 @@ python-matplotlib:
     pip:
       depends: [pkg-config, freetype, libpng12-dev]
       packages: [matplotlib]
+python-mock:
+  osx:
+    pip:
+      packages: [mock]
 python-netifaces:
   osx:
     pip:


### PR DESCRIPTION
See http://answers.ros.org/question/153156/rosdep-error-while-i-try-to-install-ros-on-os-x-108/
