### PR TITLE
pr2_ethercat_drivers: 1.8.11-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5073,7 +5073,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/pr2_ethercat_drivers-release.git
-      version: 1.8.8-1
+      version: 1.8.11-0
     source:
       type: git
       url: https://github.com/PR2/pr2_ethercat_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_ethercat_drivers` to `1.8.11-0`:
- upstream repository: https://github.com/PR2/pr2_ethercat_drivers.git
- release repository: https://github.com/ros-gbp/pr2_ethercat_drivers-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.8.8-1`
## ethercat_hardware
- No changes
## fingertip_pressure
- No changes
## pr2_ethercat_drivers
- No changes
