### PR TITLE
hironx_tutorial: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2058,6 +2058,21 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
       version: 0.3.1-0
     status: maintained
+  hironx_tutorial:
+    doc:
+      type: git
+      url: https://github.com/tork-a/hironx_tutorial.git
+      version: tag
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/tork-a/hironx_tutorial-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/tork-a/hironx_tutorial.git
+      version: tag
+    status: maintained
   hlugv_common:
     doc:
       type: svn


### PR DESCRIPTION
Increasing version of package(s) in repository `hironx_tutorial` to `0.1.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
