### PR TITLE
rocon_concert: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2981,6 +2981,21 @@ repositories:
       type: git
       url: https://github.com/robotics-in-concert/rocon_concert.git
       version: indigo
+    release:
+      packages:
+      - concert_conductor
+      - concert_master
+      - concert_schedulers
+      - concert_service_link_graph
+      - concert_service_manager
+      - concert_service_utilities
+      - concert_utilities
+      - rocon_concert
+      - rocon_tf_reconstructor
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/rocon_concert-release.git
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_concert.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_concert` to `0.6.0-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_concert
- release repository: https://github.com/yujinrobot-release/rocon_concert-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## concert_conductor

```
* documentation for the concert conductor.
* use proper lists for hubs/concerts now roslaunch can handle it.
* need the invite handle so we can uninvite it later, this was a regresion
  and this fixes #230 <https://github.com/robotics-in-concert/rocon_concert/issues/230>.
* need the invite handle so we can uninvite it later, this was a regresion
  and this fixes #230 <https://github.com/robotics-in-concert/rocon_concert/issues/230>.
* update publisher queue_size to avoid warning in indigo.
* pass ip info along in concert client publishing.
* remove debugging print.
* bifurcating shell/gui processing for concert_conductor_graph
* bugfix accidentally cancelled publisher pulls with the service pulls, #222 <https://github.com/robotics-in-concert/rocon_concert/issues/222>
* remove unused conductor process pulls once they're done with, #222 <https://github.com/robotics-in-concert/rocon_concert/issues/222>
* unregister the gateway info subscriber after we've finished with it.
* sphinx docs for concert conductor
* wireless handling and not using gone clients to generate concert aliases.
* small documentation on how the state machine works.
* Updated Idle->Available to reflect state name refactoring and relevant
  comments.
  Dummy transition handler for wireless dropouts.
* ConcertClientException no longer useed.
* eliminate redundant rapp_status and use uri's properly.
* bugfixes to reenable chatter concert.
* client status/gateway-info update handling and alot of minor fixes.
* concert client publishers reintegrated in for the new conductor
* don't go hunting for the gateway, configure it instead.
* concert transitions now working for conductor v2.
* relax timeouts on advertised concert client pulled services, fixes #217 <https://github.com/robotics-in-concert/rocon_concert/issues/217>
* rapp_handler -> rocon_scheduler_requests
* a convenience rapp handler class for external users.
* expose invited clients only once their handles have been flipped across.
* interactions moved to rocon_tools, also updates for the rocon_utilities breakup.
* explanatory comment about the application namespace.
* make specific an exception message
* catch a shutdown exception.
* check rocon version of concert clients by conductor.
* updates for the new rocon uri
* platform tuple overhaul.
* update for recently moved modules to rocon_tools, also platform_tuples refactoring.
* remove unused variable.
* remove unused variable.
* cancel pulls when a client leaves, fixes #169 <https://github.com/robotics-in-concert/rocon_concert/issues/169> and ignore hash names, not friendly names, fixes #170 <https://github.com/robotics-in-concert/rocon_concert/issues/170>.
* cancel_pulls -> _cancel_pulls, fixes #165 <https://github.com/robotics-in-concert/rocon_concert/issues/165>
* better checking for local clients.
* bugfix service connection errors and delays from rogue clients in the conductor.
* republish uninvited clients, closes #144 <https://github.com/robotics-in-concert/rocon_concert/issues/144>
* accept remote gateways with ip 'localhost' as local clients.
* working towards the compatibility tree scheduler.
* disambiguate concert client update topics
* expose connection statistics. closes #35 <https://github.com/robotics-in-concert/rocon_concert/issues/35>
* only publish invited concert clients.
* handle corner case when uninviting disappearing clients.
* better handling and logging of failed invitations in various scenarios.
* only try to uninvite already invited clients.
* conductor cleanup.
* invite local clients only (good for testing), closes #108 <https://github.com/robotics-in-concert/rocon_concert/issues/108>
* remove legacy web app client handling from the conductor, closes #127 <https://github.com/robotics-in-concert/rocon_concert/issues/127>.
* catch a ros shutdown exception in the conductor spin.
* bugfix Invite->BatchInvite.
* external shutdown hooks for gateway and hub.
* added shutdown hook for the conductor, but it's not yet fully operational.
* bugfix a used variable before definition.
* service exception handler when inviting.
* quietly ignore invitation failures from local snobs.
* fix unhandled service exception when ros shutsdown.
* deprecate the old platform info message.
* refactoring for a concert master launcher and fix old legacy tutorials.
* scheduler
* parallel service working. some changes in conductor. conductor returns always false for lock now
* use wallsleeps to avoid simulation problems, closes #46 <https://github.com/robotics-in-concert/rocon_concert/issues/46>.
* simple role manager launcher that publishes the concert icon, closes #38 <https://github.com/robotics-in-concert/rocon_concert/issues/38>.
* concert_roles stub package.
* Contributors: Daniel Stonier, Jihoon Lee, piyushk
```
