### PR TITLE
navigation: 1.11.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1557,7 +1557,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.11.8-0
+      version: 1.11.9-0
     source:
       type: git
       url: https://github.com/ros-planning/navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.11.9-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.11.8-0`
## amcl
- No changes
## base_local_planner

```
* uses ::hypot(x, y) instead of sqrt(x*x, y*y)
* No need to use limits->
* Contributors: Enrique Fernández Perdomo
```
## carrot_planner
- No changes
## clear_costmap_recovery
- No changes
## costmap_2d

```
* fix hypot issues, add comments to tests from tracking this down
* dynamically reconfigure the previously uninitialised variable 'combination_method', closes #187 <https://github.com/ros-planning/navigation/issues/187>.
* uses ::hypot(x, y) instead of sqrt(x*x, y*y)
* Contributors: Daniel Stonier, Michael Ferguson, Enrique Fernández Perdomo
```
## dwa_local_planner
- No changes
## fake_localization
- No changes
## global_planner

```
* uses ::hypot(x, y) instead of sqrt(x*x, y*y)
* Contributors: Enrique Fernández Perdomo
```
## map_server
- No changes
## move_base

```
* uses ::hypot(x, y) instead of sqrt(x*x, y*y)
* Contributors: Enrique Fernández Perdomo
```
## move_base_msgs
- No changes
## move_slow_and_clear
- No changes
## nav_core
- No changes
## navfn

```
* uses ::hypot(x, y) instead of sqrt(x*x, y*y)
* Contributors: Enrique Fernández Perdomo
```
## navigation
- No changes
## robot_pose_ekf

```
* fix robot_pose_ekf test
* Contributors: Michael Ferguson
```
## rotate_recovery
- No changes
## voxel_grid
- No changes
