### PR TITLE
ompl_visual_tools: 2.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2277,6 +2277,21 @@ repositories:
       url: https://github.com/ros-gbp/ompl-release.git
       version: 0.14.2002850-0
     status: maintained
+  ompl_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/ompl_visual_tools
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/davetcoleman/ompl_visual_tools-release.git
+      version: 2.0.1-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/ompl_visual_tools
+      version: hydro-devel
+    status: developed
   open_karto:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2280,7 +2280,7 @@ repositories:
   ompl_visual_tools:
     doc:
       type: git
-      url: https://github.com/davetcoleman/ompl_visual_tools
+      url: https://github.com/davetcoleman/ompl_visual_tools.git
       version: hydro-devel
     release:
       tags:
@@ -2289,7 +2289,7 @@ repositories:
       version: 2.0.1-0
     source:
       type: git
-      url: https://github.com/davetcoleman/ompl_visual_tools
+      url: https://github.com/davetcoleman/ompl_visual_tools.git
       version: hydro-devel
     status: developed
   open_karto:


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl_visual_tools` to `2.0.1-0`:
- upstream repository: https://github.com/davetcoleman/ompl_rviz_viewer.git
- release repository: https://github.com/davetcoleman/ompl_visual_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## ompl_visual_tools

```
* Updated README
* Removed lightning dependencies
* Renamed ompl_rviz_viewer to ompl_visual_tools
* Initial
* Contributors: Dave Coleman
```
