### PR TITLE
rocon_qt_gui: 0.7.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3148,6 +3148,26 @@ repositories:
       url: https://github.com/robotics-in-concert/rocon_multimaster.git
       version: indigo
     status: developed
+  rocon_qt_gui:
+    release:
+      packages:
+      - concert_conductor_graph
+      - concert_qt_service_info
+      - concert_qt_teleop
+      - rocon_admin_app
+      - rocon_gateway_graph
+      - rocon_qt_app_manager
+      - rocon_qt_gui
+      - rocon_qt_library
+      - rocon_qt_listener
+      - rocon_qt_master_info
+      - rocon_qt_teleop
+      - rocon_remocon
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/rocon_qt_gui-release.git
+      version: 0.7.0-0
+    status: developed
   rocon_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_qt_gui` to `0.7.0-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_qt_gui.git
- release repository: https://github.com/yujinrobot-release/rocon_qt_gui-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## concert_qt_service_info

```
* Mismatched install file reference fix
* Fixed installs CMake for concert_service_info
* Fixed/re-inserted installs
* Fixed typo, removed unneccessary imports
* Add Qt Plugin
* Contributors: kentsommer
```
## concert_qt_teleop

```
* teleop namespacing for concert teleop closes #148 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/148>
* oops
* oops
* use capture_timeout param
* capture timeout parameter added, #122 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/122>.
* use parameters to initialise maximum velocities, #121 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/121>.
* fix callback construction sequence (broke due to rocon/concert teleop
  refactoring).
* fix callback construction sequence (broke due to rocon/concert teleop
  refactoring).
* rocon_qt_teleop added.
* rocon_logo -> joystick icon update.
* minor bugfix to the remocon web browser callback and better feedback on teleop problems.
* minor import name bugfix due to recent refactoring.
* usage help message for concert_teleop
* concert_teleop_app -> concert_qt_teleop to fit our naming scheme.
* Contributors: Daniel Stonier, Jihoon Lee, Yujin, jihoonl
```
## rocon_qt_app_manager

```
* rename selected to preferred
* add selected field. now use name instead of display name
* start app logs error if no rapp has selected.
* add implementation tree and user can select them to start
* Merge conflicts with parameter update
* rocon_qt_app_manager UI upgrade
* now public parameters are configurable via qt app manager
* cleanup comments
* rename app to rapp
* fixed #92 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/92>
* fixed #91 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/91>
* make app manager gui
* Contributors: DongWook Lee, Jihoon Lee, kentsommer
```
## rocon_qt_library

```
* remove debugging print.
* update publisher queue_size to avoid warning in indigo.
* rocon_qt_teleop added.
* Contributors: Daniel Stonier
```
## rocon_qt_master_info

```
* Mismatched install file reference fix
* Fixed/re-inserted installs
* have to use python qt bindings otherwise standalone has errors.
* rqt plugin for master info, also split rocon and concert rqt folders.
* Contributors: Daniel Stonier, kentsommer
```
## rocon_qt_teleop

```
* add changelogs
* don't need the rocon_teleop launcher, it's distracting.
* use parameters to initialise maximum velocities, #121 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/121>.
* rocon_qt_teleop added.
* Contributors: Daniel Stonier, Jihoon Lee
* don't need the rocon_teleop launcher, it's distracting.
* use parameters to initialise maximum velocities, #121 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/121>.
* rocon_qt_teleop added.
* Contributors: Daniel Stonier
```
## rocon_remocon

