### PR TITLE
console_bridge: 0.2.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -334,7 +334,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/console_bridge-release.git
-      version: 0.2.7-0
+      version: 0.2.8-0
     status: maintained
   control_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `console_bridge` to `0.2.8-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.2.7-0`
