### PR TITLE
jackal_desktop: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1808,6 +1808,24 @@ repositories:
       url: https://github.com/ipa320/ipa_canopen.git
       version: indigo_dev
     status: maintained
+  jackal_desktop:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal_desktop.git
+      version: indigo-devel
+    release:
+      packages:
+      - jackal_desktop
+      - jackal_viz
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal_desktop-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/jackal/jackal_desktop.git
+      version: indigo-devel
+    status: developed
   joystick_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_desktop` to `0.1.0-0`:
- upstream repository: https://github.com/jackal/jackal_desktop.git
- release repository: https://github.com/clearpath-gbp/jackal_desktop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## jackal_desktop
- No changes
## jackal_viz

```
* Initial release.
* Contributors: Mike Purvis
```
