### PR TITLE
rosbridge_suite: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3888,7 +3888,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.6.1-0`:
- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.6.0-0`
## rosapi

```
* make rosapis use absolute namespace
* Contributors: Jihoon Lee
```
## rosbridge_library

```
* Handle float infinity and NAN s
* Windows-related fix for PIL Image module import
* Fixed typo in raising type errors.
* something messed up indentation
  not sure how that could happen, worked here.
* map Inf and NaN to null
  JSON does not support Inf and NaN values. Currently they are just written into the JSON and JSON.parse on the client side will fail. Correct is to map them to null which will then be parsed correctly by JSON.parse on the client side.
  The issue with that is that the shortcut for lists of floats might be impossible (maybe someone else with more experience in python comes up with something else?). Maybe something similar is necessary in the to_inst case, but I can not really test them.
  Real world application is to process laser scans, they contain inf and nan values for some drivers if the measurements are invalid or out of range.
* Update .travis.yml and package.xml for rosbridge_library tests
* Put back unregister for the publisher and clarify the reconnect behavior
  of the test case. The exponential backoff of the client causes hard to
  understand timing of the events.
  All specs passed locally on hydro:
  SUMMARY
  * RESULT: SUCCESS
  * TESTS: 103
  * ERRORS: 0
  * FAILURES: 0
* Add copyright notice to the file
* Remove extra whitespace
* Make the test more deterministic
* Remove circular dependency.
* Contributors: Achim Königs, Alex Sorokin, Alexander Sorokin, Jonathan Wade, jon-weisz
```
## rosbridge_server
- No changes
## rosbridge_suite
- No changes
