### PR TITLE
simple_robot_control: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5450,11 +5450,6 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: hydro-devel
     status: maintained
-  rosdbm:
-    doc:
-      type: git
-      url: https://github.com/ricardoej/rosdbm.git
-      version: master
   rosdoc_lite:
     doc:
       type: git
@@ -6354,6 +6349,17 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/sicktoolbox_wrapper-release.git
       version: 2.5.3-1
+    status: maintained
+  simple_robot_control:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/bosch-ros-pkg/simple_robot_control-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/bosch-ros-pkg/simple_robot_control.git
+      version: hydro-devel
     status: maintained
   skeleton_markers:
     doc:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5450,6 +5450,11 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: hydro-devel
     status: maintained
+  rosdbm:
+    doc:
+      type: git
+      url: https://github.com/ricardoej/rosdbm.git
+      version: master
   rosdoc_lite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_robot_control` to `0.0.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## simple_robot_control

```
* preempt action for the arm functionality
* Contributors: Karol Hausman (CR/RTC1.1-NA)
```
