### PR TITLE
schunk_modular_robotics: 0.5.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3925,6 +3925,28 @@ repositories:
       url: https://github.com/ros-visualization/rviz_fixed_view_controller.git
       version: indigo-devel
     status: developed
+  schunk_modular_robotics:
+    doc:
+      type: git
+      url: https://github.com/ipa320/schunk_modular_robotics.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - schunk_description
+      - schunk_libm5api
+      - schunk_modular_robotics
+      - schunk_powercube_chain
+      - schunk_sdh
+      - schunk_simulated_tactile_sensors
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/schunk_modular_robotics-release.git
+      version: 0.5.5-0
+    source:
+      type: git
+      url: https://github.com/ipa320/schunk_modular_robotics.git
+      version: indigo_dev
+    status: maintained
   sentis_tof_m100:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_modular_robotics` to `0.5.5-0`:
- upstream repository: https://github.com/ipa320/schunk_modular_robotics.git
- release repository: https://github.com/ipa320/schunk_modular_robotics-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## schunk_description

```
* merge with hydro_dev
* spaces
* obsolete dependency
* Gazebo only detect links with inertia
* fix pg70 property name
* consistency changes due to new transmission format
* consistency changes due to latest gazebo tag format
* remove unused meshes
* fix arm_1_link mesh + use collision stl
* merge with latest 320 updates
* pg70 description and fixed origins for lwa4d
* pg70 setup
* mesh file
* Coloured mesh files
* use meshes with reduced vertices and reduce joint_limits for moveit_config
* use meshes with reduced vertices and reduce joint_limits for moveit_config
* cleaning up after testing
* lwa4d: fixed offsets error
* inertias for arm_1_link
* new meshes
* temporary modifications for easier controller tuning
* use inertias and physic properties from controller_tuning tests
* modifications in tranmissions, removing of bumpers and small cleanups
* Renamed links and added shoulder model
* mesh for shoulder added
* origin for collision model is in the center of the box
* pg70 collada model
* wrong lenght
* materials should not be loaded in the components urdf
* beautify mesh files
* Merge pull request #81 <https://github.com/ipa320/schunk_modular_robotics/issues/81> from ipa320/hydro_release_candidate
  bring back changes from Hydro release candidate
* New maintainer
* Redefined color LightGrey
* Contributors: Alexander Bubeck, Felix Messmer, Nadia Hammoudeh García, Tim Fröhlich, ipa-cob3-8, ipa-fxm, ipa-nhg
```
## schunk_libm5api
- No changes
## schunk_modular_robotics

```
* Merge pull request #81 <https://github.com/ipa320/schunk_modular_robotics/issues/81> from ipa320/hydro_release_candidate
  bring back changes from Hydro release candidate
* New maintainer
* Contributors: Nadia Hammoudeh García, ipa-nhg
```
## schunk_powercube_chain

```
* cleaning up
* New maintainer
* Contributors: ipa-fxm, ipa-nhg
```
## schunk_sdh

```
* enforce sdh operation mode on init
* cleaning up
* Merge pull request #81 <https://github.com/ipa320/schunk_modular_robotics/issues/81> from ipa320/hydro_release_candidate
  bring back changes from Hydro release candidate
* Update package.xml
* New maintainer
* Contributors: Florian Weisshardt, Mathias Lüdtke, Nadia Hammoudeh García, ipa-fxm, ipa-nhg
```
## schunk_simulated_tactile_sensors

```
* modifications in tranmissions, removing of bumpers and small cleanups
* Contributors: Alexander Bubeck
```
