### PR TITLE
rospilot_deps: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2541,6 +2541,17 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: indigo-devel
     status: maintained
+  rospilot_deps:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rospilot/rospilot_deps-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/rospilot/rospilot_deps.git
+      version: tag
+    status: developed
   rqt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot_deps` to `0.0.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## rospilot_deps

```
* Allow changing camera device path while cam node is running
* Improve error handling in raw_usb_cam_node
  Print an error message and retry, instead of exiting the process
* Fix compiler error
* Remove self_test dependency
* Initial commit
* Contributors: Christopher Berner
```
