### PR TITLE
Add openni related rosdep keys on OS X homebrew.

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -189,6 +189,14 @@ libopencv-dev:
   osx:
     homebrew:
       packages: [opencv]
+libopenni-dev:
+  osx:
+    homebrew:
+      packages: [openni]
+libopenni-sensor-primesense-dev:
+  osx:
+    homebrew:
+      packages: [totakke/openni/sensor-kinect]
 libpcap:
   osx:
     homebrew:


### PR DESCRIPTION
libopenni-dev --> openni (in homebrew/science)
libopenni-sensor-primesense-dev --> totakke/openni/sensor-kinect
