### PR TITLE
ros_control: 0.8.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2520,7 +2520,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.8.0-1
+      version: 0.8.1-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.8.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.8.0-1`
## controller_interface
- No changes
## controller_manager
- No changes
## controller_manager_msgs
- No changes
## controller_manager_tests
- No changes
## hardware_interface
- No changes
## joint_limits_interface

```
* Use upstream liburdfdom-dev package.
  Refs ros/rosdistro#4633 <https://github.com/ros/rosdistro/issues/4633>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## ros_control
- No changes
## rqt_controller_manager

```
* Register plugin under a group. Fixes #162 <https://github.com/pal-robotics/ros_control/issues/162>.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## transmission_interface
- No changes
