### PR TITLE
fix freenect_stack source pointers for Groovy

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1210,7 +1210,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/freenect_stack.git
-      version: master
+      version: freenect_stack-0.2.2
     release:
       packages:
       - freenect_camera
@@ -1223,7 +1223,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/freenect_stack.git
-      version: master
+      version: freenect_stack-0.2.2
     status: maintained
   freiburg_tools:
     doc:


### PR DESCRIPTION
ref: ros-drivers/freenect_stack#11
