### PR TITLE
concert_services: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -559,6 +559,17 @@ repositories:
       type: git
       url: https://github.com/robotics-in-concert/concert_services.git
       version: indigo
+    release:
+      packages:
+      - concert_service_admin
+      - concert_service_gazebo
+      - concert_service_teleop
+      - concert_service_turtlesim
+      - concert_services
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/concert_services-release.git
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/concert_services.git


### PR DESCRIPTION
Increasing version of package(s) in repository `concert_services` to `0.1.1-0`:
- upstream repository: https://github.com/robotics-in-concert/concert_services.git
- release repository: https://github.com/yujinrobot-release/concert_services-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## concert_service_admin

```
* usable configuration for service priorities.
* os restrictions on interactions
* rocon_service -> concert_service
* Contributors: Daniel Stonier
```
## concert_service_gazebo

```
* update for the new rocon launch api, closes #15 <https://github.com/robotics-in-concert/concert_services/issues/15>
* use proper lists for hubs/concerts now roslaunch can handle it.
* updated robot.launch to reflect recent changes to concert_client.launch
* Updating readme to reflect package name changes
  After a bit of thought, I've renamed the segbot specific packages. I've updated the readme here to reflect that change.
* minor bugfix for the teleop app due to recent refactoring.
* eclipse files and add to metapackage.
* Revert "renamed segbot_rocon to rocon_segbot"
  This reverts commit 31fa619b08f7798f48bef7f8004a618c3f106c17.
* renamed segbot_rocon to rocon_segbot
* changed to an unordered list
* added a README
* added documentation
* all concerts started through this service should use simulated time
* fixed package.xml and remove dependencies that were not needed
* removed segbot and turtlebot specific components, moved segbot components to segbot specific repository
* added new icon file
* gazebo service now up and running! need to orchestrate teleoperation and navigation
* ready to test with full concert service scenario
* basic version is working, but correct running is order dependent. needs investigation...
* started some initial tests of the gazebo segbot manager, although outside the services framework
* some changes from yesterday for the gazebo service. Need to look at this in more detail tonight
* ready for testing on the concert
* a bit more work towards adding the gazebo service
* separating robot specific components from the gazebo_robot_manager
* separated turtlebot and segbot files. now ready to implement segbot_robot_manager
* some initial testing with launch multiple turtlebots and segbots in gazebo outside the concert framework
* initial commit for concert_service_gazebo
* Contributors: Daniel Stonier, Piyush Khandelwal
```
## concert_service_teleop

```
* teleop service uses video_teleop
* update publisher queue_size to avoid warning in indigo.
* specify capture timeout as a parameter for concert teleop.
* parameterised velocities for concert teleop.
* upgrades for the rapp manager launch overhaul.
* concert_teleop_app -> concert_teleop
* remove rocon_scheduler_requests from run_depend
* expose available and preemptible teleop robots
* usable configuration for service priorities.
* rocon_scheduler_requests -> concert_scheduling/concert_scheduler_requests
* make sure lock is available before functions use it, fixes #6 <https://github.com/robotics-in-concert/concert_services/issues/6>.
* rocon_service -> concert_service
* Contributors: Daniel Stonier, Jihoon Lee
```
## concert_service_turtlesim

```
* hatchling no longer installable.
* full launcher configuration via service parameters, closes #17 <https://github.com/robotics-in-concert/concert_services/issues/17>.
* use proper lists for hubs/concerts now roslaunch can handle it.
* turtlesim2 moving in, closes #16 <https://github.com/robotics-in-concert/concert_services/issues/16>
* updated to use the new rocon launch api.
* upgrades for the rapp manager launch overhaul.
* minor bugfix for the teleop app due to recent refactoring.
* bugfix hatchling to work without the deprecated remote_controller publisher from the app manager, fixes #11 <https://github.com/robotics-in-concert/concert_services/issues/11>.
* local machine args as for chatter concert, #7 <https://github.com/robotics-in-concert/concert_services/issues/7>.
* locks around threaded worker functions which can multiply call over a single ros xmlrpc service tunnel (and thus mangle interleaving requests/responses, fixes #9 <https://github.com/robotics-in-concert/concert_services/issues/9>
* remove some debug comments.
* usable configuration for service priorities.
* longer timeout for gateway discovery.
* rocon_service -> concert_service
* Contributors: Daniel Stonier
```
## concert_services

```
* eclipse files and add to metapackage.
* rocon_service -> concert_service
* Contributors: Daniel Stonier
```
