### PR TITLE
nmea_navsat_driver: 0.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1200,6 +1200,11 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/nmea_navsat_driver.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/nmea_navsat_driver-release.git
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/nmea_navsat_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_navsat_driver` to `0.4.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## nmea_navsat_driver

```
* Initial release for Indigo
* Fix #5: Empty fields spam rosout with warnings. Driver now outputs sensor_msgs/NavSatFix messages that may contain NaNs in position and covariance when receiving invalid fixes from the device.
```
