### PR TITLE
pr2_tuck_arms_app: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5053,6 +5053,12 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_surrogate-release.git
       version: 0.0.4-0
+  pr2_tuck_arms_app:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/TheDash/pr2_tuck_arms_app-release.git
+      version: 1.0.2-0
   prosilica_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_tuck_arms_app` to `1.0.2-0`:
- upstream repository: https://github.com/PR2/pr2_tuck_arms_app.git
- release repository: https://github.com/TheDash/pr2_tuck_arms_app-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## pr2_tuck_arms_app
- No changes
