### PR TITLE
pr2_navigation_apps: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5117,6 +5117,26 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_navigation-release.git
       version: 0.1.22-0
+  pr2_navigation_apps:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_navigation_apps.git
+      version: hydro-devel
+    release:
+      packages:
+      - pr2_2dnav
+      - pr2_2dnav_local
+      - pr2_2dnav_slam
+      - pr2_navigation_apps
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/TheDash/pr2_navigation_apps-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_navigation_apps.git
+      version: hydro-devel
+    status: maintained
   pr2_pan_tilt:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_navigation_apps` to `1.0.1-0`:
- upstream repository: https://github.com/PR2/pr2_navigation_apps.git
- release repository: https://github.com/TheDash/pr2_navigation_apps-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
