### PR TITLE
rosjava_build_tools: 0.1.34-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5335,7 +5335,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_build_tools-release.git
-      version: 0.1.33-0
+      version: 0.1.34-0
     source:
       type: git
       url: https://github.com/rosjava/rosjava_build_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_build_tools` to `0.1.34-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.33-0`
## rosjava_build_tools

```
* assist rospack to speedup by ignoring the installed maven directories.
```
