### PR TITLE
rqt_capabilities: 0.1.0-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3886,6 +3886,13 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: groovy-devel
     status: maintained
+  rqt_capabilities:
+    release:
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_capabilities-release.git
+      version: 0.1.0-0
+    status: developed
   rqt_common_plugins:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_capabilities` to `0.1.0-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## rqt_capabilities

```
* Initial Release
* Contributors: Marcus Liebhardt, William Woodall
```
