### PR TITLE
laser_proc: 0.1.4-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1257,7 +1257,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/laser_proc-release.git
-      version: 0.1.4-0
+      version: 0.1.4-1
     source:
       type: git
       url: https://github.com/ros-perception/laser_proc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_proc` to `0.1.4-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.4-0`
## laser_proc

```
* Install fix for Android.
* Contributors: Chad Rockey
```
