### PR TITLE
openni2_launch: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1637,6 +1637,21 @@ repositories:
       url: https://github.com/ros-drivers/openni2_camera.git
       version: indigo-devel
     status: developed
+  openni2_launch:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni2_launch.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/openni2_launch.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni2_launch.git
+      version: indigo-devel
+    status: maintained
   openni_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_launch` to `0.2.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `null`
## openni2_launch

```
* Remove machine arg, as it is not necessary.
* Add tf_prefix same as openni
* Defaults for depth processing are set apropriately for both hardware and software registration.
* Contributors: Libor Wagner, Mark Pitchless, Michael Ferguson, Piyush Khandelwal
```
