### PR TITLE
jsk_recognition: 0.1.15-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1936,6 +1936,7 @@ repositories:
       packages:
       - checkerboard_detector
       - imagesift
+      - jsk_libfreenect2
       - jsk_pcl_ros
       - jsk_perception
       - jsk_recognition
@@ -1943,7 +1944,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.1.14-0
+      version: 0.1.15-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.1.15-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.14-0`
## jsk_libfreenect2

```
* add new package: jsk_libfreenect2
* Contributors: Ryohei Ueda
```
