### PR TITLE
Adding cob_environment_perception to documentation index for hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -678,6 +678,15 @@ repositories:
       url: https://github.com/ipa320/cob_driver.git
       version: hydro_dev
     status: developed
+  cob_environment_perception:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_environment_perception.git
+      version: hydro_dev
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_environment_perception.git
+      version: hydro_dev
   cob_environments:
     doc:
       type: git


### PR DESCRIPTION
I'd like cob_environment_perception to be indexed and documented on ros.org.
