### PR TITLE
slam_gmapping: 1.3.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2935,7 +2935,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/slam_gmapping-release.git
-      version: 1.3.2-0
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/ros-perception/slam_gmapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_gmapping` to `1.3.2-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.3.2-0`
