### PR TITLE
rtmros_common: 1.2.4-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6326,7 +6326,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.2.3-0
+      version: 1.2.4-1
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.2.4-1`:
- upstream repository: https://github.com/start-jsk/rtmros_common.git
- release repository: https://github.com/tork-a/rtmros_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.2.3-0`
## hrpsys_ros_bridge

```
* (test/test-pa10.test) support GUI argument
* (test/test-pa10.py)   add test for /command
* (hrpsys_ros_bridge/src/HrpsysJointTrajectoryBridge.cpp) support <controller>/command, see #537
* (README.md) fix document, based on snozawa's comment
* Contributors: Kei Okada
```
## hrpsys_tools
- No changes
## openrtm_ros_bridge
- No changes
## openrtm_tools
- No changes
## rosnode_rtc
- No changes
## rtmbuild
- No changes
## rtmros_common
- No changes
