### PR TITLE
ros_comm_msgs: 1.10.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1822,7 +1822,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm_msgs-release.git
-      version: 1.10.1-1
+      version: 1.10.2-0
     source:
       type: git
       url: https://github.com/ros/ros_comm_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm_msgs` to `1.10.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `1.10.1-1`
## rosgraph_msgs

```
* add TopicStatistics message (#1 <https://github.com/ros/ros_comm_msgs/pull/1>)
```
## std_srvs
- No changes
