### PR TITLE
rtshell_core: 3.0.3-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4029,7 +4029,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/rtshell_core-release.git
-      version: 3.0.2-0
+      version: 3.0.3-0
     source:
       type: git
       url: https://github.com/start-jsk/rtshell_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell_core` to `3.0.3-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `3.0.2-0`
## rtctree

```
* add depends to git and CA-cert fix
* Contributors: Kei Okada
```
## rtshell

```
* add depends to git and CA-cert fix
* Contributors: Kei Okada
```
## rtshell_core
- No changes
## rtsprofile

```
* add depends to git and CA-cert fix
* Contributors: Kei Okada
```
