### PR TITLE
jsk_recognition: 0.1.21-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1965,7 +1965,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.1.20-0
+      version: 0.1.21-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.1.21-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.20-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_libfreenect2
- No changes
## jsk_pcl_ros

```
* Add utility methods for 2-D geometry
* Add new nodelet to filter bounding box array
* Check align axis before aligning boundingbox in ClusterPointIndicesDecomposer
* Add diagnostic information to EuclideanClusteringExtraction
* Add diagnostic information to MultiPlaneExtraction
* Add processing frame id information to PlaneRejector's diagnostic
* Add diagnostic information to ClusterPointIndicesDecomposer
* Add diagnostics to PlaneRejector
* Add more diagnostics to OrganizedMultiPlaneSegmentation and fix global
  hook for ConvexHull
* Contributors: Ryohei Ueda
```
## jsk_perception

```
* Add more diagnostics to OrganizedMultiPlaneSegmentation and fix global
  hook for ConvexHull
* Contributors: Ryohei Ueda
```
## jsk_recognition
- No changes
## resized_image_transport
- No changes
