### PR TITLE
ros_controllers: 0.8.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1937,29 +1937,31 @@ repositories:
       url: https://github.com/ros/ros_comm_msgs.git
       version: indigo-devel
     status: maintained
-  ros_control:
+  ros_controllers:
     doc:
       type: git
-      url: https://github.com/ros-controls/ros_control.git
+      url: https://github.com/ros-controls/ros_controllers.git
       version: indigo-devel
     release:
       packages:
-      - controller_interface
-      - controller_manager
-      - controller_manager_msgs
-      - controller_manager_tests
-      - hardware_interface
-      - joint_limits_interface
-      - ros_control
-      - rqt_controller_manager
-      - transmission_interface
+      - diff_drive_controller
+      - effort_controllers
+      - force_torque_sensor_controller
+      - forward_command_controller
+      - gripper_action_controller
+      - imu_sensor_controller
+      - joint_state_controller
+      - joint_trajectory_controller
+      - position_controllers
+      - ros_controllers
+      - velocity_controllers
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/ros_control-release.git
+      url: https://github.com/ros-gbp/ros_controllers-release.git
       version: 0.8.0-0
     source:
       type: git
-      url: https://github.com/ros-controls/ros_control.git
+      url: https://github.com/ros-controls/ros_controllers.git
       version: indigo-devel
     status: developed
   ros_tutorials:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1937,6 +1937,25 @@ repositories:
       url: https://github.com/ros/ros_comm_msgs.git
       version: indigo-devel
     status: maintained
+  ros_control:
+    doc:
+      type: git
+      url: https://github.com/roscontrols/ros_control.git
+      version: indigodevel
+    release:
+      packages:
+       controller_interface
+       controller_manager
+       controller_manager_msgs
+       controller_manager_tests
+       hardware_interface
+       joint_limits_interface
+       ros_control
+       rqt_controller_manager
+       transmission_interface
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosgbp/ros_controlrelease.git
   ros_controllers:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1940,23 +1940,28 @@ repositories:
   ros_control:
     doc:
       type: git
-      url: https://github.com/roscontrols/ros_control.git
-      version: indigodevel
+      url: https://github.com/ros-controls/ros_control.git
+      version: indigo-devel
     release:
       packages:
-       controller_interface
-       controller_manager
-       controller_manager_msgs
-       controller_manager_tests
-       hardware_interface
-       joint_limits_interface
-       ros_control
-       rqt_controller_manager
-       transmission_interface
+      - controller_interface
+      - controller_manager
+      - controller_manager_msgs
+      - controller_manager_tests
+      - hardware_interface
+      - joint_limits_interface
+      - ros_control
+      - rqt_controller_manager
+      - transmission_interface
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/rosgbp/ros_controlrelease.git
-  ros_controllers:
+      url: https://github.com/ros-gbp/ros_control-release.git
+      version: 0.8.0-0
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros_control.git
+      version: indigo-devel
+    status: developed
     doc:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1962,6 +1962,7 @@ repositories:
       url: https://github.com/ros-controls/ros_control.git
       version: indigo-devel
     status: developed
+  ros_controllers:
     doc:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.8.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
## diff_drive_controller

```
* Add base_frame_id param (defaults to base_link)
  The nav_msgs/Odometry message specifies the child_frame_id field,
  which was previously not set.
  This commit creates a parameter to replace the previously hard-coded
  value of the child_frame_id of the published tf frame, and uses it
  in the odom message as well.
* Contributors: enriquefernandez
```
## effort_controllers

```
* Remove rosbuild artifacts. Fix #90 <https://github.com/ros-controls/ros_controllers/issues/90>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## force_torque_sensor_controller

```
* Add missing controller resources to install target
* Remove rosbuild artifacts. Fix #90 <https://github.com/ros-controls/ros_controllers/issues/90>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## forward_command_controller

```
* Remove rosbuild artifacts. Fix #90 <https://github.com/ros-controls/ros_controllers/issues/90>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## gripper_action_controller
- No changes
## imu_sensor_controller

```
* Add missing controller resources to install target
* Remove rosbuild artifacts. Fix #90 <https://github.com/ros-controls/ros_controllers/issues/90>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## joint_state_controller

```
* Add missing controller resources to install target
* Remove rosbuild artifacts. Fix #90 <https://github.com/ros-controls/ros_controllers/issues/90>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## joint_trajectory_controller

```
* Remove rosbuild artifacts. Fix #90 <https://github.com/ros-controls/ros_controllers/issues/90>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## position_controllers

```
* Remove rosbuild artifacts. Fix #90 <https://github.com/ros-controls/ros_controllers/issues/90>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## ros_controllers
- No changes
## velocity_controllers

```
* Remove rosbuild artifacts. Fix #90 <https://github.com/ros-controls/ros_controllers/issues/90>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
