### PR TITLE
rqt_common_plugins: 0.3.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4705,7 +4705,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.3.9-0
+      version: 0.3.10-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `0.3.10-0`:
- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/ros-gbp/rqt_common_plugins-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.3.9-0`
## rqt_action
- No changes
## rqt_bag

```
* fix topic type retrieval for multiple bag files (#279 <https://github.com/ros-visualization/rqt_common_plugins/issues/279>)
* fix region_changed signal emission when no start/end stamps are set
* improve right-click menu
* improve popup management (#280 <https://github.com/ros-visualization/rqt_common_plugins/issues/280>)
* implement recording of topic subsets
* sort the list of topics
* update plugin scripts to use full name to avoid future naming collisions
```
## rqt_bag_plugins

```
* add displaying of depth image thumbnails
```
## rqt_common_plugins
- No changes
## rqt_console

```
* update plugin scripts to use full name to avoid future naming collisions
```
## rqt_dep

```
* update plugin scripts to use full name to avoid future naming collisions
```
## rqt_graph

```
* update plugin scripts to use full name to avoid future naming collisions
```
## rqt_image_view

```
* update plugin scripts to use full name to avoid future naming collisions
```
## rqt_launch

```
* update plugin scripts to use full name to avoid future naming collisions
```
## rqt_logger_level

```
* update plugin scripts to use full name to avoid future naming collisions
```
## rqt_msg

```
* update plugin scripts to use full name to avoid future naming collisions
```
## rqt_plot

```
* update plugin scripts to use full name to avoid future naming collisions
```
## rqt_publisher

```
* update plugin scripts to use full name to avoid future naming collisions
```
## rqt_py_common
- No changes
## rqt_py_console

```
* update plugin scripts to use full name to avoid future naming collisions
```
## rqt_reconfigure

```
* update plugin scripts to use full name to avoid future naming collisions
```
## rqt_service_caller

```
* update plugin scripts to use full name to avoid future naming collisions
```
## rqt_shell

```
* update plugin scripts to use full name to avoid future naming collisions
```
## rqt_srv

```
* update plugin scripts to use full name to avoid future naming collisions
```
## rqt_top

```
* update plugin scripts to use full name to avoid future naming collisions
```
## rqt_topic

```
* update plugin scripts to use full name to avoid future naming collisions
```
## rqt_web

```
* update plugin scripts to use full name to avoid future naming collisions
```
