### PR TITLE
kobuki_msgs: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1436,7 +1436,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki_msgs-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_msgs` to `0.6.1-0`:
- upstream repository: https://github.com/yujinrobot/kobuki_msgs.git
- release repository: https://github.com/yujinrobot-release/kobuki_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.6.0-0`
