### PR TITLE
vision_visp: 0.7.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3989,7 +3989,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.7.4-0
+      version: 0.7.5-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.7.5-0`:
- upstream repository: https://github.com/lagadic/vision_visp.git
- release repository: https://github.com/lagadic/vision_visp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.7.4-0`
## vision_visp

```
* indigo-0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_auto_tracker

```
* indigo-0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_bridge

```
* Revert previous commit that breaks compat
* indigo-0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_camera_calibration

```
* indigo-0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_hand2eye_calibration

```
* indigo-0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_tracker

```
* indigo-0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
