### PR TITLE
shared_serial: 0.2.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3055,11 +3055,20 @@ repositories:
       url: https://github.com/ros-gbp/shape_tools-release.git
       version: 0.2.1-0
   shared_serial:
+    doc:
+      type: git
+      url: https://github.com/wcaarls/shared_serial.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wcaarls/shared_serial-release.git
-      version: 0.2.1-0
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/wcaarls/shared_serial.git
+      version: master
+    status: maintained
   sicktoolbox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `shared_serial` to `0.2.1-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.2.1-0`
## shared_serial

```
* OSX Compatibility (Hans Gaiser)
```
