### PR TITLE
schunk_svh_driver: 0.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4804,7 +4804,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_svh_driver` to `0.1.5-0`:
- upstream repository: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.1.4-0`
## schunk_svh_driver

```
* Moved rviz config to etc and changed gui to a default no show
* Fixed a counting variable which was comparing signed with unsigned
* Changed the way to install udev rules to be a script for devel and a rosrun for install targets
* Enabled the svh_sin_test node by default as this is easier to start
* Changed the logging mechanism to use ~/.ros/log instead of the project folder as this is not writable in installs
  Also changed many default values and how the config values are read to provide better user experience
* Added a queue size to the topics published by the plugin as it is required by hydro
* Contributors: Georg Heppner
```
