### PR TITLE
usb_cam: 0.1.5-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4717,11 +4717,12 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/bosch-ros-pkg-release/usb_cam-release.git
-      version: 0.1.3-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/bosch-ros-pkg/usb_cam.git
       version: groovy-devel
+    status: maintained
   uwsim_bullet:
     release:
       tags:

--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4712,7 +4712,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/bosch-ros-pkg/usb_cam.git
-      version: groovy-devel
+      version: master
     release:
       tags:
         release: release/groovy/{package}/{version}
@@ -4721,7 +4721,7 @@ repositories:
     source:
       type: git
       url: https://github.com/bosch-ros-pkg/usb_cam.git
-      version: groovy-devel
+      version: develop
     status: maintained
   uwsim_bullet:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam` to `0.1.5-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.1.3-0`
## usb_cam

```
* auto format
* cleanup of readme and such
* Merge branch 'hydro-devel' of github.com:bosch-ros-pkg/usb_cam
* Merge pull request #11 from pronobis/hydro-devel
  Fixed a bug with av_free missing by adding a proper include.
* Fixed a bug with av_free missing by adding a proper include on Ubuntu 14.04.
* Merge pull request #7 from cottsay/groovy-devel
  Use pkg-config to find avcodec and swscale
* Merge pull request #5 from FriedCircuits/hydro-devel
  Remove requirments for self_test
* Use pkg-config to find avcodec and swscale
* Update package.xml
* Remove selftest
* Remove selftest
* Update usb_cam_node.cpp
* Merge pull request #2 from jonbinney/7_17
  swap out deprecated libavcodec functions
* swap out deprecated libavcodec functions
* Contributors: Andrzej Pronobis, Jon Binney, Russell Toris, Scott K Logan, William
```
