### PR TITLE
topic_proxy: 0.1.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6186,6 +6186,10 @@ repositories:
       url: https://github.com/robinJKU/tools_robin.git
       version: hydro-devel
   topic_proxy:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/topic_proxy.git
+      version: master
     release:
       packages:
       - blob
@@ -6193,7 +6197,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/topic_proxy-release.git
-      version: 0.1.0-0
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/topic_proxy.git
+      version: master
+    status: maintained
   turtlebot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_proxy` to `0.1.0-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.0-0`
## blob

```
* blob: fixed serialization from messages to blobs/instantiation from
  blobs to messages
* blob: added member functions to access compressed data or set blob from
  compressed data stream
* blob: serialize an empty blob as empty uncompressed array
* blob: added Blob::serialize() method to serialize objects into blobs
* initial version
```
## topic_proxy

```
* initial version
```
