### PR TITLE
carl_bot: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -312,6 +312,27 @@ repositories:
       url: https://github.com/osrf/capabilities.git
       version: master
     status: maintained
+  carl_bot:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/carl_bot.git
+      version: master
+    release:
+      packages:
+      - carl_bot
+      - carl_bringup
+      - carl_description
+      - carl_dynamixel
+      - carl_teleop
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/carl_bot-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/carl_bot.git
+      version: develop
+    status: maintained
   carl_estop:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_bot` to `0.0.1-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_bot.git
- release repository: https://github.com/wpi-rail-release/carl_bot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## carl_bot

```
* revert changelogs
* changelog updated
* READMEs and Travis build
* minor cleanup
* Pulled in new teleop code
* Moved carl_navigation from carl_bot package to its own package
* carl teleop cleanup
* cleanup of metapackage
* Created package for carl navigation.
* Fixed missing EOF new lines
* Created carl_bringup package.
* Contributors: Russell Toris, Steven Kordell
```
## carl_bringup

```
* revert changelogs
* changelog updated
* jaco arm interactive manipulation now launches on carl startup
* carl_dynamixel package cleanup
* cleanup of carl_description
* launch cleanup
* minor cleanup
* launch file launches teleop on startup
* updated run dependencies needed for launch files
* updated launch files
* increased rate of tf updating from joint_states
* joint_state_publisher now updates based on the jaco arm's published joint states
* Switched local planner
* Visual odometry disabled by default.
* Refactoring
* Parameter changes. Autonomous navigation significantly improved.
* Parameter changes.
* Using openni2 launch instead of camera node
* Using openni2 for asus
* Added visual odometry and efk node to launch.
* Parameter modifications.
* Removed asus for now
* Fixed frame for laser scan data
* Fixed included launch file path
* Fixed missing EOF new lines
* Created launch files for robot model, sensors, segway, and minimal bringup.
* Created carl_bringup package.
* Contributors: =, Russell Toris, Steven Kordell, dekent, spkordell
```
## carl_description

```
* recompiled URDF
* revert changelogs
* changelog updated
* Updated Collision Model
* Added creative camera
* Added meshes for creative camera
* added front servo to joint state publisher
* Rotated right_rear_strut 180 degrees
* redid front cover
* redid front cover
* covers redone
* retextured back cover
* retextured back cover
* new asus model
* updated URDF
* revert asus
* asus test
* fixed size of metal texture
* minified new rear strut
* Added red color to rear_strut model itself
* minified new table plate
* New tiny plate
* moved originals back (materials reference broken)
* base plate test
* Set fixed frame to base_footprint
* Re-exported asus collada
* updated CARL urdf
* fixed install cmake bug
* minifyied materials
* robot URDF files installed
* recompiled URDF
* READMEs and Travis build
* minified XML in Collada modles
* cleanup of carl_description
* launch cleanup
* carl_description updated to use jaco_description instead of jaco_model, more carl_teleop cleanup
* Updated urdf to use jaco_description
* Rviz configuration adjustements
* Updated collision model
* Added new servo mount to model
* Added newly machined components to urdf
* Changed default camera angle
* Fixed issue with some camera transformes beign published multiple times by different nodes.
* Fixed base_footprint tf
* Added transform to base_footprint
* Fixed missing EOF new lines
* Added launch file for viewing the robot model.
* Changed initial pose of caster and repositioned cover.
* Fixed indentation
* Added asus xtion.
* Added new lines to end of files.
* Refactoring
* Refactoring
* Refactoring
* Refactoring.
* Refactoring.
* Refactoring.
* Renamed meshes to follow ROS conventions
* Renamed a couple meshes.
* Added lettering
* Updates to collision model
* Fixed transforms to match origins of new meshes
* Replaced STLs with Collada files.
* Removed unnused meshes
* Added back cover
* Added collision for caster
* Added front plate
* Added side walls
* Simplifications to collision model
* Switched to xacro format. Added jaco arm to model.
* Removed spaces from mesh file names
* Removed spaces from mesh file names
* Removed CAD models
* Fixed origin of STLs and reoriented axis of urdf
* Fixed collision origins
* Fixed origins for visualization.
* Fixed some origin alignment issues.
* Fixed rotation axis for camera tilt link
* Fixed rotation axis for camera tilt link
* Added more links
* Added meshes for wheels and base
* Started urdf
* Added STLs
* Added carl cad
* Added carl_description package.
* Contributors: =, Russell Toris, Steven Kordell, dekent
```
## carl_dynamixel

```
* revert changelogs
* changelog updated
* updated the joint names
* added servo_pan_tilt to carl_dynamixel launch file
* added front_joints_node to install
* fixed creative range
* fixed the launch file
* velocity commands and teleop controls for the second camera
* Switched to front
* Merged my changes
* adjustments to asus joint servo speed
* Servo velocity control and teleop initial commit
* output mapped to screen
* removed dumb output
* removed dumb output
* changed launch file to look for config scripts
* carl_dynamixel package cleanup
* updated run dependencies needed for launch files
* updated launch files
* added dependency in carl_dynamixel for dynamixel_msgs to be generated first
* corrected the link name
* fixed error
* fixed minor changes
* updated the joint publisher to publish radians for the servo angle
* removed a launch file in carl_dynamixel
* updated carl_dynamixel to publish joint states and added a yaml to define the joints
* added carl_dynamixel
* Contributors: Chris Dunkers, Russell Toris, dekent
```
## carl_teleop

```
* revert changelogs
* changelog updated
* bugfix for camera teleop controls
* velocity commands and teleop controls for the second camera
* adjustments to asus joint servo speed
* Servo velocity control and teleop initial commit
* possible fix for arm stopping during teleop mode switches
* carl_teleop cleanup
* carl_description updated to use jaco_description instead of jaco_model, more carl_teleop cleanup
* updated jaco_msgs to wpi_jaco_msgs, misc. cleanup
* added keyboard teleop for the JACO arm to CARL keyboard teleop
* Added arm control to CARL teleop, and analog controller functionality to the base teleop
* carl teleop cleanup
* Using relative namespace for teleop node and loading default parameters for covarience.
* Reversed angular commands
* Added ability to cancel navigation planning with the controller
* Joy teleop only publishes cmd_vel when deadman switch is pressed.
* cleanup of carl teleop nodes
* cleanup of carl joy teleop
* Added launch file for joystick teleop.
* Added joy to build dependencies
* Removed unnecessary function
* Now using right joystick for angular control
* Added fixes is response to code review: authorship credit, doxygen, and formatting.
* Added deadman swtich and boost button.
* Added keyboard teleop
* Joy Teleop Works
* Created cpp file for joystick teleop
* Created package for carl teleoperation.
* Contributors: Russell Toris, Steven Kordell, dekent
```
