### PR TITLE
moveit_planners: 0.5.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1329,7 +1329,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_planners-release.git
-      version: 0.5.5-0
+      version: 0.5.5-1
     status: maintained
   moveit_plugins:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_planners` to `0.5.5-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.5.5-0`
## moveit_planners
- No changes
## moveit_planners_ompl

```
* update build system for ROS indigo
* Removed duplicate call to setPlanningScene(), added various comments
* Contributors: Dave Coleman, Ioan Sucan
```
