### PR TITLE
jsk_visualization: 1.0.11-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2008,7 +2008,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.10-0
+      version: 1.0.11-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.11-0`:
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.0.10-0`
## jsk_interactive
- No changes
## jsk_interactive_marker

```
* jsk_interactive_marker does not depend on geometry
* Contributors: Ryohei Ueda
```
## jsk_interactive_test
- No changes
## jsk_rqt_plugins
- No changes
## jsk_rviz_plugins

```
* Do not ues deprecated PLUGINLIB_DECLARE_CLASS
* Draw polygon as 'face' on PolygonArrayDisplay
* Use jsk_topic_tools::colorCategory20 to colorize automatically
* Add tool plugin to close/open all the displays on rviz
* Contributors: Ryohei Ueda
```
