### PR TITLE
rocon_msgs: 0.7.5-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1630,7 +1630,6 @@ repositories:
       - concert_msgs
       - concert_service_msgs
       - gateway_msgs
-      - rocon_annotation_msgs
       - rocon_app_manager_msgs
       - rocon_device_msgs
       - rocon_interaction_msgs
@@ -1642,7 +1641,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-      version: 0.7.3-0
+      version: 0.7.5-2
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs` to `0.7.5-2`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.7.3-0`
## rocon_msgs

```
* graveyarding rocon_annotation_msgs (no longer used).
```
