### PR TITLE
razer_hydra: 0.0.13-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1532,6 +1532,17 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/random_numbers-release.git
       version: 0.2.0-0
+  razer_hydra:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/razer_hydra-release.git
+      version: 0.0.13-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/razer_hydra.git
+      version: 0.0.13
+    status: maintained
   resource_retriever:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `razer_hydra` to `0.0.13-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `null`
