### PR TITLE
nanomsg: 0.4.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2725,7 +2725,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/nanomsg-release.git
-      version: 0.4.0-0
+      version: 0.4.0-1
     status: maintained
   nao_extras:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `nanomsg` to `0.4.0-1`:
- upstream repository: https://github.com/stonier/nanomsg.git
- release repository: https://github.com/yujinrobot-release/nanomsg-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.4.0-0`
