### PR TITLE
vision_opencv: 1.10.17-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6566,7 +6566,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.10.17-0
+      version: 1.10.17-1
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.10.17-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `1.10.17-0`
## cv_bridge
- No changes
## image_geometry

```
* remove references to 1.11.* as it creates errors on teh farm
* Contributors: Vincent Rabaud
```
## vision_opencv

```
* remove references to 1.11.* as it creates errors on teh farm
* Contributors: Vincent Rabaud
```
