### PR TITLE
sparse_bundle_adjustment: 1.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2930,6 +2930,13 @@ repositories:
       url: https://github.com/ros-perception/slam_gmapping.git
       version: hydro-devel
     status: maintained
+  sparse_bundle_adjustment:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
+      version: 1.6.1-0
+    status: maintained
   sql_database:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sparse_bundle_adjustment` to `1.6.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## sparse_bundle_adjustment

```
* Release sba as a ROS package (for slam_karto)
* Contributors: Jon Binney, Michael Ferguson
```
