### PR TITLE
rqt_common_plugins: 0.3.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3020,7 +3020,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.3.6-0
+      version: 0.3.7-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `0.3.7-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.3.6-0`
## rqt_action

```
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_bag

```
* fix compatibility with Groovy, use queue_size for Python publishers only when available (#243 <https://github.com/ros-visualization/rqt_common_plugins/issues/243>)
* use thread for loading bag files, emit region changed signal used by plotting plugin (#239 <https://github.com/ros-visualization/rqt_common_plugins/issues/239>)
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_bag_plugins

```
* add plotting plugin (#239 <https://github.com/ros-visualization/rqt_common_plugins/issues/239>)
* fix rqt_bag to plot array members (#253 <https://github.com/ros-visualization/rqt_common_plugins/issues/253>)
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_common_plugins
- No changes
## rqt_console

```
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_dep

```
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_graph

```
* fix compatibility with Groovy, use TopicStatistics only if available (#252 <https://github.com/ros-visualization/rqt_common_plugins/issues/252>)
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_image_view
- No changes
## rqt_launch

```
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_logger_level

```
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_msg

```
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_plot

```
* fix missing import (#248 <https://github.com/ros-visualization/rqt_common_plugins/issues/248>)
* significant improvements and unification of different plot backends (#239 <https://github.com/ros-visualization/rqt_common_plugins/issues/239>, #231 <https://github.com/ros-visualization/rqt_common_plugins/issues/231>)
* make more things plottable including arrays and simple message types (#246 <https://github.com/ros-visualization/rqt_common_plugins/issues/246>)
* make DataPlot a proxy for its plot widget, redraw after loading new data, add clear_values (#236 <https://github.com/ros-visualization/rqt_common_plugins/issues/236>)
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_publisher

```
* fix compatibility with Groovy, use queue_size for Python publishers only when available (#243 <https://github.com/ros-visualization/rqt_common_plugins/issues/243>)
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_py_common

```
* improve topic helpers to make more things plottable (#246 <https://github.com/ros-visualization/rqt_common_plugins/issues/246>)
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_py_console

```
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_reconfigure

```
* fix slider bar, add context menus for common operations (#251 <https://github.com/ros-visualization/rqt_common_plugins/issues/251>)
* fix bug in float range calculations (#241 <https://github.com/ros-visualization/rqt_common_plugins/issues/241>)
* remove experimental suffix from rqt_reconfigure (#256 <https://github.com/ros-visualization/rqt_common_plugins/issues/256>)
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_service_caller

```
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_shell

```
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_srv

```
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_top

```
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_topic

```
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
## rqt_web

```
* export architecture_independent flag in package.xml (#254 <https://github.com/ros-visualization/rqt_common_plugins/issues/254>)
```
