### PR TITLE
arbotix: 0.10.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -102,7 +102,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/vanadiumlabs/arbotix_ros-release.git
-      version: 0.9.2-0
+      version: 0.10.0-0
     status: maintained
   ardrone_autonomy:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `arbotix` to `0.10.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.9.2-0`
## arbotix
- No changes
## arbotix_controllers

```
* Set queue_size=5 on all publishers
* Check if command exceeds opening limits
* Contributors: Jorge Santos
```
## arbotix_firmware
- No changes
## arbotix_msgs
- No changes
## arbotix_python

```
* Set queue_size=5 on all publishers
* Contributors: Jorge Santos
```
## arbotix_sensors

```
* Set queue_size=5 on all publishers
* Contributors: Jorge Santos
```
