### PR TITLE
ros_comm: 1.11.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2495,7 +2495,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.4-0
+      version: 1.11.5-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.5-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.11.4-0`
## message_filters
- No changes
## ros_comm
- No changes
## rosbag

```
* Fix typo in rosbag usage
* Contributors: lrasinen
```
## rosbag_storage

```
* convert to use console bridge from upstream debian package (ros/rosdistro#4633 <https://github.com/ros/rosdistro/issues/4633>)
```
## rosconsole

```
* rename variables within rosconsole macros (#442 <https://github.com/ros/ros_comm/issues/442>)
```
## roscpp

```
* improve handling dropped connections (#434 <https://github.com/ros/ros_comm/issues/434>)_
* add header needed for Android (#441 <https://github.com/ros/ros_comm/issues/441>)
* fix typo for parameter used for statistics (#448 <https://github.com/ros/ros_comm/issues/448>)
```
## rosgraph
- No changes
## roslaunch
- No changes
## roslz4
- No changes
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy
- No changes
## rosservice
- No changes
## rostest
- No changes
## rostopic
- No changes
## roswtf
- No changes
## topic_tools
- No changes
## xmlrpcpp
- No changes
