### PR TITLE
capabilities: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -123,6 +123,16 @@ repositories:
       type: git
       url: https://github.com/osrf/capabilities.git
       version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/capabilities-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/osrf/capabilities.git
+      version: master
+    status: maintained
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `capabilities` to `0.1.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## capabilities

```
* First release
* Contributors: Esteve Fernandez, Marcus Liebhardt, Tully Foote, William Woodall
```
