### PR TITLE
realtime_tools: 1.9.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1621,6 +1621,21 @@ repositories:
       url: https://github.com/ros-drivers/razer_hydra.git
       version: 0.0.13
     status: maintained
+  realtime_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: branch
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/realtime_tools-release.git
+      version: 1.9.0-0
+    source:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: indigo-devel
+    status: maintained
   resource_retriever:
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1625,7 +1625,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git
-      version: branch
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `1.9.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
## realtime_tools

```
* Remove rosbuild artifacts.
* Cleaned up CMake and removed unnecessary dependencies
* Contributors: Adolfo Rodriguez Tsouroukdissian, Dave Coleman
```
