### PR TITLE
kobuki_desktop: 0.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2085,7 +2085,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki_desktop-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_desktop` to `0.4.1-0`:
- upstream repository: https://github.com/yujinrobot/kobuki_desktop.git
- release repository: https://github.com/yujinrobot-release/kobuki_desktop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.4.0-0`
## kobuki_dashboard
- No changes
## kobuki_desktop
- No changes
## kobuki_gazebo
- No changes
## kobuki_gazebo_plugins

```
* kobuki_gazebo_plugins: makes bump detection more reliable
* remove duplicated spinonce
* renamed updater to updates and loader to loads. reorder headers
* tf_prefix added. base_prefix added
* Contributors: Jihoon Lee, Marcus Liebhardt
```
## kobuki_qtestsuite
- No changes
## kobuki_rviz_launchers
- No changes
