### PR TITLE
shadow_robot_ethercat: 1.3.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3325,7 +3325,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/shadow-robot/sr-ros-interface-ethercat-release.git
-      version: 1.3.2-0
+      version: 1.3.3-0
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ros-interface-ethercat.git


### PR DESCRIPTION
Increasing version of package(s) in repository `shadow_robot_ethercat` to `1.3.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.3.2-0`
