### PR TITLE
capabilities: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -427,6 +427,16 @@ repositories:
       type: git
       url: https://github.com/osrf/capabilities.git
       version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/capabilities-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/osrf/capabilities.git
+      version: master
+    status: maintained
   care_o_bot:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `capabilities` to `0.1.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## capabilities

```
* First release
* Contributors: Esteve Fernandez, Marcus Liebhardt, Tully Foote, William Woodall
```
