### PR TITLE
Added tu-darmstadt-ros-pkg repositories to indigo

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4033,11 +4033,6 @@ repositories:
       type: svn
       url: https://code.ros.org/svn/ros/stacks/roslisp_support/trunk
       version: HEAD
-  rosmatlab:
-    doc:
-      type: git
-      url: https://github.com/tu-darmstadt-ros-pkg/rosmatlab.git
-      version: master
   rospack:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5941,11 +5941,6 @@ repositories:
       url: https://github.com/ros-gbp/roslisp_repl-release.git
       version: 0.3.3-0
     status: maintained
-  rosmatlab:
-    doc:
-      type: git
-      url: https://github.com/tu-darmstadt-ros-pkg/rosmatlab.git
-      version: master
   rospack:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7166,6 +7166,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/ublox.git
+      version: catkin
   ueye:
     doc:
       type: hg

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3891,11 +3891,6 @@ repositories:
       url: https://github.com/ros-gbp/roslisp-release.git
       version: 1.9.15-0
     status: maintained
-  rosmatlab:
-    doc:
-      type: git
-      url: https://github.com/tu-darmstadt-ros-pkg/rosmatlab.git
-      version: master
   rospack:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -696,6 +696,11 @@ repositories:
       url: https://github.com/ros-controls/control_toolbox.git
       version: indigo-devel
     status: maintained
+  cpp_introspection:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/cpp_introspection.git
+      version: master
   demo_pioneer:
     doc:
       type: git
@@ -1302,6 +1307,90 @@ repositories:
       url: https://github.com/unboundedrobotics-gbp/grasping_msgs-gbp.git
       version: 0.3.0-0
     status: developed
+  hector_gazebo:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
+      version: indigo-devel
+    release:
+      packages:
+      - hector_gazebo
+      - hector_gazebo_plugins
+      - hector_gazebo_thermal_camera
+      - hector_gazebo_worlds
+      - hector_sensors_gazebo
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
+    status: maintained
+  hector_localization:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_localization.git
+      version: catkin
+    release:
+      packages:
+      - hector_localization
+      - hector_pose_estimation
+      - hector_pose_estimation_core
+      - message_to_tf
+      - world_magnetic_model
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
+    status: maintained
+  hector_models:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_models.git
+      version: indigo-devel
+    release:
+      packages:
+      - hector_components_description
+      - hector_models
+      - hector_sensors_description
+      - hector_xacro_tools
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
+    status: maintained
+  hector_navigation:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_navigation.git
+      version: master
+  hector_nist_arenas_gazebo:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_nist_arenas_gazebo.git
+      version: indigo-devel
+  hector_quadrotor:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor.git
+      version: indigo-devel
+    release:
+      packages:
+      - hector_quadrotor
+      - hector_quadrotor_controller
+      - hector_quadrotor_controller_gazebo
+      - hector_quadrotor_demo
+      - hector_quadrotor_description
+      - hector_quadrotor_gazebo
+      - hector_quadrotor_gazebo_plugins
+      - hector_quadrotor_model
+      - hector_quadrotor_pose_estimation
+      - hector_quadrotor_teleop
+      - hector_uav_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_quadrotor-release.git
+    status: maintained
+  hector_quadrotor_apps:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor_apps.git
+      version: master
   hector_slam:
     doc:
       type: git
@@ -1326,6 +1415,31 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
       version: 0.3.3-0
+    status: maintained
+  hector_vision:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_vision.git
+      version: master
+  hector_visualization:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_visualization.git
+      version: master
+  hector_worldmodel:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_worldmodel.git
+      version: catkin
+    release:
+      packages:
+      - hector_object_tracker
+      - hector_worldmodel
+      - hector_worldmodel_geotiff_plugins
+      - hector_worldmodel_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
     status: maintained
   hokuyo_node:
     doc:
@@ -3777,6 +3891,11 @@ repositories:
       url: https://github.com/ros-gbp/roslisp-release.git
       version: 1.9.15-0
     status: maintained
+  rosmatlab:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/rosmatlab.git
+      version: master
   rospack:
     doc:
       type: git
@@ -4417,6 +4536,19 @@ repositories:
       url: https://github.com/wcaarls/threemxl.git
       version: master
     status: maintained
+  topic_proxy:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/topic_proxy.git
+      version: master
+    release:
+      packages:
+      - blob
+      - topic_proxy
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/topic_proxy-release.git
+    status: maintained
   turtlebot_arm:
     doc:
       type: git
@@ -4440,6 +4572,11 @@ repositories:
       url: https://github.com/turtlebot/turtlebot_arm.git
       version: indigo-devel
     status: developed
+  ublox:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/ublox.git
+      version: catkin
   ueye:
     doc:
       type: hg


### PR DESCRIPTION
The following repositories are going to be released in indigo soon after having done some pre-release tests:
- hector_gazebo
- hector_localization
- hector_models
- hector_quadrotor
- hector_worldmodel
- topic_proxy

The `release:` sections have no version tags yet (no releases, only for prerelease testing with version "latest").

The following repositories have been added to build documentation only:
- cpp_introspection
- hector_navigation
- hector_nist_arenas_gazebo
- hector_quadrotor_apps
- hector_vision
- hector_visualization
- rosmatlab
- ublox
