### PR TITLE
uwsim_bullet: 2.82.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5124,6 +5124,13 @@ repositories:
       url: https://github.com/bosch-ros-pkg/usb_cam.git
       version: develop
     status: maintained
+  uwsim_bullet:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/uji-ros-pkg/uwsim_bullet-release.git
+      version: 2.82.1-0
+    status: maintained
   velodyne:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_bullet` to `2.82.1-0`:
- upstream repository: https://github.com/uji-ros-pkg/uwsim_bullet.git
- release repository: https://github.com/uji-ros-pkg/uwsim_bullet-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
