### PR TITLE
cob_perception_common: 0.5.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -465,6 +465,28 @@ repositories:
       url: https://github.com/ipa320/cob_extern.git
       version: indigo_dev
     status: maintained
+  cob_perception_common:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_perception_common.git
+      version: indigo_dev
+    release:
+      packages:
+      - cob_cam3d_throttle
+      - cob_image_flip
+      - cob_object_detection_msgs
+      - cob_perception_common
+      - cob_perception_msgs
+      - cob_vision_utils
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/cob_perception_common-release.git
+      version: 0.5.5-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_perception_common.git
+      version: indigo_dev
+    status: maintained
   cob_substitute:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_perception_common` to `0.5.5-0`:
- upstream repository: https://github.com/ipa320/cob_perception_common.git
- release repository: https://github.com/ipa320/cob_perception_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## cob_image_flip

```
* Merge pull request #26 <https://github.com/ipa320/cob_perception_common/issues/26> from ipa320/hydro_dev
  updates from hydro_dev
* fix wrong opencv dep
* Contributors: Alexander Bubeck, Florian Weisshardt
```
## cob_object_detection_msgs
- No changes
## cob_perception_common
- No changes
## cob_perception_msgs
- No changes
## cob_vision_utils

```
* Merge pull request #26 <https://github.com/ipa320/cob_perception_common/issues/26> from ipa320/hydro_dev
  updates from hydro_dev
* Merge branch 'hydro_dev' of github.com:ipa320/cob_perception_common into indigo_dev
* fix wrong opencv dep
* added install tags
* Contributors: Alexander Bubeck, Florian Weisshardt, ipa-fxm
```
