### PR TITLE
catkin: 0.5.88-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -527,7 +527,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.5.86-0
+      version: 0.5.88-0
     status: maintained
   clasp:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.5.88-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.5.86-0`
## catkin

```
* reset CATKIN_SHELL in devel space generated env.sh files (#652 <https://github.com/ros/catkin/issues/652>, #655 <https://github.com/ros/catkin/issues/655>)
* ignore cd path echo when using CDPATH (#654 <https://github.com/ros/catkin/issues/654>)
* expose PYTHON_EXECUTABLE to environment hook .em templates (#645 <https://github.com/ros/catkin/issues/645>)
```
