### PR TITLE
applanix_driver: 0.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -126,7 +126,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/applanix_driver-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/applanix_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `applanix_driver` to `0.0.4-0`:
- upstream repository: https://github.com/clearpathrobotics/applanix_driver.git
- release repository: https://github.com/clearpath-gbp/applanix_driver-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.3-0`
## applanix_bridge

```
* Removing diagnostic_msgs from find_package because it isn't needed at build, it's handled by the run_depends, and it makes the build servers cry.
* Contributors: Kareem Shehata
```
## applanix_driver
- No changes
## applanix_msgs
- No changes
