### PR TITLE
ecl_tools: 0.60.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -534,7 +534,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_tools-release.git
-      version: 0.60.1-0
+      version: 0.60.1-1
     source:
       type: git
       url: https://github.com/stonier/ecl_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_tools` to `0.60.1-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.60.1-0`
## ecl_build

```
* ecl_check_for->ecl_detect for consistency.
* use catkin exports for cmake modules, closes #2 <https://github.com/stonier/ecl_tools/issues/2>
* Contributors: Daniel Stonier
```
