### PR TITLE
imu_compass: 0.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2460,11 +2460,20 @@ repositories:
       url: https://github.com/ros-gbp/image_transport_plugins-release.git
       version: 1.8.21-0
   imu_compass:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/imu_compass.git
+      version: master
     release:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/imu_compass-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/imu_compass.git
+      version: master
+    status: maintained
   imu_pipeline:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_compass` to `0.0.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.3-0`
## imu_compass

```
* successful test with kingfisher June 30 2014
* adding the publishing of calibrated magnetometer data for debug purposes
* Contributors: Mike Purvis, Prasenjit Mukherjee
```
