### PR TITLE
nmea_msgs: 0.1.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3553,7 +3553,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-drivers-gbp/nmea_msgs-release.git
-      version: 0.1.0-0
+      version: 0.1.0-1
     status: maintained
   nmea_navsat_driver:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_msgs` to `0.1.0-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.1.0-0`
## nmea_msgs

```
* Initial version (released into Hydro)
* Supports NMEA0183 sentences
```
