### PR TITLE
uwsim_bullet: 2.82.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6345,11 +6345,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/uji-ros-pkg/underwater_simulation-release.git
-      version: 1.3.1-1
-    source:
-      type: git
-      url: https://github.com/uji-ros-pkg/underwater_simulation.git
-      version: branch
+      version: 1.3.1-0
     status: maintained
   unique_identifier:
     doc:
@@ -6500,7 +6496,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/uji-ros-pkg/uwsim_bullet-release.git
-      version: 2.82.1-0
+      version: 2.82.1-1
     status: maintained
   uwsim_osgbullet:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_bullet` to `2.82.1-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `2.82.1-0`
