### PR TITLE
std_capabilities: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5187,13 +5187,6 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: groovy-devel
     status: maintained
-  rqt_capabilities:
-    release:
-      tags:
-        release: release/hydro/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_capabilities-release.git
-      version: 0.1.0-0
-    status: developed
   rqt_common_plugins:
     doc:
       type: git
@@ -5805,6 +5798,13 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/stage_ros-release.git
       version: 1.7.2-0
+  std_capabilities:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/std_capabilities-release.git
+      version: 0.1.0-0
+    status: developed
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `std_capabilities` to `0.1.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## std_capabilities

```
* Initial Release
* Contributors: Marcus Liebhardt, William Woodall
```
