### PR TITLE
hector_localization: 0.1.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1937,7 +1937,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
-      version: 0.1.1-0
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_localization.git
+      version: catkin
     status: maintained
   hector_models:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_localization` to `0.1.1-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.1-0`
## hector_localization

```
* made hector_localization a true metapackage
* Contributors: Johannes Meyer
```
## hector_pose_estimation

```
* Fixed boost 1.53 issues
  changed boost::shared_dynamic_cast to boost::dynamic_pointer_cast and
  boost::shared_static_cast to boost::static_pointer_cast
* readded tf_prefix support (was removed from tf::TransformBroadcaster in hydro)
* hector_pose_estimation/rtt_hector_pose_estimation: removed optional usage of package hector_uav_msgs and created a separate package hector_quadrotor_pose_estimation instead
* fixed unresolved symbols when loading the nodelet, renamed plugin description xml file
* Contributors: Christopher Hrabia, Johannes Meyer
```
## hector_pose_estimation_core

```
* Fixed boost 1.53 issues
  changed boost::shared_dynamic_cast to boost::dynamic_pointer_cast and
  boost::shared_static_cast to boost::static_pointer_cast
* hector_pose_estimation_core: rotate rate vector to nav frame in PoseEstimation::getState()
  All vectors in state messages (e.g. on topic /state) are given in nav frame. The rate vector
  has not been converted from body until now.
* Contributors: Christopher Hrabia, Johannes Meyer
```
## message_to_tf

```
* added missing dependency to roscpp
* Contributors: Johannes Meyer
```
## world_magnetic_model

```
* Use "Public Domain" license for world_magnetic_model
  WMM is public domain:
  http://www.ngdc.noaa.gov/geomag/WMM/license.shtml
* Contributors: Scott K Logan
```
