### PR TITLE
mavros: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1526,7 +1526,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/vooon/mavros-release.git
-      version: 0.5.0-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/vooon/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.6.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.5.0-0`
## mavros

```
* plugin: local_position: Use same timestamp in topic and TF.
  Issue #33 <https://github.com/vooon/mavros/issues/33>.
* plugins: TF thread required, remove notes.
  Issue #33 <https://github.com/vooon/mavros/issues/33>.
* launch: Add example launch for PX4
  Issue #45 <https://github.com/vooon/mavros/issues/45>.
* plugin: imu_pub: Fix attitude store in UAS
  Issue #33 <https://github.com/vooon/mavros/issues/33>.
  Fix #53 <https://github.com/vooon/mavros/issues/53>.
* plugins: Disable position topics if tf_listen enabled
  Also change default frame names: vision and setpoint.
  Issue #33 <https://github.com/vooon/mavros/issues/33>.
* plugins: Fix typo in frame_id params.
  Issue #33 <https://github.com/vooon/mavros/issues/33>.
* plugins: Add vision and setpoint TF listeners
  Also change parameter names to same style.
  Issue #33 <https://github.com/vooon/mavros/issues/33>.
* plugin: vision_position: Add PositionWithCovarianceStamped option
  Issue #33 <https://github.com/vooon/mavros/issues/33>.
* Add boost filesystem lib to link
  On some platforms its absence breaks build by:
  undefined reference to boost::filesystem::path::codecvt()
* launch: Add example for APM2
  Fix #45 <https://github.com/vooon/mavros/issues/45>.
* plugin: setpoint_position: Initial import
  And some small doc changes in other position plugins.
  Issue #33 <https://github.com/vooon/mavros/issues/33>.
* node: Add connection change message
  Fix #52 <https://github.com/vooon/mavros/issues/52>.
* plugins: vision_position: Initial import
  TODO: check ENU->NED maths.
  Issue #33 <https://github.com/vooon/mavros/issues/33>.
* plugins: Remove unneded 'FCU' from diag
* plugin: local_position: Change plane conversion
  Bug: #49 <https://github.com/vooon/mavros/issues/49>.
* plugin: imu_pub: Fix magnetic vector convertions
  Bug: #49 <https://github.com/vooon/mavros/issues/49>.
* Use dialects list from package
* plugin: local_position: Fix orientation source
  Part of #33 <https://github.com/vooon/mavros/issues/33>.
* node: Show target system on startup
  Fix #47 <https://github.com/vooon/mavros/issues/47>.
* plugin: local_position: Initial add
  Receive LOCAL_POSITION_NED message and publish it via TF and PoseStamped
  topic in ENU frame.
  Part of #33 <https://github.com/vooon/mavros/issues/33>.
* node: Use boost::make_shared for message allocation
  Fix #46 <https://github.com/vooon/mavros/issues/46>.
* plugins: Use boost::make_shared for message allocation
  Part of #46 <https://github.com/vooon/mavros/issues/46>.
* plugin: imu_pub: Fix misprint in fill function
  Fix magnetometer vector convertion (HR IMU).
  Related #33 <https://github.com/vooon/mavros/issues/33>.
* plugin: imu_pub: setup cleanup.
* Update readme
* plugin: gps: Fix gps_vel calculation
  Fix #42 <https://github.com/vooon/mavros/issues/42>.
* plugins: Make name and messages methods const. (breaking).
  WARNING: this change broke external plugins.
  Please add const to get_name() and get_supported_messages().
  Part of #38 <https://github.com/vooon/mavros/issues/38>.
* plugins: Use mavlink_msg_*_pack_chan() functions
  Fix #43 <https://github.com/vooon/mavros/issues/43>.
* mavconn: Reuse tx buffer (resize by extents)
  Part of #38 <https://github.com/vooon/mavros/issues/38>.
* mavconn: Do not finalize messages if id pair match
  mavlink_*_pack also do finalize, so explicit finalization just
  recalculate crc and seq number (doubles work).
  Test later if we need check seq too.
* mavconn: Documentation and cleanup
  Make MAVConn classes noncopyable.
  Remove copy-paste copy and following async_write calls.
  Reserve some space in tx queues.
  Replace auto_ptr with unique_ptr.
* test: Fix header include
* mavconn: Fix possible array overrun in channel alocation.
  Problem found by clang.
* fix some roslint errors
* mavconn: move headers to include
* node: Implement plugin blacklist.
  New parameter: ~/plugin_blacklist lists plugin aliases
  with glob syntax.
  Fix #36 <https://github.com/vooon/mavros/issues/36>.
* plugins: Change constants to constexpr (for gcc 4.6)
* mavconn: Add gencpp dependency (utils.h requiers generated header)
* Move duplicate Mavlink.msg copy to utils.h
* Remove tests that requires connection to FCU
* plugins: imu_pub: Fix PX4 imu/data linear_accelerarion field
  Should fix: #39 <https://github.com/vooon/mavros/issues/39>.
* plugins: imu_pub: Add magnitic covariance
  Trying to move constants with constexpr.
  Related: #13 <https://github.com/vooon/mavros/issues/13>.
* Remove testing info
  Need to remove tests that could not run on build farm.
* Contributors: Vladimir Ermakov
```
