### PR TITLE
bwi_common: 0.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -333,13 +333,14 @@ repositories:
       - bwi_common
       - bwi_gazebo_entities
       - bwi_mapper
+      - bwi_planning_common
       - bwi_tools
       - bwi_web
       - utexas_gdc
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/bwi_common-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi_common` to `0.2.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.2.0-0`
## bwi_common

```
* Move ``bwi_planning_common`` here from the ``bwi_planning``
  repository (bwi_planning#1 <https://github.com/utexas-bwi/bwi_planning/issues/1>).
```
## bwi_gazebo_entities
- No changes
## bwi_mapper
- No changes
## bwi_planning_common

```
* Initial release to Hydro.
* Add roslaunch file checks.  This required providing default values
  for the ``map_file`` arguments.
* Install launch files.
* Move ``bwi_planning_common`` to ``bwi_common`` from the
  ``bwi_planning`` repository (bwi_planning#1 <https://github.com/utexas-bwi/bwi_planning/issues/1>).
* Updating bwi_planning code for the ICAPS 2014 paper.
* Added resolveDoor function.  Added ability to add cost samples using
  a service in the node.
* Added planning common (formerly segbot_common).
```
## bwi_tools
- No changes
## bwi_web
- No changes
## utexas_gdc

```
* Updated map PGM file to be obstacle free.
```
