### PR TITLE
jsk_recognition: 0.1.15-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2851,6 +2851,7 @@ repositories:
       packages:
       - checkerboard_detector
       - imagesift
+      - jsk_libfreenect2
       - jsk_pcl_ros
       - jsk_perception
       - jsk_recognition
@@ -2858,7 +2859,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.1.14-0
+      version: 0.1.15-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.1.15-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.14-0`
## jsk_libfreenect2

```
* add new package: jsk_libfreenect2
* Contributors: Ryohei Ueda
```
