### PR TITLE
depthimage_to_laserscan: 1.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -378,7 +378,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/depthimage_to_laserscan-release.git
-      version: 1.0.6-1
+      version: 1.0.7-0
     source:
       type: git
       url: https://github.com/ros-perception/depthimage_to_laserscan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthimage_to_laserscan` to `1.0.7-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.0.6-1`
## depthimage_to_laserscan

```
* Merge pull request #11 <https://github.com/ros-perception/depthimage_to_laserscan/issues/11> from ros-perception/hydro-devel
  Update indigo devel with angle fix
* Merge pull request #8 <https://github.com/ros-perception/depthimage_to_laserscan/issues/8> from vliedel/hydro-devel
  fixed angle_increment
* fixed angle_increment
* Merge pull request #7 <https://github.com/ros-perception/depthimage_to_laserscan/issues/7> from bulwahn/hydro-devel
  check for CATKIN_ENABLE_TESTING
* check for CATKIN_ENABLE_TESTING
* Added ARCHIVE DESTINATION
* Contributors: Chad Rockey, Lukas Bulwahn, vliedel
```
