### PR TITLE
shared_serial: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3054,6 +3054,12 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/shape_tools-release.git
       version: 0.2.1-0
+  shared_serial:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wcaarls/shared_serial-release.git
+      version: 0.2.1-0
   sicktoolbox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `shared_serial` to `0.2.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## shared_serial

```
* OSX Compatibility (Hans Gaiser)
```
