### PR TITLE
turtlebot_arm: 0.3.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4028,7 +4028,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_arm-release.git
-      version: 0.3.0-0
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_arm.git
+      version: indigo-devel
     status: developed
   ueye:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_arm` to `0.3.0-1`:
- upstream repository: https://github.com/turtlebot/turtlebot_arm.git
- release repository: https://github.com/turtlebot-release/turtlebot_arm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.3.0-0`
## turtlebot_arm_bringup

```
* First indigo release
```
## turtlebot_arm_description

```
* First indigo release
```
## turtlebot_arm_ikfast_plugin

```
* First indigo release
```
## turtlebot_arm_kinect_calibration

```
* First indigo release
```
## turtlebot_arm_moveit_config

```
* First indigo release
```
## turtlebot_arm_moveit_demos

```
* First indigo release
```
