### PR TITLE
ros: 1.11.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2678,7 +2678,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.11.3-0
+      version: 1.11.4-0
     source:
       type: git
       url: https://github.com/ros/ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.11.4-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.11.3-0`
## mk
- No changes
## rosbash
- No changes
## rosboost_cfg

```
* fix dry rosboost_cfg to support finding boost in multiarch lib folder (#62 <https://github.com/ros/ros/issues/62>)
```
## rosbuild

```
* fix dry rosboost_cfg to support finding boost in multiarch lib folder (#62 <https://github.com/ros/ros/issues/62>)
```
## rosclean
- No changes
## roscreate
- No changes
## roslang
- No changes
## roslib
- No changes
## rosmake
- No changes
## rosunit
- No changes
