### PR TITLE
moveit_visual_tools: 1.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2632,7 +2632,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git
-      version: hydro-devel
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -2641,7 +2641,7 @@ repositories:
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git
-      version: hydro-devel
+      version: indigo-devel
     status: developed
   mrpt_navigation:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2637,7 +2637,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 1.2.1-0
+      version: 1.3.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `1.3.0-0`:
- upstream repository: https://github.com/davetcoleman/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.2.1-0`
## moveit_visual_tools

```
* Added new getRandColor() function
* Added TRANSLUCENT2 color
* Added two new publishSphere() functions
* New convertPointToPose function
* Reduced sleep timer for starting all publishers from 0.5 seconds to 0.2 seconds
* Removed stacktrace tool because already exists in moveit_core
* New publishText function that allows custom scale and id number be passed in
* Removed deprecated getEEParentLink() function
* Added new scale sizes
* Added new processCollisionObvMsg()
* Added new setPlanningSceneMonitor()
* Deprecated removeAllColisionObejcts()
* Created new removeAllCollisionObjectsPS()
* Added new publishCollisionFloor()
* Added new loadCollisionSceneFromFile()
* New color purple
* Added new setBaseFrame() function
* Contributors: Dave Coleman
```
