### PR TITLE
kobuki: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1374,6 +1374,24 @@ repositories:
       type: git
       url: https://github.com/yujinrobot/kobuki.git
       version: indigo
+    release:
+      packages:
+      - kobuki
+      - kobuki_apps
+      - kobuki_auto_docking
+      - kobuki_bumper2pc
+      - kobuki_capabilities
+      - kobuki_controller_tutorial
+      - kobuki_description
+      - kobuki_keyop
+      - kobuki_node
+      - kobuki_random_walker
+      - kobuki_safety_controller
+      - kobuki_testsuite
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/kobuki-release.git
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki` to `0.6.0-0`:
- upstream repository: https://github.com/yujinrobot/kobuki.git
- release repository: https://github.com/yujinrobot-release/kobuki-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## kobuki

```
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Jorge Santos
```
## kobuki_apps

```
* sync package version. remove author e-mail
* updates icons for apps and app manager launcher
* adds minor changes due to capability server and app manager updates
* updates for new rapp lists
* kobuki_apps: fixes spelling mistake in run dependency
* adds cleanup and updates for the recent changes in capabilities dev
* kobuki_apps: adds provider specific remappings for random walker app
* adds kobuki_apps
* Contributors: Jihoon Lee, Marcus Liebhardt
* updates icons for apps and app manager launcher
* adds minor changes due to capability server and app manager updates
* updates for new rapp lists
* kobuki_apps: fixes spelling mistake in run dependency
* adds cleanup and updates for the recent changes in capabilities dev
* kobuki_apps: adds provider specific remappings for random walker app
* adds kobuki_apps
* Contributors: Marcus Liebhardt
```
## kobuki_auto_docking

```
* leaning comments
* refactoring
* publish debug message even if auto dock is not running
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Jihoon Lee, Jorge Santos, jihoonl
```
## kobuki_bumper2pc

```
* added comments to explain about the faraway points
* added side_point_angle param to change the angle of the bumper pointcloud's side points
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Jorge Santos, Kaijen Hsiao
```
## kobuki_capabilities

```
* moves app manager launcher to kobuki_capabilities (solves #331 <https://github.com/yujinrobot/kobuki/issues/331>)
* kobuki_capabilities: adds nodelet manager support for bringup provider
* updates and extends kobuki's capabilities
* adds cleanup and updates for the recent changes in capabilities dev
* kobuki_capabilities: adds provider specific remappings and fixes
  semantic interface remappings
* adds an initial set of kobuki-specific interfaces and providers plus idle node
* adds kobuki_capabilities
* Contributors: Jihoon Lee, Marcus Liebhardt
* moves app manager launcher to kobuki_capabilities (solves #331 <https://github.com/yujinrobot/kobuki/issues/331>)
* kobuki_capabilities: adds nodelet manager support for bringup provider
* updates and extends kobuki's capabilities
* adds cleanup and updates for the recent changes in capabilities dev
* kobuki_capabilities: adds provider specific remappings and fixes
  semantic interface remappings
* adds an initial set of kobuki-specific interfaces and providers plus idle node
* adds kobuki_capabilities
* Contributors: Marcus Liebhardt
```
## kobuki_controller_tutorial

```
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Jorge Santos
```
## kobuki_description

```
* update body friction and revert torque limit
* update kobuki_gazebo.urdf.xacro to make gazebo simulation more stable.
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: John Hsu, Jorge Santos
```
## kobuki_keyop

```
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Jorge Santos
```
## kobuki_node

```
* remove kobuki_capabilities dependency from package.xml remove author emails
* moves app manager launcher to kobuki_capabilities (solves #331 <https://github.com/yujinrobot/kobuki/issues/331>)
* kobuki_node: adds shutdown flag to nodelet (fixes #324 <https://github.com/yujinrobot/kobuki/issues/324>)
* fixes typo
* updates icons for apps and app manager launcher
* adds minor changes due to capability server and app manager updates
* updates for new rapp lists
* publish_tf arg for the launcher.
* removes rviz launcher and dependency (fixes #315 <https://github.com/yujinrobot/kobuki/issues/315>)
* adds app manager and capability server launcher for kobuki
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Daniel Stonier, Jihoon Lee, Jorge Santos, Marcus Liebhardt
```
## kobuki_random_walker

```
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Jorge Santos
```
## kobuki_safety_controller

```
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Jorge Santos
```
## kobuki_testsuite

```
* Angular/linear acceleration script added.
* customisable rotate rate.
* Add missing run dependency on yocs_cmd_vel_mux
* Contributors: Daniel Stonier, Jorge Santos, jihoonl
```
