### PR TITLE
rosdep python-imaging: fix case for pip `Pillow`

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -438,7 +438,7 @@ python-gtk2:
 python-imaging:
   osx:
     pip:
-      packages: [pillow]
+      packages: [Pillow]
 python-kitchen:
   osx:
     pip:


### PR DESCRIPTION
The installed check in rosdep pip installer is case sensitive.

See https://github.com/ros/rosdistro/pull/5220#issuecomment-51660100
