### PR TITLE
nav2_platform: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3124,6 +3124,26 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/brown-release/nasa_r2_simulator_release.git
       version: 0.5.3-1
+  nav2_platform:
+    doc:
+      type: git
+      url: https://github.com/paulbovbel/nav2_platform.git
+      version: hydro-devel
+    release:
+      packages:
+      - nav2_bringup
+      - nav2_driver
+      - nav2_navigation
+      - nav2_platform
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/paulbovbel/nav2_platform-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/paulbovbel/nav2_platform.git
+      version: hydro-devel
+    status: maintained
   navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nav2_platform` to `0.0.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## nav2_bringup

```
* add port argument
* refactor launch structure
* initial commit for support packages
* Contributors: Paul Bovbel
```
## nav2_driver

```
* fix dependencies
* update documentation
* add nav2remote module
* initial dir structure
* Contributors: Paul Bovbel
```
## nav2_navigation

```
* refactor launch structure
* fix dependencies
* initial commit for support packages
* Contributors: Paul Bovbel, agentx3r
```
## nav2_platform

```
* skeleton structure for all packages
* Contributors: Paul Bovbel
```
