### PR TITLE
jsk_roseus: 1.1.19-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2687,7 +2687,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.18-0
+      version: 1.1.19-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.19-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.1.18-0`
## euslisp

```
* c274553 (Euslisp : models/*-robot.l, models/*-object.l) : Update  sensor access ; do not overwrite :cameras method in each robot file,  remove unused :cameras method from object files discussed in euslisp/jskeus/pull/92
* 3378b05 (Euslisp : load-irt-all-objects.l) Add dewalt-drill and unknown-side-table to conversion list at euslib's r62547 commit
* 5e77f0e (Euslisp : models/hitachi-fiesta-refrigerator-object.l, models/patra-robot.l, models/room73b2-hitachi-fiesta-refrigerator-object.l) Update rbrain converted models
* 1564d0a (jskeus : irtrobot.l, robot-model-usage.l, sample-robot-model.l) Add sensor accessosr and test codes discussed in euslisp/jskeus/pull/72 and jsk-ros-pkg/jsk_model_tools/issues/18
* 9996bf0 (Euslisp : primt.l) Henry Baker's contribution of 2013 July
* aca5c68 (jskeus : README.md) Update README.md
* Contributors: Henry Baker, Shunichi Nozawa, Kei Okada
```
## geneus
- No changes
## jsk_roseus
- No changes
## roseus

```
* (#112,#113) fix service persist without keyward
  ros::service-call (name value &optional (persist nil))
* Contributors: Kei Okada, Ryohei Ueda
```
## roseus_msgs
- No changes
## roseus_smach
- No changes
