### PR TITLE
remove console_bridge, urdfdom, urdfdom_headers from indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -378,13 +378,6 @@ repositories:
       url: https://github.com/robotics-in-concert/concert_services.git
       version: indigo
     status: developed
-  console_bridge:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/console_bridge-release.git
-      version: 0.2.8-0
-    status: maintained
   control_msgs:
     doc:
       type: git
@@ -3312,20 +3305,6 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/urdf_tutorial-release.git
       version: 0.2.3-0
-    status: maintained
-  urdfdom:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/urdfdom-release.git
-      version: 0.3.0-2
-    status: maintained
-  urdfdom_headers:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/urdfdom_headers-release.git
-      version: 0.3.0-2
     status: maintained
   urdfdom_py:
     release:


### PR DESCRIPTION
Do **NOT** merge until all ROS package have been rereleased to use the system packages instead.

After merging also remove the indigo related branches / tags / tracks form the corresponding gbp repos.
