### PR TITLE
pr2_tuck_arms_app: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5047,6 +5047,12 @@ repositories:
       url: https://github.com/PR2/pr2_simulator.git
       version: hydro-devel
     status: maintained
+  pr2_tuck_arms_app:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/TheDash/pr2_tuck_arms_app-release.git
+      version: 1.0.1-0
   prosilica_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_tuck_arms_app` to `1.0.1-0`:
- upstream repository: https://github.com/PR2/pr2_tuck_arms_app.git
- release repository: https://github.com/TheDash/pr2_tuck_arms_app-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
