### PR TITLE
universal_robot: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4154,6 +4154,30 @@ repositories:
       url: https://github.com/ros-geographic-info/unique_identifier.git
       version: master
     status: maintained
+  universal_robot:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/universal_robot.git
+      version: indigo
+    release:
+      packages:
+      - universal_robot
+      - ur10_moveit_config
+      - ur5_moveit_config
+      - ur_bringup
+      - ur_description
+      - ur_driver
+      - ur_gazebo
+      - ur_kinematics
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-industrial-release/universal_robot-release.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/ros-industrial/universal_robot.git
+      version: indigo-devel
+    status: developed
   urdf_tutorial:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robot` to `1.0.3-0`:
- upstream repository: https://github.com/ros-industrial/universal_robot.git
- release repository: https://github.com/ros-industrial-release/universal_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
