### PR TITLE
rocon_app_platform: 0.7.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1620,6 +1620,16 @@ repositories:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git
       version: indigo
+    release:
+      packages:
+      - rocon_app_manager
+      - rocon_app_platform
+      - rocon_app_utilities
+      - rocon_apps
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/rocon_app_platform-release.git
+      version: 0.7.0-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_app_platform` to `0.7.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `null`
## rocon_app_manager

```
* support for rapp indexing over a remote repository's cached tarball.
* support for rapp indexing over the local ROS_PACKAGE_PATH.
* complete capability support for rapps.
* relieve rapp_manager of pairing responsibilities, now done via rocon_interactions <http://wiki.ros.org/rocon_interactions>.
* revamped launcher file configuration for standalone, multimaster.
* move from tuples to rocon_uri's for platform specifications.
* support for rapp remappings.
* Contributors: Daniel Stonier, Jihoon Lee, Marcus Liebhardt, Piyush Khandelwal, Yujin
```
## rocon_app_platform

```
* pairing responsibility removed from the rapp platform (now handled by rocon_interactions <http://wiki.ros.org/rocon_interactions>).
* platform tuples upgraded to rocon_uri's in every component
* capabilities support inside the rapp manager
* rapp upgrade - initial implementation of rapp heirarchies
* rapp upgrade - support for remote package caching
* rapp upgrade - support for local package indexing
* updated maintainers and authors.
* Contributors: Daniel Stonier
```
## rocon_app_utilities

```
* command line suite for rapp indexing, caching, dependency installing.
* remote repository index caching.
* local ros package path rapp indexer.
* Contributors: Jihoon Lee
```
## rocon_apps

```
* added local index generator.
* remove legacy pairing information (now handled by rocon_interactions <http://wiki.ros.org/rocon_interactions>).
* new icons, new teleop ancestor rapp.
* upgrade from tuples to rocon uri's for compatibility checks.
* rename interface into public_interface
* remove required from chirp launcher - creates alot of bleeding when it naturally dies!
* make use of required roslaunch tag in rapps, closes #127 <https://github.com/robotics-in-concert/rocon_app_platform/issues/127>.
* rapps now loading from package manifest exports instead of rapp lists, #121 <https://github.com/robotics-in-concert/rocon_app_platform/issues/121>.
* updated maintainers and authors.
* capability suport
* limit sharing of the listener.
* share option for infinite shares, closes #94 <https://github.com/robotics-in-concert/rocon_app_platform/issues/94>
* deprecate the old platform info message, #88 <https://github.com/robotics-in-concert/rocon_app_platform/issues/88>
* capability integration: adds retrievel of available capabilities from the server
* Contributors: Daniel Stonier, Dirk Thomas, Esteve Fernandez, Jihoon Lee, Marcus Liebhardt
```
