### PR TITLE
geometry_tutorials: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -802,6 +802,24 @@ repositories:
       url: https://github.com/ros/geometry_experimental.git
       version: indigo-devel
     status: maintained
+  geometry_tutorials:
+    doc:
+      type: git
+      url: https://github.com/geometry_tutorials.git
+      version: hydro-devel
+    release:
+      packages:
+      - geometry_tutorials
+      - turtle_tf
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/geometry_tutorials-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/geometry_tutorials.git
+      version: hydro-devel
+    status: maintained
   gps_umd:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_tutorials` to `0.2.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
## turtle_tf

```
* Fixed catkinized
* Updated dependency on turtlesim, turtlesim switched to using geometry_msgs/Twist from turtlesim/Velocity msgs
```
