### PR TITLE
rosh_core: 1.0.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5673,7 +5673,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/OSUrobotics/rosh_core-release.git
-      version: 1.0.6-0
+      version: 1.0.7-0
     source:
       type: git
       url: https://github.com/OSUrobotics/rosh_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_core` to `1.0.7-0`:
- upstream repository: https://github.com/OSUrobotics/rosh_core.git
- release repository: https://github.com/OSUrobotics/rosh_core-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.6-0`
## rosh

```
* replace rxgraph with rqt_graph (doesn't support ns args)
* Contributors: Dan Lazewatsky
```
## rosh_core
- No changes
## roshlaunch
- No changes
