### PR TITLE
Consider installing pillow instead of PIL on OS X

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -438,7 +438,7 @@ python-gtk2:
 python-imaging:
   osx:
     pip:
-      packages: [PIL]
+      packages: [pillow]
 python-kitchen:
   osx:
     pip:


### PR DESCRIPTION
Compare:

https://github.com/ros/rosdistro/blob/master/rosdep/python.yaml#L406
https://github.com/ros/rosdistro/blob/master/rosdep/osx-homebrew.yaml#L438

Most of the distros are using pillow instead of PIL. PIL has to be installed outside of rosdep due to extra pip flags required, cf:

http://wiki.ros.org/indigo/Installation/OSX/Homebrew/Source#os.2BAC8-OSX.2BAC8-Homebrew.2BAC8-troubleshooting.PIL_fails_to_install_on_OS_X_10.9_.28Mavericks.29

@wjwwood, @NikolausDemmel, any reason it has to stay as PIL?
