### PR TITLE
geometry_experimental: 0.5.4-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -820,7 +820,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry_experimental-release.git
-      version: 0.5.4-0
+      version: 0.5.4-1
     source:
       type: git
       url: https://github.com/ros/geometry_experimental.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_experimental` to `0.5.4-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.5.4-0`
## geometry_experimental
- No changes
## tf2

```
* switch to boost signals2 following ros/ros_comm#267 <https://github.com/ros/ros_comm/issues/267>, blocking ros/geometry#23 <https://github.com/ros/geometry/issues/23>
* Contributors: Tully Foote
```
## tf2_bullet
- No changes
## tf2_geometry_msgs
- No changes
## tf2_kdl
- No changes
## tf2_msgs
- No changes
## tf2_py
- No changes
## tf2_ros

```
* surpressing autostart on the server objects to not incur warnings
* switch to boost signals2 following ros/ros_comm#267 <https://github.com/ros/ros_comm/issues/267>, blocking ros/geometry#23 <https://github.com/ros/geometry/issues/23>
* fix compilation with gcc 4.9
* make can_transform correctly wait
* explicitly set the publish queue size for rospy
* Contributors: Tully Foote, Vincent Rabaud, v4hn
```
## tf2_tools
- No changes
