### PR TITLE
moveit_simple_grasps: 1.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3654,7 +3654,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/davetcoleman/moveit_simple_grasps-release.git
-      version: 1.0.1-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_simple_grasps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_simple_grasps` to `1.1.0-0`:
- upstream repository: https://github.com/davetcoleman/moveit_simple_grasps.git
- release repository: https://github.com/davetcoleman/moveit_simple_grasps-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.1-0`
## moveit_simple_grasps

```
* Fixed grasp pose rotation
* Created new verbose constructor flag to enable easy debugging
* Allow a grasp pose to be rotated along z axis
* Created new pick place pipeline template
* Moved ClamArm config to this repo
* Updated package description
* Updated README
* Contributors: Dave Coleman
```
