### PR TITLE
hector_localization: 0.1.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2033,7 +2033,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/hector_localization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_localization` to `0.1.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.2-0`
## hector_localization
- No changes
## hector_pose_estimation
- No changes
## hector_pose_estimation_core
- No changes
## message_to_tf

```
* message_to_tf: fixed base_link transform publishing (was removed in 77f2cc2334d15fc0e9395ceb9b40cd4601448289)
* Contributors: Johannes Meyer
```
## world_magnetic_model
- No changes
