### PR TITLE
ecl_tools: 0.61.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1115,7 +1115,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_tools-release.git
-      version: 0.60.1-1
+      version: 0.61.0-0
     source:
       type: git
       url: https://github.com/stonier/ecl_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_tools` to `0.61.0-0`:
- upstream repository: https://github.com/stonier/ecl_tools.git
- release repository: https://github.com/yujinrobot-release/ecl_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.60.1-1`
## ecl_build

```
* convenience macros for cxx11 flag checks and settings.
```
