### PR TITLE
Adding pi_trees to documentation index for hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4607,6 +4607,11 @@ repositories:
       type: git
       url: https://github.com/pirobot/pi_tracker.git
       version: hydro-devel
+  pi_trees:
+    doc:
+      type: git
+      url: https://github.com/pirobot/pi_trees.git
+      version: hydro-devel
   play_motion:
     doc:
       type: git


### PR DESCRIPTION
I'd like pi_trees to be indexed and documented on ros.org.
