### PR TITLE
Adding tedusar_manipulation to documentation index for hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6653,6 +6653,11 @@ repositories:
       url: https://github.com/clearpath-gbp/libswiftnav-release.git
       version: 0.8.0-2
     status: maintained
+  tedusar_manipulation:
+    doc:
+      type: git
+      url: https://intra.ist.tugraz.at/gitlab/robocup/tedusar_manipulation.git
+      version: hydro-devel
   teleop_twist_keyboard:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6656,8 +6656,8 @@ repositories:
   tedusar_manipulation:
     doc:
       type: git
-      url: https://intra.ist.tugraz.at/gitlab/robocup/tedusar_manipulation.git
-      version: hydro-devel
+      url: https://github.com/johmau85/tedusar_manipulation.git
+      version: master
   teleop_twist_keyboard:
     doc:
       type: git


### PR DESCRIPTION
I would like tedusar_manipulation to be indexed and documented on ros.org.
