### PR TITLE
ros_controllers: 0.8.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2700,7 +2700,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.8.0-1
+      version: 0.8.1-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.8.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.8.0-1`
## diff_drive_controller
- No changes
## effort_controllers

```
* Add depend on angles
* Contributors: Scott K Logan
```
## force_torque_sensor_controller
- No changes
## forward_command_controller
- No changes
## gripper_action_controller
- No changes
## imu_sensor_controller
- No changes
## joint_state_controller
- No changes
## joint_trajectory_controller

```
* joint_trajectory_controller: Critical targets declared before calling catkin_package
* check for CATKIN_ENABLE_TESTING
* Contributors: Jonathan Bohren, Lukas Bulwahn
```
## position_controllers
- No changes
## ros_controllers
- No changes
## velocity_controllers
- No changes
