### PR TITLE
uwsim_osgworks: 3.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6314,7 +6314,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/uji-ros-pkg/uwsim_osgworks-release.git
-      version: 3.0.1-0
+      version: 3.0.2-0
     status: maintained
   v4r_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_osgworks` to `3.0.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `3.0.1-0`
