### PR TITLE
orocos_kinematics_dynamics: 1.2.2-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1757,11 +1757,12 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/smits/orocos-kdl-release.git
-      version: 1.2.2-1
+      version: 1.2.2-2
     source:
       type: git
       url: https://github.com/orocos/orocos_kinematics_dynamics.git
       version: master
+    status: maintained
   pcl_conversions:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kinematics_dynamics` to `1.2.2-2`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `1.2.2-1`
