### PR TITLE
jsk_visualization: 1.0.4-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1948,13 +1948,15 @@ repositories:
       version: master
     release:
       packages:
+      - jsk_interactive
       - jsk_interactive_marker
+      - jsk_interactive_test
       - jsk_rqt_plugins
       - jsk_rviz_plugins
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.4-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.0.3-0`
## jsk_interactive

```
* jsk_interactive: catkinize
* Contributors: Kei Okada
```
## jsk_interactive_marker

```
* jsk_interactive_marker: fix for rosbuild, add mk/rosbuild to package.xml
* add "execute the plan" and "force to replan" mouse menu to footstep_marker
* add bounding_box_marker to select jsk_pcl_ros/BoundingBoxArray
* Contributors: Kei Okada, Ryohei Ueda
```
## jsk_interactive_test

```
* jsk_interactive_test: catkinize pckage
* Contributors: Kei Okada
```
## jsk_rqt_plugins

```
* jsk_rqt_plugins: add mk/rosbuild to build_depend
* jsk_rqt_plugins) install missing .ui file
* Contributors: Isaac IY Saito, Kei Okada
```
## jsk_rviz_plugins

```
* jsk_rviz_plugins: use depend tag add mk/rosbuild to build_depend
* update the initial parameter of FootstepDisplay
* add line width property to BoundingBoxArrayDisplay
* add new plugin: BoundingBoxArray for jsk_pcl_ros/BoundingBoxArray
* Contributors: Kei Okada, Ryohei Ueda
```
