### PR TITLE
fanuc: 0.2.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1482,7 +1482,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-industrial-release/fanuc-release.git
-      version: 0.2.0-0
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/ros-industrial/fanuc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fanuc` to `0.2.0-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.2.0-0`
## fanuc

```
* first Hydro release.
* remove arm_navigation pkgs (#61 <https://github.com/ros-industrial/fanuc/issues/61>)
* deprecate fanuc_assets, introduce fanuc_resources
* for a complete list of changes see the commit log for 0.2.0 <https://github.com/ros-industrial/fanuc/compare/0.1.1...0.2.0>
```
## fanuc_assets

```
* first Hydro release.
* deprecate fanuc_assets, introduce fanuc_resources
* cleanup of all CMakeLists and package manifests:

    * closing keywords should have empty parenthesis (#62 <https://github.com/ros-industrial/fanuc/issues/62>)
    * update CMakeLists to follow Catkin CMake coding standards (#62 <https://github.com/ros-industrial/fanuc/issues/62>)
    * ArmNav and support pkgs are architecture independent.

* for a complete list of changes see the commit log for 0.2.0 <https://github.com/ros-industrial/fanuc/compare/0.1.1...0.2.0>
```
## fanuc_driver

```
* first Hydro release.
* Karel driver updates:

    * cleanup variable scopes at program and routine level
    * allow runtime configuration of important settings (#71 <https://github.com/ros-industrial/fanuc/issues/71>, #8 <https://github.com/ros-industrial/fanuc/issues/8>, #2 <https://github.com/ros-industrial/fanuc/issues/2>)
    * use controller Alarm Log to post ROS-I warnings and errors (#73 <https://github.com/ros-industrial/fanuc/issues/73>)
    * fix faulty detection of controller operating mode (#3 <https://github.com/ros-industrial/fanuc/issues/3>)

* make all directories lowercase (#23 <https://github.com/ros-industrial/fanuc/issues/23>)
* cleanup of all CMakeLists and package manifests:

    * link to simple_message as well (#59 <https://github.com/ros-industrial/fanuc/issues/59>)
    * link against catkin_LIBRARIES (#57 <https://github.com/ros-industrial/fanuc/issues/57>)
    * prefix CMake targets with PROJECT_NAME (#47 <https://github.com/ros-industrial/fanuc/issues/47>)
    * closing keywords should have empty parenthesis (#62 <https://github.com/ros-industrial/fanuc/issues/62>)
    * update CMakeLists to follow Catkin CMake coding standards (#62 <https://github.com/ros-industrial/fanuc/issues/62>)
    * list run_depends in alphabetical order (#62 <https://github.com/ros-industrial/fanuc/issues/62>)
    * add missing xacro run depends (#67 <https://github.com/ros-industrial/fanuc/issues/67>)
    * add missing depends to support pkgs (#64 <https://github.com/ros-industrial/fanuc/issues/64>)
    * ArmNav and support pkgs are architecture independent.
    * update model specifications with available information.

* introduction of roslaunch testing of launch files:

    * move roslaunch to build_depend (#76 <https://github.com/ros-industrial/fanuc/issues/76>)
    * test launchfiles with roslaunch (#30 <https://github.com/ros-industrial/fanuc/issues/30>)

* prefix include elements with xacro ns (#38 <https://github.com/ros-industrial/fanuc/issues/38>)
* for a complete list of changes see the commit log for 0.2.0 <https://github.com/ros-industrial/fanuc/compare/0.1.1...0.2.0>
```
## fanuc_m10ia_support

```
* first Hydro release.
* deprecate fanuc_assets, introduce fanuc_resources
* cleanup of all CMakeLists and package manifests:

    * closing keywords should have empty parenthesis (#62 <https://github.com/ros-industrial/fanuc/issues/62>)
    * update CMakeLists to follow Catkin CMake coding standards (#62 <https://github.com/ros-industrial/fanuc/issues/62>)
    * list run_depends in alphabetical order (#62 <https://github.com/ros-industrial/fanuc/issues/62>)
    * add missing xacro run depends (#67 <https://github.com/ros-industrial/fanuc/issues/67>)
    * add missing depends to support pkgs (#64 <https://github.com/ros-industrial/fanuc/issues/64>)
    * ArmNav and support pkgs are architecture independent.
    * update model specifications with available information.

* introduction of roslaunch testing of launch files:

    * move roslaunch to build_depend (#76 <https://github.com/ros-industrial/fanuc/issues/76>)
    * test launchfiles with roslaunch (#30 <https://github.com/ros-industrial/fanuc/issues/30>)

* prefix include elements with xacro ns (#38 <https://github.com/ros-industrial/fanuc/issues/38>)
* for a complete list of changes see the commit log for 0.2.0 <https://github.com/ros-industrial/fanuc/compare/0.1.1...0.2.0>
```
## fanuc_m16ib_support

```
* first Hydro release.
* deprecate fanuc_assets, introduce fanuc_resources
* cleanup of all CMakeLists and package manifests:

    * closing keywords should have empty parenthesis (#62 <https://github.com/ros-industrial/fanuc/issues/62>)
    * update CMakeLists to follow Catkin CMake coding standards (#62 <https://github.com/ros-industrial/fanuc/issues/62>)
    * list run_depends in alphabetical order (#62 <https://github.com/ros-industrial/fanuc/issues/62>)
    * add missing xacro run depends (#67 <https://github.com/ros-industrial/fanuc/issues/67>)
    * add missing depends to support pkgs (#64 <https://github.com/ros-industrial/fanuc/issues/64>)
    * ArmNav and support pkgs are architecture independent.
    * update model specifications with available information.

* introduction of roslaunch testing of launch files:

    * move roslaunch to build_depend (#76 <https://github.com/ros-industrial/fanuc/issues/76>)
    * test launchfiles with roslaunch (#30 <https://github.com/ros-industrial/fanuc/issues/30>)

* prefix include elements with xacro ns (#38 <https://github.com/ros-industrial/fanuc/issues/38>)
* for a complete list of changes see the commit log for 0.2.0 <https://github.com/ros-industrial/fanuc/compare/0.1.1...0.2.0>
```
## fanuc_m430ia_support

```
* first Hydro release.
* deprecate fanuc_assets, introduce fanuc_resources
* cleanup of all CMakeLists and package manifests:

    * closing keywords should have empty parenthesis (#62 <https://github.com/ros-industrial/fanuc/issues/62>)
    * update CMakeLists to follow Catkin CMake coding standards (#62 <https://github.com/ros-industrial/fanuc/issues/62>)
    * list run_depends in alphabetical order (#62 <https://github.com/ros-industrial/fanuc/issues/62>)
    * add missing xacro run depends (#67 <https://github.com/ros-industrial/fanuc/issues/67>)
    * add missing depends to support pkgs (#64 <https://github.com/ros-industrial/fanuc/issues/64>)
    * ArmNav and support pkgs are architecture independent.
    * update model specifications with available information.

* introduction of roslaunch testing of launch files:

    * move roslaunch to build_depend (#76 <https://github.com/ros-industrial/fanuc/issues/76>)
    * test launchfiles with roslaunch (#30 <https://github.com/ros-industrial/fanuc/issues/30>)

* prefix include elements with xacro ns (#38 <https://github.com/ros-industrial/fanuc/issues/38>)
* for a complete list of changes see the commit log for 0.2.0 <https://github.com/ros-industrial/fanuc/compare/0.1.1...0.2.0>
```
## fanuc_resources

```
* first Hydro release.
* deprecate fanuc_assets, introduce fanuc_resources
* cleanup of all CMakeLists and package manifests:

    * closing keywords should have empty parenthesis (#62 <https://github.com/ros-industrial/fanuc/issues/62>)
    * update CMakeLists to follow Catkin CMake coding standards (#62 <https://github.com/ros-industrial/fanuc/issues/62>)
    * ArmNav and support pkgs are architecture independent.

* for a complete list of changes see the commit log for 0.2.0 <https://github.com/ros-industrial/fanuc/compare/0.1.1...0.2.0>
```
