### PR TITLE
Fix python-imaging dep for Fedora 19, 20

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -400,8 +400,8 @@ python-imaging:
   debian: [python-imaging]
   fedora:
     beefy: [python-imaging]
-    heisenbug: [python-pillow]
-    schrödinger’s: [python-pillow]
+    heisenbug: [python-pillow, python-pillow-qt]
+    schrödinger’s: [python-pillow, python-pillow-qt]
     spherical: [python-imaging]
   freebsd: [py27-imaging]
   gentoo: [dev-python/imaging]


### PR DESCRIPTION
Looks like the qt stuff is provided by a separate sub-package of pillow, where `python-imaging` provided it under the same package.

Thanks!
