### PR TITLE
rocon_tools: 0.1.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2121,7 +2121,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_tools-release.git
-      version: 0.1.6-0
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_tools` to `0.1.8-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.1.6-0`
## rocon_launch

```
* bugfix a variable name typo in ``RosLaunchConfiguration`` (``option``->``options``).
```
