### PR TITLE
Add lib32asound2 to rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -879,6 +879,9 @@ kgraphviewer:
     portage:
       packages: [media-gfx/kgraphviewer]
   ubuntu: [kgraphviewer]
+lib32asound2:
+  debian: [lib32asound2]
+  ubuntu: [lib32asound2]
 libann-dev:
   arch: [ann]
   debian: [libann-dev]


### PR DESCRIPTION
lib32asound2 is needed to use ALSA from a x86 build program
