### PR TITLE
log4cpp: 2.7.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3115,7 +3115,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/log4cpp-release.git
-      version: 2.7.0-0
+      version: 2.7.0-1
     source:
       type: git
       url: https://git.gitorious.org/orocos-toolchain/log4cpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `log4cpp` to `2.7.0-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `2.7.0-0`
## log4cpp

```
* catkin: added run_depend from catkin to package.xml for released packages
  Signed-off-by: Johannes Meyer <mailto:johannes@intermodalics.eu>
* cmake: added install rule for package.xml
  Signed-off-by: Johannes Meyer <mailto:meyer@fsr.tu-darmstadt.de>
* catkin: add export tag for plain cmake packages
  Signed-off-by: Ruben Smits <mailto:ruben.smits@intermodalics.eu>
* cmake: use cmake_current_binary dir instead of cmake_binary_dir
  Signed-off-by: Ruben Smits <mailto:ruben.smits@intermodalics.eu>
```
