### PR TITLE
rail_segmentation: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3675,7 +3675,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_segmentation.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_segmentation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_segmentation` to `0.0.2-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_segmentation.git
- release repository: https://github.com/wpi-rail-release/rail_segmentation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.1-0`
## rail_segmentation

```
* added object clearing service and clearing on segmentation of zero objects
* Updated segmentation with an option for on-robot segmentation, added documentation
* Updated segmentation service to allow segmentation in either the map frame or the robot frame, also added optional object clearing on segmentation call
* merge
* updates for pick and place
* Contributors: dekent
```
