### PR TITLE
cob_extern: 0.5.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -404,6 +404,16 @@ repositories:
       type: git
       url: https://github.com/ipa320/cob_extern.git
       version: indigo_dev
+    release:
+      packages:
+      - cob_extern
+      - libntcan
+      - libpcan
+      - libphidgets
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/cob_extern-release.git
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/ipa320/cob_extern.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_extern` to `0.5.3-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## cob_extern

```
* Update package.xml
* New maintainer
* Contributors: Florian Weisshardt, ipa-nhg
```
## libntcan
- No changes
## libpcan

```
* merge
* fix install script
* using version 7.9 of libpcan
* Contributors: ipa-fmw, ipa-nhg
```
## libphidgets

```
* Merge pull request #39 <https://github.com/ipa320/cob_extern/issues/39> from ipa-fmw/hydro_dev
  change maintainer
* Update package.xml
* removed unused makefile
* added checksum for new tarball
* updated libphidget version
* Contributors: Florian Weisshardt, Nadia Hammoudeh García, ipa-bnm
```
