### PR TITLE
geometry_experimental: 0.4.12-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1964,7 +1964,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/geometry_experimental-release.git
-      version: 0.4.11-0
+      version: 0.4.12-0
     source:
       type: git
       url: https://github.com/ros/geometry_experimental.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_experimental` to `0.4.12-0`:
- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry_experimental-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.4.11-0`
## geometry_experimental
- No changes
## tf2
- No changes
## tf2_bullet
- No changes
## tf2_geometry_msgs
- No changes
## tf2_kdl
- No changes
## tf2_msgs
- No changes
## tf2_py
- No changes
## tf2_ros

```
* python patch for #57 <https://github.com/ros/geometry_experimental/issues/57>
  instead of patching lower level API expose the tuple to the user only if requested via optional argument
* adding unit tests to cover #43 <https://github.com/ros/geometry_experimental/issues/43>
* Make transform_listener reset tf buffer on loop detection
  This makes tf2 work with rosbag --clock --loop as expected.
* Contributors: Tully Foote, v4hn
```
## tf2_tools
- No changes
