### PR TITLE
universal_teleop: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6595,6 +6595,21 @@ repositories:
       url: https://github.com/ros-industrial/universal_robot.git
       version: hydro-devel
     status: developed
+  universal_teleop:
+    doc:
+      type: git
+      url: https://github.com/lrse/ros-universal-teleop.git
+      version: 0.1.0
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/lrse-ros-release/universal_teleop-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/lrse/ros-universal-teleop.git
+      version: master
+    status: maintained
   uos_slam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_teleop` to `0.1.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## universal_teleop

```
* launch files
* tidy up for release
* added axis scaling; robot now stops after override is released
* launch files for ardrone; changes for ardrone(_autonomy); changed defaults
* fix for hydro
* first version
* Contributors: v01d
```
