### PR TITLE
rocon_tools: 0.1.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3061,7 +3061,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_tools-release.git
-      version: 0.1.8-0
+      version: 0.1.9-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_tools` to `0.1.9-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_tools.git
- release repository: https://github.com/yujinrobot-release/rocon_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.1.8-0`
## rocon_bubble_icons
- No changes
## rocon_console
- No changes
## rocon_ebnf

```
* move from symbolic links to includes for changelogs to avoid eclipse bewilderment.
* Contributors: Daniel Stonier
```
## rocon_icons

```
* move from symbolic links to includes for changelogs to avoid eclipse bewilderment.
* Contributors: Daniel Stonier
```
## rocon_interactions

```
* Fix timeouts
* move from symbolic links to includes for changelogs to avoid eclipse bewilderment.
* Contributors: Daniel Stonier, kentsommer
```
## rocon_launch

```
* move from symbolic links to includes for changelogs to avoid eclipse bewilderment.
* debugging error added for catching pid problem, #53 <https://github.com/robotics-in-concert/rocon_tools/issues/53>.
* added a bypass and logged a warning when the parent pid is not yet available when cancelling spawned windows, #53 <https://github.com/robotics-in-concert/rocon_tools/issues/53>
* catch an error if a shutdown signal can't find its terminal process.
* Contributors: Daniel Stonier
```
## rocon_master_info

```
* move from symbolic links to includes for changelogs to avoid eclipse bewilderment.
* Contributors: Daniel Stonier
```
## rocon_python_comms

```
* to fix #54 <https://github.com/robotics-in-concert/rocon_tools/issues/54>
* move from symbolic links to includes for changelogs to avoid eclipse bewilderment.
* Contributors: Daniel Stonier, Jihoon Lee
```
## rocon_python_redis

```
* move from symbolic links to includes for changelogs to avoid eclipse bewilderment.
* Contributors: Daniel Stonier
```
## rocon_python_utils

```
* move from symbolic links to includes for changelogs to avoid eclipse bewilderment.
* Contributors: Daniel Stonier
```
## rocon_python_wifi

```
* move from symbolic links to includes for changelogs to avoid eclipse bewilderment.
* Contributors: Daniel Stonier
```
## rocon_semantic_version

```
* move from symbolic links to includes for changelogs to avoid eclipse bewilderment.
* Contributors: Daniel Stonier
```
## rocon_tools
- No changes
## rocon_uri

```
* move from symbolic links to includes for changelogs to avoid eclipse bewilderment.
* debugging error added for catching pid problem, #53 <https://github.com/robotics-in-concert/rocon_tools/issues/53>.
* Contributors: Daniel Stonier
```
