### PR TITLE
cob_control: 0.5.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -427,6 +427,29 @@ repositories:
       url: https://github.com/ipa320/cob_common.git
       version: indigo_dev
     status: maintained
+  cob_control:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_control.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_base_velocity_smoother
+      - cob_collision_velocity_filter
+      - cob_control
+      - cob_footprint_observer
+      - cob_lookat_controller
+      - cob_trajectory_controller
+      - cob_twist_controller
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/cob_control-release.git
+      version: 0.5.4-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_control.git
+      version: indigo_dev
+    status: maintained
   cob_environments:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.5.4-0`:
- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## cob_control

```
* added meta-package
* Contributors: ipa-fxm
```
## cob_lookat_controller

```
* added explicit default argument queue_size
* move launch files to cob_robots
* fix dependency-hell on multiple cores
* moved cob_lookat_controller
* Contributors: Alexander Bubeck, Felix Messmer, ipa-fxm
```
## cob_twist_controller

```
* fix dependency-hell on multiple cores
* moved cob_twist_controller
* Contributors: Alexander Bubeck, ipa-fxm
```
