### PR TITLE
nasa_r2_common: 1.0.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3755,17 +3755,23 @@ repositories:
       version: master
     status: developed
   nasa_r2_common:
+    doc:
+      type: git
+      url: https://github.com/DLu/nasa_r2_common.git
+      version: hydro
     release:
       packages:
       - nasa_r2_common
+      - r2_control
       - r2_description
-      - r2_dynamic_reconfigure
+      - r2_fullbody_moveit_config
+      - r2_moveit_config
       - r2_msgs
-      - r2_teleop
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/brown-release/nasa_r2_common_release.git
-      version: 0.1.3-0
+      version: 1.0.0-1
+    status: maintained
   nasa_r2_simulator:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `nasa_r2_common` to `1.0.0-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.3-0`
