### PR TITLE
jsk_roseus: 1.1.17-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -931,7 +931,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.16-0
+      version: 1.1.17-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.17-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.1.16-0`
## euslisp
- No changes
## geneus
- No changes
## jsk_roseus
- No changes
## roseus
- No changes
## roseus_msgs

```
* Merge pull request #104 from k-okada/add_more_packages
  add more package to generate messages
* add more package to generate messages
```
## roseus_smach
- No changes
