### PR TITLE
rqt_ez_publisher: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3035,7 +3035,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/OTL/rqt_ez_publisher-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/OTL/rqt_ez_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_ez_publisher` to `0.0.5-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.4-0`
## rqt_ez_publisher

```
* Fix test wait
```
