### PR TITLE
rosserial: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4395,7 +4395,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rosserial-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ros-drivers/rosserial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial` to `0.6.2-0`:
- upstream repository: https://github.com/ros-drivers/rosserial.git
- release repository: https://github.com/ros-gbp/rosserial-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.6.1-0`
## rosserial
- No changes
## rosserial_arduino

```
* Clean up rosserial_arduino/package.xml
* Generic CMake helpers.
* Contributors: Mike Purvis
```
## rosserial_client

```
* Generic CMake helpers for ros_lib generation and in-package firmwares.
* Fix output of make_library when package has only messages
* Added time out to the state machine
* Contributors: Jason Scatena, Michael Ferguson, Mike Purvis
```
## rosserial_embeddedlinux
- No changes
## rosserial_msgs
- No changes
## rosserial_python

```
* Added MD5 verification for request and response messags upon ServiceClient registration.
* Enabled registration of service clients
* Contributors: Jonathan Jekir
```
## rosserial_server

```
* Bugfix for interrupted sessions.
  This is a two-part fix for an issue causes a segfault when the device
  disappears during operation, for example a ttyACM device which is unplugged.
  The AsyncReadBuffer part avoids calling a callback after the object
  owning it has destructed, and the SerialSession part avoids recreating
  itself until the previous instance has finished the destructor and been
  full destroyed.
* Add dependency on rosserial_msgs_gencpp, fixes #133 <https://github.com/ros-drivers/rosserial/issues/133>
* Make ServiceClient::handle public, to fix compilation bug on some platforms.
* Enabled registration of service clients
* Add namespaces to headers, swap ROS thread to foreground.
* Move headers to include path, rename to follow ROS style.
```
## rosserial_windows
- No changes
## rosserial_xbee
- No changes
