### PR TITLE
qt_gui_core: 0.2.26-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4930,7 +4930,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.2.25-0
+      version: 0.2.26-0
     source:
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.2.26-0`:
- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.2.25-0`
## qt_dotgraph
- No changes
## qt_gui

```
* prevent floating of plugins via double-click when -f flag is set (#48 <https://github.com/ros-visualization/qt_gui_core/issues/48>)
```
## qt_gui_app
- No changes
## qt_gui_cpp
- No changes
## qt_gui_py_common
- No changes
