### PR TITLE
ros_web_video: 0.1.7-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3566,6 +3566,21 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: groovy-devel
     status: maintained
+  ros_web_video:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/ros_web_video.git
+      version: master
+    release:
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/RobotWebTools-release/ros_web_video-release.git
+      version: 0.1.7-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/ros_web_video.git
+      version: develop
+    status: maintained
   rosauth:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_web_video` to `0.1.7-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## ros_web_video

```
* submodule moved to HTTPS
* git submodules now used instead of willow servers for ffmpeg
* v1.2.0 libvpx
* libvpx added
* moved to submodule
* cmake cleanup
* basic cleanup
* adding travis.yml
* adding travis.yml
* Contributors: Julius Kammerl, Russell Toris
```
