### PR TITLE
segbot_apps: 0.2.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5427,11 +5427,13 @@ repositories:
     release:
       packages:
       - segbot_apps
+      - segbot_gui
+      - segbot_logical_translator
       - segbot_navigation
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/segbot_apps-release.git
-      version: 0.1.5-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/utexas-bwi/segbot_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot_apps` to `0.2.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.1.5-0`
## segbot_apps
- No changes
## segbot_gui

```
* now catkin_lint approved. found a bug where a plugin file was not
  being installed
* increased default font size in the segbot gui
* added missing run dependencies
* added ability to ask a text-input question
* better pep8 conformity
* rqt simple question plugin is now ready
* added a new gui package with a question dialog plugin for rqt
* Contributors: Jack O'Quin, Piyush Khandelwal, piyushk
```
## segbot_logical_translator

```
* now actually read in object approach file
* added the ability to approach an object, as well as added the
  ability to approach a door from any accessible location
* now catkin_lint approved
* better error checking, shared global nodehandle, added ability to
  sense whether a door is open or not
* moved the cost estimator to the bwi_planning package
* moved gazebo stuff to separate simulated app
* Contributors: Jack O'Quin, Piyush Khandelwal, piyushk
```
## segbot_navigation

```
* use ``roslaunch_add_files_check()`` to test that required launch
  file dependencies are declared.
```
