### PR TITLE
jsk_common: 1.0.21-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2505,11 +2505,12 @@ repositories:
       - pr2_groovy_patches
       - rospatlite
       - rosping
+      - sklearn
       - stereo_synchronizer
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.20-0
+      version: 1.0.21-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.21-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.0.20-0`
## assimp_devel
- No changes
## collada_urdf_jsk_patch
- No changes
## depth_image_proc_jsk_patch

```
* forget to add manifest.xml.patch
* Contributors: Kei Okada
```
## downward
- No changes
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha
- No changes
## image_view2

```
* does not check 0.5sec test if the image_view2 is in series mode.
* not use ros::Rate's sleep, use cvWaitKey to captuere
  keys to be pressed
* Contributors: Ryohei Ueda
```
## image_view_jsk_patch
- No changes
## jsk_common
- No changes
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_tools
- No changes
## jsk_topic_tools
- No changes
## laser_filters_jsk_patch
- No changes
## libsiftfast
- No changes
## multi_map_server
- No changes
## openni_tracker_jsk_patch

```
* use geometry package to install orocos_kdl, since orocos_kdl is not installed via rosdep https://github.com/ros/rosdistro/pull/4336
* Contributors: Kei Okada
```
## opt_camera
- No changes
## posedetection_msgs
- No changes
## pr2_groovy_patches
- No changes
## rospatlite
- No changes
## rosping
- No changes
## sklearn

```
* launch prefix
* remove unneeded files
* modify bags and add sample
* add sklearn
* Contributors: Kei Okada, Yuto Inagaki
```
## stereo_synchronizer
- No changes
