### PR TITLE
rail_segmentation: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3621,6 +3621,21 @@ repositories:
       url: https://github.com/WPI-RAIL/rail_maps.git
       version: develop
     status: maintained
+  rail_segmentation:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_segmentation.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/rail_segmentation.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_segmentation.git
+      version: develop
+    status: maintained
   random_numbers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_segmentation` to `0.0.1-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_segmentation.git
- release repository: https://github.com/wpi-rail-release/rail_segmentation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## rail_segmentation

```
* bad source file fixed
* pcl_ros build
* pcl_ros build
* travis tests
* travis now runs updates
* indigo ros_pcl added
* cleanup for release
* segmentation tuning and updates
* stopped segmentation from identifying non-horizontal planes
* initial commit
* Contributors: Russell Toris, dekent
```
