### PR TITLE
class_loader: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -255,7 +255,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/class_loader-release.git
-      version: 0.2.5-1
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/ros/class_loader.git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `0.3.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.2.5-1`
## class_loader

```
* Use system-provided console-bridge
* Contributors: Esteve Fernandez
```
