### PR TITLE
teleop_twist_joy: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3603,6 +3603,21 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  teleop_twist_joy:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/teleop_twist_joy.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-teleop/teleop_twist_joy-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-teleop/teleop_twist_joy.git
+      version: indigo-devel
+    status: developed
   tf2_web_republisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `0.1.0-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## teleop_twist_joy

```
* Added configurations for Logitech Attack3 and Extreme 3D Pro joysticks.
* Initial version, with example config for PS3 joystick.
* Contributors: Mike Purvis, Tony Baltovski
```
