### PR TITLE
openslam_gmapping: 0.1.0-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4199,7 +4199,8 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/openslam_gmapping-release.git
-      version: 0.1.0-1
+      version: 0.1.0-2
+    status: maintained
   optris_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openslam_gmapping` to `0.1.0-2`:
- upstream repository: https://github.com/ros-perception/openslam_gmapping
- release repository: https://github.com/ros-gbp/openslam_gmapping-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11-dev`
- previous version for package: `0.1.0-1`
## openslam_gmapping

```
* Forked from https://openslam.informatik.uni-freiburg.de/data/svn/gmapping/trunk/
* Catkinized and prepared for release into the ROS ecosystem
```
