### PR TITLE
moveit_simple_grasps: 1.2.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2655,7 +2655,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/davetcoleman/moveit_simple_grasps.git
-      version: hydro-devel
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -2664,7 +2664,7 @@ repositories:
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_simple_grasps.git
-      version: hydro-devel
+      version: indigo-devel
     status: developed
   moveit_visual_tools:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2660,7 +2660,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/moveit_simple_grasps-release.git
-      version: 1.1.0-0
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_simple_grasps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_simple_grasps` to `1.2.0-1`:
- upstream repository: https://github.com/davetcoleman/moveit_simple_grasps.git
- release repository: https://github.com/davetcoleman/moveit_simple_grasps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.1.0-0`
## moveit_simple_grasps
- No changes
