### PR TITLE
control_toolbox: 1.11.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -293,7 +293,7 @@ repositories:
   control_toolbox:
     doc:
       type: git
-      url: https://github.com/ros-controls/ros_control.git
+      url: https://github.com/ros-controls/control_toolbox.git
       version: indigo-devel
     release:
       tags:
@@ -302,7 +302,7 @@ repositories:
       version: 1.11.0-0
     source:
       type: git
-      url: https://github.com/ros-controls/ros_control.git
+      url: https://github.com/ros-controls/control_toolbox.git
       version: indigo-devel
     status: maintained
   demo_pioneer:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -290,6 +290,21 @@ repositories:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
       version: indigo-devel
+  control_toolbox:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros_control.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/control_toolbox-release.git
+      version: 1.11.0-0
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros_control.git
+      version: indigo-devel
+    status: maintained
   demo_pioneer:
     doc:
       type: git
@@ -1620,21 +1635,6 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/razer_hydra.git
       version: 0.0.13
-    status: maintained
-  realtime_tools:
-    doc:
-      type: git
-      url: https://github.com/ros-controls/realtime_tools.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/realtime_tools-release.git
-      version: 1.9.0-0
-    source:
-      type: git
-      url: https://github.com/ros-controls/realtime_tools.git
-      version: indigo-devel
     status: maintained
   resource_retriever:
     release:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1636,6 +1636,21 @@ repositories:
       url: https://github.com/ros-drivers/razer_hydra.git
       version: 0.0.13
     status: maintained
+  realtime_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/realtime_tools-release.git
+      version: 1.9.0-0
+    source:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: indigo-devel
+    status: maintained
   resource_retriever:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `1.11.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
## control_toolbox

```
* Remove rosbuild artifacts
* Cleaned up CMake and removed unnecessary dependencies
* Made default value negative to match valid range
* Fix for i_clamp_min to be negative in dynamic reconfigure
* Fix abs/fabs problem with Clang and libc++
* Contributors: Adolfo Rodriguez Tsouroukdissian, Dave Coleman, Marco Esposito
```
