### PR TITLE
Removed ompl_rviz_viewer from doc job

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2845,11 +2845,6 @@ repositories:
       url: https://github.com/ros-gbp/ompl-release.git
       version: 0.12.2002388-0
     status: maintained
-  ompl_rviz_viewer:
-    doc:
-      type: git
-      url: https://github.com/davetcoleman/ompl_rviz_viewer.git
-      version: master
   open_karto:
     release:
       tags:


### PR DESCRIPTION
The branch it was pointing to no longer exists, and support for Groovy is gone.
