### PR TITLE
nmea_msgs: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1089,6 +1089,11 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/nmea_msgs.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/nmea_msgs-release.git
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/nmea_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_msgs` to `0.1.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## nmea_msgs

```
* Initial version (released into Hydro)
* Supports NMEA0183 sentences
```
