### PR TITLE
clasp: 3.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -486,6 +486,11 @@ repositories:
       type: git
       url: https://github.com/utexas-bwi/clasp.git
       version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/utexas-bwi-gbp/clasp-release.git
+      version: 3.0.3-0
     source:
       type: git
       url: https://github.com/utexas-bwi/clasp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clasp` to `3.0.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## clasp

```
* Released to ROS Hydro.
* updated repo with clasp 3.0.3
* Contributors: Piyush Khandelwal
```
