### PR TITLE
sr_ronex: 0.9.9-3 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4896,7 +4896,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/shadow-robot/ros_ethercat-release.git
-      version: 0.1.6-1
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/shadow-robot/ros_ethercat.git
@@ -5943,7 +5943,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/shadow-robot/sr-ronex-release.git
-      version: 0.9.9-2
+      version: 0.9.9-3
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ronex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_ronex` to `0.9.9-3`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `0.9.9-2`
## sr_ronex
- No changes
## sr_ronex_controllers
- No changes
## sr_ronex_drivers
- No changes
## sr_ronex_examples
- No changes
## sr_ronex_external_protocol
- No changes
## sr_ronex_hardware_interface
- No changes
## sr_ronex_launch
- No changes
## sr_ronex_msgs
- No changes
## sr_ronex_test
- No changes
## sr_ronex_transmissions
- No changes
## sr_ronex_utilities
- No changes
