### PR TITLE
rviz_animated_view_controller: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2545,6 +2545,17 @@ repositories:
       url: https://github.com/ros-visualization/rviz.git
       version: indigo-devel
     status: maintained
+  rviz_animated_view_controller:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rviz_animated_view_controller-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rviz_animated_view_controller.git
+      version: indigo-devel
+    status: developed
   rviz_fixed_view_controller:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_animated_view_controller` to `0.1.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `null`
## rviz_animated_view_controller

```
* force package version
* add demo launch file
* update urls in package.xml
* minor style fix
* update plugin macro
* apply catkin_lint
* catkinized
* minor change
* separating...
* separating packages
* preparing for first release
* removes CameraPlacementTrajectory from everything
* removes CameraPlacementTrajectory
* fixes singularity; simplifies up-vector
* splits up msgs and plugin
* moving from visualization trunk
* Contributors: Adam Leeper, Sachin Chitta, aleeper
```
