### PR TITLE
cob_common: 0.5.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -394,6 +394,19 @@ repositories:
       type: git
       url: https://github.com/ipa320/cob_common.git
       version: indigo_dev
+    release:
+      packages:
+      - brics_actuator
+      - cob_common
+      - cob_description
+      - cob_msgs
+      - cob_srvs
+      - desire_description
+      - raw_description
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/cob_common-release.git
+      version: 0.5.4-0
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.5.4-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `null`
## brics_actuator

```
* update changelog
* cleaning up debs
* cleaning up debs
* Contributors: Florian Weisshardt, ipa-fxm
```
## cob_common

```
* update changelog
* introducing cob_msgs package in order to replace pr2_msgs
* cleaning up debs
* cleaning up debs
* Merge pull request #95 <https://github.com/ipa320/cob_common/issues/95> from ipa320/hydro_release_candidate
  bring back changes from Hydro release candidate
* New maintainer
* Contributors: Felix Messmer, Florian Weisshardt, Nadia Hammoudeh García, ipa-fxm, ipa-nhg
```
## cob_description

```
* update changelog
* consistency changes due to latest gazebo tag format
* unify materials
* consitency changes due to new transmission format
* unify materials
* include gazebo_ros dependendy to export materials
* merge with hydro_dev
* cleanup dependencies
* new collision mesh
* beautify indentation + cleaning up
* beautify indentation
* merge with hydro_dev
* for cob3 the topic name should be /cam3d..
* adapt to latest changes in official ros-industrial repo
* Coloured mesh files
* use base mesh with less vertices for collision checking
* use correct mesh for collision geometry
* re-export meshes from meshlab to fix assimp error message
* better approximation of inertias for some more cob4 components
* fixed center of masses
* use default damping
* correct inertias for cob4 torso
* enable gravity
* rotate scanner
* temporary commit for torso inertias
* merged with ipa320/hydro_dev
* removed bumpers and changed transmission config to new syntax
* update gazebo tags for sensor plugins
* no inertia in base_footprint
* deleted unnecessary head versions
* update gazebo tags for sensor plugins
* wrong topic names
* un-hardcodize ur-macro
* beautify mesh files
* Merge pull request #95 <https://github.com/ipa320/cob_common/issues/95> from ipa320/hydro_release_candidate
  bring back changes from Hydro release candidate
* New head_center_link
* New maintainer
* update cob4_base stl file
* remove material physic properties of wheels to use default, fixes #90 <https://github.com/ipa320/cob_common/issues/90>
* deleted offset
* Merge error
* merge
* New stl files for cob4
* fix xacro:include tag
* New center joint on torso
* New center joint on torso
* fix softkinetic settings
* fix urdf test
* merge cob4
* Contributors: Alexander Bubeck, Felix Messmer, Florian Weisshardt, Nadia Hammoudeh García, fmw, ipa-cob3-8, ipa-cob4-1, ipa-fxm, ipa-fxm-fm, ipa-nhg
```
## cob_msgs

```
* add maintainer
* update changelog
* introducing cob_msgs package in order to replace pr2_msgs
* Contributors: Felix Messmer, Florian Weisshardt
```
## cob_srvs

```
* update changelog
* cleaning up debs
* cleaning up debs
* Contributors: Florian Weisshardt, ipa-fxm
```
## desire_description

```
* update changelog
* consistency changes due to latest gazebo tag format
* consitency changes due to new transmission format
* merge with hydro_dev
* cleanup dependencies
* beautify indentation + cleaning up
* Merge pull request #112 <https://github.com/ipa320/cob_common/issues/112> from ipa-cob4-1/hydro_dev
  Rotated sick_s300 mesh file
* use the  macros instead 3.14...
* Merge github.com:ipa-cob4-1/cob_common into hydro_dev
* switch laser scanner orientation
* removed bumpers and changed transmission config to new syntax
* no inertia in base_footprint
* Merge pull request #95 <https://github.com/ipa320/cob_common/issues/95> from ipa320/hydro_release_candidate
  bring back changes from Hydro release candidate
* New maintainer
* Contributors: Alexander Bubeck, Felix Messmer, Florian Weisshardt, Nadia Hammoudeh García, ipa-cob4-1, ipa-fxm, ipa-nhg
```
## raw_description

```
* update changelog
* consistency changes due to latest gazebo tag format
* consitency changes due to new transmission format
* unify materials
* include gazebo_ros dependendy to export materials
* merge with hydro_dev
* cleanup dependencies
* beautify indentation + cleaning up
* better approximation of inertias
* Merge pull request #112 <https://github.com/ipa320/cob_common/issues/112> from ipa-cob4-1/hydro_dev
  Rotated sick_s300 mesh file
* use the  macros instead 3.14...
* Merge github.com:ipa-cob4-1/cob_common into hydro_dev
* switch laser scanner orientation
* removed bumpers and changed transmission config to new syntax
* no inertia in base_footprint
* use collada material description
* remove material physic properties of wheels to use default, fixes #90 <https://github.com/ipa320/cob_common/issues/90>
* Contributors: Alexander Bubeck, Felix Messmer, Florian Weisshardt, ipa-bnm, ipa-cob4-1, ipa-fxm, ipa-nhg
```
