### PR TITLE
rospilot: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2541,6 +2541,17 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: indigo-devel
     status: maintained
+  rospilot:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rospilot/rospilot-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/rospilot/rospilot.git
+      version: tag
+    status: developed
   rospilot_deps:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot` to `0.0.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## rospilot

```
* Initial release of rospilot
* Contributors: Christopher Berner, bordicon, cberner
```
