### PR TITLE
genpy: 0.4.17-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1307,7 +1307,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.4.16-0
+      version: 0.4.17-0
     source:
       type: git
       url: https://github.com/ros/genpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.4.17-0`:
- upstream repository: git@github.com:ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.4.16-0`
## genpy

```
* make TVal more similar to generated messages for introspection (ros/std_msgs#6 <https://github.com/ros/std_msgs/issues/6>)
* resolve message classes from dry packages (ros/ros_comm#293 <https://github.com/ros/ros_comm/issues/293>, #28 <https://github.com/ros/genpy/issues/28>)
```
