### PR TITLE
mavros: 0.5.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3200,6 +3200,11 @@ repositories:
       type: git
       url: https://github.com/vooon/mavros.git
       version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/vooon/mavros-release.git
+      version: 0.5.0-0
     source:
       type: git
       url: https://github.com/vooon/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.5.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## mavros

```
* Remove mavlink submodule and move it to package dependency
  Bloom release tool don't support git submodules,
  so i've ceate a package as described in http://wiki.ros.org/bloom/Tutorials/ReleaseThirdParty .
  Fix #35 <https://github.com/vooon/mavros/issues/35>.
* plugins: param: add missing gcc 4.6 fix.
* plugins: fix const initializers for gcc 4.6
* plugins: imu_pub: fix const initializers for gcc 4.6
  Fix for build failure devel-hydro-mavros #4 <https://github.com/vooon/mavros/issues/4>.
* Add support for GCC 4.6 (C++0x, ubuntu 12.04)
  I don't use complete c++11, so we could switch to c++0x if it supported.
* plugins: rc_io: Add override rcin service
  Fix: #22 <https://github.com/vooon/mavros/issues/22>.
* plugins: sys_status: fix timeouts
  Fix #26 <https://github.com/vooon/mavros/issues/26>.
* plugins: sys_status: add set stream rate service
  Some additional testing required.
  Fix #23 <https://github.com/vooon/mavros/issues/23>.
* Remove unused boost libarary: timer
  Build on jenkins for hydro failed on find boost_timer.
* 0.4.1
* Add changelog for releasing via bloom
```
