### PR TITLE
openni2_launch: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1701,7 +1701,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/openni2_launch.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_launch` to `0.2.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.8`
- previous version for package: `0.2.0-0`
## openni2_launch

```
* Force device_id to string type
* Contributors: Dariush Forouher, Michael Ferguson
```
