### PR TITLE
openni2_launch: 0.1.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3913,7 +3913,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/openni2_launch.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_launch` to `0.1.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.1.3-0`
## openni2_launch

```
* Force device_id to string type
* Contributors: Dariush Forouher
```
