### PR TITLE
serial: 1.2.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4797,7 +4797,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wjwwood/serial-release.git
-      version: 1.2.0-0
+      version: 1.2.0-2
     source:
       type: git
       url: https://github.com/wjwwood/serial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `serial` to `1.2.0-2`:
- upstream repository: https://github.com/wjwwood/serial.git
- release repository: https://github.com/wjwwood/serial-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12-dev`
- previous version for package: `1.2.0-0`
## serial

```
* Removed vestigial ``read_cache_`` private member variable from Serial::Serial
* Fixed usage of scoped locks
  Previously they were getting destroyed immediately because they were not stored in a temporary scope variable
* Added check of return value from close in Serial::SerialImpl::close () in unix.cc and win.cc
* Added ability to enumerate ports on linux and windows.
  Updated serial_example.cc to show example of port enumeration.
* Fixed compile on VS2013
* Added functions ``waitReadable`` and ``waitByteTimes`` with implemenations for Unix to support high performance reading
* Contributors: Christopher Baker, Craig Lilley, Konstantina Kastanara, Mike Purvis, William Woodall
```
