### PR TITLE
rospilot_deps: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2688,7 +2688,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rospilot/rospilot_deps-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/rospilot/rospilot_deps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot_deps` to `0.0.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.0.2-0`
## rospilot_deps

```
* Include source for pymavlink
* Contributors: Christopher Berner
```
