### PR TITLE
epos_driver-released: 0.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1476,7 +1476,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tkucner/epos_driver-released.git
-      version: 0.0.3-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/tkucner/epos_driver-released.git


### PR DESCRIPTION
Increasing version of package(s) in repository `epos_driver-released` to `0.0.5-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.3-0`
