### PR TITLE
freenect_stack: 0.3.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -692,7 +692,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/freenect_stack-release.git
-      version: 0.3.2-0
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/ros-drivers/freenect_stack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `freenect_stack` to `0.3.2-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.3.2-0`
## freenect_camera

```
* Add include for log4cxx/logger.h (#10 <https://github.com/ros-drivers/freenect_stack/issues/10>).
```
## freenect_launch
- No changes
## freenect_stack
- No changes
