### PR TITLE
bwi_planning: 0.2.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -351,6 +351,14 @@ repositories:
       type: git
       url: https://github.com/utexas-bwi/bwi_planning.git
       version: master
+    release:
+      packages:
+      - bwi_planning
+      - bwi_planning_icaps14
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/utexas-bwi-gbp/bwi_planning-release.git
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi_planning.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi_planning` to `0.2.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## bwi_planning

```
* Initial release to Hydro.
* Moved clasp to a separate repository.
* Fixed bugs while marking door, also added backwards compatible
  action goto to base action executor.
* Add missing dependency on gringo.
* Now print expected next state when observations don't match up.
* Added an abstract planner.
* Spring Symposium code is now working.
* Updating bwi_planning code for the ICAPS 2014 paper.
* Added ability to track planning times at each iteration.
* Added a script to run the experiment and reset it as necessary.
* Fixed heuristics in krr2014 version.
* Fixed simulation door file. corners no longer needed with the door.
* Added roslaunch unit test and missing launch run dependencies.
```
## bwi_planning_icaps14

```
* Initial release to Hydro.
* Spring Symposium code is now working.
* Updating bwi_planning code for the ICAPS 2014 paper.
```
