### PR TITLE
cob_driver: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -578,7 +578,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.5.7-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.6.0-0`:
- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.7-0`
## cob_base_drive_chain
- No changes
## cob_camera_sensors
- No changes
## cob_canopen_motor
- No changes
## cob_driver
- No changes
## cob_generic_can

```
* Fixed typo
* Extended with ReciveMsgTimeout method.
* Correction...
* Extended CanPeakSysUSB for usage without (obsolete) Ini-file, some stuff clearly written
* Contributors: Denis Štogl
```
## cob_head_axis
- No changes
## cob_light
- No changes
## cob_phidgets
- No changes
## cob_relayboard
- No changes
## cob_sick_lms1xx
- No changes
## cob_sick_s300
- No changes
## cob_sound
- No changes
## cob_undercarriage_ctrl
- No changes
## cob_utilities
- No changes
## cob_voltage_control

```
* trying to fix cob_voltage_control buildfarm error
* missing dependency
* Contributors: Florian Weisshardt, ipa-fxm
```
