### PR TITLE
rtmros_nextage: 0.2.12-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5373,7 +5373,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.2.11-0
+      version: 0.2.12-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.2.12-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `0.2.11-0`
## nextage_description
- No changes
## nextage_moveit_config
- No changes
## nextage_ros_bridge

```
* Resolves #48 <https://github.com/tork-a/rtmros_nextage/issues/48>
* Contributors: Isaac IY Saito
```
## rtmros_nextage
- No changes
