### PR TITLE
Fixes for gentoo in base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -214,8 +214,8 @@ avrdude:
   arch: [avrdude]
   fedora: [avrdude]
   gentoo:
-  portage:
-    packages: [dev-embedded/avrdude]
+    portage:
+      packages: [dev-embedded/avrdude]
   ubuntu: [avrdude]
 bazaar:
   arch: [bzr]
@@ -578,7 +578,7 @@ freeimage:
   arch: [freeimage]
   debian: [libfreeimage-dev]
   fedora: [freeimage-devel]
-  gentoo: [freeimage]
+  gentoo: [media-libs/freeimage]
   macports: [freeimage]
   rhel: [freeimage-devel]
   ubuntu: [libfreeimage-dev]
@@ -626,7 +626,7 @@ gforth:
   arch: [gforth]
   debian: [gforth]
   fedora: [gforth]
-  gentoo: [gforth]
+  gentoo: [dev-lang/gforth]
   macports: [gforth]
   ubuntu: [gforth]
 gfortran:
@@ -663,7 +663,7 @@ glut:
   arch: [freeglut]
   debian: [freeglut3-dev]
   fedora: [freeglut-devel]
-  gentoo: [freeglut]
+  gentoo: [media-libs/freeglut]
   macports: [freeglut]
   rhel: [freeglut-devel]
   ubuntu: [freeglut3-dev]
@@ -677,7 +677,7 @@ gnuplot:
 google-mock:
   arch: [gmock]
   fedora: [gmock]
-  gentoo: [gmock]
+  gentoo: [dev-cpp/gmock]
   ubuntu: [google-mock]
 gradle:
   arch: [gradle]
@@ -687,7 +687,7 @@ graphicsmagick:
   arch: [graphicsmagick]
   debian: [libgraphicsmagick++1-dev]
   fedora: [GraphicsMagick-c++-devel]
-  gentoo: [imagemagick]
+  gentoo: [media-gfx/imagemagick]
   macports: [GraphicsMagick]
   ubuntu: [libgraphicsmagick++1-dev]
 graphviz:
@@ -833,7 +833,7 @@ jasper:
   arch: [jasper]
   debian: [libjasper-dev]
   fedora: [jasper-devel]
-  gentoo: [jasper]
+  gentoo: [media-libs/jasper]
   macports: [jasper]
   opensuse: [libjasper-devel]
   ubuntu: [libjasper-dev]
@@ -1228,7 +1228,7 @@ libjpeg:
   arch: [libjpeg-turbo]
   debian: [libjpeg8-dev]
   fedora: [libjpeg-turbo-devel]
-  gentoo: [libjpeg-turbo]
+  gentoo: [media-libs/libjpeg-turbo]
   macports: [jpeg]
   opensuse: [libjpeg62-devel]
   ubuntu:
@@ -1393,7 +1393,7 @@ libois-dev:
   ubuntu: [libois-dev]
 libopencv-dev:
   fedora: [opencv-devel]
-  gentoo: [opencv]
+  gentoo: [media-libs/opencv]
   macports: [opencv]
   ubuntu:
     saucy: [libopencv-dev]
@@ -1857,7 +1857,7 @@ libusb:
   arch: [libusb-compat]
   debian: [libusb-0.1-4]
   fedora: [libusb]
-  gentoo: [libusb-compat]
+  gentoo: [dev-libs/libusb-compat]
   macports: [libusb]
   ubuntu: [libusb-0.1-4]
 libusb-1.0:
@@ -1893,7 +1893,7 @@ libv4l-dev:
   arch: [v4l-utils]
   debian: [libv4l-dev]
   fedora: [libv4l-devel]
-  gentoo: [v4l-utils]
+  gentoo: [media-libs/libv4l]
   opensuse: [libv4l-devel]
   ubuntu: [libv4l-dev]
 libvlc:
@@ -1924,7 +1924,7 @@ libx11:
   arch: [libx11]
   debian: [libx11-dev]
   fedora: [libX11]
-  gentoo: [libX11]
+  gentoo: [x11-libs/libX11]
   macports: [xorg-libX11]
   ubuntu: [libx11-dev]
 libx11-dev:
@@ -2048,7 +2048,7 @@ lua-dev:
 lz4:
   debian: [liblz4-dev]
   fedora: [lz4-devel]
