### PR TITLE
pal_vision_segmentation: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4128,6 +4128,11 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/pal_vision_segmentation.git
       version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/pal-gbp/pal_vision_segmentation-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/pal-robotics/pal_vision_segmentation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_vision_segmentation` to `0.0.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## pal_vision_segmentation

```
* Cleanup and readme before release
* First catkin version of pal_vision_segmentation
* Contributors: Bence Magyar, Jordi Pages
```
