### PR TITLE
Mavlink and mavros package repos moved to mavlink organization.

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3488,12 +3488,12 @@ repositories:
   mavlink:
     doc:
       type: git
-      url: https://github.com/vooon/mavlink-gbp-release.git
+      url: https://github.com/mavlink/mavlink-gbp-release.git
       version: release/hydro/mavlink
     release:
       tags:
         release: release/hydro/{package}/{version}
-      url: https://github.com/vooon/mavlink-gbp-release.git
+      url: https://github.com/mavlink/mavlink-gbp-release.git
       version: 2014.10.01-0
     status: maintained
   mavros:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3499,7 +3499,7 @@ repositories:
   mavros:
     doc:
       type: git
-      url: https://github.com/vooon/mavros.git
+      url: https://github.com/mavlink/mavros.git
       version: master
     release:
       packages:
@@ -3507,11 +3507,11 @@ repositories:
       - mavros_extras
       tags:
         release: release/hydro/{package}/{version}
-      url: https://github.com/vooon/mavros-release.git
+      url: https://github.com/mavlink/mavros-release.git
       version: 0.8.0-0
     source:
       type: git
-      url: https://github.com/vooon/mavros.git
+      url: https://github.com/mavlink/mavros.git
       version: master
     status: developed
   maxwell:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2410,7 +2410,7 @@ repositories:
   mavros:
     doc:
       type: git
-      url: https://github.com/vooon/mavros.git
+      url: https://github.com/mavlink/mavros.git
       version: master
     release:
       packages:
@@ -2418,11 +2418,11 @@ repositories:
       - mavros_extras
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/vooon/mavros-release.git
+      url: https://github.com/mavlink/mavros-release.git
       version: 0.8.0-0
     source:
       type: git
-      url: https://github.com/vooon/mavros.git
+      url: https://github.com/mavlink/mavros.git
       version: master
     status: developed
   media_export:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2399,12 +2399,12 @@ repositories:
   mavlink:
     doc:
       type: git
-      url: https://github.com/vooon/mavlink-gbp-release.git
+      url: https://github.com/mavlink/mavlink-gbp-release.git
       version: release/indigo/mavlink
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/vooon/mavlink-gbp-release.git
+      url: https://github.com/mavlink/mavlink-gbp-release.git
       version: 2014.09.22-0
     status: maintained
   mavros:


### PR DESCRIPTION
Just url update. Old path still works.
