### PR TITLE
bwi: 0.2.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -328,6 +328,16 @@ repositories:
       type: git
       url: https://github.com/utexas-bwi/bwi.git
       version: master
+    release:
+      packages:
+      - bwi
+      - bwi_desktop
+      - bwi_desktop_full
+      - bwi_launch
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/utexas-bwi-gbp/bwi-release.git
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi` to `0.2.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## bwi

```
* release to Hydro
* create separate desktop and desktop full metapackages
* add clasp to repository list
* divide into a metapackage and a bwi_launch package
* bwi: new top-level repository
* Contributors: Jack O'Quin
```
## bwi_desktop

```
* release to Hydro
* create separate desktop metapackage
* Contributors: Jack O'Quin
```
## bwi_desktop_full

```
* release to Hydro
* create separate desktop full metapackage
* Contributors: Jack O'Quin
```
## bwi_launch

```
* release to Hydro
* make a separate bwi_launch package
* Contributors: Jack O'Quin
```
