### PR TITLE
tf2_web_republisher: 0.2.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6875,7 +6875,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/tf2_web_republisher-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/RobotWebTools/tf2_web_republisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_web_republisher` to `0.2.2-0`:
- upstream repository: https://github.com/RobotWebTools/tf2_web_republisher.git
- release repository: https://github.com/RobotWebTools-release/tf2_web_republisher-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.2.1-0`
## tf2_web_republisher

```
* release prepare
* Merge pull request #14 from T045T/send_initial_transformation
  make sure at least one transformation is sent
* make sure at least one transformation is sent, even if the tf is (and stays) the identity
* Merge pull request #13 from T045T/develop
  stop sending TF updates when removing a cancelled goal
* stop sending TF updates when removing a cancelled goal
* URLs added to package XML
* Contributors: Nils Berg, Russell Toris
```
