### PR TITLE
people: 1.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4433,12 +4433,16 @@ repositories:
     release:
       packages:
       - face_detector
+      - leg_detector
       - people
       - people_msgs
+      - people_tracking_filter
+      - people_velocity_tracker
+      - social_navigation_layers
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/OSUrobotics/people-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/wg-perception/people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `people` to `1.0.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.0.3-0`
## leg_detector

```
* Merging leg_detector into people
* Contributors: David Lu!!
```
## people_tracking_filter

```
* merging people_tracking_filter into people
* Contributors: David Lu!!
```
## people_velocity_tracker

```
* Merging people_velocity_tracker into people
* Contributors: David Lu!!
```
## social_navigation_layers

```
* merging Social Navigation Layer into people
* Contributors: David Lu!!
```
