### PR TITLE
pr2_navigation: 0.1.22-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4993,6 +4993,24 @@ repositories:
       url: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
       version: 1.8.0-0
     status: maintained
+  pr2_navigation:
+    release:
+      packages:
+      - laser_tilt_controller_filter
+      - pr2_move_base
+      - pr2_navigation
+      - pr2_navigation_config
+      - pr2_navigation_global
+      - pr2_navigation_local
+      - pr2_navigation_perception
+      - pr2_navigation_self_filter
+      - pr2_navigation_slam
+      - pr2_navigation_teleop
+      - semantic_point_annotator
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/TheDash/pr2_navigation-release.git
+      version: 0.1.22-0
   pr2_power_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_navigation` to `0.1.22-0`:
- upstream repository: https://github.com/PR2/pr2_navigation.git
- release repository: https://github.com/TheDash/pr2_navigation-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## laser_tilt_controller_filter
- No changes
## pr2_move_base
- No changes
## pr2_navigation
- No changes
## pr2_navigation_config
- No changes
## pr2_navigation_global
- No changes
## pr2_navigation_local
- No changes
## pr2_navigation_perception
- No changes
## pr2_navigation_self_filter
- No changes
## pr2_navigation_slam
- No changes
## pr2_navigation_teleop
- No changes
## semantic_point_annotator

```
* Removed dependency on pcl
* Contributors: TheDash
```
