### PR TITLE
qt_gui_core: 0.2.25-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4824,7 +4824,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.2.22-0
+      version: 0.2.25-0
     source:
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.2.25-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.2.22-0`
## qt_dotgraph
- No changes
## qt_gui
- No changes
## qt_gui_app
- No changes
## qt_gui_cpp

```
* fix finding specific version of PythonLibs with CMake 3 (#45 <https://github.com/ros-visualization/qt_gui_core/issues/45>)
```
## qt_gui_py_common

```
* add CheckBoxGroup class (#44 <https://github.com/ros-visualization/qt_gui_core/issues/44>)
```
