### PR TITLE
rosbag_image_compressor: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5651,6 +5651,21 @@ repositories:
       url: https://github.com/WPI-RAIL/rosauth.git
       version: develop
     status: maintained
+  rosbag_image_compressor:
+    doc:
+      type: git
+      url: https://github.com/ros/rosbag_image_compressor.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/rosbag_image_compressor-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/ros/rosbag_image_compressor.git
+      version: indigo-devel
+    status: maintained
   rosbag_migration_rule:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_image_compressor` to `0.1.1-0`:
- upstream repository: https://github.com/ros/rosbag_image_compressor.git
- release repository: https://github.com/ros-gbp/rosbag_image_compressor-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## rosbag_image_compressor

```
* fixing installation
* Contributors: Tully Foote
```
