### PR TITLE
jackal: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1808,6 +1808,24 @@ repositories:
       url: https://github.com/ipa320/ipa_canopen.git
       version: indigo_dev
     status: maintained
+  jackal:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal.git
+      version: indigo-devel
+    release:
+      packages:
+      - jackal_description
+      - jackal_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/jackal/jackal.git
+      version: indigo-devel
+    status: developed
   joystick_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.1.0-0`:
- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## jackal_description

```
* Updated description with v0.9 hardware changes.
* Contributors: Mike Purvis
```
## jackal_msgs

```
* New jackal_msgs package.
* Contributors: Mike Purvis
```
