### PR TITLE
rqt_ez_publisher: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5873,7 +5873,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/OTL/rqt_ez_publisher-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/OTL/rqt_ez_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_ez_publisher` to `0.0.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.1-0`
## rqt_ez_publisher

```
* MoveUP/Down and use icon
* Fix cmake (remove python packages from find_package)
* Support repeat publish
* support Header
* add queue_size for publisher for indigo
* for python3
```
