### PR TITLE
pr2_gripper_sensor: 1.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5036,6 +5036,10 @@ repositories:
       url: https://github.com/kth-ros-pkg/pr2_ft_moveit_config.git
       version: hydro
   pr2_gripper_sensor:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_gripper_sensor.git
+      version: hydro-devel
     release:
       packages:
       - pr2_gripper_sensor
@@ -5045,7 +5049,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_gripper_sensor-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_gripper_sensor.git
+      version: hydro-devel
+    status: maintained
   pr2_hack_the_future:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_gripper_sensor` to `1.0.3-0`:
- upstream repository: https://github.com/PR2/pr2_gripper_sensor.git
- release repository: https://github.com/TheDash/pr2_gripper_sensor-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.2-0`
## pr2_gripper_sensor
- No changes
## pr2_gripper_sensor_action
- No changes
## pr2_gripper_sensor_controller
- No changes
## pr2_gripper_sensor_msgs
- No changes
