### PR TITLE
vision_opencv: 1.11.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2830,7 +2830,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.11.2-0
+      version: 1.11.2-1
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.11.2-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `1.11.2-0`
## cv_bridge

```
* Add depend on python for cv_bridge
* Contributors: Scott K Logan
```
## image_geometry
- No changes
## vision_opencv
- No changes
