### PR TITLE
control_msgs: 1.3.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -308,11 +308,12 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/control_msgs-release.git
-      version: 1.3.0-1
+      version: 1.3.0-2
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
       version: indigo-devel
+    status: maintained
   control_toolbox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `1.3.0-2`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.3.0-1`
## control_msgs

```
* Add error_string to action result.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
