### PR TITLE
dynamixel_motor: 0.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -550,6 +550,18 @@ repositories:
       url: https://github.com/ros/dynamic_reconfigure.git
       version: master
     status: maintained
+  dynamixel_motor:
+    release:
+      packages:
+      - dynamixel_controllers
+      - dynamixel_driver
+      - dynamixel_motor
+      - dynamixel_msgs
+      - dynamixel_tutorials
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/arebgun/dynamixel_motor-release.git
+      version: 0.4.0-0
   ecl_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_motor` to `0.4.0-0`:
- upstream repository: https://github.com/arebgun/dynamixel_motor.git
- release repository: https://github.com/arebgun/dynamixel_motor-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## dynamixel_controllers

```
* stack is now catkin compatible
```
## dynamixel_driver

```
* stack is now catkin compatible
```
## dynamixel_motor

```
* stack is now catkin compatible
```
## dynamixel_msgs

```
* stack is now catkin compatible
```
## dynamixel_tutorials

```
* stack is now catkin compatible
```
