### PR TITLE
wu_ros_tools: 0.1.0-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7183,7 +7183,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/wu-robotics/wu_ros_tools.git
-      version: 0.1.0-0
+      version: 0.1.0-2
     status: maintained
   x52_joyext:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `wu_ros_tools` to `0.1.0-2`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.0-0`
