### PR TITLE
rospy_message_converter: 0.3.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2699,6 +2699,11 @@ repositories:
       type: git
       url: https://github.com/baalexander/rospy_message_converter.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/jihoonl/rospy_message_converter-release.git
+      version: 0.3.0-2
     source:
       type: git
       url: https://github.com/baalexander/rospy_message_converter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospy_message_converter` to `0.3.0-2`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## rospy_message_converter
- No changes
