### PR TITLE
multisense_ros: 1.0.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3615,6 +3615,28 @@ repositories:
       url: https://github.com/fkie/multimaster_fkie.git
       version: hydro-devel
     status: maintained
+  multisense_ros:
+    doc:
+      type: hg
+      url: https://bitbucket.org/osrf/multisense_ros
+      version: 1.0.0
+    release:
+      packages:
+      - multisense
+      - multisense_bringup
+      - multisense_cal_check
+      - multisense_description
+      - multisense_lib
+      - multisense_ros
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
+      version: 1.0.0-1
+    source:
+      type: hg
+      url: https://bitbucket.org/osrf/multisense_ros
+      version: default
+    status: developed
   nao_extras:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `multisense_ros` to `1.0.0-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.4`
- previous version for package: `null`
