### PR TITLE
moveit_visual_tools: 1.0.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3210,7 +3210,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 0.2.0-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `1.0.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `0.2.0-0`
## moveit_visual_tools

```
* Enabled dual arm manipulation
* Removed notions of a global planning group, ee group name, or ee parent link.
* Changed functionality of loadEEMarker
* Added new print function
* Made getPlanningSceneMonitor() private function
* Renamed loadPathPub()
* Added tool for visualizing unmangled stack trace
* Created function for publishing non-animated grasps
* Created new publishGraph function. Renamed publishCollisionTree to publishCollisionGraph
* Created functions for loading publishers with a delay
* Removed old method of removing all collision objects
* Created better testing functionality
* Changed return type from void to bool for many functions
* Changed way trajectory is timed
* Created new publishIKSolutions() function for grasp poses, etc
* Added new MoveIt robot state functionality
* Added visualize grasp functionality
* Removed unnecessary run dependencies
* Updated README
```
