### PR TITLE
ecl_manipulation: 0.60.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -497,7 +497,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_manipulation-release.git
-      version: 0.60.0-0
+      version: 0.60.0-1
     source:
       type: git
       url: https://github.com/stonier/ecl_manipulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_manipulation` to `0.60.0-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.60.0-0`
