### PR TITLE
hector_localization: 0.1.2-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1453,7 +1453,8 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
-      version: 0.1.0-1
+      version: 0.1.2-0
+    status: maintained
   hector_models:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_localization` to `0.1.2-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.0-1`
## hector_localization
- No changes
## hector_pose_estimation
- No changes
## hector_pose_estimation_core

```
* added cmake_modules dependency for the Eigen cmake config
* Contributors: Johannes Meyer
```
## message_to_tf

```
* Add parameter for optionally not publishing roll/pitch to tf
* Don´t publish roll/pitch (to be parametrized soon)
* Contributors: Stefan Kohlbrecher, hector1
```
## world_magnetic_model

```
* fixed "format not a string literal and no format arguments" security error
* Contributors: Johannes Meyer
```
