### PR TITLE
p2os: 1.0.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2030,6 +2030,20 @@ repositories:
       url: https://github.com/orocos/orocos_kinematics_dynamics.git
       version: master
     status: maintained
+  p2os:
+    release:
+      packages:
+      - p2os_doc
+      - p2os_driver
+      - p2os_launch
+      - p2os_msgs
+      - p2os_teleop
+      - p2os_urdf
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/allenh1/p2os-release.git
+      version: 1.0.11-0
+    status: developed
   pcl_conversions:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `1.0.11-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## p2os_doc

```
* Added documentation package. Currently just the p2os_driver. Also removed a line in p2os_launch cmake list.
* Contributors: Hunter Allen
```
## p2os_driver
- No changes
## p2os_launch
- No changes
## p2os_msgs

```
* Fixed dependency issues and cleaned up package.xml and CMakeLists.txt for p2os_driver and p2os_msgs
* Separated p2os_driver and p2os_msgs
* Contributors: Aris Synodinos
```
## p2os_teleop
- No changes
## p2os_urdf
- No changes
