### PR TITLE
visp: 2.9.0-11 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2822,7 +2822,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 2.9.0-10
+      version: 2.9.0-11
     status: maintained
   visp_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `2.9.0-11`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `2.9.0-10`
