### PR TITLE
sr_ronex: 0.9.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2184,7 +2184,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/shadow-robot/ros_ethercat-release.git
-      version: 0.1.6-1
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/shadow-robot/ros_ethercat.git
@@ -2570,7 +2570,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/shadow-robot/sr-ronex-release.git
-      version: 0.9.8-0
+      version: 0.9.9-0
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ronex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_ronex` to `0.9.9-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.7`
- previous version for package: `0.9.8-0`
## sr_ronex
- No changes
## sr_ronex_controllers
- No changes
## sr_ronex_drivers
- No changes
## sr_ronex_examples
- No changes
## sr_ronex_external_protocol
- No changes
## sr_ronex_hardware_interface
- No changes
## sr_ronex_launch
- No changes
## sr_ronex_msgs
- No changes
## sr_ronex_test
- No changes
## sr_ronex_transmissions
- No changes
## sr_ronex_utilities
- No changes
