### PR TITLE
razer_hydra: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1938,7 +1938,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/razer_hydra-release.git
-      version: 0.0.13-2
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/ros-drivers/razer_hydra.git


### PR DESCRIPTION
Increasing version of package(s) in repository `razer_hydra` to `0.2.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.0.13-2`
## razer_hydra

```
* setting indigo-devel to 0.2.x tags
* Merge branch 'hydro-devel' into indigo-devel
* fix CMake formatting
* Merge branch 'hydro-devel' into indigo-devel
* change ROS_INFO to ROS_DEBUG
  Conflicts:
  src/hydra.cpp
* Merge commit 'fbced1dda9972f3c54ccee8c61dae6993285ed8b' into hydro-devel
* Merge pull request #6 from jhu-lcsr-forks/walltime-fix
  switching driver time to use WallTime to enable using the driver with sim time.
* Merge branch 'cottsay-hydro-devel' into indigo-devel
* fix license tag in package.xml
* switching driver time to use WallTime to enable using the driver with sim time.
* Use "Public Domain" license for razer_hydra
  Source files in the project state that the code is Public Domain
* Contributors: Adam Leeper, Kel Guerin, Scott K Logan, Tully Foote
```
