### PR TITLE
carl_safety: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -398,6 +398,21 @@ repositories:
       url: https://github.com/WPI-RAIL/carl_navigation.git
       version: develop
     status: maintained
+  carl_safety:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/carl_safety.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/carl_safety-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/carl_safety.git
+      version: develop
+    status: maintained
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_safety` to `0.0.1-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_safety.git
- release repository: https://github.com/wpi-rail-release/carl_safety-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## carl_safety

```
* cleanup for release
* adjusted safety override near computer desks
* Added discouragement for CARL attempting to crash into our computers, remote run stop should now work for autonomous nav as well
* slowed down spin rate
* created launch file, added dependency on robot_pose_publisher for launch
* implemented boundary for manual nav
* more debugging
* debugging
* initial commit
* Contributors: Russell Toris, dekent
```
