### PR TITLE
geometry: 1.10.8-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1735,7 +1735,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/geometry-release.git
-      version: 1.10.8-0
+      version: 1.10.8-1
     source:
       type: git
       url: https://github.com/ros/geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry` to `1.10.8-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.10.8-0`
## eigen_conversions
- No changes
## geometry
- No changes
## kdl_conversions
- No changes
## tf

```
* Port groovy-devel patch to hydro-devel
* Added rosconsole as catkin dependency for catkin_package
* Add rosconsole as runtime dependency
* Contributors: Michael Ferguson, Mirza Shah
```
## tf_conversions

```
* add missing runtime dependency on python_orocos_kdl for the pyKDL
* Contributors: Tully Foote
```
