### PR TITLE
filters: 1.7.4-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1523,11 +1523,15 @@ repositories:
       version: 0.2.9-1
     status: maintained
   filters:
+    doc:
+      type: git
+      url: https://github.com/ros/filters.git
+      version: hydro-devel
     release:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/filters-release.git
-      version: 1.7.4-0
+      version: 1.7.4-2
     source:
       type: git
       url: https://github.com/ros/filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `1.7.4-2`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.7.4-0`
