### PR TITLE
Revert "cob_perception_common: 0.5.11-0 in 'hydro/distribution.yaml' [bl...

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -851,7 +851,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/cob_perception_common-release.git
-      version: 0.5.11-0
+      version: 0.5.10-1
     source:
       type: git
       url: https://github.com/ipa320/cob_perception_common.git


### PR DESCRIPTION
Reverts ros/rosdistro#5468  @ipa-fmw 

This release is building packages numbered 0.6.1 but declares itself 0.5.11 causing the buildfarm to infinite loop. 

I think the upstream was incorrect when running the release. 
