### PR TITLE
moveit_core: 0.5.8-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -628,8 +628,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/fcl-release.git
-      version: 0.3.1-0
-    status: maintained
+      version: 0.3.0-1
   filters:
     release:
       tags:
@@ -1150,8 +1149,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/libccd-release.git
-      version: 1.5.0-1
-    status: maintained
+      version: 1.5.0-0
   libfreenect:
     release:
       tags:
@@ -1307,7 +1305,8 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_core-release.git
-      version: 0.5.8-0
+      version: 0.5.8-1
+    status: maintained
   moveit_ikfast:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_core` to `0.5.8-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.5.8-0`
## moveit_core

```
* Dix bad includes after upstream catkin fix
* update how we find eigen: this is needed for indigo
* Contributors: Ioan A Sucan, Dirk Thomas, Vincent Rabaud
```
