### PR TITLE
jsk_recognition: 0.1.12-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2759,7 +2759,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.1.11-0
+      version: 0.1.12-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.1.12-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.11-0`
## checkerboard_detector

```
* add two nodelets (DelayPointCloud and DepthImageError) to jsk_pcl_ros
  and publish u/v coordinates of the checkerboard from checkerboard_detector.
  * DepthImageError is just a skelton yet.
  * DelayPointCloud re-publishes pointcloud with specified delay time.
  * publish u/v coordinates from checkerboard_detector.
  * frame_id broadcasted from objectdetection_tf_publisher.py is configurable
* Contributors: Ryohei Ueda
```
## imagesift
- No changes
## jsk_pcl_ros

```
* Merge pull request #210 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/210> from aginika/add-remove-nan-funtion-line
  Add remove nan funtion line
* prevent nan pointcloud error with inserting removeNan function in ParticleFilterTracking
* fix environment modeling and changed api to lock/unlock environment
* remove border region from environment model
* publish diagnostic information from OrganizedMultiPlaneSementation
* take the average of plane coefficients to be combined in EnvironmentPlaneModeling
* wait transform before transforming in PolygonArrayTransformer
* convert convex line information into grid cell before computing grid cell
* fix normalization of the normal when creating Polygon object
* catch more exceptions in TfTransformPointCloud nodelet
* Supress debug message from ColorHistogramMatcher
* fill x-y-z field to publish correct pose of the pointcloud from ColorHistogramMatcher
* publish the pose of the best matched candidate in ColorHistogramMatcher
* publish selected handle pose
* publish u, v, true_depth and observed_depth
* fix the order of Mat::at
* add two nodelets (DelayPointCloud and DepthImageError) to jsk_pcl_ros
  and publish u/v coordinates of the checkerboard from checkerboard_detector.
  * DepthImageError is just a skelton yet.
  * DelayPointCloud re-publishes pointcloud with specified delay time.
  * publish u/v coordinates from checkerboard_detector.
  * frame_id broadcasted from objectdetection_tf_publisher.py is configurable
* copy the header of the input cloud to the output cloud in SelectedClusterPublisher
* Contributors: Ryohei Ueda, Yuto Inagaki, Eisoku Kuroiwa, Yusuke Furuta
```
## jsk_perception

```
* fix to use catkin to link rospack
* Contributors: Dave Coleman, Kei Okada
```
## jsk_recognition
- No changes
## resized_image_transport
- No changes
