### PR TITLE
xsens_driver: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2785,6 +2785,17 @@ repositories:
       url: https://github.com/jbohren/xdot.git
       version: indigo-devel
     status: developed
+  xsens_driver:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ethz-asl/ethzasl_xsens_driver-release.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/ethz-asl/ethzasl_xsens_driver.git
+      version: 1.0.3
+    status: maintained
   zeroconf_avahi_suite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xsens_driver` to `1.0.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
## xsens_driver

```
* Inclusion of launch file
* Additions and fixes from PAL robotics
* Add local frame conversion for calibrated imu data (acc, gyr, mag)
* Contributors: Enrique Fernandez, Francis Colas, Paul Mathieu, Sam Pfeiffer
```
