### PR TITLE
control_toolbox: 1.10.4-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -897,7 +897,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/control_toolbox-release.git
-      version: 1.10.4-1
+      version: 1.10.4-2
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_toolbox.git
+      version: hydro-devel
     status: maintained
   convex_decomposition:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `1.10.4-2`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.10.4-1`
## control_toolbox

```
* Added Travis support
* Renamed manifest.xml so it doesn't break rosdep
* Expanded range of PID and windup gains for certain applications.
* Expanded range of PID and windup gains for certain applications. Lowered default integral and derivative gain
* check for CATKIN_ENABLE_TESTING
* Add some comments to Parameters.cfg
* Add support for dynamic_reconfigure for rosbuild
* Contributors: Austin Hendrix, Dave Coleman, Lukas Bulwahn, Paul Dinh
```
