### PR TITLE
app_manager: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -127,6 +127,21 @@ repositories:
       type: git
       url: https://github.com/rosjava/android_remocons.git
       version: hydro
+  app_manager:
+    doc:
+      type: git
+      url: https://github.com/pr2/app_manager.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/app_manager-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/pr2/app_manager.git
+      version: hydro-devel
+    status: maintained
   applanix_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `app_manager` to `1.0.1-0`:
- upstream repository: https://github.com/pr2/app_manager.git
- release repository: https://github.com/ros-gbp/app_manager-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
