### PR TITLE
ros_comm: 1.11.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1789,6 +1789,7 @@ repositories:
       - roscpp
       - rosgraph
       - roslaunch
+      - roslz4
       - rosmaster
       - rosmsg
       - rosnode
@@ -1804,7 +1805,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.0-1
+      version: 1.11.1-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `1.11.0-1`
## message_filters

```
* update API to use boost::signals2 (#267 <https://github.com/ros/ros_comm/issues/267>)
```
## ros_comm
- No changes
## rosbag

```
* add lz4 compression to rosbag (Python and C++) (#356 <https://github.com/ros/ros_comm/issues/356>)
* fix rosbag record --node (#357 <https://github.com/ros/ros_comm/issues/357>)
* move rosbag dox to rosbag_storage (#389 <https://github.com/ros/ros_comm/issues/389>)
```
## rosbag_storage

```
* add lz4 compression to rosbag (Python and C++) (#356 <https://github.com/ros/ros_comm/issues/356>)
* move rosbag dox to rosbag_storage (#389 <https://github.com/ros/ros_comm/issues/389>)
```
## rosconsole
- No changes
## roscpp

```
* update API to use boost::signals2 (#267 <https://github.com/ros/ros_comm/issues/267>)
* only update param cache when being subscribed (#351 <https://github.com/ros/ros_comm/issues/351>)
* ensure to remove delete parameters completely
* invalidate cached parent parameters when namespace parameter is set / changes (#352 <https://github.com/ros/ros_comm/issues/352>)
* add optional topic/connection statistics (#398 <https://github.com/ros/ros_comm/issues/398>)
* add transport information in SlaveAPI::getBusInfo() for roscpp & rospy (#328 <https://github.com/ros/ros_comm/issues/328>)
* add AsyncSpinner::canStart() to check if a spinner can be started
```
## rosgraph

```
* add architecture_independent flag in package.xml (#391 <https://github.com/ros/ros_comm/issues/391>)
```
## roslaunch

```
* fix roslaunch anonymous function to generate the same output for the same input (#297 <https://github.com/ros/ros_comm/issues/297>)
* add doc attribute to roslaunch arg tags (#379 <https://github.com/ros/ros_comm/issues/379>)
* print parameter values in roslaunch (#89 <https://github.com/ros/ros_comm/issues/89>)
* add architecture_independent flag in package.xml (#391 <https://github.com/ros/ros_comm/issues/391>)
```
## roslz4

```
* initial release
```
## rosmaster

```
* add architecture_independent flag in package.xml (#391 <https://github.com/ros/ros_comm/issues/391>)
```
## rosmsg

```
* fix rosmsg to find messages existing only in devel space (e.g. messages generated for actions) (#385 <https://github.com/ros/ros_comm/issues/385>)
* add architecture_independent flag in package.xml (#391 <https://github.com/ros/ros_comm/issues/391>)
```
## rosnode

```
* add architecture_independent flag in package.xml (#391 <https://github.com/ros/ros_comm/issues/391>)
```
## rosout
- No changes
## rosparam

```
* add architecture_independent flag in package.xml (#391 <https://github.com/ros/ros_comm/issues/391>)
```
## rospy

```
* improve asynchonous publishing performance (#373 <https://github.com/ros/ros_comm/issues/373>)
* add warning when queue_size is omitted for rospy publisher (#346 <https://github.com/ros/ros_comm/issues/346>)
* add optional topic/connection statistics (#398 <https://github.com/ros/ros_comm/issues/398>)
* add transport information in SlaveAPI::getBusInfo() for roscpp & rospy (#328 <https://github.com/ros/ros_comm/issues/328>)
* allow custom error handlers for services (#375 <https://github.com/ros/ros_comm/issues/375>)
* add architecture_independent flag in package.xml (#391 <https://github.com/ros/ros_comm/issues/391>)
```
## rosservice

```
* add architecture_independent flag in package.xml (#391 <https://github.com/ros/ros_comm/issues/391>)
```
## rostest

```
* add architecture_independent flag in package.xml (#391 <https://github.com/ros/ros_comm/issues/391>)
```
## rostopic

```
* add check for message fields when determining message type (#376 <https://github.com/ros/ros_comm/issues/376>)
```
## roswtf

```
* update roswtf test for upcoming rospack 2.2.3
* add architecture_independent flag in package.xml (#391 <https://github.com/ros/ros_comm/issues/391>)
```
## topic_tools

```
* add transform tool allowing to perform Python operations between message fields taken from several topics (ros/rosdistro#398 <https://github.com/ros/ros_comm/issues/398>)
```
## xmlrpcpp

```
* fix day comparison for rpc value of type timestamp (#395 <https://github.com/ros/ros_comm/issues/395>)
```
