### PR TITLE
rocon_multimaster: 0.7.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1472,6 +1472,20 @@ repositories:
       type: git
       url: https://github.com/robotics-in-concert/rocon_multimaster.git
       version: indigo
+    release:
+      packages:
+      - rocon_gateway
+      - rocon_gateway_tests
+      - rocon_gateway_utils
+      - rocon_hub
+      - rocon_hub_client
+      - rocon_multimaster
+      - rocon_test
+      - rocon_unreliable_experiments
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/rocon_multimaster-release.git
+      version: 0.7.0-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_multimaster.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_multimaster` to `0.7.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## rocon_gateway

```
* client to hub connection statistics
* move flip handling from pubsub channels to encrypted posting on the hubs
* disconnect/reconnect to the hub handling
* pep8 and code analysis
* catch and handle many exceptions
* multi-version support for redis servers, currently v2.2 and v2.6
* Contributors: Daniel Stonier, Jorge Santos, Marcus Liebhardt, Piyush Khandelwal, piyushk
```
## rocon_hub

```
* support for redis server v2.6
* update for recently moved modules to rocon_tools, also platform_tuples module refactoring.
* interpret time_since_last_seen as an int, not a float. #233 <https://github.com/robotics-in-concert/rocon_multimaster/issues/233>
* pep8
* bugfix wired alive ping status' on the hub, closes #224 <https://github.com/robotics-in-concert/rocon_multimaster/issues/224>
* gateway to hub pinger
* parameterise the external shutdown timeout.
* external shutdown hooks for gateway and hub.
* variable length split, so pull from the start, not the back, closes #211 <https://github.com/robotics-in-concert/rocon_multimaster/issues/211>
* better pretty printing in remote_gateway_info_script. update time_last_seen after the first failure as well
* graceful error handling for ping output parse failure. closes #185 <https://github.com/robotics-in-concert/rocon_multimaster/issues/185>
* connection statistics on the hub.
* reverting default gateway dropout time to 2 hours
* clean out old redis home directory when restarting the hub, closes #166 <https://github.com/robotics-in-concert/rocon_multimaster/issues/166>
* ensure that gateway_info is completely available before adding a ping to that machine. closes #198 <https://github.com/robotics-in-concert/rocon_multimaster/issues/198>
* first draft of the hub sidekick is complete. closes #182 <https://github.com/robotics-in-concert/rocon_multimaster/issues/182>. closes #183 <https://github.com/robotics-in-concert/rocon_multimaster/issues/183>
* using wallsleep clock instead of rospy.sleep. progress towards #191 <https://github.com/robotics-in-concert/rocon_multimaster/issues/191>
* Contributors: Daniel Stonier, Piyush Khandelwal
```
## rocon_multimaster

```
* rocon_launch moved to rocon_tools
* utilities broken up and moved to rocon_tools
* Contributors: Daniel Stonier
```
## rocon_test

```
* bugfix rocon test breakage due to rocon_launch arg mapping api change.
* update for recently moved modules to rocon_tools.
* utilities broken up and moved to rocon tools.
* fix rocon_test logging for ctest execution, #200 <https://github.com/robotics-in-concert/rocon_multimaster/issues/200>
* fix rocon_tests, closes #157 <https://github.com/robotics-in-concert/rocon_multimaster/issues/157>
* using wallsleep clock instead of rospy.sleep. progress towards #191 <https://github.com/robotics-in-concert/rocon_multimaster/issues/191>
* Contributors: Daniel Stonier, Piyush Khandelwal
```
