### PR TITLE
Update argos3d_p100 and sentis_tof_m100 for Indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -84,10 +84,6 @@ repositories:
       type: git
       url: https://github.com/voxel-dot-at/argos3d_p100_ros_pkg.git
       version: master
-    source:
-      type: git
-      url: https://github.com/voxel-dot-at/argos3d_p100_ros_pkg.git
-      version: master
   bfl:
     release:
       tags:
@@ -2619,10 +2615,6 @@ repositories:
     status: developed
   sentis_tof_m100:
     doc:
-      type: git
-      url: https://github.com/voxel-dot-at/sentis_tof_m100_pkg.git
-      version: master
-    source:
       type: git
       url: https://github.com/voxel-dot-at/sentis_tof_m100_pkg.git
       version: master


### PR DESCRIPTION
Removed source tag for argos3d_p100 and sentis_tof_m100 pakages in indigo as Jenkins build fails. Private driver libraries are missing as they can not be distributed (hardware provider depend).
