### PR TITLE
ros_comm: 1.11.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2630,7 +2630,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.5-0
+      version: 1.11.6-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.6-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.11.5-0`
## message_filters
- No changes
## ros_comm
- No changes
## rosbag

```
* fix rosbag record prefix (#449 <https://github.com/ros/ros_comm/issues/449>)
```
## rosbag_storage
- No changes
## rosconsole
- No changes
## roscpp

```
* check ROS_HOSTNAME for localhost / ROS_IP for 127./::1 and prevent connections from other hosts in that case (#452 <https://github.com/ros/ros_comm/issues/452>)_
```
## rosgraph
- No changes
## roslaunch

```
* fix printing of non-ascii roslaunch parameters (#454 <https://github.com/ros/ros_comm/issues/454>)
* add respawn_delay attribute to node tag in roslaunch (#446 <https://github.com/ros/ros_comm/issues/446>)
* write traceback for exceptions in roslaunch to log file
```
## roslz4

```
* fix finding specific version of PythonLibs with CMake 3
```
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy

```
* make MasterProxy thread-safe (#459 <https://github.com/ros/ros_comm/issues/459>)
* check ROS_HOSTNAME for localhost / ROS_IP for 127./::1 and prevent connections from other hosts in that case (#452 <https://github.com/ros/ros_comm/issues/452>)_
```
## rosservice
- No changes
## rostest

```
* resolving naming conflicts when multiple test are added with arguments (#462 <https://github.com/ros/ros_comm/issues/462>)
```
## rostopic
- No changes
## roswtf
- No changes
## topic_tools
- No changes
## xmlrpcpp
- No changes
