### PR TITLE
pocketsphinx: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1755,6 +1755,21 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: groovy-devel
     status: maintained
+  pocketsphinx:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/pocketsphinx.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/pocketsphinx-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/mikeferguson/pocketsphinx.git
+      version: hydro-devel
+    status: maintained
   pr2_mechanism_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pocketsphinx` to `0.3.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `null`
## pocketsphinx

```
* Convert print statements to rosinfo/rosdebugs
* Change language model at runtime + specify audio source
```
