### PR TITLE
interaction_cursor_3d: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2353,6 +2353,22 @@ repositories:
       url: https://github.com/ros-industrial-release/industrial_metapackages-release.git
       version: 0.0.1-0
     status: developed
+  interaction_cursor_3d:
+    release:
+      packages:
+      - interaction_cursor_3d
+      - interaction_cursor_demo
+      - interaction_cursor_msgs
+      - interaction_cursor_rviz
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/aleeper/interaction_cursor_3d-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/aleeper/interaction_cursor_3d.git
+      version: 0.0.3
+    status: developed
   interactive_marker_proxy:
     release:
       url: https://github.com/ros-gbp/interactive_marker_proxy-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `interaction_cursor_3d` to `0.0.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
## interaction_cursor_3d
- No changes
## interaction_cursor_demo

```
* fix and tweak demo launch
* Contributors: Adam Leeper
```
## interaction_cursor_msgs
- No changes
## interaction_cursor_rviz
- No changes
