### PR TITLE
pandaboard-middleware: 0.0.0-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2950,6 +2950,23 @@ repositories:
         release: release/groovy/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
       version: 1.0.9-0
+  pandaboard-middleware:
+    doc:
+      type: git
+      url: https://github.com/zentai/pandaboard-middleware-release.git
+      version: tag
+    release:
+      packages:
+      - intf
+      - robot
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/zentai/pandaboard-middleware-release.git
+      version: 0.0.0-0
+    source:
+      type: git
+      url: https://github.com/zentai/pandaboard-middleware-release.git
+      version: tag
   pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pandaboard-middleware` to `0.0.0-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
