### PR TITLE
nav2_platform: 0.0.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3200,7 +3200,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/paulbovbel/nav2_platform-release.git
-      version: 0.0.4-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/paulbovbel/nav2_platform.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nav2_platform` to `0.0.6-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.0.4-0`
## nav2_driver
- No changes
## nav2_navigation
- No changes
## nav2_platform
- No changes
