### PR TITLE
moveit_commander: 0.5.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3388,7 +3388,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/moveit_commander-release.git
-      version: 0.5.5-0
+      version: 0.5.7-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_commander.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_commander` to `0.5.7-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.5.5-0`
## moveit_commander

```
* Merge pull request #21 <https://github.com/ros-planning/moveit_commander/issues/21> from pirobot/hydro-devel
  Added set_support_surface_name function to move_group.py
* Added set_support_surface_name function to move_group.py
* Contributors: Patrick Goebel, Sachin Chitta
```
