### PR TITLE
catkin: 0.6.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -182,7 +182,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.6.4-1
+      version: 0.6.5-0
     status: maintained
   class_loader:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.6.5-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.6.4-1`
## catkin

```
* fix regression in catkin_make_isolated from 0.6.4 (#624 <https://github.com//ros/catkin/issues/624>)
* fix problem when catkin_make / catkin_make_isolated is invoked in a symlinked folder (#638 <https://github.com//ros/catkin/issues/638>)
```
