### PR TITLE
ros_web_video: 0.1.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1691,7 +1691,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/ros_web_video-release.git
-      version: 0.1.10-0
+      version: 0.1.11-0
     source:
       type: git
       url: https://github.com/RobotWebTools/ros_web_video.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_web_video` to `0.1.11-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.1.10-0`
## ros_web_video

```
* CA-cert fix
* Contributors: Russell Toris
```
