### PR TITLE
Add rqt_ez_publisher for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2970,6 +2970,16 @@ repositories:
       url: https://github.com/ros-visualization/rqt_common_plugins.git
       version: groovy-devel
     status: developed
+  rqt_ez_publisher:
+    doc:
+      type: git
+      url: https://github.com/OTL/rqt_ez_publisher.git
+      version: hydro-devel
+    source:
+      type: git
+      url: https://github.com/OTL/rqt_ez_publisher.git
+      version: hydro-devel
+    status: maintained
   rqt_robot_plugins:
     release:
       packages:


### PR DESCRIPTION
add rqt_ez_publisher for indigo/distribution.yaml.
(use hydro-devel for now)
