### PR TITLE
interaction_cursor_3d: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -957,13 +957,14 @@ repositories:
   interaction_cursor_3d:
     release:
       packages:
+      - interaction_cursor_3d
       - interaction_cursor_demo
       - interaction_cursor_msgs
       - interaction_cursor_rviz
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/aleeper/interaction_cursor_3d-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/aleeper/interaction_cursor_3d.git


### PR DESCRIPTION
Increasing version of package(s) in repository `interaction_cursor_3d` to `0.0.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
## interaction_cursor_3d

```
* add metapackage
* Contributors: Adam Leeper
```
## interaction_cursor_demo

```
* add missing run depend
* add metapackage
* update to use fixed view controller
* apply catkin_lint
* Contributors: Adam Leeper
```
## interaction_cursor_msgs

```
* add metapackage
* apply catkin_lint
* Contributors: Adam Leeper
```
## interaction_cursor_rviz

```
* add metapackage
* apply catkin_lint
* Choose the 'best' control when grabbing an object.
* Contributors: Adam Leeper, Dane Powell
```
