### PR TITLE
openni_camera: 1.9.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1618,6 +1618,11 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/openni_camera.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/openni_camera-release.git
+      version: 1.9.2-1
     source:
       type: git
       url: https://github.com/ros-drivers/openni_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_camera` to `1.9.2-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
## openni_camera

```
* adding missing include of log4cxx/logger.h previously transitively included.
* Contributors: Tully Foote
```
