### PR TITLE
prepare libfreenect for Indigo release

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1113,7 +1113,7 @@ repositories:
   libfreenect:
     release:
       tags:
-        release: release/hydro/{package}/{version}
+        release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/libfreenect-release.git
     status: maintained
   libg2o:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1110,6 +1110,12 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/libccd-release.git
       version: 1.5.0-0
+  libfreenect:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/libfreenect-release.git
+    status: maintained
   libg2o:
     release:
       tags:


### PR DESCRIPTION
This is so we can run a pre-release test on the build farm before actually releasing this 3rd-party package.
