### PR TITLE
cob_driver: 0.5.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -427,6 +427,37 @@ repositories:
       url: https://github.com/ipa320/cob_common.git
       version: indigo_dev
     status: maintained
+  cob_driver:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_driver.git
+      version: indigo_dev
+    release:
+      packages:
+      - cob_base_drive_chain
+      - cob_camera_sensors
+      - cob_canopen_motor
+      - cob_driver
+      - cob_generic_can
+      - cob_head_axis
+      - cob_light
+      - cob_phidgets
+      - cob_relayboard
+      - cob_sick_lms1xx
+      - cob_sick_s300
+      - cob_sound
+      - cob_undercarriage_ctrl
+      - cob_utilities
+      - cob_voltage_control
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/cob_driver-release.git
+      version: 0.5.7-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_driver.git
+      version: indigo_dev
+    status: maintained
   cob_environments:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.5.7-0`:
- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## cob_base_drive_chain

```
* Merge pull request #163 <https://github.com/ipa320/cob_driver/issues/163> from ipa320/hydro_dev
  updates from hydro_dev
* 0.5.6
* update changelog
* adding timestamp to diagnostic message
* Cleaned up cob_driver with reduced deps to compile on indigo
* fix install tags
* remove deprecated launch files in cob_driver and add nodes to cob_robots
* Contributors: Alexander Bubeck, Florian Weisshardt, ipa-fxm
```
## cob_camera_sensors

```
* Merge pull request #163 <https://github.com/ipa320/cob_driver/issues/163> from ipa320/hydro_dev
  updates from hydro_dev
* 0.5.6
* update changelog
* Cleaned up cob_driver with reduced deps to compile on indigo
* Contributors: Alexander Bubeck, Florian Weisshardt
```
## cob_canopen_motor

```
* Merge pull request #163 <https://github.com/ipa320/cob_driver/issues/163> from ipa320/hydro_dev
  updates from hydro_dev
* 0.5.6
* update changelog
* Cleaned up cob_driver with reduced deps to compile on indigo
* Contributors: Alexander Bubeck, Florian Weisshardt
```
## cob_driver

```
* remove dep to cob_hokuyo
* Merge pull request #163 <https://github.com/ipa320/cob_driver/issues/163> from ipa320/hydro_dev
  updates from hydro_dev
* 0.5.6
* update changelog
* merge
* remove obsolete cob_hwboard dependendcy
* update meta-package
* update meta-package
* merge with ipa320
* Merge pull request #135 <https://github.com/ipa320/cob_driver/issues/135> from ipa320/hydro_release_candidate
  bring back changes from Hydro release candidate
* Merge branch 'hydro_dev' of github.com:ipa-bnm/cob_driver into hydro_vel_control
* New maintainer
* first version of frame_tracker publishing twists
* minor
* first draft for cob_twist_controller
* Contributors: Florian Weisshardt, Nadia Hammoudeh García, ipa-fxm, ipa-nhg
```
## cob_generic_can

```
* Merge pull request #163 <https://github.com/ipa320/cob_driver/issues/163> from ipa320/hydro_dev
  updates from hydro_dev
* 0.5.6
* update changelog
* Cleaned up cob_driver with reduced deps to compile on indigo
* Contributors: Alexander Bubeck, Florian Weisshardt
```
## cob_head_axis

```
* Merge pull request #163 <https://github.com/ipa320/cob_driver/issues/163> from ipa320/hydro_dev
  updates from hydro_dev
* 0.5.6
* update changelog
* added explicit default argument queue_size
* Cleaned up cob_driver with reduced deps to compile on indigo
* Contributors: Alexander Bubeck, Felix Messmer, Florian Weisshardt
```
## cob_light

```
* Merge pull request #163 <https://github.com/ipa320/cob_driver/issues/163> from ipa320/hydro_dev
  updates from hydro_dev
* 0.5.6
* update changelog
* added explicit default argument queue_size
* Cleaned up cob_driver with reduced deps to compile on indigo
* port settings fixed
* added light support for conrad ms-35 led controller
* Contributors: Alexander Bubeck, Felix Messmer, Florian Weisshardt, ipa-bnm
```
## cob_phidgets

```
* Merge pull request #163 <https://github.com/ipa320/cob_driver/issues/163> from ipa320/hydro_dev
  updates from hydro_dev
* 0.5.6
* update changelog
* merge
* fix CMakeLists.txt
* small changes to remove warnings
* Cleaned up cob_driver with reduced deps to compile on indigo
* fix install tag
* Merge pull request #136 <https://github.com/ipa320/cob_driver/issues/136> from ipa-fmw/hydro_dev
  change maintainer and add missing dependency
* Update package.xml
* fix
* use board_name instead serial_num in debug outputs
* CMakeLists include_dirs order
* renaming topic name
* voltage info from phidgets
* message generation dependencies
* catkin dependencies
* message generation
* added c++11 support to phidgets CMakeLists
* added phidgets to CMakelists
* fix cob_phidget release pipeline error
* Fixes the Jenkins Release Error
* Contributors: Alexander Bubeck, Florian Weisshardt, Nadia Hammoudeh García, Thiago de Freitas Oliveira Araujo, Your full name, ipa-bnm
```
## cob_relayboard

```
* Merge pull request #163 <https://github.com/ipa320/cob_driver/issues/163> from ipa320/hydro_dev
  updates from hydro_dev
