### PR TITLE
ros_ethercat: 0.1.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2125,7 +2125,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/shadow-robot/ros_ethercat-release.git
-      version: 0.1.4-0
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/shadow-robot/ros_ethercat.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ethercat` to `0.1.6-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `0.1.4-0`
## ros_ethercat
- No changes
## ros_ethercat_eml
- No changes
## ros_ethercat_hardware
- No changes
## ros_ethercat_loop
- No changes
## ros_ethercat_model
- No changes
