### PR TITLE
ros: 1.11.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1768,7 +1768,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.11.0-0
+      version: 1.11.1-0
     source:
       type: git
       url: https://github.com/ros/ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.11.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `1.11.0-0`
## mk

```
* add missing run dependency on rosbuild (#47 <https://github.com/ros/ros/issues/47>)
* python 3 compatibility
```
## rosbash

```
* add rosrun --prefix, update completion (#52 <https://github.com/ros/ros/issues/52>)
```
## rosboost_cfg
- No changes
## rosbuild

```
* fix CMake warning with 2.8.12 and newer (#44 <https://github.com/ros/ros/issues/44>)
* use catkin_install_python() to install Python scripts (#46 <https://github.com/ros/ros/issues/46>)
* python 3 compatibility
```
## rosclean
- No changes
## roscreate

```
* python 3 compatibility
```
## roslang
- No changes
## roslib

```
* add optional argument force_recrawl to getPlugins() function
* use catkin_install_python() to install Python scripts (#46 <https://github.com/ros/ros/issues/46>)
* python 3 compatibility
```
## rosmake

```
* python 3 compatibility
```
## rosunit

```
* use catkin_install_python() to install Python scripts (#46 <https://github.com/ros/ros/issues/46>)
* python 3 compatibility
```
