### PR TITLE
kobuki_core: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1369,6 +1369,16 @@ repositories:
       type: git
       url: https://github.com/yujinrobot/kobuki_core.git
       version: indigo
+    release:
+      packages:
+      - kobuki_core
+      - kobuki_dock_drive
+      - kobuki_driver
+      - kobuki_ftdi
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/kobuki_core-release.git
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core` to `0.6.0-0`:
- upstream repository: https://github.com/yujinrobot/kobuki_core.git
- release repository: https://github.com/yujinrobot-release/kobuki_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## kobuki_core
- No changes
## kobuki_dock_drive

```
* Redevelopment of kobuki dock drive algorithm.
* Contributors: Jihoon Lee
```
## kobuki_driver

```
* add linear and angular test plot image
* kobuki_driver : Updated doxygen. Issue #10 <https://github.com/yujinrobot/kobuki_core/issues/10>.
* Contributors: Younghun Ju, jihoonl
```
## kobuki_ftdi

```
* Fix compilation.
  - fix the names of the pkg-config libraries of libusb and libftdi. I checked on Ubuntu and OS X.
  - ftdi-eeprom is not a library and has no pkg-config file.
* Update the readme in kobuki_ftdi
* Create README.md
* kobuki_ftdi : Updated doxygen document.
* Contributors: Jihoon Lee, Nikolaus Demmel, Younghun Ju
```
