### PR TITLE
nasa_r2_common: 1.0.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3755,17 +3755,23 @@ repositories:
       version: master
     status: developed
   nasa_r2_common:
+    doc:
+      type: git
+      url: https://github.com/DLu/nasa_r2_common.git
+      version: hydro
     release:
       packages:
       - nasa_r2_common
+      - r2_control
       - r2_description
-      - r2_dynamic_reconfigure
+      - r2_fullbody_moveit_config
+      - r2_moveit_config
       - r2_msgs
-      - r2_teleop
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/brown-release/nasa_r2_common_release.git
-      version: 0.1.3-0
+      version: 1.0.0-1
+    status: maintained
   nasa_r2_simulator:
     release:
       packages:
@@ -4802,7 +4808,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/python_qt_binding-release.git
-      version: 0.2.14-0
+      version: 0.2.12-0
     source:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git
@@ -4824,7 +4830,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.2.25-0
+      version: 0.2.22-0
     source:
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git
@@ -5907,7 +5913,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rqt-release.git
-      version: 0.2.14-1
+      version: 0.2.14-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt.git
@@ -5952,7 +5958,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.3.8-0
+      version: 0.3.4-0
     status: developed
   rqt_ez_publisher:
     doc:
@@ -6000,7 +6006,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-      version: 0.3.6-0
+      version: 0.3.3-0
     status: maintained
   rtmros_common:
     doc:
@@ -6710,7 +6716,7 @@ repositories:
     source:
       type: git
       url: https://github.com/Terabee/terarangerone-ros.git
-      version: master
+      version: 0.1.0
     status: developed
   tf2_web_republisher:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `nasa_r2_common` to `1.0.0-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.3-0`
