### PR TITLE
sql_database 0.4.8

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5618,10 +5618,13 @@ repositories:
       url: https://github.com/ros-interactive-manipulation/sql_database.git
       version: hydro-devel
     release:
+      packages:
+      - database_interface
+      - student_database
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/sql_database-release.git
-      version: 0.4.7-0
+      version: 0.4.8-0
   sr_config:
     doc:
       type: git


### PR DESCRIPTION
Pull request generated by hand; not that bloom-release pull request generation failed like this:

```
==> Generating pull request to distro file located at 'https://raw.github.com/ros/rosdistro/master/hydro/distribution.yaml'
Would you like to add source information for this repository? [Y/n]? 
Please enter information which points ot the active development branch for this repository.
This information is used to run continuous integration jobs and for developers to checkout from.
VCS type [git, svn, hg, bzr]: git
VCS url: https://github.com/ros-interactive-manipulation/sql_database.git
VCS version [commit, tag, branch, etc]: hydro-devel
Would you like to add a maintenance status for this repository? [Y/n]? n
Unified diff for the ROS distro file located at '/tmp/tmpyElg9Z/sql_database-0.4.8-0.patch':
--- hydro/distribution.yaml
+++ hydro/distribution.yaml
@@ -5621,7 +5621,11 @@
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/sql_database-release.git
-      version: 0.4.7-0
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-interactive-manipulation/sql_database.git
+      version: hydro-devel
   sr_config:
     doc:
       type: git
Failed to open pull request: ValueError - No JSON object could be decoded
```
