### PR TITLE
bwi: 0.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -338,14 +338,13 @@ repositories:
       version: master
     release:
       packages:
-      - bwi
       - bwi_desktop
       - bwi_desktop_full
       - bwi_launch
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/bwi-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi` to `0.2.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `0.2.0-0`
## bwi_desktop
- No changes
## bwi_desktop_full

```
* bwi_desktop_full: add python-bloom, remove openni_tracker (#9 <https://github.com/utexas-bwi/bwi/issues/9>)
* Contributors: Jack O'Quin
```
## bwi_launch
- No changes
