### PR TITLE
rocon_multimaster: 0.7.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2091,7 +2091,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_multimaster-release.git
-      version: 0.7.2-0
+      version: 0.7.3-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_multimaster.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_multimaster` to `0.7.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.7.2-0`
## rocon_gateway

```
* lists instead of semi-colon separated strings for hub whitelist/blacklist parameters.
* keep trying to resolve zeroconf hubs instead of blacklisting them so we can come back from wireless dropouts, #271 <https://github.com/robotics-in-concert/rocon_multimaster/issues/271>.
* update publisher queue_size to avoid warning in indigo.
* Contributors: Daniel Stonier
```
## rocon_gateway_tests

```
* reduce the gateway unavailable timeout for convenient wireless testing.
* fix inconsistently referenced flip_all.yaml.
* Contributors: Daniel Stonier
```
## rocon_hub

```
* support for redis on trusty, version 2.8.
* remove unused gateway_ping_frequency parameter, #271 <https://github.com/robotics-in-concert/rocon_multimaster/issues/271>.
* Contributors: Daniel Stonier
```
## rocon_hub_client

```
* lists instead of semi-colon separated strings for hub whitelist/blacklist parameters.
* keep trying to resolve zeroconf hubs instead of blacklisting them so we can come back from wireless dropouts, #271 <https://github.com/robotics-in-concert/rocon_multimaster/issues/271>.
* Contributors: Daniel Stonier
```
## rocon_multimaster

```
* minor wireless handling bugfixes.
* rocon tests upgraded to use the new rocon launch api.
```
## rocon_test

```
* update for the new rocon launch api.
* Contributors: Daniel Stonier
```
