### PR TITLE
Adding labust_common_msgs to documentation index for hydro

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2061,11 +2061,6 @@ repositories:
       type: git
       url: https://github.com/uos/kurt_navigation.git
       version: groovy
-  labust_ros_pkg:
-    doc:
-      type: git
-      url: https://github.com/labust/labust-ros-pkg.git
-      version: groovy-devel
   langs:
     doc:
       type: git

--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2061,6 +2061,11 @@ repositories:
       type: git
       url: https://github.com/uos/kurt_navigation.git
       version: groovy
+  labust_ros_pkg:
+    doc:
+      type: git
+      url: https://github.com/labust/labust-ros-pkg.git
+      version: groovy-devel
   langs:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2995,11 +2995,16 @@ repositories:
       type: git
       url: https://github.com/uos/kurt_navigation.git
       version: hydro
+  labust_common_msgs:
+    doc:
+      type: git
+      url: https://github.com/labust/labust-common-msgs.git
+      version: master
   labust_ros_pkg:
     doc:
       type: git
       url: https://github.com/labust/labust-ros-pkg.git
-      version: hydro-devel
+      version: master
   langs:
     source:
       type: git


### PR DESCRIPTION
I'd like labust_common_msgs to be indexed and documented on ros.org and remove the labust_ros_pkg entry from groovy since the groovy branch will be deprecated.
