### PR TITLE
kobuki: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1374,6 +1374,24 @@ repositories:
       type: git
       url: https://github.com/yujinrobot/kobuki.git
       version: indigo
+    release:
+      packages:
+      - kobuki
+      - kobuki_apps
+      - kobuki_auto_docking
+      - kobuki_bumper2pc
+      - kobuki_capabilities
+      - kobuki_controller_tutorial
+      - kobuki_description
+      - kobuki_keyop
+      - kobuki_node
+      - kobuki_random_walker
+      - kobuki_safety_controller
+      - kobuki_testsuite
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/kobuki-release.git
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki` to `0.6.1-0`:
- upstream repository: https://github.com/yujinrobot/kobuki.git
- release repository: https://github.com/yujinrobot-release/kobuki-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## kobuki
- No changes
## kobuki_apps
- No changes
## kobuki_auto_docking
- No changes
## kobuki_bumper2pc
- No changes
## kobuki_capabilities

```
* sync with current app manager launcher. default kobuki capabilities param file added
* Contributors: Jihoon Lee
```
## kobuki_controller_tutorial
- No changes
## kobuki_description
- No changes
## kobuki_keyop
- No changes
## kobuki_node
- No changes
## kobuki_random_walker
- No changes
## kobuki_safety_controller
- No changes
## kobuki_testsuite
- No changes
