### PR TITLE
urdf_tutorial: 0.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2480,6 +2480,13 @@ repositories:
       url: https://github.com/ros-geographic-info/unique_identifier.git
       version: master
     status: maintained
+  urdf_tutorial:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/urdf_tutorial-release.git
+      version: 0.2.3-0
+    status: maintained
   urdfdom:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tutorial` to `0.2.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
## urdf_tutorial

```
* Merge pull request #7 <https://github.com/ros/urdf_tutorial/issues/7> from gavanderhoorn/issue6_source_vs_devel_vs_install
  Fix issue #6 <https://github.com/ros/urdf_tutorial/issues/6>: No robot model when using display.launch (again)
* Setup new directory structure and move files around.
* Contributors: Ioan A Sucan, gavanderhoorn
```
