### PR TITLE
moveit_python: 0.2.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3249,7 +3249,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/mikeferguson/moveit_python-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/mikeferguson/moveit_python.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_python` to `0.2.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.2.1-0`
## moveit_python

```
* pass full result in pick and place
* Contributors: Michael Ferguson
```
