### PR TITLE
jsk_roseus: 1.1.18-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1900,7 +1900,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.17-1
+      version: 1.1.18-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.18-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.1.17-1`
## euslisp

```
* omit euslisp test codes which are arleady tested in jskeus/irteus/test
* fix test-irtrobot.test ;; we do not need to set demo-function for irteus-demo.l after https://github.com/euslisp/jskeus/pull/87
* Contributors: nozawa
```
## geneus

```
* previous commit does not work with multiple CMAKE_PREFIX_PATH
* do not compile if users already installed with roseus-msgs package
* Contributors: Kei Okada
```
## jsk_roseus
- No changes
## roseus
- No changes
## roseus_msgs
- No changes
## roseus_smach
- No changes
