### PR TITLE
wu_ros_tools: 0.1.0-3 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7359,6 +7359,10 @@ repositories:
       url: https://github.com/clearpath-gbp/wireless-release.git
       version: 0.0.2-0
   wu_ros_tools:
+    doc:
+      type: git
+      url: https://github.com/DLu/wu_ros_tools.git
+      version: hydro
     release:
       packages:
       - catkinize_this
@@ -7370,7 +7374,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/wu-robotics/wu_ros_tools.git
-      version: 0.1.0-2
+      version: 0.1.0-3
+    source:
+      type: git
+      url: https://github.com/DLu/wu_ros_tools.git
+      version: hydro
     status: maintained
   x52_joyext:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `wu_ros_tools` to `0.1.0-3`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.0-2`
