### PR TITLE
rqt_ez_publisher: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5869,6 +5869,11 @@ repositories:
       type: git
       url: https://github.com/OTL/rqt_ez_publisher.git
       version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/OTL/rqt_ez_publisher-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/OTL/rqt_ez_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_ez_publisher` to `0.0.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## rqt_ez_publisher

```
* more easy topic publisher
```
