### PR TITLE
rocon_msgs: 0.7.7-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3007,7 +3007,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-      version: 0.7.5-3
+      version: 0.7.7-1
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs` to `0.7.7-1`:
- upstream repository: http://github.com/robotics-in-concert/rocon_msgs.git
- release repository: https://github.com/yujinrobot-release/rocon_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.7.5-3`
