### PR TITLE
jsk_visualization: 1.0.10-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2007,7 +2007,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.9-0
+      version: 1.0.10-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.10-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.0.9-0`
## jsk_interactive
- No changes
## jsk_interactive_marker

```
* add new executable to control CameraInfo with interactive marker
* Contributors: Ryohei Ueda
```
## jsk_interactive_test
- No changes
## jsk_rqt_plugins
- No changes
## jsk_rviz_plugins

```
* Fix color of people visualizer by initializing color to sky blue
* Fix texture color of camera info by filling color value of texture image
* Fix caching of overlay textures of OverlayMenuDisplay to support
  changing menus
* add relay camera info node
* Add new plugin to visualize sensor_msgs/CameraInfo
* Ignore first message means CLOSE in OverlayMenuDisplay
* Contributors: Ryohei Ueda, Yusuke Furuta
```
