### PR TITLE
Revert "warehouse_ros: 0.8.7-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4263,7 +4263,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/warehouse_ros-release.git
-      version: 0.8.7-0
+      version: 0.8.6-0
     status: maintained
   wpi_jaco:
     doc:


### PR DESCRIPTION
Reverts ros/rosdistro#5295

Release 0.8.7 breaks downstream packages. http://jenkins.ros.org/view/IbinS32/job/ros-indigo-moveit-ros-warehouse_binarydeb_saucy_i386/53/console

```
/opt/ros/indigo/lib/libcpp_common.so -lboost_system -lboost_thread -lpthread -lconsole_bridge -lboost_program_options -Wl,-rpath,/opt/ros/indigo/lib:/tmp/buildd/ros-indigo-moveit-ros-warehouse-0.5.19-0saucy-20140818-0616/obj-i686-linux-gnu/devel/lib: 
/usr/bin/ld: /usr/lib/gcc/i686-linux-gnu/4.8/../../../../lib/libmongoclient.a(ssl_manager.o): undefined reference to symbol 'SSL_get_verify_result@@OPENSSL_1.0.0'
/lib/i386-linux-gnu/libssl.so.1.0.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

@isucan @v4hn 

From: https://github.com/ros-planning/warehouse_ros/pull/14 With the addition of exporting MongoDB's libraries it also needs to export OpenSSL librarires so MongoDB can resolve all symbols.
