### PR TITLE
robot_model: 1.11.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2354,7 +2354,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.11.3-0
+      version: 1.11.4-0
     status: maintained
   robot_pose_publisher:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.11.4-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.11.3-0`
## collada_parser

```
* collada_parser: add extract actuators, fix for using nominal torque
* moving to new dependency for urdfdom and urdfdom_headers. https://github.com/ros/rosdistro/issues/4633
* Contributors: Tully Foote, YoheiKakiuchi
```
## collada_urdf

```
* moving to new dependency for urdfdom and urdfdom_headers. https://github.com/ros/rosdistro/issues/4633
* Fix clash with assimp 3.1 in CMake.
* Contributors: Benjamin Chrétien, Tully Foote
```
## joint_state_publisher

```
* Update package.xml
  Updating author and maintainer email for consistency
* Contributors: David Lu!!
```
## kdl_parser
- No changes
## robot_model
- No changes
## urdf

```
* moving to new dependency for urdfdom and urdfdom_headers. https://github.com/ros/rosdistro/issues/4633
* Contributors: Tully Foote
```
## urdf_parser_plugin

```
* moving to new dependency for urdfdom and urdfdom_headers. https://github.com/ros/rosdistro/issues/4633
* Contributors: Tully Foote
```
