### PR TITLE
jsk_visualization: 1.0.5-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1963,7 +1963,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.5-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.0.4-0`
## jsk_interactive

```
* add load-ros-manifest jsk_interactive_marker
* Contributors: Yusuke Furuta
```
## jsk_interactive_marker

```
* add param to designate tf origin
* add new menu to call "estimate occlusion"
* skip planning until release the marker
* automatically snap the footstep marker to the plane if ~use_plane_snap
  is set to true
* publish the selected bounding box as BondingBoxArray for visualization
* publish the selected box as well as the index of the box
* add dummy camera launch file
* Contributors: Masaki Murooka, Ryohei Ueda, Yusuke Furuta
```
## jsk_interactive_test
- No changes
## jsk_rqt_plugins

```
* fix jsk_rqt_plugins for groovy users
* only one topic should be taken into account. the argument of the topics
  cannot be an array
* add rqt plugin to visualize histogram
* Contributors: Ryohei Ueda
```
## jsk_rviz_plugins

```
* add overlay camera display
* close overlay menu firmly
* add new rviz plugin: OverlayImage
  visualize sensor_msgs::Image as HUD on rviz 3D rendering window
* add new plugin: OverlayMenu
* Contributors: Ryohei Ueda
```
