### PR TITLE
cob_manipulation: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -652,7 +652,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_manipulation-release.git
-      version: 0.5.2-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/ipa320/cob_manipulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_manipulation` to `0.6.0-0`:
- upstream repository: https://github.com/ipa320/cob_manipulation.git
- release repository: https://github.com/ipa320/cob_manipulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.5.2-0`
## cob_grasp_generation

```
* Merge branch 'hydro_dev' into hydro_release_candidate
* Merge branch 'hydro_dev' into hydro_release_candidate
* 0.5.1
* add changelogs
* Contributors: Florian Weisshardt, ipa-fxm
```
## cob_kinematics

```
* add catkin_INCLUDE_DIRS to cob_kinematics
* Merge pull request #43 <https://github.com/ipa320/cob_manipulation/issues/43> from ipa320/hydro_dev
  bringin updates from hydro_dev
* Merge branch 'hydro_dev' into hydro_release_candidate
* Merge branch 'hydro_dev' into hydro_release_candidate
* 0.5.1
* add changelogs
* Contributors: Florian Weisshardt, Scott K Logan, ipa-fxm
```
## cob_lookat_action

```
* Merge branch 'hydro_dev' into hydro_release_candidate
* 0.5.1
* add changelogs
* Contributors: Florian Weisshardt, ipa-fxm
```
## cob_manipulation

```
* Merge branch 'hydro_dev' into hydro_release_candidate
* Merge branch 'hydro_dev' into hydro_release_candidate
* 0.5.1
* add changelogs
* Contributors: Florian Weisshardt, ipa-fxm
```
## cob_moveit_config

```
* Merge branch 'hydro_dev' into hydro_release_candidate
* 0.5.1
* add changelogs
* Contributors: Florian Weisshardt, ipa-fxm
```
## cob_moveit_interface

```
* 0.5.1
* add changelogs
* Contributors: Florian Weisshardt
```
## cob_pick_place_action

```
* 0.5.1
* add changelogs
* Contributors: Florian Weisshardt
```
## cob_tactiletools

```
* Merge branch 'hydro_dev' into hydro_release_candidate
* 0.5.1
* add changelogs
* Contributors: Florian Weisshardt
```
## cob_tray_monitor

```
* 0.5.1
* add changelogs
* Contributors: Florian Weisshardt
```
