### PR TITLE
urdfdom_headers: 0.3.0-2 in indigo/distribution.yaml [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3179,7 +3179,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/urdfdom_headers-release.git
-      version: 0.3.0-1
+      version: 0.3.0-2
     status: maintained
   urdfdom_py:
     release:


### PR DESCRIPTION
truncated for testing
