### PR TITLE
libccd: 1.5.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1149,7 +1149,8 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/libccd-release.git
-      version: 1.5.0-0
+      version: 1.5.0-1
+    status: maintained
   libfreenect:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libccd` to `1.5.0-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `1.5.0-0`
