### PR TITLE
shadow_robot_ethercat: 1.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3308,6 +3308,29 @@ repositories:
       url: https://github.com/shadow-robot/sr-ros-interface.git
       version: indigo-devel
     status: developed
+  shadow_robot_ethercat:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr-ros-interface-ethercat.git
+      version: indigo-devel
+    release:
+      packages:
+      - shadow_robot_ethercat
+      - sr_edc_controller_configuration
+      - sr_edc_ethercat_drivers
+      - sr_edc_launch
+      - sr_edc_muscle_tools
+      - sr_external_dependencies
+      - sr_robot_lib
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/shadow-robot/sr-ros-interface-ethercat-release.git
+      version: 1.3.2-0
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr-ros-interface-ethercat.git
+      version: indigo-devel
+    status: developed
   shape_tools:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `shadow_robot_ethercat` to `1.3.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
