### PR TITLE
jsk_recognition: 0.1.8-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1920,7 +1920,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.1.7-0
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.1.8-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.7-0`
## checkerboard_detector
- No changes
## imagesift

```
* maked configure_file to create imagesurf, imagestar and imagebrisk automatically
* added the programs to use cv_detection
* Contributors: Yu Ohara
```
## jsk_pcl_ros

```
* add min_indices parameter to ignore the grid which does not include
  enough points.
* add throttle for bounding box visualization in
  organized_multi_plane_segmentation.launch.
  Because it may be too fast to see...
* add ~publish_tf=false to several nodelets in organized_multi_plane_segmentation.launch
* fix typo of launch file
* run ColorHistogramMatcher with GridSampler
* implement GridSampler
* find object based on hsv color histogram of the pointcloud
* implement simple handle detector to grasp
* refactor cluster decomposer class
  run PCA to compute orientation of bounding box
* run PCA to compute bouding box
* fix segmentation fault
* estimate occlusion in EnvironmentPlaneModeling
* fix several bags for plane-based environment modeling
* fix the header of the output of the estimation of occlusion
* do not compute transformation if no points are available
* does not publish pointclouds if transformation failed
* merge remote branch origin/master
* fulfill occluded reagion with pointcloud by OccludedPlaneEstimator
* debug and substitute stamp value to header/stamp
  add cloth classification sample
* only make will be executed on hydro
* fix typo: oclusoin -> occlusion
* add new nodelet: EnvironmentPlaneModeling
* use pcl::PointXYZRGB rather than pcl::PointXYZRGBNormal
* add normal estimation to organized multi plane segmentation
* d varaible of the normal should be transformed correctly by PolygonArrayTransfomer.
  fix transformation compuation to normalize d parameter
* add depent tag to ml_classifiers
* add more rosparameters to ParticleFilterTracking
* add MACHINE and GDB argument
* add program to compute color histogram (rgb and hsv color space)
* add cloth classification sample
* change the namespace of the topics to use tracking.launch from the other launch files
* add OcludedPlaneEstimator nodelet to estimate the ocluded planes
* new nodelet to transform PolygonArray and ModelCoefficientsArray
* add nodelet to publish static jsk_pcl_ros/PolygonArray with timestamp
  synchronized with the pointclouds
* Contributors: Ryohei Ueda, Yuto Inagaki, Masaki Murooka, Yusuke Furuta
```
## jsk_perception

```
* initialize _img_ptr at first
* convert color image to GRAY
* add nodelet to detect circles based on hough transformation
* add program to compute color histogram (rgb and hsv color space)
* maked configure_file to create imagesurf, imagestar and imagebrisk automatically
* added the programs to use cv_detection
* Contributors: Ryohei Ueda, Yu Ohara, Yusuke Furuta
```
## jsk_recognition
- No changes
## resized_image_transport
- No changes
