### PR TITLE
geographic_info: 0.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1301,6 +1301,15 @@ repositories:
       type: git
       url: https://github.com/ros-geographic-info/geographic_info.git
       version: master
+    release:
+      packages:
+      - geodesy
+      - geographic_info
+      - geographic_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-geographic-info/geographic_info-release.git
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/ros-geographic-info/geographic_info.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geographic_info` to `0.3.2-0`:
- upstream repository: https://github.com/ros-geographic-info/geographic_info.git
- release repository: https://github.com/ros-geographic-info/geographic_info-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## geodesy
- No changes
## geographic_info
- No changes
## geographic_msgs
- No changes
