### PR TITLE
common_msgs: 1.11.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -227,7 +227,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.11.2-0
+      version: 1.11.3-0
     source:
       type: git
       url: https://github.com/ros/common_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.11.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `1.11.2-0`
## actionlib_msgs

```
* Export architecture_independent flag in package.xml
* Contributors: Scott K Logan
```
## common_msgs
- No changes
## diagnostic_msgs

```
* Export architecture_independent flag in package.xml
* Contributors: Scott K Logan
```
## geometry_msgs

```
* Export architecture_independent flag in package.xml
* Contributors: Scott K Logan
```
## nav_msgs

```
* Export architecture_independent flag in package.xml
* Contributors: Scott K Logan
```
## sensor_msgs

```
* clean up documentation of sensor_msgs so that wiki generated doxygen is readable
* Export architecture_independent flag in package.xml
* Contributors: Michael Ferguson, Scott K Logan
```
## shape_msgs

```
* Export architecture_independent flag in package.xml
* Contributors: Scott K Logan
```
## stereo_msgs

```
* Export architecture_independent flag in package.xml
* Contributors: Scott K Logan
```
## trajectory_msgs

```
* Export architecture_independent flag in package.xml
* Contributors: Scott K Logan
```
## visualization_msgs

```
* Export architecture_independent flag in package.xml
* Contributors: Scott K Logan
```
