### PR TITLE
ipa_canopen: 0.5.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2431,7 +2431,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/ipa_canopen-release.git
-      version: 0.5.4-0
+      version: 0.5.5-0
     source:
       type: git
       url: https://github.com/ipa320/ipa_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ipa_canopen` to `0.5.5-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.5.4-0`
## ipa_canopen

```
* Merge pull request #62 <https://github.com/ipa320/ipa_canopen/issues/62> from ipa320/hydro_release_candidate
  bring back changes from Hydro release candidate
* New maintainer
* Contributors: Thiago de Freitas Oliveira Araujo, ipa-nhg
```
## ipa_canopen_core

```
* merge conflict
* hydro
* Check if the operation mode was correctly set
* Changing to reset communication instead of reset node
* Adjusts the diagnostics
* Changes the behaviour when a node can not be found
* Merge pull request #32 <https://github.com/ipa320/ipa_canopen/issues/32> from thiagodefreitas/groovy_dev
  Fixes init bug
* Fixes init bug
* Merge pull request #30 <https://github.com/ipa320/ipa_canopen/issues/30> from thiagodefreitas/groovy_dev
  Generalized mapping functions
* Provides the sync type option for the mapping generalization
* Fixes problems for the inialization of Schunk devices
* First version of generalized mapping functions
* disable testing
* Merge pull request #27 <https://github.com/ipa320/ipa_canopen/issues/27> from kalectro/groovy_dev
  allow motor state to be changed in both directions
* allow motor state to be changed in both directions
* Contributors: Florian Weisshardt, Florian Weißhardt, Kai Franke, ipa-fmw, ipa-nhg, thiagodefreitas
```
## ipa_canopen_ros

```
* change warning message
* merge conflict
* hydro
* Diagnostics with name
* Diagnostics with name
* Diagnostics with name
* Adjusts the diagnostics
* Merge pull request #58 <https://github.com/ipa320/ipa_canopen/issues/58> from thiagodefreitas/hydro_dev
  Changes the behaviour when a node can not be found
* Changes the behaviour when a node can not be found
* Adds some diagnostics
* Fixes init bug
* Fixes problems for the inialization of Schunk devices
* First version of generalized mapping functions
* Contributors: Thiago de Freitas Oliveira Araujo, ipa-cob4-1, ipa-nhg, ros, thiagodefreitas
```
