### PR TITLE
smart_battery_msgs: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3777,10 +3777,16 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/smart_battery_msgs.git
       version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/smart_battery_msgs-release.git
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/smart_battery_msgs.git
       version: master
+    status: maintained
   sparse_bundle_adjustment:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `smart_battery_msgs` to `0.1.0-0`:
- upstream repository: https://github.com/ros-drivers/smart_battery_msgs.git
- release repository: https://github.com/ros-gbp/smart_battery_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## smart_battery_msgs

```
* initial commit
* Contributors: Jihoon Lee
```
