### PR TITLE
care_o_bot: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -347,6 +347,17 @@ repositories:
       url: https://github.com/osrf/capabilities.git
       version: master
     status: maintained
+  care_o_bot:
+    release:
+      packages:
+      - care_o_bot
+      - care_o_bot_robot
+      - care_o_bot_simulation
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/care-o-bot-release.git
+      version: 0.6.0-0
+    status: maintained
   carl_bot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `care_o_bot` to `0.6.0-0`:
- upstream repository: https://github.com/ipa320/care-o-bot.git
- release repository: https://github.com/ipa320/care-o-bot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
