### PR TITLE
Add gazebo dep for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -598,6 +598,7 @@ gawk:
   ubuntu: [gawk]
 gazebo:
   arch: [gazebo]
+  fedora: [gazebo-devel]
   ubuntu:
     precise: [gazebo]
     quantal: [gazebo]


### PR DESCRIPTION
This package isn't quite in Fedora quite yet, but it will be very soon [1]. In any case, it shouldn't hurt to add it a bit early...it helps not to have to use a separate fork of `rosdistro` for testing.

Thanks,

--scott

[1] https://bugzilla.redhat.com/show_bug.cgi?id=825409
