### PR TITLE
pr2_apps: 0.5.9-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4979,8 +4979,13 @@ repositories:
       version: master
     status: maintained
   pr2_apps:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_apps.git
+      version: hydro-devel
     release:
       packages:
+      - pr2_app_manager
       - pr2_apps
       - pr2_mannequin_mode
       - pr2_position_scripts
@@ -4990,7 +4995,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_apps-release.git
-      version: 0.5.6-1
+      version: 0.5.9-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_apps.git
+      version: hydro-devel
+    status: maintained
   pr2_calibration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_apps` to `0.5.9-0`:
- upstream repository: https://github.com/PR2/pr2_apps.git
- release repository: https://github.com/TheDash/pr2_apps-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.5.6-1`
## pr2_app_manager

```
* Updated pr2_app_manager, now compiles in hydro
* Updated pr2_app_manager
* Added pr2_app_manager package
* Contributors: TheDash
```
## pr2_apps

```
* Added app manager to package.xml
* Contributors: TheDash
```
## pr2_mannequin_mode
- No changes
## pr2_position_scripts
- No changes
## pr2_teleop
- No changes
## pr2_teleop_general
- No changes
## pr2_tuckarm
- No changes
