### PR TITLE
Add Fedora 20 to release_platforms for H and I

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3,6 +3,8 @@
 # see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
+  fedora:
+  - heisenbug
   ubuntu:
   - precise
   - quantal

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3,6 +3,8 @@
 # see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
+  fedora:
+  - heisenbug
   ubuntu:
   - saucy
   - trusty


### PR DESCRIPTION
This was prematurely merged long ago, but was reverted due to (https://github.com/ros-infrastructure/rosdep/pull/302). This does mean that adding any non-Ubuntu platforms to `release_platforms` will break any `rosdep` < 0.10.26, where the latest version is 0.10.28.

So to verify that major platforms have a sufficient version available:
- [x] Arch: https://aur.archlinux.org/packages/python-rosdep/
- [x] Fedora: https://apps.fedoraproject.org/packages/python-rosdep
- [x] Pypi: https://pypi.python.org/pypi/rosdep/0.10.27
- [x] Ubuntu: http://packages.ros.org/ros/ubuntu/pool/main/r/rosdep/
