### PR TITLE
ueye: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5070,6 +5070,12 @@ repositories:
       type: hg
       url: https://bitbucket.org/kmhallen/ueye
       version: default
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/kmhallen/ueye-release.git
+      version: 0.0.1-0
+    status: maintained
   um6:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye` to `0.0.1-0`:
- upstream repository: https://bitbucket.org/kmhallen/ueye
- release repository: https://github.com/kmhallen/ueye-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## ueye

```
* Initial release into build system.
```
