### PR TITLE
razer_hydra: 0.0.21-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3361,7 +3361,12 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/razer_hydra-release.git
-      version: 0.0.11-0
+      version: 0.0.21-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/razer_hydra.git
+      version: groovy-devel
+    status: maintained
   razor_imu_9dof:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `razer_hydra` to `0.0.21-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.0.11-0`
## razer_hydra

```
* setting groovy-devel tags to increment from 0.0.20
* change ROS_INFO to ROS_DEBUG
  Conflicts:
  src/hydra.cpp
* switching driver time to use WallTime to enable using the driver with sim time.
* prefix targets during build to not collide
* Merge pull request #5 from cottsay/groovy-devel
  Use "Public Domain" license for razer_hydra
* Use "Public Domain" license for razer_hydra
* Contributors: Adam Leeper, Kel Guerin, Scott K Logan, Tully Foote
```
