### PR TITLE
ros_web_video: 0.1.10-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3594,7 +3594,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/RobotWebTools-release/ros_web_video-release.git
-      version: 0.1.7-0
+      version: 0.1.10-0
     source:
       type: git
       url: https://github.com/RobotWebTools/ros_web_video.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_web_video` to `0.1.10-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.1.7-0`
## ros_web_video

```
* ignores downloads
* Remove submodule entry
* modules removed
* submodules being weird
* Contributors: Russell Toris
```
