### PR TITLE
jsk_recognition: 0.1.17-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1968,7 +1968,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.1.16-0
+      version: 0.1.17-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.1.17-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.16-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_libfreenect2
- No changes
## jsk_pcl_ros

```
* add laser_registration.launch
* Contributors: Yuki Furuta
```
## jsk_perception

```
* add mk/git to build_depend
* Contributors: Kei Okada
```
## jsk_recognition
- No changes
## resized_image_transport
- No changes
