### PR TITLE
jsk_common: 1.0.27-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1822,7 +1822,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.26-1
+      version: 1.0.27-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.27-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.0.26-1`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## collada_urdf_jsk_patch
- No changes
## depth_image_proc_jsk_patch
- No changes
## downward
- No changes
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha
- No changes
## image_view2

```
* publish the mouse position to movepoint topic during mouse move event
* Contributors: Ryohei Ueda
```
## image_view_jsk_patch
- No changes
## jsk_common
- No changes
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_tools
- No changes
## jsk_topic_tools

```
* add nodelet to relay topic
* Contributors: Ryohei Ueda
```
## laser_filters_jsk_patch
- No changes
## libsiftfast
- No changes
## multi_map_server
- No changes
## openni_tracker_jsk_patch
- No changes
## opt_camera
- No changes
## posedetection_msgs
- No changes
## pr2_groovy_patches
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## sklearn

```
* refactor return type
* Contributors: Yuto Inagaki
```
## stereo_synchronizer
- No changes
