### PR TITLE
eband_local_planner: 0.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1197,7 +1197,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/eband_local_planner-release.git
-      version: 0.1.2-0
+      version: 0.2.1-0
     status: developed
   ecl_core:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `eband_local_planner` to `0.2.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.1.2-0`
## eband_local_planner

```
* added jack as a maintainer for the package
* 0.2.0
* updated changelogs in preparation of v0.2.0
* changing some fudge factors
* removed band hack. attempting band repair algorithm now
* changes to hysteresis loop. still has some problems
* fixed indentation. closes #10 <https://github.com/utexas-bwi/eband_local_planner/issues/10>
* eband_local_planner now fails when new frames cannot be added to the band. closes #9 <https://github.com/utexas-bwi/eband_local_planner/issues/9>
* Contributors: Piyush Khandelwal
```
