### PR TITLE
rqt_common_plugins: 0.3.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2615,7 +2615,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.3.5-1
+      version: 0.3.6-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `0.3.6-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.3.5-1`
## rqt_action
- No changes
## rqt_bag

```
* fix closing and reopening topic views
* use queue_size for Python publishers
```
## rqt_bag_plugins
- No changes
## rqt_common_plugins
- No changes
## rqt_console
- No changes
## rqt_dep
- No changes
## rqt_graph
- No changes
## rqt_image_view
- No changes
## rqt_launch
- No changes
## rqt_logger_level
- No changes
## rqt_msg
- No changes
## rqt_plot

```
* subscribe to any known topic, even if currently not available (#233 <https://github.com/ros-visualization/rqt_common_plugins/pull/233>)
```
## rqt_publisher

```
* use queue_size for Python publishers
```
## rqt_py_common
- No changes
## rqt_py_console
- No changes
## rqt_reconfigure

```
* remove unnecessary margins to improve usability on small screens (#228 <https://github.com/ros-visualization/rqt_common_plugins/issues/228>)
```
## rqt_service_caller
- No changes
## rqt_shell
- No changes
## rqt_srv
- No changes
## rqt_top
- No changes
## rqt_topic
- No changes
## rqt_web
- No changes
