### PR TITLE
rqt_common_plugins: 0.3.9-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6078,7 +6078,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.3.8-0
+      version: 0.3.9-0
     status: developed
   rqt_ez_publisher:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `0.3.9-0`:
- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/ros-gbp/rqt_common_plugins-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.3.8-0`
## rqt_action
- No changes
## rqt_bag

```
* fix visibility with dark Qt theme (#263 <https://github.com/ros-visualization/rqt_common_plugins/issues/263>)
```
## rqt_bag_plugins

```
* add missing dependency on python-cairo (#269 <https://github.com/ros-visualization/rqt_common_plugins/issues/269>)
```
## rqt_common_plugins
- No changes
## rqt_console
- No changes
## rqt_dep
- No changes
## rqt_graph

```
* fix rendering of namespace boxes (#266 <https://github.com/ros-visualization/rqt_common_plugins/issues/266>)
```
## rqt_image_view
- No changes
## rqt_launch
- No changes
## rqt_logger_level
- No changes
## rqt_msg
- No changes
## rqt_plot

```
* fix handling of variable-sized arrays (#261 <https://github.com/ros-visualization/rqt_common_plugins/issues/261>)
```
## rqt_publisher
- No changes
## rqt_py_common
- No changes
## rqt_py_console
- No changes
## rqt_reconfigure
- No changes
## rqt_service_caller
- No changes
## rqt_shell
- No changes
## rqt_srv
- No changes
## rqt_top
- No changes
## rqt_topic
- No changes
## rqt_web
- No changes
