### PR TITLE
jsk_visualization: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2631,7 +2631,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `1.0.1-0`
## jsk_interactive_marker

```
* add interactive_markers and urdf
```
## jsk_rqt_plugins
- No changes
## jsk_rviz_plugins

```
* Fixes a moc generation error with boost >= 1.48
* add color which will be deviced by curvature
```
