### PR TITLE
play_motion: 0.4.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3883,11 +3883,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/pal-gbp/play_motion-release.git
-      version: 0.3.5-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion.git
       version: hydro-devel
+    status: developed
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion` to `0.4.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.3.5-0`
## play_motion

```
* Add install() rule for headers
* Fetch time_from_start as a double. (#28 <https://github.com/pal-robotics/play_motion/issues/28>)
* MoveIt! integration (#36 <https://github.com/pal-robotics/play_motion/issues/36>)
* Allow to disable motion planning altogether.
* Silence compiler warnings.
* Add move_joint script (#33 <https://github.com/pal-robotics/play_motion/issues/33>)
* Don't compute approach time if specified.
* Handle first waypoints with time_from_start == 0.
* Add service call to query available motions.
* Isolate move_group async spinner from rest of node (#31 <https://github.com/pal-robotics/play_motion/issues/31>)
* Make planning optional. Deprecate reach_time.
* First prototype of motion planning support.
* Refactor how controllers are checked.
* Allow cast from int to double in xmlrpc helpers (#28 <https://github.com/pal-robotics/play_motion/issues/28>)
* Contributors: Adolfo Rodriguez Tsouroukdissian, Paul Mathieu
```
## play_motion_msgs

```
* Add service call to query available motions.
* Make planning optional. Deprecate reach_time.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
