### PR TITLE
[rosdistro] multimaster_fkie: 0.3.12-0 in 'groovy/distribution.yaml' and 'hydro/distribution.yaml'

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2519,7 +2519,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.3.11-0
+      version: 0.3.12-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3642,7 +3642,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.3.11-0
+      version: 0.3.12-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository multimaster_fkie to 0.3.12-0:

distro file: groovy/distribution.yaml
bloom version: 0.5.10
previous version for package: 0.3.11-0

distro file: hydro/distribution.yaml
bloom version: 0.5.10
previous version for package: 0.3.11-0
