### PR TITLE
rqt_ez_publisher: 0.2.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6125,7 +6125,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/OTL/rqt_ez_publisher-release.git
-      version: 0.2.0-0
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/OTL/rqt_ez_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_ez_publisher` to `0.2.0-1`:
- upstream repository: https://github.com/OTL/rqt_ez_publisher.git
- release repository: https://github.com/OTL/rqt_ez_publisher-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.2.0-0`
## rqt_ez_publisher

```
* Add tf for dependency
* Refactoring
  - Use base_widget
  - divided widgets into widget/
  - moved publishers into publisher/
  - rpy to quaternion_module/
* do not create header/seq
* Convert Quaternion to RPY
```
