### PR TITLE
image_common: 1.11.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -929,7 +929,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/image_common-release.git
-      version: 1.11.3-0
+      version: 1.11.3-1
     source:
       type: git
       url: https://github.com/ros-perception/image_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `1.11.3-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.11.3-0`
## camera_calibration_parsers
- No changes
## camera_info_manager

```
* Add public member function to manually set camera info (#19 <https://github.com/ros-perception/image_common/issues/19>)
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* Contributors: Jack O'Quin, Jonathan Bohren, Lukas Bulwahn
```
## image_common
- No changes
## image_transport
- No changes
## polled_camera
- No changes
