### PR TITLE
rocon_tutorials: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3214,6 +3214,17 @@ repositories:
       type: git
       url: https://github.com/robotics-in-concert/rocon_tutorials.git
       version: indigo
+    release:
+      packages:
+      - chatter_concert
+      - rocon_app_manager_tutorials
+      - rocon_gateway_tutorials
+      - rocon_tutorials
+      - turtle_concert
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/rocon_tutorials-release.git
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_tutorials` to `0.6.1-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_tutorials.git
- release repository: https://github.com/yujinrobot-release/rocon_tutorials-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## chatter_concert
- No changes
## rocon_gateway_tutorials
- No changes
## rocon_tutorials

```
* remove unnecessary run_depend
* Contributors: Jihoon Lee
```
## turtle_concert
- No changes
