### PR TITLE
Add ftdi-eeprom for homebrew

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -96,6 +96,10 @@ freetype:
   osx:
     homebrew:
       packages: [freetype]
+ftdi-eeprom:
+  osx:
+    homebrew:
+      packages: [libftdi0]
 gazebo:
   osx:
     homebrew:


### PR DESCRIPTION
With this installed, the `kobuki_ftdi` package compiles.
