### PR TITLE
rospack: 2.2.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2367,7 +2367,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
-      version: 2.2.3-0
+      version: 2.2.3-1
     source:
       type: git
       url: https://github.com/ros/rospack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.2.3-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `2.2.3-0`
## rospack

```
* find library for exact Python version (even if not in CMake provided list of version numbers) (#40 <https://github.com/ros/rospack/issues/40>)
* find TinyXML using cmake_modules (#24 <https://github.com/ros/rospack/issues/24>)
* make error messages tool specific (rospack vs. rosstack) (#38 <https://github.com/ros/rospack/issues/38>)
```
