### PR TITLE
openrtm_aist: 1.1.0-6 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3155,7 +3155,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/openrtm_aist-release.git
-      version: 1.1.0-5
+      version: 1.1.0-6
     status: developed
   openslam_gmapping:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist` to `1.1.0-6`:
- upstream repository: http://svn.openrtm.org/OpenRTM-aist/tags/RELEASE_1_1_0/OpenRTM-aist/
- release repository: https://github.com/tork-a/openrtm_aist-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.1.0-5`
