### PR TITLE
cob_control: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -551,14 +551,18 @@ repositories:
       - cob_base_velocity_smoother
       - cob_collision_velocity_filter
       - cob_control
+      - cob_control_mode_adapter
       - cob_footprint_observer
+      - cob_frame_tracker
+      - cob_hardware_interface
       - cob_lookat_controller
+      - cob_path_broadcaster
       - cob_trajectory_controller
       - cob_twist_controller
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.5.4-2
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.6.0-0`:
- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.4-2`
## cob_control_mode_adapter

```
* resolve namespace problem with velocity controller topics hardware vs. simulation
* resolve namespace problem of controller_manager hardware vs. simulation
* new package cob_control_mode_adapter
* Contributors: ipa-fxm
```
## cob_frame_tracker

```
* update version number
* update changelog
* beautify package xml and CMakeLists
* add missing dependencies
* update interactive marker when not tracking
* introducing PID for frame_tracker, generalization of interactive_frame_target
* new menu entry: reset_tracking
* make frame_tracker and interactive_marker more generic to be used with non-lookat twist_control
* moved frame_tracker to separate package
* update interactive marker when not tracking
* introducing PID for frame_tracker, generalization of interactive_frame_target
* new menu entry: reset_tracking
* make frame_tracker and interactive_marker more generic to be used with non-lookat twist_control
* moved frame_tracker to separate package
* Contributors: Felix Messmer, Florian Weisshardt, ipa-fxm
```
## cob_hardware_interface

```
* debug threading, do not start controllers from hardware_interface directly
* some renaming
* topic-based hardware_interface works
* merge with velocity_interface_controller (hydro)
* fix ascii characters
* added missing dependency
* backup before switching to indigo
* beautify package xml and CMakeLists
* add missing dependencies
* threading gefrickel
* further implement hardware interface
* bare bones concept node for cob_hwinterface_vel
* introducing cob_hardware_interface package
* threading gefrickel
* further implement hardware interface
* bare bones concept node for cob_hwinterface_vel
* introducing cob_hardware_interface package
* Contributors: Felix Messmer, ipa-fxm, ipa-fxm-fm
```
## cob_lookat_controller

```
* update changelog
* Merge branch 'indigo_dev' of github.com:ipa-fxm/cob_control into velocity_interface_controller_indigo
* Merge branch 'indigo_dev' into velocity_interface_controller_indigo
* beautify package xml and CMakeLists
* add missing dependencies
* merge with stash
* merge with fxm
* comparing lookat_controller and twist_controller
* moved frame_tracker to separate package
* debug stuff for lookat_controller
* merge with stash
* merge with fxm
* comparing lookat_controller and twist_controller
* moved frame_tracker to separate package
* debug stuff for lookat_controller
* Contributors: Christian Ehrmann, Felix Messmer, Florian Weisshardt, ipa-fxm
```
## cob_path_broadcaster

```
* erge branch 'velocity_interface_controller_indigo' of github.com:ipa-fxm-cm/cob_control into velocity_interface_controller_indigo
* new command move_circ added
* New CMake File and cob_articulation got new functions
* fixed install tags
* catkin_lint'ing
* merge with velocity_interface_controller (hydro)
* fix ascii characters
* Added xml parser for motion primitives move_ptp and move_lin
* beautify package xml and CMakeLists
* new package cob_path_broadcaster
* new package cob_path_broadcaster
* Contributors: Christoph Mark, Felix Messmer, ipa-fxm, ipa-fxm-cm
```
