### PR TITLE
pal_vision_segmentation: 1.0.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4410,7 +4410,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/pal-gbp/pal_vision_segmentation-release.git
-      version: 0.0.1-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/pal-robotics/pal_vision_segmentation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_vision_segmentation` to `1.0.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.1-0`
## pal_vision_segmentation

```
* Add depth_segmentation node
* Do not show images unless explicit argument in unit test
* Remove ros init from test
* Timestamp is taken from the original image
* Contributors: Bence Magyar, Jordi Pages, Mariia Dmitrieva
```
