### PR TITLE
stage: 4.1.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2091,6 +2091,13 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/srdfdom-release.git
       version: 0.2.6-0
+  stage:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/stage-release.git
+      version: 4.1.1-1
+    status: maintained
   std_capabilities:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `stage` to `4.1.1-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `null`
