### PR TITLE
rviz: 1.10.16-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5530,7 +5530,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.10.15-0
+      version: 1.10.16-0
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.10.16-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `1.10.15-0`
## rviz

```
* Fix an issue with rendering laser scans: #762 <https://github.com/ros-visualization/rviz/issues/762>
* Contributors: Vincent Rabaud, William Woodall
```
