### PR TITLE
rospilot_deps: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2855,7 +2855,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rospilot/rospilot_deps-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/rospilot/rospilot_deps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot_deps` to `0.0.5-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.4-0`
## rospilot_deps

```
* Add missing files
* Make gitignore less aggressive
* Contributors: Christopher Berner
```
