### PR TITLE
ipa_canopen: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1864,7 +1864,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/ipa_canopen-release.git
-      version: 0.5.7-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/ipa320/ipa_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ipa_canopen` to `0.6.0-0`:
- upstream repository: https://github.com/ipa320/ipa_canopen.git
- release repository: https://github.com/ipa320/ipa_canopen-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.7-0`
## ipa_canopen

```
* 0.5.7
* update changelog
* Contributors: Florian Weisshardt
```
## ipa_canopen_core

```
* 0.5.7
* update changelog
* Contributors: Florian Weisshardt
```
## ipa_canopen_ros

```
* 0.5.7
* update changelog
* parses new layout for X_driver.yaml canopen components
* Contributors: Florian Weisshardt, ipa-fxm
```
