### PR TITLE
jsk_recognition: 0.1.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2459,7 +2459,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.1.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.1.3-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros

```
* fixed compile error jsk_pcl_ros
* Contributors: Kei Okada, Ryohei Ueda, Yuto Inagaki
```
## jsk_perception

```
* add sparse_image program to jsk_percepton
* make edge_detector nodelet class
* Contributors: Ryohei Ueda, furushchev
* Merge pull request #47 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/47> from k-okada/add_rosbuild
* Contributors: Kei Okada
```
## jsk_recognition
- No changes
## resized_image_transport
- No changes
