### PR TITLE
octomap: 1.5.7-1 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2709,6 +2709,10 @@ repositories:
       url: https://kforge.ros.org/gridutils/git
       version: master
   octomap:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap.git
+      version: v1.5-fixes
     release:
       packages:
       - octomap
@@ -2716,7 +2720,11 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/octomap-release.git
-      version: 1.5.7-0
+      version: 1.5.7-1
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap.git
+      version: v1.5-fixes
     status: maintained
   octomap_mapping:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap` to `1.5.7-1`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.5.7-0`
