### PR TITLE
turtlebot_arm: 0.3.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5148,6 +5148,7 @@ repositories:
     release:
       packages:
       - turtlebot_arm
+      - turtlebot_arm_block_manipulation
       - turtlebot_arm_bringup
       - turtlebot_arm_description
       - turtlebot_arm_ikfast_plugin
@@ -5157,7 +5158,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_arm-release.git
-      version: 0.3.2-0
+      version: 0.3.3-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot_arm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_arm` to `0.3.3-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_arm.git
- release repository: https://github.com/turtlebot-release/turtlebot_arm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.3.2-0`
## turtlebot_arm

```
* Add turtlebot_arm_block_manipulation package
```
## turtlebot_arm_block_manipulation

```
* Updated version for indigo/moveit of the old turtlebot_block_manipulation
```
## turtlebot_arm_bringup
- No changes
## turtlebot_arm_description
- No changes
## turtlebot_arm_ikfast_plugin
- No changes
## turtlebot_arm_kinect_calibration
- No changes
## turtlebot_arm_moveit_config
- No changes
## turtlebot_arm_moveit_demos
- No changes
