### PR TITLE
jsk_pr2eus: 0.1.6-3 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1835,7 +1835,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_pr2eus-release.git
-      version: 0.1.5-0
+      version: 0.1.6-3
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.1.6-3`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.1.5-0`
## jsk_pr2eus
- No changes
## pr2eus

```
* Merge pull request #32 from k-okada/add_roseus_msgs
  remove roseus_msgs from run_depend
* remove roseus_msgs from run_depend
```
