### PR TITLE
rqt_ez_publisher: 0.2.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5965,7 +5965,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/OTL/rqt_ez_publisher-release.git
-      version: 0.1.0-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/OTL/rqt_ez_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_ez_publisher` to `0.2.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.0-0`
## rqt_ez_publisher

```
* Add tf for dependency
* Refactoring
  - Use base_widget
  - divided widgets into widget/
  - moved publishers into publisher/
  - rpy to quaternion_module/
* do not create header/seq
* Convert Quaternion to RPY
```
