### PR TITLE
Remove from hydro: outdated ubuntu dependency

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3766,10 +3766,6 @@ repositories:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
       version: indigo-devel
-    source:
-      type: git
-      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
-      version: indigo-devel
     status: maintained
   multi_level_map:
     doc:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3761,12 +3761,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/cogniteam/mr_teleoperator-release.git
       version: 0.2.6-1
-  mrpt_navigation:
-    doc:
-      type: git
-      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
-      version: indigo-devel
-    status: maintained
   multi_level_map:
     doc:
       type: git


### PR DESCRIPTION
This package requires libmrpt-dev >=1.0.0 and hydro is built against a too old Ubuntu version. 

So I think it's better to just remove the "source:" section. I still want the docs to be build online, that's why I don't remove the "mrpt:" entry completely. 
Let me know if there is any issue.
