### PR TITLE
jsk_common: 1.0.37-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2790,6 +2790,7 @@ repositories:
       - jsk_footstep_msgs
       - jsk_gui_msgs
       - jsk_hark_msgs
+      - jsk_tilt_laser
       - jsk_tools
       - jsk_topic_tools
       - laser_filters_jsk_patch
@@ -2809,7 +2810,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.36-0
+      version: 1.0.37-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.37-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.36-0`
## jsk_tilt_laser

```
* commonize tilt_laser_assembler
* added codes to controll tilt_speed with dynamixel_reconfigure
* Fix: rospy.debug -> rospy.logdebug
* add jsk_tilt_laser
* Contributors: Furushchev, Ryohei Ueda, YoheiKakiuchi
```
