### PR TITLE
ipa_canopen: 0.5.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2493,7 +2493,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/ipa_canopen-release.git
-      version: 0.5.5-0
+      version: 0.5.6-0
     source:
       type: git
       url: https://github.com/ipa320/ipa_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ipa_canopen` to `0.5.6-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.5.5-0`
## ipa_canopen
- No changes
## ipa_canopen_core
- No changes
## ipa_canopen_ros

```
* Error install tags
* Contributors: ipa-cob4-1
```
