### PR TITLE
pr2_ps3_joystick_app: 1.0.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5219,6 +5219,21 @@ repositories:
       url: https://github.com/PR2/pr2_props_app.git
       version: hydro-devel
     status: maintained
+  pr2_ps3_joystick_app:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_ps3_joystick_app.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/TheDash/pr2_ps3_joystick_app-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_ps3_joystick_app.git
+      version: hydro-devel
+    status: maintained
   pr2_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_ps3_joystick_app` to `1.0.1-1`:
- upstream repository: https://github.com/PR2/pr2_ps3_joystick_app.git
- release repository: https://github.com/TheDash/pr2_ps3_joystick_app-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
