### PR TITLE
jsk_roseus: 1.1.11-2 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1875,10 +1875,11 @@ repositories:
       - jsk_roseus
       - roseus
       - roseus_msgs
+      - roseus_smach
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.10-0
+      version: 1.1.11-2
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.11-2`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.1.10-0`
## euslisp
- No changes
## geneus
- No changes
## jsk_roseus
- No changes
## roseus
- No changes
## roseus_msgs
- No changes
## roseus_smach

```
* catkinize roseus_smach
* Contributors: Kei Okada
```
