### PR TITLE
sr_visualization: 1.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3466,6 +3466,35 @@ repositories:
       url: https://github.com/shadow-robot/sr-ronex.git
       version: indigo-devel
     status: developed
+  sr_visualization:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr-visualization.git
+      version: indigo-devel
+    release:
+      packages:
+      - sr_gui_bootloader
+      - sr_gui_change_controllers
+      - sr_gui_change_muscle_controllers
+      - sr_gui_controller_tuner
+      - sr_gui_grasp_controller
+      - sr_gui_hand_calibration
+      - sr_gui_joint_slider
+      - sr_gui_motor_resetter
+      - sr_gui_movement_recorder
+      - sr_gui_muscle_driver_bootloader
+      - sr_gui_self_test
+      - sr_visualization
+      - sr_visualization_icons
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/shadow-robot/sr-visualization-release.git
+      version: 1.3.1-0
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr-visualization.git
+      version: indigo-devel
+    status: developed
   srdfdom:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_visualization` to `1.3.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## sr_gui_bootloader
- No changes
## sr_gui_change_controllers
- No changes
## sr_gui_change_muscle_controllers
- No changes
## sr_gui_controller_tuner
- No changes
## sr_gui_grasp_controller
- No changes
## sr_gui_hand_calibration
- No changes
## sr_gui_joint_slider
- No changes
## sr_gui_motor_resetter
- No changes
## sr_gui_movement_recorder
- No changes
## sr_gui_muscle_driver_bootloader
- No changes
## sr_gui_self_test
- No changes
## sr_visualization
- No changes
## sr_visualization_icons
- No changes
