### PR TITLE
rtmros_hironx: 1.0.17-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5998,7 +5998,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.16-1
+      version: 1.0.17-1
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.17-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.0.16-1`
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* 1st fully functional release (robot-compile-setup.sh, robot-system-check).
* Add install script for Vision PC Ubuntu.
* Add Nitta JR3 driver
* Adjust a few launch files to accommodate servo controller argument.
* Contributors: Kei Okada, Isaac IY Saito, Hajime Saito
```
## rtmros_hironx

```
* 1st fully functional release (robot-compile-setup.sh, robot-system-check).
* Add install script for Vision PC Ubuntu.
* Add Nitta JR3 driver
* Adjust a few launch files to accommodate servo controller argument.
* Contributors: Kei Okada, Isaac IY Saito, Hajime Saito
```
