### PR TITLE
sicktoolbox: 1.0.103-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2922,7 +2922,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/sicktoolbox-release.git
-      version: 1.0.103-0
+      version: 1.0.103-2
     source:
       type: git
       url: https://github.com/ros-drivers/sicktoolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sicktoolbox` to `1.0.103-2`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.0.103-0`
