### PR TITLE
diagnostics: 1.8.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -502,7 +502,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/diagnostics-release.git
-      version: 1.8.4-0
+      version: 1.8.5-0
     source:
       type: git
       url: https://github.com/ros/diagnostics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `1.8.5-0`:
- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros-gbp/diagnostics-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.8.4-0`
