### PR TITLE
um6: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1955,6 +1955,21 @@ repositories:
       type: hg
       url: https://bitbucket.org/kmhallen/ueye
       version: default
+  um6:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/um6.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/um6-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/um6.git
+      version: indigo-devel
+    status: maintained
   unique_identifier:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `um6` to `1.0.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
## um6

```
* Add roslint.
* Use astyle to fix braces and spacing.
* #if guard for <endian.h> include on OS X.
* Contributors: Mike Purvis
```
