### PR TITLE
avt_vimba_camera: 0.0.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -149,7 +149,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/srv/avt_vimba_camera-release.git
-      version: 0.0.3-0
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/srv/avt_vimba_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `avt_vimba_camera` to `0.0.3-1`:
- upstream repository: https://github.com/srv/avt_vimba_camera.git
- release repository: https://github.com/srv/avt_vimba_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.3-0`
