### PR TITLE
camera1394: 1.10.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -276,6 +276,11 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/camera1394.git
       version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/camera1394-release.git
+      version: 1.10.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/camera1394.git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera1394` to `1.10.0-0`:
- upstream repository: https://github.com/ros-drivers/camera1394.git
- release repository: https://github.com/ros-drivers-gbp/camera1394-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## camera1394
- No changes
