### PR TITLE
vision_visp: 0.7.5-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4797,7 +4797,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.7.4-0
+      version: 0.7.5-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.7.5-0`:
- upstream repository: https://github.com/lagadic/vision_visp.git
- release repository: https://github.com/lagadic/vision_visp-release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.7.4-0`
## vision_visp

```
* 0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_auto_tracker

```
* 0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_bridge

```
* Revert previous commit that breaks compat
* 0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_camera_calibration

```
* 0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_hand2eye_calibration

```
* 0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_tracker

```
* 0.7.4
* Prepare changelogs
* Contributors: Fabien Spindler
```
