### PR TITLE
kobuki: 0.5.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2696,7 +2696,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki-release.git
-      version: 0.5.5-1
+      version: 0.5.6-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki` to `0.5.6-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.5.5-1`
## kobuki

```
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Jorge Santos
```
## kobuki_auto_docking

```
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Jorge Santos
```
## kobuki_bumper2pc

```
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Jorge Santos
```
## kobuki_controller_tutorial

```
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Jorge Santos
```
## kobuki_description

```
* update body friction and revert torque limit
* update kobuki_gazebo.urdf.xacro to make gazebo simulation more stable.
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: John Hsu, Jorge Santos
```
## kobuki_keyop

```
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Jorge Santos
```
## kobuki_node

```
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Jorge Santos
```
## kobuki_random_walker

```
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Jorge Santos
```
## kobuki_safety_controller

```
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Jorge Santos
```
## kobuki_testsuite

```
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Jorge Santos
```
