### PR TITLE
laser_filtering: 0.0.3-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2123,7 +2123,7 @@ repositories:
   laser_filtering:
     doc:
       type: git
-      url: https://github.com/DLu/laser_filtering
+      url: https://github.com/DLu/laser_filtering.git
       version: groovy
     release:
       packages:
@@ -2135,7 +2135,7 @@ repositories:
       version: 0.0.3-0
     source:
       type: git
-      url: https://github.com/DLu/laser_filtering
+      url: https://github.com/DLu/laser_filtering.git
       version: groovy
     status: maintained
   laser_filters:

--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2120,6 +2120,24 @@ repositories:
       type: svn
       url: https://code.ros.org/svn/ros-pkg/stacks/laser_drivers/trunk
       version: HEAD
+  laser_filtering:
+    doc:
+      type: git
+      url: https://github.com/DLu/laser_filtering
+      version: groovy
+    release:
+      packages:
+      - laser_filtering
+      - map_laser
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/wu-robotics/laser_filtering_release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/DLu/laser_filtering
+      version: groovy
+    status: maintained
   laser_filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filtering` to `0.0.3-0`:
- upstream repository: https://github.com/DLu/laser_filtering.git
- release repository: https://github.com/wu-robotics/laser_filtering_release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
