### PR TITLE
nav2_platform: 0.0.7-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2729,6 +2729,26 @@ repositories:
       url: https://github.com/ros-nao/nao_viz.git
       version: master
     status: developed
+  nav2_platform:
+    doc:
+      type: git
+      url: https://github.com/paulbovbel/nav2_platform.git
+      version: hydro-devel
+    release:
+      packages:
+      - nav2_bringup
+      - nav2_driver
+      - nav2_navigation
+      - nav2_platform
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/paulbovbel/nav2_platform-release.git
+      version: 0.0.7-1
+    source:
+      type: git
+      url: https://github.com/paulbovbel/nav2_platform.git
+      version: hydro-devel
+    status: maintained
   navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nav2_platform` to `0.0.7-1`:
- upstream repository: https://github.com/paulbovbel/nav2_platform.git
- release repository: https://github.com/paulbovbel/nav2_platform-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## nav2_bringup
- No changes
## nav2_driver

```
* Fix retry behaviour
* Contributors: Paul Bovbel
```
## nav2_navigation
- No changes
## nav2_platform

```
* Update package.xml
* Contributors: Paul Bovbel
```
