### PR TITLE
removed ros_web_video to move to offical RWT release repo

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3573,16 +3573,6 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: groovy-devel
     status: maintained
-  ros_web_video:
-    doc:
-      type: git
-      url: https://github.com/RobotWebTools/ros_web_video.git
-      version: groovy-devel
-    release:
-      tags:
-        release: release/groovy/{package}/{version}
-      url: https://github.com/ros-gbp/ros_web_video-release.git
-      version: 0.1.6-0
   rosauth:
     doc:
       type: git


### PR DESCRIPTION
Removed depthcloud_encoder to re-release it into the official Robot Web Tools release repo (https://github.com/RobotWebTools-release/ros_web_video-release). Will rerun bloom once merged.
