### PR TITLE
rospilot: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2827,7 +2827,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rospilot/rospilot-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/rospilot/rospilot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot` to `0.0.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.2-0`
## rospilot

```
* Change web_ui to use pkg_resources for static assets
* Add udev rule to installation targets
* Contributors: Christopher Berner
```
