### PR TITLE
genpy: 0.5.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -693,7 +693,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.5.0-0
+      version: 0.5.1-0
     source:
       type: git
       url: https://github.com/ros/genpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.5.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `0.5.0-0`
## genpy

```
* resolve message classes from dry packages (ros/ros_comm#293 <https://github.com/ros/ros_comm/issues/293>)
* add architecture_independent flag in package.xml (#27 <https://github.com/ros/genpy/issues/27>)
```
