### PR TITLE
laser_filtering: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3023,6 +3023,16 @@ repositories:
       url: https://github.com/ros-perception/laser_assembler.git
       version: hydro-devel
     status: maintained
+  laser_filtering:
+    release:
+      packages:
+      - laser_filtering
+      - map_laser
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/wu-robotics/laser_filtering_release.git
+      version: 0.0.1-0
+    status: maintained
   laser_filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filtering` to `0.0.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
