### PR TITLE
capabilities: 0.1.1-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -434,7 +434,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/capabilities-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/osrf/capabilities.git


### PR DESCRIPTION
Increasing version of package(s) in repository `capabilities` to `0.1.1-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `0.1.0-0`
## capabilities

```
* Add entry in setup.py to install package data
* Fixed up testing
* Updates link to API doc
* Contributors: Marcus Liebhardt, William Woodall
```
