### PR TITLE
pr2_make_a_map_app: 1.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5045,7 +5045,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_make_a_map_app-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/PR2/pr2_make_a_map_app.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_make_a_map_app` to `1.0.3-0`:
- upstream repository: https://github.com/PR2/pr2_make_a_map_app.git
- release repository: https://github.com/TheDash/pr2_make_a_map_app-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.2-0`
## pr2_make_a_map_app

```
* Changed topics to topic; bug fix
* Fixed cmake bug
* Contributors: TheDash
```
