### PR TITLE
rospack: 2.2.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4089,7 +4089,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
-      version: 2.2.4-0
+      version: 2.2.5-0
     source:
       type: git
       url: https://github.com/ros/rospack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.2.5-0`:
- upstream repository: https://github.com/ros/rospack
- release repository: https://github.com/ros-gbp/rospack-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `2.2.4-0`
## rospack

```
* support tags defined in package format 2 (#43 <https://github.com/ros/rospack/issues/43>)
```
