### PR TITLE
vision_visp: 0.7.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2811,7 +2811,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.7.3-0
+      version: 0.7.3-1
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.7.3-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.7.3-0`
## vision_visp

```
* indigo-0.7.2
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_auto_tracker

```
* Fix to install models folder
* indigo-0.7.2
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_bridge

```
* indigo-0.7.2
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_camera_calibration

```
* indigo-0.7.2
* Prepare changelogs
* Contributors: Fabien Spindler, Thomas Moulard
```
## visp_hand2eye_calibration

```
* indigo-0.7.2
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_tracker

```
* Prepare changelogs
* Contributors: Fabien Spindler
```
