### PR TITLE
ros_comm: 1.11.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3114,7 +3114,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.8-0
+      version: 1.11.9-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.9-0`:
- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.11.8-0`
## message_filters
- No changes
## ros_comm
- No changes
## rosbag
- No changes
## rosbag_storage
- No changes
## rosconsole
- No changes
## roscpp

```
* add accessor to expose whether service is persistent (#489 <https://github.com/ros/ros_comm/issues/489>)
* populate delivered_msgs field of TopicStatistics message (#486 <https://github.com/ros/ros_comm/issues/486>)
```
## rosgraph
- No changes
## roslaunch

```
* fix usage of logger before it is initialized (#490 <https://github.com/ros/ros_comm/issues/490>) (regression from 1.11.6)
```
## roslz4
- No changes
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy

```
* populate delivered_msgs field of TopicStatistics message (#486 <https://github.com/ros/ros_comm/issues/486>)
```
## rosservice
- No changes
## rostest
- No changes
## rostopic
- No changes
## roswtf
- No changes
## topic_tools
- No changes
## xmlrpcpp
- No changes
