### PR TITLE
turtlebot_create: 2.2.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6225,7 +6225,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_create-release.git
-      version: 2.2.0-0
+      version: 2.2.0-1
     status: maintained
   turtlebot_create_desktop:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_create` to `2.2.0-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `2.2.0-0`
## create_description

```
* adds bugtracker and repo info to package.xml
* removes laser simulation
```
## create_driver

```
* adds bugtracker and repo info to package.xml
```
## create_node

```
* adds bugtracker and repo info to package.xml
```
## turtlebot_create

```
* adds bugtracker and repo info to package.xml
```
