### PR TITLE
depthimage_to_laserscan: 1.0.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1108,7 +1108,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/depthimage_to_laserscan-release.git
-      version: 1.0.6-2
+      version: 1.0.7-0
     status: maintained
   diagnostics:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `depthimage_to_laserscan` to `1.0.7-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.0.6-2`
## depthimage_to_laserscan

```
* Merge pull request #11 <https://github.com/ros-perception/depthimage_to_laserscan/issues/11> from ros-perception/hydro-devel
  Update indigo devel with angle fix
* Merge pull request #8 <https://github.com/ros-perception/depthimage_to_laserscan/issues/8> from vliedel/hydro-devel
  fixed angle_increment
* fixed angle_increment
* Merge pull request #7 <https://github.com/ros-perception/depthimage_to_laserscan/issues/7> from bulwahn/hydro-devel
  check for CATKIN_ENABLE_TESTING
* check for CATKIN_ENABLE_TESTING
* Added ARCHIVE DESTINATION
* Contributors: Chad Rockey, Lukas Bulwahn, vliedel
```
