### PR TITLE
octomap_ros: 0.2.6-1 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2745,9 +2745,9 @@ repositories:
       version: groovy-devel
     release:
       tags:
-        release: release/{package}/{upstream_version}
+        release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/octomap_ros-release.git
-      version: 0.2.6-0
+      version: 0.2.6-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_ros` to `0.2.6-1`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.2.6-0`
