### PR TITLE
kobuki_msgs: 0.5.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2745,7 +2745,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki_msgs-release.git
-      version: 0.5.0-0
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_msgs` to `0.5.0-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.5.0-0`
## kobuki_msgs

```
* Add new message ControllerInfo for custom PID gain setting of kobuki's wheel controller.
* Migrate changelog from ros wiki to this repo.
* Add bugtracker and repo URLs.
```
