### PR TITLE
jsk_recognition: 0.1.16-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1944,7 +1944,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.1.15-0
+      version: 0.1.16-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.1.16-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.15-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_libfreenect2

```
* Install files generated in jsk_libfreenect2
* Contributors: Ryohei Ueda
```
## jsk_pcl_ros

```
* bugfix: add depth_image_creator to jsk_pcl_nodelet on catkin.cmake
* a launch file for stereo camera using pointgrey
* Publish ModelCoefficients from EdgeDepthRefinement
* Add new nodelet to detect parallel edge
* Remove duplicated edges according to the line coefficients in
  EdgeDepthRefinement
* do not use EIGEN_ALIGNED_NEW_OPERATOR and use onInit super method on
  PointcloudScreenpoint
* Remove several unused headers from ParticleFilterTracking
* not compile OrganizedEdgeDetector on groovy
* add a new nodelet to refine edges based on depth connectivity
* Detect straight edges from organized pointcloud
* toggle edge feature by rqt_reqoncifugre in OrganizedEdgeDetector
* add new nodelet: OrganizedEdgeDetector, which is only available with
  latest PCL
* Do not include header of cloud viewer in region_growing_segmentation.h
* Add more diagnostic information to OrganizedMultiPlaneSegmentation
* downsample rgb as well as pointcloud in openni2_remote.launch
* add new nodelet: BorderEstimator
* Contributors: Ryohei Ueda, Yuki Furuta
```
## jsk_perception

```
* do not use rosrun in the script of jsk_perception/src/eusmodel_template_gen.sh
* Contributors: Ryohei Ueda
```
## jsk_recognition
- No changes
## resized_image_transport

```
* remove static variables from ImageResizer because now it is used as
  nodelet
* add client for resize image
* Contributors: Ryohei Ueda, Yusuke Furuta
```
