### PR TITLE
hironx_tutorial: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2264,7 +2264,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/hironx_tutorial-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/tork-a/hironx_tutorial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hironx_tutorial` to `0.1.2-0`:
- upstream repository: https://github.com/tork-a/hironx_tutorial.git
- release repository: https://github.com/tork-a/hironx_tutorial-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.1.1-0`
## hironx_tutorial

```
* (stampit) Fix #11 <https://github.com/tork-a/hironx_tutorial/issues/11> (rtm connect error).
* (stampit) Use correct hand command names.
* Contributors: Isaac I.Y. Saito
```
