### PR TITLE
hector_localization: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1953,7 +1953,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
-      version: 0.1.1-1
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/hector_localization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_localization` to `0.1.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.1-1`
## hector_localization
- No changes
## hector_pose_estimation
- No changes
## hector_pose_estimation_core

```
* added cmake_modules dependency for the Eigen cmake config
* Contributors: Johannes Meyer
```
## message_to_tf

```
* Add parameter for optionally not publishing roll/pitch to tf
* Don´t publish roll/pitch (to be parametrized soon)
* Contributors: Stefan Kohlbrecher, hector1
```
## world_magnetic_model

```
* fixed "format not a string literal and no format arguments" security error
* Contributors: Johannes Meyer
```
