### PR TITLE
iai_common_msgs: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2235,6 +2235,29 @@ repositories:
       type: git
       url: https://github.com/code-iai/iai_common_msgs.git
       version: master
+    release:
+      packages:
+      - data_vis_msgs
+      - designator_integration_msgs
+      - dna_extraction_msgs
+      - grasp_stability_msgs
+      - iai_common_msgs
+      - iai_content_msgs
+      - iai_kinematics_msgs
+      - iai_pancake_perception_action
+      - mln_robosherlock_msgs
+      - saphari_msgs
+      - scanning_table_msgs
+      - sherlock_sim_msgs
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/code-iai-release/iai_common_msgs-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/code-iai/iai_common_msgs.git
+      version: master
+    status: developed
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iai_common_msgs` to `0.0.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
