### PR TITLE
ros_comm: 1.10.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4968,7 +4968,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.10.2-0
+      version: 1.10.3-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.10.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.10.2-0`
## message_filters
- No changes
## ros_comm
- No changes
## rosbag
- No changes
## rosbag_storage
- No changes
## rosconsole
- No changes
## roscpp

```
* add AsyncSpinner::canStart() to check if a spinner can be started
```
## rosgraph
- No changes
## rosgraph_msgs
- No changes
## roslaunch
- No changes
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy

```
* improve asynchonous publishing performance (#373 <https://github.com/ros/ros_comm/issues/373>)
* allow custom error handlers for services (#375 <https://github.com/ros/ros_comm/issues/375>)
```
## rosservice
- No changes
## rostest
- No changes
## rostopic
- No changes
## roswtf
- No changes
## std_srvs
- No changes
## topic_tools
- No changes
## xmlrpcpp

```
* fix day comparison for rpc value of type timestamp (#395 <https://github.com/ros/ros_comm/issues/395>)
```
