### PR TITLE
bfl: 0.7.0-6 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -66,7 +66,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/bfl-release.git
-      version: 0.7.0-5
+      version: 0.7.0-6
     status: maintained
   bond_core:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `bfl` to `0.7.0-6`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.6`
- previous version for package: `0.7.0-5`
