### PR TITLE
openni2_camera: 0.1.2-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3896,7 +3896,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 0.1.2-0
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: hydro-devel
+    status: maintained
   openni2_launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `0.1.2-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.1.2-0`
## openni2_camera

```
* Fix CMake error.
* Contributors: Benjamin Chretien, Michael Ferguson
```
