### PR TITLE
cob_robots: 0.5.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -579,6 +579,28 @@ repositories:
       url: https://github.com/ipa320/cob_perception_common.git
       version: indigo_dev
     status: maintained
+  cob_robots:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_robots.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_bringup
+      - cob_controller_configuration_gazebo
+      - cob_default_robot_config
+      - cob_hardware_config
+      - cob_monitoring
+      - cob_robots
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/cob_robots-release.git
+      version: 0.5.4-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_robots.git
+      version: indigo_dev
+    status: maintained
   cob_substitute:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.5.4-0`:
- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## cob_bringup

```
* remove obsolete cob_hwboard
* remove obsolete dependency
* changes due to introduction of cob_msgs
* merge with hydro_dev
* separated ports for tray and torso
* Last update cob3-8
* setup cob3-8
* cob3-8 setup
* do not use twist_controller on real hardware yet
* added cob_image_flip dependency
* renamed pg70
* setup cob3-8
* tabified file
* start lightcontroller on raw3-3 bringup
* use twist controller for cob4-1 torso
* add twist controller launch file
* moved lookat_controller yaml and launch files
* cleaning up debs
* separate controller and driver yaml file
* cob3-8 with new structure
* merge conflict
* update cob4.xml
* moved base_controller to controllers folder
* Merge branch 'hydro_dev' of https://github.com/ipa320/cob_robots into feature/raw3-4-configs
* Added cob3-8
* cleaning up debs
* added missing launch file argument for image_flip
* add lookat launch file
* Merge pull request #188 <https://github.com/ipa320/cob_robots/issues/188> from ipa-cob4-1/hydro_dev
  Adapt cob_image_flip and new tag for openni2 driver
* another retab
* Retabbing raw3-4.xml
* Retabbing base.launch
* multiple config changes for raw3-4
* adapted image_flip
* adapted image_flip
* needed machine tag for openni2
* component_solo for canopen components
* component_solo for canopen components
* bring latest raw3-3 changes to new structure
* Added cob_image_flip driver
* start grippers in simulation
* Merge branch 'enhancement/separation_driver_control' into merge-aub
* added torso powerball to robot config
* use correct executable
* merge with ipa320
* some renaming as discussed
* separation of driver and controller
* merge with hydro_dev
* add cob4-2
* added voltage ctrl yaml for raw3-3
* beautifying
* added arguments to softkinetic launch file
* remove deprecated launch files in cob_driver and add nodes to cob_robots
* Renamed positions
* changes due to renaming from sdh to gripper and generic gazebo_services
* New maintainer
* added paths to field configs
* tab vs spaces
* tabs vs. spaces
* Merge remote-tracking branch 'origin/groovy_dev' into merge_groovy-dev
  Conflicts:
  CMakeLists.txt
  cob_bringup/robots/cob4-1.xml
  cob_controller_configuration_gazebo/controller/torso_controller_cob4.yaml
  cob_hardware_config/cob4-1/urdf/calibration_default.urdf.xacro
  cob_hardware_config/common/cob4.rviz
  cob_hardware_config/raw3-3/urdf/raw3-3.urdf.xacro
