### PR TITLE
Removed tu-darmstadt-ros-pkg source entries

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2034,10 +2034,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
       version: 0.3.3-0
-    source:
-      type: git
-      url: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
-      version: hydro-devel
     status: maintained
   hector_localization:
     doc:
@@ -2055,10 +2051,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
       version: 0.1.3-0
-    source:
-      type: git
-      url: https://github.com/tu-darmstadt-ros-pkg/hector_localization.git
-      version: catkin
     status: maintained
   hector_models:
     doc:
@@ -2075,10 +2067,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
       version: 0.3.1-1
-    source:
-      type: git
-      url: https://github.com/tu-darmstadt-ros-pkg/hector_models.git
-      version: hydro-devel
     status: maintained
   hector_navigation:
     doc:
@@ -2112,10 +2100,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_quadrotor-release.git
       version: 0.3.2-1
-    source:
-      type: git
-      url: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor.git
-      version: hydro-devel
     status: maintained
   hector_quadrotor_apps:
     doc:
@@ -2151,10 +2135,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
       version: 0.3.3-0
-    source:
-      type: git
-      url: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git
-      version: catkin
     status: maintained
   hector_turtlebot:
     doc:
@@ -2191,10 +2171,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
       version: 0.3.1-1
-    source:
-      type: git
-      url: https://github.com/tu-darmstadt-ros-pkg/hector_worldmodel.git
-      version: catkin
     status: maintained
   hironx_tutorial:
     doc:
@@ -6756,10 +6732,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/topic_proxy-release.git
       version: 0.1.0-1
-    source:
-      type: git
-      url: https://github.com/tu-darmstadt-ros-pkg/topic_proxy.git
-      version: master
     status: maintained
   turtlebot:
     doc:


### PR DESCRIPTION
During [RoboCup 2014](http://www.robocup2014.org) there might be several commits in these repos that cause failing devel jobs and will be cleaned up afterwards. Therefore we better switch them off until after the event to avoid build server load and email notifications.
