### PR TITLE
add indigo doc job for ros arduino bridge

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2967,6 +2967,11 @@ repositories:
       url: https://github.com/ros/ros.git
       version: indigo-devel
     status: maintained
+  ros_arduino_bridge:
+    doc:
+      type: git
+      url: https://github.com/hbrobotics/ros_arduino_bridge.git
+      version: hydro-devel
   ros_comm:
     doc:
       type: git


### PR DESCRIPTION
yes, hydro-devel is correct, we have not branched, simply making it clear on the wiki that this branch works under indigo as well.
