### PR TITLE
designator_integration: 0.0.0-1 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -741,11 +741,15 @@ repositories:
       version: 1.0.5-0
     status: maintained
   designator_integration:
+    doc:
+      type: git
+      url: https://github.com/code-iai/designator_integration.git
+      version: master
     release:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/code-iai-release/designator_integration-release.git
-      version: 0.0.0-0
+      version: 0.0.0-1
     source:
       type: git
       url: https://github.com/code-iai/designator_integration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `designator_integration` to `0.0.0-1`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `0.0.0-0`
