### PR TITLE
baxter: 1.0.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -202,7 +202,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RethinkRobotics-release/baxter-release.git
-      version: 0.7.0-0
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/RethinkRobotics/baxter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `baxter` to `1.0.0-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `0.7.0-0`
