### PR TITLE
teleop_twist_keyboard: 0.5.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6910,7 +6910,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/teleop_twist_keyboard-release.git
-      version: 0.5.0-0
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/ros-teleop/teleop_twist_keyboard.git
+      version: master
     status: maintained
   terarangerone-ros:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_keyboard` to `0.5.0-1`:
- upstream repository: https://github.com/ros-teleop/teleop_twist_keyboard.git
- release repository: https://github.com/ros-gbp/teleop_twist_keyboard-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.0-0`
## teleop_twist_keyboard

```
* Initial import from brown_remotelab
* Convert to catkin
```
