### PR TITLE
ros: 1.11.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2666,7 +2666,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.11.2-0
+      version: 1.11.3-0
     source:
       type: git
       url: https://github.com/ros/ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.11.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.11.2-0`
## mk
- No changes
## rosbash
- No changes
## rosboost_cfg
- No changes
## rosbuild

```
* suppress warning for rosbuild target "test" with CMake 3.0 (#61 <https://github.com/ros/ros/issues/61>)
```
## rosclean
- No changes
## roscreate
- No changes
## roslang
- No changes
## roslib

```
* remove linking against "rt" library on Android (#57 <https://github.com/ros/ros/issues/57>)
* disable delayed expansion in Windows environment hook (#60 <https://github.com/ros/ros/issues/60>)
```
## rosmake

```
* fix Python 3 regression in rosmake (#54 <https://github.com/ros/ros/issues/54>)
```
## rosunit
- No changes
