### PR TITLE
Fix empty rule (xulrunner: debian)

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2792,7 +2792,7 @@ xterm:
   ubuntu: [xterm]
 xulrunner-1.9.2:
   arch: [xulrunner]
-  debian:
+  debian: []
   fedora: [xulrunner]
   ubuntu:
     karmic: [xulrunner-1.9.2]


### PR DESCRIPTION
This was causing an error when running `rosdep db` on debian:

```
InvalidData: rosdep OS definition for [xulrunner-1.9.2:debian] must be a dictionary, string, or list: None
```
