### PR TITLE
rocon_app_platform: 0.7.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2970,7 +2970,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_app_platform-release.git
-      version: 0.7.1-0
+      version: 0.7.2-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_app_platform` to `0.7.2-0`:
- upstream repository: http://github.com/robotics-in-concert/rocon_app_platform
- release repository: https://github.com/yujinrobot-release/rocon_app_platform-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.7.1-0`
## rocon_app_manager

```
* instead of exception. deprecated warning
* add error message for having old style
* type information added
* re align the args
* align the args
* add the rosbridge setting for using rosbridge on pairing mode
* remove legacy app store url.
* Refined the comment for the preferred defaults
  Also removed legacy app_store_url.
* use preferred instead of selected and defaults
* use yaml format for default app parsing
* preferred or default rapp selection
* rewrote get_available rapp logic
* multiple chirp working
* Fix import to include copy
* Remove copy. Wrong branch :/
* Fix import to include copy
* merging work on public parameters for the rapps/rapp manager.
* Move to use copy.deepcopy
* Set rapp manager namespace handles to be private
* Fix if else re-use
* Correct testing defaults back to standard
* public parameter works
* parses parameters from file
* 0.7.1
* use proper lists for hubs/concerts now roslaunch can handle it.
* fix defaults
* Remove debug prints
* Interactions for turtlebot on indigo update. Remove namespacing for standalone
* rocon_app_manager: CMakeLists.txt(12): error: missing COMPONENTS keyword before 'roslint
* Contributors: Daniel Stonier, DongWook Lee, Jihoon Lee, Kent Sommer, kentsommer
```
## rocon_app_platform

```
* 0.7.1
* Contributors: Daniel Stonier
```
## rocon_app_utilities

```
* it updates its indices when it adds or removes repo
* bugfix for #260 <https://github.com/robotics-in-concert/rocon_app_platform/issues/260> #253 <https://github.com/robotics-in-concert/rocon_app_platform/issues/253>
* now indexer works fine. rapp stores resources path in yaml_data
* now it uses normalised path and provides more debug messages
* add optional arguments on rocon_app cmd tool closes issue #259 <https://github.com/robotics-in-concert/rocon_app_platform/issues/259>
* improve top-level arg parser logic. Now it does not validate the full launch xml though.
* update comments. absolute to relative
* remove debug message
* It marks invalid rapp if it contains tuple based resource. and give error
* update rapp spec document
* relative path working
* in the middle of change to relative path
* add simple indicator
* multiple chirp working
* parses parameters from file
* 0.7.1
* Merge branch 'indigo' into hydro-devel
* rocon_app_utilities: error: unconfigured build_depend on 'rocon_python_utils rocon_uri
* Contributors: Daniel Stonier, Jihoon Lee
```
## rocon_apps

```
* type information added
* install chirp_apps, icons, and talker script
* remove rocon_bubble_icons dependency
* relative path rapps
* cleanup teleop rapp and enable video_teleop virtual rapp
* disable robot teleop and video teleop until resolving capabilitiy
* update rapp description
* merging changes
* postfix for chirp apss
* rename angry_cat to angry_cat_chirp
* multiple chirp working
* have robot_teleop and video teleop
* Merge branch 'indigo' into teleop_rapp_anchestor
* Explain defaults
* Add defaults
* Add rocon license
* Remove Willow Garage license
* parses parameters from file
* launch args for public parameters
* configurable talker
* 0.7.1
* configurable talker
* rocon_apps: splits teleop rapp into virtual and implementation rapp
* rocon_apps: implements teleop rapp anchestor
* Contributors: Daniel Stonier, Jihoon Lee, Kent Sommer, Marcus Liebhardt
```
