### PR TITLE
genpy: 0.5.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -693,7 +693,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.5.1-0
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/ros/genpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.5.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.6`
- previous version for package: `0.5.1-0`
## genpy

```
* fix usage of load_manifest() introduced in 0.5.1 (#28 <https://github.com/ros/genpy/issues/28>)
```
