### PR TITLE
jsk_control-release: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2794,6 +2794,30 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_common.git
       version: master
     status: developed
+  jsk_control-release:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_control.git
+      version: master
+    release:
+      packages:
+      - eus_nlopt
+      - eus_qp
+      - eus_qpoases
+      - joy_mouse
+      - jsk_footstep_controller
+      - jsk_footstep_planner
+      - jsk_ik_server
+      - jsk_teleop_joy
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/tork-a/jsk_control-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_control.git
+      version: master
+    status: developed
   jsk_model_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_control-release` to `0.1.1-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_control.git
- release repository: https://github.com/tork-a/jsk_control-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## eus_nlopt

```
* catkinize, add package.xml and catkin.cmake, use ROS_BUILD flag, and fix lib loader to use LD_LIBRARY_PATH
* rename arg names, x -> state-vector, f -> evaluation function, g -> equality function, h -> inequality function
* remove test dir
* rename m -> *nlopt-plugin*
* add solve-nlopt-ik-thread function
* add callback function
* fix env value,
* add axis-matrix arg,
* if response is not best, revert robot angle-vector
* revert Makefile
* chmode a+x node & maanger
* delete some files
* add launch file, solve ik separatery and return the best result
* bug fix, nlopt-ik-manager
* add nlopt-ik-manager.l, combine the ik result and publish the best one
* some minor changes hogehoge
* add nlopt-ik-node.l, solve ik with s equation
* move atlas-ik* files to ik dir
* add nlopt-ik-overwrite.l, causion, this program overwrite the method of :inverse-kinematics in cascaded-link
* list check add
* enable to use eus-ik with algoright id > 18
* base min max value add
* add debug-view=:success-draw mode, draw only when the const value is updated
* fix maxeval value, enough large
* add ik-test function for check
* bug fix: root-link has no joint
* bug fix: target-centroid-pos can be used
* bug fix: ik-param send super nlopt-object
* add centroid control, bug has some bug
* bug fix: requrie path change from . to ..
* initial commit nlopt-ik.l
* move test files into test dir
* nlopt-object: able to set max-time and max-eval
* add max-eval, max-time variable
* bug fix: nlopt-fdh return interger
* :simple-jacobian function add
* object wrapper for nlotp add
* euslisp global value add for local non-derivetive functinos
* add local non-derivetive functions, with no test
* remove duplicate simple-jacobian function
* update simple-jacobina, able to use for matrix jacobian
* add Makefile, just rosmake command build all files
* bug fix: cmakelist.txt missing links
* initial commit eus_nlopt, ik ssample add
* Contributors: Shintaro Noda
```
## eus_qp

```
* use find_package(catkin COMPONENTS cmake_modules)
* add dependancies of euslisp and eigen
* bag fix load-library functions
* fix eiquadprog.l, plugin load from LD_LIBRARY_PATH
* add package.xml,
* add solve-eiquadprog-raw-with-error function, solve qp with error tolerance, usage=solve-eiquadprog :eiquadprog-function 'solve-eiquadprog-raw-with-error,
* bug fix of check_constraints function, args order change
* eq constraints check fix, but this is unbeliabable mistake, why it could be move?
* returns nil if eiquadprog is not solved
* fix args for qp_lib.cpp change
* add some comment, and constrants check result set in global value flag
* add constraints check functions
* remove unused comment
* fix debug mode stop the main functino
* rename state variable name from f0
* rename eq -> equality , non-eq -> inequality
* fix typo ;; min->max
* .l bug fix, eq constraints mean CEx + ce = 0
* fix test function, plus minus changed
* add Makefile
* add eus_qp dir, solve qp problem with euslisp, use eigenquadprog library
* Contributors: Shintaro Noda, Shunichi Nozawa
```
## eus_qpoases

```
* Add euslisp package for qpOASES, which is a qp solver
* Contributors: Shunichi Nozawa
```
## joy_mouse

```
* add script to control head via trackball
* add new package: joy_mouse to publish Joy message from mouse input
* Contributors: Ryohei Ueda
```
## jsk_footstep_controller

