### PR TITLE
rtt_geometry: 2.7.0-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5882,7 +5882,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_geometry-release.git
-      version: 2.7.0-1
+      version: 2.7.0-2
     source:
       type: git
       url: https://github.com/orocos/rtt_geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_geometry` to `2.7.0-2`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `2.7.0-1`
