### PR TITLE
schunk_svh_driver: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4778,6 +4778,11 @@ repositories:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git
       version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver-release.git
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_svh_driver` to `0.1.0-0`:
- upstream repository: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## schunk_svh_driver

```
* First public release: Contains Low-Level Driver, 3D-Model and ROS-Node
* Contributors: Georg Heppner, Lars Pfotzer, Nils Berg, Andreas Hermann, Steffen Rühl
```
