### PR TITLE
turtlebot_msgs: 2.2.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6251,7 +6251,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_msgs-release.git
-      version: 2.2.0-0
+      version: 2.2.0-1
     status: developed
   turtlebot_simulator:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_msgs` to `2.2.0-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `2.2.0-0`
## turtlebot_msgs

```
* Changelog added
```
