### PR TITLE
camera_umd: 0.2.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -498,11 +498,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ktossell/camera_umd-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/ktossell/camera_umd.git
       version: master
+    status: maintained
   capabilities:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_umd` to `0.2.2-0`:
- upstream repository: https://github.com/ktossell/camera_umd.git
- release repository: https://github.com/ktossell/camera_umd-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.2.1-0`
## camera_umd
- No changes
## jpeg_streamer
- No changes
## uvc_camera

```
* Print warnings instead of crashing when camera features are unavailable.
* Support V4L drivers that need user-writable mmap regions (e.g., bttv).
* Fixed nodelet names in the launch files.
* Added camera_name parameter, sent to camera_info_manager.
* Contributors: James Sarrett, Ken Tossell
```
