### PR TITLE
capabilities: 0.2.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -513,7 +513,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/capabilities-release.git
-      version: 0.1.1-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/osrf/capabilities.git


### PR DESCRIPTION
Increasing version of package(s) in repository `capabilities` to `0.2.0-0`:
- upstream repository: https://github.com/osrf/capabilities.git
- release repository: https://github.com/ros-gbp/capabilities-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11-dev`
- previous version for package: `0.1.1-0`
## capabilities

```
* downgrade one of the exceptions to a warning
* fixup tests to reflect changes to client API
* Increase queue_size to 1000 for publishers
* Add queue_size arg for all publishers
* change exception behavior for use/free_capability in client API
* A rosdistro agnostic documentation reference
* conditionally try to stop reverse deps, since other reverse deps may have already stopped it
* make stopping the launch manager more robust to errors
* adds support of namespaces for capability nodelets
* Contributors: Jon Binney, Marcus Liebhardt, Nikolaus Demmel, William Woodall, kentsommer
```
