### PR TITLE
qt_ros: 0.2.7-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2461,6 +2461,26 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: groovy-devel
     status: maintained
+  qt_ros:
+    doc:
+      type: git
+      url: https://github.com/stonier/qt_ros.git
+      version: indigo
+    release:
+      packages:
+      - qt_build
+      - qt_create
+      - qt_ros
+      - qt_tutorials
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/qt_ros-release.git
+      version: 0.2.7-1
+    source:
+      type: git
+      url: https://github.com/stonier/qt_ros.git
+      version: indigo
+    status: maintained
   rail_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_ros` to `0.2.7-1`:
- upstream repository: https://github.com/stonier/qt_ros.git
- release repository: https://github.com/yujinrobot-release/qt_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## qt_build

```
* update for indigo
```
## qt_create

```
* update for indigo
```
## qt_ros

```
* update for indigo
```
## qt_tutorials

```
* update for indigo
```
