### PR TITLE
ros_ethercat: 0.1.7-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5405,7 +5405,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/shadow-robot/ros_ethercat-release.git
-      version: 0.1.7-0
+      version: 0.1.7-1
     source:
       type: git
       url: https://github.com/shadow-robot/ros_ethercat.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ethercat` to `0.1.7-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.7-0`
## ros_ethercat
- No changes
## ros_ethercat_eml
- No changes
## ros_ethercat_hardware
- No changes
## ros_ethercat_loop
- No changes
## ros_ethercat_model
- No changes
