### PR TITLE
moveit_visual_tools: 1.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1918,7 +1918,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 1.1.0-0
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `1.2.0-0`:
- upstream repository: https://github.com/davetcoleman/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.1.0-0`
## moveit_visual_tools

```
* Added XXLarge size
* Added global_scale feature
* Added hideRobot() functionality
* Added removeAllCollisionObjects from planning scene monitor
* Added publishCollisionSceneFromFile function
* Formatting
* Contributors: Dave Coleman
```
