### PR TITLE
abb: 1.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -23,7 +23,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-industrial-release/abb-release.git
-      version: 1.1.1-0
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/ros-industrial/abb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `abb` to `1.1.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.1.1-0`
## abb

```
* No changes
```
## abb_common

```
* No changes
```
## abb_moveit_plugins

```
* Merge pull request #36 <https://github.com/ros-industrial/abb/issues/36> from cottsay/moveit_plugins_dep
  moveit_plugins: add depend on tf_conversions
* Contributors: Scott K Logan, Shaun Edwards
```
## irb_2400_moveit_config

```
* No changes
```
## irb_6640_moveit_config

```
* No changes
```
