### PR TITLE
designator_integration: 0.0.0-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -740,6 +740,17 @@ repositories:
       url: https://github.com/ros-gbp/depthimage_to_laserscan-release.git
       version: 1.0.5-0
     status: maintained
+  designator_integration:
+    release:
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/code-iai-release/designator_integration-release.git
+      version: 0.0.0-0
+    source:
+      type: git
+      url: https://github.com/code-iai/designator_integration.git
+      version: master
+    status: developed
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `designator_integration` to `0.0.0-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
