### PR TITLE
schunk_modular_robotics: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4662,7 +4662,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/schunk_modular_robotics-release.git
-      version: 0.5.7-2
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/ipa320/schunk_modular_robotics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_modular_robotics` to `0.6.0-0`:
- upstream repository: https://github.com/ipa320/schunk_modular_robotics.git
- release repository: https://github.com/ipa320/schunk_modular_robotics-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.7-2`
## schunk_description

```
* beautification
* fix bad merge
* cleaning up
* merge
* Merge branch 'indigo_dev' into velocity_interface_controller_indigo
* Merge branch 'velocity_interface_controller' of github.com:ipa-fxm-fm/schunk_modular_robotics into velocity_interface_controller
* use velocity interface, fix link name
* added common xacro files
* back to CAD inertia
* changed inertia of link 5
* fix center of mass
* get rid off safety_controller and gazebo tags for more intuitive testing
* switch to velocity interface
* added inertias and limits for lwa4d
* Merge branch 'hydro_dev' into velocity_interface_controller
* back to CAD inertia
* changed inertia of link 5
* merge with new_model
* merge with 320
* fix center of mass
* get rid off safety_controller and gazebo tags for more intuitive testing
* switch to velocity interface
* Contributors: Felix Messmer, ipa-fxm, ipa-fxm-fm
```
## schunk_libm5api
- No changes
## schunk_modular_robotics
- No changes
## schunk_powercube_chain
- No changes
## schunk_sdh
- No changes
## schunk_simulated_tactile_sensors
- No changes
