### PR TITLE
pr2_kinematics: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4937,6 +4937,15 @@ repositories:
       type: git
       url: https://github.com/kth-ros-pkg/pr2_ft_moveit_config.git
       version: hydro
+  pr2_kinematics:
+    release:
+      packages:
+      - pr2_arm_kinematics
+      - pr2_kinematics
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/TheDash/pr2_kinematics-release.git
+      version: 1.0.2-0
   pr2_mechanism:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_kinematics` to `1.0.2-0`:
- upstream repository: https://github.com/PR2/pr2_kinematics.git
- release repository: https://github.com/TheDash/pr2_kinematics-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## pr2_arm_kinematics

```
* Removed dependency on kinematics_base, replaced with moveit functionality
* Contributors: TheDash
```
## pr2_kinematics
- No changes
