### PR TITLE
sicktoolbox_wrapper: 2.5.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1992,6 +1992,21 @@ repositories:
       url: https://github.com/ros-drivers/sicktoolbox.git
       version: catkin
     status: maintained
+  sicktoolbox_wrapper:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/sicktoolbox_wrapper.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/sicktoolbox_wrapper-release.git
+      version: 2.5.3-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/sicktoolbox_wrapper.git
+      version: indigo-devel
+    status: maintained
   slam_gmapping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sicktoolbox_wrapper` to `2.5.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
