### PR TITLE
laser_filtering: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3031,6 +3031,10 @@ repositories:
       version: hydro-devel
     status: maintained
   laser_filtering:
+    doc:
+      type: git
+      url: https://github.com/DLu/laser_filtering.git
+      version: hydro_devel
     release:
       packages:
       - laser_filtering
@@ -3038,7 +3042,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/wu-robotics/laser_filtering_release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/DLu/laser_filtering.git
+      version: hydro_devel
     status: maintained
   laser_filters:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filtering` to `0.0.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.1-0`
