### PR TITLE
ros_control: 0.7.2-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4872,7 +4872,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.7.2-0
+      version: 0.7.2-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.7.2-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.7.2-0`
## controller_interface
- No changes
## controller_manager
- No changes
## controller_manager_msgs
- No changes
## controller_manager_tests
- No changes
## hardware_interface
- No changes
## joint_limits_interface
- No changes
## ros_control
- No changes
## rqt_controller_manager

```
* Add plugin resources to installation target.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## transmission_interface
- No changes
