### PR TITLE
ompl_visual_tools: 2.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2304,7 +2304,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/ompl_visual_tools-release.git
-      version: 2.0.1-0
+      version: 2.1.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/ompl_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl_visual_tools` to `2.1.0-0`:
- upstream repository: https://github.com/davetcoleman/ompl_rviz_viewer.git
- release repository: https://github.com/davetcoleman/ompl_visual_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `2.0.1-0`
## ompl_visual_tools

```
* Removed getSolutionPlannerName that is not available in OMPL released version
* Updated README
* Renamed file to rrt_demo.cpp
* Cleanup since change to moveit_visual_tools
* Specify OMPL version
* Fixed marker topic path
* Contributors: Dave Coleman
```
