### PR TITLE
rosconsole_bridge: 0.4.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2886,7 +2886,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rosconsole_bridge-release.git
-      version: 0.4.1-0
+      version: 0.4.2-0
     source:
       type: git
       url: https://github.com/ros/rosconsole_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole_bridge` to `0.4.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.4.1-0`
## rosconsole_bridge

```
* update maintainers
```
