### PR TITLE
pr2_calibration: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4866,6 +4866,20 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_apps-release.git
       version: 0.5.6-0
+  pr2_calibration:
+    release:
+      packages:
+      - dense_laser_assembler
+      - laser_joint_processor
+      - laser_joint_projector
+      - pr2_calibration
+      - pr2_calibration_launch
+      - pr2_dense_laser_snapshotter
+      - pr2_se_calibration_launch
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/TheDash/pr2_calibration-release.git
+      version: 1.0.2-0
   pr2_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_calibration` to `1.0.2-0`:
- upstream repository: https://github.com/PR2/pr2_calibration.git
- release repository: https://github.com/TheDash/pr2_calibration-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
