### PR TITLE
mongodb_store: 0.0.3-0 in 'hydro/distribution.yaml' 

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3570,6 +3570,18 @@ repositories:
       url: https://github.com/sniekum/ml_classifiers.git
       version: master
     status: developed
+  mongodb_store:
+    release:
+      packages:
+      - mongodb_log
+      - mongodb_store
+      - mongodb_store_cpp_client
+      - mongodb_store_msgs
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/mongodb_store.git
+      version: 0.0.3-0
+    status: developed
   motoman:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3581,6 +3581,10 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
       version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/strands-project/mongodb_store.git
+      version: hydro-devel
     status: developed
   motoman:
     doc:


### PR DESCRIPTION
This is a follow-up to https://github.com/ros/rosdistro/pull/5223

Documentation is here: https://github.com/strands-project/mongodb_store/tree/hydro-devel/mongodb_store
## mongodb_store (hydro) - 0.0.3-0

The packages in the `mongodb_store` repository were released into the `hydro` distro by running `/usr/bin/bloom-release --track hydro -r hydro mongodb_store --edit` on `Thu, 04 Sep 2014 13:55:32 -0000`

These packages were released:
- `mongodb_log`
- `mongodb_store`
- `mongodb_store_cpp_client`
- `mongodb_store_msgs`

Version of package(s) in repository `mongodb_store`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- rosdistro version: `0.0.3-0`
- old version: `null`
- new version: `0.0.3-0`

Versions of tools used:
- bloom version: `0.5.11`
- catkin_pkg version: `0.2.4`
- rosdep version: `0.10.30`
- rosdistro version: `0.3.5`
- vcstools version: `0.1.35`
