### PR TITLE
turtlebot: 2.2.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6177,7 +6177,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot-release.git
-      version: 2.2.4-0
+      version: 2.2.5-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot` to `2.2.5-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `2.2.4-0`
## linux_hardware
- No changes
## turtlebot
- No changes
## turtlebot_bringup
- No changes
## turtlebot_description

```
* Check if unit-testing is enabled
  CATKIN_ENABLE_TESTING is a late addtion to catkin. This updates the
  package to comply with the strict checking rule.
* Contributors: Adam Lee
```
