### PR TITLE
roslisp: 1.9.17-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6478,7 +6478,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/roslisp-release.git
-      version: 1.9.15-0
+      version: 1.9.17-0
     status: maintained
   roslisp_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp` to `1.9.17-0`:
- upstream repository: git://github.com/ros/roslisp.git
- release repository: https://github.com/ros-gbp/roslisp-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.9.15-0`
## roslisp

```
* Merge pull request #20 <https://github.com/ros/roslisp/issues/20> from daewok/use_sim_time
  use_sim_time parameter should be absolute.
* Merge pull request #18 <https://github.com/ros/roslisp/issues/18> from airballking/fix-issue17
  fix for ASDF3 compatibility
* Merge pull request #16 <https://github.com/ros/roslisp/issues/16> from jannikb/master
  Fixed Issue ros/roslisp#12 <https://github.com/ros/roslisp/issues/12>
* Merge pull request #15 <https://github.com/ros/roslisp/issues/15> from jannikb/master
  Start fixing issue ros/roslisp#12 <https://github.com/ros/roslisp/issues/12>
* Contributors: Eric Timmons, Georg Bartels, Jannik Buckelo, Lorenz Mösenlechner
```
