### PR TITLE
sparse_bundle_adjustment: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2952,6 +2952,13 @@ repositories:
       url: https://github.com/ros-gbp/slam_karto-release.git
       version: 0.7.0-0
     status: maintained
+  sparse_bundle_adjustment:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
+      version: 0.3.0-0
+    status: maintained
   sql_database:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sparse_bundle_adjustment` to `0.3.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## sparse_bundle_adjustment

```
* import cleaned up sba (this is the version from wg)
* Contributors: Michael Ferguson
```
