### PR TITLE
battery_monitor_rmp: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -179,7 +179,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/battery_monitor_rmp-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/battery_monitor_rmp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `battery_monitor_rmp` to `0.0.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `0.0.1-0`
## battery_monitor_rmp

```
* fixed node name in launch
* missing dep added for travis
* travis now pull messages from source
* removed unused build deps
* moved to rmp_msgs
* Contributors: Russell Toris
```
