### PR TITLE
hector_quadrotor: 0.3.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2182,7 +2182,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_quadrotor-release.git
-      version: 0.3.2-1
+      version: 0.3.3-0
     status: maintained
   hector_quadrotor_apps:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_quadrotor` to `0.3.3-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_quadrotor-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.3.2-1`
## hector_quadrotor

```
* moved simulation package dependencies from hector_quadrotor metapackage to hector_quadrotor_gazebo
* Contributors: Johannes Meyer
```
## hector_quadrotor_controller

```
* fixed some compiler warnings and missing return values
* increased integral gain for attitude stabilization (fix #12)
* make a copy of the root NodeHandle in all controllers
  For some reason deconstructing the TwistController resulted in a pure virtual function call without this patch.
* Contributors: Johannes Meyer
```
## hector_quadrotor_controller_gazebo
- No changes
## hector_quadrotor_demo
- No changes
## hector_quadrotor_description
- No changes
## hector_quadrotor_gazebo

```
* cleaned up launch files and fixed argument forwarding to spawn_quadrotor.launch
* removed all RTT related plugins
* added separate update timer for MotorStatus output in propulsion plugin
* added launch file argument to enable/disable pose estimation
* moved simulation package dependencies from hector_quadrotor metapackage to hector_quadrotor_gazebo
* Contributors: Johannes Meyer
```
## hector_quadrotor_gazebo_plugins

```
* fixed some compiler warnings and missing return values
* added separate update timer for MotorStatus output in propulsion plugin
* Contributors: Johannes Meyer
```
## hector_quadrotor_model

```
* fixed target_link_libraries() line for the quadrotor_aerodynamics library
* fixed missing cmake commands to link with boost and roscpp
* always use newest available motor command in propulsion plugin
* added cmake_modules dependency
* Contributors: Johannes Meyer, Rasit Eskicioglu
```
## hector_quadrotor_pose_estimation
- No changes
## hector_quadrotor_teleop

```
* added run dependency to joy package (joystick drivers)
* Contributors: Johannes Meyer
```
## hector_uav_msgs

```
* updated value type in RawImu message to int16
* added new ControllerState status constant FLYING
* added CLIMBRATE and TURNRATE constants to ControllerState message
* Contributors: Johannes Meyer
```
