### PR TITLE
rqt_robot_plugins: 0.3.4-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2461,7 +2461,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-      version: 0.3.4-0
+      version: 0.3.4-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins` to `0.3.4-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.3.4-0`
## rqt_moveit
- No changes
## rqt_nav_view
- No changes
## rqt_pose_view
- No changes
## rqt_robot_dashboard
- No changes
## rqt_robot_monitor
- No changes
## rqt_robot_plugins
- No changes
## rqt_robot_steering
- No changes
## rqt_runtime_monitor

```
* fix selection persistence across state transitions (#60 <https://github.com/ros-visualization/rqt_robot_plugins/pull/60>)
```
## rqt_rviz

```
* add menu hiding and config as command-line args (#62 <https://github.com/ros-visualization/rqt_robot_plugins/pull/62>)
```
## rqt_tf_tree
- No changes
