### PR TITLE
kobuki: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1490,7 +1490,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki.git
@@ -4173,21 +4173,6 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_joy.git
       version: indigo-devel
     status: developed
-  teleop_twist_keyboard:
-    doc:
-      type: git
-      url: https://github.com/ros-teleop/teleop_twist_keyboard.git
-      version: master
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/teleop_twist_keyboard-release.git
-      version: 0.5.0-0
-    source:
-      type: git
-      url: https://github.com/ros-teleop/teleop_twist_keyboard.git
-      version: master
-    status: maintained
   tf2_web_republisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki` to `0.6.4-0`:
- upstream repository: https://github.com/yujinrobot/kobuki.git
- release repository: https://github.com/yujinrobot-release/kobuki-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.6.3-0`
## kobuki
- No changes
## kobuki_auto_docking
- No changes
## kobuki_bumper2pc
- No changes
## kobuki_capabilities
- No changes
## kobuki_controller_tutorial
- No changes
## kobuki_description
- No changes
## kobuki_keyop
- No changes
## kobuki_node

```
* Merge branch 'indigo' of https://github.com/yujinrobot/kobuki into indigo
* rename run_depend of kobuki_node from kobuki_apps to kobuki_rapps
* Contributors: Jihoon Lee
```
## kobuki_random_walker
- No changes
## kobuki_rapps
- No changes
## kobuki_safety_controller
- No changes
## kobuki_testsuite
- No changes
