### PR TITLE
genmsg: 0.5.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -678,7 +678,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/genmsg-release.git
-      version: 0.5.1-0
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/ros/genmsg.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.5.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `0.5.1-0`
## genmsg

```
* refactor to generate pkg-msg-paths.cmake via configure_file() instead of empy (#43 <https://github.com/ros/genmsg/issues/43>)
* fix python 3 compatibility (#45 <https://github.com/ros/genmsg/issues/45>)
* remove debug message introduced in 0.5.1 (#42 <https://github.com/ros/genmsg/issues/42>)
```
