### PR TITLE
libpointmatcher: 1.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3145,7 +3145,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ethz-asl/libpointmatcher-release.git
-      version: 1.2.0-0
+      version: 1.2.1-0
     source:
       type: git
       url: https://github.com/ethz-asl/libpointmatcher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libpointmatcher` to `1.2.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.2.0-0`
