### PR TITLE
srv_tools: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5078,6 +5078,18 @@ repositories:
       type: git
       url: https://github.com/srv/srv_tools.git
       version: indigo
+    release:
+      packages:
+      - bag_tools
+      - launch_tools
+      - plot_tools
+      - pointcloud_tools
+      - srv_tools
+      - tf_tools
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/srv/srv_tools-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/srv/srv_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `srv_tools` to `0.0.1-0`:
- upstream repository: https://github.com/srv/srv_tools.git
- release repository: https://github.com/srv/srv_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
