### PR TITLE
rqt_capabilities: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2017,6 +2017,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: groovy-devel
     status: maintained
+  rqt_capabilities:
+    doc:
+      type: git
+      url: https://github.com/osrf/rqt_capabilities.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_capabilities-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/osrf/rqt_capabilities.git
+      version: master
+    status: developed
   rqt_common_plugins:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_capabilities` to `0.1.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `null`
## rqt_capabilities

```
* Install resources and plugin.xml file
* Contributors: William Woodall
```
