### PR TITLE
cob_perception_common: 0.5.11-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -841,7 +841,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/cob_perception_common-release.git
-      version: 0.5.10-1
+      version: 0.5.11-0
     source:
       type: git
       url: https://github.com/ipa320/cob_perception_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_perception_common` to `0.5.11-0`:
- upstream repository: https://github.com/ipa320/cob_perception_common.git
- release repository: https://github.com/ipa320/cob_perception_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.10-1`
## cob_image_flip
- No changes
## cob_object_detection_msgs
- No changes
## cob_perception_common
- No changes
## cob_perception_msgs
- No changes
## cob_vision_utils

```
* add tinyxml to package.xml
* Contributors: Florian Weisshardt
```
