### PR TITLE
jsk_visualization: 0.0.2-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1885,6 +1885,25 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git
       version: master
     status: developed
+  jsk_visualization:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_visualization.git
+      version: master
+    release:
+      packages:
+      - jsk_interactive_marker
+      - jsk_rqt_plugins
+      - jsk_rviz_plugins
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/tork-a/jsk_visualization-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_visualization.git
+      version: master
+    status: developed
   katana_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `0.0.2-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## jsk_interactive_marker

```
* compile executables after message generation
* wait for service before making service client
* remove dependency on hrpsys_gazebo_atlas when using pr2
* Merge branch 'master' of https://github.com/jsk-ros-pkg/jsk_visualization into service-persistent-true
* use rotation-axis in inverse-kinematics
* set persistent true in dynamic_tf_publisher_client
* delete code using robot_state_publisher
* delete move_base_marker
* add jsk_pcl_ros message dependency
* change the location of catkin_package and generate_messages
* change marker frame id to /map
* Add method to set marker root link to robot root link
* Not use joint_state_publisher but use dynamic_tf_publisher when making
  robot marker
* add method to publish base pose
* add an interface to call footstep_controller from other programs to footstep_marker
* support foot offset parameters for initial feet placements
* use tf_conversions and eigen_conversions to convert tf::Transform to geometry_msgs::Pose
* use tf::Transform to store offset information
* implement readPoseParam
  a function to read geometry_msgs/Pose from a rosparameter
* add gitignore to jsk_interactive_marker
* add move base marker sample
* add controller to move base
* use tf_prefix instead of model name
* divide ik-controller.l into class and make instance
* use yaml for move base marker
* use 'tf_prefix_' instead of 'model_name_ + /'
* #7 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/7>: fix typo of jsk_interactive_marker of manifest.xml
* #7 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/7>: reverted depend tags in manifest.xml of jsk_interactive_markers
* #7 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/7>: add actionlib dependency to jsk_interactive_marker
* #7 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/7>: fix catkin cmake syntax: CATKIN-DEPENDS -> CATKIN_DEPENDS
* #7 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/7>: fix description of jsk_interactive_marker/manifest.xml
* use rosdep name for rviz and actionlib_msgs
* add urdf marker in order to move base link
* add method to get joint state from robot
* update footstep_marker in order to reset iniital pose
* not use ik-server
* trying to deal with new ik server
* fixing urdf_model_marker to link urdf_model_maker_main.cpp
* divide urdf_model_marker into class definition and main function
* fixing the position of the frame id
* use interactive_marker_helpers
* initialize feet position correctly
* add hand frame slot in ik-controller
* delete ros warining and make faster
* modify pass to pr2 ik server
* adding marker to visualize initial state
* adding method to estimate initial state of footstep from frame_id
* catkinize jsk_interactive_marker for hydro
* use joint state publisher when using pr2
* add mesh file path in linkMarkerMap
* fix bag in method to find ros package path from full path
* add method to move root link
* add ik controller and launch file
* update urdf model markers testfile
* adding marker_6dof, which is controllable via rostopic and rviz
* add launch file to controll robot with interactive marker
* add base_frame parameter in point_cloud_marker
* supporting z-direction
* calling SnapIt from outer program
* enable footstep planner in sample
* support to disable planner calling from footstep_marker
* add use_visible_color parameter to change color
* adding interactive marker for footstep planning
* adding footstep interactive marker
* set Use Link as Arm by default
* rotate hand in local coordinates
* add src to convert .world to .yaml
* rename Don't allow rotation / allow rotation, use 6D / 3D, 3D (positon) as default
* add subscriber to toggle rotation axis
* add subscriber to toggle start ik
* add center sphere marker to control position
* change door marker size
* show footsteps each 2
* remenmber previous door position
* fix previous step button
* supporting showing footstep list
* set foot step by rosparam
* update
* change resolution of knob color
* change control size to max size of box
* add color knob
* get scale from urdf
* clean up code and write dummy 0 joint-angle to Joint::PRISMATIC
* add wall in door_foot.cpp
* change foot position when open door
* use robot description in atlas-real
* add sphere and box marker in urdf model marker
* add sphere and box marker in urdf model marker
* be quiet
* updating rviz
* add look at menu and message
* add marker to visualize door and foot
* fix foot position of triangle
* add move it exec cancel button
* update defaultset
* fix bag of urdf_model_marker
* add Triangle Marker to visualize foot position
* add Touch It msg
* adding clear function for external program
* changing default value
* not publish joint state all time
* adding some external control
* updating for external programs
* untabify
* add change marker size menu
* stop ik by default
* fix bag and reset marker id when clear button is pressed
* add IM to get designated Point Cloud
* add menu to select using ik server
* reset when marker was reset
* fix to use joint_state_publisher and robot_state_publisher
* add joint_state_publisher.py
* add use_dynamic_tf to disable dynamic tf
* change marker size of urdf marker
* publishJointState on resetMarkerCB
* add special pose (fg manip pose)
* we can show and hide interactive marker
* add .rviz  for interactive_marker
* change frame-id from odom to map
* modify caliculation of tf from odom to marker
* add menu to cancel planned motion
* add visualizaion mode to visualize IK
* we can select Arm Ik , Torso Ik or Fullbody Ik
* add registration mode in urdf_model_marker
* added marker_array for viewing collision lines in rviz
* add .rviz for atlas_joint_marker
* Use package:// instead of file:// to designate mesh file name
* use jsk urdf model for atlas
* add launch file for moving joints for atlas
* update README.txt
* display parent link marker when fixed joint clicked
* add joint limit in joint robot marker
* add Function to set 1 Joint Angle
* reset robot marker to real robot
* add patch file for atlas.urdf to use RobotIM
* add Move Robot Joint Marker
* add cylinder marker when joint dont include mesh
* add yaml for Fridge model in 73b2
* add msg to designate marker movement
* attach Grasp Point to Model Marker
* change display of move marker when clicking
* use configuration yaml file to set models
* get full path of gazebo model
* set Move Marker based on Joint axis
* add dependancy on dynamic_tf_publisher
* making interactive marker based on urdf model
* add finger interactive marker
* add menu to change whether robot use torso
* add Marker Type in msgs
* add hand shape interactive marker
* add interactive operation sample of eus simulator
* add head marker and change msg
* add jsk_interactive_markers/ by yusuke furuta
* Contributors: Kei Okada, Ryohei Ueda, Yusuke Furuta, Masaki Murooka, Shintaro Noda, tarukosu, Youhei Kakiuchi
```
## jsk_rqt_plugins

```
* add --no-legend option to disable legend
* support polygon mode. if you want to plot in line mode, please add -L option
* implement 3d plotter
* add jsk_rqt_plugins directory
* Contributors: Ryohei Ueda
```
## jsk_rviz_plugins

```
* overlay sample for groovy
* make NormalDisplay work on catkin.
  add normal_visual.cpp to jsk_rviz_plugins.so
