### PR TITLE
robot_localization: 1.1.2-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4525,7 +4525,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 1.1.2-0
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/cra-ros-pkg/robot_localization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `1.1.2-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `1.1.2-0`
