### PR TITLE
gazebo_ros_pkgs: 2.3.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1757,7 +1757,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.3.6-0
+      version: 2.3.7-0
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.3.7-0`:
- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `2.3.6-0`
## gazebo_msgs
- No changes
## gazebo_plugins

```
* Merge pull request #204 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/204> from fsuarez6/hydro-devel
  gazebo_plugins: Adding ForceTorqueSensor Plugin
* Updated to Apache 2.0 license
* check deprecation of gazebo::Joint::SetAngle by SetPosition
* compatibility with gazebo 4.x
* Added Gaussian Noise generator
* publish organized pointcloud from openni plugin
* Changed measurement direction to "parent to child"
* gazebo_plugin: Added updateRate parameter to the gazebo_ros_imu plugin
* gazebo_plugins: Adding ForceTorqueSensor Plugin
* ros_camera_utils: Adding CameraInfoManager to satisfy full ROS camera API (relies on https://github.com/ros-perception/image_common/pull/20 )
  ros_camera_utils: Adding CameraInfoManager to satisfy full ROS camera API (relies on https://github.com/ros-perception/image_common/pull/20 )
* Contributors: John Hsu, Jonathan Bohren, Ryohei Ueda, fsuarez6, gborque, hsu, Jon Binney
```
## gazebo_ros

```
* check physics engine type before calling set_physics_properties and get_physics_properteis
* Contributors: John Hsu
```
## gazebo_ros_control
- No changes
## gazebo_ros_pkgs
- No changes
