### PR TITLE
battery_monitor_rmp: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -155,6 +155,21 @@ repositories:
       url: https://github.com/wjwwood/ax2550.git
       version: master
     status: maintained
+  battery_monitor_rmp:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/battery_monitor_rmp.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/battery_monitor_rmp-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/battery_monitor_rmp.git
+      version: develop
+    status: maintained
   bfl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `battery_monitor_rmp` to `0.0.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## battery_monitor_rmp

```
* cleanup
* Merge pull request #1 <https://github.com/WPI-RAIL/battery_monitor_rmp/issues/1> from cmdunkers/master
  added the code to monitor the RMP Feedback for the battery states
* added the code to monitor the RMP Feedback for the battery states
* Initial commit
* Contributors: Chris Dunkers, Russell Toris
```
