### PR TITLE
libfovis: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2254,7 +2254,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/srv/libfovis-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     status: maintained
   libfreenect:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `libfovis` to `0.0.7-0`:
- upstream repository: https://github.com/srv/libfovis.git
- release repository: https://github.com/srv/libfovis-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.6-0`
