### PR TITLE
nodelet_core: 1.9.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1695,7 +1695,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.8.3-1
+      version: 1.9.0-0
     source:
       type: git
       url: https://github.com/ros/nodelet_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.8.3-1`
## nodelet

```
* Fix initialization error handling (#13 <https://github.com/ros/nodelet_core/issues/13>)
* Contributors: Esteve Fernandez
```
## nodelet_core
- No changes
## nodelet_topic_tools
- No changes
