### PR TITLE
mavlink: 1.0.9-10 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1734,7 +1734,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/vooon/mavlink-gbp-release.git
-      version: 1.0.9-9
+      version: 1.0.9-10
     status: maintained
   mavros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `1.0.9-10`:
- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/vooon/mavlink-gbp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.9-9`
