### PR TITLE
rviz_fixed_view_controller: 0.0.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2483,7 +2483,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rviz_fixed_view_controller-release.git
-      version: 0.0.2-0
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rviz_fixed_view_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_fixed_view_controller` to `0.0.2-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.0.2-0`
## rviz_fixed_view_controller

```
* update urls in package.xml
* initial commit
* Contributors: Adam Leeper
```
