### PR TITLE
common_tutorials: 0.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -206,6 +206,27 @@ repositories:
       url: https://github.com/ros/common_msgs.git
       version: indigo-devel
     status: maintained
+  common_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/common_tutorials.git
+      version: hydro-devel
+    release:
+      packages:
+      - actionlib_tutorials
+      - common_tutorials
+      - nodelet_tutorial_math
+      - pluginlib_tutorials
+      - turtle_actionlib
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/common_tutorials-release.git
+      version: 0.1.7-0
+    source:
+      type: git
+      url: https://github.com/ros/common_tutorials.git
+      version: hydro-devel
+    status: maintained
   concert_scheduling:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_tutorials` to `0.1.7-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
