### PR TITLE
baxter_tools: 1.0.0-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -233,7 +233,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/RethinkRobotics-release/baxter_tools-release.git
-      version: 0.7.0-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/RethinkRobotics/baxter_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `baxter_tools` to `1.0.0-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `0.7.0-0`
## baxter_tools

```
* Updates baxter_tools scripts to verify software version compatibility
* Updates update_robot adding instructions for attaching grippers before proceeding with update
* Fixes update_robot timeout for identifying available updates by increasing timeout to five seconds
```
