### PR TITLE
willow_maps: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8253,6 +8253,21 @@ repositories:
       type: git
       url: https://github.com/RafBerkvens/wifi_scan.git
       version: master
+  willow_maps:
+    doc:
+      type: git
+      url: https://github.com/pr2/willow_maps.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/willow_maps-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/pr2/willow_maps.git
+      version: hydro-devel
+    status: maintained
   win_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `willow_maps` to `1.0.1-0`:
- upstream repository: https://github.com/pr2/willow_maps.git
- release repository: https://github.com/ros-gbp/willow_maps-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
