### PR TITLE
sparse_bundle_adjustment: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2989,7 +2989,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     status: maintained
   sql_database:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `sparse_bundle_adjustment` to `0.3.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.3.0-0`
## sparse_bundle_adjustment

```
* add depend on eigen
* Contributors: Michael Ferguson
```
