### PR TITLE
uwsim_osgocean: 1.0.2-7 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6507,21 +6507,21 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/uji-ros-pkg/uwsim_osgbullet-release.git
-      version: 3.0.1-1
+      version: 3.0.1-0
     status: maintained
   uwsim_osgocean:
     release:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/uji-ros-pkg/uwsim_osgocean-release.git
-      version: 1.0.2-6
+      version: 1.0.2-7
     status: maintained
   uwsim_osgworks:
     release:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/uji-ros-pkg/uwsim_osgworks-release.git
-      version: 3.0.3-2
+      version: 3.0.3-1
     status: maintained
   v4r_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_osgocean` to `1.0.2-7`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.0.2-6`
