### PR TITLE
rospack: 2.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2889,7 +2889,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
-      version: 2.2.3-1
+      version: 2.2.4-0
     source:
       type: git
       url: https://github.com/ros/rospack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.2.4-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `2.2.3-1`
## rospack

```
* fix find_package(PythonLibs ...) with CMake 3 (#42 <https://github.com/ros/rospack/issues/42>)
```
