### PR TITLE
rwi_ros: 1.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6258,7 +6258,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/wu-robotics/rwi_ros.git
-      version: 1.1.0-0
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/DLu/rwi_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rwi_ros` to `1.1.1-0`:
- upstream repository: https://github.com/DLu/rwi_ros
- release repository: https://github.com/wu-robotics/rwi_ros.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.1.0-0`
