### PR TITLE
pr2_props: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5169,6 +5169,21 @@ repositories:
       url: https://github.com/PR2/pr2_precise_trajectory.git
       version: hydro-devel
     status: maintained
+  pr2_props:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_props.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/TheDash/pr2_props-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_props.git
+      version: hydro-devel
+    status: maintained
   pr2_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_props` to `1.0.2-0`:
- upstream repository: https://github.com/PR2/pr2_props.git
- release repository: https://github.com/TheDash/pr2_props-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## pr2_props

```
* Removed stackification -> Hydro catkinization
* Contributors: TheDash
```
