### PR TITLE
rtmros_gazebo: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6736,6 +6736,25 @@ repositories:
       url: https://github.com/start-jsk/rtmros_common.git
       version: master
     status: developed
+  rtmros_gazebo:
+    doc:
+      type: git
+      url: https://github.com/start-jsk/rtmros_gazebo.git
+      version: master
+    release:
+      packages:
+      - eusgazebo
+      - hrpsys_gazebo_general
+      - hrpsys_gazebo_msgs
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/tork-a/rtmros_gazebo-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/start-jsk/rtmros_gazebo.git
+      version: master
+    status: developed
   rtmros_hironx:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_gazebo` to `0.1.1-0`:
- upstream repository: https://github.com/start-jsk/rtmros_gazebo.git
- release repository: https://github.com/tork-a/rtmros_gazebo-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## eusgazebo

```
* fixed minor bug to read static argument
* add option for displaying gazebo viewer
* added eusgazebo/test
* added eusgazebo/samples
* added eusgazebo/euslisp core files.
* add eusgazebo package directory
* Contributors: Masaki Murooka
```
## hrpsys_gazebo_general

```
* Initial release of hrpsys_gazebo_general
* Contributors: Kei Okada, Ryohei Ueda, YoheiKakiuchi, Masaki Murooka, Shinichiro Noda
```
## hrpsys_gazebo_msgs

```
* add ref_position/velocity to RobotState.msg
* add kpv_position and kpv_velocity
* catkinize hrpsys_gazebo_msgs
* this commit might connect to r5648
* re-organize rtmros_common, add openrtm_common, rtmros_tutorials, rtmros_hironx, rtmros_gazebo, openrtm_apps, See Issue 137
* Contributors: Kei Okada, Youhei Kakiuchi
```
