### PR TITLE
rtmros_common: 1.2.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6209,7 +6209,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.2.2-0
+      version: 1.2.3-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.2.3-0`:
- upstream repository: https://github.com/start-jsk/rtmros_common.git
- release repository: https://github.com/tork-a/rtmros_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.2.2-0`
## hrpsys_ros_bridge
- No changes
## hrpsys_tools
- No changes
## openrtm_ros_bridge
- No changes
## openrtm_tools
- No changes
## rosnode_rtc
- No changes
## rtmbuild

```
* fix rtmbuild.cmake
* Contributors: terasawa
```
## rtmros_common
- No changes
