### PR TITLE
hector_gazebo: 0.3.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1920,7 +1920,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
-      version: 0.3.2-0
+      version: 0.3.3-0
+    source:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
+      version: hydro-devel
     status: maintained
   hector_localization:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_gazebo` to `0.3.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.3.2-0`
## hector_gazebo
- No changes
## hector_gazebo_plugins
- No changes
## hector_gazebo_thermal_camera

```
* Fix bad bug with index access
* Contributors: Stefan Kohlbrecher
```
## hector_gazebo_worlds
- No changes
## hector_sensors_gazebo
- No changes
