### PR TITLE
pr2_hack_the_future: 1.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5089,6 +5089,22 @@ repositories:
       url: https://github.com/ros-gbp/pr2_power_drivers-release.git
       version: 1.1.2-0
     status: maintained
+  pr2_precise_trajectory:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_precise_trajectory.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/TheDash/pr2_precise_trajectory-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_precise_trajectory.git
+      version: hydro-devel
+    status: maintained
+    status_description: Maintained
   pr2_robot:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5016,7 +5016,6 @@ repositories:
       url: https://github.com/PR2/pr2_hack_the_future.git
       version: hydro-devel
     status: maintained
-    status_description: Maintained
   pr2_kinematics:
     release:
       packages:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5104,7 +5104,6 @@ repositories:
       url: https://github.com/PR2/pr2_precise_trajectory.git
       version: hydro-devel
     status: maintained
-    status_description: Maintained
   pr2_robot:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4992,6 +4992,31 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_gripper_sensor-release.git
       version: 1.0.2-0
+  pr2_hack_the_future:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_hack_the_future.git
+      version: hydro-devel
+    release:
+      packages:
+      - hack_the_web_program_executor
+      - pr2_hack_the_future
+      - pr2_joint_teleop
+      - pr2_simple_interface
+      - program_queue
+      - queue_web
+      - rviz_backdrop
+      - slider_gui
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/TheDash/pr2_hack_the_future-release.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_hack_the_future.git
+      version: hydro-devel
+    status: maintained
+    status_description: Maintained
   pr2_kinematics:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_hack_the_future` to `1.0.3-0`:
- upstream repository: https://github.com/PR2/pr2_hack_the_future.git
- release repository: https://github.com/TheDash/pr2_hack_the_future-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
