### PR TITLE
jsk_recognition: 0.1.20-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2926,7 +2926,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.1.19-0
+      version: 0.1.20-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.1.20-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.19-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_libfreenect2

```
* Add autoconf to jsk_libfreenect2
* Contributors: Ryohei Ueda
```
## jsk_pcl_ros

```
* Not use inliers to colorize pointcloud based on distance from planes
* Add check to be able to make convex or not on ColorizeDistanceFromPlane
  and OrganizedMultiPlaneSegmentation
* add ~use_normal to use noraml to segment multi planes
* add new nodelet to segment multiple planese by applying RANSAC recursively
* Contributors: Ryohei Ueda
```
## jsk_perception
- No changes
## jsk_recognition
- No changes
## resized_image_transport
- No changes
