### PR TITLE
ros_controllers: 0.7.2-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4899,7 +4899,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.7.2-0
+      version: 0.7.2-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.7.2-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.7.2-0`
## diff_drive_controller
- No changes
## effort_controllers
- No changes
## force_torque_sensor_controller
- No changes
## forward_command_controller
- No changes
## gripper_action_controller

```
* Added missing deps to package.xml
* Contributors: Scott K Logan
```
## imu_sensor_controller
- No changes
## joint_state_controller
- No changes
## joint_trajectory_controller
- No changes
## position_controllers
- No changes
## ros_controllers
- No changes
## velocity_controllers
- No changes
