### PR TITLE
cob_environments: 0.5.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -399,6 +399,24 @@ repositories:
       url: https://github.com/ipa320/cob_common.git
       version: indigo_dev
     status: maintained
+  cob_environments:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_environments.git
+      version: indigo_dev
+    release:
+      packages:
+      - cob_default_env_config
+      - cob_environments
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/cob_environments-release.git
+      version: 0.5.2-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_environments.git
+      version: indigo_dev
+    status: maintained
   cob_extern:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_environments` to `0.5.2-0`:
- upstream repository: https://github.com/ipa320/cob_environments.git
- release repository: https://github.com/ipa320/cob_environments-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## cob_default_env_config

```
* cleaning up
* New maintainer
* Contributors: ipa-fxm, ipa-nhg
```
## cob_environments

```
* Update package.xml
* New maintainer
* Contributors: Florian Weisshardt, ipa-nhg
```
