### PR TITLE
baxter_common: 1.0.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -222,7 +222,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RethinkRobotics-release/baxter_common-release.git
-      version: 0.7.0-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/RethinkRobotics/baxter_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `baxter_common` to `1.0.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.7.0-0`
