### PR TITLE
hrpsys: 315.2.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2390,7 +2390,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/hrpsys-release.git
-      version: 315.2.5-1
+      version: 315.2.6-0
     source:
       type: git
       url: https://github.com/start-jsk/hrpsys.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys` to `315.2.6-0`:
- upstream repository: https://github.com/start-jsk/hrpsys.git
- release repository: https://github.com/tork-a/hrpsys-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `315.2.5-1`
## hrpsys

```
* New Feature
* Fix
* hrpsys_config
* I/F improvement
* Document update
* Contributors: Kei Okada, Shunichi Nozawa, Isaac IY Saito
```
