### PR TITLE
rosh_robot_plugins: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3405,7 +3405,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/OSUrobotics/rosh_robot_plugins-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/OSUrobotics/rosh_robot_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_robot_plugins` to `1.0.2-0`:
- upstream repository: https://github.com/OSUrobotics/rosh_robot_plugins.git
- release repository: https://github.com/OSUrobotics/rosh_robot_plugins-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.1-0`
## rosh_common
- No changes
## rosh_geometry

```
* Prevent beginning of tf frame names from being lost in ipython tab completion
* Fix error creating QuaternionStamped
* Contributors: Dan Lazewatsky
```
## rosh_robot
- No changes
## rosh_robot_plugins

```
* fix maintainer
* Remove "rosh" run depend
  Fixes wiki package header for this and rosh
* Contributors: Dan Lazewatsky
```
