### PR TITLE
schunk_modular_robotics: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4726,7 +4726,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/schunk_modular_robotics-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/ipa320/schunk_modular_robotics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_modular_robotics` to `0.6.1-0`:
- upstream repository: https://github.com/ipa320/schunk_modular_robotics.git
- release repository: https://github.com/ipa320/schunk_modular_robotics-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.6.0-0`
## schunk_description

```
* 1=true
* fix bumper plugins
* merge
* fixed center of mass and inertias
* Contributors: ipa-fxm, ipa-fxm-fm
```
## schunk_libm5api
- No changes
## schunk_modular_robotics
- No changes
## schunk_powercube_chain
- No changes
## schunk_sdh
- No changes
## schunk_simulated_tactile_sensors
- No changes
