### PR TITLE
wpi_jaco: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4088,7 +4088,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/wpi_jaco-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/wpi_jaco.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wpi_jaco` to `0.0.4-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.3-0`
## jaco_description

```
* fixed install cmake bug
* recompiled URDF
* fixed URDF to load minified files
* updated pre-compiled URDF
* minified XML
* removed large unused mesh originals
* removed large unused mesh originals
* Removed soft links
* Using low poly version of all meshes
* Removed duplicate meshes
* Improved meshes and URDF
* Contributors: Russell Toris, Steven Kordell
```
## jaco_interaction

```
* documentation
* installs rviz config now
* updated package names in launch files
* Contributors: Russell Toris, dekent
```
## jaco_sdk

```
* fixes broken include link
* correctly links against JACO libraries via cmake
* Contributors: Russell Toris
```
## wpi_jaco
- No changes
## wpi_jaco_msgs

```
* documentation
* Contributors: dekent
```
## wpi_jaco_wrapper

```
* documentation
* renamed namespace in library
* fixed header names in cpp files
* renamed wrapper headers
* correctly links against JACO libraries via cmake
* updated package names in launch files
* Contributors: Russell Toris, dekent
```
