### PR TITLE
axis_camera: 0.1.0-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -153,10 +153,16 @@ repositories:
       type: git
       url: https://github.com/clearpathrobotics/axis_camera.git
       version: master
+    release:
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/clearpath-gbp/axis_camera-release.git
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/axis_camera.git
       version: master
+    status: maintained
   baxter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `axis_camera` to `0.1.0-0`:
- upstream repository: https://github.com/clearpathrobotics/axis_camera.git
- release repository: https://github.com/clearpath-gbp/axis_camera-release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## axis_camera
- No changes
