### PR TITLE
Adding rosR with 32bit and 64bit support to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2245,6 +2245,16 @@ repositories:
       url: https://github.com/ros/ros.git
       version: indigo-devel
     status: maintained
+  rosR:
+    doc:
+      type: svn
+      url: http://svn.code.sf.net/p/ivs-ros-pkg/code/trunk/rosR
+      version: HEAD
+  rosR_demos:
+    doc:
+      type: svn
+      url: http://svn.code.sf.net/p/ivs-ros-pkg/code/trunk/rosR_demos
+      version: HEAD
   ros_comm:
     doc:
       type: git


### PR DESCRIPTION
rosR now runs on 32bit as well as on 64bit systems as well as on indigo 
