### PR TITLE
turtlebot_viz: 2.2.3-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6281,7 +6281,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_viz-release.git
-      version: 2.2.3-0
+      version: 2.2.3-1
     status: maintained
   typelib:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_viz` to `2.2.3-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `2.2.3-0`
## turtlebot_dashboard
- No changes
## turtlebot_interactive_markers
- No changes
## turtlebot_rviz_launchers
- No changes
## turtlebot_viz
- No changes
