### PR TITLE
libvimba: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2109,7 +2109,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/srv/libvimba-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
   linux_peripheral_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libvimba` to `0.0.2-0`:
- upstream repository: https://github.com/srv/libvimba.git
- release repository: https://github.com/srv/libvimba-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.1-0`
## libvimba
- No changes
