### PR TITLE
realtime_tools: 1.8.3-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4477,7 +4477,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/realtime_tools-release.git
-      version: 1.8.3-0
+      version: 1.8.3-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: hydro-devel
     status: maintained
   receive_ublox:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `1.8.3-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.8.3-0`
## realtime_tools

```
* Fix linking
  The library needs to be linked against roscpp and Boost thread.
  GCC won't complain about missing symbols for a shared library,
  but other linkers (like clang's) will not accept it by default.
* Added Travis support
* Renamed manifest.xml so it doesn't brek rosdep
* Contributors: Adolfo Rodriguez Tsouroukdissian, Dave Coleman, Paul Mathieu
```
