### PR TITLE
ros_ethernet_rmp: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3022,7 +3022,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/ros_ethernet_rmp-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/ros_ethernet_rmp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ethernet_rmp` to `0.0.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.2-0`
## ros_ethernet_rmp

```
* Merge pull request #11 from cmdunkers/develop
  added in joint state publisher from the segway feedback for the wheels
* added the correct joint lint names
* fixed package name
* added a joint state publisher for the wheels based ont he feedback
* Contributors: Chris Dunkers, Russell Toris
```
