### PR TITLE
ros_emacs_utils: 0.4.1-2 in 'indigo/distribution.yaml' [bloom] test

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3799,7 +3799,6 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/code-iai-release/ros_emacs_utils-release.git
-      version:
     source:
       type: git
       url: https://github.com/code-iai/ros_emacs_utils.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3803,7 +3803,7 @@ repositories:
     source:
       type: git
       url: https://github.com/code-iai/ros_emacs_utils.git
-      version: 'branch: master'
+      version: master
     status: maintained
   ros_ethercat:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3788,6 +3788,23 @@ repositories:
       url: https://github.com/ros-controls/ros_controllers.git
       version: indigo-devel
     status: developed
+  ros_emacs_utils:
+    release:
+      packages:
+      - ros_emacs_utils
+      - rosemacs
+      - roslisp_repl
+      - slime_ros
+      - slime_wrapper
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/code-iai-release/ros_emacs_utils-release.git
+      version:
+    source:
+      type: git
+      url: https://github.com/code-iai/ros_emacs_utils.git
+      version: 'branch: master'
+    status: maintained
   ros_ethercat:
     doc:
       type: git


### PR DESCRIPTION
Only for a pre-release test so far. Hence the empty version.
