### PR TITLE
threemxl: 0.2.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3225,6 +3225,12 @@ repositories:
       url: https://github.com/RobotWebTools/tf2_web_republisher.git
       version: develop
     status: maintained
+  threemxl:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wcaarls/threemxl-release.git
+      version: 0.2.0-1
   ueye:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `threemxl` to `0.2.0-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## threemxl

```
* Add getAcceleration and getLinearAcceleration and fix some wrong data handling
* OSX Compile fixes (Hans Gaiser)
```
