### PR TITLE
rtmros_hironx: 1.0.25-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6809,13 +6809,15 @@ repositories:
       version: hydro-devel
     release:
       packages:
+      - hironx_calibration
       - hironx_moveit_config
       - hironx_ros_bridge
+      - hironx_tutorial
       - rtmros_hironx
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.24-0
+      version: 1.0.25-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.25-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.24-0`
## hironx_calibration

```
* New package hironx_calibration added.
* Contributors: Kei Okada, Isaac IY Saito
```
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* (hironx_ros_bridge)

    * Add impedance controller.
    * Add Kinect launch file.

* Contributors: Hiroaki Yaguchi, Isaac IY Saito, Kei Okada
```
## hironx_tutorial

```
* New package hironx_tutorial added.
* Contributors: Isaac IY Saito
```
## rtmros_hironx

```
* New package hironx_calibration, hironx_tutorial added.
* (hironx_ros_bridge)

    * Add impedance controller.
    * Add Kinect launch file.

* Contributors: Hiroaki Yaguchi, Isaac IY Saito, Kei Okada
```
