### PR TITLE
robot_model: 1.11.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2486,6 +2486,10 @@ repositories:
       version: indigo-devel
     status: maintained
   robot_model:
+    doc:
+      type: git
+      url: https://github.com/ros/robot_model.git
+      version: indigo-devel
     release:
       packages:
       - collada_parser
@@ -2498,7 +2502,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.11.4-0
+      version: 1.11.5-0
+    source:
+      type: git
+      url: https://github.com/ros/robot_model.git
+      version: indigo-devel
     status: maintained
   robot_pose_publisher:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.11.5-0`:
- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11-dev`
- previous version for package: `1.11.4-0`
## collada_parser
- No changes
## collada_urdf
- No changes
## joint_state_publisher
- No changes
## kdl_parser

```
* Update KDL SegmentMap interface to optionally use shared pointers
  The KDL Tree API optionally uses shared pointers on platforms where
  the STL containers don't support incomplete types.
* Contributors: Brian Jensen
```
## robot_model
- No changes
## urdf
- No changes
## urdf_parser_plugin
- No changes
