### PR TITLE
rosh_robot_plugins: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2910,6 +2910,26 @@ repositories:
       url: https://github.com/OSUrobotics/rosh_core.git
       version: hydro-devel
     status: maintained
+  rosh_robot_plugins:
+    doc:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_robot_plugins.git
+      version: hydro-devel
+    release:
+      packages:
+      - rosh_common
+      - rosh_geometry
+      - rosh_robot
+      - rosh_robot_plugins
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/OSUrobotics/rosh_robot_plugins-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_robot_plugins.git
+      version: hydro-devel
+    status: maintained
   roslint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_robot_plugins` to `1.0.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## rosh_common

```
* catkinizing
```
## rosh_geometry

```
* Print a message when trying to load rosh_geometry if roscore isn't running
* catkinizing
```
## rosh_robot

```
* catkinizing
```
## rosh_robot_plugins

```
* catkinizing
```
