### PR TITLE
wu_ros_tools: 0.1.1-1 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4881,6 +4881,10 @@ repositories:
       url: https://github.com/ros-windows/win_ros.git
       version: groovy-devel
   wu_ros_tools:
+    doc:
+      type: git
+      url: https://github.com/DLu/wu_ros_tools.git
+      version: groovy
     release:
       packages:
       - catkinize_this
@@ -4892,7 +4896,12 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/wu-robotics/wu_ros_tools.git
-      version: 0.1.0-5
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/DLu/wu_ros_tools.git
+      version: groovy
+    status: maintained
   x52_joyext:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wu_ros_tools` to `0.1.1-1`:
- upstream repository: https://github.com/DLu/wu_ros_tools
- release repository: https://github.com/wu-robotics/wu_ros_tools.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.1.0-5`
