### PR TITLE
Adding barrett_hand to documentation index for hydro and groovy

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -163,6 +163,16 @@ repositories:
       url: https://github.com/clearpathrobotics/axis_camera.git
       version: master
     status: maintained
+  barrett_hand:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/barrett_hand.git
+      version: groovy-devel
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/barrett_hand.git
+      version: groovy-devel
+    status: maintained
   baxter:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -232,6 +232,16 @@ repositories:
       url: https://github.com/clearpathrobotics/axis_camera.git
       version: master
     status: maintained
+  barrett_hand:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/barrett_hand.git
+      version: hydro-devel
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/barrett_hand.git
+      version: hydro-devel
+    status: maintained
   baxter:
     doc:
       type: git


### PR DESCRIPTION
I'd like barrett_hand package to be indexed and documented on ros.org
