### PR TITLE
ros_realtime: 1.0.7-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5814,6 +5814,10 @@ repositories:
     release:
       url: https://github.com/ros-gbp/ros_http_video_streamer-release.git
   ros_realtime:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_realtime.git
+      version: hydro-devel
     release:
       packages:
       - allocators
@@ -5824,7 +5828,14 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/ros_realtime-release.git
-      version: 1.0.4-0
+      version: 1.0.7-1
+    source:
+      type: git
+      url: https://github.com/ros/ros_realtime.git
+      version: hydro-devel
+    status: maintained
+    status_description: This will be maintained as long as the PR2 project is maintained
+      or until a proven reliable method, or design methodology takes its place.
   ros_tutorials:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5834,8 +5834,6 @@ repositories:
       url: https://github.com/ros/ros_realtime.git
       version: hydro-devel
     status: maintained
-    status_description: This will be maintained as long as the PR2 project is maintained
-      or until a proven reliable method, or design methodology takes its place.
   ros_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_realtime` to `1.0.7-1`:
- upstream repository: https://github.com/ros/ros_realtime.git
- release repository: https://github.com/TheDash/ros_realtime-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.4-0`
## ros_realtime
- No changes
