### PR TITLE
urg_node: 0.1.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3168,7 +3168,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/urg_node-release.git
-      version: 0.1.7-1
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/ros-drivers/urg_node.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node` to `0.1.8-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.7-1`
## urg_node

```
* Merge pull request #6 <https://github.com/ros-drivers/urg_node/issues/6> from mikeferguson/indigo-devel
  Add default device status on UST-20LX
* Add default device status on UST-20LX
* Contributors: Chad Rockey, Michael Ferguson
```
