### PR TITLE
moveit_visual_tools: 1.3.0-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3843,7 +3843,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 1.2.1-0
+      version: 1.3.0-2
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `1.3.0-2`:
- upstream repository: https://github.com/davetcoleman/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.2.1-0`
## moveit_visual_tools

```
* Added new getRandColor() function
* Added TRANSLUCENT2 color
* Added two new publishSphere() functions
* New convertPointToPose function
* Reduced sleep timer for starting all publishers from 0.5 seconds to 0.2 seconds
* Removed stacktrace tool because already exists in moveit_core
* New publishText function that allows custom scale and id number be passed in
* Removed deprecated getEEParentLink() function
* Added new scale sizes
* Added new processCollisionObvMsg()
* Added new setPlanningSceneMonitor()
* Deprecated removeAllColisionObejcts()
* Created new removeAllCollisionObjectsPS()
* Added new publishCollisionFloor()
* Added new loadCollisionSceneFromFile()
* New color purple
* Added new setBaseFrame() function
* Contributors: Dave Coleman
```
