### PR TITLE
hector_localization: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1455,10 +1455,10 @@ repositories:
       - hector_pose_estimation
       - hector_pose_estimation_core
       - message_to_tf
-      - world_magnetic_model
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
+      version: 0.1.4-0
     status: maintained
   hector_models:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_localization` to `0.1.4-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_localization.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## hector_localization

```
* Removed package world_magnetic_model as it is currently not used by hector_pose_estimation
  The package is still available in the world_magnetic_model branch.
* Contributors: Johannes Meyer
```
## hector_pose_estimation
- No changes
## hector_pose_estimation_core

```
* calculate euler angles directly in pose update without Eigen
  Eigen's eulerAngles() returns wrong yaw angles in Trusty for some reason.
* Contributors: Johannes Meyer
```
## message_to_tf
- No changes
