### PR TITLE
carl_navigation: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4447,7 +4447,6 @@ repositories:
       type: git
       url: https://github.com/uos/sick_tim.git
       version: indigo
-      status: developed
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -4457,6 +4456,7 @@ repositories:
       type: git
       url: https://github.com/uos/sick_tim.git
       version: indigo
+      status: developed
   sicktoolbox:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -149,7 +149,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/srv/avt_vimba_camera-release.git
-      version: 0.0.7-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/srv/avt_vimba_camera.git
@@ -392,7 +392,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_navigation-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_navigation.git
@@ -2109,7 +2109,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/srv/libvimba-release.git
-      version: 0.0.2-0
+      version: 0.0.1-0
   linux_peripheral_interfaces:
     doc:
       type: git
@@ -4447,16 +4447,10 @@ repositories:
       type: git
       url: https://github.com/uos/sick_tim.git
       version: indigo
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/uos-gbp/sick_tim-release.git
-      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/uos/sick_tim.git
       version: indigo
-    status: developed
   sicktoolbox:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4456,7 +4456,7 @@ repositories:
       type: git
       url: https://github.com/uos/sick_tim.git
       version: indigo
-      status: developed
+    status: developed
   sicktoolbox:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -149,7 +149,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/srv/avt_vimba_camera-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/srv/avt_vimba_camera.git
@@ -2109,7 +2109,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/srv/libvimba-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
   linux_peripheral_interfaces:
     doc:
       type: git
@@ -4447,6 +4447,12 @@ repositories:
       type: git
       url: https://github.com/uos/sick_tim.git
       version: indigo
+      status: developed
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/uos-gbp/sick_tim-release.git
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/uos/sick_tim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_navigation` to `0.0.2-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_navigation.git
- release repository: https://github.com/wpi-rail-release/carl_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.1-0`
## carl_navigation

```
* robot_pose_publisher now launched with AMCL
* Contributors: Russell Toris
```
