### PR TITLE
geometric_shapes: 0.4.0-0 in indigo/distribution.yaml [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -859,7 +859,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.3.8-2
+      version: 0.4.0-0
     status: maintained
   geometry:
     doc:


### PR DESCRIPTION
truncated for testing
