### PR TITLE
baxter_examples: 1.0.0-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -203,7 +203,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/RethinkRobotics-release/baxter_examples-release.git
-      version: 0.7.0-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/RethinkRobotics/baxter_examples.git
@@ -233,7 +233,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/RethinkRobotics-release/baxter_tools-release.git
-      version: 1.0.0-0
+      version: 0.7.0-0
     source:
       type: git
       url: https://github.com/RethinkRobotics/baxter_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `baxter_examples` to `1.0.0-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `0.7.0-0`
## baxter_examples

```
* Adds joint_position_waypoints example program
* Updates ik_service_client to validate unpacked results and seed types
* Updates gripper_cuff_control to automatically calibrate on gripper type change
* Updates navigator_io to use navigator wheel_changed signal
* Updates all examples to verify robot software version by default when enabling
* Updates all examples using gripper to verify gripper firmware version
* Updates joint_recorder to record at 100Hz
* Updates joint_velocity_wobbler to run at 500Hz
```
