### PR TITLE
Release rosserial 0.6.0 for indigo.

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2652,6 +2652,31 @@ repositories:
       url: https://github.com/baalexander/rospy_message_converter.git
       version: indigo-devel
     status: maintained
+  rosserial:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/rosserial.git
+      version: indigo-devel
+    release:
+      packages:
+      - rosserial
+      - rosserial_arduino
+      - rosserial_client
+      - rosserial_embeddedlinux
+      - rosserial_msgs
+      - rosserial_python
+      - rosserial_server
+      - rosserial_windows
+      - rosserial_xbee
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rosserial-release.git
+      version: 0.6.0-2
+    source:
+      type: git
+      url: https://github.com/ros-drivers/rosserial.git
+      version: indigo-devel
+    status: maintained
   rqt:
     doc:
       type: git


### PR DESCRIPTION
Had to create this manually as bloom was having some issues with it. Looks like it may have been trying to use the same branch name as for the hydro release.

```
Open a pull request from 'rosdistro/rosdistro:bloom-rosserial-0' into 'ros/rosdistro:master'?
Continue [Y/n]?
==> git checkout -b bloom-rosserial-0
Switched to a new branch 'bloom-rosserial-0'
==> Pulling latest rosdistro branch
remote: Counting objects: 38854, done.
remote: Compressing objects: 100% (23478/23478), done.
remote: Total 38854 (delta 21894), reused 29326 (delta 15356)
Receiving objects: 100% (38854/38854), 6.29 MiB | 2.01 MiB/s, done.
Resolving deltas: 100% (21894/21894), done.
From https://github.com/ros/rosdistro
 * branch            master     -> FETCH_HEAD
==> Writing new distribution file: indigo/distribution.yaml
==> git add indigo/distribution.yaml
==> git commit -m "rosserial: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]"
[bloom-rosserial-0 db2519f] rosserial: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]
 1 file changed, 25 insertions(+)
==> Pushing changes to fork
To https://177c3c97be053d6ad8765f053b64fd7082f70c3f:x-oauth-basic@github.com/mikepurvis/rosdistro.git
 ! [rejected]        bloom-rosserial-0 -> bloom-rosserial-0 (fetch first)
error: failed to push some refs to 'https://177c3c97be053d6ad8765f053b64fd7082f70c3f:x-oauth-basic@github.com/mikepurvis/rosdistro.git'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Failed to open pull request: CalledProcessError - Command 'git push https://177c3c97be053d6ad8765f053b64fd7082f70c3f:x-oauth-basic@github.com/mikepurvis/rosdistro.git bloom-rosserial-0' returned non-zero exit status 1
```
