### PR TITLE
openni2_launch: 0.1.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3793,7 +3793,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/openni2_launch.git
-      version: 0.1.2-0
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni2_launch.git
+      version: hydro-devel
+    status: maintained
   openni_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_launch` to `0.1.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.6`
- previous version for package: `0.1.2-0`
## openni2_launch

```
* Add tf_prefix same as openni
* Fix issue #9 <https://github.com/ros-drivers/openni2_launch/issues/9>
  This way the defaults for depth processing are set apropriately for both
  hardware and software registration.
* Contributors: Libor Wagner, Mark Pitchless, Michael Ferguson
```
