### PR TITLE
visp: 2.9.0-8 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1941,7 +1941,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 2.9.0-7
+      version: 2.9.0-8
     status: maintained
   visualization_tutorials:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `2.9.0-8`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `2.9.0-7`
