### PR TITLE
jackal_simulator: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1850,6 +1850,14 @@ repositories:
       type: git
       url: https://github.com/jackal/jackal_simulator.git
       version: indigo-devel
+    release:
+      packages:
+      - jackal_gazebo
+      - jackal_simulator
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal_simulator-release.git
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/jackal/jackal_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_simulator` to `0.2.0-0`:
- upstream repository: https://github.com/jackal/jackal_simulator
- release repository: https://github.com/clearpath-gbp/jackal_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## jackal_gazebo

```
* Default world for Jackal sim is now a green one.
* Add missing dependencies on Gazebo plugin packages.
* Contributors: Mike Purvis
```
## jackal_simulator
- No changes
