### PR TITLE
image_transport_plugins: 1.9.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1136,7 +1136,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/image_transport_plugins-release.git
-      version: 1.9.0-0
+      version: 1.9.1-0
     source:
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `1.9.1-0`:
- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros-gbp/image_transport_plugins-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11-dev`
- previous version for package: `1.9.0-0`
