### PR TITLE
rviz: 1.10.15-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5476,7 +5476,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.10.14-0
+      version: 1.10.15-0
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.10.15-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `1.10.14-0`
## rviz

```
* Forward ported #707
  Update frame_manager.cpp
  Changed TF listener to use a dedicated thread.
* Fix segfault on exit for OSX
* Fixed rendering of mesh resource type markers with respect to texture rendering and color tinting
* Fix memory leak in BillboardLine destructor (material not being destroyed correctly)
* EffortDisplay: Added a check to avoid segfaults when receiving a joint state without efforts
* Speed up point cloud rendering
  this is mostly caching some computations and using proper loop iterations
* Contributors: Hans Gaiser, Jordan Brindza, Mirko, Timm Linder, Vincent Rabaud, William Woodall
```
