### PR TITLE
carl_estop: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -321,7 +321,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_estop-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_estop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_estop` to `0.0.2-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_estop.git
- release repository: https://github.com/wpi-rail-release/carl_estop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.1-0`
## carl_estop

```
* moved to new messages
* updated travis
* Contributors: Russell Toris
```
