### PR TITLE
jsk_planning: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2486,6 +2486,26 @@ repositories:
       url: https://github.com/tork-a/jsk_model_tools-release.git
       version: master
     status: developed
+  jsk_planning:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_planning.git
+      version: master
+    release:
+      packages:
+      - pddl_msgs
+      - pddl_planner
+      - pddl_planner_viewer
+      - task_compiler
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/tork-a/jsk_planning-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_planning.git
+      version: master
+    status: developed
   jsk_pr2eus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_planning` to `0.1.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## pddl_msgs

```
* catkinize jsk_planning
* support metrics and functions, [#89 <https://github.com/jsk-ros-pkg/jsk_planning/issues/89>]
* remove hoge message
* add functions slots
* add support constants for pddl-domain
* uncomment data valiable in pddl action and fix launch files
* update for diamondaback
* add on_condition slot
* move 3rdparty/pddl to jsk-ros-pkg/pddl, because pddl stack except ff is developed by R.Ueda and JSK, now 3rdparty
* mv jtalk and pddl to 3rdparty directory
* add PDDLActionArray message
* add pddl stack
* Contributors: Kei Okada, Manabu Saito, Ryohei Ueda, Youhei Kakiuchi
```
## pddl_planner

```
* pddl_planner: add samples
* catkinize jsk_planning
* add solved-fridge-graph.l
* update step-state in a while loop
* merge ffha and downward clients
* suport fastdownward
* added metric plan sample
* fix: using single state in a node
* fix for metric plan
* rename action grasp-can -> grasp-object
* fix global variable name
* add comments to search_object plan
* udpate action name
* fix typo
* add pddl-plan-to-graph function for creating plan graph
* use require and provide in pddl_planner
* add pddl demo for searching an object where it is
* make enable to use specific failed action name
* fix waring message
* add keyword for using copy
* fix typo
* remove negative precondition keyword
* fix order of pddl effects
* update return value
* add planning domain for fridge demo
* read-from-string except ff:
* add :durative-actions examples
* set default display_graph value to true
* revert wrong fommit r4686 and fix when ~display_graph is not set
* mv samples/agentsystem.py  demos/hanoi/solve-hanoi.py
* delete eus-sample.l, this is duplicate of demos/hanoi/solve-hanoi.l
* fix ffha.launch to show final domain representation, and fix pddl.py to check if final rep. is showen in the output
* delete debug files
* add comment to samples/agentsystem.py
* add sample-pddl
* support metrics and functions, [#89 <https://github.com/jsk-ros-pkg/jsk_planning/issues/89>]
* use default variables, see [#89 <https://github.com/jsk-ros-pkg/jsk_planning/issues/89>]
* add comment -g 6 -h 2 sometimes does not returns result
* ff does not have :data
* use append instaed of push-back
* add comment
* fix, old api?
* remove load command for irtgraph.l
* do not add the condition(state) already exists, and state compare test 'eq'->'not xor'
* changed the end condition in add-failed-nodes
* fix bug in sort-condition
* sort compare function should be <= or >=
* changed append -> union in apply-act function
* changed to use unreviewed version of irtgraph.l
* change the loop condition to make correct plan graph. (ex. Act1 is needed only after Act2 is failed)
* move some sample scripts to new package, task_compiler
* add level argument in demo-failure-recovery-task.launch
* add sample script for pddl->smach
* change sorting method to ignore negation of ffha-result conditions
* remove space from name of pddl-state, and make-readable-graph method
* move convert script from pddl to smach
* fix, add additional(fixed) condition to solved result
* add simple sample for PDDL->SMACH
* change name of predicates
* set 3 goals in pddl/2011_saito
* add goal nodes once
* add convert function from domain to eus script template
* fix add-failed-nodes for multiple results
* add another goal condition in one PDDL domain
* update PDDL-SMACH converter, I want to patch smach_viewer
* add smach convert sample
* dump :functions if functions slot is specified
* add additional-conditions for constant condition
* change for using REACHABLE
* add debug keyword for pddl-planning and fix minor bug
* delete REACHABLE predicates
* spell sepalate -> separate
* add knock door navigation problem
* add launch files for making graph pdf file
* add result parser and pddl samples
* add eus-pddl-client program
* update parser for pddl result
* add support constants for pddl-domain
* fix sample for using result parser
* add ffha-result-parser.l for making conditions of each step
* uncomment data valiable in pddl action and fix launch files
* fix, allow null parameters
* add ffha to the dependency
* add ffha (ff like pddl solver)
* fix: action parse when using typing
* fix: parse properly for more than 10 results
* update for latest roseus format
* move 3rdparty/pddl to jsk-ros-pkg/pddl, because pddl stack except ff is developed by R.Ueda and JSK, now 3rdparty
* mv jtalk and pddl to 3rdparty directory
* add pddl stack
* Contributors: Kei Okada, Yuki Furuta, Manabu Saito, Hiroyuki Mikita, Ryohei Ueda, Youhei Kakiuchi
```
## pddl_planner_viewer

```
* catkinize jsk_planning
* start pddl_planner_viewer first
* move 3rdparty/pddl to jsk-ros-pkg/pddl, because pddl stack except ff is developed by R.Ueda and JSK, now 3rdparty
* mv jtalk and pddl to 3rdparty directory
* add sample launch file for pddl_planner_viewer
* remove a comment from wxpython tutorial
* add pddl_planner_viewer package
* Contributors: Kei Okada, Ryohei Ueda
```
## task_compiler

```
* catkinize jsk_planning
* add argument for debug
* fix minor bug
* update depend on roseus_smach
* forgot to add romeo_action.l
* added sample programs for romeo
* removed pr2eus_openrave dependency
* fixed pr2eus_openrave method name
* remove mismatched parentheses
* object in ADL typing may be keyword, should not use??
* dump generated state machine to /tmp/action_state_machine.l for reuse
* add room cleaning sample of task_compiler
* remove empty file
* add scripts for room cleaning planning sample, but it will work tomorrow
* change debug print
* fix smach_structure publish properly timing, add user input action to task_compiler
* add level 0 example and fix bug in launch syntax
* add new package task_compiler, which is a converter from PDDL description to SMACH executable graph.
* Contributors: Kei Okada, Manabu Saito, Hiroyuki Mikita, Youhei Kakiuchi
```
