### PR TITLE
ml_classifiers: 0.3.1-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2461,6 +2461,12 @@ repositories:
       url: https://github.com/RobotWebTools/mjpeg_server.git
       version: develop
     status: maintained
+  ml_classifiers:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/jolting/ml_classifiers-release.git
+      version: 0.3.1-2
   mongodb_store:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ml_classifiers` to `0.3.1-2`:
- upstream repository: https://github.com/jolting/ml_classifiers.git
- release repository: https://github.com/jolting/ml_classifiers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## ml_classifiers

```
* Fix build for indigo
* Merge pull request #2 <https://github.com/sniekum/ml_classifiers/issues/2> from davetcoleman/rospack_dep
  Missing dep on rosdep
* Missing dep on rosdep
* updated version number
* Merge pull request #1 <https://github.com/sniekum/ml_classifiers/issues/1> from k-okada/hydro
  upgrade to hydro
* upgrade to hydro
* added rosdep eigen
* removed eigen rosdep
* updated version
* fixed rosdep
* Switched linear kernel to RBF
* Moved to github
* Contributors: Dave Coleman, Hunter Laux, Kei Okada, Scott Niekum, sniekum
```
