### PR TITLE
rbdl: 2.3.1-5 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2761,6 +2761,21 @@ repositories:
       url: https://github.com/ros-drivers/razer_hydra.git
       version: indigo-devel
     status: maintained
+  rbdl:
+    doc:
+      type: hg
+      url: https://bitbucket.org/rbdl/rbdl
+      version: v2.3.1
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/isura/rbdl-release.git
+      version: 2.3.1-5
+    source:
+      type: hg
+      url: https://bitbucket.org/rbdl/rbdl
+      version: default
+    status: developed
   realtime_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rbdl` to `2.3.1-5`:
- upstream repository: https://bitbucket.org/rbdl/rbdl
- release repository: https://github.com/isura/rbdl-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
