### PR TITLE
razer_hydra: 0.0.12-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4459,7 +4459,8 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/razer_hydra-release.git
-      version: 0.0.12-0
+      version: 0.0.12-2
+    status: maintained
   realtime_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `razer_hydra` to `0.0.12-2`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.0.12-0`
