### PR TITLE
abb: 1.1.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -19,13 +19,20 @@ repositories:
       packages:
       - abb
       - abb_common
+      - abb_driver
+      - abb_irb2400_moveit_config
+      - abb_irb2400_moveit_plugins
+      - abb_irb2400_support
+      - abb_irb5400_support
+      - abb_irb6600_support
+      - abb_irb6640_moveit_config
       - abb_moveit_plugins
       - irb_2400_moveit_config
       - irb_6640_moveit_config
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-industrial-release/abb-release.git
-      version: 1.1.2-0
+      version: 1.1.3-0
     source:
       type: git
       url: https://github.com/ros-industrial/abb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `abb` to `1.1.3-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.10`
- previous version for package: `1.1.2-0`
## abb

```
* Merged changes from hydro (release) branch.  Changes include only release artifacts
* meta: add IRB 2400 & 6640 MoveIt configs and plugin pkgs.
* meta: add new IRB support packages (2400, 5400 & 6600).
* driver: move driver (Rapid and nodes) into separate package.
  Node sources, headers and launch files copied from abb_common.
* Contributors: Shaun Edwards, gavanderhoorn
```
## abb_common

```
* Merged changes from hydro (release) branch.  Changes include only release artifacts
* Add deprecation notice to old packages.
  And point users to the replacements.
* common: add roslaunch testing.
  In preparation of repository refactoring: roslaunch tests will be
  used to perform regression testing to make sure all changes remain
  backward compatible (wrt executable artefacts, resources and launch
  files).
* Contributors: Shaun Edwards, gavanderhoorn
```
## abb_driver

```
* driver: reintroduce coupling factor default.
  Reverts 3765cd6.
* Bump versions.
* driver: remove default for J23 coupling parameter.
  Users should explicitly provide this on the command line, or use one
  of the convenience launchfiles provided with the support packages.
  It is of critical importance that this parameter is set to the
  correct value, and should therefore not be supplied a default in
  a (for end-users) file with low visibility.
* driver: move driver (Rapid and nodes) into separate package.
  Node sources, headers and launch files copied from abb_common.
* Contributors: gavanderhoorn
```
## abb_irb2400_moveit_config

```
* Bump versions.
* irb2400: update MoveIt config to use IKFast plugin.
* irb2400: (re)add plan execution support to MoveIt package.
* irb2400: add basic (regenerated) MoveIt package.
  Regenerated package, updated version of the irb_2400_moveit_config.
  This uses the files from the abb_irb2400_support package.
  Note: acceleration limits are identical to those specified in the
  old irb_2400_moveit_config package (ie: 1.0 m/s^2), which should
  be updated to more realistic values.
* Contributors: gavanderhoorn
```
## abb_irb2400_moveit_plugins

```
* Bump versions.
* irb2400: add regenerated IKFast Moveit plugin.
* Contributors: gavanderhoorn
```
## abb_irb2400_support

```
* Bump versions.
* support: add roslaunch testing.
* support: add robot interface and visualisation convenience launchfiles.
  Defaults for 'J23_coupled' argument/parameter copied from irb_2400_moveit_config
  and irb_6640_moveit_config packages.
  TODO: provide default for coupling factor of IRB 5400 (no existing value available).
* irb2400: move IRB 2400 support into separate support pkg.
  Meshes and urdfs copied from abb_common package.
* Contributors: gavanderhoorn
```
## abb_irb5400_support

```
* Bump versions.
* support: add roslaunch testing.
* support: add robot interface and visualisation convenience launchfiles.
  Defaults for 'J23_coupled' argument/parameter copied from irb_2400_moveit_config
  and irb_6640_moveit_config packages.
  TODO: provide default for coupling factor of IRB 5400 (no existing value available).
* irb5400: move IRB 5400 support into separate support pkg.
  Meshes and urdfs copied from abb_common package.
* Contributors: gavanderhoorn
```
## abb_irb6600_support

```
* Bump versions.
* support: add roslaunch testing.
* support: add robot interface and visualisation convenience launchfiles.
  Defaults for 'J23_coupled' argument/parameter copied from irb_2400_moveit_config
  and irb_6640_moveit_config packages.
  TODO: provide default for coupling factor of IRB 5400 (no existing value available).
* irb6600: move IRB 6600 support into separate support pkg.
  Meshes and urdfs copied from abb_common package.
* Contributors: gavanderhoorn
```
## abb_irb6640_moveit_config

```
* Bump versions.
* irb6640: (re)add plan execution support to MoveIt package.
* irb6640: add basic (regenerated) MoveIt package.
  Regenerated package, updated version of the irb_6640_moveit_config.
  This uses the files from the abb_irb6600_support package.
* Contributors: gavanderhoorn
```
## abb_moveit_plugins

```
* Merged changes from hydro (release) branch.  Changes include only release artifacts
* Add deprecation notice to old packages.
  And point users to the replacements.
* Contributors: Shaun Edwards, gavanderhoorn
```
## irb_2400_moveit_config

```
* Merged changes from hydro (release) branch.  Changes include only release artifacts
* Add deprecation notice to old packages.
  And point users to the replacements.
* Contributors: Shaun Edwards, gavanderhoorn
```
## irb_6640_moveit_config

```
* Merged changes from hydro (release) branch.  Changes include only release artifacts
* Add deprecation notice to old packages.
  And point users to the replacements.
* Contributors: Shaun Edwards, gavanderhoorn
```
