### PR TITLE
rqt_capabilities: 0.1.2-3 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4014,7 +4014,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/rqt_capabilities-release.git
-      version: 0.1.2-1
+      version: 0.1.2-3
     status: developed
   rqt_common_plugins:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_capabilities` to `0.1.2-3`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.2-1`
## rqt_capabilities

```
* put in instrospection plugin group, fixes #12 <https://github.com/osrf/rqt_capabilities/issues/12>
* Contributors: William Woodall
```
