### PR TITLE
jsk_visualization: 1.0.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2839,7 +2839,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.6-0
+      version: 1.0.7-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.7-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.0.6-0`
## jsk_interactive
- No changes
## jsk_interactive_marker

```
* add new program: pointcloud_cropper to crop pointcloud with interactive marker
* add config file for interactive point cloud
* update launch for pr2 gripper
* receive handle pose and publish it
* pick and place sample eus
* add reset root pose functions
* add reset marker callback
* rm empty line
* revert README.txt
* move .rviz.default to .rviz when making
* rename .rviz to .rviz.default
* use Eigen::Vector3f in footstep_marker because of the change of the api
  of jsk_pcl_ros
* depends on ${catkin_EXPORTED_TARGETS} to wait for message generation
* update footstep_marker to publish snapped pose to the planes
* support resuming the previous footstep on footstep_marker
* toggle 6dof marker via menu of footstep_marker
* toggle visualization of 6dof marker of footstep_marker via ~show_6dof_control parameter
* publish hand marker pose
* publish selected marker index
* snap the goal direction to the planes even with joy stick command
* do not use deprecated functions to convert tf and kdl instances to avoid
  compilation warning
* add 'Cancel Walk' menu to footstep marker
* Initialize the position of the marker to the frame if ~initial_reference_frame is specified
* register planDoneCB to the sendGoal function to the planner in footstep_marker
* asynchronously get the result of the footstep planning in footstep_marker
* add interactive_point_cloud.h
* add bounding box
* change paramater with dynamic reconfigure
* publish marker pose
* add interactive point cloud
* Contributors: Ryohei Ueda, Yusuke Furuta
```
## jsk_interactive_test
- No changes
## jsk_rqt_plugins
- No changes
## jsk_rviz_plugins

```
* show "stalled" if no diagnostic message received in OverlayDiagnosticDisplay
* add utility class for Overlay: OverlayObject and ScopedPixelBuffer in overlay_utils.cpp
* spcify max/min values for the properties of Plotter2D
* fix color error when changing the size of the window of Plotter2D
* add offset to compute the absolute position of the grid
* Remove non-used color property in OverlayDiagnosticsDisplay
* Remove OverlayDiagnostic correctly (not remaining overlay texture).
* under line of the caption should be longer than the length of the
  caption in TargetVisualizer
* align the position of the text of TargetVisualizer to left
* add CancelAction and PublishTopic plugin to hydro of jsk_rviz_plugin
* add visualizer to visualize pose stamped with target mark
* Contributors: Ryohei Ueda
```
