### PR TITLE
octomap_rviz_plugins: 0.0.4-1 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2762,7 +2762,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/octomap_rviz_plugins-release.git
-      version: 0.0.4-0
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_rviz_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_rviz_plugins` to `0.0.4-1`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.0.4-0`
