### PR TITLE
m4atx_battery_monitor: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1620,7 +1620,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/m4atx_battery_monitor-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/m4atx_battery_monitor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `m4atx_battery_monitor` to `0.0.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.1-0`
## m4atx_battery_monitor

```
* moved .sh to .bash
* permissions script added to install
* Contributors: Russell Toris
* usb dev added
* comments
* moved script
* Merge branch 'cmdunkers-develop' into develop
* merege
* Added a script to make sure the device can be read from
  script applies appropriate permissions
* revert to 0.0.0'
* Added a startup script
* Contributors: Chris Dunkers, Russell Toris
```
