### PR TITLE
driver_common: 1.6.8-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -326,6 +326,27 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: indigo-devel
     status: maintained
+  driver_common:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/driver_common.git
+      version: indigo-devel
+    release:
+      packages:
+      - driver_base
+      - driver_common
+      - timestamp_tools
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/driver_common-release.git
+      version: 1.6.8-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/driver_common.git
+      version: indigo-devel
+    status: end-of-life
+    status_description: Will be released only as long as required for PR2 drivers
+      (hokuyo_node, wge100_driver)
   dynamic_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `driver_common` to `1.6.8-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## driver_base
- No changes
## driver_common
- No changes
## timestamp_tools
- No changes
