### PR TITLE
moveit_planners: 0.5.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3453,7 +3453,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/moveit_planners-release.git
-      version: 0.5.4-0
+      version: 0.5.6-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_planners.git
+      version: hydro-devel
     status: maintained
   moveit_plugins:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_planners` to `0.5.6-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.5.4-0`
## moveit_planners
- No changes
## moveit_planners_ompl

```
* Fix for getMeasure() virtual function OMPL change
* Move OMPL paths before catkin to avoid compilation against ROS OMPL package when specifying a different OMPL installation
* Fixed bug which limited the number of plans considered to the number of threads.
* Contributors: Chris Lewis, Dave Coleman, Ryan Luna
```
