### PR TITLE
avt_vimba_camera: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -140,6 +140,21 @@ repositories:
       url: https://github.com/ros-drivers/audio_common.git
       version: hydro-devel
     status: maintained
+  avt_vimba_camera:
+    doc:
+      type: git
+      url: https://github.com/srv/avt_vimba_camera.git
+      version: 0.0.3
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/srv/avt_vimba_camera-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/srv/avt_vimba_camera.git
+      version: 0.0.3
+    status: maintained
   ax2550:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `avt_vimba_camera` to `0.0.3-0`:
- upstream repository: https://github.com/srv/avt_vimba_camera.git
- release repository: https://github.com/srv/avt_vimba_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
