### PR TITLE
vision_visp: 0.7.4-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4769,7 +4769,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.7.3-0
+      version: 0.7.4-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.7.4-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.7.3-0`
## vision_visp

```
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_auto_tracker

```
* Update and fix content of README files
* Download the tutorial-qrcode.bag bag file from a new location that allows the download without SSL certificate
* 0.7.3
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_bridge

```
* Update and fix content of README files
* Revised with comments from fspindle
* Changed the way boost is linked
* Renamed conversion tool
* Mark camera parameter converter for installation
* minor changes
* Support for distortion camera parameter model
* Delete existing output file
* tool for converting visp camera parameter files to/from ros camera  parameter files
* 0.7.3
* Prepare changelogs
* Contributors: Fabien Spindler, Riccardo Spica
```
## visp_camera_calibration

```
* Update and fix content of README files
* Fix to allow calibration on images that are not 640x480
* 0.7.3
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_hand2eye_calibration

```
* Update and fix content of README files
* 0.7.3
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_tracker

```
* Update and fix content of README files
* 0.7.3
* Prepare changelogs
* Contributors: Fabien Spindler
```
