### PR TITLE
roscpp_core: 0.5.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2760,7 +2760,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.5.2-0
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/ros/roscpp_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.5.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.5.2-0`
## cpp_common

```
* add missing boost dependency (#24 <https://github.com/ros/roscpp_core/issues/24>)
```
## roscpp_serialization
- No changes
## roscpp_traits
- No changes
## rostime
- No changes
