### PR TITLE
rosh_desktop_plugins: 1.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5692,7 +5692,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/OSUrobotics/rosh_desktop_plugins-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/OSUrobotics/rosh_desktop_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_desktop_plugins` to `1.0.3-0`:
- upstream repository: https://github.com/OSUrobotics/rosh_desktop_plugins.git
- release repository: https://github.com/OSUrobotics/rosh_desktop_plugins-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.2-0`
## rosh_desktop
- No changes
## rosh_desktop_plugins
- No changes
## rosh_visualization

```
* A belated additional fix for #1 <https://github.com/OSUrobotics/rosh_desktop_plugins/issues/1> - make sure image_view is installed
* Contributors: Dan Lazewatsky
```
