### PR TITLE
actionlib: 1.11.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -31,7 +31,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.11.0-1
+      version: 1.11.1-0
     source:
       type: git
       url: https://github.com/ros/actionlib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.11.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.6`
- previous version for package: `1.11.0-1`
## actionlib

```
* Fix uninitialised execute_thread_ member pointer
* Make rostest in CMakeLists optional
* Use catkin_install_python() to install Python scripts
* Contributors: Dirk Thomas, Esteve Fernandez, Jordi Pages, Lukas Bulwahn
```
