### PR TITLE
ros_comm: 1.10.11-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5441,7 +5441,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.10.10-0
+      version: 1.10.11-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.10.11-0`:
- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.10.10-0`
## message_filters
- No changes
## ros_comm
- No changes
## rosbag
- No changes
## rosbag_storage
- No changes
## rosconsole
- No changes
## roscpp

```
* add accessor to expose whether service is persistent (#489 <https://github.com/ros/ros_comm/issues/489>)
* only update param cache when being subscribed (#351 <https://github.com/ros/ros_comm/issues/351>)
* ensure to remove delete parameters completely
* invalidate cached parent parameters when namespace parameter is set / changes (#352 <https://github.com/ros/ros_comm/issues/352>)
```
## rosgraph
- No changes
## rosgraph_msgs
- No changes
## roslaunch

```
* fix the ROS_MASTER_URI environment variable logic on Windows (#2 <https://github.com/windows/ros_comm/issues/2>)
```
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy
- No changes
## rosservice
- No changes
## rostest

```
* resolving naming conflicts when multiple test are added with arguments (#462 <https://github.com/ros/ros_comm/issues/462>)
```
## rostopic
- No changes
## roswtf
- No changes
## std_srvs
- No changes
## topic_tools
- No changes
## xmlrpcpp
- No changes
