### PR TITLE
libfreenect: 0.1.2-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2283,7 +2283,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/image_common-release.git
-      version: 1.11.3-1
+      version: 1.11.3-0
     source:
       type: git
       url: https://github.com/ros-perception/image_common.git
@@ -2894,7 +2894,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-drivers-gbp/libfreenect-release.git
-      version: 0.1.2-1
+      version: 0.1.2-2
     status: maintained
   libg2o:
     release:
@@ -6542,7 +6542,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-drivers-gbp/velodyne-release.git
-      version: 1.1.2-1
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libfreenect` to `0.1.2-2`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.2-1`
