### PR TITLE
humanoid_msgs: 0.3.0-1 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1570,11 +1570,12 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/humanoid_msgs-release.git
-      version: 0.3.0-0
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ahornung/humanoid_msgs.git
       version: devel
+    status: maintained
   humanoid_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `humanoid_msgs` to `0.3.0-1`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.3.0-0`
## humanoid_msgs
- No changes
## humanoid_nav_msgs

```
* Add service to (re)plan between feet as start and goal.
* Contributors: Armin Hornung
```
