### PR TITLE
camera_umd: 0.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -222,7 +222,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ktossell/camera_umd-release.git
-      version: 0.2.2-1
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/ktossell/camera_umd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_umd` to `0.2.3-0`:
- upstream repository: https://github.com/ktossell/camera_umd.git
- release repository: https://github.com/ktossell/camera_umd-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.2.2-1`
## camera_umd
- No changes
## jpeg_streamer
- No changes
## uvc_camera

```
* Disabled hardcoded default parameters.
* Contributors: Ken Tossell
```
