### PR TITLE
repository_name: 0.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1452,6 +1452,23 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/random_numbers-release.git
       version: 0.2.0-0
+  repository_name:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_node.git
+      version: indigo-devel
+    release:
+      packages:
+      - urg_node
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/urg_node-release.git
+      version: 0.1.7-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/urg_node.git
+      version: indigo-devel
+    status: maintained
   resource_retriever:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `repository_name` to `0.1.7-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## urg_node

```
* Added more robust plug/unplug reconnect behavior.
* Added more robustness and the ability to continually reloop and reconnect until node is shutdown.
* Fix initialization crash.
* Install fix for Android.
* Missed a willowgarage email.
* Contributors: Chad Rockey
```
