### PR TITLE
ml_classifiers: 0.3.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3100,7 +3100,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/sniekum/ml_classifiers-release.git
-      version: 0.3.0-0
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/sniekum/ml_classifiers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ml_classifiers` to `0.3.0-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.3.0-0`
