### PR TITLE
cob_environments: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -607,7 +607,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_environments-release.git
-      version: 0.5.3-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/ipa320/cob_environments.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_environments` to `0.6.0-0`:
- upstream repository: https://github.com/ipa320/cob_environments.git
- release repository: https://github.com/ipa320/cob_environments-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.3-0`
## cob_default_env_config

```
* catkin_lint'ing
* merge with ipa320
* catkin_lint'ing
* Merge pull request #70 <https://github.com/ipa320/cob_environments/issues/70> from ipa320/hydro_dev
  add dependency to roslaunch
* 0.5.3
* update changelog
* add dependency to roslaunch
* Contributors: Florian Weisshardt, ipa-fxm
```
## cob_environments

```
* 0.5.3
* update changelog
* Contributors: Florian Weisshardt
```
