### PR TITLE
arbotix: 0.9.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -51,6 +51,24 @@ repositories:
       type: git
       url: https://github.com/ros/angles.git
       version: master
+  arbotix:
+    doc:
+      type: git
+      url: https://github.com/vanadiumlabs/arbotix_ros.git
+      version: hydro-devel
+    release:
+      packages:
+      - arbotix
+      - arbotix_controllers
+      - arbotix_firmware
+      - arbotix_msgs
+      - arbotix_python
+      - arbotix_sensors
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/vanadiumlabs/arbotix_ros-release.git
+      version: 0.9.2-0
+    status: maintained
   ardrone_autonomy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `arbotix` to `0.9.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `null`
## arbotix
- No changes
## arbotix_controllers

```
* cleanup gripper controllers, mark deprecations
* Contributors: Michael Ferguson
```
## arbotix_firmware
- No changes
## arbotix_msgs
- No changes
## arbotix_python
- No changes
## arbotix_sensors
- No changes
