### PR TITLE
xdot: 2.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2052,6 +2052,17 @@ repositories:
       url: https://github.com/ros/xacro.git
       version: indigo-devel
     status: maintained
+  xdot:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/jbohren/xdot-release.git
+      version: 2.0.1-0
+    source:
+      type: git
+      url: https://github.com/jbohren/xdot.git
+      version: indigo-devel
+    status: developed
   zeroconf_avahi_suite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xdot` to `2.0.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## xdot
- No changes
