### PR TITLE
rqt_robot_plugins: 0.3.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3057,7 +3057,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-      version: 0.3.5-0
+      version: 0.3.6-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins` to `0.3.6-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.3.5-0`
## rqt_moveit
- No changes
## rqt_nav_view

```
* fix compatibility with Groovy, use queue_size for Python publishers only when available (#67 <https://github.com/ros-visualization/rqt_robot_plugins/pull/67>)
```
## rqt_pose_view
- No changes
## rqt_robot_dashboard
- No changes
## rqt_robot_monitor
- No changes
## rqt_robot_plugins
- No changes
## rqt_robot_steering

```
* fix compatibility with Groovy, use queue_size for Python publishers only when available (#67 <https://github.com/ros-visualization/rqt_robot_plugins/pull/67>)
```
## rqt_runtime_monitor
- No changes
## rqt_rviz
- No changes
## rqt_tf_tree
- No changes
