### PR TITLE
joystick_drivers: 1.10.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1218,6 +1218,23 @@ repositories:
       url: https://github.com/ipa320/ipa_canopen.git
       version: indigo_dev
     status: maintained
+  joystick_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: indigo-devel
+    release:
+      packages:
+      - joy
+      - joystick_drivers
+      - ps3joy
+      - spacenav_node
+      - wiimote
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/joystick_drivers-release.git
+      version: 1.10.0-0
+    status: maintained
   jsk_pr2eus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `1.10.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## joy

```
* First indigo release
```
## joystick_drivers

```
* First indigo release
```
## ps3joy

```
* First indigo reelase
* Update ps3joy/package.xml URLs with github user ros to ros-drivers
* Prompt for sudo password when required
* Contributors: Felix Kolbe, Jonathan Bohren, dawonn
```
## spacenav_node

```
* First indigo release
```
## wiimote

```
* First indigo release
```
