### PR TITLE
ros_statistics_msgs: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3226,6 +3226,21 @@ repositories:
       url: https://github.com/WPI-RAIL/ros_ethernet_rmp.git
       version: develop
     status: maintained
+  ros_statistics_msgs:
+    doc:
+      type: git
+      url: https://github.com/osrf/ros_statistics_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/ros_statistics_msgs-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/osrf/ros_statistics_msgs.git
+      version: master
+    status: maintained
   ros_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_statistics_msgs` to `0.1.0-0`:
- upstream repository: https://github.com/osrf/ros_statistics_msgs.git
- release repository: https://github.com/ros-gbp/ros_statistics_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## ros_statistics_msgs

```
* Uses Apache 2.0 license
* Initial release of HostStatistics and NodeStatistics
* Contributors: William Woodall, dan brooks
```
