### PR TITLE
kobuki: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1391,7 +1391,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki` to `0.6.2-0`:
- upstream repository: https://github.com/yujinrobot/kobuki.git
- release repository: https://github.com/yujinrobot-release/kobuki-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.6.1-0`
## kobuki
- No changes
## kobuki_apps
- No changes
## kobuki_auto_docking
- No changes
## kobuki_bumper2pc
- No changes
## kobuki_capabilities
- No changes
## kobuki_controller_tutorial
- No changes
## kobuki_description
- No changes
## kobuki_keyop
- No changes
## kobuki_node

```
* add queue_size on publiehrs #338 <https://github.com/yujinrobot/kobuki/issues/338>
* fixing the file link resolves #339 <https://github.com/yujinrobot/kobuki/issues/339>
* Contributors: Jihoon Lee
```
## kobuki_random_walker
- No changes
## kobuki_safety_controller
- No changes
## kobuki_testsuite

```
* move out the message to kobuki_msgs
* add queue_size for publishers in testsuite
* Contributors: Jihoon Lee
```
