### PR TITLE
sicktoolbox: 1.0.103-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6155,7 +6155,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/sicktoolbox-release.git
-      version: 1.0.103-0
+      version: 1.0.103-2
     status: maintained
   sicktoolbox_wrapper:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `sicktoolbox` to `1.0.103-2`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.0.103-0`
