### PR TITLE
baxter: 1.0.0-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -168,7 +168,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/RethinkRobotics-release/baxter-release.git
-      version: 0.7.0-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/RethinkRobotics/baxter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `baxter` to `1.0.0-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `0.7.0-0`
