### PR TITLE
rtmros_hironx: 1.0.18-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6039,7 +6039,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.17-1
+      version: 1.0.18-1
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.18-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.0.17-1`
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* (hironx_client) Fixed some methods not returning what super class returns.
* Contributors: Isaac IY Saito
```
## rtmros_hironx

```
* (hironx_client) Fixed some methods not returning what super class returns.
* Contributors: Isaac IY Saito
```
