### PR TITLE
ros_tutorials: 0.5.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1842,7 +1842,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_tutorials-release.git
-      version: 0.4.3-1
+      version: 0.5.0-0
     source:
       type: git
       url: https://github.com/ros/ros_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `0.5.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `0.4.3-1`
## ros_tutorials
- No changes
## roscpp_tutorials
- No changes
## rospy_tutorials

```
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* use queue_size for rospy.Publisher (ros/ros_comm#169 <https://github.com/ros/ros_comm/issues/169>)
* use catkin_install_python() to install Python scripts (#17 <https://github.com/ros/ros_tutorials/issues/17>)
```
## turtlesim

```
* add indigo turtle
* add disabled code to easily spawn all available turtle types
```
