### PR TITLE
xv_11_laser_driver: 0.2.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8023,11 +8023,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/rohbotics/xv_11_laser_driver-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/rohbotics/xv_11_laser_driver.git
       version: hydro-devel
+    status: maintained
   yocs_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xv_11_laser_driver` to `0.2.2-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `0.2.1-0`
## xv_11_laser_driver

```
* added install rule for include files
* Contributors: Rohan Agrawal
```
