### PR TITLE
carl_bot: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -393,11 +393,12 @@ repositories:
       - carl_bringup
       - carl_description
       - carl_dynamixel
+      - carl_interactive_manipulation
       - carl_teleop
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_bot-release.git
-      version: 0.0.5-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_bot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_bot` to `0.0.7-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_bot.git
- release repository: https://github.com/wpi-rail-release/carl_bot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.5-0`
## carl_bot
- No changes
## carl_bringup

```
* carl_interactive_manipulation added
* launches carl_interactive_manipulation instead of the jaco-only interactive markers
* Contributors: Russell Toris, dekent
```
## carl_description
- No changes
## carl_dynamixel
- No changes
## carl_interactive_manipulation

```
* carl_interactive_manipulation added
* Contributors: Russell Toris
```
## carl_teleop
- No changes
