### PR TITLE
Updated source and doc uris for orocos_toolchain repos

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3137,8 +3137,9 @@ repositories:
       version: 2.7.0-1
     source:
       type: git
-      url: https://git.gitorious.org/orocos-toolchain/log4cpp.git
+      url: https://github.com/orocos-toolchain/log4cpp.git
       version: toolchain-2.7
+    status: maintained
   manipulation_msgs:
     release:
       tags:
@@ -3904,7 +3905,7 @@ repositories:
   ocl:
     doc:
       type: git
-      url: https://git.gitorious.org/orocos-toolchain/ocl.git
+      url: https://github.com/orocos-toolchain/ocl.git
       version: toolchain-2.7
     release:
       tags:
@@ -3913,9 +3914,9 @@ repositories:
       version: 2.7.0-5
     source:
       type: git
-      url: https://git.gitorious.org/orocos-toolchain/ocl.git
+      url: https://github.com/orocos-toolchain/ocl.git
       version: toolchain-2.7
-    status: developed
+    status: maintained
   octomap:
     doc:
       type: git
@@ -4236,8 +4237,9 @@ repositories:
       version: 2.7.0-4
     source:
       type: git
-      url: https://git.gitorious.org/orocos-toolchain/orogen.git
+      url: https://github.com/orocos-toolchain/orogen.git
       version: toolchain-2.7
+    status: maintained
   p2os:
     release:
       packages:
@@ -5831,7 +5833,7 @@ repositories:
   rtt:
     doc:
       type: git
-      url: https://git.gitorious.org/orocos-toolchain/rtt.git
+      url: https://github.com/orocos-toolchain/rtt.git
       version: toolchain-2.7
     release:
       tags:
@@ -5840,9 +5842,9 @@ repositories:
       version: 2.7.0-9
     source:
       type: git
-      url: https://git.gitorious.org/orocos-toolchain/rtt.git
+      url: https://github.com/orocos-toolchain/rtt.git
       version: toolchain-2.7
-    status: developed
+    status: maintained
   rtt_geometry:
     doc:
       type: git
@@ -5913,8 +5915,9 @@ repositories:
       version: 2.7.0-2
     source:
       type: git
-      url: https://git.gitorious.org/orocos-toolchain/rtt_typelib.git
+      url: https://github.com/orocos-toolchain/rtt_typelib.git
       version: toolchain-2.7
+    status: maintained
   rviz:
     doc:
       type: git
@@ -6602,8 +6605,9 @@ repositories:
       version: 2.7.0-5
     source:
       type: git
-      url: https://git.gitorious.org/orocos-toolchain/typelib.git
+      url: https://github.com/orocos-toolchain/typelib.git
       version: toolchain-2.7
+    status: maintained
   ublox:
     doc:
       type: git
@@ -6794,8 +6798,9 @@ repositories:
       version: 2.7.0-1
     source:
       type: git
-      url: https://git.gitorious.org/orocos-toolchain/utilmm.git
+      url: https://github.com/orocos-toolchain/utilmm.git
       version: toolchain-2.7
+    status: maintained
   utilrb:
     release:
       tags:
@@ -6804,8 +6809,9 @@ repositories:
       version: 2.7.0-3
     source:
       type: git
-      url: https://git.gitorious.org/orocos-toolchain/utilrb.git
+      url: https://github.com/orocos-toolchain/utilrb.git
       version: toolchain-2.7
+    status: maintained
   uwsim_bullet:
     release:
       tags:


### PR DESCRIPTION
Moved from Gitorious to GitHub.
