### PR TITLE
keyboard: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2037,6 +2037,17 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git
       version: master
     status: maintained
+  keyboard:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/lrse-ros-release/keyboard-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/lrse/ros-keyboard.git
+      version: master
+    status: developed
   kobuki:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `keyboard` to `0.1.1-0`:
- upstream repository: https://github.com/lrse/ros-keyboard.git
- release repository: https://github.com/lrse-ros-release/keyboard-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## keyboard

```
* README
* stuff
* fix for hydro
* switched from ncurses to SDL
* constants from ncurses
* initial commit
* Contributors: v01d
```
