### PR TITLE
jsk_common: 1.0.22-1 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1830,7 +1830,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.22-0
+      version: 1.0.22-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.22-1`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.0.22-0`
## assimp_devel
- No changes
## collada_urdf_jsk_patch
- No changes
## depth_image_proc_jsk_patch
- No changes
## downward
- No changes
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha
- No changes
## image_view2
- No changes
## image_view_jsk_patch
- No changes
## jsk_common
- No changes
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_tools
- No changes
## jsk_topic_tools

```
* add new nodelet: HzMeasure to measure message rate
* display info in debug mode
* print ignoring tf
* Merge remote-tracking branch 'tarukosu/ignore-specific-transform' into ignore-specific-transform
* add output='screen'
* use joint_states_pruned_buffered instead of _update
* remap /joint_states to /joint_states_pruned_update
* add ignoreing tf config
* add launch file for send joint state and other tf
* prune velocity and effort in joint state
* ignoring tf designated in yaml
* Contributors: Ryohei Ueda, Yusuke Furuta
```
## laser_filters_jsk_patch
- No changes
## libsiftfast
- No changes
## multi_map_server
- No changes
## openni_tracker_jsk_patch
- No changes
## opt_camera
- No changes
## posedetection_msgs
- No changes
## pr2_groovy_patches
- No changes
## rospatlite
- No changes
## rosping
- No changes
## sklearn

```
* remove duplicated change log
* Contributors: Kei Okada
```
## stereo_synchronizer
- No changes
