### PR TITLE
navigation_2d: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1830,6 +1830,26 @@ repositories:
       type: git
       url: https://github.com/skasperski/navigation_2d.git
       version: indigo
+    release:
+      packages:
+      - nav2d
+      - nav2d_exploration
+      - nav2d_karto
+      - nav2d_localizer
+      - nav2d_msgs
+      - nav2d_navigator
+      - nav2d_operator
+      - nav2d_remote
+      - nav2d_tutorials
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/skasperski/navigation_2d-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/skasperski/navigation_2d.git
+      version: indigo-dev
+    status: developed
   nmea_comms:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_2d` to `0.1.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
