### PR TITLE
interactive_marker_proxy-release: 0.1.2-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1716,6 +1716,23 @@ repositories:
         release: release/groovy/{package}/{version}
       url: https://github.com/aleeper/interaction_cursor_3d-release.git
       version: 0.0.1-0
+  interactive_marker_proxy-release:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/interactive_marker_proxy.git
+      version: develop
+    release:
+      packages:
+      - interactive_marker_proxy
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/RobotWebTools-release/interactive_marker_proxy-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/interactive_marker_proxy.git
+      version: develop
+    status: maintained
   interactive_marker_twist_server:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_marker_proxy-release` to `0.1.2-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## interactive_marker_proxy

```
* cleanup
* Contributors: Russell Toris
```
