### PR TITLE
laser_proc: 0.1.3-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2997,7 +2997,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/laser_proc-release.git
-      version: 0.1.3-0
+      version: 0.1.3-1
     status: maintained
   leap_motion:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_proc` to `0.1.3-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.3-0`