```
* fix the menu when walking is canceled and update the pose from joy stick according
  to the snapped pose availble by marker
* pop menu when cancel the footstep and support resuming from joystick
* cancel walking via joystick
* update diagnostics information about footstep planning and joy stick stuff
* add diagnostics.yaml for footstep environment
* add diagnostics_aggregator and use ps3joy in hrp2jsknt_real.launch
* add foot contact monitor and initialize the pose of the footstep_marker in hrp2jsknt_real.launch
* publish diagnostic status according to the contact state of the feet
* add a script to publish /ground frame according to the contact state of the feet
* interruptible footstep controller
* Merge pull request #52 <https://github.com/jsk-ros-pkg/jsk_control/issues/52> from garaemon/update-env-server
  update usage of env server in footstep planner according to the latest changeset of jsk_recognition
* update usage of env server according to the latest changeset of
  jsk_recognition
* support multiple instances per one plugin class
* add interface to get log of footstep
* use env server of jsk_pcl_ros
* wait controller until it's activated with infinite timeout
* add a launch file to start footstep stuff for real robot
* fix transformations of coordinates of jsk_footstep_controller
* run sample only one time
* add more debug messages
* fix transformations
* transform footstep relative to hrpsys coordinate system
* use the first step to adjust coordination system, not use offset parameter
  in footstep-controller
* refactoring footstep-controller.l
* make the codes within 80 columns: footstep-controller.l
* fix syntax of footstep-controller.l
* foostep_controller: apply offset specified by rosparam
* read end-coords-offset in footstep-controller
* use config file in sample launch file and add that config file
* update footstep successors parameters
* add autonomous sample launch file
* update several successors parameters
* prepend initial footstep and start st first
* remove dumb lines to shorten code: footstep-controller.l
* fix the argument of execute-cb and fix several trivial syntax errors
* add footstep_controller to sample launch file
* specify offset and frame_id of the legs to JoyFootstepPlanner
* update the foot offset parameter
* add sample launch file for hrp2jsknt
* remove comment from package.xml
* add manifest.xml to jsk_footstep_controller
* install launch directory of jsk_footstep_controller
* add script to move pose only
* instantiating ros bridge client
* controller to execute footstep on hrpsys
* Contributors: Ryohei Ueda
```
## jsk_footstep_planner

```
* use lock/unlock service of environment server to lock/unlock the environment during planning
* compile euslisp file before running footstep planner
* publish footstep for visualization from planner
* update usage of env server according to the latest changeset of
  jsk_recognition
* use env server of jsk_pcl_ros
* ignore emtpy polygon message
* prepend initial steps to the result of the footstep planning
* call x::window-main-onw only if *debug* is t in jsk_footstep_planner/footstep-planner-node.l
* support 6dof planning
* adding model for footstep planning
* finalize footstep by goal steps
* supporting slope in footstep planning
* update for slope planning
* begins to support slope
* automatically choose the goal footstep
* store goal footstep to the problem class
* supress debug message of footstep planner
* update python scripts for catkin
* load msgs directory
* fix dependency
* keep permission of euslisp codes
* catkinize jsk_footstep_planner
* fix to keep orientation after projection to the planes
* supporting z-direction movement in planning
* supporting timeout of planning
* adding jsk_footstep_planner, euslisp implementation
* Contributors: Ryohei Ueda, Masaki Murooka
```
## jsk_ik_server

