### PR TITLE
Add python-trep dep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1273,6 +1273,17 @@ python-tk:
     saucy: [python-tk]
     trusty: [python-tk]
     trusty_python3: [python3-tk]
+python-trep:
+  debian:
+    pip:
+      packages: [trep]
+  fedora:
+    pip:
+      packages: [trep]
+  macports: [py27-trep]
+  ubuntu:
+    pip:
+      packages: [trep]
 python-twisted-bin:
   debian: [python-twisted-bin]
   fedora: [python-twisted-core]


### PR DESCRIPTION
Adding the trep python module as a system dependency to rosdep. http://murpheylab.github.io/trep
