### PR TITLE
rosh_core: 1.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5419,6 +5419,10 @@ repositories:
       version: master
     status: maintained
   rosh_core:
+    doc:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_core.git
+      version: hydro-devel
     release:
       packages:
       - rosh
@@ -5427,7 +5431,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/OSUrobotics/rosh_core-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
+    source:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_core.git
+      version: hydro-devel
     status: maintained
   rosh_desktop_plugins:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_core` to `1.0.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.0.3-0`
## rosh

```
* warn if roscore isn't running (fixes #1 <https://github.com/OSUrobotics/rosh_core/issues/1>)
* Fixing calls to deprecated roslib.rosenv (fixes #2 <https://github.com/OSUrobotics/rosh_core/issues/2>)
* Contributors: Dan Lazewatsky
```
## rosh_core
- No changes
## roshlaunch
- No changes
