### PR TITLE
gps_umd: 0.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -766,6 +766,16 @@ repositories:
       url: https://github.com/ros/geometry_experimental.git
       version: indigo-devel
     status: maintained
+  gps_umd:
+    release:
+      packages:
+      - gps_common
+      - gps_umd
+      - gpsd_client
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ktossell/gps_umd-release.git
+      version: 0.1.7-0
   hokuyo_node:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `0.1.7-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.6`
- previous version for package: `null`
## gpsd_client

```
* Fix a segfault when there is no GPS fix: time will be NaN which causes the ROS timestamp message to throw a Boost rounding exception.
* Contributors: Stuart Alldritt
```
