### PR TITLE
ros_comm: 1.11.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2973,7 +2973,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.7-0
+      version: 1.11.8-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.8-0`:
- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.11.7-0`
## message_filters
- No changes
## ros_comm
- No changes
## rosbag
- No changes
## rosbag_storage
- No changes
## rosconsole
- No changes
## roscpp

```
* fix C++11 compatibility issue (#483 <https://github.com/ros/ros_comm/issues/483>)
```
## rosgraph
- No changes
## roslaunch

```
* remove implicit rostest dependency and use rosunit instead (#475 <https://github.com/ros/ros_comm/issues/475>)
* accept stdin input alongside files (#472 <https://github.com/ros/ros_comm/issues/472>)
```
## roslz4
- No changes
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy

```
* fix topic/connection statistics reporting code (#482 <https://github.com/ros/ros_comm/issues/482>)
```
## rosservice
- No changes
## rostest
- No changes
## rostopic

```
* fix handling of array index when being part of the topic (#480 <https://github.com/ros/ros_comm/issues/480>)
* support splice arguments in 'rostopic echo' (#480 <https://github.com/ros/ros_comm/issues/480>)
```
## roswtf
- No changes
## topic_tools
- No changes
## xmlrpcpp
- No changes
