### PR TITLE
carl_navigation: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -442,7 +442,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_navigation-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_navigation` to `0.0.3-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_navigation.git
- release repository: https://github.com/wpi-rail-release/carl_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.2-0`
## carl_navigation

```
* final version of location server
* build fix
* travis fix test
* message generation added
* started carl navigation
* footprint updated
* Contributors: Russell Toris
```
