### PR TITLE
jsk_roseus: 1.1.13-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2568,7 +2568,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.12-1
+      version: 1.1.13-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.13-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.1.12-1`
## euslisp
- No changes
## geneus
- No changes
## jsk_roseus
- No changes
## roseus

```
* add more message when install roseus
* Contributors: Kei Okada
```
## roseus_msgs
- No changes
## roseus_smach
- No changes
