### PR TITLE
moveit_visual_tools: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1445,6 +1445,21 @@ repositories:
       url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
       version: 0.5.9-0
     status: maintained
+  moveit_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/moveit_visual_tools.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/davetcoleman/moveit_visual_tools-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/moveit_visual_tools.git
+      version: hydro-devel
+    status: developed
   nao_extras:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `1.0.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## moveit_visual_tools

```
* Updated README
* Indigo support
* Fix for strict cppcheck and g++ warnings/errors
* Compatibilty fix for Eigen package in ROS Indigo
* Fix uninitialized
* Fix functions with no return statement and other cppcheck errors
* Contributors: Bence Magyar, Dave Coleman, Jordi Pages
```
