### PR TITLE
carl_bot: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -327,7 +327,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_bot-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_bot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_bot` to `0.0.3-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_bot.git
- release repository: https://github.com/wpi-rail-release/carl_bot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.2-0`
## carl_bot
- No changes
## carl_bringup

```
* added calibration files for the asus
* Contributors: David Kent
```
## carl_description

```
* updated URDF
* added calibration files for the asus
* Contributors: David Kent, Russell Toris
```
## carl_dynamixel
- No changes
## carl_teleop

```
* updates to teleop due to the bug in switching arm control modes
* Contributors: dekent
```
