### PR TITLE
openslam_gmapping: 0.1.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1933,7 +1933,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/openslam_gmapping-release.git
-      version: 0.1.0-1
+      version: 0.1.0-2
     status: maintained
   orocos_kinematics_dynamics:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `openslam_gmapping` to `0.1.0-2`:
- upstream repository: https://github.com/ros-perception/openslam_gmapping
- release repository: https://github.com/ros-gbp/openslam_gmapping-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11-dev`
- previous version for package: `0.1.0-1`
## openslam_gmapping

```
* Forked from https://openslam.informatik.uni-freiburg.de/data/svn/gmapping/trunk/
* Catkinized and prepared for release into the ROS ecosystem
```
