### PR TITLE
slam_gmapping: 1.3.2-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6174,7 +6174,8 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/slam_gmapping-release.git
-      version: 1.3.2-0
+      version: 1.3.2-1
+    status: maintained
   sql_database:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_gmapping` to `1.3.2-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.3.2-0`
