### PR TITLE
rosbridge_suite: 0.5.4-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3626,7 +3626,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git
-      version: groovy-devel
+      version: master
     release:
       packages:
       - rosapi
@@ -3640,7 +3640,7 @@ repositories:
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git
-      version: groovy-devel
+      version: develop
     status: maintained
   rosconsole_bridge:
     doc:

--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3636,7 +3636,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.4.5-0
+      version: 0.5.4-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.5.4-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.4.5-0`
## rosapi

```
* add rosnode and rosgraph
* Contributors: Jihoon Lee
```
## rosbridge_library

```
* removing wrong import
* test case for fixed size of uint8 array
* uses regular expresion to match uint8 array and char array.
* logerr when it fails while message_conversion
* Contributors: Jihoon Lee
```
## rosbridge_server
- No changes
## rosbridge_suite
- No changes
