### PR TITLE
jsk_common: 1.0.45-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2849,12 +2849,11 @@ repositories:
       - rostwitter
       - sklearn
       - speech_recognition_msgs
-      - stereo_synchronizer
       - voice_text
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.41-0
+      version: 1.0.45-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.45-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.0.41-0`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## collada_urdf_jsk_patch
- No changes
## depth_image_proc_jsk_patch
- No changes
## downward
- No changes
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha
- No changes
## image_view2
- No changes
## image_view_jsk_patch
- No changes
## jsk_common
- No changes
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_tilt_laser
- No changes
## jsk_tools
- No changes
## jsk_topic_tools
- No changes
## laser_filters_jsk_patch
- No changes
## libsiftfast
- No changes
## multi_map_server
- No changes
## nlopt
- No changes
## openni_tracker_jsk_patch
- No changes
## opt_camera
- No changes
## posedetection_msgs
- No changes
## pr2_groovy_patches
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter

```
* Merge pull request #543 from k-okada/use_deb_request
  rewrite twitter.py to use ubuntu python-oauth2 and python-request
* rewrite twitter.py to use ubuntu python-oauth2 and python-request
```
## sklearn
- No changes
## speech_recognition_msgs
- No changes
## voice_text
- No changes
