### PR TITLE
rosh_desktop_plugins: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2910,6 +2910,25 @@ repositories:
       url: https://github.com/OSUrobotics/rosh_core.git
       version: hydro-devel
     status: maintained
+  rosh_desktop_plugins:
+    doc:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_desktop_plugins.git
+      version: master
+    release:
+      packages:
+      - rosh_desktop
+      - rosh_desktop_plugins
+      - rosh_visualization
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/OSUrobotics/rosh_desktop_plugins-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_desktop_plugins.git
+      version: master
+    status: maintained
   rosh_robot_plugins:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_desktop_plugins` to `1.0.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## rosh_desktop
- No changes
## rosh_desktop_plugins
- No changes
## rosh_visualization
- No changes
