### PR TITLE
topic_proxy: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4671,6 +4671,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/topic_proxy-release.git
+      version: 0.1.1-0
     status: maintained
   turtlebot_arm:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_proxy` to `0.1.1-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/topic_proxy.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/topic_proxy-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## blob
- No changes
## topic_proxy

```
* Fixed missing return value in Client::init()
* Contributors: Johannes Meyer
```
