### PR TITLE
gazebo_ros_pkgs: 2.4.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -713,7 +713,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.4.3-0
+      version: 2.4.3-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.4.3-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `2.4.3-0`
## gazebo_msgs
- No changes
## gazebo_plugins

```
* gazebo_plugins: add run-time dependency on gazebo_ros
* Merge pull request #176 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/176> from ros-simulation/issue_175
  Fix #175 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/175>: dynamic reconfigure dependency error
* Remove unneeded dependency on pcl_ros
* Fix #175 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/175>: dynamic reconfigure dependency error
* Contributors: Steven Peters
```
## gazebo_ros

```
* added osx support for gazebo start scripts
* Remove gazebo_ros dependency on gazebo_plugins
* Contributors: Markus Achtelik, Steven Peters
```
## gazebo_ros_control

```
* Compatibility with Indigo's ros_control.
  Also fixes #184 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/184>.
* Remove build-time dependency on gazebo_ros.
* Fix broken build due to wrong rosconsole macro use
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## gazebo_ros_pkgs
- No changes
