### PR TITLE
baxter_common: 1.0.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -290,7 +290,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RethinkRobotics-release/baxter_common-release.git
-      version: 1.0.0-0
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/RethinkRobotics/baxter_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `baxter_common` to `1.0.1-1`:
- upstream repository: https://github.com/RethinkRobotics/baxter_common.git
- release repository: https://github.com/RethinkRobotics-release/baxter_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.0-0`
