### PR TITLE
genpy: 0.4.17-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1674,7 +1674,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.4.16-0
+      version: 0.4.17-0
     source:
       type: git
       url: https://github.com/ros/genpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.4.17-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.4.16-0`
## genpy

```
* make TVal more similar to generated messages for introspection (ros/std_msgs#6 <https://github.com/ros/std_msgs/issues/6>)
* resolve message classes from dry packages (ros/ros_comm#293 <https://github.com/ros/ros_comm/issues/293>, #28 <https://github.com/ros/genpy/issues/28>)
```
