### PR TITLE
jsk_roseus: 1.1.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -913,7 +913,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.14-0
+      version: 1.1.15-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.15-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.1.14-0`
## euslisp
- No changes
## geneus

```
* compile message even if not catkinized
* Contributors: Kei Okada
```
## jsk_roseus
- No changes
## roseus
- No changes
## roseus_msgs

```
* compile message even if not catkinized
* Contributors: Kei Okada
```
## roseus_smach
- No changes
