### PR TITLE
razer_hydra: 0.0.13-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1825,7 +1825,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/razer_hydra-release.git
-      version: 0.0.13-1
+      version: 0.0.13-2
     source:
       type: git
       url: https://github.com/ros-drivers/razer_hydra.git


### PR DESCRIPTION
Increasing version of package(s) in repository `razer_hydra` to `0.0.13-2`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.0.13-1`
