### PR TITLE
rosbridge_suite: 0.5.6-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3767,7 +3767,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.5.5-1
+      version: 0.5.6-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.5.6-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.5.5-1`
