### PR TITLE
openslam_gmapping: 0.1.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1933,7 +1933,8 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/openslam_gmapping-release.git
-      version: 0.1.0-0
+      version: 0.1.0-1
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openslam_gmapping` to `0.1.0-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.0-0`
## openslam_gmapping

```
* Forked from https://openslam.informatik.uni-freiburg.de/data/svn/gmapping/trunk/
* Catkinized and prepared for release into the ROS ecosystem
```
