### PR TITLE
libfovis: 0.0.4-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3314,7 +3314,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/srv/libfovis-release.git
-      version: 0.0.4-0
+      version: 0.0.4-1
   libfreenect:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libfovis` to `0.0.4-1`:
- upstream repository: https://github.com/srv/libfovis.git
- release repository: https://github.com/srv/libfovis-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.4-0`
