### PR TITLE
driver_common: 1.6.8-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -420,7 +420,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/driver_common-release.git
-      version: 1.6.8-1
+      version: 1.6.8-2
     source:
       type: git
       url: https://github.com/ros-drivers/driver_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `driver_common` to `1.6.8-2`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.6.8-1`
## driver_base
- No changes
## driver_common
- No changes
## timestamp_tools
- No changes
