### PR TITLE
moveit_visual_tools: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3391,7 +3391,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `1.0.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.0.0-0`
## moveit_visual_tools

```
* Updated README
* Indigo support
* Fix for strict cppcheck and g++ warnings/errors
* Compatibilty fix for Eigen package in ROS Indigo
* Fix uninitialized
* Fix functions with no return statement and other cppcheck errors
* Contributors: Bence Magyar, Dave Coleman, Jordi Pages
```
