### PR TITLE
libfreenect: 0.1.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1120,6 +1120,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/libfreenect-release.git
+      version: 0.1.2-1
     status: maintained
   libg2o:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `libfreenect` to `0.1.2-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
