### PR TITLE
p2os: 1.0.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2030,6 +2030,18 @@ repositories:
       url: https://github.com/orocos/orocos_kinematics_dynamics.git
       version: master
     status: maintained
+  p2os:
+    release:
+      packages:
+      - p2os_driver
+      - p2os_launch
+      - p2os_teleop
+      - p2os_urdf
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/allenh1/p2os-release.git
+      version: 1.0.10-0
+    status: developed
   pcl_conversions:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2037,6 +2037,8 @@ repositories:
       - p2os_launch
       - p2os_teleop
       - p2os_urdf
+      - p2os_msgs
+      - p2os_doc
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `1.0.10-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## p2os_driver
- No changes
## p2os_launch
- No changes
## p2os_teleop

```
* Added issue tracker to package.xml for telop
* Contributors: Hunter Allen
```
## p2os_urdf

```
* Added meshes directory to CMake install dir.
* Removed unneccessary files
* Contributors: Hunter Allen
```
