### PR TITLE
navigation: 1.11.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1423,6 +1423,40 @@ repositories:
       url: https://github.com/ros-nao/nao_robot.git
       version: devel
     status: developed
+  navigation:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation.git
+      version: hydro-devel
+    release:
+      packages:
+      - amcl
+      - base_local_planner
+      - carrot_planner
+      - clear_costmap_recovery
+      - costmap_2d
+      - dwa_local_planner
+      - fake_localization
+      - global_planner
+      - map_server
+      - move_base
+      - move_base_msgs
+      - move_slow_and_clear
+      - nav_core
+      - navfn
+      - navigation
+      - robot_pose_ekf
+      - rotate_recovery
+      - voxel_grid
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/navigation-release.git
+      version: 1.11.7-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/navigation.git
+      version: hydro-devel
+    status: maintained
   navigation_2d:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.11.7-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `null`
## amcl

```
* removes useless this->z_max = z_max assignment
* Fix warning string.
* Contributors: Jeremiah Via, enriquefernandez
```
## base_local_planner

```
* fixes latch_xy_goal_tolerance param not taken
* update build to find eigen using cmake_modules
* Trajectory: fix constness of getter methods
* Use hypot() instead of sqrt(x*x, y*y)
* Fix bug in distance calculation for trajectory rollout
* Some documentation fixes in SimpleTrajectoryGenerator
* Contributors: Michael Ferguson, Siegfried-A. Gevatter Pujals, enriquefernandez
```
## carrot_planner
- No changes
## clear_costmap_recovery

```
* update build to find eigen using cmake_modules
* Contributors: Michael Ferguson
```
## costmap_2d

```
* uses %u instead of %d for unsigned int
* update build to find eigen using cmake_modules
* inflation_layer: place .top() & .pop() calls together
* add parameter to configure whether full costmap is published each time
* Contributors: Michael Ferguson, Siegfried-A. Gevatter Pujals, agentx3r, enriquefernandez
```
## dwa_local_planner

```
* update build to find eigen using cmake_modules
* Contributors: Michael Ferguson
```
## fake_localization
- No changes
## global_planner
- No changes
## map_server

```
* make rostest in CMakeLists optional
* Contributors: Lukas Bulwahn
```
## move_base

```
* update build to find eigen using cmake_modules
* Fix classloader warnings on exit of move_base
* Contributors: Michael Ferguson
```
## move_base_msgs
- No changes
## move_slow_and_clear

```
* update build to find eigen using cmake_modules
* Contributors: Michael Ferguson
```
## nav_core
- No changes
## navfn

```
* update build to find eigen using cmake_modules
* Contributors: Michael Ferguson
```
## navigation
- No changes
## robot_pose_ekf

```
* Even longer Time limit for EKF Test
* make rostest in CMakeLists optional
* Contributors: David Lu!!, Lukas Bulwahn
```
## rotate_recovery

```
* update build to find eigen using cmake_modules
* Contributors: Michael Ferguson
```
## voxel_grid

```
* uses %u instead of %d for unsigned int
* Contributors: enriquefernandez
```
