### PR TITLE
rqt_ez_publisher: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5923,7 +5923,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/OTL/rqt_ez_publisher-release.git
-      version: 0.0.3-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/OTL/rqt_ez_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_ez_publisher` to `0.1.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.3-0`
## rqt_ez_publisher

```
* Change default for double 1.0
* Support tf and header
* fix bug with array
* fix type bug
```
