### PR TITLE
catkin: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -159,7 +159,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     status: maintained
   class_loader:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.6.4-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `0.6.3-0`
## catkin

```
* add architecture independent flag in package.xml (#625 <https://github.com/ros/catkin/issues/625>)
* add error message for circular dependencies in catkin_make_isolated and catkin_topological_order (#607 <https://github.com/ros/catkin/issues/607>, #608 <https://github.com/ros/catkin/issues/608>)
* add multiarch support for catkin environment files (#545 <https://github.com/ros/catkin/issues/545>)
* add workspace marker file for catkin_make / catkin_make_isolated (#304 <https://github.com/ros/catkin/issues/304>)
* allow better performance for repeated invocations of find_in_workspaces()
* consider test_depends for topolocial order (#612 <https://github.com/ros/catkin/issues/612>)
* invoke empy with specific Python interpreter (#620 <https://github.com/ros/catkin/issues/620>)
* support setting ${PROJECT_NAME}_LIBRARIES before invoking catkin_package() (#609 <https://github.com/ros/catkin/issues/609>)
* update package manifest to format 2 (#619 <https://github.com/ros/catkin/issues/619>)
* fixes:

    * fix catkin_find to not return path with '/.' suffix (#621 <https://github.com/ros/catkin/issues/621>)
    * fix python path setting for plain cmake workspaces (#618 <https://github.com/ros/catkin/issues/618>)
    * improve unicode handling (#615 <https://github.com/ros/catkin/issues/615>)
    * replace CMake usage of IMPORTED_IMPLIB with IMPORTED_LOCATION (#616 <https://github.com/ros/catkin/issues/616>)
    * do not call chpwd hooks in setup.zsh (#613 <https://github.com/ros/catkin/issues/613>)
    * set catkin_* variables only when find_package(catkin COMPONENTS ...) (#629 <https://github.com/ros/catkin/issues/629>)

```
