### PR TITLE
ardrone_autonomy: 1.3.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -128,6 +128,11 @@ repositories:
       type: git
       url: https://github.com/AutonomyLab/ardrone_autonomy.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/AutonomyLab/ardrone_autonomy-release.git
+      version: 1.3.7-0
     source:
       type: git
       url: https://github.com/AutonomyLab/ardrone_autonomy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ardrone_autonomy` to `1.3.7-0`:
- upstream repository: https://github.com/AutonomyLab/ardrone_autonomy.git
- release repository: https://github.com/AutonomyLab/ardrone_autonomy-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## ardrone_autonomy

```
* Use git protocol instead of https for cmake external project (fixes ca-certificate issues on the build farm)
```
