### PR TITLE
korg_nanokontrol: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1355,6 +1355,21 @@ repositories:
       url: https://github.com/yujinrobot/kobuki_soft.git
       version: indigo
     status: developed
+  korg_nanokontrol:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/korg_nanokontrol.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/korg_nanokontrol-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/korg_nanokontrol.git
+      version: master
+    status: maintained
   laser_assembler:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `korg_nanokontrol` to `0.1.2-0`:
- upstream repository: https://github.com/ros-drivers/korg_nanokontrol.git
- release repository: https://github.com/ros-gbp/korg_nanokontrol-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
