### PR TITLE
random_numbers: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3345,11 +3345,20 @@ repositories:
       version: develop
     status: maintained
   random_numbers:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/random_numbers
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/random_numbers-release.git
-      version: 0.2.0-0
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/random_numbers
+      version: master
+    status: maintained
   razer_hydra:
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3347,7 +3347,7 @@ repositories:
   random_numbers:
     doc:
       type: git
-      url: https://github.com/ros-planning/random_numbers
+      url: https://github.com/ros-planning/random_numbers.git
       version: master
     release:
       tags:
@@ -3356,7 +3356,7 @@ repositories:
       version: 0.3.0-0
     source:
       type: git
-      url: https://github.com/ros-planning/random_numbers
+      url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
   razer_hydra:


### PR DESCRIPTION
Increasing version of package(s) in repository `random_numbers` to `0.3.0-0`:
- upstream repository: https://github.com/ros-planning/random_numbers
- release repository: https://github.com/ros-gbp/random_numbers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.2.0-0`
## random_numbers

```
* Update README.md with Documentation
* Allow the randomly generated seed to be saved so that experiments / benc...
* Initialize static int to 0
* Save the first_seed even when passed in manually.
* Allow the randomly generated seed to be saved so that experiments / benchmarks can be recreated in the future
* Added ability to specify random number generator seed for stochastic behavior
* Added travis build status indicator in README.md
* Contributors: Dave Coleman, Dave Hershberger, Ioan A Sucan
```
