### PR TITLE
rqt_common_plugins: 0.3.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2016,6 +2016,40 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: groovy-devel
     status: maintained
+  rqt_common_plugins:
+    release:
+      packages:
+      - rqt_action
+      - rqt_bag
+      - rqt_bag_plugins
+      - rqt_common_plugins
+      - rqt_console
+      - rqt_dep
+      - rqt_graph
+      - rqt_image_view
+      - rqt_launch
+      - rqt_logger_level
+      - rqt_msg
+      - rqt_plot
+      - rqt_publisher
+      - rqt_py_common
+      - rqt_py_console
+      - rqt_reconfigure
+      - rqt_service_caller
+      - rqt_shell
+      - rqt_srv
+      - rqt_top
+      - rqt_topic
+      - rqt_web
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_common_plugins-release.git
+      version: 0.3.5-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_common_plugins.git
+      version: groovy-devel
+    status: developed
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `0.3.5-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `null`
## rqt_action
- No changes
## rqt_bag

```
* fix raw view not showing fields named 'msg' (#226 <https://github.com/ros-visualization/rqt_common_plugins/issues/226>)
```
## rqt_bag_plugins

```
* fix PIL/Pillow error (#224 <https://github.com/ros-visualization/rqt_common_plugins/issues/224>)
```
## rqt_common_plugins
- No changes
## rqt_console
- No changes
## rqt_dep

```
* using CATKIN_ENABLE_TESTING to optionally configure tests (#220 <https://github.com/ros-visualization/rqt_common_plugins/pull/220>)
```
## rqt_graph

```
* add displaying of topic/connection statistics along edges (#214 <https://github.com/ros-visualization/rqt_common_plugins/pull/214>)
* using CATKIN_ENABLE_TESTING to optionally configure tests (#220 <https://github.com/ros-visualization/rqt_common_plugins/pull/220>)
```
## rqt_image_view

```
* list image transport topics if parent image topic is not available (#215 <https://github.com/ros-visualization/rqt_common_plugins/issues/215>)
```
## rqt_launch
- No changes
## rqt_logger_level
- No changes
## rqt_msg
- No changes
## rqt_plot

```
* change minimum padding to enable viewing arbitrarily small values (#223 <https://github.com/ros-visualization/rqt_common_plugins/pull/223>)
* redraw plot only on new data to reduce cpu load, especially with matplot (#219 <https://github.com/ros-visualization/rqt_common_plugins/issues/219>)
```
## rqt_publisher
- No changes
## rqt_py_common
- No changes
## rqt_py_console
- No changes
## rqt_reconfigure

```
* numerous improvements and bug fixes (#209 <https://github.com/ros-visualization/rqt_common_plugins/pull/209>, #210 <https://github.com/ros-visualization/rqt_common_plugins/pull/210>)
* add option to open list of names from command line (#214 <https://github.com/ros-visualization/rqt_common_plugins/pull/214>)
```
## rqt_service_caller
- No changes
## rqt_shell
- No changes
## rqt_srv
- No changes
## rqt_top
- No changes
## rqt_topic
- No changes
## rqt_web
- No changes
