### PR TITLE
vision_visp: 0.7.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3394,7 +3394,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.7.3-1
+      version: 0.7.4-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.7.4-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.7.3-1`
## vision_visp

```
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_auto_tracker

```
* Update and fix content of README files
* Download the tutorial-qrcode.bag bag file from a new location that allows the download without SSL certificate
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_bridge

```
* Update and fix content of README files
* Revised with comments from fspindle
* Changed the way boost is linked
* Renamed conversion tool
* Mark camera parameter converter for installation
* minor changes
* Support for distortion camera parameter model
* Delete existing output file
* tool for converting visp camera parameter files to/from ros camera  parameter files
* Prepare changelogs
* Contributors: Fabien Spindler, Riccardo Spica
```
## visp_camera_calibration

```
* Update and fix content of README files
* Fix to allow calibration on images that are not 640x480
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_hand2eye_calibration

```
* Update and fix content of README files
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_tracker

```
* Update and fix content of README files
* Contributors: Fabien Spindler
```
