### PR TITLE
swiftnav: 0.8.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5832,7 +5832,7 @@ repositories:
   swiftnav:
     doc:
       type: git
-      url: https://github.com/swift-nav/libswiftnav
+      url: https://github.com/swift-nav/libswiftnav.git
       version: v0.8
     release:
       tags:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5830,11 +5830,16 @@ repositories:
       url: https://github.com/srv/stereo_slam.git
       version: hydro
   swiftnav:
+    doc:
+      type: git
+      url: https://github.com/swift-nav/libswiftnav
+      version: v0.8
     release:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/libswiftnav-release.git
-      version: 0.0.4-0
+      version: 0.8.0-0
+    status: maintained
   teleop_twist_keyboard:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `swiftnav` to `0.8.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.0.4-0`
