### PR TITLE
robot_localization: 0.1.3-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3463,7 +3463,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 0.1.2-2
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/cra-ros-pkg/robot_localization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `0.1.3-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.2-2`
## robot_localization

```
* Some changes to ease GPS integration
* Addition of differential integration of pose data
* Some documentation cleanup
* Added UTM transform node and launch file
* Bug fixes
```
