### PR TITLE
fcl: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -628,7 +628,8 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/fcl-release.git
-      version: 0.3.0-1
+      version: 0.3.1-0
+    status: maintained
   filters:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fcl` to `0.3.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.3.0-1`
