### PR TITLE
turtlebot_simulator: 2.1.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6265,7 +6265,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_simulator-release.git
-      version: 2.1.1-0
+      version: 2.1.1-1
     status: maintained
   turtlebot_viz:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_simulator` to `2.1.1-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `2.1.1-0`
## turtlebot_gazebo

```
* Rename cmd_vel_mux as yocs_cmd_vel_mux.
```
## turtlebot_simulator
- No changes
