### PR TITLE
jsk_roseus: 1.1.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2539,7 +2539,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.7-1
+      version: 1.1.8-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.8-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.1.7-1`
## euslisp

```
* add test codes using irteus motion codes copied from euslib/demo/ik/ik-test.l
* Contributors: nozawa
```
## geneus
- No changes
## jsk_roseus
- No changes
## roseus

```
* create symlink in global/bin/roseus
* Contributors: Kei Okada
```
## roseus_msgs

```
* run rosdep init and rosdep update before create messages
* add more package to depends
* Contributors: Kei Okada
```
