### PR TITLE
Update osx-homebrew.yaml

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -96,7 +96,7 @@ freetype:
   osx:
     homebrew:
       packages: [freetype]
-ftdi-eeprom:
+libftdi-dev:
   osx:
     homebrew:
       packages: [libftdi0]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -96,10 +96,6 @@ freetype:
   osx:
     homebrew:
       packages: [freetype]
-libftdi-dev:
-  osx:
-    homebrew:
-      packages: [libftdi0]
 gazebo:
   osx:
     homebrew:
@@ -157,6 +153,10 @@ libflann-dev:
   osx:
     homebrew:
       packages: [flann]
+libftdi-dev:
+  osx:
+    homebrew:
+      packages: [libftdi0]
 libglew-dev:
   osx:
     homebrew:


### PR DESCRIPTION
homebrew package is `libftdi0` should be `libftdi-dev`, not `ftdi-eeprom`. The latter is a separate package, but not yet packaged in homebrew.
