### PR TITLE
hrpsys: 315.2.3-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1556,7 +1556,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/hrpsys-release.git
-      version: 315.2.2-0
+      version: 315.2.3-0
     source:
       type: git
       url: https://github.com/start-jsk/hrpsys.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys` to `315.2.3-0`:
- upstream repository: https://github.com/start-jsk/hrpsys.git
- release repository: https://github.com/tork-a/hrpsys-release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `315.2.2-0`
## hrpsys

```
* Adjusted to OpenRTM 1.1.1
* use OCTOMAP_LIBRARY_DIRS instead of OCTOMAP_DIR, Fix #258
* Use boost library for copysign because copysign in cmath only can be used in C++11 later
* samplerobot
  * Add example for impedancecontroller rtc.
  * Add examples for samplerobot by copying from start-jsk/hrpsys/samples discussed in https://github.com/fkanehiro/hrpsys-base/issues/240.
  * Add setFootSteps examples.
  * Add samples for DataLogger and Stabilizer.
  * Add example for impedancecontroller rtc
* (JointPathEx.*, AutoBalancer, Stabilizer, ImpedanceController) : Remove solveLimbIK and use calcInverseKinematics2Loop
* (samplerobot_auto_balancer.py, AutoBalancer.cpp) Fix overwriting of target foot coords, add example to check non-default stride stopping, and check RECTANGLE swing orbit
* JointPathEx.*
  * Move nullspace codes to reduce difference between calcInverseKinematics2Loop and solveLimbIK.
  * Remove unnecessary transition_count and resetting of nullspace vector.
  * Move nullspace codes to reduce difference between calcInverseKinematics2Loop and solveLimbIK.
* hrpsys_config.py
  * Add readDigitalOutput.
  * Add connection for st qCurrent.
  * Add comment upon setTargetPose IK failure.
  * Add logger connection for walking RTCs.
  Use Group to find eef name. PEP8 improvement.
* Stabilizer.*
  * Add new stabilizer control law (currently not enabled).
  * Use :end_effector instead of link origin in IK and fix mode transition.
  * Add getParameter function for stabilizer parameter
* create_changelog.sh
  * Add script for changelog from subdirectory information (discussed in jsk-ros-pkg/jsk_roseus#134 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/134>)
* GaitGenerator.*
  * Fix bug of swing foot calculation and add reset orbit
  * Support rectangle foot swing orbit
* (AutoBalancerService.idl, AutoBalancer.*, GaitGenerator.*, testGaitGenerator) : Enable to configure swing orbit type
* (TorqueController) Added TwoDofControllerDynamicsModel option to initialize process. Use dynamic model based on equation of motion.
* Fixed default tauMax from model. climit -> climit*gearRatio*torqueConst
* Modified m_loop type int -> long long
* Contributors: Kei Okada, Shunichi Nozawa
```
