### PR TITLE
libpointmatcher: 1.2.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3190,7 +3190,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ethz-asl/libpointmatcher-release.git
-      version: 1.2.1-0
+      version: 1.2.2-0
     source:
       type: git
       url: https://github.com/ethz-asl/libpointmatcher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libpointmatcher` to `1.2.2-0`:
- upstream repository: https://github.com/ethz-asl/libpointmatcher/
- release repository: https://github.com/ethz-asl/libpointmatcher-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.2.1-0`
## libpointmatcher

```
* Yaml-cpp0.3 now built with libpointmatcher for compatibility with newer Ubuntu systems using yaml-cpp0.5
```
