### PR TITLE
jackal_desktop: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1876,7 +1876,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_desktop-release.git
-      version: 0.1.1-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/jackal/jackal_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_desktop` to `0.2.0-0`:
- upstream repository: https://github.com/jackal/jackal_desktop.git
- release repository: https://github.com/clearpath-gbp/jackal_desktop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.1.1-0`
## jackal_desktop
- No changes
## jackal_viz

```
* Support front_laser arg in view_model.launch.
* Add view_robot launcher for marker teleop.
* Contributors: Mike Purvis
```
