### PR TITLE
hector_models: 0.3.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1953,7 +1953,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
-      version: 0.3.1-0
+      version: 0.3.1-1
+    source:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_models.git
+      version: hydro-devel
     status: maintained
   hector_navigation:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_models` to `0.3.1-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.3.1-0`
## hector_components_description

```
* Re-parent LIDAR and camera mount to top_box_link
* Add xacro macros for setting dimensions
* Remove obsolete files
* Add UTM-30LX macro to vision box xacro
* Add hector ugv vision box to hector_components_description package for better reusability
* Contributors: Stefan Kohlbrecher
```
## hector_models

```
* made hector_models a true metapackage
* Moved package hector_sensors_gazebo to ../hector_gazebo
* Contributors: Johannes Meyer
```
## hector_sensors_description

```
* added hokuyo_utm30lx_model and hokuyo_utm30lx_gpu macros and disabled gpu laser in default hokuyo_utm30lx macro
* use gpu_ray sensor in hydro
* Contributors: Johannes Meyer
```
## hector_xacro_tools
- No changes
