### PR TITLE
wpi_jaco: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4356,13 +4356,14 @@ repositories:
       - jaco_description
       - jaco_interaction
       - jaco_sdk
+      - jaco_teleop
       - wpi_jaco
       - wpi_jaco_msgs
       - wpi_jaco_wrapper
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/wpi_jaco-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/wpi_jaco.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wpi_jaco` to `0.0.5-0`:
- upstream repository: https://github.com/RIVeR-Lab/wpi_jaco.git
- release repository: https://github.com/wpi-rail-release/wpi_jaco-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.4-0`
## jaco_description
- No changes
## jaco_interaction

```
* release prep
* removed interactive markers for segmented objects, this functionality was moved to carl_interactive_manipulation as it is more robot-specific
* segmented objects interactive marker clearing
* adjusted teleop due to a mode switching bug in the arm; moved teleop to jaco_teleop and included support for segmentation in jaco_interaction
* adjusted retract position
* adjusted retract position
* Home and retract actions added to interactive markers
* Contributors: David Kent, Russell Toris, dekent
```
## jaco_sdk
- No changes
## jaco_teleop

```
* release prep
* adjusted teleop due to a mode switching bug in the arm; moved teleop to jaco_teleop and included support for segmentation in jaco_interaction
* Contributors: Russell Toris, dekent
```
## wpi_jaco
- No changes
## wpi_jaco_msgs

```
* release prep
* Home and retract actions added to interactive markers
* Contributors: Russell Toris, dekent
```
## wpi_jaco_wrapper

```
* release prep
* adjusted teleop due to a mode switching bug in the arm; moved teleop to jaco_teleop and included support for segmentation in jaco_interaction
* fix for issue with single angular position commands
* testing retract command
* adjusted retract position
* Home and retract actions added to interactive markers
* Contributors: Russell Toris, dekent
```
