### PR TITLE
gperftools_21: 2.1.0-10 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1709,6 +1709,13 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/geometry_tutorials-release.git
       version: 0.2.0-0
+  gperftools_21:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/gperftools_21-release.git
+      version: 2.1.0-10
+    status: maintained
   gps_umd:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gperftools_21` to `2.1.0-10`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
