### PR TITLE
fixed Debian rules

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3580,7 +3580,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.0.3-0
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
our initial release keeps failing: http://jenkins.ros.org/job/ros-hydro-mongodb-log_sourcedeb/33/
By mistake we generated a release only for precise, not for quantal and raring. This is only a fix of the Debian rules (now including those two distors).
