### PR TITLE
pr2_precise_trajectory: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5089,6 +5089,22 @@ repositories:
       url: https://github.com/ros-gbp/pr2_power_drivers-release.git
       version: 1.1.2-0
     status: maintained
+  pr2_precise_trajectory:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_precise_trajectory.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/TheDash/pr2_precise_trajectory-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_precise_trajectory.git
+      version: hydro-devel
+    status: maintained
+    status_description: Maintained
   pr2_robot:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5104,7 +5104,6 @@ repositories:
       url: https://github.com/PR2/pr2_precise_trajectory.git
       version: hydro-devel
     status: maintained
-    status_description: Maintained
   pr2_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_precise_trajectory` to `1.0.1-0`:
- upstream repository: https://github.com/PR2/pr2_precise_trajectory.git
- release repository: https://github.com/TheDash/pr2_precise_trajectory-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## pr2_precise_trajectory

```
* Catkinization complete.
* things
* Added fixes
* Moved action -> msg
* Pckage.xml
* remove makefile
* Initial conversion
* Removed stack xml for hydro devel
* Add ignores.
* Stackagify.
* Move everything down a level
* Moving ros 0.5 branch into trunk
* Contributors: Austin Hendrix, David Lu, Erik Karulf, TheDash
```
