### PR TITLE
cram_3rdparty: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -971,7 +971,8 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/cram_3rdparty-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
+    status: maintained
   cram_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cram_3rdparty` to `0.1.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.1-0`
