### PR TITLE
open_karto: 1.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4060,11 +4060,16 @@ repositories:
       version: hydro-devel
     status: maintained
   open_karto:
+    doc:
+      type: git
+      url: git@github.com:ros-perception/open_karto.git
+      version: indigo-devel
     release:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/open_karto-release.git
-      version: 1.0.1-0
+      version: 1.1.0-0
+    status: maintained
   open_street_map:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_karto` to `1.1.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.0.1-0`
## open_karto

```
* Release as a pure catkin ROS package
```
