### PR TITLE
rviz: 1.9.36-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4137,7 +4137,11 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.9.35-2
+      version: 1.9.36-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rviz.git
+      version: groovy-devel
     status: maintained
   rx:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.9.36-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `1.9.35-2`
## rviz

```
* Added CI with travis-ci for Groovy
* Fix memory leak in BillboardLine destructor (material not being destroyed correctly) #746
* Changed TF listener to use a dedicated thread #707
* Contributors: Jordan Brindza, Timm Linder, William Woodall
```
