### PR TITLE
wu_ros_tools: 0.2.2-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4907,6 +4907,8 @@ repositories:
       packages:
       - catkinize_this
       - easy_markers
+      - joy_listener
+      - kalman_filter
       - manifest_cleaner
       - rosbaglive
       - roswiki_node
@@ -4914,7 +4916,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/wu-robotics/wu_ros_tools.git
-      version: 0.1.1-1
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/DLu/wu_ros_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wu_ros_tools` to `0.2.2-0`:
- upstream repository: https://github.com/DLu/wu_ros_tools
- release repository: https://github.com/wu-robotics/wu_ros_tools.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.1.1-1`
