### PR TITLE
prosilica_driver: 1.9.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4805,13 +4805,21 @@ repositories:
       version: hydro-devel
     status: maintained
   prosilica_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_driver.git
+      version: hydro-devel
     release:
       packages:
       - prosilica_camera
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-drivers-gbp/prosilica_driver-release.git
-      version: 1.9.3-0
+      version: 1.9.4-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_driver.git
+      version: hydro-devel
     status: maintained
   prosilica_gige_sdk:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `prosilica_driver` to `1.9.4-0`:
- upstream repository: https://github.com/ros-drivers/prosilica_driver.git
- release repository: https://github.com/ros-drivers-gbp/prosilica_driver-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.9.3-0`
