### PR TITLE
shadow_robot_ethercat: 1.3.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7152,11 +7152,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/shadow-robot/sr-ros-interface-ethercat-release.git
-      version: 1.3.0-2
+      version: 1.3.4-0
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ros-interface-ethercat.git
       version: hydro-devel
+    status: maintained
   shape_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `shadow_robot_ethercat` to `1.3.4-0`:
- upstream repository: https://github.com/shadow-robot/sr-ros-interface-ethercat.git
- release repository: https://github.com/shadow-robot/sr-ros-interface-ethercat-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.3.0-2`
## shadow_robot_ethercat
- No changes
## sr_edc_controller_configuration
- No changes
## sr_edc_ethercat_drivers

```
* remove redundant message
```
## sr_edc_launch
- No changes
## sr_edc_muscle_tools
- No changes
## sr_external_dependencies
- No changes
## sr_robot_lib

```
* Cosmetic changes in hand driver code.
```
