### PR TITLE
velodyne_height_map: 0.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4099,6 +4099,11 @@ repositories:
       type: git
       url: https://github.com/jack-oquin/velodyne_height_map.git
       version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/jack-oquin-ros-releases/velodyne_height_map-release.git
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/jack-oquin/velodyne_height_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_height_map` to `0.4.1-0`:
- upstream repository: https://github.com/jack-oquin/velodyne_height_map.git
- release repository: https://github.com/jack-oquin-ros-releases/velodyne_height_map-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## velodyne_height_map
- No changes
