### PR TITLE
denso: 0.2.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1118,7 +1118,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/start-jsk/denso-release.git
-      version: 0.2.7-0
+      version: 0.2.8-0
     source:
       type: git
       url: https://github.com/start-jsk/denso.git


### PR DESCRIPTION
Increasing version of package(s) in repository `denso` to `0.2.8-0`:
- upstream repository: https://github.com/start-jsk/denso.git
- release repository: https://github.com/start-jsk/denso-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.2.7-0`
## denso

```
* Add xtion checkerboard demo launch file.
* vs060_moveit_config/launch/moveit.rviz: add robot model to rviz
* Corrected build_dependency (add robot_mechanism_controllers, robot_state_publisher)
* Correct robot name (vs06 -> vs060)
* Rename repository (Fix https://github.com/start-jsk/denso/issues/13, https://github.com/start-jsk/denso/issues/14)
* Add moveit_commander test
* Add rostest for /denso_vs060_moveit_demo_simulation.launch
* Corrected copyright (only for some packages)
* Comfort to ROS Cpp style guide. Start adding comments (sorry two different types of commits mixed up here...editor did it and I can't revert it)
* Contributors: Kei Okada, Isaac IY Saito
```
## denso_controller

```
* (denso_controller) Corrected copyright
* Comfort to ROS Cpp style guide. Start adding comments (sorry two different types of commits mixed up here...editor did it and I can't revert it)
* Contributors: Isaac IY Saito
```
## denso_launch

```
* Add xtion checkerboard demo launch file.
* Add moveit_commander test
* Correct robot name (vs06 -> vs060)
* Add rostest for /denso_vs060_moveit_demo_simulation.launch
* Contributors: Isaac IY Saito, Kei Okada
```
## vs060
- No changes
## vs060_moveit_config

```
* Add xtion checkerboard demo launch file.
* vs060_moveit_config/launch/moveit.rviz: add robot model to rviz
* Corrected build_dependency (add robot_mechanism_controllers, robot_state_publisher)
* Correct robot name (vs06 -> vs060)
* Contributors: Isaac IY Saito, Kei Okada
```
