### PR TITLE
lms1xx: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1683,7 +1683,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/lms1xx-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/lms1xx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lms1xx` to `0.1.1-0`:
- upstream repository: https://github.com/clearpathrobotics/LMS1xx.git
- release repository: https://github.com/clearpath-gbp/lms1xx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.1.0-0`
## lms1xx

```
* Changed the pkg and name so that the launch file is able to find the package.
* Fix assignment in if() to comparison.
* Contributors: Jeff Schmidt, Mike Purvis
```
