### PR TITLE
slam_karto: 0.7.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2941,6 +2941,17 @@ repositories:
       url: https://github.com/ros-perception/slam_gmapping.git
       version: hydro-devel
     status: maintained
+  slam_karto:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/slam_karto.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/slam_karto-release.git
+      version: 0.7.0-0
+    status: maintained
   sparse_bundle_adjustment:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_karto` to `0.7.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## slam_karto

```
* First release in a very, very long time.
* Catkinized, updated to work with catkinized open_karto and sba
* Contributors: Jon Binney, Michael Ferguson
```
