### PR TITLE
rospilot: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3744,7 +3744,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rospilot/rospilot-release.git
-      version: 0.0.4-0
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/rospilot/rospilot
+      version: master
     status: developed
   rospilot_deps:
     release:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3747,7 +3747,7 @@ repositories:
       version: 0.1.0-0
     source:
       type: git
-      url: https://github.com/rospilot/rospilot
+      url: https://github.com/rospilot/rospilot.git
       version: master
     status: developed
   rospilot_deps:


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot` to `0.1.0-0`:
- upstream repository: https://github.com/rospilot/rospilot.git
- release repository: https://github.com/rospilot/rospilot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.4-0`
## rospilot

```
* Add PTP support
* Add init.d script to auto start rospilot
* Contributors: Christopher Berner
```
