### PR TITLE
depthimage_to_laserscan: 1.0.6-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1108,7 +1108,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/depthimage_to_laserscan-release.git
-      version: 1.0.6-0
+      version: 1.0.6-1
     status: maintained
   diagnostics:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `depthimage_to_laserscan` to `1.0.6-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.0.6-0`
## depthimage_to_laserscan

```
* Removed y component from projected beam radius.
```
