### PR TITLE
pluginlib: 1.10.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1471,7 +1471,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.9.25-0
+      version: 1.10.0-0
     source:
       type: git
       url: https://github.com/ros/pluginlib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.10.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.9.25-0`
