### PR TITLE
rospack: 2.1.24-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4042,7 +4042,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
-      version: 2.1.23-0
+      version: 2.1.24-0
     source:
       type: git
       url: https://github.com/ros/rospack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.1.24-0`:
- upstream repository: https://github.com/ros/rospack
- release repository: https://github.com/ros-gbp/rospack-release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `2.1.23-0`
## rospack

```
* support tags defined in package format 2 (#43 <https://github.com/ros/rospack/issues/43>)
```
