### PR TITLE
cob_navigation: 0.6.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -647,6 +647,30 @@ repositories:
       url: https://github.com/ipa320/cob_manipulation.git
       version: indigo_dev
     status: maintained
+  cob_navigation:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_navigation.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_linear_nav
+      - cob_mapping_slam
+      - cob_navigation
+      - cob_navigation_config
+      - cob_navigation_global
+      - cob_navigation_local
+      - cob_navigation_slam
+      - cob_scan_unifier
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/cob_navigation-release.git
+      version: 0.6.0-2
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_navigation.git
+      version: indigo_dev
+    status: maintained
   cob_perception_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_navigation` to `0.6.0-2`:
- upstream repository: https://github.com/ipa320/cob_navigation.git
- release repository: https://github.com/ipa320/cob_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## cob_linear_nav
- No changes
## cob_mapping_slam

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* fix dependencies
* Contributors: Florian Weisshardt
```
## cob_navigation

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* fix dependencies
* Contributors: Florian Weisshardt
```
## cob_navigation_config
- No changes
## cob_navigation_global

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* fix dependencies
* Contributors: Florian Weisshardt
```
## cob_navigation_local
- No changes
## cob_navigation_slam
- No changes
## cob_scan_unifier
- No changes
