### PR TITLE
catkin: 0.6.9-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -253,7 +253,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.6.9-0
+      version: 0.6.9-1
     status: maintained
   class_loader:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.6.9-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.6.9-0`
## catkin

```
* fix regression from 0.6.8 (#676 <https://github.com/ros/catkin/issues/676>)
```
