### PR TITLE
rosbridge_suite: 0.6.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5009,7 +5009,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.5.5-1
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.6.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.5.5-1`
## rosapi

```
* Ensure proper locking for Parameter Server access
* Contributors: Lasse Rasinen
```
## rosbridge_library

```
* Ensure that service name is a string
  Closes #104 <https://github.com/RobotWebTools/rosbridge_suite/issues/104>
* Contributors: Piyush Khandelwal
```
## rosbridge_server
- No changes
## rosbridge_suite
- No changes
