### PR TITLE
flir_ptu: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -769,7 +769,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_ptu-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/ros-drivers/flir_ptu.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_ptu` to `0.1.4-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.3-0`
## flir_ptu_description

```
* Fix weird urdf issue with floating tilt joint.
* Add comments to the example URDF.
* Contributors: Mike Purvis
```
## flir_ptu_driver

```
* Fix repository and bug-tracker URLs.
* Add more URL elements
* Update package description
* Fix tabs->spaces in launch file.
* Contributors: Mike Purvis
```
## flir_ptu_viz

```
* Update and install the rviz config as well.
* Install launch files for viz.
* Contributors: Mike Purvis
```
