### PR TITLE
flir_ptu: 0.1.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1515,7 +1515,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_ptu-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/ros-drivers/flir_ptu.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_ptu` to `0.1.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.1.2-0`
## flir_ptu_description
- No changes
## flir_ptu_driver

```
* catkin_lint fixes
* Contributors: Mike Purvis
```
## flir_ptu_viz

```
* catkin_lint fixes
* Switch roslaunch to a build dependency
* Add launchfile tests
* Contributors: Mike Purvis
```
