### PR TITLE
remove sparse_bundle_adjustment

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2952,13 +2952,6 @@ repositories:
       url: https://github.com/ros-gbp/slam_karto-release.git
       version: 0.7.0-0
     status: maintained
-  sparse_bundle_adjustment:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
-      version: 1.6.1-0
-    status: maintained
   sql_database:
     release:
       tags:


### PR DESCRIPTION
I just released this, but realized it's totally whacked out. Looks like the farm hasn't reconfigured to build it yet? if so, can we safely pull it?
