### PR TITLE
camera1394: 1.9.5-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -432,7 +432,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-drivers-gbp/camera1394-release.git
-      version: 1.9.5-0
+      version: 1.9.5-1
     source:
       type: git
       url: https://github.com/ros-drivers/camera1394.git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera1394` to `1.9.5-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.9.5-0`
## camera1394
- No changes
