### PR TITLE
hokuyo_node: 1.7.8-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2164,7 +2164,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/hokuyo_node-release.git
-      version: 1.7.8-0
+      version: 1.7.8-1
     status: maintained
   household_objects_database:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hokuyo_node` to `1.7.8-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.7.8-0`
## hokuyo_node

```
* Merge pull request #8 <https://github.com/ros-drivers/hokuyo_node/issues/8> from trainman419/hydro-devel
  Use rosconsole to set logger levels. Fixes #7 <https://github.com/ros-drivers/hokuyo_node/issues/7>
* Use rosconsole to set logger levels. Fixes #7 <https://github.com/ros-drivers/hokuyo_node/issues/7>
* Added changelog
* Contributors: Chad Rockey, chadrockey, trainman419
```
