### PR TITLE
microstrain_3dmgx2_imu: 1.5.12-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1417,7 +1417,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/microstrain_3dmgx2_imu-release.git
-      version: 1.5.12-0
+      version: 1.5.12-2
     source:
       type: git
       url: https://github.com/ros-drivers/microstrain_3dmgx2_imu.git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_3dmgx2_imu` to `1.5.12-2`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.5.12-0`
## microstrain_3dmgx2_imu

```
* Added dependency on log4cxx.
* Contributors: Chad Rockey
```
