### PR TITLE
rtshell_core: 3.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5257,7 +5257,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtshell_core-release.git
-      version: 3.0.1-0
+      version: 3.0.2-0
     source:
       type: git
       url: https://github.com/start-jsk/rtshell_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell_core` to `3.0.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `3.0.1-0`
## rtctree

```
* use 3.0.1 of rtctree, due to #34
* Contributors: Kei Okada
```
## rtshell
- No changes
## rtshell_core
- No changes
## rtsprofile
- No changes
