### PR TITLE
ax2550: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -119,6 +119,21 @@ repositories:
       type: git
       url: https://github.com/voxel-dot-at/argos3d_p100_ros_pkg.git
       version: master
+  ax2550:
+    doc:
+      type: git
+      url: https://github.com/wjwwood/ax2550.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wjwwood/ax2550-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/wjwwood/ax2550.git
+      version: master
+    status: maintained
   bfl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ax2550` to `0.1.1-0`:
- upstream repository: https://github.com/wjwwood/ax2550.git
- release repository: https://github.com/wjwwood/ax2550-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11-dev`
- previous version for package: `null`
