### PR TITLE
cob_calibration_data: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -489,7 +489,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_calibration_data-release.git
-      version: 0.5.2-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/ipa320/cob_calibration_data.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_calibration_data` to `0.6.0-0`:
- upstream repository: https://github.com/ipa320/cob_calibration_data.git
- release repository: https://github.com/ipa320/cob_calibration_data-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.2-0`
## cob_calibration_data

```
* Merge pull request #68 <https://github.com/ipa320/cob_calibration_data/issues/68> from ipa-fxm/indigo_dev
  [Indigo] Bring in Hydro updates
* Merge branch 'hydro_dev' of github.com:ipa320/cob_calibration_data into indigo_dev
* Merge pull request #67 <https://github.com/ipa320/cob_calibration_data/issues/67> from ipa-cob4-2/hydro_dev
  added cob4-2 to the robot list
* Merge branch 'hydro_dev' of https://github.com/ipa-cob4-2/cob_calibration_data into hydro_dev
* Added cob4-2 robot CMakeLists
* Merge pull request #66 <https://github.com/ipa320/cob_calibration_data/issues/66> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #65 <https://github.com/ipa320/cob_calibration_data/issues/65> from ipa-fxm/indigo_dev
  Hydro updates
* Merge pull request #11 <https://github.com/ipa320/cob_calibration_data/issues/11> from ipa-fxm/hydro_dev
  Hydro updates
* Merge pull request #64 <https://github.com/ipa320/cob_calibration_data/issues/64> from ipa-cob3-8/hydro_dev
  cob3-8 calibration
* Merge branch 'hydro_dev' of github.com:ipa-cob3-8/cob_calibration_data into hydro_dev
* cob3-8 calibration
* cob3-8 calibration
* Contributors: Florian Weisshardt, Nadia Hammoudeh García, ipa-cob3-8, ipa-cob4-2, ipa-fxm, ipa-nhg
```
