### PR TITLE
interaction_cursor_3d: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -964,7 +964,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/aleeper/interaction_cursor_3d-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/aleeper/interaction_cursor_3d.git


### PR DESCRIPTION
Increasing version of package(s) in repository `interaction_cursor_3d` to `0.0.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `0.0.2-0`
## interaction_cursor_3d
- No changes
## interaction_cursor_demo

```
* fix and tweak demo launch
* Contributors: Adam Leeper
```
## interaction_cursor_msgs
- No changes
## interaction_cursor_rviz
- No changes
