### PR TITLE
Removing wet kdl

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2867,17 +2867,6 @@ repositories:
       type: git
       url: https://github.com/RCPRG-ros-pkg/orocos_controllers.git
       version: electric
-  orocos_kdl:
-    release:
-      packages:
-      - kdl
-      - orocos_kdl
-      - orocos_kinematics_dynamics
-      - python_orocos_kdl
-      tags:
-        release: release/{package}/{upstream_version}
-      url: https://github.com/ros-gbp/orocos_kdl-release.git
-      version: 1.1.99-13
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
The dry one was masking this one in the debbuilds. We tried removing
that one and it broke a bunch of packages. Removing this one as it was
masked anyway. https://code.google.com/p/ros-dry-releases/source/detail?r=410