* fix for using ambient_sound
* rename the name of plugin from PolygonArrayDisplay to PolygonArray
* add rviz_plugins icons
* change the color of the pie chart according to the absolute value
* smaller size for the font and add new line to the text of diagnostics display
* add a bool property to toggle auto scale for Plotter2DDisplay
* Merge remote-tracking branch 'refs/remotes/origin/master' into add-auto-color-changing-feature-to-plotters
  Conflicts:
  jsk_rviz_plugins/src/plotter_2d_display.cpp
  jsk_rviz_plugins/src/plotter_2d_display.h
* add auto color change boolean property and max color to change
  the color according to the value
* add sample for overlay rviz plugins
* support DELETE action to disable OvelrayText
* use qt to draw OverlayText
* does not call setSceneBlending twice
* add caption to 2d plotter
* add margin to plotter
* does not create QPainter without argument to supress the warning message of "painter not activate"
* initialize orbit_theta_ and check overflow of the value
* add update_interval_ to control the time to update the chart
* do not delete movable text in when the widget is disabled, delete it in deconstructor
* does not plot a chart if rviz is invoked with the plotter plugin disabled
* add DiagnosticsDisplay
* call hide in the destructor of overlay widgets
* add text to show caption and value.
  in order to toggle caption, added new check box.
  as caption, use the widget name.
* implement piechart on rviz using overlay technique
* add showborder property to 2d rviz plotter
* add plotter2d plugin
* use non-static and uniq string for overlay object
* implement OverlayText display plugin
* compile overlay text display
* add OverlayText.msg
* delete unneeded wrench files
* delete unneeded effort related files
* Merge pull request #23 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/23> from aginika/add-normal-diplay
  Add normal diplay
* add color channel and style property
* update to display in rviz
* update norml_display
* add normal_displays and normal_visuals
* delete point_display.cpp and point_visual.cpp
* Add the line to make the code in hydro
* ignore lib directory under jsk_rviz_plugins
* add gitignore for jsk_rviz_plugins
* do not create .so file under src directory
* depends on rviz using <depend> tag, because rviz failed to detect plugins from jsk_rviz_plugins without depend tag
* remove duplicated include line from polygon_array_display.h
  this duplication and quates in #include line happens compilation error about
  moc file of qt4
* #7 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/7>: add wxwidgets dependency to jsk_rviz_plugins
* add dummy jsk-rviz-plugins.test
* use rosdep name for rviz and actionlib_msgs
* rendering backside face
* enabling alpha blending for PolygonArray
* fixing catkin cmake and dependency
* adding plugin to visualize PolygonArray
* add depends to jsk_footstep_msgs
* clear cache when toggle the check box of Footstep
* adding rviz plugin to visualize footstep
* paint point black if color is not available
* add select_point_cloud_publish_action for publish select points (no color)
* select action using combobox
* change msg type to actionlib_msgs
* add panel to cancel action
* add jsk_rviz_plugin::PublishTopic and remove Effort, wrenchStamped, PointStamped
* add rviz panel to send empty msg
* comment out SOURCE_FILES waiting for Issue #246 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/246>
* use EXTRA_CMAKE_FLAGS to check to use ROSBUILD
* add dependencies to jsk_hark_msgs
* fix: validateFloats should be class method
* fix strequal ROS_DISTRO env
* use ROS_Distributions instead of ROS_DISTRO for electric
* add ambient_sound for groovy
* write libjsk_rviz_plugins under {PROJECT_SOURCE_DIR}/lib for and add export rviz to packages.xml, for groovy/catkin compile
* add debug message
* remove LIBRARY_OUTPUT_PATH and use catkin_package
* fix version
* fix to install plugin_descriptoin.xml and libjsk_rviz_plugins.so
* add comments
* fix for electric
* change msg:hark_msgs/HarkPower -> jsk_hark_msgs/HarkPower
* support groovy/cmake compile
* fix typo jsk_rviz_plugin -> jsk_rviz_plugins
* add test
* add package.xml
* add grad property
* added display ambient sound power
* add robot_description property
* add effort/max_effort property
* fix set sample color value for any scale value
* support enable button for each joint #3597460 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/3597460>
* remove color property
* fix when max_effort is zero, #3595106 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/3595106>
* support scale for effort_plugin, #3595106 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/3595106>
* update jsk_rviz_plugins
* add jsk_rviz_plugins
* Contributors: Kei Okada, Ryohei Ueda, Yuto Inagaki, Shohei Fujii, Yusuke Furuta, Satoshi Iwaishi, Youhei Kakiuchi
```
