### PR TITLE
ar_track_alvar_msgs: 0.5.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -65,10 +65,16 @@ repositories:
       type: git
       url: https://github.com/sniekum/ar_track_alvar_msgs.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/ar_track_alvar_msgs-release.git
+      version: 0.5.0-0
     source:
       type: git
       url: https://github.com/sniekum/ar_track_alvar_msgs.git
       version: indigo-devel
+    status: maintained
   arbotix:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar_msgs` to `0.5.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
