### PR TITLE
shadow_robot: 1.3.5-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7132,7 +7132,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/shadow-robot/sr-ros-interface-release.git
-      version: 1.3.4-0
+      version: 1.3.5-2
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ros-interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `shadow_robot` to `1.3.5-2`:
- upstream repository: https://github.com/shadow-robot/sr-ros-interface.git
- release repository: https://github.com/shadow-robot/sr-ros-interface-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.3.4-0`
## shadow_robot
- No changes
## sr_description
- No changes
## sr_example
- No changes
## sr_gazebo_plugins
- No changes
## sr_hand
- No changes
## sr_hardware_interface
- No changes
## sr_kinematics
- No changes
## sr_mechanism_controllers
- No changes
## sr_mechanism_model
- No changes
## sr_moveit_config
- No changes
## sr_movements
- No changes
## sr_robot_msgs
- No changes
## sr_self_test
- No changes
## sr_standalone
- No changes
## sr_tactile_sensors

```
* gazebo dependency fix
* Contributors: Toni Oliver
```
## sr_utilities
- No changes
