### PR TITLE
wpi_jaco: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4057,7 +4057,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/wpi_jaco-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/wpi_jaco.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wpi_jaco` to `0.0.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.1-0`
## jaco_description

```
* diff fixed
* Updated xacro files to use jaco_description instead of jaco_model, generated urdf for standalone_arm
* Contributors: Russell Toris, dekent
```
## jaco_interaction
- No changes
## jaco_sdk

```
* libusb-1.0 added to deps
* Contributors: Russell Toris
```
## wpi_jaco
- No changes
## wpi_jaco_msgs
- No changes
## wpi_jaco_wrapper
- No changes
