### PR TITLE
orocos_kinematics_dynamics: 1.3.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4384,11 +4384,12 @@ repositories:
     release:
       packages:
       - orocos_kdl
+      - orocos_kinematics_dynamics
       - python_orocos_kdl
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/smits/orocos-kdl-release.git
-      version: 1.2.2-0
+      version: 1.3.0-0
     source:
       type: git
       url: https://github.com/orocos/orocos_kinematics_dynamics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kinematics_dynamics` to `1.3.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.2.2-0`
