### PR TITLE
vision_visp: 0.7.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7339,7 +7339,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.7.4-0
+      version: 0.7.5-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.7.5-0`:
- upstream repository: https://github.com/lagadic/vision_visp.git
- release repository: https://github.com/lagadic/vision_visp-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.7.4-0`
## vision_visp

```
* hydro-0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_auto_tracker

```
* hydro-0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_bridge

```
* Revert previous commit that breaks compat
* hydro-0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_camera_calibration

```
* hydro-0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_hand2eye_calibration

```
* hydro-0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_tracker

```
* hydro-0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
