### PR TITLE
Use indigo-devel branch for rqt_ez_publisher

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3030,12 +3030,12 @@ repositories:
     doc:
       type: git
       url: https://github.com/OTL/rqt_ez_publisher.git
-      version: hydro-devel
+      version: indigo-devel
     source:
       type: git
       url: https://github.com/OTL/rqt_ez_publisher.git
-      version: hydro-devel
-    status: maintained
+      version: indigo-devel
+    status: developed
   rqt_robot_plugins:
     release:
       packages:


### PR DESCRIPTION
Use indigo-devel branch for rqt_ez_publisher.

and change status developed.
