### PR TITLE
turtlebot_create: 2.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6828,7 +6828,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_create-release.git
-      version: 2.2.0-1
+      version: 2.2.1-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot_create.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_create` to `2.2.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `2.2.0-1`
## create_description
- No changes
## create_driver

```
* Remove open() to fix double-open exception. Improve error info when an exception on opening serial port happens
* Contributors: Paul Bouchier
```
## create_node

```
* Remove open() to fix double-open exception. Improve error info when an exception on opening serial port happens
* Bug fixes
* Attempt to use the usb to serial converter's id
  If the robot receives a velocity command we'll assume that it's been
  brought up and must now move.  If we don't have the kinect's serial number
  yet assume we won't ever get it.  Instead attempt to find a calibration file
  that matches the serial number of the usb to serial converter that should be
  attached at /dev/ttyUSB0.  This setup will prevent the calibration script from
  running indefinitely waiting for a kinect that might never come.
* Import calibration load script
  This script uses the serial number of the attached kinect to identify the turtlebot that is currently connected and attempts to load a calibration file for it from a standard location.
  Needs more work to detect an xtion plugged in instead of a kinect, as well as if neither are plugged in.
* Contributors: Kenneth Bogert, Paul Bouchier
```
## turtlebot_create
- No changes
