### PR TITLE
Add doc jobs for object_recognition_msgs

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3697,6 +3697,10 @@ repositories:
       version: master
     status: maintained
   object_recognition_msgs:
+    doc:
+      type: git
+      url: https://github.com/wg-perception/object_recognition_msgs.git
+      version: master
     release:
       tags:
         release: release/hydro/{package}/{version}

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1581,6 +1581,10 @@ repositories:
       version: master
     status: maintained
   object_recognition_msgs:
+    doc:
+      type: git
+      url: https://github.com/wg-perception/object_recognition_msgs.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}


### PR DESCRIPTION
So we actually get nicely rendered messages, and we can click through from moveit_msgs.
