### PR TITLE
yocs_msgs: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3466,10 +3466,16 @@ repositories:
       type: git
       url: https://github.com/yujinrobot/yocs_msgs.git
       version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/yocs_msgs-release.git
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/yujinrobot/yocs_msgs.git
       version: indigo
+    status: developed
   yujin_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yocs_msgs` to `0.6.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## yocs_msgs

```
* Merge pull request #3 <https://github.com/yujinrobot/yocs_msgs/issues/3> from yujinrobot/ar_pair
* ar pair messages
  remove update ar pair service. instead creates ar pair list
* Merge pull request #1 <https://github.com/yujinrobot/yocs_msgs/issues/1> from yujinrobot/waypoints
  Waypoints
* success flag
* add waypoint service
* waypoint list added
* version bump for igloo development
* Add extra messages containing semantic map objects.
* Contributors: Jihoon Lee, Jorge Santos, Marcus Liebhardt
```
