### PR TITLE
usb_cam: 0.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4191,7 +4191,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/bosch-ros-pkg-release/usb_cam-release.git
-      version: 0.1.6-0
+      version: 0.1.7-0
     source:
       type: git
       url: https://github.com/bosch-ros-pkg/usb_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam` to `0.1.7-0`:
- upstream repository: https://github.com/bosch-ros-pkg/usb_cam.git
- release repository: https://github.com/bosch-ros-pkg-release/usb_cam-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.1.6-0`
## usb_cam

```
* changelog fixed
* minor cleanup and ability to change camera name and info
* Contributors: Russell Toris
```
