### PR TITLE
pr2_calibration: 1.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4896,7 +4896,7 @@ repositories:
   pr2_calibration:
     doc:
       type: git
-      url: https://github.com/PR2/pr2_calibration
+      url: https://github.com/PR2/pr2_calibration.git
       version: hydro-devel
     release:
       packages:
@@ -4913,7 +4913,7 @@ repositories:
       version: 1.0.4-0
     source:
       type: git
-      url: https://github.com/PR2/pr2_calibration
+      url: https://github.com/PR2/pr2_calibration.git
       version: hydro-devel
     status: maintained
   pr2_common:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4894,6 +4894,10 @@ repositories:
       url: https://github.com/TheDash/pr2_apps-release.git
       version: 0.5.6-1
   pr2_calibration:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_calibration
+      version: hydro-devel
     release:
       packages:
       - dense_laser_assembler
@@ -4906,7 +4910,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_calibration-release.git
-      version: 1.0.2-0
+      version: 1.0.4-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_calibration
+      version: hydro-devel
+    status: maintained
   pr2_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_calibration` to `1.0.4-0`:
- upstream repository: https://github.com/PR2/pr2_calibration.git
- release repository: https://github.com/TheDash/pr2_calibration-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.2-0`
## dense_laser_assembler
- No changes
## laser_joint_processor
- No changes
## laser_joint_projector
- No changes
## pr2_calibration
- No changes
## pr2_calibration_launch
- No changes
## pr2_dense_laser_snapshotter
- No changes
## pr2_se_calibration_launch

```
* Added install destination; bugfix
* Contributors: TheDash
```
