### PR TITLE
jsk_pr2eus: 0.1.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -909,7 +909,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_pr2eus-release.git
-      version: 0.1.5-1
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.1.6-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.1.5-1`
## jsk_pr2eus
- No changes
## pr2eus

```
* Merge pull request #32 from k-okada/add_roseus_msgs
  remove roseus_msgs from run_depend
* remove roseus_msgs from run_depend
```
