### PR TITLE
pr2_shield_teleop: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5184,6 +5184,21 @@ repositories:
       url: https://github.com/ros-gbp/pr2_robot-release.git
       version: 1.6.6-0
     status: maintained
+  pr2_shield_teleop:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_shield_teleop.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/TheDash/pr2_shield_teleop-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_shield_teleop.git
+      version: hydro-devel
+    status: maintained
   pr2_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_shield_teleop` to `1.0.1-0`:
- upstream repository: https://github.com/PR2/pr2_shield_teleop.git
- release repository: https://github.com/TheDash/pr2_shield_teleop-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## pr2_shield_teleop

```
* hydro-devel upgrade
* 0.1.1
* Merge branch 'master' into groovy-devel
* Add camera throttle and head position to launch.
* Version 0.1.0
* Add ignores.
* Add stack.xml and dependency on pr2_teleop.
* initial commit
* Contributors: Austin Hendrix, David Gossow, TheDash, ahendrix
```
