### PR TITLE
people: 1.0.6-1 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3072,7 +3072,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/OSUrobotics/people-release.git
-      version: 1.0.6-0
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/wg-perception/people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `people` to `1.0.6-1`:
- upstream repository: https://github.com/wg-perception/people.git
- release repository: https://github.com/OSUrobotics/people-release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.6-0`
