### PR TITLE
ros_ethernet_rmp: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3010,7 +3010,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/ros_ethernet_rmp-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/ros_ethernet_rmp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ethernet_rmp` to `0.0.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.1-0`
## ros_ethernet_rmp

```
* Merge pull request #10 from cmdunkers/develop
  fixed the yaw rates for carl
* fixed the yaw rates for carl
* Contributors: Chris Dunkers, Russell Toris
```
