### PR TITLE
grasping_msgs: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -915,6 +915,17 @@ repositories:
       url: https://github.com/davetcoleman/graph_msgs.git
       version: master
     status: maintained
+  grasping_msgs:
+    doc:
+      type: git
+      url: https://github.com/unboundedrobotics/grasping_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/unboundedrobotics-gbp/grasping_msgs-gbp.git
+      version: 0.3.0-0
+    status: developed
   hokuyo_node:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grasping_msgs` to `0.3.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## grasping_msgs

```
* prepare public release
* Contributors: Michael Ferguson
```
