### PR TITLE
segbot_simulator: 0.2.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5447,11 +5447,12 @@ repositories:
     release:
       packages:
       - segbot_gazebo
+      - segbot_simulation_apps
       - segbot_simulator
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/segbot_simulator-release.git
-      version: 0.1.5-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/utexas-bwi/segbot_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot_simulator` to `0.2.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.1.5-0`
## segbot_gazebo

```
* use ``roslaunch_add_file_check()`` to test launch file
  dependencies.
* add missing ``map_server`` dependency.
```
## segbot_simulation_apps

```
* initial release to Hydro
* install header correctly
* removed catkin_lint errors
* moved resolveDoor to common functions in bwi_planning_common
* added service to modify door status
* added a package for simulation apps. For now, added a door handler.
```
## segbot_simulator
- No changes
