### PR TITLE
frontier_exploration: 0.2.1-5 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1279,6 +1279,21 @@ repositories:
       url: https://github.com/ros-drivers/freenect_stack.git
       version: master
     status: maintained
+  frontier_exploration:
+    doc:
+      type: git
+      url: https://github.com/paulbovbel/frontier_exploration.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/paulbovbel/frontier_exploration-release.git
+      version: 0.2.1-5
+    source:
+      type: git
+      url: https://github.com/paulbovbel/frontier_exploration.git
+      version: hydro-devel
+    status: maintained
   gazebo2rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `frontier_exploration` to `0.2.1-5`:
- upstream repository: https://github.com/paulbovbel/frontier_exploration.git
- release repository: https://github.com/paulbovbel/frontier_exploration-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## frontier_exploration

```
* Update example launch files
* Update package.xml
* Contributors: Paul Bovbel
```
