### PR TITLE
typelib: 2.7.0-5 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6568,7 +6568,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/typelib-release.git
-      version: 2.7.0-4
+      version: 2.7.0-5
     source:
       type: git
       url: https://git.gitorious.org/orocos-toolchain/typelib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `typelib` to `2.7.0-5`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `2.7.0-4`
## typelib

```
* catkin: added run_depend on catkin to package.xml for released packages
  Signed-off-by: Johannes Meyer <mailto:johannes@intermodalics.eu>
* make typelib work on Mac OSX system
  Signed-off-by: Ruben Smits <mailto:ruben.smits@mech.kuleuven.be>
  Conflicts:
  bindings/ruby/CMakeLists.txt
* cmake: add support for x84_64 OSX systems
  Signed-off-by: Ruben Smits <mailto:ruben@intermodalics.eu>
  Conflicts:
  bindings/ruby/CMakeLists.txt
* Make it compile on osx
* fix lib extension for macosx
  Signed-off-by: Ruben Smits <mailto:ruben.smits@mech.kuleuven.be>
* catkin: provide catkin compatible package.xml file
  Signed-off-by: Ruben Smits <mailto:ruben.smits@intermodalics.eu>
```
