### PR TITLE
utilmm: 2.7.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6760,7 +6760,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/utilmm-release.git
-      version: 2.7.0-0
+      version: 2.7.0-1
     source:
       type: git
       url: https://git.gitorious.org/orocos-toolchain/utilmm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `utilmm` to `2.7.0-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `2.7.0-0`
## utilmm

```
* catkin: added run_depend on catkin to package.xml for released packages
  Signed-off-by: Johannes Meyer <mailto:johannes@intermodalics.eu>
* catkin: provide catkin compatible package.xml file
  Signed-off-by: Ruben Smits <mailto:ruben.smits@intermodalics.eu>
```
