### PR TITLE
rosserial: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2878,7 +2878,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rosserial-release.git
-      version: 0.6.0-2
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/ros-drivers/rosserial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial` to `0.6.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.6.0-2`
## rosserial
- No changes
## rosserial_arduino
- No changes
## rosserial_client

```
* Remove ID_TX_STOP define
* Fix ID_TX_STOP in the client lib.
* Contributors: Mike Purvis
```
## rosserial_embeddedlinux
- No changes
## rosserial_msgs
- No changes
## rosserial_python
- No changes
## rosserial_server
- No changes
## rosserial_windows
- No changes
## rosserial_xbee
- No changes
