### PR TITLE
rosh_core: 1.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3009,7 +3009,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/OSUrobotics/rosh_core-release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/OSUrobotics/rosh_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_core` to `1.0.6-0`:
- upstream repository: https://github.com/OSUrobotics/rosh_core.git
- release repository: https://github.com/OSUrobotics/rosh_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.5-0`
## rosh

```
* fix a typo in Package._get_launches
* fixes from catkin_lint
* make sure rosh.impl gets installed
* Contributors: Dan Lazewatsky
```
## rosh_core
- No changes
## roshlaunch

```
* fixes from catkin_lint
* Contributors: Dan Lazewatsky
```
