### PR TITLE
utilrb: 2.7.0-3 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6770,7 +6770,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/utilrb-release.git
-      version: 2.7.0-2
+      version: 2.7.0-3
     source:
       type: git
       url: https://git.gitorious.org/orocos-toolchain/utilrb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `utilrb` to `2.7.0-3`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `2.7.0-2`
## utilrb

```
* catkin: added run_depend on catkin to package.xml for released packages
  Signed-off-by: Johannes Meyer <mailto:johannes@intermodalics.eu>
* adding minimum cmake version
* catkin: add CMakeLists.txt that installs utilrb and add package.xml to make it buildable with catkin
  Signed-off-by: Ruben Smits <mailto:ruben.smits@mech.kuleuven.be>
* remove the use of hosted gems
  Signed-off-by: Ruben Smits <mailto:ruben.smits@mech.kuleuven.be>
* add ruby extension extension lookup to also support OSX
  Signed-off-by: Ruben Smits <mailto:ruben.smits@mech.kuleuven.be>
```
