### PR TITLE
message_multiplexing: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2379,6 +2379,27 @@ repositories:
       url: https://github.com/ros/message_generation.git
       version: groovy-devel
     status: maintained
+  message_multiplexing:
+    doc:
+      type: git
+      url: https://github.com/stonier/message_multiplexing.git
+      version: indigo
+    release:
+      packages:
+      - mm_core_msgs
+      - mm_eigen_msgs
+      - mm_messages
+      - mm_mux_demux
+      - mm_vision_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/message_multiplexing-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/stonier/message_multiplexing.git
+      version: indigo
+    status: maintained
   message_runtime:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_multiplexing` to `0.1.1-0`:
- upstream repository: https://github.com/stonier/message_multiplexing.git
- release repository: https://github.com/yujinrobot-release/message_multiplexing-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## mm_core_msgs

```
* string encoder/decoder.
* public list of test message identifiers.
```
## mm_eigen_msgs

```
* getting ready for eigen messages.
```
## mm_messages

```
* message registry for run-time loading of messages
* (sub)packet header structures
```
## mm_mux_demux

```
* publisher and subscriber frontends.
* multiplexer and demultiplexer.
```
## mm_vision_msgs

```
* image and image pair encoders/decoders.
```
