### PR TITLE
Added official SCHUNK SVH Hand driver package from FZI Karlsruhe for HYDRO

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7043,6 +7043,21 @@ repositories:
       url: https://github.com/ipa320/schunk_modular_robotics.git
       version: hydro_dev
     status: developed
+  schunk_svh_driver:
+    doc:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver-release.git
+      version: 0.1.4-0
+    source:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git
+      version: master
+    status: maintained
   scriptable_monitoring:
     doc:
       type: git


### PR DESCRIPTION
Our driver package is identical for Indigo and Hydro. Therefor we would like to offer it also for Hydro.
It was tested by us on both distros.
