### PR TITLE
yujin_maps: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4210,7 +4210,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/yujin_maps-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/yujinrobot/yujin_maps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yujin_maps` to `0.2.2-0`:
- upstream repository: https://github.com/yujinrobot/yujin_maps.git
- release repository: https://github.com/yujinrobot-release/yujin_maps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.2.1-0`
## yujin_maps

```
* lower occupid threshold from 0.65 to 0.55
* Contributors: Jihoon Lee
```
