### PR TITLE
iai_common_msgs: 0.0.0-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1574,7 +1574,7 @@ repositories:
       version: 0.0.0-0
     source:
       type: git
-      url: https://github.com/code-iai/iai_common_msgs
+      url: https://github.com/code-iai/iai_common_msgs.git
       version: master
     status: developed
   ias_common:

--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1555,6 +1555,28 @@ repositories:
       type: git
       url: https://github.com/code-iai/iai_common_msgs.git
       version: master
+    release:
+      packages:
+      - data_vis_msgs
+      - designator_integration_msgs
+      - grasp_stability_msgs
+      - iai_common_msgs
+      - iai_content_msgs
+      - iai_kinematics_msgs
+      - iai_pancake_perception_action
+      - mln_robosherlock_msgs
+      - saphari_msgs
+      - scanning_table_msgs
+      - sherlock_sim_msgs
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/code-iai-release/iai_common_msgs-release.git
+      version: 0.0.0-0
+    source:
+      type: git
+      url: https://github.com/code-iai/iai_common_msgs
+      version: master
+    status: developed
   ias_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iai_common_msgs` to `0.0.0-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
