### PR TITLE
carl_estop: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -297,6 +297,21 @@ repositories:
       url: https://github.com/osrf/capabilities.git
       version: master
     status: maintained
+  carl_estop:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/carl_estop.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/carl_estop-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/carl_estop.git
+      version: develop
+    status: maintained
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_estop` to `0.0.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## carl_estop

```
* cleanup
* Merge pull request #2 from cmdunkers/master
  Tested sucessfully
* changed the messages to contain the word estop
* tested sucessfully
* testing
* Merge pull request #1 from cmdunkers/master
  Carl estop
* made the changed the checking ans sending frequency
* added in a command to turn the segway to standby and then back to tractor mode
* switching the speaking words
* added launch files
* fixed actionlib issues
* added initial code
* Initial commit
* Contributors: Chris Dunkers, Christopher Dunkers, Russell Toris
```
