### PR TITLE
control_msgs: 1.2.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -887,7 +887,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/control_msgs-release.git
-      version: 1.2.0-0
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: hydro-devel
+    status: maintained
   control_toolbox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `1.2.0-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.2.0-0`
