### PR TITLE
hector_localization: 0.1.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2204,11 +2204,10 @@ repositories:
       - hector_pose_estimation
       - hector_pose_estimation_core
       - message_to_tf
-      - world_magnetic_model
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
-      version: 0.1.3-0
+      version: 0.1.5-0
     status: maintained
   hector_models:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_localization` to `0.1.5-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_localization.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.3-0`
## hector_localization
- No changes
## hector_pose_estimation

```
* hector_pose_estimation: make private variables protected to allow access from specialized pose_estimation classes
* hector_pose_estimation: fixed wrong indicies bug in GPS pose publisher
* Contributors: Johannes Meyer
```
## hector_pose_estimation_core

```
* fixed rate conversion to nav frame for the state message
* initialize reference values to NaN instead of 0.0 and added measurement/auto_* parameters consitently
  Added parameters:
  - gps/auto_reference
  - height/auto_elevation
  - baro/auto_elevation
  Already existed before:
  - magnetic/auto_heading
  All auto_* parameters are true by default.
* Contributors: Johannes Meyer
```
## message_to_tf

```
* get subscribed topic from the command line
* initialize origin when publishing imu transform and fixed imu pose output (fix #6)
* Contributors: Johannes Meyer
```
