### PR TITLE
ros_topology_msgs: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3241,6 +3241,21 @@ repositories:
       url: https://github.com/osrf/ros_statistics_msgs.git
       version: master
     status: maintained
+  ros_topology_msgs:
+    doc:
+      type: git
+      url: https://github.com/osrf/ros_topology_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/ros_topology_msgs-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/osrf/ros_topology_msgs.git
+      version: master
+    status: maintained
   ros_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_topology_msgs` to `0.1.0-0`:
- upstream repository: https://github.com/osrf/ros_topology_msgs.git
- release repository: https://github.com/ros-gbp/ros_topology_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## ros_topology_msgs

```
* Initial commit with Apache 2.0 license
* Contributors: William Woodall, dan brooks
```
