### PR TITLE
Update argos3d_p100 and sentis_tof_m100 for Indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -83,11 +83,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/voxel-dot-at/argos3d_p100_ros_pkg.git
-      version: master
-    source:
-      type: git
-      url: https://github.com/voxel-dot-at/argos3d_p100_ros_pkg.git
-      version: master
+      version: maste
   bfl:
     release:
       tags:
@@ -2619,10 +2615,6 @@ repositories:
     status: developed
   sentis_tof_m100:
     doc:
-      type: git
-      url: https://github.com/voxel-dot-at/sentis_tof_m100_pkg.git
-      version: master
-    source:
       type: git
       url: https://github.com/voxel-dot-at/sentis_tof_m100_pkg.git
       version: master


### PR DESCRIPTION
Removed source tag in indigo/distributions.yaml for packages argos3d_p100 and sentis_tof_m100 as they depend in private driver libraries that can not be distributed (hardware provider depend).
Jenkins build fails.
