### PR TITLE
Adding guardian_sim to documentation index for hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2040,6 +2040,16 @@ repositories:
       url: https://github.com/ros-drivers/gscam.git
       version: master
     status: maintained
+  guardian_sim:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/guardian_sim.git
+      version: hydro-devel
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/guardian_sim.git
+      version: hydro-devel
+    status: developed
   handle_detector:
     doc:
       type: git


### PR DESCRIPTION
I'd like guardian_sim to be indexed and documented at ros.org
