### PR TITLE
neo_driver-release: 0.1.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2615,7 +2615,11 @@ repositories:
       url: https://github.com/DLu/navigation_layers.git
       version: hydro
     status: maintained
-  neo_driver-release:
+  neo_driver:
+    doc:
+      type: git
+      url: https://github.com/neobotix/neo_driver.git
+      version: indigo_dev
     release:
       packages:
       - neo_base_mp_400
@@ -2632,7 +2636,7 @@ repositories:
     source:
       type: git
       url: https://github.com/neobotix/neo_driver.git
-      version: 0.1.2
+      version: indigo_dev
     status: developed
   nmea_comms:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2615,6 +2615,25 @@ repositories:
       url: https://github.com/DLu/navigation_layers.git
       version: hydro
     status: maintained
+  neo_driver-release:
+    release:
+      packages:
+      - neo_base_mp_400
+      - neo_base_mp_500
+      - neo_msgs
+      - neo_platformctrl_diff
+      - neo_platformctrl_mecanum
+      - neo_relayboard
+      - neo_watchdogs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/neobotix/neo_driver-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/neobotix/neo_driver.git
+      version: 0.1.2
+    status: developed
   nmea_comms:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `neo_driver-release` to `0.1.2-1`:
- upstream repository: https://github.com/neobotix/neo_driver.git
- release repository: https://github.com/neobotix/neo_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## neo_base_mp_400
- No changes
## neo_base_mp_500
- No changes
## neo_msgs

```
* pr2_msgs and neo_relayboard messages removed or moved to new package neo_msgs
* Contributors: Osiron007
```
## neo_platformctrl_diff
- No changes
## neo_platformctrl_mecanum
- No changes
## neo_relayboard

```
* fixed .temperature to .data for std_msgs::Int16
* pr2_msgs and neo_relayboard messages removed or moved to new package neo_msgs
* pr2 dep removed
* removed pr2_msgs from CMakeFiles
* pr2_msgs removed from build and run dependecies
* Contributors: Osiron007
```
## neo_watchdogs

```
* fixed .temperature to .data for std_msgs::Int16
* --> removed
* neo_watchdogs updated message files from pr2_msgs to neo_msgs
* pr2 dep removed
* removed pr2_msgs from CMakeFiles
* pr2_msgs removed from build and run dependecies
* Contributors: Osiron007
```
