### PR TITLE
camera_info_manager_py: 0.2.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -457,7 +457,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/camera_info_manager_py-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/ros-perception/camera_info_manager_py.git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_info_manager_py` to `0.2.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `0.2.2-0`
## camera_info_manager_py
- No changes