```
* use singleton class to maintain view point of rviz to have persistency
  across several plugins
* support multiple instances per one plugin class
* Merge pull request #47 <https://github.com/jsk-ros-pkg/jsk_control/issues/47> from s-noda/ik_server_publish_default_end_cords
  ik server publishes posestamped of default-end-coords
* add publish statement of default end coords as posestameped message, frame_id = root-link
* remove needless comments
* Merge branch 'master' of https://github.com/jsk-ros-pkg/jsk_control into ik-server-remote-unused-overwrite
* support jsk_teleop_joy in robot-controller-sample.launch of jsk_ik_server
* remove needless ik-server class definitions
* support other robot, not only staro in robot-controller-sample.launch
* forbit to generate viewer if display missing
* add dependacy on rostes
* remove needless ik-server impl
* add test files and rostest declearation in catkin,cmake and CMakeLists.txt
* remove :cog-convergence-check, :inverse-kinemtiacs-with-error functions
* add sample dir, using spacenav and ik-server, control robot
* add IK_OPTION argument to staro-ik-server-test.launch
* add staro-ik-server.launch
* add IK_OPTION argument to hrp2jsk-ik-server-test.launch
* add additional-ik-options
* added staro specific code for ik-server
* fix usage of cog-convergence-check function, correspond to irtmode.l update
* #9 <https://github.com/jsk-ros-pkg/jsk_control/issues/9>: install moveit_msgs with package.xml for jsk_ik_server
* fix udpate-support-links timing, please call this fucntion after initialization of ik-server
* hand existance check add
* add default-end-coords variable, forbit to use :end-coords statement
* add client_test_with_leg flag, check if support polygon correctly transformed
* fix transformation of support links, convert support polygon  to the target coordinate
* fix supprot-link usage, and remove :end-coords
* bug fix, use link name as frame_id
* add configuration dir, but now, not supported yet
* supprot group_name=whole_body, fix-limb='(:rleg :lleg)
* /odom transformation validated without tf
* ik-server transform all coords using robot model and from-id,
* fix name -> link matching, use find-link-from-name funciton
* convert all frame_id to root-link-frame-id slots, if null, convert using robot model
* fix for collision check, add slot variable of defualt collisoin link
* fix the timing of make-convex function, just before call-ik-server
* add some parameter for collision avoidance
* :ik-server-call function support collision-avoidance-link-pair
* all-test.launch add, for test
* added launch/hrp2jsknt-ik-server.launch
* added svn exclude in installation of jsk_ik_server/catkin.cmake
* fix ik-server return joint_State, link names -> joint names
* joint-state message methods check fix, for hydro
* moveit_msgs::MoveItErrorCodes::*NO_IK_SOLUTION* check fix
* bound check for hydro message type change
* assoc hrp2jsknt model hand and wrist
* add link-list arguments, hrp2 model separate into body and hands
* pr2 has no leg limbs
* add some comment, and test programs are changed to use :fix-limbs option
* fix robot link-list slots variable, pr2 had not had gripper links
* remap /solve_ik -> //solve
* fix typo, transfrom -> transform
* multi_dof_joint_States :joint_transforms -> :transform in hydro
* hrp2 ik-server files donot use tf
* multi-6dof-joint-states supported,
* remove viewer arg from :update-joint-states
* comment quaternion usage
* base coords in joint_states, eular angle and quaternion supported
* add slots value ik-server-name and ik-server-service-name to set node name and service name
* add ik-server-call function, this functions can be used just the same as euslisp :fullbody-inverse-kinematics functions
* mv fullbody-ik-client-test.l to test dir and fix some dependancy of test launcher files. please check test launcher files before change configuration
* remove unused require statement
* remove test dependancy from manifest.xml, it's ok? to remove pr2eus and atlashogehoge
* catkinize jsk_ik_server
* make fullbody ik client class for ik server
* add :support-links args, change foot-convex and targe-centroid-pos
* remove unused comment, and some arg name fix
* :fix-limbs '(:limb1 :limb2 ....) supported
* simplyfy :fullbody-ik-main, old versino move to old-ik-server.k
* load only robot model file instead of interface file.
* remove fix-limb-cords slots,
* change ik-server-test.launch for fullbody-ik-client.l
* hrp2jsk-test fucntino add
* change dir configuration, each ik-server.l move to ik-server-impl dir
* add :inverse-kinematics function, causion, to fix pr2 model torso, :torso-fix t :use-torso 0 option needed
* fix ik-server-call function, options has nil list supported
* fix objects usage
* add some test functions
* rename *hoge* slot variable to hoge
* rename eus-fullbody-ik-ex -> ik-server-util, i think -ex is terrible naming
* remove unused functions
* add old-ik-server, from hrpsys_gazebo_atlas
* change order m -> mm
* joint name convert to string, and robot-model -> cascaded-link
* change euscollada-robot -> robot-model
* add viewer slots in ik-server class, not only irtviewr, but pickview can be used
* remove global variables, usage, generate robot object, and call (ik-server-call :robot )
* move-target, taget-coords, links-list length check add
* change some comment, not so important
* overwrite make-convex function, bacause hrp2 has toe joint
* centroid < convex check add
* additional-weight-list supported,
* bug fix, if target-centrid-pos == null, then not call cog-ceonvergence check
* add base coords to return statement of ik-server
* arrow object in ik-server viewer trach the first coordinamte of target ones
* debug-view flag can be changed
* ik-sever.l validated with fullbody-ik-client.l, but there is a strange change, base link tranformation need to be called twice?(line: 270)
* fullbody-ik-cline.l add, call ik-server with the same argment of euslisp :fullbody-inverse-kinematics functino
* coordinates fix
* fix some key name of ik_request
* add fullbody-inverse-kinematics-service-cb functino, for group_name =:fullbody-inverse-kinematics, not tested
* do not load robot-interface.l , load just model.l
* added hrp2 launch files
* deleted atlas-eus-ik-client.l
* remove arm_navigation_msgs
* add more debug messages
* not load pr2-interface.l, just load model files.
* reverted last commit. added hrp2jsk, hrp2jsknt server programs.
* merge pr2 and atlas ik server
* deleted atlas-eus-ik-client.l : client program is common for all robots.
* use make-foot-convex for humanoid robot
* removed atlas-end-coords.l: this is copy of the file under hrpsys_gazebo_atlas and is not necessary here.
* removed atlas specified files from eus-fullbody-ik-ex.l and ik-server.l
* change fullbody-ik function to class method
* add eus ik server package
* Contributors: Ryohei Ueda, Yohei Kakiuchi, Yusuke Furuta, Kei Okada, Masaki Murooka, Shintaro Noda
```
## jsk_teleop_joy

