### PR TITLE
multisense_ros: 1.0.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3588,7 +3588,7 @@ repositories:
   multisense_ros:
     doc:
       type: hg
-      url: https://hsu@bitbucket.org/osrf/multisense_ros
+      url: https://bitbucket.org/osrf/multisense_ros
       version: 1.0.0
     release:
       packages:
@@ -3604,7 +3604,7 @@ repositories:
       version: 1.0.0-0
     source:
       type: hg
-      url: https://hsu@bitbucket.org/osrf/multisense_ros
+      url: https://bitbucket.org/osrf/multisense_ros
       version: default
     status: developed
   nao_extras:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3585,6 +3585,28 @@ repositories:
       url: https://github.com/fkie/multimaster_fkie.git
       version: hydro-devel
     status: maintained
+  multisense_ros:
+    doc:
+      type: hg
+      url: https://hsu@bitbucket.org/osrf/multisense_ros
+      version: 1.0.0
+    release:
+      packages:
+      - multisense
+      - multisense_bringup
+      - multisense_cal_check
+      - multisense_description
+      - multisense_lib
+      - multisense_ros
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
+      version: 1.0.0-0
+    source:
+      type: hg
+      url: https://hsu@bitbucket.org/osrf/multisense_ros
+      version: default
+    status: developed
   nao_extras:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `multisense_ros` to `1.0.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
