### PR TITLE
rosh_desktop_plugins: 1.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5733,7 +5733,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/OSUrobotics/rosh_desktop_plugins-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/OSUrobotics/rosh_desktop_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_desktop_plugins` to `1.0.4-0`:
- upstream repository: https://github.com/OSUrobotics/rosh_desktop_plugins.git
- release repository: https://github.com/OSUrobotics/rosh_desktop_plugins-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.3-0`
## rosh_desktop
- No changes
## rosh_desktop_plugins
- No changes
## rosh_visualization

```
* undo commit that happened on the wrong branch
* Contributors: Dan Lazewatsky
```
