### PR TITLE
segbot_apps: 0.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5437,7 +5437,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/segbot_apps-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/utexas-bwi/segbot_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot_apps` to `0.2.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.2.0-0`
## segbot_apps

```
* Add segbot_gui and segbot_logical_translator dependencies (#16 <https://github.com/utexas-bwi/segbot_apps/issues/16>)
```
## segbot_gui
- No changes
## segbot_logical_translator
- No changes
## segbot_navigation
- No changes
