### PR TITLE
gazebo_ros_pkgs: 2.4.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -815,7 +815,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.4.3-1
+      version: 2.4.4-0
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.4.4-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `2.4.3-1`
## gazebo_msgs

```
* Fix repo names in package.xml's
* Contributors: Jon Binney
```
## gazebo_plugins

```
* Merge branch 'hydro-devel' into indigo-devel
* gazebo_ros_diff_drive gazebo_ros_tricycle_drive encoderSource option names updated
* gazebo_ros_diff_drive is now able to use the wheels rotation of the optometry or the gazebo ground truth based on the 'odometrySource' parameter
* simple linear controller for the tricycle_drive added
* second robot for testing in tricycle_drive_scenario.launch added
* Merge remote-tracking branch 'upstream/hydro-devel' into hydro-devel
* BDS licenses header fixed and tricycle drive plugin added
* format patch of hsu applied
* Updated package.xml
* Fix repo names in package.xml's
* ros diff drive supports now an acceleration limit
* Pioneer model: Diff_drive torque reduced
* GPU Laser test example added
* fixed gpu_laser to work with workspaces
* hand_of_god: Adding hand-of-god plugin
  ros_force: Fixing error messages to refer to the right plugin
* Remove unneeded dependency on pcl_ros
* minor fixes on relative paths in xacro for pioneer robot
* gazebo test model pionneer 3dx updated with xacro path variables
* pioneer model update for the multi_robot_scenario
* Merge remote-tracking branch 'upstream/hydro-devel' into hydro-devel
* fixed camera to work with workspaces
* fixed links related to changed name
* diff drive name changed to multi robot scenario
* working camera added
* Merge remote-tracking branch 'upstream/hydro-devel' into hydro-devel
* fix in pioneer xacro model for diff_drive
* Laser colour in rviz changed
* A test model for the ros_diff_drive ros_laser and joint_state_publisher added
* the ros_laser checkes now for the model name and adds it als prefix
* joint velocity fixed using radius instead of diameter
* ROS_INFO on laser plugin added to see if it starts
* fetched with upstream
* gazebo_ros_diff_drive was enhanced to publish the wheels tf or the wheels joint state depending on two additinal xml options <publishWheelTF> <publishWheelJointState>
* Gazebo ROS joint state publisher added
* Contributors: Dave Coleman, John Hsu, Jon Binney, Jonathan Bohren, Markus Bader, Steven Peters
```
## gazebo_ros

```
* Fix repo names in package.xml's
* fix issue #198 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/198>
  Operator ``==`` is not recognized by sh scripts.
* Add verbose parameter
  Add verbose parameter for --verbose gazebo flag
* added osx support for gazebo start scripts
* Contributors: Arn-O, Jon Binney, Markus Achtelik, Vincenzo Comito
```
## gazebo_ros_control

```
* Update package.xml
  Add new maintainer.
* Should fix build error for binary releases.
  See: http://www.ros.org/debbuild/indigo.html?q=gazebo_ros_control
* Updated package.xml
* gazebo_ros_control: default_robot_hw_sim:  Suppressing pid error message
  Depends on ros-controls/control_toolbox#21 <https://github.com/ros-controls/control_toolbox/issues/21>
* Revert 4776545, as it belongs in indigo-devel.
* Fix repo names in package.xml's
* gazebo_ros_control: default_robot_hw_sim: Suppressing pid error message, depends on ros-controls/control_toolbox#21 <https://github.com/ros-controls/control_toolbox/issues/21>
* gazebo_ros_control: Add dependency on angles
* gazebo_ros_control: Add build-time dependency on gazebo
  This fixes a regression caused by a889ef8b768861231a67b78781514d834f631b8e
* Contributors: Adolfo Rodriguez Tsouroukdissian, Alexander Bubeck, Dave Coleman, Jon Binney, Jonathan Bohren, Scott K Logan
```
## gazebo_ros_pkgs

```
* Updated package.xml
* Fix repo names in package.xml's
* Contributors: Dave Coleman, Jon Binney
```
