### PR TITLE
imu_compass: 0.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2468,7 +2468,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/imu_compass-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/imu_compass.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_compass` to `0.0.5-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.4-0`
## imu_compass

```
* removing bag references from sample hard-iron calibration output file
* fixing example launch file to reflect changes in param intake in the node
* Contributors: Prasenjit Mukherjee
```
