### PR TITLE
gperftools: 2.1.0-9 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1709,6 +1709,12 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/geometry_tutorials-release.git
       version: 0.2.0-0
+  gperftools:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/gperftools-release.git
+      version: 2.1.0-9
   gps_umd:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gperftools` to `2.1.0-9`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
