### PR TITLE
baxter_interface: 1.0.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -252,7 +252,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RethinkRobotics-release/baxter_interface-release.git
-      version: 0.7.0-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/RethinkRobotics/baxter_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `baxter_interface` to `1.0.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `0.7.0-0`
## baxter_interface

```
* Adds new 'raw' joint position control mode
* Updates robot_enable to validate SDK versus robot software versions
* Updates joint trajectory action server adding linear, cubic and quintic spline fitting
* Updates joint trajectory action server adding raw joint position control mode option for trajectory execution
* Updates joint trajectory action server allowing execution parameters from messages to override parameter server options
* Updates Limb class to use tcp_nodelay transport hint for joint states, endpoint state, and joint commands
* Updates Limb class move_to_joint_positions adding optional accuracy threshold argument
* Updates Gripper class to validate compatible gripper firmware versions
* Updates Gripper class adding signaling on type, gripping, and moving state changes
* Updates Gripper class adding convenience reset methods for reverting custom gripper properties
* Updates Navigator class wheel_changed signal to use difference since last value
* Renames Gripper class hardware_version to hardware_name
* Fixes Head's nod incorrect wait_for validation
```
