### PR TITLE
ros_grant-release: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4148,14 +4148,12 @@ repositories:
       url: https://github.com/WPI-RAIL/ros_ethernet_rmp.git
       version: develop
     status: maintained
-  ros_grant-release:
+  ros_grant:
     doc:
       type: git
       url: https://github.com/shadow-robot/ros_grant.git
       version: indigo-devel
     release:
-      packages:
-      - ros_grant
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/shadow-robot/ros_grant-release.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4148,6 +4148,23 @@ repositories:
       url: https://github.com/WPI-RAIL/ros_ethernet_rmp.git
       version: develop
     status: maintained
+  ros_grant-release:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/ros_grant.git
+      version: indigo-devel
+    release:
+      packages:
+      - ros_grant
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/shadow-robot/ros_grant-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/shadow-robot/ros_grant.git
+      version: indigo-devel
+    status: maintained
   ros_statistics_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_grant-release` to `0.0.1-0`:
- upstream repository: https://github.com/shadow-robot/ros_grant.git
- release repository: https://github.com/shadow-robot/ros_grant-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
