### PR TITLE
rosserial: 0.5.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5535,11 +5535,17 @@ repositories:
       - rosserial_msgs
       - rosserial_python
       - rosserial_server
+      - rosserial_windows
       - rosserial_xbee
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rosserial-release.git
-      version: 0.5.5-0
+      version: 0.5.6-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/rosserial.git
+      version: hydro-devel
+    status: maintained
   rovio:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial` to `0.5.6-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.5.5-0`
## rosserial
- No changes
## rosserial_arduino

```
* Add Mike Purvis as maintainer
* Updated examples for Arduino 1.+
* Added Teensy 3.1 support (MK20DX256)
* Updated ArduinoHardware.h to add Teensy 3.0 support
* Contributors: Michael Ferguson, Mike Purvis, Moju Zhao, Tony Baltovski, kjanesch
```
## rosserial_client

```
* Add Mike Purvis as maintainer
* make tf topic absolute instead of relative to prevent remapping with <group> tag
* fix: msg id serialization
* fix: wrong message lenght, if message size more than 255
* fix odometry deserialization error http://answers.ros.org/question/73807/rosserial-deserialization-error/
* add better debugging information when packages are missing dependencies
* remove ID_TX_STOP from rosserial_msgs/msg/TopicInfo.msg, using hardcode modification.
* fix the dupilcated registration problem of subscriber
* Contributors: Michael Ferguson, Mike Purvis, Moju Zhao, agentx3r, denis
```
## rosserial_embeddedlinux

```
* Add Mike Purvis as maintainer to all but xbee.
* Contributors: Mike Purvis
```
## rosserial_msgs

```
* Add Mike Purvis as maintainer to all but xbee.
* remove ID_TX_STOP from rosserial_msgs/msg/TopicInfo.msg, using hardcode modification. fix the dupilcated registration problem of subscriber
* modified rosserial
* Contributors: Mike Purvis, Moju Zhao
```
## rosserial_python

```
* Add Mike Purvis as maintainer to all but xbee.
* Added the missing inWaiting() to RosSerialServer
* improvement: inform user of mismatched checksum for topic_id and msg
* Fix indent on if-block.
* Check for data in buffer before attempting to tryRead. Insert a 1ms sleep to avoid pegging the processor.
* Better warning message for tryRead.
* fix two points: 1. the number of bytes to read for chk_byte, 2. the wrong indentation about the defination of sendDiagnostics()
* Try-block to handle IOErrors thrown from tryRead
* Merge from hydro-devel.
* fix the dupilcated registration problem of subscriber
* remove ID_TX_STOP from rosserial_msgs/msg/TopicInfo.msg, using hardcode modification. fix the dupilcated registration problem of subscriber
* modified rosserial
* modified rosserial
* Contributors: Girts Linde, Mike Purvis, Moju Zhao, bakui, denis
```
## rosserial_server

```
* Fixed build error due to variable being read as a function due to missing parenthesis
* Add rosserial_python as dependency of rosserial_server
* Contributors: Mike Purvis, spaghetti-
```
## rosserial_windows

```
* first created by Kareem Shehata
```
## rosserial_xbee
- No changes
