### PR TITLE
jsk_roseus: 1.1.8-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1876,7 +1876,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.7-0
+      version: 1.1.8-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.8-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.1.7-0`
## euslisp

```
* add test codes using irteus motion codes copied from euslib/demo/ik/ik-test.l
* Contributors: nozawa
```
## geneus
- No changes
## jsk_roseus
- No changes
## roseus

```
* create symlink in global/bin/roseus
* Contributors: Kei Okada
```
## roseus_msgs

```
* run rosdep init and rosdep update before create messages
* add more package to depends
* Contributors: Kei Okada
```
