### PR TITLE
metapackages: 1.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1323,7 +1323,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/metapackages-release.git
-      version: 1.1.1-0
+      version: 1.1.2-0
     status: maintained
   microstrain_3dmgx2_imu:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `metapackages` to `1.1.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.1.1-0`
