### PR TITLE
ros_ethernet_rmp: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3094,7 +3094,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/ros_ethernet_rmp-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/ros_ethernet_rmp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ethernet_rmp` to `0.0.4-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.3-0`
## ros_ethernet_rmp

```
* fixed looking for wrong packages
* travis now pull messages from source
* moved messages to rmp_msgs
* Merge pull request #16 from cmdunkers/develop
  changed to rmp_msgs
* changed to rmp_msgs
* Battery monitor added to travis
* fixed CMakeLists bug
* Merge pull request #15 from cmdunkers/develop
  direction!
* direction!
* Merge pull request #14 from cmdunkers/develop
  radians!
* radians!
* missing thing
* launch file fix
* Merge pull request #12 from cmdunkers/develop
  Fixed issues with the wheel joint state
* fixed the modulo
* Fixed issues with the wheel joint state
  added the battery monitor to the launch file
* Contributors: Chris Dunkers, David Kent, Russell Toris, dekent
```
