### PR TITLE
sicktoolbox_wrapper: 2.5.3-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6166,7 +6166,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/sicktoolbox_wrapper-release.git
-      version: 2.5.3-0
+      version: 2.5.3-1
     status: maintained
   skeleton_markers:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `sicktoolbox_wrapper` to `2.5.3-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `2.5.3-0`
