### PR TITLE
bwi_common: 0.2.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -368,7 +368,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/bwi_common-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi_common` to `0.2.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.2.3-0`
## bwi_common
- No changes
## bwi_gazebo_entities

```
* cleaned up most catkin_lint warnings. closes #6 <https://github.com/utexas-bwi/bwi_common/issues/6>
* it is now necessary to specify noise for a sensor, otherwise the
  camera plugin does not work. closes #4 <https://github.com/utexas-bwi/bwi_common/issues/4>
* Contributors: Piyush Khandelwal
```
## bwi_mapper

```
* cleaned up most catkin_lint warnings. closes #6 <https://github.com/utexas-bwi/bwi_common/issues/6>
* Added support for YAML-CPP 0.5+.  The new yaml-cpp API removes the
  "node >> outputvar;" operator, and it has a new way of loading
  documents.
* Contributors: Piyush Khandelwal, Scott K Logan
```
## bwi_planning_common

```
* cleaned up most catkin_lint warnings. closes #6 <https://github.com/utexas-bwi/bwi_common/issues/6>
* Added support for YAML-CPP 0.5+.  The new yaml-cpp API removes the
  "node >> outputvar;" operator, and it has a new way of loading
  documents.
* Contributors: Piyush Khandelwal, Scott K Logan
```
## bwi_tools
- No changes
## bwi_web

```
* cleaned up most catkin_lint warnings. closes #6 <https://github.com/utexas-bwi/bwi_common/issues/6>
* Contributors: Piyush Khandelwal
```
## utexas_gdc

```
* cleaned up most catkin_lint warnings. closes #6 <https://github.com/utexas-bwi/bwi_common/issues/6>
* Contributors: Piyush Khandelwal
```
