### PR TITLE
ros_emacs_utils: 0.4.1-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -149,7 +149,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/srv/avt_vimba_camera-release.git
-      version: 0.0.7-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/srv/avt_vimba_camera.git
@@ -392,7 +392,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_navigation-release.git
-      version: 0.0.2-0
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_navigation.git
@@ -2109,7 +2109,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/srv/libvimba-release.git
-      version: 0.0.2-0
+      version: 0.0.1-0
   linux_peripheral_interfaces:
     doc:
       type: git
@@ -3788,6 +3788,23 @@ repositories:
       url: https://github.com/ros-controls/ros_controllers.git
       version: indigo-devel
     status: developed
+  ros_emacs_utils:
+    release:
+      packages:
+      - ros_emacs_utils
+      - rosemacs
+      - roslisp_repl
+      - slime_ros
+      - slime_wrapper
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/code-iai-release/ros_emacs_utils-release.git
+      version: 0.4.1-2
+    source:
+      type: git
+      url: https://github.com/code-iai/ros_emacs_utils.git
+      version: 'branch: master'
+    status: maintained
   ros_ethercat:
     doc:
       type: git
@@ -4447,16 +4464,10 @@ repositories:
       type: git
       url: https://github.com/uos/sick_tim.git
       version: indigo
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/uos-gbp/sick_tim-release.git
-      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/uos/sick_tim.git
       version: indigo
-    status: developed
   sicktoolbox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_emacs_utils` to `0.4.1-2`:
- upstream repository: https://github.com/code-iai/ros_emacs_utils.git
- release repository: https://github.com/code-iai-release/ros_emacs_utils-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
