### PR TITLE
dynamic_reconfigure: 1.5.37-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -842,11 +842,12 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.5.34-0
+      version: 1.5.37-0
     source:
       type: git
       url: https://github.com/ros/dynamic_reconfigure.git
       version: master
+    status: maintained
   dynamixel_motor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.5.37-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.5.34-0`
## dynamic_reconfigure

```
* Decode level of ParamDescription
* Added testsuite
* Avoid collisions with parameter names (#6 <https://github.com/ros/dynamic_reconfigure/issues/6>)
* Contributors: Esteve Fernandez, pgorczak
```
