### PR TITLE
jsk_visualization: 1.0.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2957,7 +2957,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.7-0
+      version: 1.0.8-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.8-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.0.7-0`
## jsk_interactive
- No changes
## jsk_interactive_marker

```
* control marker with topic
* reset hand pose
* update catkin.cmake for urdf_control_marker
* root control marker for urdf marker
* rename config file
* use jsk_topic_tools::TimeAccumulator instead of jsk_pcl_ros::TimeAccumulator
* add include for catkin
* Contributors: Ryohei Ueda, Yusuke Furuta
```
## jsk_interactive_test

```
* use joy_mouse package
* Contributors: Ryohei Ueda
```
## jsk_rqt_plugins
- No changes
## jsk_rviz_plugins

```
* add enum menu to TargetVisualizer and PeoplePositionMeasurementDisplay
  to select the style of the visualizer
* do not depends on people_msgs on groovy
* add SimpeCircleFacingVisualizer class
* separate a code to draw visualizer into facing_visualizer.cpp
* add rviz plugin for face_detector
* cleanup package.xml of jsk_rviz_plugins
* Contributors: Ryohei Ueda
```
