### PR TITLE
segbot: 0.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5461,7 +5461,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/segbot-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/utexas-bwi/segbot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot` to `0.2.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.2.0-0`
## segbot
- No changes
## segbot_bringup

```
* segbot_bringup: install udev rules (#26 <https://github.com/utexas-bwi/segbot/issues/26>)
* fix some problems catkin_lint discovered
```
## segbot_description

```
* fix some problems catkin_lint discovered
```
## segbot_firmware
- No changes
## segbot_sensors

```
* fix some problems catkin_lint discovered
* segbot_sensors: make roslaunch checks complete (#20 <https://github.com/utexas-bwi/segbot/issues/20>)
```
