### PR TITLE
kobuki_desktop: 0.3.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2970,7 +2970,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki_desktop-release.git
-      version: 0.3.2-1
+      version: 0.3.3-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_desktop` to `0.3.3-0`:
- upstream repository: https://github.com/yujinrobot/kobuki_desktop.git
- release repository: https://github.com/yujinrobot-release/kobuki_desktop-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.3.2-1`
## kobuki_dashboard
- No changes
## kobuki_desktop
- No changes
## kobuki_gazebo
- No changes
## kobuki_gazebo_plugins

```
* Fix compilation on OS X.
  - without this linking fails on OS X (10.9)
  - prefer find_package over pkg-config, since pkg-config does not link
  transitive dependencies (see https://bitbucket.org/osrf/gazebo/issue/1202)
* Contributors: Nikolaus Demmel
```
## kobuki_qtestsuite
- No changes
## kobuki_rviz_launchers
- No changes
