### PR TITLE
nao_robot: 0.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1379,6 +1379,18 @@ repositories:
       type: git
       url: https://github.com/ros-nao/nao_robot.git
       version: master
+    release:
+      packages:
+      - nao_bringup
+      - nao_description
+      - nao_driver
+      - nao_msgs
+      - nao_pose
+      - nao_robot
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/nao_robot-release.git
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/ros-nao/nao_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_robot` to `0.2.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
## nao_bringup

```
* Add missing nao_sim.launch to nao_bringup install
```
## nao_description

```
* Fix #17 <https://github.com/ros-nao/nao_robot/issues/17>: add dependency on sensor_msgs in nao_description
```
## nao_driver

```
* Fix dependency of nao_driver on camera_info_manager_py
* Fix nao_controller for incomplete NAOs
* Get nao_diagnostic_updater.py running again
```
## nao_msgs
- No changes
## nao_pose
- No changes
## nao_robot

```
* Update nao_robot package.xml
```
