### PR TITLE
Updated the Gentoo Dependencies

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1857,12 +1857,13 @@ libusb:
   arch: [libusb-compat]
   debian: [libusb-0.1-4]
   fedora: [libusb]
-  gentoo: [virtual/libusb]
+  gentoo: [libusb-compat]
   macports: [libusb]
   ubuntu: [libusb-0.1-4]
 libusb-1.0:
   arch: [libusbx]
   debian: [libusb-1.0-0]
+  gentoo: [=dev-libs/libusb-1.0*]
   fedora:
     beefy: [libusb1]
     heisenbug: [libusbx]
@@ -1873,6 +1874,7 @@ libusb-1.0:
 libusb-1.0-dev:
   arch: [libusbx]
   debian: [libusb-1.0-0-dev]
+  gentoo: [=dev-libs/libusb-1.0*]
   fedora:
     beefy: [libusb1-devel]
     heisenbug: [libusbx-devel]
@@ -1891,7 +1893,7 @@ libv4l-dev:
   arch: [v4l-utils]
   debian: [libv4l-dev]
   fedora: [libv4l-devel]
-  gentoo: [media-tv/v4l-utils]
+  gentoo: [v4l-utils]
   opensuse: [libv4l-devel]
   ubuntu: [libv4l-dev]
 libvlc:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1863,23 +1863,23 @@ libusb:
 libusb-1.0:
   arch: [libusbx]
   debian: [libusb-1.0-0]
-  gentoo: [=dev-libs/libusb-1.0*]
   fedora:
     beefy: [libusb1]
     heisenbug: [libusbx]
     schrödinger’s: [libusbx]
     spherical: [libusbx]
+  gentoo: [=dev-libs/libusb-1.0*]
   opensuse: [libusb-1_0-0]
   ubuntu: [libusb-1.0-0]
 libusb-1.0-dev:
   arch: [libusbx]
   debian: [libusb-1.0-0-dev]
-  gentoo: [=dev-libs/libusb-1.0*]
   fedora:
     beefy: [libusb1-devel]
     heisenbug: [libusbx-devel]
     schrödinger’s: [libusbx-devel]
     spherical: [libusbx-devel]
