### PR TITLE
robot_state_publisher: 1.10.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2524,11 +2524,19 @@ repositories:
       version: develop
     status: maintained
   robot_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/robot_state_publisher.git
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/robot_state_publisher-release.git
-      version: 1.10.2-0
+      version: 1.10.3-0
+    source:
+      type: git
+      url: https://github.com/ros/robot_state_publisher.git
+      version: indigo-devel
     status: maintained
   robot_upstart:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `1.10.3-0`:
- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros-gbp/robot_state_publisher-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.10.2-0`
## robot_state_publisher

```
* add version depend on orocos_kdl >= 1.3.0
  Conflicts:
  package.xml
* Update KDL SegmentMap interface to optionally use shared pointers
  The KDL Tree API optionally uses shared pointers on platforms where
  the STL containers don't support incomplete types.
* Contributors: Brian Jensen, William Woodall
```
