### PR TITLE
dynamic_reconfigure: 1.5.37-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1164,7 +1164,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.5.36-0
+      version: 1.5.37-0
     source:
       type: git
       url: https://github.com/ros/dynamic_reconfigure.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.5.37-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.5.36-0`
## dynamic_reconfigure

```
* Decode level of ParamDescription
* Added testsuite
* Avoid collisions with parameter names (#6 <https://github.com/ros/dynamic_reconfigure/issues/6>)
* Contributors: Esteve Fernandez, pgorczak
```
