### PR TITLE
people: 1.0.6-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3061,6 +3061,23 @@ repositories:
       type: git
       url: https://github.com/wg-perception/people.git
       version: groovy-devel
+    release:
+      packages:
+      - face_detector
+      - leg_detector
+      - people
+      - people_msgs
+      - people_tracking_filter
+      - people_velocity_tracker
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/OSUrobotics/people-release.git
+      version: 1.0.6-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/people.git
+      version: groovy
+    status: maintained
   pepperl_fuchs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `people` to `1.0.6-0`:
- upstream repository: https://github.com/wg-perception/people.git
- release repository: https://github.com/OSUrobotics/people-release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
