### PR TITLE
removed depthcloud encoder for move to official RWT release repo

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -699,13 +699,6 @@ repositories:
     doc:
       type: git
       url: https://github.com/jizhang-cmu/demo_rgbd.git
-  depthcloud_encoder:
-    release:
-      tags:
-        release: release/groovy/{package}/{version}
-      url: https://github.com/ros-gbp/depthcloud_encoder-release.git
-      version: 0.0.3-0
-    status: maintained
   depthimage_to_laserscan:
     doc:
       type: git


### PR DESCRIPTION
Removed depthcloud_encoder to re-release it into the official Robot Web Tools release repo (https://github.com/RobotWebTools-release/depthcloud_encoder-release). Will rerun bloom once merged.
