### PR TITLE
ros_ethernet_rmp: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3789,7 +3789,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/ros_ethernet_rmp-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/ros_ethernet_rmp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ethernet_rmp` to `0.0.6-0`:
- upstream repository: https://github.com/WPI-RAIL/ros_ethernet_rmp.git
- release repository: https://github.com/wpi-rail-release/ros_ethernet_rmp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.5-0`
## ros_ethernet_rmp

```
* fixed wheel direction for joint state publisher to work correctly with the fixed urdf
* Contributors: dekent
```
