### PR TITLE
geographic_info: 0.3.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1687,7 +1687,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-geographic-info/geographic_info-release.git
-      version: 0.3.1-0
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ros-geographic-info/geographic_info.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geographic_info` to `0.3.1-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.3.1-0`
## geodesy
- No changes
## geographic_info
- No changes
## geographic_msgs
- No changes
