### PR TITLE
catkin: 0.6.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -187,7 +187,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.6.6-0
+      version: 0.6.7-0
     status: maintained
   class_loader:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.6.7-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.6.6-0`
## catkin

```
* reset CATKIN_SHELL in devel space generated env.sh files (#652 <https://github.com/ros/catkin/issues/652>, #655 <https://github.com/ros/catkin/issues/655>)
* ignore cd path echo when using CDPATH (#654 <https://github.com/ros/catkin/issues/654>)
* use PYTHON_EXECUTABLE for _setup_util.py (#646 <https://github.com/ros/catkin/issues/646>)
* expose PYTHON_EXECUTABLE to environment hook .em templates (#645 <https://github.com/ros/catkin/issues/645>)
* catkin_prepare_release:

    * add --no-push to catkin_prepare_release (#657 <https://github.com/ros/catkin/issues/657>)
    * flush stdin before asking for input (#658 <https://github.com/ros/catkin/issues/658>)

```
