### PR TITLE
yocs_msgs: 0.5.2-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6779,7 +6779,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/yujinrobot-release/yocs_msgs-release.git
-      version: 0.5.2-0
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/yujinrobot/yocs_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yocs_msgs` to `0.5.2-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.5.2-0`
## yocs_msgs

```
* Move YOCS messages to its own stack.
```
