### PR TITLE
navigation_2d: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3469,6 +3469,26 @@ repositories:
       type: git
       url: https://github.com/skasperski/navigation_2d.git
       version: hydro
+    release:
+      packages:
+      - nav2d
+      - nav2d_exploration
+      - nav2d_karto
+      - nav2d_localizer
+      - nav2d_msgs
+      - nav2d_navigator
+      - nav2d_operator
+      - nav2d_remote
+      - nav2d_tutorials
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/skasperski/navigation_2d-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/skasperski/navigation_2d.git
+      version: hydro
+    status: developed
   navigation_tutorials:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_2d` to `0.1.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `null`
