### PR TITLE
geometry_experimental: 0.5.5-1 in indigo/distribution.yaml [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -901,7 +901,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry_experimental-release.git
-      version: 0.5.5-0
+      version: 0.5.5-1
     source:
       type: git
       url: https://github.com/ros/geometry_experimental.git


### PR DESCRIPTION
truncated for testing
