### PR TITLE
interactive_markers: 1.9.10-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1679,7 +1679,11 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/interactive_markers-release.git
-      version: 1.9.9-0
+      version: 1.9.10-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: groovy-devel
     status: maintained
   ipa_canopen:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `1.9.10-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.9.9-0`
## interactive_markers

```
* fix threading bugs
  Fix locking of data structures shared across threads.
* Contributors: Acorn Pooley
```
