### PR TITLE
segwayrmp: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6467,6 +6467,21 @@ repositories:
       type: git
       url: https://github.com/sri-robotics/segwayrmp.git
       version: hydro
+    release:
+      packages:
+      - rmp_base
+      - rmp_description
+      - rmp_msgs
+      - rmp_teleop
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/sri-robotics/segwayrmp-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/sri-robotics/segwayrmp.git
+      version: hydro
+    status: maintained
   sentis_tof_m100:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `segwayrmp` to `0.0.1-0`:
- upstream repository: https://github.com/sri-robotics/segwayrmp.git
- release repository: https://github.com/sri-robotics/segwayrmp-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
