### PR TITLE
opencv2: 2.4.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2175,6 +2175,14 @@ repositories:
       type: git
       url: https://github.com/ros-geographic-info/open_street_map.git
       version: master
+  opencv2:
+    release:
+      packages:
+      - opencv
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/opencv2-release.git
+      version: 2.4.11-0
   opencv_candidate:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `opencv2` to `2.4.11-0`:
- upstream repository: https://github.com/stonier/opencv2
- release repository: https://github.com/yujinrobot-release/opencv2-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
