### PR TITLE
robot_localization: 0.1.2-1 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3413,7 +3413,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 0.1.2-0
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/cra-ros-pkg/robot_localization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `0.1.2-1`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.1.2-0`
