### PR TITLE
jsk_roseus: 1.1.4-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2474,11 +2474,13 @@ repositories:
       packages:
       - euslisp
       - geneus
+      - jsk_roseus
       - roseus
+      - roseus_msgs
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.3-0
+      version: 1.1.4-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.4-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.1.3-0`
## euslisp

```
* add test code for using robot-model class
* Contributors: Shunnichi Nozawa
```
## geneus

```
* use roseus_INSTALL_DIR variables so that we can put message file in different locate #68
* #63 seems introduce new bugs, reporeted on https://github.com/jsk-ros-pkg/jsk_visualization/pull/19
* Contributors: Kei Okada
```
## jsk_roseus

```
* jsk_roseus: add metapackage
* Contributors: Kei Okada
```
## roseus

```
* check msg file udder CMAKE_PREFIX_PATH (#68)
* (#31) use 120 as wait-for-transform
* Contributors: Kei Okada
```
## roseus_msgs

```
* add roseus_msgs that generates files under share/roseus/ros (#68)
* Contributors: Kei Okada
```
