### PR TITLE
prevent continuous triggering by using branch name not tag version..

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6710,7 +6710,7 @@ repositories:
     source:
       type: git
       url: https://github.com/Terabee/terarangerone-ros.git
-      version: 0.1.0
+      version: master
     status: developed
   tf2_web_republisher:
     doc:


### PR DESCRIPTION
Fixes #4995. https://issues.jenkins-ci.org/browse/JENKINS-23299
