### PR TITLE
cob_robots: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -720,7 +720,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.5.4-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.6.0-0`:
- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.4-0`
## cob_bringup

```
* moved frame_tracker to separate package
* moved frame_tracker to separate package
* Contributors: ipa-fxm
```
## cob_controller_configuration_gazebo

```
* fix typo
* fake_diagnostics for actuators
* setup cob4-2
* install tags
* added cob4-2
* missing install tag
* cob4-1 and cob4-2 using latest features of cob_control
* topic-based hardware_interface works
* merge with velocity_interface_controller (hydro)
* backup before switching to indigo
* remove deprecated hybrid stuff
* update parameters for cob4-1 + cob4-2
* add default argument queue_size
* updated parameters and launch files, modified adapter for switching
* back to velocity controllers
* more testing
* pure JointVelocityController - no JointPositionController
* use interactive_target also for non-lookat twist_control
* moved frame_tracker to separate package
* first tests with velocity_interface_controller for lwa4p_extended arms
* use adapter as pure velocity adapter
* use VelocityJointInterface for cob4_torso
* updated parameters and launch files, modified adapter for switching
* back to velocity controllers
* more testing
* use same PIDs as in ros-industrial repo
* pure JointVelocityController - no JointPositionController
* use interactive_target also for non-lookat twist_control
* moved frame_tracker to separate package
* first tests with velocity_interface_controller for lwa4p_extended arms
* use adapter as pure velocity adapter
* use VelocityJointInterface for cob4_torso
* Contributors: Felix Messmer, Florian Weisshardt, ipa-fxm, ipa-fxm-fm, ipa-nhg
```
## cob_default_robot_config

```
* setup cob4-2
* Contributors: ipa-nhg
```
## cob_hardware_config

```
* setup cob4-2
* fix laser inversion
* update parameters for cob4-1 + cob4-2
* update parameters for cob4-1 + cob4-2
* updated parameters and launch files, modified adapter for switching
* merge wih ipa-fxm
* parameterization for frame_tracker and interactive_frame_target
* use interactive_target also for non-lookat twist_control
* moved frame_tracker to separate package
* tune lookat_controller for cob4_torso
* use VelocityJointInterface for cob4_torso
* updated parameters and launch files, modified adapter for switching
* merge wih ipa-fxm
* parameterization for frame_tracker and interactive_frame_target
* use interactive_target also for non-lookat twist_control
* moved frame_tracker to separate package
* tune lookat_controller for cob4_torso
* use VelocityJointInterface for cob4_torso
* Contributors: Felix Messmer, ipa-fxm, ipa-fxm-fm, ipa-nhg
```
## cob_monitoring
- No changes
## cob_robots
- No changes
