### PR TITLE
kobuki_core: 0.5.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2716,7 +2716,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki_core-release.git
-      version: 0.5.3-0
+      version: 0.5.4-0
     status: developed
   kobuki_desktop:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core` to `0.5.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.5.3-0`
## kobuki_core
- No changes
## kobuki_dock_drive
- No changes
## kobuki_driver

```
* Fixed typos.
* Fixed typos
* updating hydro-devel to hydro
* kobuki_driver : Updated doxygen. Issue #10 <https://github.com/yujinrobot/kobuki_core/issues/10>.
* kobuki_driver : Fixed a typo on doxygen.
* kobuki_driver : Updated doxygen document.
* kobuki_driver : Updated doxygen document.
* Contributors: Jihoon Lee, Younghun Ju
```
## kobuki_ftdi

```
* kobuki_ftdi : Updated doxygen document.
* Contributors: Younghun Ju
```
