### PR TITLE
common_msgs: 1.11.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -220,7 +220,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.11.1-0
+      version: 1.11.2-0
     source:
       type: git
       url: https://github.com/ros/common_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.11.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `1.11.1-0`
## actionlib_msgs
- No changes
## common_msgs
- No changes
## diagnostic_msgs

```
* Add STALE to DiagnosticStatus level enum
* Contributors: Austin
```
## geometry_msgs
- No changes
## nav_msgs
- No changes
## sensor_msgs
- No changes
## shape_msgs
- No changes
## stereo_msgs
- No changes
## trajectory_msgs
- No changes
## visualization_msgs
- No changes
