### PR TITLE
xv_11_laser_driver: 0.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8018,7 +8018,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/rohbotics/xv_11_laser_driver.git
-      version: tag
+      version: 0.2.1
     release:
       tags:
         release: release/hydro/{package}/{version}
@@ -8027,7 +8027,7 @@ repositories:
     source:
       type: git
       url: https://github.com/rohbotics/xv_11_laser_driver.git
-      version: 0.2.1
+      version: hydro-devel
   yocs_msgs:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8015,11 +8015,19 @@ repositories:
       url: https://github.com/JJJJJJJack/xsens_reader.git
       version: hydro
   xv_11_laser_driver:
+    doc:
+      type: git
+      url: https://github.com/rohbotics/xv_11_laser_driver.git
+      version: tag
     release:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/rohbotics/xv_11_laser_driver-release.git
-      version: 0.1.2-2
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/rohbotics/xv_11_laser_driver.git
+      version: 0.2.1
   yocs_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xv_11_laser_driver` to `0.2.1-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `0.1.2-2`
## xv_11_laser_driver

```
* merged Steve Dillo's include file
* Merge pull request #1 <https://github.com/rohbotics/xv_11_laser_driver/issues/1> from rohbotics/master
  Merge master and hydro-devel
* Contributors: Rohan Agrawal
```
