### PR TITLE
depthimage_to_laserscan: 1.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -303,6 +303,21 @@ repositories:
       url: https://github.com/RobotWebTools/depthcloud_encoder.git
       version: develop
     status: maintained
+  depthimage_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/depthimage_to_laserscan.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/depthimage_to_laserscan-release.git
+      version: 1.0.6-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/depthimage_to_laserscan.git
+      version: indigo-devel
+    status: maintained
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthimage_to_laserscan` to `1.0.6-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## depthimage_to_laserscan

```
* Removed y component from projected beam radius.
```
