### PR TITLE
Updating release of robot_localization to 1.1.2-0

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4409,11 +4409,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 0.1.0-3
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/cra-ros-pkg/robot_localization.git
-      version: master
+      version: hydro-devel
     status: maintained
   robot_model:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `1.1.2-0`. Also changed source to point to hydro-devel.
