### PR TITLE
jsk_visualization: 0.0.3-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1898,7 +1898,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `0.0.3-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.0.2-0`
## jsk_interactive_marker
- No changes
## jsk_rqt_plugins
- No changes
## jsk_rviz_plugins

```
* supress erro message of NormalDisplay
* depends to hark_msgs is no longer needed
* Contributors: Kei Okada, Ryohei Ueda
```
