### PR TITLE
robot_model: 1.10.20-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5079,7 +5079,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.10.18-1
+      version: 1.10.20-0
     source:
       type: git
       url: https://github.com/ros/robot_model.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.10.20-0`:
- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.10.18-1`
## collada_parser

```
* Added extract actuators, fix for using nominal torque
* Removed visual and collision meshes if there are no vertices
* Removed use of visual and collision groups
* Fix problem with root coordinates
* Contributors: YoheiKakiuchi
```
## collada_urdf

```
* Fix clash with assimp 3.1 in CMake.
* Now stores original mesh file name and location
* Contributors: Benjamin Chrétien, YoheiKakiuchi
```
## joint_state_publisher

```
* Update package.xml
  Updating author and maintainer for consistency.
* Contributors: David Lu!!
```
## kdl_parser

```
* add version dependency on orocos_kdl >= 1.3.0
* kdl_parser: Adding kdl library explicitly so that dependees can find it
* Update KDL SegmentMap interface to optionally use shared pointers
  The KDL Tree API optionally uses shared pointers on platforms where
  the STL containers don't support incomplete types.
* Contributors: Brian Jensen, Jonathan Bohren, William Woodall
```
## resource_retriever
- No changes
## robot_model
- No changes
## urdf
- No changes
## urdf_parser_plugin
- No changes
