### PR TITLE
laser_filters: 1.7.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1154,7 +1154,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/laser_filters-release.git
-      version: 1.7.0-0
+      version: 1.7.1-0
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `1.7.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.7.0-0`
## laser_filters

```
* Tests expect NaN for invalid ranges
* Modify intensity, scan shadow, and range filters to set invalid values to NaN
* Contributors: Allison Tse, Jonathan Binney
```
