### PR TITLE
navigation: 1.11.12-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4160,7 +4160,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.11.11-0
+      version: 1.11.12-0
     source:
       type: git
       url: https://github.com/ros-planning/navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.11.12-0`:
- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.11.11-0`
## amcl

```
* Bug fix to remove particle weights being reset when motion model is updated
* Integrated new sensor model which calculates the observation likelihood in a probabilistic manner
  Also includes the option to do beam-skipping (to better handle observations from dynamic obstacles)
* Pose pulled from parameter server when new map received
* Contributors: Steven Kordell, hes3pal
```
## base_local_planner

```
* Bugfix uninitialised occ_cost variable usage
  This fixes #256 <https://github.com/ros-planning/navigation/issues/256>.
* base_local_planner: adds waitForTransform
* Fixed issue causing trajectory planner returning false to isGoalReach ed even when it's control thread finishes executing
* Contributors: Daniel Stonier, Marcus Liebhardt, hes3pal
```
## carrot_planner
- No changes
## clear_costmap_recovery

```
* Clarify debug messages
* Initial Clearing Costmap parameter change
* Contributors: David Lu!!, Michael Ferguson
```
## costmap_2d

```
* costmap_2d: export library layers
* Merge pull request #198 <https://github.com/ros-planning/navigation/issues/198> from kmhallen/hydro-devel
  Fixed costmap_2d clearing from service /move_base/clear_costmaps
* Costmap Layer comments
* Add destructors for all of the layers to remove the dynamic parameter clients
* Add method for removing static observations (for testing)
* Move testing_helper
* Initial Clearing Costmap parameter change
* Fixed costmap_2d clearing from service /move_base/clear_costmaps
* Contributors: David Lu!!, Kevin Hallenbeck, Michael Ferguson
```
## dwa_local_planner
- No changes
## fake_localization
- No changes
## global_planner

```
* Add Gradient Path's cycle limit to GridPath
* When clearing endpoint, do not overwrite potentials
* Consolidate usage of POT_HIGH
* Contributors: David V. Lu!!
```
## map_server

```
* map_server: [style] alphabetize dependencies
* map_server: remove vestigial export line
  the removed line does not do anything in catkin
* Contributors: William Woodall
```
## move_base
- No changes
## move_base_msgs
- No changes
## move_slow_and_clear
- No changes
## nav_core
- No changes
## navfn
- No changes
## navigation
- No changes
## robot_pose_ekf

```
* Fix EKF topic name so that it is unaffected by tf_prefix
* Install launch files, closes #249 <https://github.com/ros-planning/navigation/issues/249>
* Fixed hardcoded tf frames issue by fetching base_footprint_frame_ value from param server and using it in OdomEstimation filter
* Fixed hardcoded tf frames issue by adding variables for output and base_footprint frames along with mutator methods
* Contributors: Jochen Sprickerhof, Michael Ferguson, Murilo FM
```
## rotate_recovery
- No changes
## voxel_grid
- No changes
