### PR TITLE
ardrone_autonomy: 1.3.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -156,7 +156,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/AutonomyLab/ardrone_autonomy-release.git
-      version: 1.3.6-1
+      version: 1.3.7-0
     source:
       type: git
       url: https://github.com/AutonomyLab/ardrone_autonomy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ardrone_autonomy` to `1.3.7-0`:
- upstream repository: https://github.com/AutonomyLab/ardrone_autonomy.git
- release repository: https://github.com/AutonomyLab/ardrone_autonomy-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.3.6-1`
## ardrone_autonomy

```
* Use git protocol instead of https for cmake external project (fixes ca-certificate issues on the build farm)
```
