### PR TITLE
rtmros_hironx: 1.0.21-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6141,7 +6141,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.20-0
+      version: 1.0.21-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.21-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.20-0`
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* (robot installability check)

    * Update md5sum to 7/17/2014 KWD version.
    * Update checker QNX binary.
    * Many improvements (no duplicate ssh password. Add tool's version. Fix memory-checking regex).
    * save result to db.
    * save hrpsys veresion.

* (test_hironx_ros_bridge) add assertion, fix to work on simulation.
* (doc) Add unit tests policy.
* Contributors: Kei Okada, Isaac I.Y. Saito
```
## rtmros_hironx

```
* (robot installability check)

    * Update md5sum to 7/17/2014 KWD version.
    * Update checker QNX binary.
    * Many improvements (no duplicate ssh password. Add tool's version. Fix memory-checking regex).
    * save result to db.
    * save hrpsys veresion.

* (test_hironx_ros_bridge) add assertion, fix to work on simulation.
* (doc) Add unit tests policy.
* Contributors: Kei Okada, Isaac I.Y. Saito
```
