### PR TITLE
sql_database: 0.4.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1924,6 +1924,12 @@ repositories:
       url: https://github.com/ros-perception/slam_gmapping.git
       version: hydro-devel
     status: maintained
+  sql_database:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/sql_database-release.git
+      version: 0.4.8-0
   srdfdom:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sql_database` to `0.4.8-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
