### PR TITLE
nodelet_core: 1.8.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1233,7 +1233,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.8.2-1
+      version: 1.8.3-0
     source:
       type: git
       url: https://github.com/ros/nodelet_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.8.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.6`
- previous version for package: `1.8.2-1`
## nodelet

```
* Add version to pluginlib dependency
* nodelet: avoid breaking bond when unloading unknown nodelet
* nodelet: refresh list of available classes if class is not found
* Fixed missing header
* Correctly check that there are enough arguments when nodelet is launched with the unload command
* Exit if Loader::load returns failure in "standalone" mode instead of continuing to run
* Contributors: Dirk Thomas, Esteve Fernandez, Forrest Voight, Gary Servin, Marcus Liebhardt, Mitchell Wills
* fix missing header (#14 <https://github.com/ros/nodelet_core/issues/14>)
* fix check that there are enough arguments when nodelet is launched with the unload command (#12 <https://github.com/ros/nodelet_core/issues/12>)
* exit if Loader::load returns failure in "standalone" mode instead of continuing to run (#11 <https://github.com/ros/nodelet_core/issues/11>)
```
## nodelet_core

```
* update changelogs
* Update maintainer field
* Contributors: Dirk Thomas, Esteve Fernandez
```
## nodelet_topic_tools

```
* update changelogs
* Update maintainer field
* fix missing boost dependency
* Contributors: Dirk Thomas, Esteve Fernandez
* fix missing boost dependency
```
