### PR TITLE
kobuki_soft: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1447,6 +1447,15 @@ repositories:
       type: git
       url: https://github.com/yujinrobot/kobuki_soft.git
       version: indigo
+    release:
+      packages:
+      - kobuki_soft
+      - kobuki_softapps
+      - kobuki_softnode
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/kobuki_soft-release.git
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_soft.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_soft` to `0.1.0-0`:
- upstream repository: https://github.com/yujinrobot/kobuki_soft
- release repository: https://github.com/yujinrobot-release/kobuki_soft-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## kobuki_soft
- No changes
## kobuki_softapps

```
* use dwa planner
* Contributors: Jihoon Lee
```
## kobuki_softnode

```
* add message dependency
* Contributors: Jihoon Lee
```
