### PR TITLE
p2os: 1.0.10-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4082,6 +4082,10 @@ repositories:
       url: https://git.gitorious.org/orocos-toolchain/orogen.git
       version: toolchain-2.7
   p2os:
+    doc:
+      type: git
+      url: https://github.com/allenh1/p2os-release
+      version: tag
     release:
       packages:
       - p2os_driver
@@ -4091,7 +4095,8 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
-      version: 1.0.9-1
+      version: 1.0.10-0
+    status: maintained
   pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `1.0.10-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.0.9-1`
## p2os_driver
- No changes
## p2os_launch
- No changes
## p2os_teleop

```
* Added issue tracker to package.xml for telop
* Contributors: Hunter Allen
```
## p2os_urdf

```
* Added meshes directory to CMake install dir.
* Removed unneccessary files
* Contributors: Hunter Allen
```
