### PR TITLE
robot_upstart: 0.0.6-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2119,6 +2119,21 @@ repositories:
       url: https://github.com/ros-gbp/robot_state_publisher-release.git
       version: 1.10.2-0
     status: maintained
+  robot_upstart:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/robot_upstart.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/robot_upstart-release.git
+      version: 0.0.6-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/robot_upstart.git
+      version: indigo-devel
+    status: maintained
   rocon:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart` to `0.0.6-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## robot_upstart

```
* Add capability to also generate amalgamated descriptions, similar to launch files.
* Update package.xml
* Contributors: Mike Purvis
```
