### PR TITLE
moveit_ros: 0.5.18-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1381,7 +1381,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.5.18-0
+      version: 0.5.18-1
     status: maintained
   moveit_setup_assistant:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ros` to `0.5.18-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.5.18-0`
## moveit_ros
- No changes
## moveit_ros_benchmarks
- No changes
## moveit_ros_benchmarks_gui

```
* add pkg-config as dep
* find PkgConfig before using pkg_check_modules
  PC specific functions mustn't be used before including PkgConfig
* Contributors: Ioan Sucan, v4hn
```
## moveit_ros_manipulation
- No changes
## moveit_ros_move_group
- No changes
## moveit_ros_perception
- No changes
## moveit_ros_planning
- No changes
## moveit_ros_planning_interface
- No changes
## moveit_ros_robot_interaction
- No changes
## moveit_ros_visualization

```
* add pkg-config as dep
* find PkgConfig before using pkg_check_modules
  PC specific functions mustn't be used before including PkgConfig
* Contributors: Ioan Sucan, v4hn
```
## moveit_ros_warehouse
- No changes
