### PR TITLE
rosbridge_suite: 0.5.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1724,6 +1724,16 @@ repositories:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git
       version: master
+    release:
+      packages:
+      - rosapi
+      - rosbridge_library
+      - rosbridge_server
+      - rosbridge_suite
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
+      version: 0.5.4-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.5.4-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## rosapi

```
* add rosnode and rosgraph
* Contributors: Jihoon Lee
```
## rosbridge_library

```
* removing wrong import
* test case for fixed size of uint8 array
* uses regular expresion to match uint8 array and char array.
* logerr when it fails while message_conversion
* Contributors: Jihoon Lee
```
## rosbridge_server
- No changes
## rosbridge_suite
- No changes
