### PR TITLE
navigation_layers: 0.2.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3757,6 +3757,15 @@ repositories:
       url: https://github.com/skasperski/navigation_2d.git
       version: hydro
     status: developed
+  navigation_layers:
+    release:
+      packages:
+      - range_sensor_layer
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/wu-robotics/navigation_layers_release.git
+      version: 0.2.0-0
+    status: maintained
   navigation_tutorials:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_layers` to `0.2.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
