### PR TITLE
kobuki_desktop: 0.3.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2533,10 +2533,11 @@ repositories:
       - kobuki_gazebo
       - kobuki_gazebo_plugins
       - kobuki_qtestsuite
+      - kobuki_rviz_launchers
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki_desktop-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     status: developed
   kobuki_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_desktop` to `0.3.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.3.1-0`
## kobuki_dashboard

```
* removes email addresses from authors
* add robot groups for rqt plugins
* Contributors: Dirk Thomas, Marcus Liebhardt
```
## kobuki_desktop

```
* removes email addresses from authors
* adds package for rviz launchers
* Contributors: Marcus Liebhardt
```
## kobuki_gazebo

```
* removes email addresses from authors
* Contributors: Marcus Liebhardt
```
## kobuki_gazebo_plugins

```
* removes email addresses from authors
* replace deprecated shared_dynamic_cast (fixes #25 <https://github.com/yujinrobot/kobuki_desktop/issues/25>)
* Contributors: Marcus Liebhardt, Samir Benmendil
```
## kobuki_qtestsuite

```
* removes email addresses from authors
* add robot groups for rqt plugins
* add robot groups for rqt plugins
* Contributors: Dirk Thomas, Marcus Liebhardt
```
## kobuki_rviz_launchers

```
* removes email addresses from authors
* adds package for rviz launchers
* Contributors: Marcus Liebhardt
* removes email addresses from authors
* adds package for rviz launchers
* Contributors: Marcus Liebhardt
```
