### PR TITLE
razer_hydra: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4543,7 +4543,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/razer_hydra-release.git
-      version: 0.0.12-2
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/razer_hydra.git
+      version: hydro-devel
     status: maintained
   realtime_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `razer_hydra` to `0.1.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.0.12-2`
## razer_hydra

```
* setting hydro-devel to 0.1.x tags
* update changelog
* fix CMake formatting
* change ROS_INFO to ROS_DEBUG
  Conflicts:
  src/hydra.cpp
* Merge commit 'fbced1dda9972f3c54ccee8c61dae6993285ed8b' into hydro-devel
* fix license tag in package.xml
* switching driver time to use WallTime to enable using the driver with sim time.
* apply catkin_lint
* Use "Public Domain" license for razer_hydra
  Source files in the project state that the code is Public Domain
* 0.0.12
* fixed install target
* udev filename -> hydro
* Contributors: Adam Leeper, David Gossow, Kel Guerin, Scott K Logan, Tully Foote
```
