### PR TITLE
Removing rocon_tools from hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4576,16 +4576,6 @@ repositories:
       url: https://github.com/robotics-in-concert/rocon_rqt_plugins.git
       version: hydro
     status: developed
-  rocon_tools:
-    doc:
-      type: git
-      url: https://github.com/robotics-in-concert/rocon_tools.git
-      version: hydro-devel
-    source:
-      type: git
-      url: https://github.com/robotics-in-concert/rocon_tools.git
-      version: hydro-devel
-    status: developed
   rocon_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Decided not to release for hydro.
