### PR TITLE
navigation: 1.11.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3475,7 +3475,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.11.7-0
+      version: 1.11.8-0
     source:
       type: git
       url: https://github.com/ros-planning/navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.11.8-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `1.11.7-0`
## amcl
- No changes
## base_local_planner
- No changes
## carrot_planner
- No changes
## clear_costmap_recovery
- No changes
## costmap_2d
- No changes
## dwa_local_planner
- No changes
## fake_localization
- No changes
## global_planner
- No changes
## map_server

```
* fix build, was broken by #175 <https://github.com/ros-planning/navigation/issues/175>
* Contributors: Michael Ferguson
```
## move_base
- No changes
## move_base_msgs
- No changes
## move_slow_and_clear
- No changes
## nav_core
- No changes
## navfn
- No changes
## navigation
- No changes
## robot_pose_ekf

```
* fix build, was broken by #175 <https://github.com/ros-planning/navigation/issues/175>
* Contributors: Michael Ferguson
```
## rotate_recovery
- No changes
## voxel_grid
- No changes
