### PR TITLE
hector_models: 0.3.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2149,7 +2149,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
-      version: 0.3.1-1
+      version: 0.3.2-0
     status: maintained
   hector_navigation:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_models` to `0.3.2-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_models.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.3.1-1`
## hector_components_description

```
* increased maximum torque for camera servos in vision_box_common.gazebo.xacro
* adapted urdf for asus xtion and added camera variables
* Add simple ps eye geometry
* Contributors: Johannes Meyer, Stefan Kohlbrecher
```
## hector_models
- No changes
## hector_sensors_description

```
* Updated asus xtion pro live mesh to reflect actual sensor dimensions, add stl version
* Contributors: Stefan Kohlbrecher
```
## hector_xacro_tools
- No changes
