### PR TITLE
rviz_fixed_view_controller: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2388,6 +2388,17 @@ repositories:
       url: https://github.com/ros-visualization/rviz.git
       version: indigo-devel
     status: maintained
+  rviz_fixed_view_controller:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rviz_fixed_view_controller-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rviz_fixed_view_controller.git
+      version: indigo-devel
+    status: developed
   serial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_fixed_view_controller` to `0.0.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
## rviz_fixed_view_controller

```
* update urls in package.xml
* initial commit
* Contributors: Adam Leeper
```
