### PR TITLE
sr_ronex: 0.9.12-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5978,7 +5978,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/shadow-robot/sr-ronex-release.git
-      version: 0.9.10-0
+      version: 0.9.12-0
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ronex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_ronex` to `0.9.12-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.9.10-0`
## sr_ronex

```
* 0.9.11
* changlogs
* 0.9.10
* Contributors: shadowmanos
```
## sr_ronex_controllers

```
* 0.9.11
* changlogs
* 0.9.10
* Contributors: shadowmanos
```
## sr_ronex_drivers

```
* 0.9.11
* changlogs
* split launch files to debug and normal
  fixed a warning
* 0.9.10
* Contributors: shadowmanos
```
## sr_ronex_examples

```
* 0.9.11
* changlogs
* 0.9.10
* Contributors: shadowmanos
```
## sr_ronex_external_protocol

```
* 0.9.11
* changlogs
* 0.9.10
* Contributors: shadowmanos
```
## sr_ronex_hardware_interface

```
* 0.9.11
* changlogs
* 0.9.10
* Contributors: shadowmanos
```
## sr_ronex_launch

```
* 0.9.11
* changlogs
* split launch files to debug and normal
  fixed a warning
* 0.9.10
* Contributors: shadowmanos
```
## sr_ronex_msgs

```
* 0.9.11
* changlogs
* 0.9.10
* Contributors: shadowmanos
```
## sr_ronex_test

```
* 0.9.11
* changlogs
* 0.9.10
* Contributors: shadowmanos
```
## sr_ronex_transmissions

```
* 0.9.11
* changlogs
* 0.9.10
* Contributors: shadowmanos
```
## sr_ronex_utilities

```
* 0.9.11
* changlogs
* 0.9.10
* Contributors: shadowmanos
```
