### PR TITLE
slam_gmapping: 1.3.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6289,7 +6289,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/slam_gmapping-release.git
-      version: 1.3.2-1
+      version: 1.3.3-0
     status: maintained
   slam_karto:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_gmapping` to `1.3.3-0`:
- upstream repository: https://github.com/ros-perception/slam_gmapping
- release repository: https://github.com/ros-gbp/slam_gmapping-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11-dev`
- previous version for package: `1.3.2-1`
## gmapping

```
* Adding the ability to set openslam_gmapping's miminumScore through the ros parameter minimumScore
* Contributors: Koen Lekkerkerker
```
## slam_gmapping
- No changes
