### PR TITLE
serial_utils: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3234,6 +3234,21 @@ repositories:
       url: https://github.com/wjwwood/serial.git
       version: master
     status: maintained
+  serial_utils:
+    doc:
+      type: git
+      url: https://github.com/wjwwood/serial_utils.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wjwwood/serial_utils-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/wjwwood/serial_utils.git
+      version: master
+    status: maintained
   shape_tools:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `serial_utils` to `0.1.0-0`:
- upstream repository: https://github.com/wjwwood/serial_utils.git
- release repository: https://github.com/wjwwood/serial_utils-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11-dev`
- previous version for package: `null`
