### PR TITLE
add pysdf to index

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4612,6 +4612,12 @@ repositories:
       url: https://github.com/ros-drivers-gbp/prosilica_gige_sdk-release.git
       version: 1.26.2-0
     status: maintained
+  pysdf:
+    doc:
+      type: git
+      url: https://github.com/andreasBihlmaier/pysdf.git
+      version: master
+    status: developed
   python_qt_binding:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2059,6 +2059,12 @@ repositories:
       url: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
       version: 1.8.0-0
     status: maintained
+  pysdf:
+    doc:
+      type: git
+      url: https://github.com/andreasBihlmaier/pysdf.git
+      version: master
+    status: developed
   python_ethernet_rmp:
     doc:
       type: git


### PR DESCRIPTION
Python library to parse SDF and represent it as class hierarchy. Also supports conversion into URDF.

This is also the basis of a complete rewrite of gazebo2rviz (see branch pysdf: https://github.com/andreasBihlmaier/gazebo2rviz/tree/pysdf)
