### PR TITLE
rtt_ros_integration: 2.7.0-3 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5884,20 +5884,20 @@ repositories:
       - rtt_actionlib_msgs
       - rtt_common_msgs
       - rtt_diagnostic_msgs
+      - rtt_dynamic_reconfigure
       - rtt_geometry_msgs
       - rtt_kdl_conversions
       - rtt_nav_msgs
       - rtt_ros
       - rtt_ros_comm
       - rtt_ros_integration
-      - rtt_ros_tests
+      - rtt_ros_msgs
       - rtt_rosclock
       - rtt_roscomm
-      - rtt_roscomm_tests
+      - rtt_rosdeployment
       - rtt_rosgraph_msgs
       - rtt_rosnode
       - rtt_rospack
-      - rtt_rospack_tests
       - rtt_rosparam
       - rtt_sensor_msgs
       - rtt_shape_msgs
@@ -5910,7 +5910,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_ros_integration-release.git
-      version: 2.7.0-2
+      version: 2.7.0-3
     source:
       type: git
       url: https://github.com/orocos/rtt_ros_integration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_ros_integration` to `2.7.0-3`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `2.7.0-2`
