### PR TITLE
rqt_ez_publisher: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3655,7 +3655,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/OTL/rqt_ez_publisher-release.git
-      version: 0.2.0-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/OTL/rqt_ez_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_ez_publisher` to `0.3.0-0`:
- upstream repository: https://github.com/OTL/rqt_ez_publisher.git
- release repository: https://github.com/OTL/rqt_ez_publisher-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.2.0-0`
## rqt_ez_publisher

```
* Add save/load button in config dialog
* Support yaml setting file
* Support action in devel environment
* update some log messages
```
