### PR TITLE
jsk_planning: 0.1.2-1 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1823,6 +1823,27 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_model_tools.git
       version: master
     status: developed
+  jsk_planning:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_planning.git
+      version: master
+    release:
+      packages:
+      - jsk_planning
+      - pddl_msgs
+      - pddl_planner
+      - pddl_planner_viewer
+      - task_compiler
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/tork-a/jsk_planning-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_planning.git
+      version: master
+    status: developed
   jsk_pr2eus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_planning` to `0.1.2-1`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
## jsk_planning

```
* add jsk_planning meta package
* Contributors: Kei Okada
```
## pddl_msgs
- No changes
## pddl_planner
- No changes
## pddl_planner_viewer
- No changes
## task_compiler
- No changes
