### PR TITLE
rail_maps: 0.2.3-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3375,7 +3375,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_maps-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_maps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_maps` to `0.2.3-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.2.2-0`
## rail_maps

```
* rotated map
* Merge pull request #3 from Spkordell/develop
  Updated rail_lab map
* Updated rail_lab map
* Contributors: Russell Toris, Steven Kordell
```
