### PR TITLE
rosserial_leonardo_cmake: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5858,7 +5858,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/rosserial_leonardo_cmake-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/rosserial_leonardo_cmake.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial_leonardo_cmake` to `0.1.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.1-0`
## rosserial_leonardo_cmake

```
* Remove unneeded build-time dependencies.
* Third time's the charm at fixing the downloader.
* Contributors: Mike Purvis
```
