### PR TITLE
pr2_hack_the_future: 1.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5040,7 +5040,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_hack_the_future-release.git
-      version: 1.0.3-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/PR2/pr2_hack_the_future.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_hack_the_future` to `1.0.5-0`:
- upstream repository: https://github.com/PR2/pr2_hack_the_future.git
- release repository: https://github.com/TheDash/pr2_hack_the_future-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.3-0`
## hack_the_web_program_executor
- No changes
## pr2_hack_the_future
- No changes
## pr2_joint_teleop
- No changes
## pr2_simple_interface
- No changes
## program_queue
- No changes
## queue_web

```
* Updated CMakeLists
* Contributors: TheDash
```
## rviz_backdrop
- No changes
## slider_gui
- No changes
