### PR TITLE
capabilities: 0.1.0-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -430,6 +430,16 @@ repositories:
       type: git
       url: https://github.com/osrf/capabilities.git
       version: master
+    release:
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/ros-gbp/capabilities-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/osrf/capabilities.git
+      version: master
+    status: maintained
   cassandra_ros:
     doc:
       type: svn


### PR DESCRIPTION
Increasing version of package(s) in repository `capabilities` to `0.1.0-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## capabilities

```
* First release
* Contributors: Esteve Fernandez, Marcus Liebhardt, Tully Foote, William Woodall
```
