### PR TITLE
libpointmatcher: 1.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1461,7 +1461,7 @@ repositories:
       version: 1.2.1-0
     source:
       type: git
-      url: https://github.com/ethz-asl/libpointmatcher
+      url: https://github.com/ethz-asl/libpointmatcher.git
       version: 1.2.1
     status: developed
   libuvc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1449,6 +1449,21 @@ repositories:
       url: https://github.com/ethz-asl/libnabo.git
       version: master
     status: maintained
+  libpointmatcher:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/libpointmatcher.git
+      version: 1.2.1
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ethz-asl/libpointmatcher-release.git
+      version: 1.2.1-0
+    source:
+      type: git
+      url: https://github.com/ethz-asl/libpointmatcher
+      version: 1.2.1
+    status: developed
   libuvc:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libpointmatcher` to `1.2.1-0`:
- upstream repository: https://github.com/ethz-asl/libpointmatcher.git
- release repository: https://github.com/ethz-asl/libpointmatcher-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
