### PR TITLE
humanoid_msgs: 0.3.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2127,7 +2127,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/humanoid_msgs-release.git
-      version: 0.3.0-0
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ahornung/humanoid_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `humanoid_msgs` to `0.3.0-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.3.0-0`
## humanoid_msgs
- No changes
## humanoid_nav_msgs

```
* Add service to (re)plan between feet as start and goal.
* Contributors: Armin Hornung
```
