### PR TITLE
(hironx_tutorial) Fix wrong versions

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2098,7 +2098,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/tork-a/hironx_tutorial.git
-      version: tag
+      version: master
     release:
       tags:
         release: release/hydro/{package}/{version}
@@ -2107,7 +2107,7 @@ repositories:
     source:
       type: git
       url: https://github.com/tork-a/hironx_tutorial.git
-      version: tag
+      version: master
     status: maintained
   hlugv_common:
     doc:


### PR DESCRIPTION
Pointed out [here](https://github.com/ros/rosdistro/commit/47d91a86dee93f627741b6806b82f34133f8cebb#commitcomment-6529916). I'm sorry for the wrong version.

I just don't have an idea where this got messed like this. I'm even comparing the [track.yml](https://github.com/tork-a/hironx_tutorial-release/blob/ce911e0044e4987ee857fd8d8ecbe243f4f5030a/tracks.yaml) that was used with that of another package I maintain that seems to be released successfully (eg. [this](https://github.com/tork-a/rtmros_nextage-release/blob/ae6eeda016322908bab84762c638c6667ad8b5d1/tracks.yaml)) but I don't see any wrongdoers.
