### PR TITLE
added libsvn-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1803,6 +1803,8 @@ libstdc++5:
       packages: [virtual/libstdc++]
   opensuse: [libstdc++33]
   ubuntu: [libstdc++5]
+libsvn-dev:
+  ubuntu: [libsvn-dev]
 libswscale-dev:
   arch: [ffmpeg]
   debian: [libswscale-dev]


### PR DESCRIPTION
added `libsvn-dev`, currently only for ubuntu as I don't know its name in other repos. Alternatively, one could add this to the existing `subversion` key to complement the `subversion` package but I believe it's cleaner this way
