### PR TITLE
carl_bot: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -362,7 +362,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_bot-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_bot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_bot` to `0.0.4-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_bot.git
- release repository: https://github.com/wpi-rail-release/carl_bot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.3-0`
## carl_bot
- No changes
## carl_bringup

```
* view added to bringup
* Updated rgb camera calibration for the ASUS
* Contributors: David Kent, Russell Toris
```
## carl_description

```
* start position of arm fixed
* fixed rotation of arm
* JACO arm added back
* rebuild of URDF
* moved to minified DAE
* re-wrote URDF to fix collision problems
* new collision test
* Contributors: Russell Toris
```
## carl_dynamixel

```
* fixed typo in front servos
* updated links for servos
* Contributors: Russell Toris
```
## carl_teleop
- No changes
