### PR TITLE
revert #4768, use OpencV ROS package for Ubuntu < Saucy

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1400,9 +1400,6 @@ libopencv-dev:
   gentoo: [media-libs/opencv]
   macports: [opencv]
   ubuntu:
-    lucid: [libopencv-dev]
-    precise: [libopencv-dev]
-    quantal: [libopencv-dev]
     saucy: [libopencv-dev]
     trusty: [libopencv-dev]
 libopenni-dev:


### PR DESCRIPTION
#4763 is invalid

```
 use OpencV ROS package for Ubuntu < Saucy
```
