### PR TITLE
aau_multi_robot: 0.1.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -10,6 +10,16 @@ release_platforms:
   - quantal
   - raring
 repositories:
+  aau_multi_robot:
+    release:
+      packages:
+      - adhoc_communication
+      - explorer
+      - map_merger
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/aau-ros/aau_multi_robot-release.git
+      version: 0.1.1-1
   abb:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aau_multi_robot` to `0.1.1-1`:
- upstream repository: https://github.com/aau-ros/aau_multi_robot.git
- release repository: https://github.com/aau-ros/aau_multi_robot-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
