### PR TITLE
openni_launch: 1.9.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1641,6 +1641,11 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/openni_launch.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/openni_launch-release.git
+      version: 1.9.5-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_launch` to `1.9.5-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
## openni_launch

```
* Test the ROS launch files, fix some errors (#10 <https://github.com/ros-drivers/openni_launch/issues/10>).
* Fix errors found by roslaunch unit test (#10 <https://github.com/ros-drivers/openni_launch/issues/10>).
* Add unit tests for launch file dependencies.
* Contributors: Jack O'Quin, jonbinney
```
