### PR TITLE
moveit_core: 0.6.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1549,11 +1549,19 @@ repositories:
       version: 0.5.6-0
     status: maintained
   moveit_core:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_core.git
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_core-release.git
-      version: 0.5.8-1
+      version: 0.6.9-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_core.git
+      version: indigo-devel
     status: maintained
   moveit_ikfast:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_core` to `0.6.9-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.5.8-1`
