### PR TITLE
sicktoolbox: 1.0.103-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -744,21 +744,6 @@ repositories:
       url: https://github.com/ros/geometry_experimental.git
       version: indigo-devel
     status: maintained
-  hokuyo_node:
-    doc:
-      type: git
-      url: https://github.com/ros-drivers/hokuyo_node.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/hokuyo_node-release.git
-      version: 1.7.8-0
-    source:
-      type: git
-      url: https://github.com/ros-drivers/hokuyo_node.git
-      version: indigo-devel
-    status: maintained
   household_objects_database_msgs:
     release:
       tags:
@@ -1962,6 +1947,21 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/shape_tools-release.git
       version: 0.2.1-0
+  sicktoolbox:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/sicktoolbox.git
+      version: catkin
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/sicktoolbox-release.git
+      version: 1.0.103-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/sicktoolbox.git
+      version: catkin
+    status: maintained
   slam_gmapping:
     doc:
       type: git
@@ -2096,21 +2096,6 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/urg_c.git
       version: master
-    status: maintained
-  urg_node:
-    doc:
-      type: git
-      url: https://github.com/ros-drivers/urg_node.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/urg_node-release.git
-      version: 0.1.7-0
-    source:
-      type: git
-      url: https://github.com/ros-drivers/urg_node.git
-      version: indigo-devel
     status: maintained
   velodyne:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `sicktoolbox` to `1.0.103-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
