### PR TITLE
libuvc: 0.0.3-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -968,7 +968,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ktossell/libuvc-release.git
-      version: 0.0.3-2
+      version: 0.0.3-3
     status: developed
   libuvc_ros:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc` to `0.0.3-3`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.0.3-2`
