### PR TITLE
moveit_python: 0.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3244,6 +3244,11 @@ repositories:
       type: git
       url: https://github.com/mikeferguson/moveit_python.git
       version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/mikeferguson/moveit_python-release.git
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/mikeferguson/moveit_python.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_python` to `0.2.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.6`
- previous version for package: `null`
## moveit_python

```
* fix pyassimp rosdep
* Contributors: Michael Ferguson
```
