### PR TITLE
Moving interactive_marker_proxy to official RWT repo

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1716,13 +1716,6 @@ repositories:
         release: release/groovy/{package}/{version}
       url: https://github.com/aleeper/interaction_cursor_3d-release.git
       version: 0.0.1-0
-  interactive_marker_proxy:
-    release:
-      tags:
-        release: release/{package}/{upstream_version}
-      url: https://github.com/ros-gbp/interactive_marker_proxy-release.git
-      version: 0.1.1-0
-    status: maintained
   interactive_marker_twist_server:
     release:
       tags:


### PR DESCRIPTION
Moving interactive_marker_proxy to https://github.com/RobotWebTools-release/interactive_marker_proxy-release. Will re-run bloom once merged.
