### PR TITLE
rqt_robot_plugins: 0.3.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6126,7 +6126,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-      version: 0.3.6-0
+      version: 0.3.7-0
     status: maintained
   rtmros_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins` to `0.3.7-0`:
- upstream repository: https://github.com/ros-visualization/rqt_robot_plugins.git
- release repository: https://github.com/ros-gbp/rqt_robot_plugins-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.3.6-0`
## rqt_moveit
- No changes
## rqt_nav_view
- No changes
## rqt_pose_view
- No changes
## rqt_robot_dashboard
- No changes
## rqt_robot_monitor
- No changes
## rqt_robot_plugins
- No changes
## rqt_robot_steering
- No changes
## rqt_runtime_monitor
- No changes
## rqt_rviz

```
* fix argument parsing (#68 <https://github.com/ros-visualization/rqt_robot_plugins/issues/68>) (regression of 0.3.5)
```
## rqt_tf_tree
- No changes
