### PR TITLE
concert_scheduling: 0.7.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -282,6 +282,16 @@ repositories:
       type: git
       url: https://github.com/utexas-bwi/concert_scheduling.git
       version: master
+    release:
+      packages:
+      - concert_resource_pool
+      - concert_scheduler_requests
+      - concert_scheduling
+      - concert_simple_scheduler
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/utexas-bwi-gbp/concert_scheduling-release.git
+      version: 0.7.0-0
     source:
       type: git
       url: https://github.com/utexas-bwi/concert_scheduling.git


### PR DESCRIPTION
Increasing version of package(s) in repository `concert_scheduling` to `0.7.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## concert_resource_pool
- No changes
## concert_scheduler_requests
- No changes
## concert_scheduling
- No changes
## concert_simple_scheduler
- No changes
