### PR TITLE
ros_ethercat: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -237,7 +237,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RethinkRobotics-release/baxter_examples-release.git
-      version: 1.0.0-0
+      version: 0.7.0-0
     source:
       type: git
       url: https://github.com/RethinkRobotics/baxter_examples.git
@@ -4787,6 +4787,26 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git
+      version: hydro-devel
+    status: developed
+  ros_ethercat:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/ros_ethercat.git
+      version: hydro-devel
+    release:
+      packages:
+      - ros_ethercat
+      - ros_ethercat_hardware
+      - ros_ethercat_loop
+      - ros_ethercat_model
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/shadow-robot/ros_ethercat-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/shadow-robot/ros_ethercat.git
       version: hydro-devel
     status: developed
   ros_glass_tools:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -237,7 +237,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RethinkRobotics-release/baxter_examples-release.git
-      version: 0.7.0-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/RethinkRobotics/baxter_examples.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ethercat` to `0.1.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
## ros_ethercat

```
* first hydro release
```
## ros_ethercat_hardware

```
* first hydro release
```
## ros_ethercat_loop

```
* first hydro release
```
## ros_ethercat_model

```
* first hydro release
```
