### PR TITLE
jaco_ros: 1.0.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2664,6 +2664,22 @@ repositories:
       type: git
       url: https://github.com/Kinovarobotics/jaco-ros.git
       version: hydro-devel
+    release:
+      packages:
+      - jaco_demo
+      - jaco_driver
+      - jaco_model
+      - jaco_msgs
+      - jaco_ros
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/clearpathrobotics/jaco_ros-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/Kinovarobotics/jaco-ros.git
+      version: hydro-devel
+    status: maintained
   joy_teleop:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jaco_ros` to `1.0.0-0`:
- upstream repository: https://github.com/Kinovarobotics/jaco-ros.git
- release repository: https://github.com/clearpathrobotics/jaco_ros-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## jaco_demo

```
* Initial catkin release
```
## jaco_driver

```
* Initial catkin release
```
## jaco_model

```
* Initial catkin release
```
## jaco_msgs

```
* Initial catkin release
```
## jaco_ros

```
* Initial catkin release
```
