### PR TITLE
std_msgs: 0.5.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2150,7 +2150,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/std_msgs-release.git
-      version: 0.5.8-1
+      version: 0.5.9-0
     source:
       type: git
       url: https://github.com/ros/std_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `std_msgs` to `0.5.9-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `0.5.8-1`
