### PR TITLE
threemxl: 0.2.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3226,11 +3226,20 @@ repositories:
       version: develop
     status: maintained
   threemxl:
+    doc:
+      type: git
+      url: https://github.com/wcaarls/threemxl.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wcaarls/threemxl-release.git
-      version: 0.2.0-1
+      version: 0.2.0-2
+    source:
+      type: git
+      url: https://github.com/wcaarls/threemxl.git
+      version: master
+    status: maintained
   ueye:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `threemxl` to `0.2.0-2`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.2.0-1`
## threemxl

```
* Add getAcceleration and getLinearAcceleration and fix some wrong data handling
* OSX Compile fixes (Hans Gaiser)
```
