### PR TITLE
Add options/install_flags for boost/pcl.

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -33,6 +33,7 @@ bison:
 boost:
   osx:
     homebrew:
+      options: [--with-python]
       packages: [boost]
 bullet:
   osx:
@@ -206,11 +207,25 @@ libpcap:
 libpcl-all:
   osx:
     homebrew:
-      packages: [pcl]
+      depends: [libpcl-all-dev]
 libpcl-all-dev:
   osx:
-    homebrew:
-      packages: [pcl]
+    leopard:
+      homebrew: [pcl]
+    lion:
+      homebrew: [pcl]
+    mavericks:
+      homebrew:
+        install_flags: [--HEAD]
+        packages: [pcl]
+    "mountain lion":
+      homebrew: [pcl]
+    snow:
+      homebrew: [pcl]
+    yosemite:
+      homebrew:
+        install_flags: [--HEAD]
+        packages: [pcl]
 libpgm:
   osx:
     homebrew:


### PR DESCRIPTION
- as long as https://github.com/ros-infrastructure/rosdep/pull/304
  is not merged these will be ignored. If we merge this before rosdep
  is updated it will make testing that rosdep change slightly more easy.
- install_flags will be used for `brew install`, but unlike options
  they are not checked for already installed packages
- for boost --with-python see https://github.com/ros-infrastructure/rosdep/issues/330
- for pcl --HEAD on Mavericks see
  - http://answers.ros.org/question/173654/cant-install-pcl-with-homebrew-on-osx-109-during-ros-hydro-installation/
  - https://github.com/ros/homebrew-hydro/issues/3
