### PR TITLE
rtshell_core: 3.0.1-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4028,7 +4028,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/rtshell_core-release.git
-      version: 3.0.0-3
+      version: 3.0.1-0
     source:
       type: git
       url: https://github.com/start-jsk/rtshell_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell_core` to `3.0.1-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `3.0.0-3`
## rtctree
- No changes
## rtshell

```
* Download 3.0.1 tarball
* add patch proposed in https://github.com/gbiggs/rtshell/pull/15
* add start_omninames.sh start starts omniNames for test code, use port 2010 for test
* (test-rtshell.py) check if nameserver exists
* display output when test failes
* Contributors: Isaac IY Saito, Kei Okada
```
## rtshell_core
- No changes
## rtsprofile
- No changes
