### PR TITLE
mavlink: 1.0.9-7 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1500,7 +1500,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/vooon/mavlink-gbp-release.git
-      version: 1.0.9-5
+      version: 1.0.9-7
     status: maintained
   mavros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `1.0.9-7`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.0.9-5`
