### PR TITLE
sicktoolbox_wrapper: 2.5.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2937,7 +2937,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/sicktoolbox_wrapper-release.git
-      version: 2.5.3-0
+      version: 2.5.3-1
     source:
       type: git
       url: https://github.com/ros-drivers/sicktoolbox_wrapper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sicktoolbox_wrapper` to `2.5.3-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `2.5.3-0`
