### PR TITLE
gfortran was removed from homebrew, but now is in the ros tap

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -107,7 +107,7 @@ gccxml:
 gfortran:
   osx:
     homebrew:
-      packages: [gcc]
+      packages: [gfortran]
 git:
   osx:
     homebrew:


### PR DESCRIPTION
After discussing this with upstream (homebrew/homebrew) we will be including a copy of the gfortran formula with our ros tap. We discussed this on the rosdep issue tracker: https://github.com/ros-infrastructure/rosdep/issues/328

So this pull request will basically be reverting this pull request: https://github.com/ros/rosdistro/pull/4443

@NikolausDemmel
