### PR TITLE
rqt: 0.2.14-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2390,7 +2390,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt-release.git
-      version: 0.2.14-0
+      version: 0.2.14-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `0.2.14-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.2.14-0`
## rqt_gui
- No changes
## rqt_gui_cpp

```
* add ros spinner thread for cpp plugins (#95 <https://github.com/ros-visualization/rqt/issues/95>)
```
## rqt_gui_py
- No changes
