### PR TITLE
rocon_multimaster: 0.7.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3031,7 +3031,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_multimaster-release.git
-      version: 0.7.3-0
+      version: 0.7.4-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_multimaster.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_multimaster` to `0.7.4-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_multimaster.git
- release repository: https://github.com/yujinrobot-release/rocon_multimaster-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.7.3-0`
## rocon_gateway
- No changes
## rocon_gateway_tests

```
* rocon_gateway_tests: CMakeLists.txt(12): error: missing COMPONENTS keyword before 'rocon_test'
* Contributors: Jihoon Lee
```
## rocon_gateway_utils

```
* rocon_gateway_utils missing COMPONENTS keyword before 'rosunit rostest
* Contributors: Jihoon Lee
```
## rocon_hub
- No changes
## rocon_hub_client
- No changes
## rocon_multimaster
- No changes
## rocon_test

```
* Merge branch 'indigo' into hydro-devel
* adding back the rostest in rocon_test
* unconfigured build_depend on 'rostest
* Contributors: Daniel Stonier, Jihoon Lee
```
## rocon_unreliable_experiments

```
* build include path 'include' does not exist
* Contributors: Jihoon Lee
```
