### PR TITLE
stage: 4.1.1-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2188,7 +2188,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/stage-release.git
-      version: 4.1.1-1
+      version: 4.1.1-2
     status: maintained
   stage_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `stage` to `4.1.1-2`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.6`
- previous version for package: `4.1.1-1`
