### PR TITLE
moveit_python: 0.2.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3328,7 +3328,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/mikeferguson/moveit_python-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/mikeferguson/moveit_python.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_python` to `0.2.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.2.3-0`
## moveit_python

```
* add list and remove object scripts, closes #2 <https://github.com/mikeferguson/moveit_python/issues/2>
* properly initialize planning scene interface, fixes #1 <https://github.com/mikeferguson/moveit_python/issues/1>
* add planner_id logic to move group interface
* remove default support name
* fix comment on result type
* add missing import
* upstream the retry logic
* Contributors: Michael Ferguson
```
