### PR TITLE
rosbridge_suite: 0.5.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2099,7 +2099,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.5.5-0
+      version: 0.5.5-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.5.5-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `0.5.5-0`
