### PR TITLE
sr-ronex: 0.9.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2490,6 +2490,33 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/sql_database-release.git
       version: 0.4.9-0
+  sr-ronex:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr-ronex.git
+      version: indigo-devel
+    release:
+      packages:
+      - sr_ronex
+      - sr_ronex_controllers
+      - sr_ronex_drivers
+      - sr_ronex_examples
+      - sr_ronex_external_protocol
+      - sr_ronex_hardware_interface
+      - sr_ronex_launch
+      - sr_ronex_msgs
+      - sr_ronex_test
+      - sr_ronex_transmissions
+      - sr_ronex_utilities
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/shadow-robot/sr-ronex-release.git
+      version: 0.9.8-0
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr-ronex.git
+      version: indigo-devel
+    status: developed
   srdfdom:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sr-ronex` to `0.9.8-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
## sr_ronex

```
* Update CHANGELOG.rst
* Contributors: Manos Nikolaidis
```
## sr_ronex_controllers

```
* Update CHANGELOG.rst
* Contributors: Manos Nikolaidis
```
## sr_ronex_drivers

```
* Update CHANGELOG.rst
* Contributors: Manos Nikolaidis
```
## sr_ronex_examples

```
* Update CHANGELOG.rst
* Contributors: Manos Nikolaidis
```
## sr_ronex_external_protocol

```
* Update CHANGELOG.rst
* Contributors: Manos Nikolaidis
```
## sr_ronex_hardware_interface

```
* Update CHANGELOG.rst
* Contributors: Manos Nikolaidis
```
## sr_ronex_launch

```
* Update CHANGELOG.rst
* Contributors: Manos Nikolaidis
```
## sr_ronex_msgs

```
* Update CHANGELOG.rst
* Contributors: Manos Nikolaidis
```
## sr_ronex_test

```
* Update CHANGELOG.rst
* Contributors: Manos Nikolaidis
```
## sr_ronex_transmissions

```
* Update CHANGELOG.rst
* Contributors: Manos Nikolaidis
```
## sr_ronex_utilities

```
* Update CHANGELOG.rst
* Contributors: Manos Nikolaidis
```
