### PR TITLE
xacro: 1.8.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6472,7 +6472,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.8.4-0
+      version: 1.8.5-0
+    source:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: hydro-devel
     status: maintained
   xdot:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.8.5-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.8.4-0`
## xacro

```
* Installed xacro relocatable fix.
* Remove the roslint_python glob, use the default one.
* Add roslint target to xacro; two whitespace fixes so that it passes.
* fix evaluation of integers in if statements
  also added a unit test, fixes #15 <https://github.com/ros/xacro/issues/15>
* fix setting of _xacro_py CMake var
  Fixes #16 <https://github.com/ros/xacro/issues/16>
* Add support for globbing multiple files in a single <xacro:include>
* code cleanup and python3 support
* check for CATKIN_ENABLE_TESTING
```
