### PR TITLE
moveit_planners: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1586,6 +1586,10 @@ repositories:
       url: https://github.com/ros-gbp/moveit_msgs-release.git
       version: 0.5.4-2
   moveit_planners:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_planners.git
+      version: indigo-devel
     release:
       packages:
       - moveit_planners
@@ -1593,7 +1597,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_planners-release.git
-      version: 0.5.5-1
+      version: 0.6.6-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_planners.git
+      version: indigo-devel
     status: maintained
   moveit_plugins:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_planners` to `0.6.6-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.5.5-1`
## moveit_planners
- No changes
## moveit_planners_ompl

```
* indigo version of moveit planners
* fix compile error on Indigo
* Fix for getMeasure() virtual function OMPL change
* Move OMPL paths before catkin to avoid compilation against ROS OMPL package when specifying a different OMPL installation
* Fixed bug which limited the number of plans considered to the number of threads.
* Contributors: Alexander Stumpf, Chris Lewis, Dave Coleman, Ryan Luna, Sachin Chitta
```
