### PR TITLE
moveit_core: 0.5.8-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1307,7 +1307,8 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_core-release.git
-      version: 0.5.8-0
+      version: 0.5.8-1
+    status: maintained
   moveit_ikfast:
     release:
       tags:
@@ -1381,7 +1382,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.5.18-1
+      version: 0.5.18-0
     status: maintained
   moveit_setup_assistant:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_core` to `0.5.8-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.5.8-0`
## moveit_core

```
* Dix bad includes after upstream catkin fix
* update how we find eigen: this is needed for indigo
* Contributors: Ioan A Sucan, Dirk Thomas, Vincent Rabaud
```
