### PR TITLE
jsk_visualization: 1.0.1-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1950,7 +1950,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 0.0.3-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.1-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `0.0.3-0`
## jsk_interactive_marker

```
* use geometry package to install orocos_kdl, since orocos_kdl is not installed via rosdep https://github.com/ros/rosdistro/pull/4336
* Contributors: Kei Okada
```
## jsk_rqt_plugins
- No changes
## jsk_rviz_plugins

```
* add README and images, modify some fails
* Contributors: Yuto Inagaki
```
