### PR TITLE
Adding segwayrmp to documentation index for distro.

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6418,6 +6418,11 @@ repositories:
       url: https://github.com/segwayrmp/segway_rmp-release.git
       version: 0.1.1-0
     status: maintained
+  segwayrmp:
+    doc:
+      type: git
+      url: https://github.com/sri-robotics/segwayrmp.git
+      version: hydro
   sentis_tof_m100:
     doc:
       type: git


### PR DESCRIPTION
I would like segwayrmp to be indexed and documented on ros.org.
