### PR TITLE
yujin_maps: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3382,7 +3382,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/yujin_maps-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/yujinrobot/yujin_maps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yujin_maps` to `0.2.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.2.0-0`
## yujin_maps

```
* cropped version of yujin_rnd map
* Contributors: Jihoon Lee
```
