### PR TITLE
cob_command_tools: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -512,7 +512,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.5.2-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.0-0`:
- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.2-0`
## cob_command_gui
- No changes
## cob_command_tools
- No changes
## cob_dashboard
- No changes
## cob_interactive_teleop

```
* fix cppcheck warnings
* Contributors: Florian Weisshardt
```
## cob_script_server
- No changes
## cob_teleop

```
* fix cppcheck warnings
* Contributors: Florian Weisshardt
```
## cob_teleop_cob4
- No changes
