### PR TITLE
ros_comm: 1.11.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2111,7 +2111,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.2-0
+      version: 1.11.3-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `1.11.2-0`
## message_filters
- No changes
## ros_comm
- No changes
## rosbag
- No changes
## rosbag_storage
- No changes
## rosconsole
- No changes
## roscpp
- No changes
## rosgraph
- No changes
## roslaunch
- No changes
## roslz4
- No changes
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy

```
* allow shutdown hooks to be any callable object (#410 <https://github.com/ros/ros_comm/issues/410>)
* add demux program and related scripts (#407 <https://github.com/ros/ros_comm/issues/407>)
* add publisher queue_size to rostopic
```
## rosservice
- No changes
## rostest
- No changes
## rostopic

```
* add publisher queue_size to rostopic
```
## roswtf
- No changes
## topic_tools

```
* add demux program and related scripts (#407 <https://github.com/ros/ros_comm/issues/407>)
```
## xmlrpcpp
- No changes
