### PR TITLE
rosprofiler: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3496,6 +3496,21 @@ repositories:
       url: https://github.com/rospilot/rospilot_deps-release.git
       version: 0.0.5-0
     status: developed
+  rosprofiler:
+    doc:
+      type: git
+      url: https://github.com/osrf/rosprofiler.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rosprofiler-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/osrf/rosprofiler.git
+      version: master
+    status: maintained
   rospy_message_converter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosprofiler` to `0.1.0-0`:
- upstream repository: https://github.com/osrf/rosprofiler.git
- release repository: https://github.com/ros-gbp/rosprofiler-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## rosprofiler

```
* Initial Release
* Contributors: William Woodall, dan brooks
```
