### PR TITLE
pr2_sith: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5193,6 +5193,21 @@ repositories:
       url: https://github.com/PR2/pr2_simulator.git
       version: hydro-devel
     status: maintained
+  pr2_sith:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_sith.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/TheDash/pr2_sith-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_sith.git
+      version: hydro-devel
+    status: maintained
   pr2_surrogate:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_sith` to `1.0.1-0`:
- upstream repository: https://github.com/PR2/pr2_sith.git
- release repository: https://github.com/TheDash/pr2_sith-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## pr2_sith

```
* Fixed Dynamic Reconfigure in CMake for Hydro
* Added package.xml
* Removed unecc file
* 0.1.2
* Add rosdep on urlgrabber. Fixes #1
* 0.1.1
* Shutdown hook done right.
* Finishing Move!
* Finished auto setup.
* Attempt at autosetup.
* Pull in resource_retriever get() since it's broken upstream.
* Add ignores.
* Add app definition.
* Stackify.
* Move everything down a level
* Moving ros 0.5 branch into trunk
* Contributors: Austin Hendrix, David Lu, Erik Karulf, TheDash, ahendrix
```
