### PR TITLE
Adding epos_driver to documentation index for distro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1469,7 +1469,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/tkucner/epos_driver-released.git
-      version: tag
+      version: upstream
     release:
       tags:
         release: release/hydro/{package}/{version}
@@ -1478,7 +1478,7 @@ repositories:
     source:
       type: git
       url: https://github.com/tkucner/epos_driver-released.git
-      version: tag
+      version: upstream
     status: developed
   erratic_robot:
     doc:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1465,14 +1465,12 @@ repositories:
       url: https://github.com/clearpathrobotics/enu.git
       version: hydro
     status: maintained
-  epos_driver-released:
+  epos_driver:
     doc:
       type: git
       url: https://github.com/tkucner/epos_driver-released.git
-      version: branch
+      version: tag
     release:
-      packages:
-      - epos_driver
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tkucner/epos_driver-released.git


### PR DESCRIPTION
I'd like epos_driver to be indexed and documented on ros.org. I hope this time it will work.
