### PR TITLE
depthimage_to_laserscan: 1.0.6-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -378,7 +378,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/depthimage_to_laserscan-release.git
-      version: 1.0.6-0
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/ros-perception/depthimage_to_laserscan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthimage_to_laserscan` to `1.0.6-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.0.6-0`
## depthimage_to_laserscan

```
* Removed y component from projected beam radius.
```
