### PR TITLE
ethzasl_icp_mapping: 0.9.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1526,6 +1526,29 @@ repositories:
       type: git
       url: https://github.com/gt-ros-pkg/ethercat-soem.git
       version: hydro-devel
+  ethzasl_icp_mapping:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/ethzasl_icp_mapping.git
+      version: 0.9.6
+    release:
+      packages:
+      - ethzasl_extrinsic_calibration
+      - ethzasl_gridmap_2d
+      - ethzasl_icp_mapper
+      - ethzasl_icp_mapper_experiments
+      - ethzasl_icp_mapping
+      - ethzasl_point_cloud_vtk_tools
+      - libpointmatcher_ros
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ethz-asl/ethzasl_icp_mapping-release.git
+      version: 0.9.6-0
+    source:
+      type: git
+      url: https://github.com/ethz-asl/ethzasl_icp_mapping.git
+      version: 0.9.6
+    status: maintained
   executive_smach:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ethzasl_icp_mapping` to `0.9.6-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## ethzasl_extrinsic_calibration

```
* continuing catkinization
* Contributors: Samuel Charreyron, Stéphane Magnenat
```
## ethzasl_gridmap_2d

```
* completed catkinization
* Contributors: Samuel Charreyron
```
## ethzasl_icp_mapper

```
* completed catkinization
* Contributors: Francis Colas, Francois Pomerleau, Philipp Kruesi, Samuel Charreyron, Stéphane Magnenat, pomerlef
```
## ethzasl_icp_mapper_experiments

```
* completed catkinization
* Contributors: Administrator, Samuel Charreyron, Stéphane Magnenat
```
## ethzasl_icp_mapping

```
* catkinization
* Contributors: Samuel Charreyron
```
## ethzasl_point_cloud_vtk_tools

```
* completed catkinization
* Contributors: Administrator, Francois Pomerleau, Samuel Charreyron, Stéphane Magnenat
```
## libpointmatcher_ros

```
* completed catkinization
* Contributors: Francois Pomerleau, Samuel Charreyron, Stéphane Magnenat
```
