### PR TITLE
ros_datacentre: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5450,6 +5450,24 @@ repositories:
       url: https://github.com/ros-controls/ros_controllers.git
       version: hydro-devel
     status: developed
+  ros_datacentre:
+    release:
+      packages:
+      - log_extractor
+      - mongodb_log
+      - ros_datacentre
+      - ros_datacentre_cpp_client
+      - ros_datacentre_msgs
+      - strands_diagnostics
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/ros_datacentre-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/strands-project/ros_datacentre.git
+      version: hydro-devel
+    status: developed
   ros_ethercat:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_datacentre` to `0.0.2-0`:
- upstream repository: https://github.com/strands-project/ros_datacentre.git
- release repository: https://github.com/strands-project-releases/ros_datacentre-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## log_extractor

```
* initialised log_extractor package
* Contributors: Marc Hanheide
```
## mongodb_log

```
* Dynamically choose MongoDB API
  Use Connection if using an older mongopy, otherwise use MongoClient.
* Cleaned up boilerplate in mongodb_log package.xml
  Removed a bunch of XML comments (that came from the package.xml
  template) from the package.xml file. Added pymongo as a run dependency.
* Main process no longer calls init_node.
  This fixes bugs related to calling init_node multiple times in the same
  process. Main process now has its own signal handler for shutting down
  cleanly.
* Added 'inserted_at' meta with proper date object to logged data.
  This added compatibility with message store and also allows native date queries on results.
* Changes to how meta info is stored.
* Added boost filesystem for new version of ld.
* Added mongo dependency
* More benchmark removal
* REmoved rrd bits.
* Removing benchmarking stuff.
* Restructuring for new repo position.
* Moved all files into mongodb_log subdirectory for later inclusion in a broader package.
* Contributors: Alex Bencz, Christian Dondrup, Nick Hawes
```
## ros_datacentre

```
* Fix #65 <https://github.com/strands-project/ros_datacentre/issues/65>. Check entry exists before accessing value.
* Dynamically choose MongoDB API
  Use Connection if using an older mongopy, otherwise use MongoClient.
* Remove dependency on bson > 2.3
  Use old hook/default interface to avoid having to install bson 2.3 from
  pip.
* Remove dependency on pymongo > 2.3
  In older versions of pymongo, Connection serves the same purpose as
  MongoClient. Updated scripts to use Connection instead of MongoClient.
  This allows the package to work with the existing rosdep definitions for
  python-pymongo (shich use the .deb version).
* Fix #63 <https://github.com/strands-project/ros_datacentre/issues/63>. Update pass through son manipulators.
* Fix #60 <https://github.com/strands-project/ros_datacentre/issues/60>. Add SONManipulator for xmlrpclib binary data.
* datacentre documentation for python
* docstrings in util module
* message store docstrings
* ready for update to use google docstrings
* adding processing of source documentation
* sphinx configuration and index
* sphinx framework for documentation
* Waiting for datacentre.
* Merge pull request #49 <https://github.com/strands-project/ros_datacentre/issues/49> from hawesie/hydro-devel
  Added replication for message store
* Changed collections type to StringList to allow for datacentre comms to task schduler.
* Change action definition to use duration into the past.
* Switched default time to 24 hours ago rather than now, to allow easier use in scheduler.
* Finishing off replicator node.
  * Added to launch file
  * Added to README
  * made client time 24 hours
* Added some minor sanity checks.
* Working and tested dump and restore with time bounds.
* Added dump and restore.
* Fixed empty list error.
* Adding Machine tag to datacentre.launch
* Tested replication and it passes first attempts.
* Adding first pass stuff for replication.
* Deletion now actually deletes...
* Added cpp example of logging multiple messages together.
* Added example of way to log related events to message store.
* Added examples of id-based operations.
* Added update_id method for updating stored object using ObjectID.
* Added updated time and caller too.
* Added inserter id and time to meta.
* Made wait more obvious
* Working binary with pointclouds.
* Added cpp example of logging multiple messages together.
* Added example of way to log related events to message store.
* Added examples of id-based operations.
* Added update_id method for updating stored object using ObjectID.
* Added updated time and caller too.
* Added inserter id and time to meta.
* Made wait more obvious
* Working binary with pointclouds.
* Fixed problem with unicode strings in headers.
* updated pkg name ros_mongodb_datacentre to ros_datacentre
* Adding delete function to MessageStoreProxy and using it in unittest.
* Adds a service to delete message by ID
* Adding an initial rostest for the message store proxy.
* Returning id correctly from service call.
* Made id query return single element.
* Added ObjectID into meta on query return
* Now returning from query srv
* Added ability to query message store by ObjectId (python only for now).
  Also added some little bits of logging.
* Adding delete function to MessageStoreProxy and using it in unittest.
* Adds a service to delete message by ID
* Adding an initial rostest for the message store proxy.
* Merge pull request #28 <https://github.com/strands-project/ros_datacentre/issues/28> from hawesie/hydro-devel
  Changes for strands_executive
* Returning id correctly from service call.
* Made id query return single element.
* [message_store] fixing query service
* Added ObjectID into meta on query return
* Now returning from query srv
* Added ability to query message store by ObjectId (python only for now).
  Also added some little bits of logging.
* [message-store] Dealing with lists in stored messages. Bug #25 <https://github.com/strands-project/ros_datacentre/issues/25>
* fixed update bug where meta info not updated got dropped from the db
* Made sure name is set correctly with using update named.
* All C++ message_store using BSON and meta returns are in json.
  This means that any legal JSON can now be used for a meta description of an object.
* Proof of concept working with C++ BSON library.
* Adding C++ interface for update.
  Fixed compile issues for srv api change.
