### PR TITLE
indigo ros_comm builds on gentoo

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2048,6 +2048,7 @@ lua-dev:
 lz4:
   debian: [liblz4-dev]
   fedora: [lz4-devel]
+  gentoo: [lz4]
   ubuntu:
     saucy: [liblz4-dev]
     trusty: [liblz4-dev]


### PR DESCRIPTION
with this additional dep, rosdep is happy with indigo ros_comm on gentoo.
