### PR TITLE
open_karto: 1.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1820,6 +1820,17 @@ repositories:
       url: https://github.com/ros-gbp/ompl-release.git
       version: 0.14.2002850-0
     status: maintained
+  open_karto:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/open_karto.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/open_karto-release.git
+      version: 1.1.0-0
+    status: maintained
   open_street_map:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_karto` to `1.1.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## open_karto

```
* Release as a pure catkin ROS package
```
