### PR TITLE
Adding epos_driver to documentation index for distro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1456,7 +1456,7 @@ repositories:
       url: https://github.com/clearpathrobotics/enu.git
       version: hydro
     status: maintained
-  epos:
+  epos_driver:
     doc:
       type: git
       url: https://github.com/tkucner/epos_driver-released.git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1456,6 +1456,11 @@ repositories:
       url: https://github.com/clearpathrobotics/enu.git
       version: hydro
     status: maintained
+  epos:
+    doc:
+      type: git
+      url: https://github.com/tkucner/epos_driver-released.git
+      version: upstream
   erratic_robot:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1378,6 +1378,11 @@ repositories:
       type: git
       url: https://github.com/vooon/mavros.git
       version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/vooon/mavros-release.git
+      version: 0.5.0-0
     source:
       type: git
       url: https://github.com/vooon/mavros.git


### PR DESCRIPTION
I would like epos_driver to be indexed and documented on ros.org.
