### PR TITLE
kobuki: 0.5.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2954,7 +2954,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki-release.git
-      version: 0.5.6-0
+      version: 0.5.7-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki` to `0.5.7-0`:
- upstream repository: https://github.com/yujinrobot/kobuki.git
- release repository: https://github.com/yujinrobot-release/kobuki-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.6-0`
## kobuki
- No changes
## kobuki_auto_docking
- No changes
## kobuki_bumper2pc
- No changes
## kobuki_controller_tutorial
- No changes
## kobuki_description
- No changes
## kobuki_keyop
- No changes
## kobuki_node
- No changes
## kobuki_random_walker
- No changes
## kobuki_safety_controller

```
* added time_to_extend_bump_cliff_events param to kobuki_safety_controller
* Contributors: Kaijen Hsiao
```
## kobuki_testsuite
- No changes
