### PR TITLE
std_capabilities: 0.1.0-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4275,6 +4275,13 @@ repositories:
       type: svn
       url: https://code.ros.org/svn/ros-pkg/stacks/stage/trunk
       version: HEAD
+  std_capabilities:
+    release:
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/ros-gbp/std_capabilities-release.git
+      version: 0.1.0-0
+    status: developed
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `std_capabilities` to `0.1.0-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## std_capabilities

```
* Initial Release
* Contributors: Marcus Liebhardt, William Woodall
```
