### PR TITLE
adding xdot to rosdep.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1387,4 +1387,4 @@ python-zmq:
     trusty: [python-zmq]
     trusty_python3: [python3-zmq]
 xdot:
-    ubuntu: [xdot]
+  ubuntu: [xdot]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1386,3 +1386,5 @@ python-zmq:
     saucy: [python-zmq]
     trusty: [python-zmq]
     trusty_python3: [python3-zmq]
+xdot:
+    ubuntu: [xdot]


### PR DESCRIPTION
Finally had to fork and do it manually. Seems github's editor causes whitespace problems.
