### PR TITLE
iai_common_msgs: 0.0.2-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1570,6 +1570,7 @@ repositories:
       packages:
       - data_vis_msgs
       - designator_integration_msgs
+      - dna_extraction_msgs
       - grasp_stability_msgs
       - iai_common_msgs
       - iai_content_msgs
@@ -1582,7 +1583,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/code-iai-release/iai_common_msgs-release.git
-      version: 0.0.0-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/code-iai/iai_common_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `iai_common_msgs` to `0.0.2-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `0.0.0-0`
