### PR TITLE
rosbag_image_compressor: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3887,7 +3887,7 @@ repositories:
       version: 0.1.0-0
     source:
       type: git
-      url: git@github.com:ros-gbp/rosbag_image_compressor-release.git
+      url: https://github.com/ros/rosbag_image_compressor.git
       version: indigo-devel
     status: maintained
   rosbag_migration_rule:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3875,6 +3875,21 @@ repositories:
       url: https://github.com/WPI-RAIL/rosauth.git
       version: develop
     status: maintained
+  rosbag_image_compressor:
+    doc:
+      type: git
+      url: https://github.com/ros/rosbag_image_compressor.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rosbag_image_compressor-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: git@github.com:ros-gbp/rosbag_image_compressor-release.git
+      version: indigo-devel
+    status: maintained
   rosbag_migration_rule:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_image_compressor` to `0.1.0-0`:
- upstream repository: https://github.com/ros/rosbag_image_compressor.git
- release repository: https://github.com/ros-gbp/rosbag_image_compressor-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## rosbag_image_compressor

```
* Create package for png compression of images in bagfiles and then
  uncompressing.
* Contributors: Tully Foote
```