+  gentoo: [=dev-libs/libusb-1.0*]
   macports: [libusb]
   opensuse: [libusb-1_0-devel]
   ubuntu: [libusb-1.0-0-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1857,6 +1857,7 @@ libusb:
   arch: [libusb-compat]
   debian: [libusb-0.1-4]
   fedora: [libusb]
+  gentoo: [virtual/libusb]
   macports: [libusb]
   ubuntu: [libusb-0.1-4]
 libusb-1.0:
@@ -1890,6 +1891,7 @@ libv4l-dev:
   arch: [v4l-utils]
   debian: [libv4l-dev]
   fedora: [libv4l-devel]
+  gentoo: [media-tv/v4l-utils]
   opensuse: [libv4l-devel]
   ubuntu: [libv4l-dev]
 libvlc:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -74,6 +74,7 @@ python-argparse:
     squeeze: [python-argparse]
     wheezy: [python-argparse]
   fedora: [python]
+  gentoo: [python]
   macports: [py27-argparse]
   opensuse: [python-argparse]
   ubuntu:
@@ -609,6 +610,7 @@ python-opencv:
 python-opengl:
   debian: [python-opengl]
   fedora: [PyOpenGL]
+  gentoo: [dev-python/pyopengl]
   macports: [py27-opengl]
   opensuse: [python-opengl]
   ubuntu:
@@ -917,6 +919,7 @@ python-qt-bindings-qwt5:
   arch: [pyqwt]
   debian: [python-qwt5-qt4]
   fedora: [PyQwt-devel]
+  gentoo: [dev-python/pyqwt]
   macports: [qwt52]
   ubuntu:
     lucid: [python-qwt5-qt4]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -411,7 +411,7 @@ python-imaging:
     schrödinger’s: [python-pillow, python-pillow-qt]
     spherical: [python-imaging]
   freebsd: [py27-imaging]
-  gentoo: [dev-python/imaging]
+  gentoo: [virtual/python-imaging]
   macports: [py27-pil]
   opensuse: [python-imaging]
   rhel: [python-imaging]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -149,6 +149,7 @@ python-catkin-pkg:
   arch: [python2-catkin_pkg]
   debian: [python-catkin-pkg]
   fedora: [python-catkin_pkg]
+  gentoo: [dev-python/catkin_pkg]
   macports: [python-catkin-pkg]
   opensuse: [python-catkin_pkg]
   osx:
@@ -519,6 +520,7 @@ python-netifaces:
   arch: [python2-netifaces]
   debian: [python-netifaces]
   fedora: [python-netifaces]
+  gentoo: [dev-python/netifaces]
   macports: [p27-netifaces]
   opensuse: [python-netifaces]
   ubuntu:
@@ -899,6 +901,7 @@ python-qt-bindings-gl:
   arch: [python2-pyqt4]
   debian: [python-qt4-gl]
   fedora: [PyQt4]
+  gentoo: [PyQt4]
   opensuse: [python-qt4-devel]
   ubuntu:
     lucid: [python-qt4-gl]
@@ -990,6 +993,7 @@ python-requests:
 python-rosdep:
   debian: [python-rosdep]
   fedora: [python-rosdep]
+  gentoo: [dev-python/rosdep]
   osx:
     pip:
       packages: [rosdep]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -203,6 +203,7 @@ python-couchdb:
 python-coverage:
   debian: [python-coverage]
   fedora: [python-coverage]
+  gentoo: [dev-python/coverage]
   ubuntu:
     lucid: [python-coverage]
     maverick: [python-coverage]
@@ -278,6 +279,7 @@ python-empy:
   arch: [python2-empy]
   debian: [python-empy]
   fedora: [python-empy]
+  gentoo: [dev-python/empy]
   macports: [py27-empy]
   opensuse: [python-empy]
   ubuntu:
@@ -498,6 +500,7 @@ python-mechanize:
 python-mock:
   debian: [python-mock]
   fedora: [python-mock]
+  gentoo: [dev-python/mock]
   ubuntu:
     lucid: [python-mock]
     maverick: [python-mock]
@@ -674,6 +677,7 @@ python-psutil:
   arch: [python2-psutil]
   debian: [python-psutil]
   fedora: [python-psutil]
+  gentoo: [dev-python/psutil]
   macports: [py27-psutil]
   opensuse: [python-psutil]
   ubuntu:
@@ -1052,6 +1056,7 @@ python-rospkg:
   arch: [python2-rospkg]
   debian: [python-rospkg]
   fedora: [python-rospkg]
+  gentoo: [dev-python/rospkg]
   macports: [py27-rospkg]
   opensuse: [python-rospkg]
   ubuntu:
@@ -1182,6 +1187,7 @@ python-sphinx:
 python-support:
   debian: [python-support]
   fedora: [python]
+  gentoo: [python]
   ubuntu:
     lucid: [python-support]
     maverick: [python-support]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -74,7 +74,7 @@ python-argparse:
     squeeze: [python-argparse]
     wheezy: [python-argparse]
   fedora: [python]
-  gentoo: [python]
+  gentoo: [virtual/python-argparse]
   macports: [py27-argparse]
   opensuse: [python-argparse]
   ubuntu:


### PR DESCRIPTION
I updated base.yaml and python.yaml with Gentoo dependencies, some existing, some on their way through:
https://bugs.gentoo.org/show_bug.cgi?id=510908

I ran nosetests with no errors and only warnings that existed before my edits. I intend to write an updated Gentoo installation guide in the roswiki when I get more important patches in.

Things that still need to be done/packaged for Gentoo:

```
# the following modules are in the rosinstall src...but I haven't figured out
# how to fix the PYTHONPATH variable to find them when running catkin_make_isolated.
genmsg
gencpp
genpy
genlisp

# do I need to package these?
catkin
rosfind

# these simply don't have packages in the portage tree yet, and I'll write ebuilds soon.
collada-dom
orocos_kld
```
