### PR TITLE
catkin: 0.5.87-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -527,7 +527,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.5.86-0
+      version: 0.5.87-0
     status: maintained
   clasp:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.5.87-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.5.86-0`
## catkin

```
* add error message for circular dependencies in catkin_make_isolated and catkin_topological_order (#607 <https://github.com/ros/catkin/issues/607>, #608 <https://github.com/ros/catkin/issues/608>)
* add workspace marker file for catkin_make / catkin_make_isolated (#304 <https://github.com/ros/catkin/issues/304>)
* allow better performance for repeated invocations of find_in_workspaces()
* consider test_depends for topolocial order (#612 <https://github.com/ros/catkin/issues/612>)
* support setting ${PROJECT_NAME}_LIBRARIES before invoking catkin_package() (#609 <https://github.com/ros/catkin/issues/609>)
* fixes:

    * fix rollback of environment when workspace has been deleted (#641 <https://github.com/ros/catkin/issues/641>)
    * fix argument handling when cm / cmi is invoked in a symlinked folder (#638 <https://github.com/ros/catkin/issues/638>)
    * fix catkin_find to not return path with '/.' suffix (#621 <https://github.com/ros/catkin/issues/621>)
    * fix python path setting for plain cmake workspaces (#618 <https://github.com/ros/catkin/issues/618>)
    * replace CMake usage of IMPORTED_IMPLIB with IMPORTED_LOCATION (#616 <https://github.com/ros/catkin/issues/616>)
    * do not call chpwd hooks in setup.zsh (#613 <https://github.com/ros/catkin/issues/613>)
    * set catkin_* variables only when find_package(catkin COMPONENTS ...) (#629 <https://github.com/ros/catkin/issues/629>)
    * remove invalid symbolic links of workspace level CMakeLists.txt file (#591 <https://github.com/ros/catkin/issues/591>)
    * fix gtest include dir when using gtest inside the workspace (#585 <https://github.com/ros/catkin/issues/585>)

```
