### PR TITLE
industrial_metapackages: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2436,7 +2436,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-industrial-release/industrial_metapackages-release.git
-      version: 0.0.1-1
+      version: 0.0.2-0
     status: developed
   interaction_cursor_3d:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_metapackages` to `0.0.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.0.1-1`
## industrial_desktop

```
* Added ABB package, updated issues link
* Contributors: Shaun Edwards
```
