### PR TITLE
hector_worldmodel: 0.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1608,6 +1608,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
+      version: 0.3.2-0
     status: maintained
   hokuyo_node:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_worldmodel` to `0.3.2-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_worldmodel.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## hector_object_tracker

```
* generalized min_distance_between_objects check for confirmed objects
* removed object class dependent code from the implementation part
* added cmake_modules dependency for the Eigen cmake config
* do no longer model victims twice if they were already confirmed
* set octomap_distance_warnings to ROS_DEBUG
* fixed qrcode mapping
* orientation of objects is now considered and filtered (optional)
* fixed publishing of not populized objects
* Contributors: Alexander Stumpf, Dorothea Koert, Johannes Meyer, Stefan Kohlbrecher
```
## hector_worldmodel
- No changes
## hector_worldmodel_geotiff_plugins

```
* write victims to file
* only draw largest qrcode into the geotiff
* qr codes may not have unique messages now
* Contributors: Alexander Stumpf, Dorothea Koert
```
## hector_worldmodel_msgs
- No changes
