### PR TITLE
Remove --universal options from homebrew rules.

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -57,7 +57,6 @@ collada-dom:
 cppunit:
   osx:
     homebrew:
-      options: [--universal]
       packages: [cppunit]
 curl:
   osx:
@@ -123,7 +122,6 @@ graphviz:
 gtest:
   osx:
     homebrew:
-      options: [--universal]
       packages: [gtest]
 gtk2:
   osx:
@@ -329,7 +327,6 @@ libxxf86vm:
 log4cxx:
   osx:
     homebrew:
-      options: [--universal]
       packages: [log4cxx]
 lua-dev:
   osx:
@@ -593,7 +590,6 @@ unzip:
 uuid:
   osx:
     homebrew:
-      options: [--universal]
       packages: [uuid]
 wxpython:
   osx:
@@ -606,7 +602,6 @@ wxwidgets:
 yaml:
   osx:
     homebrew:
-      options: [--universal]
       packages: [libyaml]
 yaml-cpp:
   osx:


### PR DESCRIPTION
- they are ignored at the moment and therefore have not been used in a long time
  - on recent OS X these options are certainly wrong, so this is a prerequisite for merging
    https://github.com/ros-infrastructure/rosdep/pull/304
