### PR TITLE
segwayrmp: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6473,10 +6473,11 @@ repositories:
       - rmp_description
       - rmp_msgs
       - rmp_teleop
+      - segwayrmp
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/sri-robotics/segwayrmp-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/sri-robotics/segwayrmp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `segwayrmp` to `0.0.2-0`:
- upstream repository: https://github.com/sri-robotics/segwayrmp.git
- release repository: https://github.com/sri-robotics/segwayrmp-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.1-0`
## rmp_base

```
* Add changelog files.
* Move license and readme files.
```
## rmp_description

```
* Add changelog files.
* Move license and readme files.
```
## rmp_msgs

```
* Add changelog files.
* Move license and readme files.
```
## rmp_teleop

```
* Add changelog files.
* Move license and readme files.
```
## segwayrmp

```
* Add segwayrmp metapackage.
* Move license and readme files.
```
