### PR TITLE
class_loader: 0.2.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -175,7 +175,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/class_loader-release.git
-      version: 0.2.4-0
+      version: 0.2.5-1
     source:
       type: git
       url: https://github.com/ros/class_loader.git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `0.2.5-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.2.4-0`
## class_loader

```
* Changed format of debug messages so that rosconsole_bridge can correctly parse the prefix
* Improved debug output
```