* Working update method on the python side. Will not work in C++ yet.
* Message store queries now return meta as well as message.
  This is only in the python client for now, but is simple to add to C++. This could be inefficient, so in the future potentially add non-meta options.
* Moved default datacentre path back to /opt/strands
* Switched strands_datacentre to ros_datacentre in here.
* Set default database and collection to be message_store.
  We decided to set these in some way I can't quite recall...
* Added message store to launch file.
  Also made HOSTNAME optional.
* C++ queries are working in a basic form.
* C++ query works
* Now using json.dumps and loads to do better queries from python. C++ is still a pain though.
* Query now returns the messages asked for
* Query structure in place
* Meta stuff working on the way in. Starting to think about querying.
* Added meta in agreed format.
* Wrapping python functionality into a class.
* Working across languages with return value now.
* Works in both languages now!
* Working from the C++ end, but this invalidates the Python again.
* Basic insert chain will work in python. Now on to C++.
* Basic idea works python to python
* Service code runs (not working though)
* Adding an insert service and the start of a message store to provide it.
* Changed db path to be more general.
* Updated launch file.
* Moved strands_datacentre to ros_datacentre
* Contributors: Alex Bencz, Bruno Lacerda, Chris Burbridge, Jaime Pulido Fentanes, Nick Hawes, Thomas Fäulhammer, cburbridge
```
## ros_datacentre_cpp_client

```
* Fixed complilation under Ubuntu.
  * removed use of toTimeT()
  * add_definitions(-std=c++0x) to allow new C++ features
* Deletion now actually deletes...
* Exporting message_store library from package.
* Merge branch 'hydro-devel' of https://github.com/hawesie/ros_datacentre into hydro-devel
  Conflicts:
  ros_datacentre_cpp_client/CMakeLists.txt
  ros_datacentre_cpp_client/include/ros_datacentre/message_store.h
* Cleaned up differences between two commits.
* Added updateID to cpp client.
* Added cpp example of logging multiple messages together.
* Changed order of MessageStoreProxy constructor arguments.
  This was done to allow more natural changing of parameters in a sensible order. It's more likely you want to change collection name first, so that is the first parameter, leaving remainder as default.
* Added point cloud test, but not including in compilation.
* Working binary with pointclouds.
* Added updateID to cpp client.
* Added cpp example of logging multiple messages together.
* Changed order of MessageStoreProxy constructor arguments.
  This was done to allow more natural changing of parameters in a sensible order. It's more likely you want to change collection name first, so that is the first parameter, leaving remainder as default.
* Added point cloud test, but not including in compilation.
* Working binary with pointclouds.
* Renamed the library to message_store and moved some files around
* Added a ros_datacentre_cpp_client library to avoid multiple definitions of some symbols
* Fixed multiple definition error in C++
* Added rostest launch file.
* Renamed to match convention.
* Added test class for cpp interface.
* Query methods now only return true when something was found.
* Added delete to example script.
* Added constant for empty bson obj.
* Added queryID to C++ side. Insert operations now return IDs. This closes #29 <https://github.com/strands-project/ros_datacentre/issues/29>.
  Minor formatting.
* Changed to get the deserialisation length from the vector length.
  This removes the bug where variable length types were incorrectly deserialised. Thanks to @nilsbore for reporting the bug.
* Changed to get the deserialisation length from the vector length.
  This removes the bug where variable length types were incorrectly deserialised. Thanks to @nilsbore for reporting the bug.
* swapping order of target link libraries to fix compiling error
* Made sure name is set correctly with using update named.
* Changed order of parameters for updateNamed to allow people to ignore BSON for as long as possible.
* All C++ message_store using BSON and meta returns are in json.
  This means that any legal JSON can now be used for a meta description of an object.
* Proof of concept working with C++ BSON library.
* Added and tested update interface to C++ side.
* Adding C++ interface for update.
  Fixed compile issues for srv api change.
* Set default database and collection to be message_store.
  We decided to set these in some way I can't quite recall...
* C++ queries are working in a basic form.
* C++ query works
* Query now returns the messages asked for
* Meta stuff working on the way in. Starting to think about querying.
* Renamed file to match python side
* Default values provided
* Moving some functionality to header file for client utils.
* Working from the C++ end, but this invalidates the Python again.
* Contributors: Bruno Lacerda, Nick Hawes, Rares Ambrus
```
## ros_datacentre_msgs

```
* Changed collections type to StringList to allow for datacentre comms to task schduler.
* Change action definition to use duration into the past.
* Working and tested dump and restore with time bounds.
* Added dump and restore.
* Adds a service to delete message by ID
* Adds a service to delete message by ID
* Proof of concept working with C++ BSON library.
* Working update method on the python side. Will not work in C++ yet.
* Removed unused MongoQueryID.srv
* Added update message type.
* Message store queries now return meta as well as message.
  This is only in the python client for now, but is simple to add to C++. This could be inefficient, so in the future potentially add non-meta options.
* Now using json.dumps and loads to do better queries from python. C++ is still a pain though.
* Query now returns the messages asked for
* Query structure in place
* Meta stuff working on the way in. Starting to think about querying.
* Added meta information as a list of string pairs
* Working across languages with return value now.
* Working from the C++ end, but this invalidates the Python again.
* Basic idea works python to python
* Service code runs (not working though)
* Adding an insert service and the start of a message store to provide it.
* Contributors: Nick Hawes, cburbridge
```
## strands_diagnostics

```
* Switched strands_datacentre to ros_datacentre in here.
* correction of import bug in strands_diagnostics
* Added files I stupidly removed.
* Moved strands_diagnostics in from strands_utils
* Contributors: Bruno Lacerda, Nick Hawes
```
