### PR TITLE
yujin_ocs: 0.6.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3556,16 +3556,12 @@ repositories:
       version: indigo
     release:
       packages:
-      - yocs_ar_marker_tracking
-      - yocs_ar_pair_approach
-      - yocs_ar_pair_tracking
       - yocs_cmd_vel_mux
       - yocs_controllers
       - yocs_diff_drive_pose_controller
       - yocs_math_toolkit
       - yocs_velocity_smoother
       - yocs_virtual_sensor
-      - yocs_waypoint_manager
       - yocs_waypoints_navi
       - yujin_ocs
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3554,10 +3554,29 @@ repositories:
       type: git
       url: https://github.com/yujinrobot/yujin_ocs.git
       version: indigo
+    release:
+      packages:
+      - yocs_ar_marker_tracking
+      - yocs_ar_pair_approach
+      - yocs_ar_pair_tracking
+      - yocs_cmd_vel_mux
+      - yocs_controllers
+      - yocs_diff_drive_pose_controller
+      - yocs_math_toolkit
+      - yocs_velocity_smoother
+      - yocs_virtual_sensor
+      - yocs_waypoint_manager
+      - yocs_waypoints_navi
+      - yujin_ocs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/yujin_ocs-release.git
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/yujinrobot/yujin_ocs.git
       version: indigo
+    status: developed
   zeroconf_avahi_suite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yujin_ocs` to `0.6.1-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
