### PR TITLE
uwsim_osgworks: 3.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5124,6 +5124,13 @@ repositories:
       url: https://github.com/bosch-ros-pkg/usb_cam.git
       version: develop
     status: maintained
+  uwsim_osgworks:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/uji-ros-pkg/uwsim_osgworks-release.git
+      version: 3.0.3-0
+    status: maintained
   velodyne:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_osgworks` to `3.0.3-0`:
- upstream repository: https://github.com/uji-ros-pkg/uwsim_osgworks.git
- release repository: https://github.com/uji-ros-pkg/uwsim_osgworks-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
