### PR TITLE
octomap: 1.6.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3712,7 +3712,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/octomap-release.git
-      version: 1.6.4-0
+      version: 1.6.5-0
     source:
       type: git
       url: https://github.com/OctoMap/octomap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap` to `1.6.5-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.6.4-0`
