### PR TITLE
slam_karto: 0.7.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6231,6 +6231,13 @@ repositories:
       url: https://github.com/ros-gbp/slam_gmapping-release.git
       version: 1.3.2-1
     status: maintained
+  slam_karto:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/slam_karto-release.git
+      version: 0.7.1-0
+    status: maintained
   sparse_bundle_adjustment:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_karto` to `0.7.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## slam_karto

```
* build updates for sba, fix install
* Contributors: Michael Ferguson
```
