### PR TITLE
rosh_desktop_plugins: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5515,6 +5515,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/OSUrobotics/rosh_desktop_plugins-release.git
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/OSUrobotics/rosh_desktop_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_desktop_plugins` to `1.0.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## rosh_desktop
- No changes
## rosh_desktop_plugins
- No changes
## rosh_visualization
- No changes
