### PR TITLE
pr2_apps: 0.5.6-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4865,7 +4865,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_apps-release.git
-      version: 0.5.6-0
+      version: 0.5.6-1
   pr2_calibration:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_apps` to `0.5.6-1`:
- upstream repository: https://github.com/PR2/pr2_apps.git
- release repository: https://github.com/TheDash/pr2_apps-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.6-0`
## pr2_apps
- No changes
## pr2_mannequin_mode
- No changes
## pr2_position_scripts
- No changes
## pr2_teleop
- No changes
## pr2_teleop_general
- No changes
## pr2_tuckarm
- No changes
