### PR TITLE
rtmros_hironx: 1.0.16-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5967,7 +5967,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.14-0
+      version: 1.0.16-1
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.16-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.0.14-0`
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* First release of install script suites (for QNX)
* (test-hironx.test, test-hironx-ros-bridge.test) Add omniNames script to start it on ros buildfarm (see https://github.com/start-jsk/rtmros_common/issues/416#issuecomment-46846623)
* (hironx_ros_bridge.launch) Pass corba port to collision detector launch
* hironx_ros_bridge_real.launch, enable ServoController for real robot
* Contributors: Kei Okada, Isaac IY Saito
```
## rtmros_hironx

```
* First release of install script suites (for QNX)
* (test-hironx.test, test-hironx-ros-bridge.test) Add omniNames script to start it on ros buildfarm (see https://github.com/start-jsk/rtmros_common/issues/416#issuecomment-46846623)
* (hironx_ros_bridge.launch) Pass corba port to collision detector launch
* hironx_ros_bridge_real.launch, enable ServoController for real robot
* Contributors: Kei Okada, Isaac IY Saito
```
