### PR TITLE
carl_demos: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -368,6 +368,21 @@ repositories:
       url: https://github.com/WPI-RAIL/carl_bot.git
       version: develop
     status: maintained
+  carl_demos:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/carl_demos.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/carl_demos-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/carl_demos.git
+      version: develop
+    status: maintained
   carl_estop:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_demos` to `0.0.1-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_demos.git
- release repository: https://github.com/wpi-rail-release/carl_demos-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## carl_demos

```
* added build and launch files
* READMEs added
* Contributors: Russell Toris
```
