### PR TITLE
perception_pcl: 1.1.9-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4775,7 +4775,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/perception_pcl-release.git
-      version: 1.1.8-0
+      version: 1.1.9-2
     source:
       type: git
       url: https://github.com/ros-perception/perception_pcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.1.9-2`:
- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.1.8-0`
## pcl_ros

```
* Created a nodelet for the CropBox filter
* Tests no longer exist
* add nodelet definitions to xml
* Contributors: Martí Morta, Paul Bovbel, Ryohei Ueda
```
## perception_pcl
- No changes
