### PR TITLE
gazebo_ros_pkgs: 2.4.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -924,7 +924,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.4.4-0
+      version: 2.4.5-0
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.4.5-0`:
- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `2.4.4-0`
## gazebo_msgs
- No changes
## gazebo_plugins

```
* Replace SetAngle with SetPosition for gazebo 4 and up
* Port fix_build branch for indigo-devel
  See pull request #221 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/221>
* Contributors: Jose Luis Rivero, Steven Peters
```
## gazebo_ros

```
* Port fix_build branch for indigo-devel
  See pull request #221 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/221>
* Contributors: Jose Luis Rivero
```
## gazebo_ros_control

```
* Fix typo: GAZEBO_VERSION_MAJOR -> GAZEBO_MAJOR_VERSION
* Port fix_build branch for indigo-devel
  See pull request #221 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/221>
* Contributors: Jose Luis Rivero, Steven Peters
```
## gazebo_ros_pkgs
- No changes
