### PR TITLE
Moving interactive_marker_proxy to official RWT repo

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2465,10 +2465,6 @@ repositories:
       url: https://github.com/aleeper/interaction_cursor_3d.git
       version: 0.0.3
     status: developed
-  interactive_marker_proxy:
-    release:
-      url: https://github.com/ros-gbp/interactive_marker_proxy-release.git
-    status: maintained
   interactive_marker_twist_server:
     doc:
       type: git


### PR DESCRIPTION
interactive_marker_proxy being moved to RWT release repo (https://github.com/RobotWebTools-release/interactive_marker_proxy-release) -- will re-run bloom once removed.
