### PR TITLE
hector_quadrotor: 0.3.2-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1986,7 +1986,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_quadrotor-release.git
-      version: 0.3.2-0
+      version: 0.3.2-1
+    source:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor.git
+      version: hydro-devel
     status: maintained
   hector_quadrotor_apps:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_quadrotor` to `0.3.2-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.3.2-0`
## hector_quadrotor

```
* added packages hector_quadrotor_controller and hector_quadrotor_controller_gazebo to meta-package
* Contributors: Johannes Meyer
```
## hector_quadrotor_controller

```
* Fix boost 1.53 issues
  changed boost::shared_dynamic_cast to boost::dynamic_pointer_cast and
  boost::shared_static_cast to boost::static_pointer_cast
* use a separate callback queue thread for the TwistController
* added optional twist limit in pose controller
* Contributors: Christopher Hrabia, Johannes Meyer
```
## hector_quadrotor_controller_gazebo
- No changes
## hector_quadrotor_demo
- No changes
## hector_quadrotor_description
- No changes
## hector_quadrotor_gazebo
- No changes
## hector_quadrotor_gazebo_plugins
- No changes
## hector_quadrotor_model
- No changes
## hector_quadrotor_pose_estimation
- No changes
## hector_quadrotor_teleop
- No changes
## hector_uav_msgs
- No changes
