### PR TITLE
Added python-msgpack rule to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -515,6 +515,16 @@ python-mock:
     saucy: [python-mock]
     trusty: [python-mock]
     trusty_python3: [python3-mock]
+python-msgpack:
+  debian: [python-msgpack]
+  fedora: [python-msgpack]
+  gentoo: [dev-python/msgpack]
+  ubuntu:
+    precise: [msgpack-python]
+    raring: [msgpack-python]
+    saucy: [msgpack-python]
+    trusty: [python-msgpack]
+    trusty_python3: [python3-msgpack]
 python-multicast:
   ubuntu:
     pip: [py-multicast]


### PR DESCRIPTION
`python-msgpack` rules for `rosdep/python.yaml`
