### PR TITLE
hector_slam: 0.3.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2092,6 +2092,7 @@ repositories:
       - hector_geotiff
       - hector_geotiff_plugins
       - hector_imu_attitude_to_tf
+      - hector_imu_tools
       - hector_map_server
       - hector_map_tools
       - hector_mapping
@@ -2103,7 +2104,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
-      version: 0.3.2-1
+      version: 0.3.3-0
     source:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_slam` to `0.3.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.3.2-1`
## hector_compressed_map_transport

```
* fixed cmake find for eigen in indigo
* fixed libopencv-dev rosdep key
* Contributors: Alexander Stumpf, Johannes Meyer
```
## hector_geotiff

```
* fixed cmake find for eigen in indigo
* added launchfile to restart geotiff node
* Contributors: Alexander Stumpf
```
## hector_geotiff_plugins
- No changes
## hector_imu_attitude_to_tf
- No changes
## hector_imu_tools

```
* hector_imu_tools: Basics of simple height etimation
* hector_imu_tools: Add tf publishers in hector_imu_tools
* hector_imu_tools: Also write out fake odometry
* hector_imu_tools: Fix typo
* hector_imu_tools: Prevent race conditions in slam, formatting
* hector_imu_tools: Small executable for generating a IMU message out of a (2d) pose and roll/pitch imu message
* Contributors: Stefan Kohlbrecher
```
## hector_map_server
- No changes
## hector_map_tools
- No changes
## hector_mapping
- No changes
## hector_marker_drawing

```
* fixed cmake find for eigen in indigo
* Contributors: Alexander Stumpf
```
## hector_nav_msgs

```
* added GetNormal service, that returns normal and orientation of an occupied cell
* Contributors: Dorothea Koert
```
## hector_slam
- No changes
## hector_slam_launch
- No changes
## hector_trajectory_server
- No changes
