### PR TITLE
rmp_msgs: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2701,6 +2701,21 @@ repositories:
       url: https://github.com/ros-drivers/rgbd_launch.git
       version: indigo-devel
     status: maintained
+  rmp_msgs:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rmp_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/rmp_msgs-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rmp_msgs.git
+      version: develop
+    status: maintained
   robot_localization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmp_msgs` to `0.0.1-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## rmp_msgs

```
* removed whitespace
* cleanup of repo
* Merge pull request #1 from cmdunkers/master
  added messages
* added messages
* Initial commit
* Contributors: Chris Dunkers, Russell Toris
```
