### PR TITLE
Point at rqt_pr2_dashboards new home in the PR2 org

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4250,7 +4250,7 @@ repositories:
   rqt_pr2_dashboard:
     doc:
       type: git
-      url: https://github.com/ros-visualization/rqt_pr2_dashboard.git
+      url: https://github.com/PR2/rqt_pr2_dashboard.git
       version: groovy-devel
   rqt_robot_plugins:
     doc:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6683,7 +6683,7 @@ repositories:
   rqt_pr2_dashboard:
     doc:
       type: git
-      url: https://github.com/ros-visualization/rqt_pr2_dashboard.git
+      url: https://github.com/PR2/rqt_pr2_dashboard.git
       version: hydro-devel
     release:
       tags:


### PR DESCRIPTION
Moved rqt_pr2_dashboard to the PR2 Organization.
Would be nice to get this merged so the next build doesn't blow up.
