### PR TITLE
rosdoc_lite: 0.2.4-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3687,7 +3687,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/rosdoc_lite-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/ros-infrastructure/rosdoc_lite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosdoc_lite` to `0.2.4-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.2.3-0`
## rosdoc_lite

```
* Groovy, Hydro and Indigo release.
* Introduce doxygen PREDEFINED tag (#47 <https://github.com/ros-infrastructure/rosdoc_lite/issues/47>).  Thanks to Fabien
  Spindler.
* Bugfix to enable devel space usage of rosdoc-lite, fixes #44 <https://github.com/ros-infrastructure/rosdoc_lite/issues/44>.
  Thanks to Daniel Stonier.
* Delete upload script which is not used anymore.  Its functionality
  is in jenkins_scripts doc_stack.py <https://github.com/ros-infrastructure/jenkins_scripts/blob/master/doc_stack.py>
* Merge pull request #41 <https://github.com/ros-infrastructure/rosdoc_lite/issues/41> to
  disable doxygen searchengine and latex generation.
* Update ros.org urls.
* Add list of actions to manifest.yaml after documenting them.
* Order list of documented msgs/srvs/actions.
* Add debug information to epyenator.
* Contributors: Daniel Stonier, Dirk Thomas, Fabien Spindler, Jack O'Quin, Tully Foote
```
