### PR TITLE
carl_navigation: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -348,6 +348,21 @@ repositories:
       url: https://github.com/WPI-RAIL/carl_estop.git
       version: develop
     status: maintained
+  carl_navigation:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/carl_navigation.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/carl_navigation-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/carl_navigation.git
+      version: develop
+    status: maintained
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_navigation` to `0.0.1-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_navigation.git
- release repository: https://github.com/wpi-rail-release/carl_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## carl_navigation

```
* fixed launch file location
* navigation launch file added
* amcl params moved to yaml
* gmapping params moved to yaml
* nav rviz config
* params updated
* navigation started
* travis fix
* gmapping parameters
* removed old code
* cleanup of readmes and such
* Merge pull request #3 from Spkordell/develop
  Get the localization map only once by making a service call
* Fixed merge conflicts
* Created navigation timeout node
* Created navigation timeout node
* Fixed some nav goals failing to cancel.
* Get the localization map only once by making a service call
* Cleaned rviz configuration
* Merge pull request #2 from Spkordell/develop
  Navigation Tuning
* Tuning
* Tuning
* Tuning
* Tuning
* Tuning
* Tuning
* tuning
* Aligned navigation boundary to new map
* Merge pull request #1 from Spkordell/develop
  Moved carl_navigation from carl_bot package to its own package
* Merge branch 'develop' of https://github.com/Spkordell/carl_navigation into develop
* Removed visual odometry from gmapping
* Tuning
* Moved carl_navigation from carl_bot package to its own package
* Initial commit
* Contributors: Russell Toris, Steven Kordell, spkordell
```
