### PR TITLE
kobuki_msgs: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1389,10 +1389,16 @@ repositories:
       type: git
       url: https://github.com/yujinrobot/kobuki_msgs.git
       version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/kobuki_msgs-release.git
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_msgs.git
       version: indigo
+    status: developed
   kobuki_soft:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_msgs` to `0.6.0-0`:
- upstream repository: https://github.com/yujinrobot/kobuki_msgs.git
- release repository: https://github.com/yujinrobot-release/kobuki_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
