### PR TITLE
rqt_robot_plugins: 0.3.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2637,7 +2637,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-      version: 0.3.4-1
+      version: 0.3.5-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins` to `0.3.5-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.3.4-1`
## rqt_moveit
- No changes
## rqt_nav_view

```
* use queue_size for Python publishers
```
## rqt_pose_view
- No changes
## rqt_robot_dashboard
- No changes
## rqt_robot_monitor
- No changes
## rqt_robot_plugins
- No changes
## rqt_robot_steering

```
* use queue_size for Python publishers
```
## rqt_runtime_monitor
- No changes
## rqt_rviz

```
* fix compilation on OS X (#64 <https://github.com/ros-visualization/rqt_robot_plugins/issues/64>)
```
## rqt_tf_tree
- No changes
