### PR TITLE
rtmros_nextage: 0.2.18-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6130,7 +6130,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.2.17-0
+      version: 0.2.18-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.2.18-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.2.17-0`
## nextage_description
- No changes
## nextage_moveit_config

```
* (moveit_config) Default speed now moderately slow.
* Contributors: Isaac IY Saito
```
## nextage_ros_bridge
- No changes
## rtmros_nextage

```
* (moveit_config) Default speed now moderately slow.
* Contributors: Isaac IY Saito
```
