### PR TITLE
rocon_app_platform: 0.7.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2030,7 +2030,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_app_platform-release.git
-      version: 0.7.0-0
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_app_platform` to `0.7.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.2`
- previous version for package: `0.7.0-0`
## rocon_app_manager

```
* use lists instead of semi-colon separated strings for hub/concert whitelists/blacklists now roslaunch can handle it.
* don't try and direct connect to a local hub by default.
* catch and handle a shutdown exception.
* update publisher queue_size to avoid warning in indigo.
* Contributors: Daniel Stonier
```
## rocon_app_platform

```
* minor runtime improvements, crash handling.
* use lists for ros parameters where practical.
```
