### PR TITLE
turtlebot_apps: 2.2.5-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6209,7 +6209,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_apps-release.git
-      version: 2.2.5-0
+      version: 2.2.5-1
     status: developed
   turtlebot_create:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_apps` to `2.2.5-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `2.2.5-0`
## pano_core
- No changes
## pano_py
- No changes
## pano_ros
- No changes
## turtlebot_actions
- No changes
## turtlebot_apps
- No changes
## turtlebot_calibration
- No changes
## turtlebot_core_apps
- No changes
## turtlebot_follower
- No changes
## turtlebot_navigation
- No changes
## turtlebot_panorama
- No changes
## turtlebot_teleop

```
* When deadman is not pressed publish once a zero twist to make the robot stop. Publisher is now latched as commented in https://github.com/turtlebot/turtlebot_apps/pull/75#issuecomment-33087125
* cmd_vel to 0 when deadman button is released
* Initialize deadman_pressed_ to false
  Initalize deadman_pressed_ to false in order to avoid the effect described in https://github.com/turtlebot/turtlebot_apps/issues/71
* Contributors: MartinPeris, Martí Morta
```
