### PR TITLE
interaction_cursor_3d: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -954,6 +954,21 @@ repositories:
       url: https://github.com/ros-perception/imu_pipeline.git
       version: indigo-devel
     status: maintained
+  interaction_cursor_3d:
+    release:
+      packages:
+      - interaction_cursor_demo
+      - interaction_cursor_msgs
+      - interaction_cursor_rviz
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/aleeper/interaction_cursor_3d-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/aleeper/interaction_cursor_3d.git
+      version: indigo-devel
+    status: developed
   interactive_marker_twist_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interaction_cursor_3d` to `0.0.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
