### PR TITLE
rtmros_hironx: 1.0.24-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6662,7 +6662,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.23-0
+      version: 1.0.24-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.24-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.23-0`
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* (hironx.py)
* Add roslint. Code cleaned to pass roslint
* Contributors: Kei Okada, Isaac IY Saito
```
## rtmros_hironx

```
* (hironx.py)
* Add roslint. Code cleaned to pass roslint
* Contributors: Kei Okada, Isaac IY Saito
```
