### PR TITLE
usb_cam: 0.1.6-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4703,7 +4703,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/bosch-ros-pkg-release/usb_cam-release.git
-      version: 0.1.5-1
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/bosch-ros-pkg/usb_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam` to `0.1.6-0`:
- upstream repository: https://github.com/bosch-ros-pkg/usb_cam.git
- release repository: https://github.com/bosch-ros-pkg-release/usb_cam-release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.1.5-1`
## usb_cam

```
* Merge pull request #14 from KaijenHsiao/master
  added support for 10-bit mono cameras advertising as YUV
* added support for 10-bit mono cameras advertising as YUV (such as Leopard Imaging's LI-USB30-V034)
* Update CHANGELOG.rst
* changelog updated
* Merge pull request #13 from vrabaud/develop
  add a a ros::spinOnce to get set_camera_info working
* add a a ros::spinOnce to get set_camera_info working
  This is explained in the docs of CameraInfoManager
  https://github.com/ros-perception/image_common/blob/hydro-devel/camera_info_manager/include/camera_info_manager/camera_info_manager.h#L71
  Also, this fixes https://github.com/ros-perception/image_pipeline/issues/78
* Contributors: Kaijen Hsiao, Russell Toris, Vincent Rabaud, sosentos
```
