### PR TITLE
orocos_kinematics_dynamics: 1.2.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4393,6 +4393,7 @@ repositories:
       type: git
       url: https://github.com/orocos/orocos_kinematics_dynamics.git
       version: master
+    status: maintained
   orocos_toolchain:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kinematics_dynamics` to `1.2.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.2.2-0`
