### PR TITLE
rtmros_hironx: 1.0.23-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4248,7 +4248,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.19-0
+      version: 1.0.23-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.23-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.19-0`
## hironx_moveit_config

```
* (hironx moveit) Remove a file added by mistake.
* Contributors: Isaac IY Saito
```
## hironx_ros_bridge

```
* (ROS cpp client) Export the right lib file (Fix #229 <https://github.com/start-jsk/rtmros_hironx/issues/229>).
* (hironx ROS client py) Add cartesian set target method. Acceptance test for it is not working yet.
* (hironx_ros) Split constants as a class.
* Contributors: Isaac I.Y. Saito
```
## rtmros_hironx
- No changes
