### PR TITLE
libuvc: 0.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3183,7 +3183,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ktossell/libuvc-release.git
-      version: 0.0.4-1
+      version: 0.0.5-0
   libuvc_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc` to `0.0.5-0`:
- upstream repository: https://github.com/ktossell/libuvc.git
- release repository: https://github.com/ktossell/libuvc-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.4-1`
