### PR TITLE
qt_ros: 0.2.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4785,7 +4785,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/yujinrobot-release/qt_ros-release.git
-      version: 0.2.5-0
+      version: 0.2.6-0
     source:
       type: git
       url: https://github.com/stonier/qt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_ros` to `0.2.6-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.2.5-0`
## qt_create

```
* bugfix catkin crawling of the templates directory.
```
