### PR TITLE
barrett_hand: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -237,6 +237,16 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/barrett_hand.git
       version: hydro-devel
+    release:
+      packages:
+      - barrett_hand
+      - bhand_controller
+      - bhand_description
+      - rqt_bhand
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/RobotnikAutomation/barrett_hand-release.git
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/barrett_hand.git


### PR DESCRIPTION
Increasing version of package(s) in repository `barrett_hand` to `0.1.0-0`:
- upstream repository: https://github.com/RobotnikAutomation/barrett_hand.git
- release repository: https://github.com/RobotnikAutomation/barrett_hand-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
