### PR TITLE
axis_camera: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -155,6 +155,21 @@ repositories:
       url: https://github.com/wjwwood/ax2550.git
       version: master
     status: maintained
+  axis_camera:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/axis_camera.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/axis_camera-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/axis_camera.git
+      version: master
+    status: maintained
   battery_monitor_rmp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `axis_camera` to `0.1.0-0`:
- upstream repository: https://github.com/clearpathrobotics/axis_camera.git
- release repository: https://github.com/clearpath-gbp/axis_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## axis_camera
- No changes
