### PR TITLE
imu_pipeline: 0.1.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1071,7 +1071,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/imu_pipeline-release.git
-      version: 0.1.3-0
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/ros-perception/imu_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_pipeline` to `0.1.3-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.3-0`
## imu_pipeline
- No changes
