### PR TITLE
segbot_simulator: 0.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5456,7 +5456,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/segbot_simulator-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/utexas-bwi/segbot_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot_simulator` to `0.2.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.2.0-0`
## segbot_gazebo
- No changes
## segbot_simulation_apps
- No changes
## segbot_simulator

```
* segbot_simulator: add segbot_simulation_apps dependency (#20 <https://github.com/utexas-bwi/segbot_simulator/issues/20>)
```
