### PR TITLE
cob_perception_common: 0.5.10-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -841,7 +841,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/cob_perception_common-release.git
-      version: 0.5.6-2
+      version: 0.5.10-0
     source:
       type: git
       url: https://github.com/ipa320/cob_perception_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_perception_common` to `0.5.10-0`:
- upstream repository: https://github.com/ipa320/cob_perception_common.git
- release repository: https://github.com/ipa320/cob_perception_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.6-2`
## cob_image_flip

```
* downgrade version for hydro
* using opencv2 instead of libopencv-dev for hydro version (should not be merged into indigo)
* 0.6.1
* update changelog
* Merge branch 'indigo_dev' into indigo_release_candidate
* fix wrong opencv dep - again
* 0.6.0
* update changelog
* 0.5.5
* Merge pull request #26 <https://github.com/ipa320/cob_perception_common/issues/26> from ipa320/hydro_dev
  updates from hydro_dev
* update changelog
* fix wrong opencv dep
* Contributors: Alexander Bubeck, Florian Weisshardt
```
## cob_object_detection_msgs

```
* downgrade version for hydro
* 0.6.1
* update changelog
* 0.6.0
* update changelog
* 0.5.5
* update changelog
* Contributors: Florian Weisshardt
```
## cob_perception_common

```
* downgrade version for hydro
* 0.6.1
* update changelog
* 0.6.0
* update changelog
* merge
* 0.5.5
* change maintainer
* update changelog
* Contributors: Florian Weisshardt
```
## cob_perception_msgs

```
* downgrade version for hydro
* 0.6.1
* update changelog
* 0.6.0
* update changelog
* 0.5.5
* update changelog
* Contributors: Florian Weisshardt
```
## cob_vision_utils

```
* downgrade version for hydro
* using opencv2 instead of libopencv-dev for hydro version (should not be merged into indigo)
* 0.6.1
* update changelog
* Merge branch 'indigo_dev' into indigo_release_candidate
* fix wrong opencv dep - again
* 0.6.0
* update changelog
* merge with hydro
* catkin_lint'ing
* 0.5.5
* Merge pull request #26 <https://github.com/ipa320/cob_perception_common/issues/26> from ipa320/hydro_dev
  updates from hydro_dev
* update changelog
* Merge branch 'hydro_dev' of github.com:ipa320/cob_perception_common into indigo_dev
* fix wrong opencv dep
* added install tags
* Contributors: Alexander Bubeck, Florian Weisshardt, ipa-fxm
```
