### PR TITLE
slam_karto: 0.7.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2982,7 +2982,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/slam_karto-release.git
-      version: 0.7.0-0
+      version: 0.7.1-0
     status: maintained
   sparse_bundle_adjustment:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_karto` to `0.7.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.7.0-0`
## slam_karto

```
* build updates for sba, fix install
* Contributors: Michael Ferguson
```
