### PR TITLE
pr2_make_a_map_app: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5021,6 +5021,21 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_kinematics-release.git
       version: 1.0.2-0
+  pr2_make_a_map_app:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_make_a_map_app.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/TheDash/pr2_make_a_map_app-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_make_a_map_app.git
+      version: hydro-devel
+    status: maintained
   pr2_map_navigation_app:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_make_a_map_app` to `1.0.2-0`:
- upstream repository: https://github.com/PR2/pr2_make_a_map_app.git
- release repository: https://github.com/TheDash/pr2_make_a_map_app-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## pr2_make_a_map_app

```
* Updated install targets in CMakeList
* Removed ROSNOBUILD
* Changelogs and removed stack.xml
* Contributors: TheDash
```
