### PR TITLE
industrial_metapackages: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2330,6 +2330,15 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/industrial_core.git
       version: hydro
+  industrial_metapackages:
+    release:
+      packages:
+      - industrial_desktop
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-industrial-release/industrial_metapackages-release.git
+      version: 0.0.1-0
+    status: developed
   interactive_marker_proxy:
     release:
       url: https://github.com/ros-gbp/interactive_marker_proxy-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_metapackages` to `0.0.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `null`
