### PR TITLE
rospy_message_converter: 0.3.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2552,6 +2552,13 @@ repositories:
       url: https://github.com/rospilot/rospilot_deps.git
       version: tag
     status: developed
+  rospy_message_converter:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/jihoonl/rospy_message_converter-release.git
+      version: 0.3.0-1
+    status: maintained
   rqt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospy_message_converter` to `0.3.0-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## rospy_message_converter
- No changes
