### PR TITLE
yujin_maps: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3334,10 +3334,16 @@ repositories:
       type: git
       url: https://github.com/yujinrobot/yujin_maps.git
       version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/yujin_maps-release.git
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/yujinrobot/yujin_maps.git
       version: master
+    status: maintained
   zeroconf_avahi_suite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yujin_maps` to `0.2.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `null`
## yujin_maps

```
* clearing legacy maps #3 <https://github.com/yujinrobot/yujin_maps/issues/3>
* Merge pull request #2 <https://github.com/yujinrobot/yujin_maps/issues/2> from kentsommer/master
  Added yujin_inno_room
* Add missing catkin_package macro
* cleaning up cmake
* adding author
* Contributors: Jihoon Lee, Jorge Santos, kentsommer
```
