### PR TITLE
ros_web_video: 0.1.10-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4675,7 +4675,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/ros_web_video-release.git
-      version: 0.1.7-0
+      version: 0.1.10-0
     source:
       type: git
       url: https://github.com/RobotWebTools/ros_web_video.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_web_video` to `0.1.10-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.1.7-0`
## ros_web_video

```
* ignores downloads
* Remove submodule entry
* modules removed
* submodules being weird
* Contributors: Russell Toris
```
