### PR TITLE
ardrone_autonomy: 1.3.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -149,7 +149,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/AutonomyLab/ardrone_autonomy-release.git
-      version: 1.3.4-0
+      version: 1.3.5-0
     source:
       type: git
       url: https://github.com/AutonomyLab/ardrone_autonomy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ardrone_autonomy` to `1.3.5-0`:
- upstream repository: https://github.com/AutonomyLab/ardrone_autonomy.git
- release repository: https://github.com/AutonomyLab/ardrone_autonomy-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.3.4-0`
## ardrone_autonomy

```
* Fixed Incorrect orientation in ardrone/imu #113  ht @tomas-c
* Added install rules for launch files. #114 ht @kbogert @fig0451
* ARDroneSDK is now fetched from an external repository. Patches are applied there.
* Add unit for pressure readings to README @garyservin
* Moved header files to include directory #110 @garyservin
* Fix ffmpeg library link order #109 @garyservin
* Contributors: Gary Servin, Mani Monajjemi
```
