### PR TITLE
ros_ethernet_rmp: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3184,7 +3184,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/ros_ethernet_rmp-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/ros_ethernet_rmp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ethernet_rmp` to `0.0.5-0`:
- upstream repository: https://github.com/WPI-RAIL/ros_ethernet_rmp.git
- release repository: https://github.com/wpi-rail-release/ros_ethernet_rmp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.4-0`
## ros_ethernet_rmp

```
* Merge pull request #17 from cmdunkers/develop
  updated yaw accel limit
* updated the yaw_accel_limit
* Merge branch 'develop' of https://github.com/cmdunkers/ros_ethernet_rmp into develop
* Merge pull request #2 from WPI-RAIL/develop
  cmdunkers
* Merge pull request #1 from WPI-RAIL/develop
  updates
* fixed joint state publisher issue
* Contributors: Chris Dunkers, Russell Toris, cmdunkers
```
