### PR TITLE
enu: 1.2.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1429,11 +1429,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/enu-release.git
-      version: 1.1.0-0
+      version: 1.2.2-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/enu.git
       version: hydro
+    status: maintained
   erratic_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `enu` to `1.2.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.1.0-0`
## enu

```
* Define _xerbla logging function to fix regression from swiftnav.
* Contributors: Mike Purvis
```
