### PR TITLE
catkin: 0.5.89-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -560,7 +560,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.5.88-0
+      version: 0.5.89-0
     source:
       type: git
       url: https://github.com/ros/catkin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.5.89-0`:
- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.88-0`
## catkin

```
* make nosetests --xunit-file argument an absolute path to work around nose bug 779 (#659 <https://github.com/ros/catkin/issues/659>)
* fix handling of CMake packages which do not install any files (#665 <https://github.com/ros/catkin/issues/665>)
* fix gtest on Arch Linux and others (#663 <https://github.com/ros/catkin/issues/663>)
* improve generation of .catkin marker file (#671 <https://github.com/ros/catkin/issues/671>, #676 <https://github.com/ros/catkin/issues/676>)
* escape messages to avoid CMake warning (#667 <https://github.com/ros/catkin/issues/667>)
* avoid using ARGN for efficiency (#669 <https://github.com/ros/catkin/issues/669>)
```
