### PR TITLE
cv_backports: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -892,6 +892,17 @@ repositories:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/cpp_introspection.git
       version: master
+  cv_backports:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/cv_backports-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/stonier/cv_backports.git
+      version: indigo
+    status: maintained
   demo_pioneer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cv_backports` to `0.1.2-0`:
- upstream repository: https://github.com/stonier/cv_backports.git
- release repository: https://github.com/yujinrobot-release/cv_backports-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## cv_backports

```
* Bugfix hanging problems due to global variable name conflicts with opencv.
```
