### PR TITLE
roslisp: 1.9.17-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4552,7 +4552,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/roslisp-release.git
-      version: 1.9.15-0
+      version: 1.9.17-0
     status: maintained
   rospack:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp` to `1.9.17-0`:
- upstream repository: git://github.com/ros/roslisp.git
- release repository: https://github.com/ros-gbp/roslisp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.9.15-0`
## roslisp

```
* Merge pull request #20 <https://github.com/ros/roslisp/issues/20> from daewok/use_sim_time
  use_sim_time parameter should be absolute.
* Merge pull request #18 <https://github.com/ros/roslisp/issues/18> from airballking/fix-issue17
  fix for ASDF3 compatibility
* Merge pull request #16 <https://github.com/ros/roslisp/issues/16> from jannikb/master
  Fixed Issue ros/roslisp#12 <https://github.com/ros/roslisp/issues/12>
* Merge pull request #15 <https://github.com/ros/roslisp/issues/15> from jannikb/master
  Start fixing issue ros/roslisp#12 <https://github.com/ros/roslisp/issues/12>
* Contributors: Eric Timmons, Georg Bartels, Jannik Buckelo, Lorenz Mösenlechner
```
