### PR TITLE
libuvc: 0.0.4-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1378,7 +1378,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ktossell/libuvc-release.git
-      version: 0.0.3-3
+      version: 0.0.4-1
     status: developed
   libuvc_ros:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc` to `0.0.4-1`:
- upstream repository: https://github.com/ktossell/libuvc.git
- release repository: https://github.com/ktossell/libuvc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.3-3`
