### PR TITLE
bwi_common: 0.2.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -340,7 +340,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/bwi_common-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi_common` to `0.2.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.2.1-0`
## bwi_common
- No changes
## bwi_gazebo_entities
- No changes
## bwi_mapper
- No changes
## bwi_planning_common

```
* Install header correctly
  (#1 <https://github.com/utexas-bwi/bwi_common/issues/1>)
```
## bwi_tools
- No changes
## bwi_web
- No changes
## utexas_gdc
- No changes
