### PR TITLE
rwi_ros: 1.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6215,6 +6215,28 @@ repositories:
       url: https://github.com/ros-visualization/rviz_fixed_view_controller.git
       version: hydro-devel
     status: developed
+  rwi_ros:
+    doc:
+      type: git
+      url: https://github.com/DLu/rwi_ros.git
+      version: hydro
+    release:
+      packages:
+      - b21_description
+      - b21_teleop
+      - ptu46
+      - ptu_control
+      - rflex
+      - rwi_ros
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/wu-robotics/rwi_ros.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/DLu/rwi_ros.git
+      version: hydro
+    status: maintained
   s3000_laser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rwi_ros` to `1.1.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
