### PR TITLE
nanomsg: 0.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2636,6 +2636,13 @@ repositories:
       url: https://github.com/fkie/multimaster_fkie.git
       version: indigo-devel
     status: maintained
+  nanomsg:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/nanomsg-release.git
+      version: 0.4.0-0
+    status: maintained
   nao_extras:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nanomsg` to `0.4.0-0`:
- upstream repository: https://github.com/stonier/nanomsg.git
- release repository: https://github.com/yujinrobot-release/nanomsg-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
