### PR TITLE
bwi_common: 0.2.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -328,6 +328,18 @@ repositories:
       type: git
       url: https://github.com/utexas-bwi/bwi_common.git
       version: master
+    release:
+      packages:
+      - bwi_common
+      - bwi_gazebo_entities
+      - bwi_mapper
+      - bwi_tools
+      - bwi_web
+      - utexas_gdc
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/utexas-bwi-gbp/bwi_common-release.git
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi_common` to `0.2.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## bwi_common

```
* Initial release to Hydro.
* Now passes catkin_lint checks.
* Added missing dependency in metapackage.
* Moved common research components from bwi_experimental to bwi_common
  repository in preparation of release.
```
## bwi_gazebo_entities

```
* Initial release to Hydro.
* Changed person color to black for easy visualization.
* Added a vizualizer for gazebo.
* Now passes catkin_lint checks.
* Moved common research components from bwi_experimental to bwi_common
  repository in preparation of release.
```
## bwi_mapper

```
* Initial release to Hydro.
* Now passes catkin_lint checks.
* Added new image configuration files.
* Minor commits while improving the quality of images.
* Updated drawing functions a bit.
* Fixed bug in new convenience function call.
* Added convenience function. expand legend automatically.
* Added bwi_mapper to common components, as it is used by both
  planning and human guidance projects.
```
## bwi_tools

```
* Initial release to Hydro.
* Now passes catkin_lint checks.
* Added ability to control the botton of bars and colors.
* Added convenience function. expand legend automatically.
* Added some common graphing functions.
* Added roslaunch helper to bwi_tools.
* Fixed dependencies in package.xml, fixed greyscale color in pgm
  image, added a python mapper helper.
* Added a boost convenience wrapper.
* Moved the unified point structure to bwi_common.
* Migrated bwi_tools to bwi_common.
```
## bwi_web

```
* Initial release to Hydro.
```
## utexas_gdc

```
* Initial release to Hydro.
* Move high-level launch scripts to bwi repo.
* Now passes catkin_lint checks.
* Fixed dependencies in package.xml, fixed greyscale color in pgm
  image, added a python mapper helper.
* Moved common research components from bwi_experimental to bwi_common
  repository in preparation of release
```
