### PR TITLE
ros_comm: 1.11.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2703,7 +2703,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.6-0
+      version: 1.11.7-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.7-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.11.6-0`
## message_filters
- No changes
## ros_comm
- No changes
## rosbag
- No changes
## rosbag_storage
- No changes
## rosconsole
- No changes
## roscpp

```
* fix segfault due to accessing a NULL pointer for some network interfaces (#465 <https://github.com/ros/ros_comm/issues/465>) (regression from 1.11.6)
```
## rosgraph
- No changes
## roslaunch

```
* fix the ROS_MASTER_URI environment variable logic on Windows (#2 <https://github.com/windows/ros_comm/issues/2>)
```
## roslz4
- No changes
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy
- No changes
## rosservice
- No changes
## rostest

```
* make rostest use a random master port and run rostests in parallel (#468 <https://github.com/ros/ros_comm/issues/468>)
```
## rostopic
- No changes
## roswtf
- No changes
## topic_tools
- No changes
## xmlrpcpp
- No changes
