### PR TITLE
motoman: 0.3.3-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2424,7 +2424,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-industrial-release/industrial_metapackages-release.git
-      version: 0.0.1-1
+      version: 0.0.1-0
     status: developed
   interaction_cursor_3d:
     release:
@@ -3177,11 +3177,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-industrial-release/motoman-release.git
-      version: 0.3.3-0
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/ros-industrial/motoman.git
       version: hydro
+    status: maintained
   moveit_commander:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `motoman` to `0.3.3-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.3.3-0`
## motoman

```
* No changes
```
## motoman_config

```
* No changes
```
## motoman_driver

```
* No changes
```
## motoman_mh5_support

```
* No changes
```
## motoman_sia10d_support

```
* No changes
```
## motoman_sia20d_moveit_config

```
* Path fix for industrial_core/#22 <https://github.com/shaun-edwards/motoman/issues/22> moveit patch
* Contributors: Shaun Edwards
```
## motoman_sia20d_support

```
* No changes
```
## motoman_sia5d_support

```
* sia5d: remove incorrect safety ctrlr tags. Fix #29 <https://github.com/shaun-edwards/motoman/issues/29>.
* Contributors: gavanderhoorn
```
