### PR TITLE
ros_controllers: 0.8.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2264,7 +2264,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.8.0-0
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.8.0-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.8.0-0`
## diff_drive_controller

```
* Add base_frame_id param (defaults to base_link)
  The nav_msgs/Odometry message specifies the child_frame_id field,
  which was previously not set.
  This commit creates a parameter to replace the previously hard-coded
  value of the child_frame_id of the published tf frame, and uses it
  in the odom message as well.
* Contributors: enriquefernandez
```
## effort_controllers

```
* Remove rosbuild artifacts. Fix #90 <https://github.com/ros-controls/ros_controllers/issues/90>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## force_torque_sensor_controller

```
* Add missing controller resources to install target
* Remove rosbuild artifacts. Fix #90 <https://github.com/ros-controls/ros_controllers/issues/90>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## forward_command_controller

```
* Remove rosbuild artifacts. Fix #90 <https://github.com/ros-controls/ros_controllers/issues/90>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## gripper_action_controller
- No changes
## imu_sensor_controller

```
* Add missing controller resources to install target
* Remove rosbuild artifacts. Fix #90 <https://github.com/ros-controls/ros_controllers/issues/90>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## joint_state_controller

```
* Add missing controller resources to install target
* Remove rosbuild artifacts. Fix #90 <https://github.com/ros-controls/ros_controllers/issues/90>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## joint_trajectory_controller

```
* Remove rosbuild artifacts. Fix #90 <https://github.com/ros-controls/ros_controllers/issues/90>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## position_controllers

```
* Remove rosbuild artifacts. Fix #90 <https://github.com/ros-controls/ros_controllers/issues/90>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## ros_controllers
- No changes
## velocity_controllers

```
* Remove rosbuild artifacts. Fix #90 <https://github.com/ros-controls/ros_controllers/issues/90>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
