### PR TITLE
linux_networking: 1.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3391,6 +3391,35 @@ repositories:
       type: git
       url: https://github.com/ktossell/libuvc_ros.git
       version: master
+  linux_networking:
+    doc:
+      type: git
+      url: https://github.com/PR2/linux_networking.git
+      version: hydro-devel
+    release:
+      packages:
+      - access_point_control
+      - asmach
+      - asmach_tutorials
+      - ddwrt_access_point
+      - hostapd_access_point
+      - ieee80211_channels
+      - linksys_access_point
+      - linux_networking
+      - multi_interface_roam
+      - network_control_tests
+      - network_detector
+      - network_monitor_udp
+      - network_traffic_control
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/TheDash/linux_networking-release.git
+      version: 1.0.4-0
+    source:
+      type: git
+      url: https://github.com/pr2/linux_networking.git
+      version: hydro-devel
+    status: maintained
   lizi_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `linux_networking` to `1.0.4-0`:
- upstream repository: https://github.com/PR2/linux_networking.git
- release repository: https://github.com/TheDash/linux_networking-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## access_point_control
- No changes
## asmach

```
* Added asmach package
* Contributors: TheDash
```
## asmach_tutorials
- No changes
## ddwrt_access_point
- No changes
## hostapd_access_point
- No changes
## ieee80211_channels
- No changes
## linksys_access_point
- No changes
## linux_networking
- No changes
## multi_interface_roam
- No changes
## network_control_tests
- No changes
## network_detector
- No changes
## network_monitor_udp
- No changes
## network_traffic_control
- No changes
