### PR TITLE
Add mongodb dep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2087,6 +2087,9 @@ mesa-common-dev:
 meshlab:
   fedora: [meshlab]
   ubuntu: [meshlab]
+mongodb:
+  fedora: [mongodb]
+  ubuntu: [mongodb]
 mongodb-dev:
   arch: [mongodb]
   debian: [libmongo-client-dev, mongodb-dev]


### PR DESCRIPTION
Now we have mongodb-dev, required to wirte mongodb clients. But some packages need mongodb as a run dependency.
