### PR TITLE
ros_control: 0.8.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2560,7 +2560,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.8.1-0
+      version: 0.8.2-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.8.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.8.1-0`
## controller_interface
- No changes
## controller_manager
- No changes
## controller_manager_msgs
- No changes
## controller_manager_tests
- No changes
## hardware_interface
- No changes
## joint_limits_interface

```
* Propagate urdfdom changes to CMakeLists.txt
  urdfdom is now standalone, so it must be find_package'd independently.
* Fix rostest, which was not being built correctly.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## ros_control
- No changes
## rqt_controller_manager
- No changes
## transmission_interface
- No changes
