### PR TITLE
rosh_core: 1.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5496,7 +5496,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/OSUrobotics/rosh_core-release.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/OSUrobotics/rosh_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_core` to `1.0.5-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.0.4-0`
## rosh

```
* fix errors caused by API changes
* Contributors: Dan Lazewatsky
```
## rosh_core
- No changes
## roshlaunch
- No changes
