### PR TITLE
ar_track_alvar: 0.5.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -56,10 +56,19 @@ repositories:
       type: git
       url: https://github.com/sniekum/ar_track_alvar.git
       version: indigo-devel
+    release:
+      packages:
+      - ar_track_alvar
+      - ar_track_alvar_meta
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/jihoonl/ar_track_alvar-release.git
+      version: 0.5.0-0
     source:
       type: git
       url: https://github.com/sniekum/ar_track_alvar.git
       version: indigo-devel
+    status: maintained
   ar_track_alvar_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar` to `0.5.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## ar_track_alvar

```
* move README to root directory
* Merge remote-tracking branch 'origin/hydro-devel' into indigo-devel
* ar_track_alvar package uses ar_track_alvar_msgs
* restructuring packages. Separate out the message package.
* Contributors: Jihoon Lee
```
## ar_track_alvar_meta

```
* add meta package
* Contributors: Jihoon Lee
```
