### PR TITLE
pcl_conversions: 0.1.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3831,11 +3831,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/pcl_conversions-release.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/ros-perception/pcl_conversions.git
       version: hydro-devel
+    status: maintained
   pcl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_conversions` to `0.1.6-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.1.5-0`
## pcl_conversions

```
* Make pcl_conversions run_depend on libpcl-all-dev
  When downstream projects build against pcl_conversions, they need the pcl headers provided by libpcl-all-dev.
* Contributors: Scott K Logan, William Woodall
```
