### PR TITLE
xacro: 1.9.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6472,7 +6472,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.8.4-0
+      version: 1.9.1-0
+    source:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: auto
     status: maintained
   xdot:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.9.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.8.4-0`
## xacro

```
* Installed xacro relocatable fix.
```
