### PR TITLE
rosdep rule: change gfortran on osx/homebrew gcc

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -107,7 +107,7 @@ gccxml:
 gfortran:
   osx:
     homebrew:
-      packages: [gfortran]
+      packages: [gcc]
 git:
   osx:
     homebrew:


### PR DESCRIPTION
After recent changes to the homebrew-provided gcc formula to make all binaries version-suffixed, but retain an additional suffix-less gfortran binary we can rely on this formula again and do not need to maintain our own gfortran formula.

This reverts #4607; see also https://github.com/ros-infrastructure/rosdep/issues/328#issuecomment-45648207

Again, people might have to manually `brew uninstall gfortran`.

@wjwwood, @colincsl
