### PR TITLE
prosilica_camera: 1.9.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2403,6 +2403,21 @@ repositories:
       url: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
       version: 1.8.0-0
     status: maintained
+  prosilica_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_driver.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/prosilica_driver-release.git
+      version: 1.9.4-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_driver.git
+      version: hydro-devel
+    status: maintained
   prosilica_gige_sdk:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `prosilica_camera` to `1.9.4-0`:
- upstream repository: https://github.com/ros-drivers/prosilica_driver.git
- release repository: https://github.com/ros-drivers-gbp/prosilica_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
