### PR TITLE
wpi_jaco: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4026,6 +4026,28 @@ repositories:
       url: https://github.com/ros-gbp/warehouse_ros-release.git
       version: 0.8.6-0
     status: maintained
+  wpi_jaco:
+    doc:
+      type: git
+      url: https://github.com/RIVeR-Lab/wpi_jaco.git
+      version: master
+    release:
+      packages:
+      - jaco_description
+      - jaco_interaction
+      - jaco_sdk
+      - wpi_jaco
+      - wpi_jaco_msgs
+      - wpi_jaco_wrapper
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/wpi_jaco-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/RIVeR-Lab/wpi_jaco.git
+      version: develop
+    status: maintained
   xacro:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wpi_jaco` to `0.0.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## jaco_description

```
* renamed JACO to WPI packages
* Contributors: Russell Toris
```
## jaco_interaction

```
* renamed JACO to WPI packages
* Contributors: Russell Toris
```
## jaco_sdk

```
* renamed JACO to WPI packages
* 0.0.1
* changelog updated
* cleanup of jaco sdk
* Added pickup action to arm control and interactive manipulation
* Added WPI to copyright for our changes and put LICENSE files
* Initial commit of ros_control jaco driver
* Contributors: Mitchell Wills, Russell Toris, Velin Dimitrov, dekent
```
## wpi_jaco

```
* renamed JACO to WPI packages
* Contributors: Russell Toris
```
## wpi_jaco_msgs

```
* renamed JACO to WPI packages
* Contributors: Russell Toris
```
## wpi_jaco_wrapper

```
* renamed JACO to WPI packages
* Contributors: Russell Toris
```
