### PR TITLE
ecl_lite: 0.60.1-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -478,7 +478,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_lite-release.git
-      version: 0.60.1-0
+      version: 0.60.1-2
     source:
       type: git
       url: https://github.com/stonier/ecl_lite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_lite` to `0.60.1-2`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.60.1-0`
## ecl_config

```
* update to catkin's CFG_EXTRAS for easy to find cmake modules.
* Contributors: Daniel Stonier
```
## ecl_time_lite

```
* update to catkin's CFG_EXTRAS for easy to find cmake modules.
* Contributors: Daniel Stonier
```
