### PR TITLE
jsk_recognition: 0.1.18-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1964,7 +1964,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.1.17-0
+      version: 0.1.18-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.1.18-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.17-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_libfreenect2

```
* add git to build_depend of jsk_libfreenect2
* do not hard-code to erase pixels in jsk_libfreenect2
* Contributors: Ryohei Ueda
```
## jsk_pcl_ros

```
* Subscribe PolygonArray message to build ConvexPolygon in ColorizeDistanceFromPlane
* Introduce global mutex for quick hull
* Fix coloring bug and add ~only_projectable parameter to visualize the
  points only if they can be projected on the convex region
* Add use_laser_pipeline argument to laserscan_registration.launch to
  toggle include laser_pileline.launch of jsk_tilt_laser or not
  Add new utility for diagnostics: addDiagnosticInformation
* Supress output from resize_points_publisher
* ROS_INFO -> NODELET_DEBUG in VoxelGridDownsampleManager
* New utilify functoin for diagnostic: addDiagnosticInformation.
  It's a simple function to add jsk_topic_tools::TimeAccumulator to
  diagnostic_updater::DiagnosticStatusWrapper.
* Colorize pointcloud according to the distance from nearest plane
* Use template functions to convert tiny type conversions
* Refine the result of connecting small multi planes in OrganizedMultiplaneSegmentation
* add hsv coherence to particle_fitler_tracker
* change color_histogram showing methods with reconfigure
* visualize color_histogram coefficience
* add new nodelet: EdgebasedCubeFinder
* use colorCategory20 function to colorize pointcloud in ClusterPointIndicesDecomposer
* visualizing connection of planes with lines in OrganizedMultiPlaneSegmentation
* use rosparam_utils of jsk_topic_tools in StaticPolygonArrayPublisher
* Contributors: Ryohei Ueda, ohara, wesleypchan
```
## jsk_perception

```
* add git to build_depend of jsk_libfreenect2
* Contributors: Ryohei Ueda
```
## jsk_recognition
- No changes
## resized_image_transport

```
* Creating publisher before subscribe topics in resized_image_transport
* Supress messages from resized_image_transport
* Contributors: Ryohei Ueda
```
