### PR TITLE
innok_heros_driver: 0.2.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2618,6 +2618,20 @@ repositories:
       url: https://github.com/ros-industrial-release/industrial_metapackages-release.git
       version: 0.0.2-0
     status: developed
+  innok_heros_driver:
+    doc:
+      type: git
+      url: https://github.com/innokrobotics/innok_heros_driver.git
+      version: hydro
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/innokrobotics/innok_heros_driver-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/innokrobotics/innok_heros_driver.git
+      version: hydro
   interaction_cursor_3d:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `innok_heros_driver` to `0.2.0-0`:
- upstream repository: https://github.com/innokrobotics/innok_heros_driver.git
- release repository: https://github.com/innokrobotics/innok_heros_driver-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## innok_heros_driver

```
* fixed launch file
* edited readme
* Merge branch 'master' of ssh://github.com/innokrobotics/innok_heros_driver
* initial commit of heros driver
* Contributors: Alwin Heerklotz
```
