### PR TITLE
python_ethernet_rmp: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2491,7 +2491,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/python_ethernet_rmp-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/python_ethernet_rmp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_ethernet_rmp` to `0.0.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.1-0`
## python_ethernet_rmp

```
* Merge pull request #6 <https://github.com/WPI-RAIL/python_ethernet_rmp/issues/6> from cmdunkers/develop
  fixed the default_bitmap issue
* Fixed the default_config bitmap to 1 instead of the default since default does not work with carl
* Merge pull request #2 <https://github.com/WPI-RAIL/python_ethernet_rmp/issues/2> from WPI-RAIL/develop
  Update CMakeLists.txt
* Merge pull request #1 <https://github.com/WPI-RAIL/python_ethernet_rmp/issues/1> from WPI-RAIL/master
  Cleanup and release of 0.0.1
* Update CMakeLists.txt
* Merge pull request #5 <https://github.com/WPI-RAIL/python_ethernet_rmp/issues/5> from WPI-RAIL/develop
  0.0.1
* Contributors: Chris Dunkers, Russell Toris, cmdunkers
```
