### PR TITLE
rocon_msgs: 0.7.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1451,6 +1451,7 @@ repositories:
       - gateway_msgs
       - rocon_annotation_msgs
       - rocon_app_manager_msgs
+      - rocon_device_msgs
       - rocon_interaction_msgs
       - rocon_msgs
       - rocon_service_pair_msgs
@@ -1460,7 +1461,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-      version: 0.7.1-0
+      version: 0.7.3-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs` to `0.7.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.7.1-0`
## rocon_device_msgs

```
* refactor rocon_devices_msgs -> rocon_device_msgs.
```
