### PR TITLE
control_toolbox: 1.11.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -322,7 +322,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/control_toolbox-release.git
-      version: 1.11.0-0
+      version: 1.11.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `1.11.0-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.11.0-0`
## control_toolbox

```
* Remove rosbuild artifacts
* Cleaned up CMake and removed unnecessary dependencies
* Made default value negative to match valid range
* Fix for i_clamp_min to be negative in dynamic reconfigure
* Fix abs/fabs problem with Clang and libc++
* Contributors: Adolfo Rodriguez Tsouroukdissian, Dave Coleman, Marco Esposito
```
