### PR TITLE
rtt_typelib: 2.7.0-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5880,7 +5880,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_typelib-release.git
-      version: 2.7.0-1
+      version: 2.7.0-2
     source:
       type: git
       url: https://git.gitorious.org/orocos-toolchain/rtt_typelib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_typelib` to `2.7.0-2`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `2.7.0-1`
## rtt_typelib

```
* catkin: added run_depend on catkin to package.xml for released packages
  Signed-off-by: Johannes Meyer <mailto:johannes@intermodalics.eu>
* Merge remote-tracking branch 'orocos/master'
* cmake: add NO_ROS_PACKAGE statement since UseOrocos.cmake gets confused in a plain cmake catkin build
  Signed-off-by: Ruben Smits <mailto:ruben@intermodalics.eu>
* catkin: provide catkin compatible package.xml file
  Signed-off-by: Ruben Smits <mailto:ruben.smits@intermodalics.eu>
* cmake: remove ROS specific build instructions and educate the user.
  Signed-off-by: Peter Soetens <mailto:peter@thesourceworks.com>
```
