### PR TITLE
bwi_planning: 0.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -386,7 +386,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/bwi_planning-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi_planning.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi_planning` to `0.2.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `0.2.0-0`
## bwi_planning

```
* added dependency on generated service file. closes #10 <https://github.com/utexas-bwi/bwi_planning/issues/10>
* modified cost_learner to have a unique build name. closes #4 <https://github.com/utexas-bwi/bwi_planning/issues/4>
* Added support for YAML-CPP 0.5+.
  The new yaml-cpp API removes the "node >> outputvar;" operator, and it
  has a new way of loading documents.
* Contributors: Piyush Khandelwal, Scott K Logan
```
## bwi_planning_icaps14
- No changes
