### PR TITLE
linux_peripheral_interface: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1635,6 +1635,15 @@ repositories:
       url: https://github.com/ktossell/libuvc_ros.git
       version: master
     status: developed
+  linux_peripheral_interface:
+    release:
+      packages:
+      - laptop_battery_monitor
+      - linux_peripheral_interfaces
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/linux_peripheral_interfaces-release.git
+      version: 0.1.0-0
   linux_peripheral_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `linux_peripheral_interface` to `0.1.0-0`:
- upstream repository: https://github.com/ros-drivers/linux_peripheral_interfaces.git
- release repository: https://github.com/ros-gbp/linux_peripheral_interfaces-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## linux_peripheral_interfaces

```
* cleanup and now it uses smart_battery_msgs
* rename metapackage as linux_peripheral_interfaces
* Contributors: Jihoon Lee
```
