### PR TITLE
xv_11_laser_driver: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5429,6 +5429,21 @@ repositories:
       url: https://github.com/ethz-asl/ethzasl_xsens_driver.git
       version: master
     status: maintained
+  xv_11_laser_driver:
+    doc:
+      type: git
+      url: https://github.com/rohbotics/xv_11_laser_driver.git
+      version: 0.2.1
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rohbotics/xv_11_laser_driver-release.git
+      version: 0.2.2-0
+    source:
+      type: git
+      url: https://github.com/rohbotics/xv_11_laser_driver.git
+      version: indigo-devel
+    status: maintained
   yocs_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xv_11_laser_driver` to `0.2.2-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.5`
- previous version for package: `null`
## xv_11_laser_driver

```
* added install rule for include files
* Contributors: Rohan Agrawal
```
