### PR TITLE
fixing versions of camera1394stereo in distribution

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -290,7 +290,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/srv/camera1394stereo.git
-      version: 1.0.3
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -299,7 +299,7 @@ repositories:
     source:
       type: git
       url: https://github.com/srv/camera1394stereo.git
-      version: 1.0.3
+      version: indigo-devel
     status: maintained
   camera_info_manager_py:
     doc:


### PR DESCRIPTION
@miquelmassot FYI these should be branches not tags. 

This causes jenkins to trigger every cycle. 
https://issues.jenkins-ci.org/browse/JENKINS-23299
