### PR TITLE
jsk_recognition: 0.1.10-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1921,7 +1921,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.1.9-1
+      version: 0.1.10-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.1.10-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.9-1`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros

```
* compute distance based on Polygon-to-ConvexCentroid in order to identify
  the grid maps
* remove debug code in PolygonArrayTransformer
* use Plane class to compute transformation of coefficients
* statical voting and rejection to the grid map to remove unstable
  recognition result
* support appending of GridMap in time series in EnvironmentPlaneModeling
* measure time to compute polygon collision in EnvironmentPlaneModeling
* add a nodelet to concatenate PolygonStamped
* publish polygon synchronized with ~trigger message
* new utility class to measure time
* change default camera name
* build and publish grid map always on EnvironmentPlaneModeling
* add launch file for openni
* Contributors: Ryohei Ueda, Yusuke Furuta
```
## jsk_perception

```
* adding oriented_gradient_node
* add calc_flow program to calc optical flow
* Contributors: Hiroaki Yaguchi, Ryohei Ueda
```
## jsk_recognition
- No changes
## resized_image_transport
- No changes
