### PR TITLE
rtmros_hironx: 1.0.20-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6099,7 +6099,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.19-1
+      version: 1.0.20-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.20-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.19-1`
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* Add ROS client. See acceptancetest_hironx.py for usage sample.
* acceptancetest_hironx.py:
  * Add tasks written in ROS.
  * Add option to wait kb input before every task.
  * Move location to /scripts so that you can call by ipython -i `rospack find hironx_ros_bridge/scripts/acceptancetest_hironx.py` (similar to hironx.py).
* Add doc about launch and test files.
* Contributors: Isaac IY Saito
```
## rtmros_hironx

```
* Add ROS client. See acceptancetest_hironx.py for usage sample.
* acceptancetest_hironx.py:
  * Add tasks written in ROS.
  * Add option to wait kb input before every task.
  * Move location to /scripts so that you can call by ipython -i `rospack find hironx_ros_bridge/scripts/acceptancetest_hironx.py` (similar to hironx.py).
* Add doc about launch and test files.
* Contributors: Isaac IY Saito
```
