### PR TITLE
rviz: 1.11.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2452,7 +2452,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.11.2-0
+      version: 1.11.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.11.2-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `1.11.2-0`
## rviz

```
* Fix an issue with rendering laser scans: #762 <https://github.com/ros-visualization/rviz/issues/762>
* Fix an issue with using boost::signal instead of boost::signal2 with tf
  tf recently moved to boost::signal2, so the effort display needed to be updated too
  I made it so that it would conditionally use boost::signal2 if the tf version is greater than or equal to 1.11.3
  I also fixed some compiler warnings in this code
  closes #700 <https://github.com/ros-visualization/rviz/issues/700>
* Contributors: Vincent Rabaud, William Woodall
```
