### PR TITLE
bride: 0.3.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -325,7 +325,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/bride-release.git
-      version: 0.3.1-0
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ipa320/bride.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bride` to `0.3.1-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.3.1-0`
