### PR TITLE
cob_command_tools: 0.5.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -419,6 +419,29 @@ repositories:
       url: https://github.com/ipa320/cob_calibration_data.git
       version: indigo_dev
     status: maintained
+  cob_command_tools:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_command_tools.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_command_gui
+      - cob_command_tools
+      - cob_dashboard
+      - cob_interactive_teleop
+      - cob_script_server
+      - cob_teleop
+      - cob_teleop_cob4
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/cob_command_tools-release.git
+      version: 0.5.2-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_command_tools.git
+      version: indigo_dev
+    status: maintained
   cob_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.5.2-0`:
- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## cob_command_gui

```
* move EmergencyStopState.msg to cob_msgs
* Cleanup for indigo and rewrite of dashboard to run without pr2_msgs
* Contributors: Alexander Bubeck, ipa-fxm
```
## cob_command_tools

```
* Update package.xml
* Contributors: Florian Weisshardt
```
## cob_dashboard

```
* fix install tags
* move EmergencyStopState.msg to cob_msgs
* changes related to introduction of cob_msgs
* add dashboard_aggregator to replace pr2_dashboard_aggregator
* Cleanup for indigo and rewrite of dashboard to run without pr2_msgs
* Update package.xml
* Contributors: Alexander Bubeck, Felix Messmer, Florian Weisshardt, ipa-fxm
```
## cob_interactive_teleop

```
* Update package.xml
* Contributors: Florian Weisshardt
```
## cob_script_server

```
* missing dependency
* added explicit default argument queue_size
* fix catkin_lint errors
* add trajectory service
* add dep to ipython
* Update package.xml
* Contributors: Felix Messmer, Florian Weisshardt, ipa-fmw-ms, ipa-fxm, ipa-jenkins, ros
```
## cob_teleop

```
* restore original cob_teleop
* moved folder
* base works, attemp arm
* Contributors: ipa-fmw-ms, ipa-fxm
```
## cob_teleop_cob4

```
* Revert "catkin_lint'ing"
  This reverts commit f7fb5ce0e5d76bc44795beee9a40e9a87a863bc6.
* catkin_lint'ing
* Delete .project
* Delete .cproject
* Merge branch 'hydro_dev' of github.com:ipa-fxm/cob_command_tools into indigo_dev
* The license tag must neither be empty
* add layout as pdf and gimp
* added README with instructions
* little cleanup
* init recover all in automoves
* gripper support for 2 joints
* service call with function
* move from sss to service calls
* led modes with yaml
* create symlink for input device
* fixed udev rules but still unreliable
* regenerated with newest bride version
* LED feedback
* make joaystick available after roscore restart
* Cleanup for indigo and rewrite of dashboard to run without pr2_msgs
* starting with ps3 status LEDs
* removed git specific file
* picked into old branch
* removed .metadata again, wasn't in local gitignore
* check if component stopped
* merged other repo
* stop components once via sss after deadman release
* merged yaml change
* changed arm twist topic
* some testing
* created launch file
* attempting usage of brides new XmlRpc
* actionlib working
* adapted to new bride version
* init_recover only once per press
* allowing homing only once per press. Restored protected region
* attemp init recover for components
* actionlib moves working except for scope visibility
* attempt action client for script server
* added right arm
* arm joint control working
* tried arm joints, but get size mismatch from vel_controller
* forgot arm_joint_velocity_max
* implemented torso. working
* some simplifying
* removed .metadata
* added comments, fixed runf_factor
* first time publishing bricsActuator/JointVelocities
* moved folder
* Contributors: Alexander Bubeck, Felix Messmer, Florian Weisshardt, ipa-cob4-2, ipa-fmw-ms, ipa-fxm
```
