### PR TITLE
turtlebot_arm: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4099,6 +4099,7 @@ repositories:
       version: indigo-devel
     release:
       packages:
+      - turtlebot_arm
       - turtlebot_arm_bringup
       - turtlebot_arm_description
       - turtlebot_arm_ikfast_plugin
@@ -4108,7 +4109,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_arm-release.git
-      version: 0.3.0-2
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot_arm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_arm` to `0.3.1-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_arm.git
- release repository: https://github.com/turtlebot-release/turtlebot_arm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.3.0-2`
## turtlebot_arm

```
* Add a metapackage
```
## turtlebot_arm_bringup
- No changes
## turtlebot_arm_description

```
* Set separated URLs for website, repository and bugtracker
```
## turtlebot_arm_ikfast_plugin

```
* Set separated URLs for website, repository and bugtracker
```
## turtlebot_arm_kinect_calibration

```
* Set separated URLs for website, repository and bugtracker
```
## turtlebot_arm_moveit_config

```
* Set separated URLs for website, repository and bugtracker
```
## turtlebot_arm_moveit_demos
- No changes
