### PR TITLE
robot_state_publisher: 1.9.11-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5047,7 +5047,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/robot_state_publisher-release.git
-      version: 1.9.10-0
+      version: 1.9.11-0
     source:
       type: git
       url: https://github.com/ros/robot_state_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `1.9.11-0`:
- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros-gbp/robot_state_publisher-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11-dev`
- previous version for package: `1.9.10-0`
## robot_state_publisher

```
* Update KDL SegmentMap interface to optionally use shared pointers
  The KDL Tree API optionally uses shared pointers on platforms where
  the STL containers don't support incomplete types.
* Contributors: Brian Jensen, Ioan A Sucan
```
