### PR TITLE
rqt_capabilities: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5398,7 +5398,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rqt_capabilities-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     status: developed
   rqt_common_plugins:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_capabilities` to `0.1.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.1.1-0`
## rqt_capabilities

```
* put in instrospection plugin group, fixes #12 <https://github.com/osrf/rqt_capabilities/issues/12>
* Contributors: William Woodall
```
