### PR TITLE
openni_launch: 1.9.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3667,7 +3667,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/openni_launch-release.git
-      version: 1.9.4-0
+      version: 1.9.5-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_launch` to `1.9.5-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.9.4-0`
## openni_launch

```
* Test the ROS launch files, fix some errors (#10 <https://github.com/ros-drivers/openni_launch/issues/10>).
* Fix errors found by roslaunch unit test (#10 <https://github.com/ros-drivers/openni_launch/issues/10>).
* Add unit tests for launch file dependencies.
* Contributors: Jack O'Quin, jonbinney
```