* merged groovy changes into hydro
* Torso  and head working
* Torso working
* integrated advanced led feedback into cob_monitor, old behaviour still working
* remap topic odometry
* flexisofft tested on robot
* Flexisoft launch and config files
* add roslaunch and urdf tests
* merge cob4
* tested on cob3-3
* setup cob4-1 xml
* Defined component_name as generic name (arm)
* merge
* merge
* default positions for cob4-1
* specific rviz configuration pro robot
* Contributors: Alexander Bubeck, Benjamin Maidel, Felix Messmer, Florian Weisshardt, Mathias Lüdtke, Nadia Hammoudeh García, abubeck, cob4-1, ipa-bnm, ipa-cob3-3, ipa-cob3-8, ipa-cob4-1, ipa-fmw, ipa-fxm, ipa-nhg, ipa-raw3-3, raw3-1 administrator
```
## cob_controller_configuration_gazebo

```
* unique identifier
* fixed yaml
* Merge branch 'hydro_dev' into indigo_dev
* setup cob3-8 simulation
* consequently remove lookat and hybrid stuff from cob3-X robots
* solve non-unique node names
* solve non-unique node names
* adapted gripper controller
* merge with hydro_dev
* Last update cob3-8
* use same PIDs as in ros-industrial repo
* no chance for tuning PID for follow_joint_trajectory controller for lwa4p -> currently do not use arms in urdf
* tune PID values for follow_joint_trajectory controller for torso
* remove obsolete i_clamp_min and i_clamp_max from yaml
* beautify
* increase spawner timeout for slow computers/complex models
* tuning controller parameters for new torso inertias
* adapted gazebo controllers
* Merge branch 'hydro_dev' of github.com:ipa320/cob_robots into indigo_dev
* test_publisher for controller tuning
* added test publisher
* fixes for raw3-3 simulation according torso-head-renaming
* moved lookat_controller yaml and launch files
* merged hydro upstream with simulation adaptions
* fix dependencies
* cleaning up debs
* cob3-8 has pg70 as gripper
* added timestamp to diagnostics msg
* cob3-8 with new structure
* moved base_controller to controllers folder
* call driver before controller
* Fixed reestructuration errors
* Added cob3-8
* fix dependencies
* cleaning up debs
* added missing launch file argument for image_flip
* Added cob_image_flip driver
* remove parameter for gazebo_adapter from cob_hardware_config
* add cob4-2
* Merge pull request #178 <https://github.com/ipa320/cob_robots/issues/178> from ipa-nhg/hydro_dev
  Inverted scanners position
* tweak ur_controller parameter
* merge with vel_control
* merge with hydro_control for new file structure
* defined ns for tray sensors (simulation)
* test and tweak head and lookat control for raw3-3
* merge with ipa320
* merge with prace updates
* Merge branch 'prace_dev' of github.com:ipa-fxm/cob_robots into prace_changes
* add gazebo_services for lookat for cob4-1
* lookat component for cob4-1
* optimize frida controller parameter
* loading controllers within adapter, no need for launch argument anymore
* changes due to renaming from sdh to gripper and generic gazebo_services
* cob4 fake diagnistics
* use gazebo joint_trajecory controller again for all components
* cleaning up
* vel_control and lookat_control with raw3-3
* changed fridas controller params
* moved file due to new structure
* Merge branch 'hydro_vel_control' into prace_changes
* Merge remote-tracking branch 'origin/groovy_dev' into merge_groovy-dev
  Conflicts:
  CMakeLists.txt
  cob_bringup/robots/cob4-1.xml
  cob_controller_configuration_gazebo/controller/torso_controller_cob4.yaml
  cob_hardware_config/cob4-1/urdf/calibration_default.urdf.xacro
  cob_hardware_config/common/cob4.rviz
  cob_hardware_config/raw3-3/urdf/raw3-3.urdf.xacro
