### PR TITLE
jsk_roseus: 1.1.12-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2567,7 +2567,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.11-1
+      version: 1.1.12-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.12-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.1.11-1`
## euslisp
- No changes
## geneus

```
* check if rosbuild_init was called
* Contributors: Kei Okada
```
## jsk_roseus
- No changes
## roseus
- No changes
## roseus_msgs

```
* add mode packages to depends
* use sudo for rosdep init
* Contributors: Kei Okada
```
## roseus_smach
- No changes
