### PR TITLE
ueye: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7714,6 +7714,16 @@ repositories:
       type: hg
       url: https://bitbucket.org/kmhallen/ueye
       version: default
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/kmhallen/ueye-release.git
+      version: 0.0.3-0
+    source:
+      type: hg
+      url: https://bitbucket.org/kmhallen/ueye
+      version: default
+    status: maintained
   ueye_cam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye` to `0.0.3-0`:
- upstream repository: https://bitbucket.org/kmhallen/ueye
- release repository: https://github.com/kmhallen/ueye-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## ueye

```
* Added pre-compiled uEye SDK for arm architecture
* Fixed macro conversion of version numbers to text. Fixes #8
* Contributors: Kevin Hallenbeck
```
