### PR TITLE
rtmros_nextage: 0.4.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6263,7 +6263,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.2.18-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.4.1-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.2.18-0`
## nextage_description

```
* Remove WAIST_Link to use only WAIST (Fix #97 <https://github.com/tork-a/rtmros_nextage/issues/97>).
* Contributors: Isaac IY Saito
```
## nextage_moveit_config

```
* Remove WAIST_Link to use only WAIST (Fix #97 <https://github.com/tork-a/rtmros_nextage/issues/97>).
* Contributors: Isaac IY Saito
```
## nextage_ros_bridge

```
* Remove WAIST_Link to use only WAIST (Fix "Either Interactive Marker or Natto-view appears, not together." #97 <https://github.com/tork-a/rtmros_nextage/issues/97>).
* DIO Accessor:

    * Ignore tests for hand lighting when on simulation (Fix #94 <https://github.com/tork-a/rtmros_nextage/issues/94>)
    * (DIO files) Minor improvement to api doc.

* Contributors: Isaac IY Saito
```
## rtmros_nextage

```
* Remove WAIST_Link to use only WAIST (Fix "Either Interactive Marker or Natto-view appears, not together." #97 <https://github.com/tork-a/rtmros_nextage/issues/97>).
* DIO Accessor:

    * Ignore tests for hand lighting when on simulation (Fix #94 <https://github.com/tork-a/rtmros_nextage/issues/94>)
    * (DIO files) Minor improvement to api doc.

* Contributors: Isaac IY Saito
```
