### PR TITLE
moveit_visual_tools: 1.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3669,7 +3669,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 1.0.1-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `1.1.0-0`:
- upstream repository: https://github.com/davetcoleman/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.1-0`
## moveit_visual_tools

```
* Bug fixes
* Fixed convertPoint32ToPose
* Added scale to publishText
* New publishPolygon, publishMarker, convertPose, convertPointToPose, and convertPoint32 functions
* New deleteAllMarkers, publishPath, publishSpheres, and convertPoseToPoint functions
* Added getCollisionWall
* Made lines darker
* Added reset marker feature
* Namespaces for publishSphere
* New publishTrajectory function
* Merging features from OMPL viewer
* Refactored functions, new robot_model intialization
* Added more rand functions and made them static
* Added graph_msgs generated messages dependence so it waits for it to be compiled
* Updated README
* Contributors: Dave Coleman, Sammy Pfeiffer
```
