### PR TITLE
ros_ethercat: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2082,6 +2082,27 @@ repositories:
       url: https://github.com/ros-controls/ros_controllers.git
       version: indigo-devel
     status: developed
+  ros_ethercat:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/ros_ethercat.git
+      version: indigo-devel
+    release:
+      packages:
+      - ros_ethercat
+      - ros_ethercat_eml
+      - ros_ethercat_hardware
+      - ros_ethercat_loop
+      - ros_ethercat_model
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/shadow-robot/ros_ethercat-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/shadow-robot/ros_ethercat.git
+      version: indigo-devel
+    status: developed
   ros_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ethercat` to `0.1.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
## ros_ethercat
- No changes
## ros_ethercat_eml
- No changes
## ros_ethercat_hardware
- No changes
## ros_ethercat_loop
- No changes
## ros_ethercat_model
- No changes
