### PR TITLE
rtshell_core: update to 3.0.2

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4029,7 +4029,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/rtshell_core-release.git
-      version: 3.0.1-0
+      version: 3.0.2-0
     source:
       type: git
       url: https://github.com/start-jsk/rtshell_core.git


### PR DESCRIPTION
I usually commit to both groovy and hydro but from from last night , when we run bloom-release for second time, it said as follows. it seems both system try to create same:

```
 * [new tag]         upstream/3.0.2 -> upstream/3.0.2
<== Pushed tags successfully
==> Generating pull request to distro file located at 'https://raw.github.com/ros/rosdistro/master/hydro/distribution.yaml'
Unified diff for the ROS distro file located at '/tmp/tmpiXWLYh/rtshell_core-3.0.2-0.patch':
--- hydro/distribution.yaml
+++ hydro/distribution.yaml
@@ -5257,7 +5257,7 @@
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtshell_core-release.git
-      version: 3.0.1-0
+      version: 3.0.2-0
     source:
       type: git
       url: https://github.com/start-jsk/rtshell_core.git
==> Checking on github for a fork to make the pull request from...
==> Using this fork to make a pull request from: k-okada/rosdistro
==> Cloning k-okada/rosdistro...
==> mkdir -p rosdistro
==> git init
Initialized empty Git repository in /tmp/38NfUD/rosdistro/.git/
Pull Request Title: rtshell_core: 3.0.2-0 in 'hydro/distribution.yaml' [bloom]
Pull Request Body : 
Increasing version of package(s) in repository `rtshell_core` to `3.0.2-0`:

- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `3.0.1-0`

## rtctree

```
- use 3.0.1 of rtctree, due to #34
- Contributors: Kei Okada

