### PR TITLE
geometry: 1.11.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -735,7 +735,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry-release.git
-      version: 1.11.2-1
+      version: 1.11.3-0
     source:
       type: git
       url: https://github.com/ros/geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry` to `1.11.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `1.11.2-1`
## eigen_conversions
- No changes
## geometry
- No changes
## kdl_conversions
- No changes
## tf

```
* convert to boost signals2 following ros/ros_comm#267 <https://github.com/ros/ros_comm/issues/267> Fixes #23 <https://github.com/ros/geometry/issues/23>. Requires ros/geometry_experimental#61 <https://github.com/ros/geometry_experimental/issues/61> as well.
* add rospy publisher queue_size argument
  ros/ros_comm#169 <https://github.com/ros/ros_comm/issues/169>
* add queue_size to tf publisher
  ros/ros_comm#169 <https://github.com/ros/ros_comm/issues/169>
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* Contributors: Lukas Bulwahn, Tully Foote
```
## tf_conversions
- No changes
