### PR TITLE
camera_umd: 0.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -222,7 +222,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ktossell/camera_umd-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/ktossell/camera_umd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_umd` to `0.2.4-0`:
- upstream repository: https://github.com/ktossell/camera_umd.git
- release repository: https://github.com/ktossell/camera_umd-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.2.3-0`
## camera_umd
- No changes
## jpeg_streamer
- No changes
## uvc_camera

```
* Added new parameters: auto_focus (bool), focus_absolute (int), auto_exposure (bool),
  exposure_absolute (int), power_line_frequency (int: 0/50/60)
* Contributors: Andreas Bihlmaier
```
