### PR TITLE
navigation: 1.11.11-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3828,7 +3828,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.11.10-0
+      version: 1.11.11-0
     source:
       type: git
       url: https://github.com/ros-planning/navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.11.11-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.11.10-0`
## amcl
- No changes
## base_local_planner

```
* Minor code cleanup
* Contributors: Enrique Fernández Perdomo
```
## carrot_planner
- No changes
## clear_costmap_recovery
- No changes
## costmap_2d

```
* removes trailing spaces and empty lines
* Contributors: Enrique Fernández Perdomo
```
## dwa_local_planner
- No changes
## fake_localization
- No changes
## global_planner

```
* Minor code cleanup
* Update package.xml
* Contributors: David Lu!!, Enrique Fernández Perdomo
```
## map_server
- No changes
## move_base

```
* removes trailing spaces and empty lines
* Contributors: Enrique Fernández Perdomo
```
## move_base_msgs
- No changes
## move_slow_and_clear

```
* Use service call, rather than system call, to call dynamic
  reconfigure when decreasing move_base speed.
* Contributors: Ryohei Ueda
```
## nav_core
- No changes
## navfn

```
* removes unused param planner_costmap_publish_frequency
* Contributors: Enrique Fernández Perdomo
```
## navigation
- No changes
## robot_pose_ekf
- No changes
## rotate_recovery
- No changes
## voxel_grid
- No changes
