### PR TITLE
grasping_msgs: 0.3.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1831,6 +1831,17 @@ repositories:
       url: https://github.com/davetcoleman/graph_msgs.git
       version: master
     status: developed
+  grasping_msgs:
+    doc:
+      type: git
+      url: https://github.com/unboundedrobotics/grasping_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/unboundedrobotics-gbp/grasping_msgs-gbp.git
+      version: 0.3.0-0
+    status: developed
   grizzly:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grasping_msgs` to `0.3.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## grasping_msgs

```
* prepare public release
* Contributors: Michael Ferguson
```
