### PR TITLE
camera_umd: 0.2.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -198,6 +198,22 @@ repositories:
       url: https://github.com/ros-perception/camera_info_manager_py.git
       version: master
     status: maintained
+  camera_umd:
+    release:
+      packages:
+      - camera_umd
+      - jpeg_streamer
+      - uvc_camera
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ktossell/camera_umd-release.git
+      version: 0.2.2-1
+    source:
+      type: git
+      url: https://github.com/ktossell/camera_umd.git
+      version: master
+    status: maintained
+    status_description: Development has moved to libuvc_camera.
   capabilities:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_umd` to `0.2.2-1`:
- upstream repository: https://github.com/ktossell/camera_umd.git
- release repository: https://github.com/ktossell/camera_umd-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## camera_umd
- No changes
## jpeg_streamer
- No changes
## uvc_camera

```
* Print warnings instead of crashing when camera features are unavailable.
* Support V4L drivers that need user-writable mmap regions (e.g., bttv).
* Fixed nodelet names in the launch files.
* Added camera_name parameter, sent to camera_info_manager.
* Contributors: James Sarrett, Ken Tossell
```
