### PR TITLE
sr_ronex: 0.9.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2682,7 +2682,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/shadow-robot/sr-ronex-release.git
-      version: 0.9.11-0
+      version: 0.9.13-0
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ronex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_ronex` to `0.9.13-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.9.11-0`
## sr_ronex

```
* 0.9.12
* changelogs
* Contributors: shadowmanos
```
## sr_ronex_controllers

```
* 0.9.12
* changelogs
* Contributors: shadowmanos
```
## sr_ronex_drivers

```
* 0.9.12
* changelogs
* split launch files to debug and normal
  fixed a warning
* Contributors: shadowmanos
```
## sr_ronex_examples

```
* 0.9.12
* changelogs
* Contributors: shadowmanos
```
## sr_ronex_external_protocol

```
* 0.9.12
* changelogs
* Contributors: shadowmanos
```
## sr_ronex_hardware_interface

```
* 0.9.12
* changelogs
* Contributors: shadowmanos
```
## sr_ronex_launch

```
* 0.9.12
* changelogs
* split launch files to debug and normal
  fixed a warning
* Contributors: shadowmanos
```
## sr_ronex_msgs

```
* 0.9.12
* changelogs
* Contributors: shadowmanos
```
## sr_ronex_test

```
* 0.9.12
* changelogs
* Contributors: shadowmanos
```
## sr_ronex_transmissions

```
* 0.9.12
* changelogs
* Contributors: shadowmanos
```
## sr_ronex_utilities

```
* 0.9.12
* changelogs
* Contributors: shadowmanos
```
