### PR TITLE
rtmros_common: 1.2.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6199,7 +6199,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.2.1-0
+      version: 1.2.2-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.2.2-0`:
- upstream repository: https://github.com/start-jsk/rtmros_common.git
- release repository: https://github.com/tork-a/rtmros_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.2.1-0`
## hrpsys_ros_bridge

```
* (rtm-ros-robot-interface)

    * Define Euslisp setter and getter from param slots names
    * Update set-st-param for Stabilizer
    * Add KalmanFilter ROS Bridge and euslisp interface to hrpsys_ros_bridge.launch
    * Add calibrate-inertia-sensor
    * Add new arguments for new st param
    * Fix end-effector name (without colon) according to https://github.com/fkanehiro/hrpsys-base/pull/301
    * Update abc and st euslisp interface according to idl update, fkanehiro/hrpsys-base#239 <https://github.com/fkanehiro/hrpsys-base/issues/239>
    * Access robot-state's imu in callback to fix https://github.com/start-jsk/rtmros_tutorials/issues/67

* Use catkin_make -C to change direcotry (Fix #523 <https://github.com/start-jsk/rtmros_common/issues/523>)
* (datalogger-log-parser.l)

    * Support https://github.com/jsk-ros-pkg/jsk_pr2eus/commit/3200b63dfcbd3c02b919fe6ad03c425e5057ee5c commit
    * Support both reference worldcoords and actual worldcoords ;; StateHolder's value is reference and kf is actual.

* added make-default-ForceCalibPosesForLegs to euslisp/calib-force-sensor-params.l
* (Force sensor)

    * fixed accessing to force sensor in calibration function
    * fix AbsoluteForceSensorService -> RemoveForceSensorLinkOffsetService

* (compile_robot_model.cmake, hrpsys.launch, hrpsys_tools_config.py) Add argument to use Unstable RTC List and configure it from cmake discussed in https://github.com/start-jsk/rtmros_gazebo/pull/61
* Contributors: Kei Okada, Kunio Kojima, Shunichi Nozawa, Masaki Murooka, Isaac IY Saito
```
## hrpsys_tools

```
* (hrpsys.launch) : Add config_file setting for HGcontroller
* (compile_robot_model.cmake, hrpsys.launch, hrpsys_tools_config.py) Add argument to use Unstable RTC List and configure it from cmake discussed in https://github.com/start-jsk/rtmros_gazebo/pull/61
* Contributors: Shunichi Nozawa
```
## openrtm_ros_bridge
- No changes
## openrtm_tools
- No changes
## rosnode_rtc
- No changes
## rtmbuild
- No changes
## rtmros_common

```
* (rtm-ros-robot-interface)

    * Define Euslisp setter and getter from param slots names
    * Update set-st-param for Stabilizer
    * Add KalmanFilter ROS Bridge and euslisp interface to hrpsys_ros_bridge.launch
    * Add calibrate-inertia-sensor
    * Add new arguments for new st param
    * Fix end-effector name (without colon) according to https://github.com/fkanehiro/hrpsys-base/pull/301
    * Update abc and st euslisp interface according to idl update, fkanehiro/hrpsys-base#239 <https://github.com/fkanehiro/hrpsys-base/issues/239>
    * Access robot-state's imu in callback to fix https://github.com/start-jsk/rtmros_tutorials/issues/67

* Use catkin_make -C to change direcotry (Fix #523 <https://github.com/start-jsk/rtmros_common/issues/523>)
* (datalogger-log-parser.l)

    * Support https://github.com/jsk-ros-pkg/jsk_pr2eus/commit/3200b63dfcbd3c02b919fe6ad03c425e5057ee5c commit
    * Support both reference worldcoords and actual worldcoords ;; StateHolder's value is reference and kf is actual.

* added make-default-ForceCalibPosesForLegs to euslisp/calib-force-sensor-params.l
* (Force sensor)

    * fixed accessing to force sensor in calibration function
    * fix AbsoluteForceSensorService -> RemoveForceSensorLinkOffsetService

* (compile_robot_model.cmake, hrpsys.launch, hrpsys_tools_config.py) Add argument to use Unstable RTC List and configure it from cmake discussed in https://github.com/start-jsk/rtmros_gazebo/pull/61
* (hrpsys.launch) : Add config_file setting for HGcontroller
* Contributors: Kei Okada, Kunio Kojima, Shunichi Nozawa, Masaki Murooka, Isaac IY Saito
```
