### PR TITLE
driver_common: 1.6.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1151,7 +1151,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/driver_common-release.git
-      version: 1.6.7-0
+      version: 1.6.8-0
     status: end-of-life
     status_description: Will be released only as long as required for PR2 drivers
       (hokuyo_node, wge100_driver)


### PR DESCRIPTION
Increasing version of package(s) in repository `driver_common` to `1.6.8-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.6.7-0`
## driver_base
- No changes
## driver_common
- No changes
## timestamp_tools
- No changes