-  gentoo: [lz4]
+  gentoo: [app-arch/lz4]
   ubuntu:
     saucy: [liblz4-dev]
     trusty: [liblz4-dev]
@@ -2122,7 +2122,7 @@ netpbm:
   arch: [netpbm]
   debian: [libnetpbm10-dev]
   fedora: [netpbm-devel]
-  gentoo: [netpbm]
+  gentoo: [media-libs/netpbm]
   macports: [netpbm]
   opensuse: [netpbm]
   ubuntu: [libnetpbm10-dev]
@@ -2139,7 +2139,7 @@ nvidia-cg:
   arch: [nvidia-cg-toolkit]
   debian: [nvidia-cg-toolkit]
   fedora: [Cg]
-  gentoo: [nvidia-cg-toolkit]
+  gentoo: [media-gfx/nvidia-cg-toolkit]
   ubuntu: [nvidia-cg-toolkit]
 omniidl:
   debian:
@@ -2223,7 +2223,7 @@ pcre:
   arch: [pcre]
   debian: [libpcre3-dev]
   fedora: [pcre-devel]
-  gentoo: [libpcre]
+  gentoo: [dev-libs/libpcre]
   macports: [pcre]
   rhel: [pcre-devel]
   ubuntu: [libpcre3-dev]
@@ -2282,6 +2282,9 @@ pyqt4-dev-tools:
     portage:
       packages: [dev-python/PyQt4]
   ubuntu: [pyqt4-dev-tools]
+python-opencv:
+  gentoo: [media-libs/opencv]
+  ubuntu: [python-opencv]
 qhull-bin:
   arch: [qhull]
   debian: [qhull-bin]
@@ -2297,7 +2300,7 @@ qt4-qmake:
   arch: [qt4]
   debian: [qt4-qmake]
   fedora: [qt-devel]
-  gentoo: [qt-core]
+  gentoo: [dev-qt/qtcore]
   macports: [qt4-mac]
   opensuse: [libqt4-devel]
   rhel: [qt-devel]
@@ -2389,15 +2392,15 @@ sdl-gfx:
   debian: [libsdl-gfx1.2-dev]
   fedora: [SDL_gfx]
   gentoo:
-  portage:
-    packages: [media-libs/sdl-gfx]
+    portage:
+      packages: [media-libs/sdl-gfx]
   ubuntu: [libsdl-gfx1.2-dev]
 sdl-image:
   arch: [sdl_image]
   debian: [libsdl-image1.2-dev]
   fedora: [SDL_image-devel]
   freebsd: [sdl_image]
-  gentoo: [sdl-image]
+  gentoo: [media-libs/sdl-image]
   macports: [libsdl_image]
   opensuse: [SDL_image]
   ubuntu: [libsdl-image1.2-dev]
@@ -2528,7 +2531,7 @@ tango-icon-theme:
   arch: [tango-icon-theme]
   debian: [tango-icon-theme]
   fedora: [tango-icon-theme]
-  gentoo: [gentoo, x11-themes/tango-icon-theme]
+  gentoo: [x11-themes/tango-icon-theme]
   macports: [tango-icon-theme]
   mandrake: [tango-icon-theme]
   opensuse: [tango-icon-theme]
@@ -2548,7 +2551,7 @@ tbb:
   arch: [intel-tbb]
   debian: [libtbb-dev]
   fedora: [tbb-devel]
-  gentoo: [tbb]
+  gentoo: [dev-cpp/tbb]
   macports: [tbb]
   opensuse: [tbb-devel]
   ubuntu: [libtbb-dev]
@@ -2794,7 +2797,7 @@ yaml:
   arch: [libyaml]
   debian: [libyaml-dev]
   fedora: [libyaml]
-  gentoo: [libyaml]
+  gentoo: [dev-libs/libyaml]
   macports: [libyaml]
   ubuntu: [libyaml-dev]
 yaml-cpp:


### PR DESCRIPTION
fix incorrect indentation in base.yaml (gentoo),
fully-qualified ebuild names for most gentoo dependencies,

add system dependencies:
image_geometry: definition of "python-opencv" for gentoo and ubuntu
cv_bridge: definition of "python-opencv" for gentoo and ubuntu