```
* don't raise exceptions when stopping dummy interactions for pairing, closes #138 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/138>.
* Changed to get icon from rocon_icons instead of rocon_remocon
* Added icons for sub applications
* Added rocon_remocon Icon
* use rocon_launch to autogenerate a meta roslauncher, #123 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/123>
* params to args for roslaunchables, closes #127 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/127>.
* launching roslaunchers in their own terminals, #123 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/123>.
* remappings for global executables.
* remove unused imports
* adding a stop all interactions button, closes #120 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/120>
* skip role list if there is only one role, closes #119 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/119>.
* handle case when no params for rosrunnable/global interactions.
* parameters for remocon rosrrunnables and globals, closes #68 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/68>
* shutdown interactions when the interactions chooser shuts down.
* fix callback construction sequence (broke due to rocon/concert teleop
  refactoring).
* delay interactive client shutdown so remocon status can be receieved by the interactions manager.
* smooth interaction-role switching, #26 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/26>.
* better feedback when the rocon master could not be found/communicated with, closes #112 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/112>
* Merge branch 'indigo' into hydro-devel
* retreat to the master chooser if rocon interactions wasn't yet found, with a warning message box, fixes #111 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/111>
* feedback for the case when a rosrunnable/global executable could not be found on the fileystem.
* feedback for the case when a roslaunch file could not be found on the filesystem.
* rocon_remocon: adds missing string variables in console output
* bugfix broken web browser lookup.
* minor bugfix to the remocon web browser callback and better feedback on teleop problems.
* don't abort if pairing support is not available.
* split main window code into different modules.
* update interactions list when stop interactions button is pressed.
* unused refresh button now marked as unused.
* signal gui updates across threads, fixes #103 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/103>
* show the pairing interaction via background colour, #98 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/98>
* pairing start/stop logic and exception handling (with message boxes) thrown in, #98 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/98>
* get web broswer moved to utils and delected cpp style destructor (python doesn't need it).
* cleanup and handling for dummy paired interactions, but no automatic stop yet, #98 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/98>
* launch info moved into a class and dummy launch type added with stub.
* checks collapsed into rocon_remocon and proper scripts discovery, fixes #54 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/54>.
* provide the remocon name when requesting interactions, #98 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/98>
* decouple rocon master lookups from the gui code.
* we can run more than one interaction in parallel, now we publish the fact, #98 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/98>.
* web interaction handling, closes #76 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/76>.
* update for interaction web app/url split.
* delete unused exception in concert checkup
* Added support for chromium browser
* get roles moved to a service
* fix the issue #80 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/80> and delete the unused log and chage the print metheod to using console module
* chagne the install role
* update the missing 78b19fab7913fcbc0d7eccf59b599b3678ae1f51 and change install file
* add the error exception handling when check up concert validation
* remove cache read and write api in remoconsub class
* remappings support for rosrunnables, closes #69 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/69>
* concert -> ros master
* trivial cleanup.
* web apps specs finalised.
* properly convert python parameters and remappings into json url fields, #63 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/63>
* minor simplification to the web app start
* support google-chrome-unstable
* temporary
* change the role of list stretch. I fix #58 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/58>
* sort role list alphabetically, closes #56 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/56>.
* shorter timeouts.
* remove unused remocon resources, #55 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/55>
* minor comments, bugfix ghost subscriber variable appearance.
* get a filtered role list, #52 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/52>
* rocon remocons using rocon icon packs...partially.
* trivial comment updates
* fix webapp loading (no master uri appending).
* hunt down interactions topics and services instead of defaulting to concert names.
* rocon remocon now independant of the concert.
* use unique hashes to populate internal lists, closes #49 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/49>
* centralise home directory utils closes #47 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/47>, increase checker timeout and simplify checker with subscriber proxy.
* basic working, of qt chatter, but logic errors still around.
* change show log about web app url
* change sniffing browser part, add sending parameter and remmaping info. to webapp
* change the exception part at determine the app type
* change the exception part
* add web launcher in remocon but only support chrome browser
* fix the exception error when finish the checkup process
* add a license
* kill process groups for global executables as well.
* support for rosrunnable and global executables, #2 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/2>.
* adjustments to drop heir-part of uri if no concert name.
* some pep8 fixes, also make sure remocon window is on top, closes #35 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/35>.
* multi-line concert name and concert connection info
* rocon_uri upgrades for rocon_remocon
* synchronised package versions.
* platform tuple overhaul.
* change add concert using master uri and host name. concert list update as soon as add concert
* change platform information at get app list part
* bugfix about the temp cache path
* disable the stop all apps button if there is no running app and change the button position in role list viewer
* add text box for settting the ros master uri and host name
* chagne the some button name and position in app list viewer
* change icon size bigger and text is smaller
* i fix #17 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/17>
* i fixed Issue #10 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/10>
* change start sub process method
* change the launch role that the already launched app is able to launch again
* change method of getting icon information and display the app icon
* code arrangement and delete app launcher scripts
* change the method of launching app and show the concert infomation in concert list viewer
* argument of host name bug fix and change the methon of subprocess terminate
* change save path to temporary path
* superflous launchers and remocon launch path bugfix.
* change unknown image format to png at check up scripts
* change unknown image format to png at check up scripts
* update the conduct graph as new message
* add validation checker about launch file
* add listener app for remocon and modify the app_launcher
* change image resources file, uuid to string uuid and code arrangment
* add parameter argument in start app launcher and code arrangement
* the timeout about waitting get role list set 1s
* add __init.py for launch without rosrun
* add time out at wait get role list part
* add argument abour host name when running the rocon remocon
* missing file update
* update
* remove broken install rule.
* upload setup.py and re-arrange the script files
* implementation of remocon sample frame
* Contributors: Daniel Stonier, DongWook Lee, Dongwook Lee, Gary Servin, Marcus Liebhardt, dwlee, kentsommer
```
