### PR TITLE
kobuki: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1398,7 +1398,6 @@ repositories:
     release:
       packages:
       - kobuki
-      - kobuki_apps
       - kobuki_auto_docking
       - kobuki_bumper2pc
       - kobuki_capabilities
@@ -1407,12 +1406,13 @@ repositories:
       - kobuki_keyop
       - kobuki_node
       - kobuki_random_walker
+      - kobuki_rapps
       - kobuki_safety_controller
       - kobuki_testsuite
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki` to `0.6.3-0`:
- upstream repository: https://github.com/yujinrobot/kobuki.git
- release repository: https://github.com/yujinrobot-release/kobuki-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.6.2-0`
## kobuki

```
* remove authors e-mail
* rename kobuki_apps as kobuki_rapps to resolve #336 <https://github.com/yujinrobot/kobuki/issues/336>
* Contributors: Jihoon Lee
```
## kobuki_auto_docking
- No changes
## kobuki_bumper2pc
- No changes
## kobuki_capabilities

```
* rename kobuki_apps as kobuki_rapps to resolve #336 <https://github.com/yujinrobot/kobuki/issues/336>
* Contributors: Jihoon Lee
```
## kobuki_controller_tutorial
- No changes
## kobuki_description
- No changes
## kobuki_keyop
- No changes
## kobuki_node
- No changes
## kobuki_random_walker
- No changes
## kobuki_rapps

```
* rename_kobuki_apps to kobuki_Rapps
* Contributors: Jihoon Lee
```
## kobuki_safety_controller

```
* added initialization for msg_ to kobuki_safety_controller
* added time_to_extend_bump_cliff_events param to kobuki_safety_controller
* Contributors: Kaijen Hsiao
```
## kobuki_testsuite
- No changes
