### PR TITLE
openrtm_aist_core: 1.1.0-11 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3039,7 +3039,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/openrtm_aist_core-release.git
-      version: 1.1.0-9
+      version: 1.1.0-11
     source:
       type: git
       url: https://github.com/start-jsk/openrtm_aist_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist_core` to `1.1.0-11`:
- upstream repository: https://github.com/start-jsk/openrtm_aist_core.git
- release repository: https://github.com/tork-a/openrtm_aist_core-release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.1.0-9`
