### PR TITLE
industrial_core: 0.3.4-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2411,11 +2411,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-industrial-release/industrial_core-release.git
-      version: 0.3.4-0
+      version: 0.3.4-1
     source:
       type: git
       url: https://github.com/ros-industrial/industrial_core.git
       version: hydro
+    status: maintained
   industrial_metapackages:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_core` to `0.3.4-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.3.4-0`
## industrial_core

```
* Fix #67 <https://github.com/ros-industrial/industrial_core/issues/67>.
```
## industrial_deprecated

```
* No change
```
## industrial_msgs

```
* No change
```
## industrial_robot_client

```
* robot_client: workaround for #46 <https://github.com/shaun-edwards/industrial_core/issues/46>. Fix #67 <https://github.com/shaun-edwards/industrial_core/issues/67>.
  This is an updated version of the workaround committed in 9df46977. Instead
  of requiring dependent packages to invoke the function defined in the
  CFG_EXTRAS cmake snippet, the snippet now sets up the linker path directly.
  Dependent packages now only need to remember to explicitly list their
  dependency on industrial_robot_client and simple_message in their
  add_library(..) statements.
* Contributors: gavanderhoorn
```
## industrial_robot_simulator

```
* No change
```
## industrial_trajectory_filters

```
* No change
```
## industrial_utils

```
* No change
```
## simple_message

```
* robot_client: workaround for #46 <https://github.com/shaun-edwards/industrial_core/issues/46>. Fix #67 <https://github.com/shaun-edwards/industrial_core/issues/67>.
  This is an updated version of the workaround committed in 9df46977. Instead
  of requiring dependent packages to invoke the function defined in the
  CFG_EXTRAS cmake snippet, the snippet now sets up the linker path directly.
  Dependent packages now only need to remember to explicitly list their
  dependency on industrial_robot_client and simple_message in their
  add_library(..) statements.
* Contributors: gavanderhoorn
```
