### PR TITLE
sba: 1.7.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2856,6 +2856,12 @@ repositories:
       url: https://github.com/ros-visualization/rviz_fixed_view_controller.git
       version: indigo-devel
     status: developed
+  sba:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/sba-release.git
+      version: 1.7.0-0
   sentis_tof_m100:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sba` to `1.7.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## sba

```
* First release in a long, long, long time
* Contributors: Jon Binney, Michael Ferguson
```
