### PR TITLE
slam_gmapping: 1.3.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6714,7 +6714,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/slam_gmapping-release.git
-      version: 1.3.4-0
+      version: 1.3.5-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/slam_gmapping.git
+      version: hydro-devel
     status: maintained
   slam_karto:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_gmapping` to `1.3.5-0`:
- upstream repository: https://github.com/ros-perception/slam_gmapping
- release repository: https://github.com/ros-gbp/slam_gmapping-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.3.4-0`
## gmapping

```
* Fixed typo in slam_gmapping_pr2.launch
  Fixed a typo in the launchfile in the parameter "map_update_interval".
* Contributors: DaMalo
```
## slam_gmapping
- No changes
