### PR TITLE
navigation_2d: 0.2.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4077,7 +4077,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/skasperski/navigation_2d-release.git
-      version: 0.1.2-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/skasperski/navigation_2d.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_2d` to `0.2.0-0`:
- upstream repository: https://github.com/skasperski/navigation_2d.git
- release repository: https://github.com/skasperski/navigation_2d-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.1.2-0`
