### PR TITLE
control_toolbox: 1.12.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -343,7 +343,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/control_toolbox-release.git
-      version: 1.11.0-1
+      version: 1.12.1-0
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `1.12.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.11.0-1`
## control_toolbox

```
* Remove broken test code. Hotfix for #18 <https://github.com/ros-controls/control_toolbox/issues/18>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
