### PR TITLE
diagnostics: 1.7.11-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -783,10 +783,16 @@ repositories:
       - diagnostic_updater
       - diagnostics
       - self_test
+      - test_diagnostic_aggregator
       tags:
-        release: release/{package}/{upstream_version}
+        release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/diagnostics-release.git
-      version: 1.7.10-0
+      version: 1.7.11-0
+    source:
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: groovy-devel
+    status: maintained
   diagnostics_monitors:
     doc:
       type: svn


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `1.7.11-0`:
- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros-gbp/diagnostics-release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.7.10-0`
