### PR TITLE
rtmros_hironx: 1.0.15-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5966,7 +5966,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.14-0
+      version: 1.0.15-2
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.15-2`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.0.14-0`
## hironx_moveit_config

```
* Enable "natto"-view on RViz.
* Disable query for start state in Moveit RViz plugin.
* Contributors: Isaac IY Saito, Kei Okada
```
## hironx_ros_bridge

```
* fix #107 <https://github.com/start-jsk/rtmros_hironx/issues/107>
* Add acceptance test code for hrpsys-based api.
* (hironx_client.py) api document improved.
* (test_hironx.py) Add a testcase to check both arms simultaneous operation
* Launch collision detection viewer ("natto"-view) by default.
* (test-hironx-ros-bridge.test) Accept corba port input
* (robot/robot-compile-hrpsys.sh) update to use github
* (hironx_client.py) Improve arg name (#issues61#issuecomment-37535993)
* (test_hironx.py, test_hironx_ik.py, test_hironx_ros_bridge.py) relax test condition to pass travis
* rename test-hironx-ros-bridge.launch -> test-hironx-ros-bridge.test
* Add depends to gnuplot for test, currently our travis code does not see test_depends so add them to the {build,run}_depend
* (#81 <https://github.com/start-jsk/rtmros_hironx/issues/81>) set test code for simulation environment
* add roslang/rosbash to depends for roslib.load_manifest()
* Contributors: Isaac IY Saito, Kei Okada
```
## rtmros_hironx

```
* fix #107 <https://github.com/start-jsk/rtmros_hironx/issues/107>
* Add acceptance test code for hrpsys-based api.
* (hironx_client.py) api document improved.
* (test_hironx.py) Add a testcase to check both arms simultaneous operation
* Launch collision detection viewer ("natto"-view) by default.
* (test-hironx-ros-bridge.test) Accept corba port input
* (robot/robot-compile-hrpsys.sh) update to use github
* (hironx_client.py) Improve arg name (#issues61#issuecomment-37535993)
* (test_hironx.py, test_hironx_ik.py, test_hironx_ros_bridge.py) relax test condition to pass travis
* (hironx_ros_bridge) rename test-hironx-ros-bridge.launch -> test-hironx-ros-bridge.test
* (hironx_ros_bridge/package.xml) we need depends to gnuplot for test, currently our travis code does not see test_depends so add them to the {build,run}_depend
* (#81 <https://github.com/start-jsk/rtmros_hironx/issues/81>) set test code for simulation environment
* (hironx_ros_bridge) add roslang/rosbash to depends for roslib.load_manifest()
* Contributors: Isaac IY Saito, Kei Okada
```
