### PR TITLE
jsk_model_tools: 0.1.5-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1859,7 +1859,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_model_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.1.5-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.4-0`
## eus_assimp
- No changes
## euscollada

```
* catkin.cmake: add *.yaml and *.sh to install
* pr2.sh: Support Hydro pr2 model path
* Contributors: Kei Okada, Shunichi Nozawa
```
## jsk_model_tools
- No changes
