### PR TITLE
rqt_graphprofiler: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3661,6 +3661,21 @@ repositories:
       url: https://github.com/OTL/rqt_ez_publisher.git
       version: indigo-devel
     status: developed
+  rqt_graphprofiler:
+    doc:
+      type: git
+      url: https://github.com/osrf/rqt_graphprofiler.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_graphprofiler-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/osrf/rqt_graphprofiler.git
+      version: master
+    status: developed
   rqt_robot_plugins:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graphprofiler` to `0.1.0-0`:
- upstream repository: https://github.com/osrf/rqt_graphprofiler.git
- release repository: https://github.com/ros-gbp/rqt_graphprofiler-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## rqt_graphprofiler

```
* Initial Release of rqt_graphprofiler
* Contributors: William Woodall, dan brooks
```
