### PR TITLE
shadow_robot: 1.3.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7122,19 +7122,22 @@ repositories:
       - sr_kinematics
       - sr_mechanism_controllers
       - sr_mechanism_model
+      - sr_moveit_config
       - sr_movements
       - sr_robot_msgs
       - sr_self_test
+      - sr_standalone
       - sr_tactile_sensors
       - sr_utilities
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/shadow-robot/sr-ros-interface-release.git
-      version: 1.3.0-6
+      version: 1.3.4-0
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ros-interface.git
       version: hydro-devel
+    status: maintained
   shadow_robot_ethercat:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `shadow_robot` to `1.3.4-0`:
- upstream repository: https://github.com/shadow-robot/sr-ros-interface.git
- release repository: https://github.com/shadow-robot/sr-ros-interface-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.3.0-6`
## shadow_robot

```
* Update package.xml
```
## sr_description

```
* Add versions of the arm and hand models that include a simulated kinect.
* Upgraded kinect definition to use plugins, reactivated simulated kinect.
* Add missing mesh for the biotac adapter for the fingers.
* Update arm description and controller params.
* Fix inertia, limits, and dynamic damping on the URDFs.
* Additional non-adjacent self-collision fix for metacarpal and proximal
```
## sr_example

```
* New demo using the new hand_commander
* Remove a potentially dangerous example (colliding fingers). Not a very interesting example either.
* Remove beeps from demo.
* Add tactile sensor data receiver to the HandCommander.
* Allow several concurrent interpolators. Coinciding joints in existing interpolators are overriden by new calls to move_hand.
* Add a python shadowhand Commander (it allows to send commands and read joint positions), and an example script that uses it.
* Tweaks for vagrant demo machine
  * Arg to start without gazebo gui
  * Launch hand sim and rviv view
```
## sr_gazebo_plugins

```
* Fix dependencies.
* Fix gazebo include paths
  This is needed to be compatible with newer Gazebo ABI/API
```
## sr_hand

```
* Add arguments to allow launching a particular robot model on gazebo.
* Checking position controllers before mixed controllers, as the former are the default ones. This speeds up the library start up time.
* Fix Hand library to work with hands with less fingers.
* Add a python shadowhand Commander (it allows to send commands and read joint positions).
```
## sr_hardware_interface
- No changes
## sr_kinematics
- No changes
## sr_mechanism_controllers

```
* Update controllers
```
## sr_mechanism_model
- No changes
## sr_moveit_config

```
* First release of this package
```
## sr_movements
- No changes
## sr_robot_msgs
- No changes
## sr_self_test

```
* Update diagnostics
```
## sr_standalone

```
* Fully working version.
```
## sr_tactile_sensors

```
* removing unused message - always compile for gazebo support
* using new tactile topic
```
## sr_utilities
- No changes
