### PR TITLE
ros_tutorials: 0.5.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1853,7 +1853,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_tutorials-release.git
-      version: 0.5.0-0
+      version: 0.5.1-0
     source:
       type: git
       url: https://github.com/ros/ros_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `0.5.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.6`
- previous version for package: `0.5.0-0`
## ros_tutorials
- No changes
## roscpp_tutorials
- No changes
## rospy_tutorials

```
* fix install when building Debian package
```
## turtlesim
- No changes
