### PR TITLE
applanix_driver: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -113,6 +113,25 @@ repositories:
       type: git
       url: https://github.com/rosjava/android_remocons.git
       version: hydro
+  applanix_driver:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/applanix_driver.git
+      version: hydro-devel
+    release:
+      packages:
+      - applanix_bridge
+      - applanix_driver
+      - applanix_msgs
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/clearpath-gbp/applanix_driver-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/applanix_driver.git
+      version: hydro-devel
+    status: maintained
   ar_kinect:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `applanix_driver` to `0.0.3-0`:
- upstream repository: https://github.com/clearpathrobotics/applanix_driver.git
- release repository: https://github.com/clearpath-gbp/applanix_driver-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
