### PR TITLE
rosconsole_bridge: 0.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2678,7 +2678,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rosconsole_bridge-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/ros/rosconsole_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole_bridge` to `0.4.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.4.0-0`
## rosconsole_bridge

```
* update find_package for console bridge to reflect 3rdparty status (#8 <https://github.com/ros/rosconsole_bridge/issues/8>)
```
