### PR TITLE
rtmros_nextage: 0.2.13-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5584,7 +5584,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git
-      version: groovy-devel
+      version: hydro-devel
     release:
       packages:
       - nextage_description
@@ -5598,7 +5598,7 @@ repositories:
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git
-      version: groovy-devel
+      version: hydro-devel
     status: developed
   rtshell_core:
     doc:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5594,7 +5594,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.2.12-0
+      version: 0.2.13-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.2.13-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.2.12-0`
## nextage_description
- No changes
## nextage_moveit_config

```
* Fix #15 <https://github.com/tork-a/rtmros_nextage/issues/15>
* Contributors: Isaac IY Saito
```
## nextage_ros_bridge
- No changes
## rtmros_nextage

```
* Fix #15 <https://github.com/tork-a/rtmros_nextage/issues/15>
* Contributors: Isaac IY Saito
```
