### PR TITLE
urg_c: 1.0.404-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2156,7 +2156,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/urg_c-release.git
-      version: 1.0.403-0
+      version: 1.0.404-0
     source:
       type: git
       url: https://github.com/ros-drivers/urg_c.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_c` to `1.0.404-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.0.403-0`
## urg_c

```
* Merge pull request #2 <https://github.com/ros-drivers/urg_c/issues/2> from dawonn/master
  Issue #1 <https://github.com/ros-drivers/urg_c/issues/1> - missing libmath link
* Ubuntu 14.04 Fix - missing libmath link
* Fix build for Android.
* Contributors: Chad Rockey, dawonn
```
