### PR TITLE
rosconsole_bridge: 0.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2678,7 +2678,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rosconsole_bridge-release.git
-      version: 0.3.4-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/ros/rosconsole_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole_bridge` to `0.4.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.3.4-0`
## rosconsole_bridge

```
* rename variables within rosconsole macros (ros/ros_comm#442 <https://github.com/ros/ros_comm/issues/442>)
* convert to use console bridge from upstream debian package (ros/rosdistro#4633 <https://github.com/ros/rosdistro/issues/4633>)
```
