### PR TITLE
Add some Fedora deps

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2059,6 +2059,7 @@ maven:
   fedora: [maven]
   ubuntu: [maven]
 mayavi:
+  fedora: [Mayavi]
   ubuntu: [mayavi2]
 mercurial:
   arch: [mercurial]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2328,6 +2328,7 @@ ruby:
     saucy: [ruby1.9.1-dev, libruby1.9.1, ruby1.9.1]
     trusty: [ruby1.9.1-dev, libruby1.9.1, ruby1.9.1]
 ruby-sass:
+  fedora: [rubygem-sass]
   ubuntu: [ruby-sass]
 sbcl:
   arch: [sbcl]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -881,6 +881,7 @@ kgraphviewer:
   ubuntu: [kgraphviewer]
 lib32asound2:
   debian: [lib32asound2]
+  fedora: [alsa-lib(x86-32), alsa-lib]
   ubuntu: [lib32asound2]
 libann-dev:
   arch: [ann]


### PR DESCRIPTION
If I'm not mistaken, should not that ruby dep be in `ruby.yaml` and not `base.yaml`? I didn't add the dep, just added Fedora to it and noticed...