```

## rtshell

- No changes

## rtshell_core

- No changes

## rtsprofile

- No changes

Open a pull request from 'rosdistro/rosdistro:bloom-rtshell_core-0' into 'ros/rosdistro:master'?
Continue [Y/n]? 
==> git checkout -b bloom-rtshell_core-0
==> Pulling latest rosdistro branch
remote: Counting objects: 34598, done.
remote: Compressing objects: 100% (19222/19222), done.
remote: Total 34598 (delta 18963), reused 29325 (delta 15356)
Receiving objects: 100% (34598/34598), 5.51 MiB | 1.29 MiB/s, done.
Resolving deltas: 100% (18963/18963), done.
From https://github.com/ros/rosdistro
 * branch            master     -> FETCH_HEAD
==> Writing new distribution file: hydro/distribution.yaml
==> git add hydro/distribution.yaml
==> git commit -m "rtshell_core: 3.0.2-0 in 'hydro/distribution.yaml' [bloom]"
[bloom-rtshell_core-0 bd5a59f] rtshell_core: 3.0.2-0 in 'hydro/distribution.yaml' [bloom]
 1 file changed, 1 insertion(+), 1 deletion(-)
==> Pushing changes to fork
To https://6566b5e95fe4be1a002f5c8e7455315bec3fd24b:x-oauth-basic@github.com/k-okada/rosdistro.git
   ab63214..bd5a59f  bloom-rtshell_core-0 -> bloom-rtshell_core-0
<== Pull request opened at: https://github.com/ros/rosdistro/pull/3951
k-okada@kokada-t430s:~/work/bloom/rtshell_core/rtshell_core$ bloom-release rtshell_core --track groovy --rosdistro groovy
==> Fetching 'rtshell_core' repository from 'https://github.com/tork-a/rtshell_core-release.git'
Cloning into '/tmp/tmp2xOHcg'...
remote: Counting objects: 5689, done.
remote: Compressing objects: 100% (3646/3646), done.
remote: Total 5689 (delta 2006), reused 5030 (delta 1781)
Receiving objects: 100% (5689/5689), 614.12 KiB | 244 KiB/s, done.
Resolving deltas: 100% (2006/2006), done.
==> Testing for push permission on release repository
==> git remote -v
origin  https://github.com/tork-a/rtshell_core-release.git (fetch)
origin  https://github.com/tork-a/rtshell_core-release.git (push)
==> git push --dry-run
Everything up-to-date
==> Releasing 'rtshell_core' using release track 'groovy'
==> git-bloom-release groovy
Processing release track settings for 'groovy'
Checking upstream devel branch for package.xml(s)
Cloning into '/tmp/tmpIKHXRO/upstream'...
remote: Counting objects: 348, done.
remote: Compressing objects: 100% (176/176), done.
remote: Total 348 (delta 217), reused 280 (delta 171)
Receiving objects: 100% (348/348), 51.46 KiB, done.
Resolving deltas: 100% (217/217), done.
Looking for packages in 'master' branch... found 4 packages.
Detected version '3.0.2' from package(s): ['rtsprofile', 'rtshell_core', 'rtctree', 'rtshell']

Executing release track 'groovy'
==> bloom-export-upstream /tmp/tmpIKHXRO/upstream git --tag 3.0.2 --display-uri https://github.com/start-jsk/rtshell_core.git --name upstream --output-dir /tmp/tmpNjuS_l
Checking out repository at 'https://github.com/start-jsk/rtshell_core.git' to reference '3.0.2'.
Exporting to archive: '/tmp/tmpNjuS_l/upstream-3.0.2.tar.gz'
md5: 9c13dd496b7bfa01dac37b9fd61bdce3

==> git-bloom-import-upstream /tmp/tmpNjuS_l/upstream-3.0.2.tar.gz  --release-version 3.0.2 --replace
The latest upstream tag in the release repository is 'upstream/3.0.2'.
Removing tag: 'upstream/3.0.2'
Importing archive into upstream branch...
Creating tag: 'upstream/3.0.2'
I'm happy.  You should be too.

==> git-bloom-generate -y rosrelease groovy --source upstream -i 0
Releasing packages: ['rtsprofile', 'rtshell_core', 'rtctree', 'rtshell']
Releasing package 'rtsprofile' for 'groovy' to: 'release/groovy/rtsprofile'
Releasing package 'rtshell_core' for 'groovy' to: 'release/groovy/rtshell_core'
Releasing package 'rtctree' for 'groovy' to: 'release/groovy/rtctree'
Releasing package 'rtshell' for 'groovy' to: 'release/groovy/rtshell'

==> git-bloom-generate -y rosdebian --prefix release/groovy groovy -i 0
Generating source debs for the packages: ['rtsprofile', 'rtctree', 'rtshell_core', 'rtshell']
Debian Incremental Version: 0
Debian Distributions: ['precise', 'oneiric', 'quantal']
Releasing for rosdistro: groovy
Placing debian template files into 'debian/groovy/rtsprofile' branch.
==> Placing templates files in the 'debian' folder.
Running 'rosdep update'...

####
#### Generating 'precise' debian for package 'rtsprofile' at version '3.0.2-0'
####
Generating debian for precise...
Package 'rtsprofile' has dependencies:
Build and Build Tool Dependencies:
  rosdep key           => precise key
  unzip                => ['unzip']
  mk                   => ['ros-groovy-mk']
  rosbuild             => ['ros-groovy-rosbuild']
  catkin               => ['ros-groovy-catkin']
==> In place processing templates in 'debian' folder.
Expanding 'debian/changelog.em' -> 'debian/changelog'
Expanding 'debian/gbp.conf.em' -> 'debian/gbp.conf'
Expanding 'debian/rules.em' -> 'debian/rules'
Expanding 'debian/control.em' -> 'debian/control'
Creating tag: debian/ros-groovy-rtsprofile_3.0.2-0_precise
####
#### Successfully generated 'precise' debian for package 'rtsprofile' at version '3.0.2-0'
####


####
#### Generating 'oneiric' debian for package 'rtsprofile' at version '3.0.2-0'
####
Generating debian for oneiric...
Package 'rtsprofile' has dependencies:
Build and Build Tool Dependencies:
  rosdep key           => oneiric key
  unzip                => ['unzip']
  mk                   => ['ros-groovy-mk']
  rosbuild             => ['ros-groovy-rosbuild']
  catkin               => ['ros-groovy-catkin']
==> In place processing templates in 'debian' folder.
Expanding 'debian/changelog.em' -> 'debian/changelog'
Expanding 'debian/gbp.conf.em' -> 'debian/gbp.conf'
Expanding 'debian/rules.em' -> 'debian/rules'
Expanding 'debian/control.em' -> 'debian/control'
Creating tag: debian/ros-groovy-rtsprofile_3.0.2-0_oneiric
####
#### Successfully generated 'oneiric' debian for package 'rtsprofile' at version '3.0.2-0'
####


####
#### Generating 'quantal' debian for package 'rtsprofile' at version '3.0.2-0'
####
Generating debian for quantal...
Package 'rtsprofile' has dependencies:
Build and Build Tool Dependencies:
  rosdep key           => quantal key
  unzip                => ['unzip']
  mk                   => ['ros-groovy-mk']
  rosbuild             => ['ros-groovy-rosbuild']
  catkin               => ['ros-groovy-catkin']
==> In place processing templates in 'debian' folder.
Expanding 'debian/changelog.em' -> 'debian/changelog'
Expanding 'debian/gbp.conf.em' -> 'debian/gbp.conf'
Expanding 'debian/rules.em' -> 'debian/rules'
Expanding 'debian/control.em' -> 'debian/control'
Creating tag: debian/ros-groovy-rtsprofile_3.0.2-0_quantal
####
#### Successfully generated 'quantal' debian for package 'rtsprofile' at version '3.0.2-0'
####

Placing debian template files into 'debian/groovy/rtctree' branch.
==> Placing templates files in the 'debian' folder.

####
#### Generating 'precise' debian for package 'rtctree' at version '3.0.2-0'
####
Generating debian for precise...
Package 'rtctree' has dependencies:
Build and Build Tool Dependencies:
  rosdep key           => precise key
  unzip                => ['unzip']
  mk                   => ['ros-groovy-mk']
  python-omniorb       => ['python-omniorb', 'python-omniorb-omg', 'omniidl-python']
  rosbuild             => ['ros-groovy-rosbuild']
  catkin               => ['ros-groovy-catkin']
==> In place processing templates in 'debian' folder.
Expanding 'debian/changelog.em' -> 'debian/changelog'
Expanding 'debian/gbp.conf.em' -> 'debian/gbp.conf'
Expanding 'debian/rules.em' -> 'debian/rules'
Expanding 'debian/control.em' -> 'debian/control'
Creating tag: debian/ros-groovy-rtctree_3.0.2-0_precise
####
#### Successfully generated 'precise' debian for package 'rtctree' at version '3.0.2-0'
####


####
#### Generating 'oneiric' debian for package 'rtctree' at version '3.0.2-0'
####
Generating debian for oneiric...
Package 'rtctree' has dependencies:
Build and Build Tool Dependencies:
  rosdep key           => oneiric key
  unzip                => ['unzip']
  mk                   => ['ros-groovy-mk']
  python-omniorb       => ['python-omniorb', 'python-omniorb-omg', 'omniidl-python']
  rosbuild             => ['ros-groovy-rosbuild']
  catkin               => ['ros-groovy-catkin']
==> In place processing templates in 'debian' folder.
Expanding 'debian/changelog.em' -> 'debian/changelog'
Expanding 'debian/gbp.conf.em' -> 'debian/gbp.conf'
Expanding 'debian/rules.em' -> 'debian/rules'
Expanding 'debian/control.em' -> 'debian/control'
Creating tag: debian/ros-groovy-rtctree_3.0.2-0_oneiric
####
#### Successfully generated 'oneiric' debian for package 'rtctree' at version '3.0.2-0'
####


####
#### Generating 'quantal' debian for package 'rtctree' at version '3.0.2-0'
####
Generating debian for quantal...
Package 'rtctree' has dependencies:
Build and Build Tool Dependencies:
  rosdep key           => quantal key
  unzip                => ['unzip']
  mk                   => ['ros-groovy-mk']
  python-omniorb       => ['python-omniorb', 'python-omniorb-omg', 'omniidl-python']
  rosbuild             => ['ros-groovy-rosbuild']
  catkin               => ['ros-groovy-catkin']
==> In place processing templates in 'debian' folder.
Expanding 'debian/changelog.em' -> 'debian/changelog'
Expanding 'debian/gbp.conf.em' -> 'debian/gbp.conf'
Expanding 'debian/rules.em' -> 'debian/rules'
Expanding 'debian/control.em' -> 'debian/control'
Creating tag: debian/ros-groovy-rtctree_3.0.2-0_quantal
####
#### Successfully generated 'quantal' debian for package 'rtctree' at version '3.0.2-0'
####

Placing debian template files into 'debian/groovy/rtshell_core' branch.
==> Placing templates files in the 'debian' folder.

####
#### Generating 'precise' debian for package 'rtshell_core' at version '3.0.2-0'
####
Generating debian for precise...
Package 'rtshell-core' has dependencies:
Run Dependencies:
  rosdep key           => precise key
  rtshell              => ['ros-groovy-rtshell']
  rtctree              => ['ros-groovy-rtctree']
  rtsprofile           => ['ros-groovy-rtsprofile']
Build and Build Tool Dependencies:
  rosdep key           => precise key
  catkin               => ['ros-groovy-catkin']
==> In place processing templates in 'debian' folder.
Expanding 'debian/changelog.em' -> 'debian/changelog'
Expanding 'debian/gbp.conf.em' -> 'debian/gbp.conf'
Expanding 'debian/rules.em' -> 'debian/rules'
Expanding 'debian/control.em' -> 'debian/control'
Creating tag: debian/ros-groovy-rtshell-core_3.0.2-0_precise
####
#### Successfully generated 'precise' debian for package 'rtshell_core' at version '3.0.2-0'
####


####
#### Generating 'oneiric' debian for package 'rtshell_core' at version '3.0.2-0'
####
Generating debian for oneiric...
Package 'rtshell-core' has dependencies:
Run Dependencies:
  rosdep key           => oneiric key
  rtshell              => ['ros-groovy-rtshell']
  rtctree              => ['ros-groovy-rtctree']
  rtsprofile           => ['ros-groovy-rtsprofile']
Build and Build Tool Dependencies:
  rosdep key           => oneiric key
  catkin               => ['ros-groovy-catkin']
==> In place processing templates in 'debian' folder.
Expanding 'debian/changelog.em' -> 'debian/changelog'
Expanding 'debian/gbp.conf.em' -> 'debian/gbp.conf'
Expanding 'debian/rules.em' -> 'debian/rules'
Expanding 'debian/control.em' -> 'debian/control'
Creating tag: debian/ros-groovy-rtshell-core_3.0.2-0_oneiric
####
#### Successfully generated 'oneiric' debian for package 'rtshell_core' at version '3.0.2-0'
####


####
#### Generating 'quantal' debian for package 'rtshell_core' at version '3.0.2-0'
####
Generating debian for quantal...
Package 'rtshell-core' has dependencies:
Run Dependencies:
  rosdep key           => quantal key
  rtshell              => ['ros-groovy-rtshell']
  rtctree              => ['ros-groovy-rtctree']
  rtsprofile           => ['ros-groovy-rtsprofile']
Build and Build Tool Dependencies:
  rosdep key           => quantal key
  catkin               => ['ros-groovy-catkin']
==> In place processing templates in 'debian' folder.
Expanding 'debian/changelog.em' -> 'debian/changelog'
Expanding 'debian/gbp.conf.em' -> 'debian/gbp.conf'
Expanding 'debian/rules.em' -> 'debian/rules'
Expanding 'debian/control.em' -> 'debian/control'
Creating tag: debian/ros-groovy-rtshell-core_3.0.2-0_quantal
####
#### Successfully generated 'quantal' debian for package 'rtshell_core' at version '3.0.2-0'
####

Placing debian template files into 'debian/groovy/rtshell' branch.
==> Placing templates files in the 'debian' folder.

####
#### Generating 'precise' debian for package 'rtshell' at version '3.0.2-0'
####
Generating debian for precise...
Package 'rtshell' has dependencies:
Run Dependencies:
  rosdep key           => precise key
  rtctree              => ['ros-groovy-rtctree']
  rtsprofile           => ['ros-groovy-rtsprofile']
Build and Build Tool Dependencies:
  rosdep key           => precise key
  unzip                => ['unzip']
  mk                   => ['ros-groovy-mk']
  rosbuild             => ['ros-groovy-rosbuild']
  rosbash              => ['ros-groovy-rosbash']
  rostest              => ['ros-groovy-rostest']
  omniorb              => ['omniorb', 'omniidl', 'omniorb-nameserver', 'libomniorb4-dev']
  catkin               => ['ros-groovy-catkin']
==> In place processing templates in 'debian' folder.
Expanding 'debian/changelog.em' -> 'debian/changelog'
Expanding 'debian/gbp.conf.em' -> 'debian/gbp.conf'
Expanding 'debian/rules.em' -> 'debian/rules'
Expanding 'debian/control.em' -> 'debian/control'
Creating tag: debian/ros-groovy-rtshell_3.0.2-0_precise
####
#### Successfully generated 'precise' debian for package 'rtshell' at version '3.0.2-0'
####


####
#### Generating 'oneiric' debian for package 'rtshell' at version '3.0.2-0'
####
Generating debian for oneiric...
Package 'rtshell' has dependencies:
Run Dependencies:
  rosdep key           => oneiric key
  rtctree              => ['ros-groovy-rtctree']
  rtsprofile           => ['ros-groovy-rtsprofile']
Build and Build Tool Dependencies:
  rosdep key           => oneiric key
  unzip                => ['unzip']
  mk                   => ['ros-groovy-mk']
  rosbuild             => ['ros-groovy-rosbuild']
  rosbash              => ['ros-groovy-rosbash']
  rostest              => ['ros-groovy-rostest']
  omniorb              => ['omniorb', 'omniidl', 'omniorb-nameserver', 'libomniorb4-dev']
  catkin               => ['ros-groovy-catkin']
==> In place processing templates in 'debian' folder.
Expanding 'debian/changelog.em' -> 'debian/changelog'
Expanding 'debian/gbp.conf.em' -> 'debian/gbp.conf'
Expanding 'debian/rules.em' -> 'debian/rules'
Expanding 'debian/control.em' -> 'debian/control'
Creating tag: debian/ros-groovy-rtshell_3.0.2-0_oneiric
####
#### Successfully generated 'oneiric' debian for package 'rtshell' at version '3.0.2-0'
####


####
#### Generating 'quantal' debian for package 'rtshell' at version '3.0.2-0'
####
Generating debian for quantal...
Package 'rtshell' has dependencies:
Run Dependencies:
  rosdep key           => quantal key
  rtctree              => ['ros-groovy-rtctree']
  rtsprofile           => ['ros-groovy-rtsprofile']
Build and Build Tool Dependencies:
  rosdep key           => quantal key
  unzip                => ['unzip']
  mk                   => ['ros-groovy-mk']
  rosbuild             => ['ros-groovy-rosbuild']
  rosbash              => ['ros-groovy-rosbash']
  rostest              => ['ros-groovy-rostest']
  omniorb              => ['omniorb', 'omniidl', 'omniorb-nameserver', 'libomniorb4-dev']
  catkin               => ['ros-groovy-catkin']
==> In place processing templates in 'debian' folder.
Expanding 'debian/changelog.em' -> 'debian/changelog'
Expanding 'debian/gbp.conf.em' -> 'debian/gbp.conf'
Expanding 'debian/rules.em' -> 'debian/rules'
Expanding 'debian/control.em' -> 'debian/control'
Creating tag: debian/ros-groovy-rtshell_3.0.2-0_quantal
####
#### Successfully generated 'quantal' debian for package 'rtshell' at version '3.0.2-0'
####





Tip: Check to ensure that the debian tags created have the same version as the upstream version you are releasing.
Everything went as expected, you should check that the new tags match your expectations, and then push to the release repo with:
  git push --all && git push --tags  # You might have to add --force to the second command if you are over-writing existing tags
<== Released 'rtshell_core' using release track 'groovy' successfully
Releasing complete, push?
Continue [Y/n]? y
==> Pushing changes to release repository for 'rtshell_core'
==> git push --all
To https://github.com/tork-a/rtshell_core-release.git
   820efa8..67a0a64  debian/groovy/oneiric/rtctree -> debian/groovy/oneiric/rtctree
   c298e2e..9a937d0  debian/groovy/oneiric/rtshell -> debian/groovy/oneiric/rtshell
   1e34f3e..59ce090  debian/groovy/oneiric/rtshell_core -> debian/groovy/oneiric/rtshell_core
   6428b9c..cd7adc4  debian/groovy/oneiric/rtsprofile -> debian/groovy/oneiric/rtsprofile
   86a1874..f142de1  debian/groovy/precise/rtctree -> debian/groovy/precise/rtctree
   fb373aa..2d5e6ca  debian/groovy/precise/rtshell -> debian/groovy/precise/rtshell
   49036d9..685c9ea  debian/groovy/precise/rtshell_core -> debian/groovy/precise/rtshell_core
   5c8fc9b..b6ea6bc  debian/groovy/precise/rtsprofile -> debian/groovy/precise/rtsprofile
   2046494..67814f2  debian/groovy/quantal/rtctree -> debian/groovy/quantal/rtctree
   e90f0b7..f5732c9  debian/groovy/quantal/rtshell -> debian/groovy/quantal/rtshell
   159aa8c..7bf9136  debian/groovy/quantal/rtshell_core -> debian/groovy/quantal/rtshell_core
   a2b8772..d9b005b  debian/groovy/quantal/rtsprofile -> debian/groovy/quantal/rtsprofile
   44d43bf..87afa1e  debian/groovy/rtctree -> debian/groovy/rtctree
   565dbb4..7b15fdf  debian/groovy/rtshell -> debian/groovy/rtshell
   20444ef..16d442e  debian/groovy/rtshell_core -> debian/groovy/rtshell_core
   3b3193c..a5ab22b  debian/groovy/rtsprofile -> debian/groovy/rtsprofile
   a651537..b3aad58  master -> master
   d4188b3..d9e93dc  patches/debian/groovy/oneiric/rtctree -> patches/debian/groovy/oneiric/rtctree
   b52f83e..3232b15  patches/debian/groovy/oneiric/rtshell -> patches/debian/groovy/oneiric/rtshell
   d40f8d5..7d14f5f  patches/debian/groovy/oneiric/rtshell_core -> patches/debian/groovy/oneiric/rtshell_core
   426a8d7..5f67c64  patches/debian/groovy/oneiric/rtsprofile -> patches/debian/groovy/oneiric/rtsprofile
   c48207f..dc3e92a  patches/debian/groovy/precise/rtctree -> patches/debian/groovy/precise/rtctree
   ed06efd..dfcfb7b  patches/debian/groovy/precise/rtshell -> patches/debian/groovy/precise/rtshell
   f4cc574..726d612  patches/debian/groovy/precise/rtshell_core -> patches/debian/groovy/precise/rtshell_core
   8876481..a33ec34  patches/debian/groovy/precise/rtsprofile -> patches/debian/groovy/precise/rtsprofile
   769be53..a171663  patches/debian/groovy/quantal/rtctree -> patches/debian/groovy/quantal/rtctree
   4740e7b..4d88376  patches/debian/groovy/quantal/rtshell -> patches/debian/groovy/quantal/rtshell
   f82d9df..134109c  patches/debian/groovy/quantal/rtshell_core -> patches/debian/groovy/quantal/rtshell_core
   59ad71d..7adba45  patches/debian/groovy/quantal/rtsprofile -> patches/debian/groovy/quantal/rtsprofile
   25db085..6ec8876  patches/debian/groovy/rtctree -> patches/debian/groovy/rtctree
   1422843..33a1f74  patches/debian/groovy/rtshell -> patches/debian/groovy/rtshell
   abf5f6d..5c49486  patches/debian/groovy/rtshell_core -> patches/debian/groovy/rtshell_core
   7bbf12c..e5e1fd0  patches/debian/groovy/rtsprofile -> patches/debian/groovy/rtsprofile
   ad255d0..b5a4a35  patches/release/groovy/rtctree -> patches/release/groovy/rtctree
   6b0eed9..867b38b  patches/release/groovy/rtshell -> patches/release/groovy/rtshell
   a6996da..0bb999f  patches/release/groovy/rtshell_core -> patches/release/groovy/rtshell_core
   12086ee..9d67940  patches/release/groovy/rtsprofile -> patches/release/groovy/rtsprofile
   8741f3e..8b12f34  release/groovy/rtctree -> release/groovy/rtctree
   56806ee..a0cb4d6  release/groovy/rtshell -> release/groovy/rtshell
   2f209ff..d6587d5  release/groovy/rtshell_core -> release/groovy/rtshell_core
   a3433cb..7fe0a1a  release/groovy/rtsprofile -> release/groovy/rtsprofile
<== Pushed changes successfully
==> Pushing tags to release repository for 'rtshell_core'
==> git push --tags
To https://github.com/tork-a/rtshell_core-release.git
 * [new tag]         debian/ros-groovy-rtctree_3.0.2-0_oneiric -> debian/ros-groovy-rtctree_3.0.2-0_oneiric
 * [new tag]         debian/ros-groovy-rtctree_3.0.2-0_precise -> debian/ros-groovy-rtctree_3.0.2-0_precise
 * [new tag]         debian/ros-groovy-rtctree_3.0.2-0_quantal -> debian/ros-groovy-rtctree_3.0.2-0_quantal
 * [new tag]         debian/ros-groovy-rtshell-core_3.0.2-0_oneiric -> debian/ros-groovy-rtshell-core_3.0.2-0_oneiric
 * [new tag]         debian/ros-groovy-rtshell-core_3.0.2-0_precise -> debian/ros-groovy-rtshell-core_3.0.2-0_precise
 * [new tag]         debian/ros-groovy-rtshell-core_3.0.2-0_quantal -> debian/ros-groovy-rtshell-core_3.0.2-0_quantal
 * [new tag]         debian/ros-groovy-rtshell_3.0.2-0_oneiric -> debian/ros-groovy-rtshell_3.0.2-0_oneiric
 * [new tag]         debian/ros-groovy-rtshell_3.0.2-0_precise -> debian/ros-groovy-rtshell_3.0.2-0_precise
 * [new tag]         debian/ros-groovy-rtshell_3.0.2-0_quantal -> debian/ros-groovy-rtshell_3.0.2-0_quantal
 * [new tag]         debian/ros-groovy-rtsprofile_3.0.2-0_oneiric -> debian/ros-groovy-rtsprofile_3.0.2-0_oneiric
 * [new tag]         debian/ros-groovy-rtsprofile_3.0.2-0_precise -> debian/ros-groovy-rtsprofile_3.0.2-0_precise
 * [new tag]         debian/ros-groovy-rtsprofile_3.0.2-0_quantal -> debian/ros-groovy-rtsprofile_3.0.2-0_quantal
 * [new tag]         release/groovy/rtctree/3.0.2-0 -> release/groovy/rtctree/3.0.2-0
 * [new tag]         release/groovy/rtshell/3.0.2-0 -> release/groovy/rtshell/3.0.2-0
 * [new tag]         release/groovy/rtshell_core/3.0.2-0 -> release/groovy/rtshell_core/3.0.2-0
 * [new tag]         release/groovy/rtsprofile/3.0.2-0 -> release/groovy/rtsprofile/3.0.2-0
<== Pushed tags successfully
==> Generating pull request to distro file located at 'https://raw.github.com/ros/rosdistro/master/groovy/distribution.yaml'
Unified diff for the ROS distro file located at '/tmp/tmprWlIiE/rtshell_core-3.0.2-0.patch':
--- groovy/distribution.yaml
+++ groovy/distribution.yaml
@@ -4029,7 +4029,7 @@
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/rtshell_core-release.git
-      version: 3.0.1-0
+      version: 3.0.2-0
     source:
       type: git
       url: https://github.com/start-jsk/rtshell_core.git
==> Checking on github for a fork to make the pull request from...
==> Using this fork to make a pull request from: k-okada/rosdistro
==> Cloning k-okada/rosdistro...
==> mkdir -p rosdistro
==> git init
Initialized empty Git repository in /tmp/BHnwfV/rosdistro/.git/
Pull Request Title: rtshell_core: 3.0.2-0 in 'groovy/distribution.yaml' [bloom]
Pull Request Body : 
Increasing version of package(s) in repository `rtshell_core` to `3.0.2-0`:

- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `3.0.1-0`

## rtctree

```
- use 3.0.1 of rtctree, due to #34
- Contributors: Kei Okada

