### PR TITLE
ecl_core: 0.61.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1036,7 +1036,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_core-release.git
-      version: 0.60.9-1
+      version: 0.61.0-0
     source:
       type: git
       url: https://github.com/stonier/ecl_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_core` to `0.61.0-0`:
- upstream repository: https://github.com/stonier/ecl_core.git
- release repository: https://github.com/yujinrobot-release/ecl_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.60.9-1`
## ecl_containers

```
* stencil for unsigned char* arrays.
* byte array converters for vector based stencils.
```
## ecl_core_apps

```
* yaw2quaternion converter.
```
## ecl_devices

```
* allow immediate socket reuse in the socket client/server
* define an undefined baud rate for apple
```
## ecl_eigen

```
* internal eigen support for v3.2.1
* bugfix missing unsupported modules in the install space.
```
## ecl_linear_algebra

```
* eigen matrix formatter api aligned with other ecl float formatters
```
## ecl_threads

```
* const'ness for appropriate thread functions
```
## ecl_time

```
* random number generator
* optional realtime stamping (not monotone) to sync with ros stamps
```
## ecl_utilities

```
* partially bound binary function members.
```
