### PR TITLE
rocon_msgs: 0.7.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1642,7 +1642,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-      version: 0.7.3-0
+      version: 0.7.4-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs` to `0.7.4-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.7.3-0`
## concert_msgs

```
* concert client messages with a more expansive set of states.
* conductor graph msg listing concert clients of all states (useful for monitoring).
* Contributors: Daniel Stonier
```
## rocon_app_manager_msgs

```
* GetStatus removed in favour of a newly created Status latched publisher.
* App -> Rapp refactoring.
* Contributors: Daniel Stonier
```
## rocon_device_msgs
- No changes
## rocon_interaction_msgs

```
* a pairing status message, #92 <https://github.com/robotics-in-concert/rocon_msgs/issues/92>
* provide our remocon name when requesting an interaction (now used by pairing), #92 <https://github.com/robotics-in-concert/rocon_msgs/issues/92>
* additional error codes for pairing, #92 <https://github.com/robotics-in-concert/rocon_msgs/issues/92>
* remocon status now correctly listing the set of running apps (not just one)
* Contributors: Daniel Stonier
```
