### PR TITLE
rtmros_common: 1.2.0-1 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4065,7 +4065,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.2.0-0
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.2.0-1`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.2.0-0`
## hrpsys_ros_bridge

```
* bump to 1.2.0for hrpsys 315.2.0
```
## hrpsys_tools

```
* bump to 1.2.0for hrpsys 315.2.0
```
## openrtm_ros_bridge

```
* bump to 1.2.0for hrpsys 315.2.0
```
## openrtm_tools

```
* bump to 1.2.0for hrpsys 315.2.0
```
## rosnode_rtc

```
* bump to 1.2.0for hrpsys 315.2.0
```
## rtmbuild

```
* bump to 1.2.0 for hrpsys 315.2.0
```
## rtmros_common

```
* bump to 1.2.0for hrpsys 315.2.0
```
