### PR TITLE
rtmros_hironx: 1.0.19-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4195,7 +4195,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.18-2
+      version: 1.0.19-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.19-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.18-2`
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* Enable RobotHardwareServiceROSBridge for when working with real robot. Fixes #138 <https://github.com/start-jsk/rtmros_hironx/issues/138> (servoOn/Off issue).
* (hironx_client) Add readDigitalOut.
* Robot installation
  * (robot-compile-openrtm.sh) Fix: Non-existent path. Add more instruction message.
  * (visionpc_install_setup.sh) Minor update (Add ros desktop-full, remove unnecessary Ubuntu init folders, ros env setting for nxouser)
* Contributors: Isaac IY Saito
```
## rtmros_hironx

```
* Enable RobotHardwareServiceROSBridge for when working with real robot. Fixes #138 <https://github.com/start-jsk/rtmros_hironx/issues/138> (servoOn/Off issue).
* (hironx_client) Add readDigitalOut.
* Robot installation
  * (robot-compile-openrtm.sh) Fix: Non-existent path. Add more instruction message.
  * (visionpc_install_setup.sh) Minor update (Add ros desktop-full, remove unnecessary Ubuntu init folders, ros env setting for nxouser)
* Contributors: Isaac IY Saito
```
