### PR TITLE
ipa_canopen: 0.5.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1474,6 +1474,15 @@ repositories:
       type: git
       url: https://github.com/ipa320/ipa_canopen.git
       version: indigo_release_candidate
+    release:
+      packages:
+      - ipa_canopen
+      - ipa_canopen_core
+      - ipa_canopen_ros
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/ipa_canopen-release.git
+      version: 0.5.7-0
     source:
       type: git
       url: https://github.com/ipa320/ipa_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ipa_canopen` to `0.5.7-0`:
- upstream repository: https://github.com/ipa320/ipa_canopen.git
- release repository: https://github.com/ipa320/ipa_canopen-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## ipa_canopen
- No changes
## ipa_canopen_core
- No changes
## ipa_canopen_ros

```
* parses new layout for X_driver.yaml canopen components
* Contributors: ipa-fxm
```
