### PR TITLE
rbdl: 2.3.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5013,6 +5013,21 @@ repositories:
       url: https://github.com/ros-drivers/razer_hydra.git
       version: hydro-devel
     status: maintained
+  rbdl:
+    doc:
+      type: hg
+      url: https://bitbucket.org/rbdl/rbdl
+      version: tag
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/isura/rbdl-release.git
+      version: 2.3.1-1
+    source:
+      type: hg
+      url: https://bitbucket.org/rbdl/rbdl
+      version: branch
+    status: developed
   realtime_tools:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5017,7 +5017,7 @@ repositories:
     doc:
       type: hg
       url: https://bitbucket.org/rbdl/rbdl
-      version: tag
+      version: v2.3.1
     release:
       tags:
         release: release/hydro/{package}/{version}
@@ -5026,7 +5026,7 @@ repositories:
     source:
       type: hg
       url: https://bitbucket.org/rbdl/rbdl
-      version: branch
+      version: default
     status: developed
   realtime_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rbdl` to `2.3.1-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
