### PR TITLE
rosbridge_suite: 0.5.4-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4717,7 +4717,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.5.3-0
+      version: 0.5.4-1
     status: maintained
   rosconsole_bridge:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.5.4-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.5.3-0`
## rosapi

```
* add rosnode and rosgraph
* Contributors: Jihoon Lee
```
## rosbridge_library

```
* removing wrong import
* test case for fixed size of uint8 array
* uses regular expresion to match uint8 array and char array.
* logerr when it fails while message_conversion
* Contributors: Jihoon Lee
```
## rosbridge_server
- No changes
## rosbridge_suite
- No changes
