### PR TITLE
ueye: 0.0.3-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5188,7 +5188,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/kmhallen/ueye-release.git
-      version: 0.0.2-1
+      version: 0.0.3-2
+    source:
+      type: hg
+      url: https://bitbucket.org/kmhallen/ueye
+      version: default
     status: maintained
   um6:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye` to `0.0.3-2`:
- upstream repository: https://bitbucket.org/kmhallen/ueye
- release repository: https://github.com/kmhallen/ueye-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.2-1`
## ueye

```
* Added pre-compiled uEye SDK for arm architecture
* Fixed macro conversion of version numbers to text. Fixes #8
* Contributors: Kevin Hallenbeck
```
