### PR TITLE
qt_gui_core: 0.2.24-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1796,7 +1796,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.2.23-0
+      version: 0.2.24-0
     source:
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.2.24-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.2.23-0`
## qt_dotgraph

```
* add work around for pydot bug in Saucy (#42 <https://github.com/ros-visualization/qt_gui_core/issues/42>)
* fix regression 0.2.23 (#41 <https://github.com/ros-visualization/qt_gui_core/issues/41>)
```
## qt_gui
- No changes
## qt_gui_app
- No changes
## qt_gui_cpp
- No changes
## qt_gui_py_common
- No changes
