### PR TITLE
pocketsphinx: 0.3.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4275,7 +4275,8 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/pocketsphinx-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
+    status: maintained
   pointgrey_camera_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pocketsphinx` to `0.3.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.3.0-0`
## pocketsphinx

```
* add ~source parameter, for setting things like 'alsasrc'
* add depend on python-gst
* Contributors: Michael Ferguson
```
