### PR TITLE
jsk_common: 1.0.37-1 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1844,6 +1844,7 @@ repositories:
       - jsk_footstep_msgs
       - jsk_gui_msgs
       - jsk_hark_msgs
+      - jsk_tilt_laser
       - jsk_tools
       - jsk_topic_tools
       - laser_filters_jsk_patch
@@ -1863,7 +1864,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.36-0
+      version: 1.0.37-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.37-1`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.36-0`
## jsk_tilt_laser

```
* commonize tilt_laser_assembler
* added codes to controll tilt_speed with dynamixel_reconfigure
* Fix: rospy.debug -> rospy.logdebug
* add jsk_tilt_laser
* Contributors: Furushchev, Ryohei Ueda, YoheiKakiuchi
```
