### PR TITLE
Adding rosdep for python-cairo, ubuntu and homebrew

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -423,6 +423,10 @@ python-argparse:
   osx:
     pip:
       packages: [argparse]
+python-cairo:
+  osx:
+    homebrew:
+      packages: [py2cairo]
 python-coverage:
   osx:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -147,6 +147,15 @@ python-bluez:
     raring: [python-bluez]
     saucy: [python-bluez]
     trusty: [python-bluez]
+python-cairo:
+  ubuntu:
+    lucid: [python-cairo]
+    oneiric: [python-cairo]
+    precise: [python-cairo]
+    quantal: [python-cairo]
+    raring: [python-cairo]
+    saucy: [python-cairo]
+    trusty: [python-cairo]
 python-catkin-pkg:
   arch: [python2-catkin_pkg]
   debian: [python-catkin-pkg]


### PR DESCRIPTION
Adding this rosdep for use in rqt_bag_plugins. Discussion in this issue:
https://github.com/ros-visualization/rqt_common_plugins/issues/267
