### PR TITLE
underwater_simulation: 1.3.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6153,7 +6153,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/uji-ros-pkg/underwater_simulation-release.git
-      version: 1.2.0-4
+      version: 1.3.1-0
     status: maintained
   unique_identifier:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `underwater_simulation` to `1.3.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `1.2.0-4`
