### PR TITLE
ml_classifiers: 0.3.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3091,6 +3091,21 @@ repositories:
       url: https://github.com/RobotWebTools/mjpeg_server.git
       version: develop
     status: maintained
+  ml_classifiers:
+    doc:
+      type: git
+      url: https://github.com/sniekum/ml_classifiers.git
+      version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/sniekum/ml_classifiers-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/sniekum/ml_classifiers.git
+      version: master
+    status: developed
   motoman:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ml_classifiers` to `0.3.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
