### PR TITLE
diagnostics: 1.8.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -335,7 +335,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/diagnostics-release.git
-      version: 1.8.2-0
+      version: 1.8.2-1
     source:
       type: git
       url: https://github.com/ros/diagnostics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `1.8.2-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.8.2-0`
