### PR TITLE
pr2_plugs: 1.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5025,6 +5025,21 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_navigation-release.git
       version: 0.1.22-0
+  pr2_plugs:
+    release:
+      packages:
+      - checkerboard_pose_estimation
+      - outlet_pose_estimation
+      - pr2_image_snapshot_recorder
+      - pr2_plugs_actions
+      - pr2_plugs_common
+      - pr2_plugs_msgs
+      - stereo_wall_detection
+      - visual_pose_estimation
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/TheDash/pr2_plugs-release.git
+      version: 1.0.4-0
   pr2_power_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_plugs` to `1.0.4-0`:
- upstream repository: https://github.com/PR2/pr2_plugs.git
- release repository: https://github.com/TheDash/pr2_plugs-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## checkerboard_pose_estimation
- No changes
## outlet_pose_estimation
- No changes
## pr2_image_snapshot_recorder
- No changes
## pr2_plugs_actions
- No changes
## pr2_plugs_common
- No changes
## pr2_plugs_msgs
- No changes
## stereo_wall_detection
- No changes
## visual_pose_estimation
- No changes
