### PR TITLE
rqt_common_plugins: 0.3.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5952,7 +5952,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.3.4-0
+      version: 0.3.8-0
     status: developed
   rqt_ez_publisher:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `0.3.8-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.3.4-0`
## rqt_action
- No changes
## rqt_bag
- No changes
## rqt_bag_plugins

```
* fix missing installation of resource subfolder
```
## rqt_common_plugins
- No changes
## rqt_console
- No changes
## rqt_dep
- No changes
## rqt_graph
- No changes
## rqt_image_view
- No changes
## rqt_launch
- No changes
## rqt_logger_level
- No changes
## rqt_msg
- No changes
## rqt_plot

```
* fix missing installation of Python subpackage
```
## rqt_publisher
- No changes
## rqt_py_common
- No changes
## rqt_py_console
- No changes
## rqt_reconfigure
- No changes
## rqt_service_caller
- No changes
## rqt_shell
- No changes
## rqt_srv
- No changes
## rqt_top
- No changes
## rqt_topic
- No changes
## rqt_web
- No changes
