### PR TITLE
mavlink: 1.0.9-6 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3342,7 +3342,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/vooon/mavlink-gbp-release.git
-      version: 1.0.9-5
+      version: 1.0.9-6
     status: maintained
   mavros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `1.0.9-6`:
- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/vooon/mavlink-gbp-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.9-5`
