### PR TITLE
cob_perception_common: 0.5.12-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -858,7 +858,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/cob_perception_common-release.git
-      version: 0.5.4-2
+      version: 0.5.12-0
     source:
       type: git
       url: https://github.com/ipa320/cob_perception_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_perception_common` to `0.5.12-0`:
- upstream repository: https://github.com/ipa320/cob_perception_common.git
- release repository: https://github.com/ipa320/cob_perception_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.4-2`
## cob_image_flip

```
* cleanup changelog
* Contributors: Florian Weisshardt
```
## cob_object_detection_msgs

```
* cleanup changelog
* Contributors: Florian Weisshardt
```
## cob_perception_common

```
* cleanup changelog
* Contributors: Florian Weisshardt
```
## cob_perception_msgs

```
* cleanup changelog
* Contributors: Florian Weisshardt
```
## cob_vision_utils

```
* cleanup changelog
* Contributors: Florian Weisshardt
```
