### PR TITLE
catkin: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -187,7 +187,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.6.5-0
+      version: 0.6.6-0
     status: maintained
   class_loader:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.6.6-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.6.5-0`
## catkin

```
* fix rollback of environment when workspace has been deleted (#641 <https://github.com/ros/catkin/issues/641>)
* fix argument handling when cm / cmi is invoked in a symlinked folder (#638 <https://github.com/ros/catkin/issues/638>)
```
