### PR TITLE
kobuki_desktop: 0.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1422,6 +1422,18 @@ repositories:
       type: git
       url: https://github.com/yujinrobot/kobuki_desktop.git
       version: indigo
+    release:
+      packages:
+      - kobuki_dashboard
+      - kobuki_desktop
+      - kobuki_gazebo
+      - kobuki_gazebo_plugins
+      - kobuki_qtestsuite
+      - kobuki_rviz_launchers
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/kobuki_desktop-release.git
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_desktop` to `0.4.0-0`:
- upstream repository: https://github.com/yujinrobot/kobuki_desktop.git
- release repository: https://github.com/yujinrobot-release/kobuki_desktop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## kobuki_dashboard

```
* now it uses dataplot class instead of mat dataplot. It still shows weird scaling though..
* removes email addresses from authors
* add robot groups for rqt plugins
* Contributors: Dirk Thomas, Jihoon Lee, Marcus Liebhardt
```
## kobuki_desktop

```
* removes email addresses from authors
* adds package for rviz launchers
* Contributors: Marcus Liebhardt
```
## kobuki_gazebo

```
* removes email addresses from authors
* Contributors: Marcus Liebhardt
```
## kobuki_gazebo_plugins

```
* cherry-picking #30 <https://github.com/yujinrobot/kobuki_desktop/issues/30>
* trivial update.
* removes email addresses from authors
* replace deprecated shared_dynamic_cast (fixes #25 <https://github.com/yujinrobot/kobuki_desktop/issues/25>)
* Contributors: Daniel Stonier, Marcus Liebhardt, Nikolaus Demmel, Samir Benmendil
```
## kobuki_qtestsuite

```
* now it uses Rqt DataPlot instead our own version
* uses dataplot
* now it uses dataplot class instead of mat dataplot. It still shows weird scaling though..
* removes email addresses from authors
* add robot groups for rqt plugins
* Contributors: Dirk Thomas, Jihoon Lee, Marcus Liebhardt
```
## kobuki_rviz_launchers

```
* removes email addresses from authors
* adds package for rviz launchers
* Contributors: Marcus Liebhardt
```
