### PR TITLE
rtmros_common: 1.0.12-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5333,7 +5333,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.0.11-0
+      version: 1.0.12-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.0.12-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.0.11-0`
## hrpsys_ros_bridge

```
* (collision_detector.launch) typo
* use odom instad of imu_floor
* do not connect port when afs is not found
* set WALKING and IMPEDANCE controller as non-default RTC
* update generate config.yaml
* add both Robot(Robot)0 and RobotHadware0 in datalogger
* add scripts for auto generating controller config yaml
* Use subprocess.Popen rather than check_call in order to call
  external process asynchronouslly
* pass argument to get-ROSBridge-method-defmacro method
* add generating urdf file to compile_robot_model.cmake
* Merge pull request #433 from k-okada/do_not_compile_idl_twice
  do not update manifets.xml and copy idl when it is not needed (#429)
* implement hrpsys_dashboard base on rqt, not on rxtools
* do not update manifets.xml and copy idl when it is not needed (#429)
* rename base-pos and base-rpy => root-pos and root-rpy
* add reading of datalogger properties
* set REALTIME=ture as default
* update :start-auto-balancer and :stop-auto-balancer method according to hrpsys-base trunk update at https://code.google.com/p/hrpsys-base/source/detail?r=1039  commit ;; we do not need to change usage of these methods
* Contributors: Isaac Saito, Kei Okada, Ryohei Ueda, YoheiKakiuchi, Shunichi Nozawa
```
## hrpsys_tools

```
* add RemoveForceSensorLinkOffset setting ;; I write both AbsoluteForceSensor and RemoveForceSensorLinkOffset for compatibility
* make fail when pa10 is fail to launch
* Contributors: Kei Okada, Shunichi Nozawa
```
## openrtm_ros_bridge
- No changes
## openrtm_tools

```
* Merge pull request #404 from k-okada/403_check_rtprint
  add add check to rtprint
* add python path to openrtm_aist_python, this will fix #403
* add test program for rtshell/rtprint
* remove redundant rosdep name from manifest.xml
* does not call shopt on zsh
* Contributors: Kei Okada, Ryohei Ueda
```
## rosnode_rtc
- No changes
## rtmbuild
- No changes
## rtmros_common
- No changes
