### PR TITLE
revert orocos_kdl

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2919,6 +2919,17 @@ repositories:
       type: git
       url: https://github.com/RCPRG-ros-pkg/orocos_controllers.git
       version: electric
+  orocos_kdl:
+    release:
+      packages:
+      - kdl
+      - orocos_kdl
+      - orocos_kinematics_dynamics
+      - python_orocos_kdl
+      tags:
+        release: release/{package}/{upstream_version}
+      url: https://github.com/ros-gbp/orocos_kdl-release.git
+      version: 1.1.99-13
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
back to dry orocos_kdl

https://github.com/ros/rosdistro/pull/4302 removed wet orocos_kdl and it OK, but now we could not find oroocs_kdl via `rosdep resolve`, so I think we need to add dry version of orocos_kdl

I copied definition from -> 
https://github.com/ros/rosdistro/blob/be9218681f14d0fac908da46902eb2f1dad084fa/groovy/distribution.yaml#L2543
