### PR TITLE
rosjava_bootstrap: 0.1.21-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5303,7 +5303,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_bootstrap-release.git
-      version: 0.1.20-1
+      version: 0.1.21-0
     source:
       type: git
       url: https://github.com/rosjava/rosjava_bootstrap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_bootstrap` to `0.1.21-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.20-1`
## rosjava_bootstrap

```
* Android gradle plugin 0.9.+->0.11.+ (studio 0.6)
* Android sdk build tools 19.0.3 -> 19.1 (studio 0.6)
* Contributors: Daniel Stonier
```
