### PR TITLE
rosbridge_suite: 0.5.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4857,7 +4857,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.5.4-1
+      version: 0.5.5-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.5.5-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `0.5.4-1`
