### PR TITLE
cmake_modules: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -181,7 +181,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/cmake_modules-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/ros/cmake_modules.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules` to `0.3.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `0.3.0-0`
## cmake_modules

```
* Export architecture_independent flag in package.xml
* Fix extended CMAKE_MODULE_PATH variable when path contains spaces
* Mention the sequencing reqirement with an example
* Contributors: Dirk Thomas, Paul Mathieu, Scott K Logan, Tully Foote, William Woodall, phuicy
```
