### PR TITLE
jsk_roseus: 1.1.20-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1269,7 +1269,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.19-0
+      version: 1.1.20-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.20-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.1.19-0`
## euslisp

```
* 2da6078 (lisp/geo/primp.l, lisp/l/common.l) revert Henry Baker's contribution of 2013 July, this breaks test code  https://github.com/euslisp/jskeus/pull/100
* c9a76d5 (-objects.l) : Assoc handles and attentions with adequate parent link ;; This bug is reported in https://github.com/euslisp/EusLisp/pull/31
* b21eda6 (.travis.yaml) : Update travis test to use irteus-demo.l and add test for eus/models
* 7755cb0 (models/drcbox-*.l) :refrain drcbox model. fix positions of objects in drcbox and color, and add casters
* 7ee3263 (drcbox-valve*.l) Import handle coordinates from rbrain models
* 5a89f25 (irt-all-scene.l, load-irt-all-scene.l) Add test codes for all irt scene models like irt-all-robots and irt-all-objects
* 0397569 (drcbox*.l) Add new models and  scene for drcbox ;; This originally derived from  https://github.com/euslisp/EusLisp/pull/27
* c9d6c82 (models/darwin.l) revert codes for collision model making according to https://github.com/euslisp/jskeus/pull/93 and https://github.com/jsk-ros-pkg/jsk_model_tools/pull/46
* 23e85ee (irteus/test/geo.l) owverwrite face-normal-vector, see https://github.com/euslisp/EusLisp/pull/21
* 454bde8 (irteus/test/geo.l): add test code for geometry functions (https://github.com/euslisp/EusLisp/pull/21)
* be1ecc0 (irtdyna.l, test-irt-motion.l) Fix bug of :cog-convergence-check and add test codes
* 99486d7 (irteus/test/joint.l) Execute test even if  display is not found
* 9e5ff99 (irteus/test/joint.l) Add min-max violation test ;; Update joint.l to replace magic number by min-angle or max-angle
* 413c575 (irteus/test/all-robots-objects.l) Add unittest for scene models corresponding to  https://github.com/euslisp/EusLisp/pull/29
* 425c9d1 (irteus/irtrobot.l) revert codes for collision model making according to https://github.com/euslisp/jskeus/pull/93 and https://github.com/jsk-ros-pkg/jsk_model_tools/pull/46
* Contributors: Shunichi Nozawa, Kei Okada, Eisoku Kuroiwa
```
## geneus

```
* cmake/roseus.cmake : workaround for groovy, prevent overwrite catkin_LIBRARIES
* cmake/roseus.cmake : do not generate message for install package, since this component is not package_found-ed so far, try to run geneus next-time
* cmake/roseus.cmake : check if _depend_output is null string
* Contributors: Kei Okada
```
## jsk_roseus
- No changes
## roseus

```
* roseus_c_util.c : remove compile_warnings
* test-genmsg.sh: add roscpp to CATKIN_DEPENDS
* test-genmsg.sh: catkin_make with --make-args VERBOSE=1
* test-genmsg.sh/test-genmsg.catkin.test : check #120 situation
* roseus.cpp : support reconnection of service when persist is set true
* Contributors: Kei Okada, Ryohei Ueda
```
## roseus_msgs
- No changes
## roseus_smach
- No changes
