### PR TITLE
m4atx_battery_monitor: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1485,6 +1485,21 @@ repositories:
       url: https://github.com/clearpathrobotics/lms1xx.git
       version: master
     status: maintained
+  m4atx_battery_monitor:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/m4atx_battery_monitor.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/m4atx_battery_monitor-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/m4atx_battery_monitor.git
+      version: develop
+    status: maintained
   manipulation_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `m4atx_battery_monitor` to `0.0.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## m4atx_battery_monitor

```
* changelog updated
* espeak now used
* node renamed
* cleanup
* Merge pull request #1 from cmdunkers/develop
  battery monitor for the car battery
* added header to fix error
* attemp to fix broken pipe by ensuring usb closed after exiting code
* Updated the conversion for the Voltage input to more accurately represent the input voltage
* corrected the include file
* changed the m4api to the newer updated version/ the more accurate one
* added in sound debug
* added a line to print the iginition voltage, should be 0
* Added smicolons
* added usb reset code
* Added a values to the message so the value can be linked to an decription
  Also cleaned up the node
* cleared the build folder
* Merge branch 'develop' of https://github.com/cmdunkers/m4atx_battery_monitor into develop
* merged in changes
* reverted to previous ros node
  config
* testing out new node code
* added git ignore
* Deleted the build folder and added a git ignore
* Got the other api to make
* added source code from umd
* minor fixups
* Wrote the code but not yet tested
* Initial commit
* Contributors: Chris Dunkers, Christopher Dunkers, Russell Toris
```
