### PR TITLE
wu_ros_tools: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7161,6 +7161,20 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/wireless-release.git
       version: 0.0.2-0
+  wu_ros_tools:
+    release:
+      packages:
+      - catkinize_this
+      - easy_markers
+      - manifest_cleaner
+      - rosbaglive
+      - roswiki_node
+      - wu_ros_tools
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/wu-robotics/wu_ros_tools.git
+      version: 0.1.0-0
+    status: maintained
   x52_joyext:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wu_ros_tools` to `0.1.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
