### PR TITLE
view_controller_msgs: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6536,6 +6536,17 @@ repositories:
       url: https://github.com/jack-oquin-ros-releases/velodyne_utils-release.git
       version: 0.4.0-0
     status: end-of-life
+  view_controller_msgs:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/view_controller_msgs-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/view_controller_msgs.git
+      version: hydro-devel
+    status: developed
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `view_controller_msgs` to `0.1.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `null`
## view_controller_msgs

```
* force correct version in package.xml
* rename scripts; install scripts
* fix test scripts
* apply catkin_lint
* catkinizing
* 0.1.1
* more attempts 2
* more attempts 2
* more attempts
* still fixing release build - 3
* still fixing release build - 2
* still fixing release build
* trys to fix msg generation
* fixed stack.xml
* changed parameter name
* moved msgs to own repo
* Initial commit
* Contributors: Adam Leeper, Sachin Chitta
```
