### PR TITLE
sql_database: 0.4.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5621,7 +5621,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/sql_database-release.git
-      version: 0.4.7-0
+      version: 0.4.8-0
   sr_config:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sql_database` to `0.4.8-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.4.7-0`
