### PR TITLE
baxter_tools: 1.0.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -252,7 +252,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RethinkRobotics-release/baxter_interface-release.git
-      version: 1.0.0-0
+      version: 0.7.0-0
     source:
       type: git
       url: https://github.com/RethinkRobotics/baxter_interface.git
@@ -267,7 +267,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RethinkRobotics-release/baxter_tools-release.git
-      version: 0.7.0-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/RethinkRobotics/baxter_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `baxter_tools` to `1.0.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `0.7.0-0`
## baxter_tools

```
* Updates baxter_tools scripts to verify software version compatibility
* Updates update_robot adding instructions for attaching grippers before proceeding with update
* Fixes update_robot timeout for identifying available updates by increasing timeout to five seconds
```
