### PR TITLE
jsk_common: 1.0.18-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1775,6 +1775,8 @@ repositories:
       - depth_image_proc_jsk_patch
       - downward
       - dynamic_tf_publisher
+      - ff
+      - ffha
       - image_view2
       - image_view_jsk_patch
       - jsk_common
@@ -1796,7 +1798,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.17-0
+      version: 1.0.18-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.18-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.0.17-0`
## assimp_devel

```
* (#408) fix revision of assimp_git
* fix patch for cmake
* catch up with update of assimp
* Contributors: Kei Okada, Yohei Kakiuchi
```
## collada_urdf_jsk_patch
- No changes
## depth_image_proc_jsk_patch
- No changes
## downward

```
* install downward
* Contributors: Kei Okada
```
## dynamic_tf_publisher
- No changes
## image_view2
- No changes
## image_view_jsk_patch
- No changes
## jsk_common
- No changes
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_tools
- No changes
## jsk_topic_tools
- No changes
## laser_filters_jsk_patch
- No changes
## libsiftfast
- No changes
## multi_map_server
- No changes
## openni_tracker_jsk_patch
- No changes
## opt_camera
- No changes
## posedetection_msgs
- No changes
## pr2_groovy_patches
- No changes
## rospatlite
- No changes
## rosping

```
* (rosping) Add pkg description, clarify difference with simular tool.
* Contributors: Isaac IY Saito
```
## stereo_synchronizer
- No changes