* use hybrid_controller only for torso - all other components need more tuning
* changes on raw3-3 to get the powerball tracking running
* restructuring for hybrid_control
* merged groovy changes into hydro
* twist controller params in yaml + parameter tuning with arms
* back to torso-only
* preliminary vel control for schunk lwa4p
* preliminary velocity_control for head and sensorring
* update velocity control launchfile
* introducing cob_control_topic_mapper
* tune parameter for cob4-1_torso-only vel control
* try vel controller for cob4-1 torso
* use some velocity controller with cob3-3
* generic launch file for starting velocity controller
* new yaml files for velocity controller
* remove velocity controller params
* beautifying
* add dependency to ros_controllers
* add missing dependency
* add roslaunch and urdf tests
* Added sensors to cob4 description
* added gazebo head controller
* added gazebo controller for prace head
* specific rviz configuration pro robot
* define default robot argument
* Contributors: Alexander Bubeck, Felix Messmer, Florian Weisshardt, ipa-bnm, ipa-cob3-8, ipa-fxm, ipa-fxm-fm, ipa-nhg
```
## cob_default_robot_config

```
* Last update cob3-8
* cob3-8 setup
* setup cob3-8
* fixed dependencies
* cleaning up debs
* cob3-8 has pg70 as gripper
* Added cob3-8
* fixed dependencies
* cleaning up debs
* support for torso configs and init on raw3-3
* merge with ipa-bnm
* added default config to open/close gripper
* changes due to renaming and parameter optimization
* add cob4-2
* use arm_joint_configurations valid for current ur_model
* test and tweak head and lookat control for raw3-3
* merge with ipa320
* Renamed positions
* lookat component for cob4-1
* changes due to renaming from sdh to gripper and generic gazebo_services
* New maintainer
* cob4 fake diagnistics
* update cob4-1 torso and head positions
* Torso working
* support powerball head axis on raw3-3
* merge cob4 (cob_default_robot_config)
* add roslaunch and urdf tests
* fix filename
* Merge branch 'groovy_dev' of github.com:ipa-bnm/cob_robots into groovy_dev
  Conflicts:
  cob_default_robot_config/raw3-1/arm_joint_configurations.yaml
  cob_default_robot_config/raw3-1/command_gui_buttons.yaml
* added command gui button for new default pos
* added new default pos
* default positions for cob4-1
* Contributors: Alexander Bubeck, Florian Weisshardt, cob4-1, ipa-bnm, ipa-cob3-8, ipa-cob4-1, ipa-fmw, ipa-fxm, ipa-nhg, ipa-raw3-3
```
## cob_hardware_config

```
* move EmergencyStopState.msg to cob_msgs
* remove obsolete cob_hwboard
* inverted scanners
* consequently remove lookat and hybrid stuff from cob3-X robots
* calibration error
* Merge pull request #209 <https://github.com/ipa320/cob_robots/issues/209> from ipa-nhg/hydro_dev
  Inverted scanners
* Update calibration_default.urdf.xacro
* Update calibration_default.urdf.xacro
  back to CAD values
* separated ports for tray and torso
* Last update cob3-8
* beautify
* Merge branch 'hydro_dev' of https://github.com/ipa320/cob_robots into hydro_dev
* setup cob3-8
* cob3-8 setup
* no chance for tuning PID for follow_joint_trajectory controller for lwa4p -> currently do not use arms in urdf
* previous value makes torso collide with base
* Inverted scanners
* Merge branch 'hydro_dev' of github.com:ipa320/cob_robots into hydro_dev
* beautify
* add all joints again
* offset error
* Undo calibration
* use the  macros instead 3.1415...
* added comment to head.yaml files
* added namespace diagnostics
* switch laser orientation for all robots
* fix safey scanner fields
* set default flexisoft safety velocity limits
* adjusted diagnostics parameters and renamed gripper_controller
* renamed pg70
* adapted gazebo controllers
* setup cob3-8 : The arm is lwa4d
* setup cob3-8
* corrected value due to inclusion of PRL100 in lwa4p_extended model
* moved lookat_controller yaml and launch files
* fix dependencies
* cleaning up debs
* use new X_driver.yaml format for all robots with canopen components
* fix service namespace
* new layout for X_driver.yaml file, solves module_ids issue
* cob3-8 has pg70 as gripper
* added classname as suggested in deprecation warning
* separate controller and driver yaml file
* cob3-8 with new structure
* merge conflict
* rename head description
* Added cob3-8
* fix dependencies
* cleaning up debs
* config changed
* use prace_tower instad of tower_symmetric
* config for ms35 light controller
* Retabbing properties
* Retabbing calibration
* multiple config changes for raw3-4
* switched digital ports for grippers
* changes due to renaming and parameter optimization
* bring latest raw3-3 changes to new structure
* Added cob_image_flip driver
* added calibration stuff for torso powerball
* added torso powerball to robot config
* renaming after merge
* some renaming as discussed
* remove parameter for gazebo_adapter from cob_hardware_config
* separation of driver and controller
* add cob4-2
* merged prace descriptions into one xacro makro
* Merge branch 'hydro_dev' of github.com:ipa320/cob_robots into hydro_dev
* added voltage ctrl yaml for raw3-3
* Merge pull request #178 <https://github.com/ipa320/cob_robots/issues/178> from ipa-nhg/hydro_dev
  Inverted scanners position
