### PR TITLE
turtlebot_arm: 0.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4690,7 +4690,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_arm-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot_arm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_arm` to `0.3.2-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_arm.git
- release repository: https://github.com/turtlebot-release/turtlebot_arm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.3.1-0`
## turtlebot_arm
- No changes
## turtlebot_arm_bringup

```
* Use gripper_controller instead of gripper_controller.py, as the later doesn't get installed
```
## turtlebot_arm_description

```
* Use base_link instead of base_footprint as the reference "fixed" frame
```
## turtlebot_arm_ikfast_plugin
- No changes
## turtlebot_arm_kinect_calibration
- No changes
## turtlebot_arm_moveit_config

```
* Add turtlebot_arm_moveit.launch: a version of demo.launch with simulation on/off
```
## turtlebot_arm_moveit_demos

```
* Use base_link instead of base_footprint as the reference "fixed" frame
```
