### PR TITLE
nasa_r2_simulator: 0.5.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3777,13 +3777,26 @@ repositories:
       version: 1.0.0-1
     status: maintained
   nasa_r2_simulator:
+    doc:
+      type: git
+      url: https://github.com/DLu/nasa_r2_simulator.git
+      version: hydro
     release:
       packages:
+      - gazebo_gripper
+      - gazebo_interface
+      - gazebo_taskboard
+      - nasa_r2_simulator
       - r2_gazebo
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/brown-release/nasa_r2_simulator_release.git
-      version: 0.5.3-1
+      version: 0.5.5-0
+    source:
+      type: git
+      url: https://github.com/DLu/nasa_r2_simulator.git
+      version: hydro
+    status: maintained
   nav2_platform:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nasa_r2_simulator` to `0.5.5-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.5.3-1`
