### PR TITLE
warehouse_ros: 0.8.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4263,7 +4263,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/warehouse_ros-release.git
-      version: 0.8.6-0
+      version: 0.8.7-0
     status: maintained
   wpi_jaco:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `0.8.7-0`:
- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/ros-gbp/warehouse_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.8.6-0`
