### PR TITLE
jsk_model_tools: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2478,7 +2478,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/tork-a/jsk_model_tools-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.1.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.1.1-0`
## eus_assimp

```
* Merge pull request #34 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/34> from k-okada/fix_to_pass_buildfirm
  Fix to pass buildfirm
* Contributors: Kei Okada
* add depends to euslisp
* added euslisp_SOURCE_PREFIX for finding eusisp package path in catkin.cmake
* Contributors: Masaki Murooka
```
## euscollada

```
* put catkin_package after find_package(catkin)
* Contributors: Kei Okada
```
## jsk_model_tools
- No changes
