### PR TITLE
pointgrey_camera_driver: 0.10.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4699,7 +4699,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
-      version: 0.9.2-0
+      version: 0.10.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/pointgrey_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointgrey_camera_driver` to `0.10.0-0`:
- upstream repository: https://github.com/ros-drivers/pointgrey_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.9.2-0`
## image_exposure_msgs
- No changes
## pointgrey_camera_driver

```
* Added frame rate parameter to launchfiles.
* Fixing lack of dynamic Bayer format detection/incorrect fixed Bayer format detection in the stereo driver, tested on BB2 hardware
* Should prevent multiple camera nodes from conflicting.
* Read camera's resulting trigger configuration.
* Read camera's resulting strobe configuration.
* Refactor GPIO pin comparison into separate function.
* Support outputting strobes.
* Enable altering trigger polarities.
* Don't overwrite currently unused fields.
* Modify firewire rule per issue #6 <https://github.com/ros-drivers/pointgrey_camera_driver/issues/6>
* Make sure camera properties are supported before enabling them
* Contributors: Aaron Denney, Jake Bruce, Jeff Schmidt, Mike Purvis, Ryan Gariepy
```
## statistics_msgs
- No changes
## wfov_camera_msgs
- No changes
