### PR TITLE
xacro: 1.9.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3530,7 +3530,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.9.1-0
+      version: 1.9.2-0
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.9.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.9.1-0`
## xacro

```
* add a few more tests to exercise the symbol table a bit more
* allow for recursive evaluation of properties in expressions
* add useful debugging information when parameters are not set
* stop test from failing the second time it is run
* unified if/unless handling, correctly handle floating point expressions
* floating point expressions not equal zero are now evaluated as True
* changed quotes to omit cmake warning
* Contributors: Robert Haschke, Mike Ferguson
```
