### PR TITLE
velodyne_height_map: 0.4.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6557,7 +6557,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/jack-oquin-ros-releases/velodyne_height_map-release.git
-      version: 0.4.1-0
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/jack-oquin/velodyne_height_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_height_map` to `0.4.1-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.4.1-0`
## velodyne_height_map
- No changes
