### PR TITLE
interactive_marker_proxy: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2481,6 +2481,21 @@ repositories:
       url: https://github.com/aleeper/interaction_cursor_3d.git
       version: hydro-devel
     status: developed
+  interactive_marker_proxy:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/interactive_marker_proxy.git
+      version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/RobotWebTools-release/interactive_marker_proxy-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/interactive_marker_proxy.git
+      version: develop
+    status: maintained
   interactive_marker_twist_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_marker_proxy` to `0.1.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## interactive_marker_proxy

```
* cleanup
* Contributors: Russell Toris
```
