### PR TITLE
handle_detector: 1.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2012,7 +2012,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/atenpas/handle_detector-release.git
-      version: 1.0.7-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/atenpas/handle_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `handle_detector` to `1.1.0-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.0.7-0`
## handle_detector

```
* updated readme
* updated CMakeLists and package.xml
* cleaned up folders; added documentation
* added importance sampling (reduces number of samples)
* Contributors: atenpas
```
