### PR TITLE
rqt_capabilities: 0.1.1-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3953,7 +3953,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/rqt_capabilities-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     status: developed
   rqt_common_plugins:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_capabilities` to `0.1.1-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `0.1.0-0`
## rqt_capabilities

```
* Install resources and plugin.xml file
* Contributors: William Woodall
```
