### PR TITLE
The source version must be a branch and not a tag

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3820,10 +3820,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tstoyanov/perception_oru-release.git
       version: 1.0.18-0
-    source:
-      type: git
-      url: https://github.com/tstoyanov/perception_oru-release.git
-      version: release-hydro-source
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
A tag causes the devel build to rebuild every time it polls. 
http://jenkins.ros.org/job/devel-hydro-perception_oru/

Rolls back part of #3849 
FYI @tstoyanov