* 0.5.6
* update changelog
* move EmergencyStopState.msg to cob_msgs + PowerBoardState works again
* Added queue_size=1 paramter to Publisher initialisation.
* changes due to introduction of cob_msgs
* small changes to remove warnings
* Cleaned up cob_driver with reduced deps to compile on indigo
* fix tabs vs spaces
* Fix python indentation problems
* Contributors: Alexander Bubeck, Denis Štogl, Felix Messmer, Florian Weisshardt, Scott K Logan, ipa-fxm
```
## cob_sick_lms1xx

```
* 0.5.6
* update changelog
* merge
* fix python3 ascii error while parsing "S"
* Corrected inversion for lms1xx
* Merge pull request #136 <https://github.com/ipa320/cob_driver/issues/136> from ipa-fmw/hydro_dev
  change maintainer and add missing dependency
* Update package.xml
* Contributors: Denis Štogl, Florian Weisshardt, Nadia Hammoudeh García, ipa-fxm
```
## cob_sick_s300

```
* Merge pull request #163 <https://github.com/ipa320/cob_driver/issues/163> from ipa320/hydro_dev
  updates from hydro_dev
* 0.5.6
* update changelog
* merge
* remove warnings
* Update cob_sick_s300.cpp
* Cleaned up cob_driver with reduced deps to compile on indigo
* Merge pull request #136 <https://github.com/ipa320/cob_driver/issues/136> from ipa-fmw/hydro_dev
  change maintainer and add missing dependency
* enabled raw reading (for intensity)
* Update package.xml
* fixed cpu load issue
* fixed time stamp issue (s300)
* merge
* small fix
* fix
* debug
* fix
* ignoring addr.
* output
* test files
* adaptation + parameter parsing
* now blocking
* parameteres for different fields
* includes
* moved telegram definition
* rmoved Bride files
* fixed offset & debug output
* added debug flag
* Contributors: Alexander Bubeck, Florian Weisshardt, Nadia Hammoudeh García, Your full name, cob4-1, ipa-cob4-1, ipa-josh
```
## cob_sound

```
* Merge pull request #163 <https://github.com/ipa320/cob_driver/issues/163> from ipa320/hydro_dev
  updates from hydro_dev
* 0.5.6
* update changelog
* merge
* Cleaned up cob_driver with reduced deps to compile on indigo
* Merge pull request #135 <https://github.com/ipa320/cob_driver/issues/135> from ipa320/hydro_release_candidate
  bring back changes from Hydro release candidate
* New maintainer
* Contributors: Alexander Bubeck, Florian Weisshardt, Nadia Hammoudeh García, ipa-nhg
```
## cob_undercarriage_ctrl

```
* Merge pull request #163 <https://github.com/ipa320/cob_driver/issues/163> from ipa320/hydro_dev
  updates from hydro_dev
* 0.5.6
* update changelog
* move EmergencyStopState.msg to cob_msgs + PowerBoardState works again
* Merge branch 'hydro_dev' of github.com:ipa-fxm/cob_driver into indigo_dev
* cob_undercarriage_ctrl: add parameter to disable tf broadcast
* updated default values for maximal velocities in ucar_ctrl_watchdog
* fixed indentation cob_undercarriage_ctrl.cpp
* updated watchdog in ucar ctrl to stop in case we receive a really high command in at least one direction
* added missing absolute value functions to velocity watchdog in undercarriage_control
* beautification of some outputs in undercarriage control
* corrected some typos and minor bugs
* split maximal allowed velocity in undercarriage control in translational and rotaional part. set velocity to zero, if the maximal allowed velocity is exceeded.
* first draft for undercarriage_control velocity-watchdog. not tested yet.
* Cleaned up cob_driver with reduced deps to compile on indigo
* fix install tags
* remove deprecated launch files in cob_driver and add nodes to cob_robots
* Contributors: Alexander Bubeck, Felix Messmer, Florian Mirus, Florian Weisshardt, ipa-fxm, ipa-mig
```
## cob_utilities

```
* Merge pull request #163 <https://github.com/ipa320/cob_driver/issues/163> from ipa320/hydro_dev
  updates from hydro_dev
* 0.5.6
* update changelog
* Cleaned up cob_driver with reduced deps to compile on indigo
* Contributors: Alexander Bubeck, Florian Weisshardt
```
## cob_voltage_control

```
* Merge pull request #163 <https://github.com/ipa320/cob_driver/issues/163> from ipa320/hydro_dev
  updates from hydro_dev
* 0.5.6
* update changelog
* merge
* move EmergencyStopState.msg to cob_msgs + PowerBoardState works again
* changes due to introduction of cob_msgs
* added message to submit voltage data
* Cleaned up cob_driver with reduced deps to compile on indigo
* increased receive buffer
* Merge pull request #136 <https://github.com/ipa320/cob_driver/issues/136> from ipa-fmw/hydro_dev
  change maintainer and add missing dependency
* Update package.xml
* fix
* fix
* voltage ctrl over phidgets
* voltage info from phidgets
* work in progress voltagectrl with cob_phidget
  Merge branch 'groovy_dev' into feature/voltagectrl_newphidget
  Conflicts:
  cob_voltage_control/ros/src/cob_voltage_control_ros.cpp
* voltagectrl work in progress
* Contributors: Alexander Bubeck, Felix Messmer, Florian Weisshardt, Nadia Hammoudeh García, ipa-bnm, ipa-fxm
```
