### PR TITLE
frontier_exploration: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1288,7 +1288,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/paulbovbel/frontier_exploration-release.git
-      version: 0.2.1-5
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/paulbovbel/frontier_exploration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `frontier_exploration` to `0.2.2-0`:
- upstream repository: https://github.com/paulbovbel/frontier_exploration.git
- release repository: https://github.com/paulbovbel/frontier_exploration-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.2.1-5`
## frontier_exploration

```
* clean up conditionals and comments for more logical flow
* switch to shared from raw ptr
* Contributors: Paul Bovbel
```
