### PR TITLE
message_multiplexing: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2390,11 +2390,12 @@ repositories:
       - mm_eigen_msgs
       - mm_messages
       - mm_mux_demux
+      - mm_radio
       - mm_vision_msgs
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/message_multiplexing-release.git
-      version: 0.1.1-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/stonier/message_multiplexing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_multiplexing` to `0.2.0-0`:
- upstream repository: https://github.com/stonier/message_multiplexing.git
- release repository: https://github.com/yujinrobot-release/message_multiplexing-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.1.1-0`
## mm_messages

```
* publisher centralised here for shared use by different messaging patterns.
```
## mm_mux_demux

```
* nanomsg pipeline and service demo programs
* mux/demux static api renamed to allow cross-class templatisation calls
```
## mm_radio

```
* gtest added
* first prototype of a 2-way pub-sub radio.
* nanomsg demo radio program
```
