### PR TITLE
rqt_ez_publisher: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3031,6 +3031,11 @@ repositories:
       type: git
       url: https://github.com/OTL/rqt_ez_publisher.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/OTL/rqt_ez_publisher-release.git
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/OTL/rqt_ez_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_ez_publisher` to `0.0.4-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## rqt_ez_publisher

```
* Update for indigo
* Fix NoneType error for make_topic_string
* Clean codes (applied pep8)
* Support byte
* Add sphinx doc
```
