### PR TITLE
urg_node: 0.1.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6104,7 +6104,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/urg_node-release.git
-      version: 0.1.6-0
+      version: 0.1.7-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/urg_node.git
+      version: hydro-devel
     status: maintained
   usb_cam:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node` to `0.1.7-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.1.6-0`
## urg_node

```
* Added more robust plug/unplug reconnect behavior.
* Added more robustness and the ability to continually reloop and reconnect until node is shutdown.
* Fix initialization crash.
* Install fix for Android.
* Missed a willowgarage email.
* Contributors: Chad Rockey
```
