### PR TITLE
jsk_common: 1.0.38-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1856,10 +1856,11 @@ repositories:
       - sklearn
       - speech_recognition_msgs
       - stereo_synchronizer
+      - voice_text
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.37-1
+      version: 1.0.38-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.38-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.0.37-1`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## collada_urdf_jsk_patch
- No changes
## depth_image_proc_jsk_patch
- No changes
## downward
- No changes
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha
- No changes
## image_view2
- No changes
## image_view_jsk_patch
- No changes
## jsk_common
- No changes
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_tilt_laser

```
* update CHANGELOG.rst
* Add ~tilt_joint_name parameter to tilt_laser_assembler.py to specify the joint name
  of tilt laser
* Change scan time according to change of joint state
* Contributors: Ryohei Ueda
```
## jsk_tools
- No changes
## jsk_topic_tools

```
* add new utility function colorCategory20 to jsk_topic_tools
* Contributors: Ryohei Ueda
```
## laser_filters_jsk_patch
- No changes
## libsiftfast
- No changes
## multi_map_server

```
* catkinize python_twoauth and voice_text, modify multi_map_server's catkin.cmake
* Contributors: Yuto Inagaki
```
## nlopt
- No changes
## openni_tracker_jsk_patch
- No changes
## opt_camera
- No changes
## posedetection_msgs
- No changes
## pr2_groovy_patches
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## sklearn
- No changes
## speech_recognition_msgs
- No changes
## stereo_synchronizer
- No changes
## voice_text

```
* catkinize python_twoauth and voice_text, modify multi_map_server's catkin.cmake
* Contributors: JSK applications, Ryohei Ueda
* catkinize python_twoauth and voice_text, modify multi_map_server's catkin.cmake
* Contributors: Yuto Inagaki
```
