### PR TITLE
keyboard: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2714,6 +2714,21 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git
       version: master
     status: developed
+  keyboard:
+    doc:
+      type: git
+      url: https://github.com/lrse/ros-keyboard.git
+      version: 0.1.1
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/lrse-ros-release/keyboard-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/lrse/ros-keyboard.git
+      version: master
+    status: maintained
   kinect_aux:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `keyboard` to `0.1.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## keyboard

```
* README
* stuff
* fix for hydro
* switched from ncurses to SDL
* constants from ncurses
* initial commit
* Contributors: v01d
```
