### PR TITLE
ecl_lite: 0.61.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1059,7 +1059,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_lite-release.git
-      version: 0.60.1-2
+      version: 0.61.0-0
     source:
       type: git
       url: https://github.com/stonier/ecl_lite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_lite` to `0.61.0-0`:
- upstream repository: https://github.com/stonier/ecl_lite.git
- release repository: https://github.com/yujinrobot-release/ecl_lite-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.60.1-2`
## ecl_time_lite

```
* unique get date string function for unique filename creation.
* optional flag for getting real time instead of monolithic posix time (this syncs with ROS)
```
