### PR TITLE
camera1394stereo: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -266,6 +266,21 @@ repositories:
       url: https://github.com/ros-drivers/camera1394.git
       version: master
     status: maintained
+  camera1394stereo:
+    doc:
+      type: git
+      url: https://github.com/srv/camera1394stereo.git
+      version: 1.0.3
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/srv/camera1394stereo-release.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/srv/camera1394stereo.git
+      version: 1.0.3
+    status: maintained
   camera_info_manager_py:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera1394stereo` to `1.0.3-0`:
- upstream repository: https://github.com/srv/camera1394stereo.git
- release repository: https://github.com/srv/camera1394stereo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
