### PR TITLE
korg_nanokontrol: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3005,11 +3005,19 @@ repositories:
       version: hydro
     status: developed
   korg_nanokontrol:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/korg_nanokontrol.git
+      version: master
     release:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/korg_nanokontrol-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/korg_nanokontrol.git
+      version: master
     status: maintained
   kurt3d:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `korg_nanokontrol` to `0.1.2-0`:
- upstream repository: https://github.com/ros-drivers/korg_nanokontrol.git
- release repository: https://github.com/ros-gbp/korg_nanokontrol-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.1.1-0`
