### PR TITLE
depthcloud_encoder: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -273,6 +273,21 @@ repositories:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
       version: indigo-devel
+  depthcloud_encoder:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/depthcloud_encoder.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotWebTools-release/depthcloud_encoder-release.git
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/depthcloud_encoder.git
+      version: develop
+    status: maintained
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthcloud_encoder` to `0.0.4-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## depthcloud_encoder

```
* source cleanup
* basic cleanup
* depricated launch package removed
* Contributors: Russell Toris
```
