### PR TITLE
gfortran is no longer a package in homebrew

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -107,7 +107,7 @@ gccxml:
 gfortran:
   osx:
     homebrew:
-      packages: [gfortran]
+      packages: [gcc]
 git:
   osx:
     homebrew:


### PR DESCRIPTION
You must now run 'brew install gcc' to get gfortran.
