### PR TITLE
octomap_msgs: 0.2.9-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2730,7 +2730,7 @@ repositories:
       version: groovy-devel
     release:
       tags:
-        release: release/{package}/{upstream_version}
+        release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/octomap_msgs-release.git
       version: 0.2.9-0
     source:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_msgs` to `0.2.9-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.2.9-0`
