### PR TITLE
rosh_core: 1.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2891,6 +2891,25 @@ repositories:
       url: https://github.com/ros-infrastructure/rosdoc_lite.git
       version: master
     status: maintained
+  rosh_core:
+    doc:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_core.git
+      version: hydro-devel
+    release:
+      packages:
+      - rosh
+      - rosh_core
+      - roshlaunch
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/OSUrobotics/rosh_core-release.git
+      version: 1.0.5-0
+    source:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_core.git
+      version: hydro-devel
+    status: maintained
   roslint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_core` to `1.0.5-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## rosh

```
* fix errors caused by API changes
* Contributors: Dan Lazewatsky
```
## rosh_core
- No changes
## roshlaunch
- No changes
