### PR TITLE
velodyne: 1.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3984,6 +3984,16 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/velodyne.git
       version: master
+    release:
+      packages:
+      - velodyne
+      - velodyne_driver
+      - velodyne_msgs
+      - velodyne_pointcloud
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/velodyne-release.git
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `1.2.0-0`:
- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros-drivers-gbp/velodyne-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## velodyne
- No changes
## velodyne_driver

```
* Fixed bug in diagnostic rate for driver (#16 <https://github.com/ros-drivers/velodyne/issues/16>)
* Contributors: Brice Rebsamen, Jack O'Quin
```
## velodyne_msgs
- No changes
## velodyne_pointcloud

```
* velodyne_pointcloud: remove model-dependent "constants" from
  rawdata.h (#28 <https://github.com/ros-drivers/velodyne/issues/28>)
* velodyne_pointcloud: change default min_range to 0.9 meters (#25 <https://github.com/ros-drivers/velodyne/issues/25>)
* Added support for YAML-CPP 0.5+ (#23 <https://github.com/ros-drivers/velodyne/pull/23>).
* Add dynamic_reconfigure feature.
* Add angular limits to the output point cloud, useful for omitting
  part of it. (#23 <https://github.com/ros-drivers/velodyne/pull/23>).
* Contributors: Jack O'Quin, Scott K Logan, Thomas Solatges
```
