### PR TITLE
carl_bot: 0.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -413,7 +413,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_bot-release.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_bot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_bot` to `0.0.8-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_bot.git
- release repository: https://github.com/wpi-rail-release/carl_bot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.7-0`
## carl_bot
- No changes
## carl_bringup
- No changes
## carl_description
- No changes
## carl_dynamixel
- No changes
## carl_interactive_manipulation

```
* adjusted point cloud visualization for segmented objects to be in keeping with rail_segmentation update
* adjusted retract position
* Revert "adjusted retract position"
  This reverts commit 01aa246c9bd241e9ad7b948c159059e407d7ceda.
* adjusted retract position
* Contributors: Russell Toris, dekent
```
## carl_teleop

```
* Revert "Changes to base teleop to increase safety"
  This reverts commit ff0796d01abd7b8640db59a5e7789940692b9b4c.
* Changes to base teleop to increase safety
* Contributors: Brian Hetherman, Russell Toris
```