* merge with hydro_control for new file structure
* merge prace
* Taking the real value for scanners position
* Inverted scanners position
* test and tweak head and lookat control for raw3-3
* Merge branch 'hydro_dev' of github.com:ipa320/cob_robots into hydro_dev
* added new longer/higher neck
* merge with ipa320
* merge with prace updates
* Merge branch 'prace_dev' of github.com:ipa-fxm/cob_robots into prace_changes
* add gazebo_services for lookat for cob4-1
* lookat component for cob4-1
* changed marker type
* increased angular threshold
* changes due to renaming from sdh to gripper and generic gazebo_services
* updated laser fields to improve transition behaviour
* New maintainer
* updated flexisoft config
* added laser field configs for cob4-1
* cob4 fake diagnistics
* cleaning up
* Merge branch 'hydro_dev' of github.com:ipa320/cob_robots into hydro_control
* vel_control and lookat_control with raw3-3
* Merge remote-tracking branch 'origin/groovy_dev' into merge_groovy-dev
  Conflicts:
  CMakeLists.txt
  cob_bringup/robots/cob4-1.xml
  cob_controller_configuration_gazebo/controller/torso_controller_cob4.yaml
  cob_hardware_config/cob4-1/urdf/calibration_default.urdf.xacro
  cob_hardware_config/common/cob4.rviz
  cob_hardware_config/raw3-3/urdf/raw3-3.urdf.xacro
* changes on raw3-3 to get the powerball tracking running
* restructuring for hybrid_control
* softkinetic cameras mount (including camera pillar) on raw3-1
* merged groovy changes into hydro
* Torso  and head working
* twist controller params in yaml + parameter tuning with arms
* added parameters for enabling and disabling sound and led's in cob_monitor
* Torso working
* back to torso-only
* preliminary vel control for schunk lwa4p
* preliminary velocity_control for head and sensorring
* integrated advanced led feedback into cob_monitor, old behaviour still working
* added rfid urdf in hydro
* tune parameter for cob4-1_torso-only vel control
* support powerball head axis on raw3-3
* try vel controller for cob4-1 torso
* separate yaml file for cob_trajector_controller params
* flexisofft tested on robot
* Flexisoft launch and config files
* Changes for the multiple chains node!
* add roslaunch and urdf tests
* merge cob4
* setup cob4-1 xml
* Added sensors to cob4 description
* added calibration data for raw3-3s head
* added gazebo controller for prace head
* merge
* Defined component_name as generic name (arm)
* clean up
* added rfid reader on raw31 in raw3-1.urdf.xacro
* fix filename
* default positions for cob4-1
* specific rviz configuration pro robot
* Contributors: Alexander Bubeck, Felipe Garcia Lopez, Felix Messmer, Florian Weisshardt, Mathias Lüdtke, Nadia Hammoudeh García, abubeck, cob4-1, ipa-bnm, ipa-cob3-8, ipa-cob4-1, ipa-fmw, ipa-fxm, ipa-nhg, ipa-raw3-3, ipa-srd, raw3-1 administrator, thiagodefreitas
```
## cob_monitoring

```
* move EmergencyStopState.msg to cob_msgs
* changes due to introduction of cob_msgs
* cleaning up debs
* cleaning up debs
* added parameters for enabling and disabling sound and led's in cob_monitor
* integrated advanced led feedback into cob_monitor, old behaviour still working
* Contributors: Felix Messmer, ipa-fxm, raw3-1 administrator
```
## cob_robots

```
* New maintainer
* Contributors: ipa-nhg
```
