### PR TITLE
python_ethernet_rmp: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1952,6 +1952,21 @@ repositories:
       url: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
       version: 1.8.0-0
     status: maintained
+  python_ethernet_rmp:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/python_ethernet_rmp.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/python_ethernet_rmp-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/python_ethernet_rmp.git
+      version: develop
+    status: maintained
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_ethernet_rmp` to `0.0.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## python_ethernet_rmp

```
* cleanup
* travis and cleanup
* Merge pull request #4 from cmdunkers/develop
  Fixed Authors
* Fixed Authros
* Merge pull request #3 from cmdunkers/develop
  basic cleanup completed
* cleanup
* basic cleanup
* Changed minor things
* Merge pull request #1 from cmdunkers/develop
  Added and modified the Segway communication code to fit our needs
* worked on modifying rmp_config_params so the dynamic varibales are the ones read in
* Made it so there is only feedback received when TX is called
* added and modified the provided segway example
* Initial commit
* Contributors: Chris Dunkers, Russell Toris
```
