### PR TITLE
bride: 0.3.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -112,6 +112,23 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: master
     status: maintained
+  bride:
+    release:
+      packages:
+      - bride
+      - bride_compilers
+      - bride_plugin_source
+      - bride_templates
+      - bride_tutorials
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/bride-release.git
+      version: 0.3.3-0
+    source:
+      type: git
+      url: https://github.com/ipa320/bride.git
+      version: develop
+    status: developed
   calibration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bride` to `0.3.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
