### PR TITLE
hector_gazebo: 0.3.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2116,7 +2116,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
-      version: 0.3.3-0
+      version: 0.3.4-0
     status: maintained
   hector_localization:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_gazebo` to `0.3.4-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.3.3-0`
## hector_gazebo

```
* Removed package gazebo_rtt_plugin
  This package is obsolete. Use the rtt_gazebo stack instead.
* Contributors: Johannes Meyer
```
## hector_gazebo_plugins

```
* replaced old copied license header in servo_plugin.cpp
* simplified attitude error calculation in gazebo_ros_imu (fixes #12)
* fixed calculation of vector-valued sensor errors and sensor error model resetting with non-zero initial drift
* linking against catkin_libraries
* Contributors: Johannes Meyer, Markus Achtelik
```
## hector_gazebo_thermal_camera
- No changes
## hector_gazebo_worlds

```
* updated world files to SDF 1.4 using gzsdf
* Change light for sick robot day 2014 world, add number panel example
* Add sick robot number panel stl file for collision geom
* Add collada files for sick robot day number panels
* Add sick robot day number panels
* Add sick robot day 2014 related files
* Add model for sick robot day 2014 ring
* added args roslaunch argument to pass additional command line arguments to gzserver
* Contributors: Johannes Meyer, Stefan Kohlbrecher
```
## hector_sensors_gazebo
- No changes
