### PR TITLE
terarangerone-ros: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6642,6 +6642,19 @@ repositories:
       url: https://github.com/ros-gbp/teleop_twist_keyboard-release.git
       version: 0.5.0-0
     status: maintained
+  terarangerone-ros:
+    release:
+      packages:
+      - terarangerone
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/Terabee/terarangerone-ros-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/Terabee/terarangerone-ros.git
+      version: 0.1.0
+    status: developed
   tf2_web_republisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `terarangerone-ros` to `0.1.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
