### PR TITLE
genmsg: 0.5.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -843,7 +843,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/genmsg-release.git
-      version: 0.5.2-0
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/ros/genmsg.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.5.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.5.2-0`
## genmsg

```
* escape messages to avoid CMake warning (#49 <https://github.com/ros/genmsg/issues/49>)
```
