### PR TITLE
Adding robotnik_msgs to documentation index for Groovy and Hydro

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3530,6 +3530,16 @@ repositories:
       type: git
       url: https://github.com/ros/robot_state_publisher.git
       version: groovy-devel
+  robotnik_msgs:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_msgs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_msgs.git
+      version: master
+    status: developed
   rocon_app_platform:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5083,6 +5083,16 @@ repositories:
       type: git
       url: https://github.com/g/roboteq.git
       version: master
+  robotnik_msgs:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_msgs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_msgs.git
+      version: master
+    status: developed
   rocon:
     doc:
       type: git


### PR DESCRIPTION
I'd like robotnik_msgs to be indexed and documented on ros.org.
