### PR TITLE
cob_simulation: 0.5.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -601,6 +601,27 @@ repositories:
       url: https://github.com/ipa320/cob_robots.git
       version: indigo_dev
     status: maintained
+  cob_simulation:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_simulation.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_bringup_sim
+      - cob_gazebo
+      - cob_gazebo_objects
+      - cob_gazebo_worlds
+      - cob_simulation
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/cob_simulation-release.git
+      version: 0.5.3-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_simulation.git
+      version: indigo_dev
+    status: maintained
   cob_substitute:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.5.3-0`:
- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
