### PR TITLE
sicktoolbox: 1.0.103-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1977,6 +1977,21 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/shape_tools-release.git
       version: 0.2.1-0
+  sicktoolbox:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/sicktoolbox.git
+      version: catkin
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/sicktoolbox-release.git
+      version: 1.0.103-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/sicktoolbox.git
+      version: catkin
+    status: maintained
   slam_gmapping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sicktoolbox` to `1.0.103-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
