### PR TITLE
rtmros_nextage: 0.2.15-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6018,7 +6018,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.2.14-0
+      version: 0.2.15-1
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.2.15-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.2.14-0`
## nextage_description
- No changes
## nextage_moveit_config

```
* Enable natto-view.
* Contributors: Isaac IY Saito
```
## nextage_ros_bridge

```
* (nextage_ros_bridge_real.launch) Init commit. This must be run when working with a real robot, instead of nextage_ros_bridge.launch. Fix #79 <https://github.com/tork-a/rtmros_nextage/issues/79>
* Disable ServoController. NXO by default does not ship with servo-controlled hand.
* Contributors: Isaac IY Saito
```
## rtmros_nextage

```
* (nextage_ros_bridge_real.launch) Init commit. This must be run when working with a real robot, instead of nextage_ros_bridge.launch. Fix #79 <https://github.com/tork-a/rtmros_nextage/issues/79>
* Disable ServoController. NXO by default does not ship with servo-controlled hand.
* Enable natto-view.
* Contributors: Isaac IY Saito
```
