### PR TITLE
zeroconf_avahi_suite: 0.2.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3019,7 +3019,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/zeroconf_avahi_suite-release.git
-      version: 0.2.3-0
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/stonier/zeroconf_avahi_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zeroconf_avahi_suite` to `0.2.3-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.2.3-0`
