### PR TITLE
s3000_laser: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6313,6 +6313,11 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/s3000_laser.git
       version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/RobotnikAutomation/s3000_laser-release.git
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/s3000_laser.git


### PR DESCRIPTION
Increasing version of package(s) in repository `s3000_laser` to `0.1.0-0`:
- upstream repository: https://github.com/RobotnikAutomation/s3000_laser.git
- release repository: https://github.com/RobotnikAutomation/s3000_laser-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## s3000_laser

```
* Adding packages dependencies and removing unused includes
* Modifying package description for Hydro branch
* Adding files for Hydro
* Initial commit
* Contributors: RobotnikRoman, Roman Navarro Garcia
```
