### PR TITLE
Revert "rosbridge_suite version back to 0.5.2"

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3703,7 +3703,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.4.5-0
+      version: 0.5.4-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4838,7 +4838,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.5.2-1
+      version: 0.5.4-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
This reverts commit 3ac77e2e1846d01d773d412dd5c3ba523af158c0.

Revert "rosbridge_suite version back to 0.4.5"

This reverts commit 0b85045644266aad9d70cd7171cf247e0fe1ca31.

These packages were released to public, they cannot go down in numbers.
