### PR TITLE
Adding rosdbm to documentation index for distro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5450,6 +5450,11 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: hydro-devel
     status: maintained
+  rosdbm:
+    doc:
+      type: git
+      url: https://github.com/ricardoej/rosdbm.git
+      version: master
   rosdoc_lite:
     doc:
       type: git


### PR DESCRIPTION
I'd like my rosdbm to be indexed and documented on ros.org.
