### PR TITLE
rviz_fixed_view_controller: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5555,6 +5555,17 @@ repositories:
       url: https://github.com/ros-visualization/rviz.git
       version: hydro-devel
     status: maintained
+  rviz_fixed_view_controller:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/rviz_fixed_view_controller-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rviz_fixed_view_controller.git
+      version: 0.0.2
+    status: developed
   sbpl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_fixed_view_controller` to `0.0.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
## rviz_fixed_view_controller

```
* update urls in package.xml
* initial commit
* Contributors: Adam Leeper
```
