### PR TITLE
Remove old groovy stacks & update branch names

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2476,21 +2476,16 @@ repositories:
       url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
       version: 0.4.2-0
     status: maintained
-  mrpt_common:
+  mrpt_navigation:
     doc:
       type: git
-      url: https://github.com/mrpt-ros-pkg/mrpt_common.git
-      version: master
-  mrpt_hwdrivers:
-    doc:
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: indigo-devel
+    source:
       type: git
-      url: https://github.com/mrpt-ros-pkg/mrpt_hwdrivers.git
-      version: master
-  mrpt_slam:
-    doc:
-      type: git
-      url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
-      version: master
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: indigo-devel
+    status: maintained
   multi_level_map:
     doc:
       type: git

--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2476,16 +2476,6 @@ repositories:
       url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
       version: 0.4.2-0
     status: maintained
-  mrpt_navigation:
-    doc:
-      type: git
-      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
-      version: indigo-devel
-    source:
-      type: git
-      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
-      version: indigo-devel
-    status: maintained
   multi_level_map:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3699,11 +3699,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
-      version: hydro-devel
+      version: indigo-devel
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
-      version: hydro-devel
+      version: indigo-devel
     status: maintained
   multi_level_map:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1910,11 +1910,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
-      version: hydro-devel
+      version: indigo-devel
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
-      version: hydro-devel
+      version: indigo-devel
     status: maintained
   multimaster_fkie:
     doc:


### PR DESCRIPTION
- Groovy: remove of 3 old (unmaintained) stacks, and replace with new one.
- Hydro & Indigo: Fix wrong branch name in Indigo; now we'll use the same upstream branch for both releases as long as it's possible. 
