### PR TITLE
abb: 1.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -13,10 +13,22 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/abb.git
       version: hydro
+    release:
+      packages:
+      - abb
+      - abb_common
+      - abb_moveit_plugins
+      - irb_2400_moveit_config
+      - irb_6640_moveit_config
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-industrial-release/abb-release.git
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/ros-industrial/abb.git
       version: hydro
+    status: developed
   ackermann_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `abb` to `1.1.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## abb

```
* Updated abb packages to Catkin
* Fixed minor issues with MoveIt configurations (updates from groovy to hydro)
* Removed arm navigation
* added metapackage subdirectory
  git-svn-id: https://swri-ros-pkg.googlecode.com/svn/branches/catkin_migration@1411 076cdf4d-ed99-c8c1-5d01-9bc0d27e81bd
* Contributors: Shaun Edwards, jrgnicho
```
## abb_common

```
* Updated package versions to match abb meta-package version, in prep for release
* Manually merged removal of include install and cleaned up CMakelist
* Cleaned up CMakelist comments and spacing
* Contributors: Berend Kupers, JeremyZoss, Joaquín Ignacio Aramendía, Shaun Edwards, gavanderhoorn, gomezc, jrgnicho, shaun-edwards
```
## abb_moveit_plugins

```
* Updated package versions to match abb meta-package version, in prep for release
* moveit_plugins: add install targets. Fix #9 <https://github.com/ros-industrial/abb/issues/9>.
* moveit_plugins: catkin pkgs are not system depends. Fix #15 <https://github.com/ros-industrial/abb/issues/15>.
* moveit_plugins: add install targets. Fix #9 <https://github.com/ros-industrial/abb/issues/9>.
* moveit_plugins: catkin pkgs are not system depends. Fix #15 <https://github.com/ros-industrial/abb/issues/15>.
* Fix issue`#1 <https://github.com/ros-industrial/abb/issues/1>`_ (modified virtual method signatures in order to match new interface)
* Contributors: JeremyZoss, Shaun Edwards, gavanderhoorn, jrgnicho, shaun-edwards
```
## irb_2400_moveit_config

```
* Updated package versions to match abb meta-package version, in prep for release
* 2400_moveit_cfg: match velocity limits with urdf. Fix #19 <https://github.com/ros-industrial/abb/issues/19>.
* moveit_cfgs: add GetPlanningScene capability. Fix #18 <https://github.com/ros-industrial/abb/issues/18>.
* moveit_cfgs: run_depend on industrial_robot_simulator. Fix #16 <https://github.com/ros-industrial/abb/issues/16>.
* 2400_moveit_cfg: match velocity limits with urdf. Fix #19 <https://github.com/ros-industrial/abb/issues/19>.
* moveit_cfgs: add GetPlanningScene capability. Fix #18 <https://github.com/ros-industrial/abb/issues/18>.
* moveit_cfgs: run_depend on industrial_robot_simulator. Fix #16 <https://github.com/ros-industrial/abb/issues/16>.
* add run_depend on moveit_simple_controller_manager
* update moveit_configs to use moveit_simple_controller_manager
* configured moveit package to use IKFast solver
  git-svn-id: https://swri-ros-pkg.googlecode.com/svn/branches/catkin_migration@1408 076cdf4d-ed99-c8c1-5d01-9bc0d27e81bd
* added rosbuild abb stack
  git-svn-id: https://swri-ros-pkg.googlecode.com/svn/branches/catkin_migration@1308 076cdf4d-ed99-c8c1-5d01-9bc0d27e81bd
* updates by latest MoveIt Setup Assistant: no dummy EEF, demo.launch auto-generated
  git-svn-id: https://swri-ros-pkg.googlecode.com/svn/trunk@1240 076cdf4d-ed99-c8c1-5d01-9bc0d27e81bd
* update IRB_2400 URDF to correct invalid tool0 offset.  Update ikfast plugins and SRDF to match.
  git-svn-id: https://swri-ros-pkg.googlecode.com/svn/trunk@1225 076cdf4d-ed99-c8c1-5d01-9bc0d27e81bd
* fix irb_2400_moveit_config URDF paths
  git-svn-id: https://swri-ros-pkg.googlecode.com/svn/trunk@1128 076cdf4d-ed99-c8c1-5d01-9bc0d27e81bd
* Merged moveit_dev branch (required semi-manual merge).  All changes were in the abb stack.  Merge untested.
  git-svn-id: https://swri-ros-pkg.googlecode.com/svn/trunk@1086 076cdf4d-ed99-c8c1-5d01-9bc0d27e81bd
* Contributors: Jeremy Zoss, JeremyZoss, Shaun Edwards, gavanderhoorn, jrgnicho, shaun-edwards
```
## irb_6640_moveit_config

```
* Updated package versions to match abb meta-package version, in prep for release
* Added new files missed in last commit
* Regenerated moveit package for irb 6640
* moveit_cfgs: add GetPlanningScene capability. Fix #18 <https://github.com/ros-industrial/abb/issues/18>.
* moveit_cfgs: run_depend on industrial_robot_simulator. Fix #16 <https://github.com/ros-industrial/abb/issues/16>.
* moveit_cfgs: add GetPlanningScene capability. Fix #18 <https://github.com/ros-industrial/abb/issues/18>.
* moveit_cfgs: run_depend on industrial_robot_simulator. Fix #16 <https://github.com/ros-industrial/abb/issues/16>.
* changed naming link_base into base_link and corrected collision meshes
* Added files for IRB6640
* Contributors: Berend Kupers, Shaun Edwards, gavanderhoorn
```