```

## rtshell

- No changes

## rtshell_core

- No changes

## rtsprofile

- No changes

Open a pull request from 'rosdistro/rosdistro:bloom-rtshell_core-0' into 'ros/rosdistro:master'?
Continue [Y/n]? y
==> git checkout -b bloom-rtshell_core-0
==> Pulling latest rosdistro branch
remote: Counting objects: 34598, done.
remote: Compressing objects: 100% (19222/19222), done.
remote: Total 34598 (delta 18963), reused 29325 (delta 15356)
Receiving objects: 100% (34598/34598), 5.51 MiB | 1.25 MiB/s, done.
Resolving deltas: 100% (18963/18963), done.
From https://github.com/ros/rosdistro
 * branch            master     -> FETCH_HEAD
==> Writing new distribution file: groovy/distribution.yaml
==> git add groovy/distribution.yaml
==> git commit -m "rtshell_core: 3.0.2-0 in 'groovy/distribution.yaml' [bloom]"
[bloom-rtshell_core-0 dd31b5b] rtshell_core: 3.0.2-0 in 'groovy/distribution.yaml' [bloom]
 1 file changed, 1 insertion(+), 1 deletion(-)
==> Pushing changes to fork
To https://6566b5e95fe4be1a002f5c8e7455315bec3fd24b:x-oauth-basic@github.com/k-okada/rosdistro.git
 ! [rejected]        bloom-rtshell_core-0 -> bloom-rtshell_core-0 (non-fast-forward)
error: failed to push some refs to 'https://6566b5e95fe4be1a002f5c8e7455315bec3fd24b:x-oauth-basic@github.com/k-okada/rosdistro.git'
To prevent you from losing history, non-fast-forward updates were rejected
Merge the remote changes (e.g. 'git pull') before pushing again.  See the
'Note about fast-forwards' section of 'git push --help' for details.
Failed to open pull request: CalledProcessError - Command 'git push https://6566b5e95fe4be1a002f5c8e7455315bec3fd24b:x-oauth-basic@github.com/k-okada/rosdistro.git bloom-rtshell_core-0' returned non-zero exit status 1
k-okada@kokada-t430s:~/work/bloom/rtshell_core/rtshell_core$ 

```
