### PR TITLE
cob_common: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -575,7 +575,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.6.1-0`:
- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.6.0-0`
## brics_actuator
- No changes
## cob_common
- No changes
## cob_description

```
* fix mesh due to assimp error
* fix bumper plugins
* fixed center of gravity and inertia formulas
* Contributors: ipa-fxm, ipa-fxm-fm
```
## cob_msgs
- No changes
## cob_srvs
- No changes
## desire_description

```
* fix bumper plugins
* Contributors: ipa-fxm
```
## raw_description

```
* 1=true
* fix bumper plugins
* Contributors: ipa-fxm
```
