### PR TITLE
cob_driver: 0.5.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -701,7 +701,6 @@ repositories:
       packages:
       - cob_base_drive_chain
       - cob_base_velocity_smoother
-      - cob_cam3d_throttle
       - cob_camera_sensors
       - cob_canopen_motor
       - cob_collision_velocity_filter
@@ -724,7 +723,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.5.3-0
+      version: 0.5.4-0
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.5.4-0`:
- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.3-0`
