### PR TITLE
Update rosdep entry mrpt for recent Ubuntu distros

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2144,6 +2144,9 @@ mrpt:
     precise: [libmrpt-dev]
     quantal: [libmrpt-dev]
     raring: [libmrpt-dev, mrpt-apps]
+    saucy: [libmrpt-dev]
+    trusty: [libmrpt-dev]
+    utopic: [libmrpt-dev]
 muparser:
   fedora: [muParser-devel]
   ubuntu: [libmuparser-dev]


### PR DESCRIPTION
When "raring" is old enough (there was a bug in those pkgs) it may be worth simplifying all versions to a single "ubuntu: " line with the proper -dev pkg.
