### PR TITLE
Adding cyton_gamma_1500_description to documentation index for hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -993,6 +993,11 @@ repositories:
       type: git
       url: https://github.com/OTL/cv_camera.git
       version: master
+  cyton_gamma_1500_description:
+    doc:
+      type: git
+      url: https://github.com/GertKanter/cyton_gamma_1500_description.git
+      version: master
   decision_making:
     doc:
       type: git


### PR DESCRIPTION
I'd like to have cyton_gamma_1500_description to be indexed and documented on ros.org.
