### PR TITLE
unique_identifier: 1.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6138,7 +6138,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-geographic-info/unique_identifier-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/ros-geographic-info/unique_identifier.git


### PR DESCRIPTION
Increasing version of package(s) in repository `unique_identifier` to `1.0.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.0.3-0`
## unique_id
- No changes
## unique_identifier
- No changes
## uuid_msgs
- No changes
