### PR TITLE
hrpsys: 315.2.1-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2109,7 +2109,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/hrpsys-release.git
-      version: 315.2.1-1
+      version: 315.2.1-2
     source:
       type: git
       url: https://github.com/start-jsk/hrpsys.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys` to `315.2.1-2`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `315.2.1-1`
## hrpsys

```
* Merge pull request #83 <https://github.com/start-jsk/hrpsys/issues/83> from k-okada/add_git
  add build_depend to git
* Contributors: Kei Okada
```
