### PR TITLE
humanoid_msgs: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -852,6 +852,24 @@ repositories:
       url: https://github.com/ros-gbp/household_objects_database_msgs-release.git
       version: 0.1.1-2
     status: maintained
+  humanoid_msgs:
+    doc:
+      type: git
+      url: https://github.com/ahornung/humanoid_msgs.git
+      version: master
+    release:
+      packages:
+      - humanoid_msgs
+      - humanoid_nav_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/humanoid_msgs-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/ahornung/humanoid_msgs.git
+      version: devel
+    status: maintained
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `humanoid_msgs` to `0.3.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
## humanoid_msgs
- No changes
## humanoid_nav_msgs

```
* Add service to (re)plan between feet as start and goal.
* Contributors: Armin Hornung
```
