### PR TITLE
cob_common: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -535,7 +535,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.5.5-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.6.0-0`:
- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.5-0`
## brics_actuator
- No changes
## cob_common
- No changes
## cob_description

```
* new sick_s300 collision model
* gazebo needs a new link for the topic, if we use the origin of the scanner (the center), the topic detects only the collision model
* Deleting s300 stl mesh because the dae file is used
* make lookat arbitrarily fast
* use VelocityJointInterface for cob4_torso
* new collision mesh
* merge with 320
* make lookat arbitrarily fast
* use VelocityJointInterface for cob4_torso
* Contributors: Florian Weisshardt, ipa-fxm, ipa-nhg
```
## cob_msgs
- No changes
## cob_srvs
- No changes
## desire_description
- No changes
## raw_description
- No changes
