### PR TITLE
hironx_tutorial: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2067,7 +2067,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/hironx_tutorial-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/tork-a/hironx_tutorial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hironx_tutorial` to `0.1.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.0-0`
## hironx_tutorial

```
* Remove install target on empty test folder to pass ROS buildfarm.
* Add leap_motion.
* Contributors: Isaac Saito
```
