### PR TITLE
urg_node: 0.1.7-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6754,7 +6754,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/urg_node-release.git
-      version: 0.1.7-0
+      version: 0.1.7-1
     source:
       type: git
       url: https://github.com/ros-drivers/urg_node.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node` to `0.1.7-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.7-0`
## urg_node

```
* Added more robust plug/unplug reconnect behavior.
* Added more robustness and the ability to continually reloop and reconnect until node is shutdown.
* Fix initialization crash.
* Install fix for Android.
* Missed a willowgarage email.
* Contributors: Chad Rockey
```
