### PR TITLE
octomap_ros: 0.3.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3760,7 +3760,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/octomap_ros-release.git
-      version: 0.3.1-0
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_ros` to `0.3.1-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.3.1-0`
## octomap_ros

```
* Fixing #3 <https://github.com/OctoMap/octomap_ros/issues/3> (explicit instantiation in conversions.cpp)
```
