### PR TITLE
cob_substitute: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -763,7 +763,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_substitute-release.git
-      version: 0.5.2-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/ipa320/cob_substitute.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_substitute` to `0.6.0-0`:
- upstream repository: https://github.com/ipa320/cob_substitute.git
- release repository: https://github.com/ipa320/cob_substitute-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.2-0`
## cob_lbr
- No changes
## cob_safety_controller
- No changes
## cob_substitute
- No changes
## frida_driver
- No changes
## prace_common
- No changes
## prace_gripper_driver
- No changes
