### PR TITLE
cob_perception_common: 0.6.1-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -628,7 +628,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_perception_common-release.git
-      version: 0.6.1-0
+      version: 0.6.1-2
     source:
       type: git
       url: https://github.com/ipa320/cob_perception_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_perception_common` to `0.6.1-2`:
- upstream repository: https://github.com/ipa320/cob_perception_common.git
- release repository: https://github.com/ipa320/cob_perception_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.6.1-0`
## cob_image_flip

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* fix wrong opencv dep - again
* Contributors: Florian Weisshardt
```
## cob_object_detection_msgs
- No changes
## cob_perception_common
- No changes
## cob_perception_msgs
- No changes
## cob_vision_utils

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* fix wrong opencv dep - again
* Contributors: Florian Weisshardt
```
