### PR TITLE
ueye: 0.0.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5132,7 +5132,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/kmhallen/ueye-release.git
-      version: 0.0.1-0
+      version: 0.0.2-1
     status: maintained
   um6:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye` to `0.0.2-1`:
- upstream repository: https://bitbucket.org/kmhallen/ueye
- release repository: https://github.com/kmhallen/ueye-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.1-0`
## ueye

```
* Updated download locations of pre-compiled uEye SDK
* add camera_id argument to change camera
* Contributors: Kevin Hallenbeck, Yutaka Kondo <mailto:yutaka.kondo@youtalk.jp>
```
