### PR TITLE
opencv2: 2.4.9-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3081,10 +3081,6 @@ repositories:
       url: https://github.com/ros-geographic-info/open_street_map.git
       version: master
   opencv2:
-    doc:
-      type: git
-      url: https://github.com/Itseez/opencv.git
-      version: '2.4'
     release:
       tags:
         release: release/indigo/{package}/{version}

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3080,6 +3080,17 @@ repositories:
       type: git
       url: https://github.com/ros-geographic-info/open_street_map.git
       version: master
+  opencv2:
+    doc:
+      type: git
+      url: https://github.com/Itseez/opencv.git
+      version: '2.4'
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/opencv2-release.git
+      version: 2.4.9-3
+    status: maintained
   opencv3:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `opencv2` to `2.4.9-3`:
- upstream repository: /home/snorri/tmp/opencv
- release repository: https://github.com/yujinrobot-release/opencv2-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
