### PR TITLE
pocketsphinx: 0.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1907,7 +1907,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/pocketsphinx-release.git
-      version: 0.3.0-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/mikeferguson/pocketsphinx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pocketsphinx` to `0.4.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.3.0-0`
## pocketsphinx

```
* add ~source parameter, for setting things like 'alsasrc'
* add depend on python-gst
* Contributors: Michael Ferguson
```
