### PR TITLE
cob_common: 0.5.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -421,7 +421,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.5.4-0
+      version: 0.5.5-0
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.5.5-0`:
- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.4-0`
## brics_actuator
- No changes
## cob_common
- No changes
## cob_description
- No changes
## cob_msgs

```
* catkin_lint'ing
* move EmergencyStopState.msg to cob_msgs
* Contributors: ipa-fxm
```
## cob_srvs
- No changes
## desire_description
- No changes
## raw_description
- No changes
