### PR TITLE
ompl: 0.14.2002850-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1657,7 +1657,8 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ompl-release.git
-      version: 0.14.1002831-0
+      version: 0.14.2002850-0
+    status: maintained
   open_street_map:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `0.14.2002850-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.14.1002831-0`
