### PR TITLE
ardrone_autonomy: 1.3.4-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -117,7 +117,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/AutonomyLab/ardrone_autonomy-release.git
-      version: 1.3.3-1
+      version: 1.3.4-0
     source:
       type: git
       url: https://github.com/AutonomyLab/ardrone_autonomy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ardrone_autonomy` to `1.3.4-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.3.3-1`
## ardrone_autonomy

```
* Decreased the frequency of magnetometer warning message
* Fixed some warnings to address #104 <https://github.com/AutonomyLab/ardrone_autonomy/issues/104>
* Contributors: Mani Monajjemi
```
