### PR TITLE
shadow_robot: 1.3.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3265,6 +3265,37 @@ repositories:
       url: https://github.com/wjwwood/serial_utils.git
       version: master
     status: maintained
+  shadow_robot:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr-ros-interface.git
+      version: indigo-devel
+    release:
+      packages:
+      - shadow_robot
+      - sr_description
+      - sr_example
+      - sr_gazebo_plugins
+      - sr_hand
+      - sr_hardware_interface
+      - sr_mechanism_controllers
+      - sr_mechanism_model
+      - sr_moveit_config
+      - sr_movements
+      - sr_robot_msgs
+      - sr_self_test
+      - sr_standalone
+      - sr_tactile_sensors
+      - sr_utilities
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/shadow-robot/sr-ros-interface-release.git
+      version: 1.3.1-1
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr-ros-interface.git
+      version: indigo-devel
+    status: developed
   shape_tools:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `shadow_robot` to `1.3.1-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## shadow_robot
- No changes
## sr_description
- No changes
## sr_example
- No changes
## sr_gazebo_plugins
- No changes
## sr_hand
- No changes
## sr_hardware_interface
- No changes
## sr_mechanism_controllers
- No changes
## sr_mechanism_model
- No changes
## sr_moveit_config
- No changes
## sr_movements
- No changes
## sr_robot_msgs
- No changes
## sr_self_test
- No changes
## sr_standalone
- No changes
## sr_tactile_sensors
- No changes
## sr_utilities
- No changes
