### PR TITLE
geometric_shapes: 0.3.8-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -779,7 +779,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.3.8-1
+      version: 0.3.8-2
     status: maintained
   geometry:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.3.8-2`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.3.8-1`
## geometric_shapes

```
* fix how we find eigen
* Contributors: Ioan Sucan
```
