### PR TITLE
moveit_plugins: 0.5.6-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1340,7 +1340,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_plugins-release.git
-      version: 0.5.6-0
+      version: 0.5.6-1
     status: maintained
   moveit_python:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_plugins` to `0.5.6-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.5.6-0`
## moveit_fake_controller_manager
- No changes
## moveit_plugins
- No changes
## moveit_simple_controller_manager

```
* Allow simple controller manager to ignore virtual joints without failing
* Contributors: Dave Coleman
```
