### PR TITLE
jackal: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1858,7 +1858,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.2.1-0`:
- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.2.0-0`
## jackal_control

```
* Depend on diff_drive_controller.
* Contributors: Mike Purvis
```
## jackal_description
- No changes
## jackal_diff_drive_controller

```
* Remove changelog entries which were confusing dpkg.
* Contributors: Mike Purvis
```
## jackal_msgs
- No changes
