### PR TITLE
navigation_layers: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2216,6 +2216,24 @@ repositories:
       url: https://github.com/skasperski/navigation_2d.git
       version: indigo-dev
     status: developed
+  navigation_layers:
+    doc:
+      type: git
+      url: https://github.com/DLu/navigation_layers
+      version: hydro
+    release:
+      packages:
+      - navigation_layers
+      - range_sensor_layer
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wu-robotics/navigation_layers_release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/DLu/navigation_layers
+      version: hydro
+    status: maintained
   nmea_comms:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_layers` to `0.2.1-0`:
- upstream repository: https://github.com/DLu/navigation_layers.git
- release repository: https://github.com/wu-robotics/navigation_layers_release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
