### PR TITLE
rtmros_hironx: 1.0.22-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6221,7 +6221,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.21-0
+      version: 1.0.22-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.22-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.21-0`
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* (RTM client) Remove redundant implementation of derived methods. Now the API doc of the methods derived from the super class, we need to refer to the upstream repository <https://github.com/fkanehiro/hrpsys-base/blob/master/python/hrpsys_config.py> until an alternative solution is introduced (discussed in <https://github.com/fkanehiro/hrpsys-base/issues/268>).
* Add hironx ros cpp client and its acceptance test by @iory
* (robot install) Many improvements.
  * Store ssh connection
* Depency improvement (removed hrpsys trajectory_msgs and pr2_controller_msgs that are transitively handled in hrpsys_ros_bridge, see #208 <https://github.com/start-jsk/rtmros_hironx/issues/208>)
* Contributors: Isaac I.Y. Saito, Kei Okada, Iory Yanokura
```
## rtmros_hironx

```
* (RTM client) Remove redundant implementation of derived methods. Now the API doc of the methods derived from the super class, we need to refer to the upstream repository <https://github.com/fkanehiro/hrpsys-base/blob/master/python/hrpsys_config.py> until an alternative solution is introduced (discussed in <https://github.com/fkanehiro/hrpsys-base/issues/268>).
* Add hironx ros cpp client and its acceptance test by @iory
* (robot install) Many improvements.
  * Store ssh connection
* Depency improvement (removed hrpsys trajectory_msgs and pr2_controller_msgs that are transitively handled in hrpsys_ros_bridge, see #208 <https://github.com/start-jsk/rtmros_hironx/issues/208>)
* Contributors: Isaac I.Y. Saito, Kei Okada, Iory Yanokura
```
