### PR TITLE
rail_maps: 0.2.4-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3418,7 +3418,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_maps-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_maps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_maps` to `0.2.4-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_maps.git
- release repository: https://github.com/wpi-rail-release/rail_maps-release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.2.3-0`
## rail_maps

```
* Maps of new RAIL Lab
* Contributors: Russell Toris
```
