### PR TITLE
ntpd_driver: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1894,6 +1894,21 @@ repositories:
       url: https://github.com/ros/nodelet_core.git
       version: hydro-devel
     status: maintained
+  ntpd_driver:
+    doc:
+      type: git
+      url: https://github.com/vooon/ntpd_driver.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/vooon/ntpd_driver-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/vooon/ntpd_driver.git
+      version: master
+    status: developed
   object_recognition_core:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ntpd_driver` to `1.0.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## ntpd_driver

```
* Rename package from ros2ntpd to ntpd_driver
  Add notes for chrony.
* Contributors: Vladimir Ermakov
```
