### PR TITLE
rocon: 0.7.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3131,6 +3131,11 @@ repositories:
       type: git
       url: https://github.com/robotics-in-concert/rocon.git
       version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/rocon-release.git
+      version: 0.7.2-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon` to `0.7.2-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon
- release repository: https://github.com/yujinrobot-release/rocon-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## rocon

```
* Fix #27 <https://github.com/robotics-in-concert/rocon/issues/27>
* Contributors: Jihoon Lee
```
