### PR TITLE
prosilica_gige_sdk: 1.26.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2403,6 +2403,21 @@ repositories:
       url: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
       version: 1.8.0-0
     status: maintained
+  prosilica_gige_sdk:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_gige_sdk.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/prosilica_gige_sdk-release.git
+      version: 1.26.3-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_gige_sdk.git
+      version: hydro-devel
+    status: maintained
   pysdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `prosilica_gige_sdk` to `1.26.3-0`:
- upstream repository: https://github.com/ros-drivers/prosilica_gige_sdk.git
- release repository: https://github.com/ros-drivers-gbp/prosilica_gige_sdk-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