```
* remap joint states and DEV
* add script to control head via trackball
* remove trackpoint_joy.py
* mvoe python scripts to parse state to src directory
* fix bag at first time
* update menu
* publish at 10hz
* set autorepeat rate
* use joy mux
* make JoyStatus class
* fix the menu when walking is canceled and update the pose from joy stick according
  to the snapped pose availble by marker
* pop menu when cancel the footstep and support resuming from joystick
* cancel walking via joystick
* update diagnostics information about footstep planning and joy stick stuff
* compile euslisp file before running footstep planner
* circle button to move arm
* Merge branch 'master' into fix-jsk-interactive-marker-plugin
  Conflicts:
  jsk_teleop_joy/launch/pr2.launch
* 

    * remove jsk_interactive_marker.launch and integrate it to pr2.launch
    * rewrite jsk_interactive_marker plugin to modern plugin style

* add plugin to show usage
* delete empty lines
* Merge branch 'master' into add-plugin-for-jsk-interactive-marker
  Conflicts:
  jsk_teleop_joy/manifest.xml
  jsk_teleop_joy/package.xml
  jsk_teleop_joy/src/jsk_teleop_joy/plugin/joy_pose_6d.py
* modify launch file
* jsk_teleop_joy depends on jsk_rviz_plugins
* update moveit teleop plugin to the latest change of moveit
* add center button to JoyStatus class and use center button
  to choose menu
* add new plugin to relay and convert joy message to ps3
* add Relay plugin to jsk_teleop_joy
* use singleton class to maintain view point of rviz to have persistency
  across several plugins
* show overlay menu on rviz to swtich plugins
* support multiple instances per one plugin class
* use diagnostic_updater package to generate diagnostic messages
  rather than publish diagnostic_msgs directly
* optimize rviz animation smoother by joy stick controller
* support jsk_teleop_joy in robot-controller-sample.launch of jsk_ik_server
* publish the status of jsk_teleop_joy to /diagnostics.
  decrease the number of the messages if the joy stick type is failed to
  be estimated.
  publish the status of the estimation to /diagnostics
* make interactive_midi_config available for hydro
* fix midi_config_player for groovy
* make midi_config_player available for hydro
* add button to control interactive marker
* transform PoseStamped when setting marker pose
* add method to set pose
* add method to change move arm
* use triangle button to send menu
* fix find -> find_module to detect catkin or rosbuild
* add config for padcontrol
* support groovy on all the plugins
* use imp module to decide use load_manifest or not
* send 'move' when circle button is pushed
* add dependancy on jsk_interactive_marker
* rename plugin scripts to avoid msg import bug
* add import statement
* use load_manifest on groovy
* use load_manifest on groovy
* add end effector controller interface
* JoyFootstepPlanner: publish execute if circle button is pushed
* JoyFootstepPlanner: reset goal pose if cross button is pushed
* determines the initial position of goal according to the specified frame_id and offset for the legs
* add tf_ext.py to jsk_teleop_joy. it's a set of utitlity function for tf
* revert to use depend tag for view_controller_msgs
* write about select button
* write about how to implement plugin
* write about how to export the plugins
* update docs
* use upper case for MIDI
* add list of plugins
* update docs
* update docs
* add link to each script
* update some docs
* add document about midi_write.py
* add movie of interactive configuretion of midi device
* use english in README.md#interactive_midi_config.py
* fix style of ordered list
* #2 <https://github.com/jsk-ros-pkg/jsk_control/issues/2>: automatically detect the game controller type at joy_footstep.launch
  use type=auto parameter
* #2 <https://github.com/jsk-ros-pkg/jsk_control/issues/2>: rename xbox.launch and xbox_footstep.launch to joy.launch and joy_footsetp.launch.
  it support many game controllers now and the name did not match the current state.
* #2 <https://github.com/jsk-ros-pkg/jsk_control/issues/2>: detect ps3 wireless automatically
* #2 <https://github.com/jsk-ros-pkg/jsk_control/issues/2>: use auto mode as default
* #2 <https://github.com/jsk-ros-pkg/jsk_control/issues/2>: update document about ps3 bluetooth
* mv jsk_joy/ jsk_teleop_joy/
* rename jsk_joy -> jsk_telop_joy
* fix to use rosdep
* adding footstep planning demo plugin
* updating the parameters
* arg1 = topic name, arg2 = device name
* fix topic name
* install subdirectory into dist_package
* auto detecting xbox/ps3wired
* use joy_main as a wrapper of jsk_joy python library
* not use roslib.load_manifest if the distro is hydro
* installing launch file and so on
* catkinized jsk_joy package
* changed frame from base_link to odom
* added JoyGoPos for plugin.xml
* added gopos.py for teleoperation locomotion command
* added gopos.launch for teleoperation locomotion command
* sample launch for marker_6dof
* tuned parameters to move camera
* adding moveit plugin for controlling moveit from gaming controllers
* launch file for pr2 moveit
* adding README
* adding configuration for launchpad mini
* adding output configuration to QuNeo
* supporting output of MIDI
* adding script to test output of midi devices
* mapping buttons automatically from axes
* update midi configuration
* script to verbose midi input
* not printing input
* adding nanokontrol2.yaml
* updating configuration file
* supporting 144/128 key event
* adding config file for icontrols pro
* adding scripts to configure midi device interactively
* changing joy footstep planner plugin to use footstep marker in jsk_interactive_marker
* adding interface to call footstep planning from game controllers
* adding verbose plugin for debugging and support wired ps3 controller
* add nanopad2_joy.py, touchpad and scene button supported
* adding sample to run xbox footstep plugin
* update orientation way to local
* supporting local z movement acoording to orientation
* adding manual footstep generator interface
* updating parameters of view rotation
* test pulibhs program for joystick, any joystick ok?
* supports to toggle follow view mode
* devided trackpoint joy publisher and status class to two files.
* added nanopad_joy.py nanopad_status.py for KORG nanoPAD2
* updating some parameters
* supporting pitch and roll
* implementing jsk_joy as plugin system
* changed class name of nanokontrol status: NanoKONTROL2 -> NanoKONTROL2Status
* add nanokontrol_status.py. convert data from Joy msg to nanoKONTROL class instance.
* support touchpad; auto-detect device id
* light turns on when button is pushed
* added device link URL of vestax_spin2
* added trackpoint_joy.py. publish thinkpad trackpoint status as Joy.
* bugfix button type
* set vestax_spin2.py execuable
* chnaged button index of akailpd8. set for PROG1 PAD mode.
* bugfix indent
* added URL of device web page for lanchpad
* add controller for vestax spin 2
* added akaiLPD8.py
* added device URL link for nanokontrol
* add script to publish joy_message with launchpad mini
* deleted debug outpu in nanokontrol_joy.py
* add rosdep name=python
* added nanokontrol_joy.py for publishing nanoKONTROL2 input as Joy.
* update some parameters
* update some parameters
* using left analog to zoom in/out
* introducing new package: jsk_joy
* Contributors: Kei Okada, Masaki Murooka, Ryohei Ueda, Satoshi Iwaishi, Yuki Furuta, Yusuke Furuta, Shunichi Nozawa, Shintaro Noda, Youhei Kakiuchi
```
