### PR TITLE
cob_navigation: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -676,7 +676,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_navigation-release.git
-      version: 0.6.0-2
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/ipa320/cob_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_navigation` to `0.6.1-0`:
- upstream repository: https://github.com/ipa320/cob_navigation.git
- release repository: https://github.com/ipa320/cob_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.6.0-2`
## cob_linear_nav
- No changes
## cob_mapping_slam
- No changes
## cob_navigation
- No changes
## cob_navigation_config

```
* added cob4-2 configuration
* Contributors: ipa-cob4-2
```
## cob_navigation_global
- No changes
## cob_navigation_local
- No changes
## cob_navigation_slam
- No changes
## cob_scan_unifier
- No changes
