### PR TITLE
epos_driver-released: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1456,6 +1456,15 @@ repositories:
       url: https://github.com/clearpathrobotics/enu.git
       version: hydro
     status: maintained
+  epos_driver-released:
+    release:
+      packages:
+      - epos_driver
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/tkucner/epos_driver-released.git
+      version: 0.0.1-0
+    status: developed
   erratic_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `epos_driver-released` to `0.0.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## epos_driver

```
* first public release for Hydro
```
