### PR TITLE
stage_ros: 1.7.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2098,6 +2098,21 @@ repositories:
       url: https://github.com/ros-gbp/stage-release.git
       version: 4.1.1-1
     status: maintained
+  stage_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-simulation/stage_ros.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/stage_ros-release.git
+      version: 1.7.2-0
+    source:
+      type: git
+      url: https://github.com/ros-simulation/stage_ros.git
+      version: master
+    status: maintained
   std_capabilities:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `stage_ros` to `1.7.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `null`
## stage_ros

```
* Changed default GUI window size to 600x400
* Added velocity to ground truth odometry
* Fixed tf (yaw component) for the base_link->camera transform.
* Fixed ground truth pose coordinate system
```
