### PR TITLE
navigation_2d: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3512,7 +3512,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/skasperski/navigation_2d-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/skasperski/navigation_2d.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_2d` to `0.1.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.1-0`
