### PR TITLE
ackermann_msgs: 0.9.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16,7 +16,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/jack-oquin/ackermann_msgs-release.git
-      version: 0.9.0-0
+      version: 0.9.1-0
     source:
       type: git
       url: https://github.com/jack-oquin/ackermann_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ackermann_msgs` to `0.9.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.9.0-0`
## ackermann_msgs

```
* Export architecture_independent flag in package.xml (#3 <https://github.com/jack-oquin/ackermann_msgs/issues/3>), thanks
  to Scott K Logan
```
