### PR TITLE
cob_substitute: 0.5.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -409,6 +409,28 @@ repositories:
       url: https://github.com/ipa320/cob_extern.git
       version: indigo_dev
     status: maintained
+  cob_substitute:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_substitute.git
+      version: indigo_dev
+    release:
+      packages:
+      - cob_lbr
+      - cob_safety_controller
+      - cob_substitute
+      - frida_driver
+      - prace_common
+      - prace_gripper_driver
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/cob_substitute-release.git
+      version: 0.5.2-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_substitute.git
+      version: indigo_dev
+    status: maintained
   common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_substitute` to `0.5.2-0`:
- upstream repository: https://github.com/ipa320/cob_substitute.git
- release repository: https://github.com/ipa320/cob_substitute-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## cob_lbr

```
* Update package.xml
* Contributors: Florian Weisshardt
```
## cob_safety_controller

```
* increade version number
* update changelog
* install tags
* substitute for cob_safety_controller
* Contributors: Florian Weisshardt, ipa-fxm
```
## cob_substitute

```
* New maintainer
* Contributors: ipa-nhg
```
## frida_driver
- No changes
## prace_common

```
* update changelog
* fixed install tags
* reduced prace substitution to one xacro
* reduced prace substitution to one xacro
* added substitution for prace_common package
* Contributors: Florian Weisshardt, ipa-bnm, ipa-fxm
```
## prace_gripper_driver
- No changes
