### PR TITLE
imu_pipeline: 0.1.2-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2429,7 +2429,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/imu_pipeline-release.git
-      version: 0.1.2-0
+      version: 0.1.2-1
     status: maintained
   imu_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_pipeline` to `0.1.2-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.2-0`
