### PR TITLE
ros: 1.11.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3072,7 +3072,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.11.4-0
+      version: 1.11.5-0
     source:
       type: git
       url: https://github.com/ros/ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.11.5-0`:
- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.11.4-0`
## mk
- No changes
## rosbash

```
* fix zsh autocompletion for published topics, msg-type and YAML (#64 <https://github.com/ros/ros/issues/64>)
```
## rosboost_cfg
- No changes
## rosbuild
- No changes
## rosclean
- No changes
## roscreate
- No changes
## roslang
- No changes
## roslib
- No changes
## rosmake
- No changes
## rosunit
- No changes
