### PR TITLE
nodelet_core: 1.8.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3763,7 +3763,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.8.2-0
+      version: 1.8.4-0
     source:
       type: git
       url: https://github.com/ros/nodelet_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.8.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.8.2-0`
## nodelet

```
* Unload nodelets if they fail to initialize
  Fixes #13 <https://github.com/ros/nodelet_core/issues/13>
```
## nodelet_core
- No changes
## nodelet_topic_tools
- No changes
