### PR TITLE
pr2_plugs: 1.0.9-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5144,6 +5144,10 @@ repositories:
       url: https://github.com/TheDash/pr2_pan_tilt-release.git
       version: 1.0.1-0
   pr2_plugs:
+    doc:
+      type: git
+      url: https://github.com/TheDash/pr2_plugs-release.git
+      version: hydro-devel
     release:
       packages:
       - checkerboard_pose_estimation
@@ -5157,7 +5161,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_plugs-release.git
-      version: 1.0.4-0
+      version: 1.0.9-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_plugs.git
+      version: hydro-devel
+    status: maintained
   pr2_power_drivers:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5146,7 +5146,7 @@ repositories:
   pr2_plugs:
     doc:
       type: git
-      url: https://github.com/TheDash/pr2_plugs-release.git
+      url: https://github.com/PR2/pr2_plugs.git
       version: hydro-devel
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_plugs` to `1.0.9-0`:
- upstream repository: https://github.com/PR2/pr2_plugs.git
- release repository: https://github.com/TheDash/pr2_plugs-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.4-0`
## checkerboard_pose_estimation
- No changes
## outlet_pose_estimation
- No changes
## pr2_image_snapshot_recorder
- No changes
## pr2_plugs_actions
- No changes
## pr2_plugs_common
- No changes
## pr2_plugs_msgs
- No changes
## stereo_wall_detection

```
* Added dependencies
* Contributors: TheDash
```
## visual_pose_estimation
- No changes
