### PR TITLE
schunk_svh_driver: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4782,7 +4782,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver-release.git
-      version: 0.1.0-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_svh_driver` to `0.1.2-0`:
- upstream repository: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.1.0-0`
## schunk_svh_driver

```
* Fixed install directives in CMake
* Contributors: Andreas Hermann
```
