### PR TITLE
Adding tedusar_ros_pkg to documentation index for groovy

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4391,6 +4391,11 @@ repositories:
       type: svn
       url: https://alufr-ros-pkg.googlecode.com/svn/trunk/symbolic_planning
       version: HEAD
+  tedusar_ros_pkg:
+    doc:
+      type: git
+      url: https://github.com/johmau85/tedusar_ros_pkg.git
+      version: master
   text_locator:
     doc:
       type: git


### PR DESCRIPTION
I would like to add my repository to be indexed and documented on ros.org. 
