### PR TITLE
octomap_msgs: 0.3.1-5 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1615,7 +1615,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/octomap_msgs-release.git
-      version: 0.3.1-4
+      version: 0.3.1-5
     source:
       type: git
       url: https://github.com/OctoMap/octomap_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_msgs` to `0.3.1-5`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.3.1-4`
## octomap_msgs

```
* Removed [binary|full]MsgDataToMap, created only incomplete OctoMap objects
  Replacement: use [binary|full]MsgToMap or msgToMap()
```
