### PR TITLE
Adding agvs to documentation index for Hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -71,6 +71,16 @@ repositories:
       url: https://github.com/ros/actionlib.git
       version: hydro-devel
     status: maintained
+  agvs:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/agvs.git
+      version: hydro-devel
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/agvs.git
+      version: hydro-devel
+    status: developed
   android_apps:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add agvs repository to be indexed and documented on ros.org
