### PR TITLE
catkin: 0.6.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -253,7 +253,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.6.7-0
+      version: 0.6.8-0
     status: maintained
   class_loader:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.6.8-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.6.7-0`
## catkin

```
* make nosetests --xunit-file argument an absolute path to work around nose bug 779 (#659 <https://github.com/ros/catkin/issues/659>)
* fix handling of CMake packages which do not install any files (#665 <https://github.com/ros/catkin/issues/665>)
* fix gtest on Arch Linux and others (#663 <https://github.com/ros/catkin/issues/663>)
* improve generation of .catkin marker file (#671 <https://github.com/ros/catkin/issues/671>, #676 <https://github.com/ros/catkin/issues/676>)
* escape messages to avoid CMake warning (#667 <https://github.com/ros/catkin/issues/667>)
* fix CMake warning for doxygen target with CMake 3 (#660 <https://github.com/ros/catkin/issues/660>)
* avoid using ARGN for efficiency (#669 <https://github.com/ros/catkin/issues/669>)
```
