### PR TITLE
jsk_common: 1.0.28-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1826,6 +1826,7 @@ repositories:
       - laser_filters_jsk_patch
       - libsiftfast
       - multi_map_server
+      - nlopt
       - openni_tracker_jsk_patch
       - opt_camera
       - posedetection_msgs
@@ -1834,11 +1835,12 @@ repositories:
       - rosping
       - rostwitter
       - sklearn
+      - speech_recognition_msgs
       - stereo_synchronizer
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.27-0
+      version: 1.0.28-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.28-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.0.27-0`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## collada_urdf_jsk_patch
- No changes
## depth_image_proc_jsk_patch
- No changes
## downward
- No changes
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha

```
* (ffha) use -n (--forward) to ignore patches that seem to be already applied
* Contributors: Kei Okada
```
## image_view2
- No changes
## image_view_jsk_patch
- No changes
## jsk_common
- No changes
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_tools

```
* add script to doctor workspace
* Contributors: Ryohei Ueda
```
## jsk_topic_tools

```
* initialize variable in relay_nodelet
* shutdown subscriber if no need to publish message in relay nodelet
* Merge pull request #466 from garaemon/add-single-executable-for-nodelet
  Add single executables for nodelets of jsk_topic_tools
* add single executable files for each nodelet in jsk_topic_tools
* add test code for block nodelet
* add nodelet to BLOCK topic pipeline according to the number of the subscribers
* add nodelet to relay topic
* Contributors: Ryohei Ueda, Yusuke Furuta
```
## laser_filters_jsk_patch

```
* add cmake_modules and mk to build_depend
* Contributors: Kei Okada
```
## libsiftfast
- No changes
## multi_map_server
- No changes
## nlopt

```
* add catkin.cmake and catkin_package declearation for generating config.cmake
* use PROJECT_SOURCE_DIR value in CMakeLists.txt for Makefile DESTDIR value instead of /home/s-noda/ros/hydro/src/jsk-ros-pkg/jsk_common/3rdparty/nlopt
* fix minor change for amenda
* change output dir from catkin_home -> nlopt dir
* remove rosmake function from CMakeLists.txt
* miss project name fix, nlopt
* add CMakeList and package.xml for catkinize
* Contributors: Shintaro Noda
```
## openni_tracker_jsk_patch
- No changes
## opt_camera

```
* (CMakeLists.txt, opt_camera/catkin.cmake): find find_package(OpenCV) to compile
* Contributors: Kei Okada
```
## posedetection_msgs
- No changes
## pr2_groovy_patches
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## sklearn
- No changes
## speech_recognition_msgs

```
* catkinize speech_recognition_msgs, see #470
* add speech_recognition_msgs
* Contributors: Yuki Furuta, Kei Okada
```
## stereo_synchronizer
- No changes
