### PR TITLE
visp: 2.9.0-4 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6604,7 +6604,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 2.9.0-3
+      version: 2.9.0-4
     status: maintained
   visp_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `2.9.0-4`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `2.9.0-3`
