### PR TITLE
jsk_roseus: 1.1.14-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2573,7 +2573,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.13-0
+      version: 1.1.14-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.14-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.1.13-0`
## euslisp

```
* Fix long first name of k-okada with traditional japanese person style
* remove euslisp codes which are arleady migrated to irteus/test and include them in test launch
* Contributors: Yuto Inagaki, Shunnichi Nozawa
```
## geneus

```
* geneus: add rospack_depends to find dependencies
* Contributors: Kei Okada
```
## jsk_roseus
- No changes
## roseus

```
* add hasHeader for roscpp >= 1.11.1
* fix typo in install roseus
* Contributors: Kei Okada
```
## roseus_msgs

```
* geneus: add rospack_depends to find dependencies
* Contributors: Kei Okada
```
## roseus_smach
- No changes
