### PR TITLE
hokuyo_node: 1.7.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -744,6 +744,21 @@ repositories:
       url: https://github.com/ros/geometry_experimental.git
       version: indigo-devel
     status: maintained
+  hokuyo_node:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/hokuyo_node.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/hokuyo_node-release.git
+      version: 1.7.8-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/hokuyo_node.git
+      version: indigo-devel
+    status: maintained
   household_objects_database_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `hokuyo_node` to `1.7.8-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## hokuyo_node

```
* Merge pull request #8 <https://github.com/ros-drivers/hokuyo_node/issues/8> from trainman419/hydro-devel
  Use rosconsole to set logger levels. Fixes #7 <https://github.com/ros-drivers/hokuyo_node/issues/7>
* Use rosconsole to set logger levels. Fixes #7 <https://github.com/ros-drivers/hokuyo_node/issues/7>
* Added changelog
* Contributors: Chad Rockey, chadrockey, trainman419
```
