### PR TITLE
graph_msgs: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -898,6 +898,21 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ktossell/gps_umd-release.git
       version: 0.1.7-0
+  graph_msgs:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/graph_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/davetcoleman/graph_msgs-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/graph_msgs.git
+      version: master
+    status: maintained
   hokuyo_node:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `graph_msgs` to `0.0.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## graph_msgs

```
* Release to indigo
* Spelling fix
* Contributors: Dave Coleman
```
