### PR TITLE
pr2_pan_tilt: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5025,6 +5025,12 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_navigation-release.git
       version: 0.1.22-0
+  pr2_pan_tilt:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/TheDash/pr2_pan_tilt-release.git
+      version: 1.0.1-0
   pr2_plugs:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_pan_tilt` to `1.0.1-0`:
- upstream repository: https://github.com/PR2/pr2_pan_tilt.git
- release repository: https://github.com/TheDash/pr2_pan_tilt-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
