### PR TITLE
openrtm_aist_core: 1.1.0-9 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4578,7 +4578,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/openrtm_aist_core-release.git
-      version: 1.1.0-8
+      version: 1.1.0-9
     source:
       type: git
       url: https://github.com/start-jsk/openrtm_aist_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist_core` to `1.1.0-9`:
- upstream repository: https://github.com/start-jsk/openrtm_aist_core.git
- release repository: https://github.com/tork-a/openrtm_aist_core-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.1.0-8`
