### PR TITLE
rtmros_common: 1.2.5-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6806,7 +6806,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.2.4-1
+      version: 1.2.5-2
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.2.5-2`:
- upstream repository: https://github.com/start-jsk/rtmros_common.git
- release repository: https://github.com/tork-a/rtmros_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.2.4-1`
## hrpsys_ros_bridge

```
* Improvement on rtm-ros-robot-interface, datalogger-log-parser, samplerobot
* Fix stamp of odom and imu
* Improve dependency: robot_pose_ekf.launch, robot_pose_ekf
* Contributors: Kei Okada, Shunichi Nozawa, YoheiKakiuchi
```
## hrpsys_tools
- No changes
## openrtm_ros_bridge

```
* Add depend on std_msgs
* Contributors: Kei Okada
```
## openrtm_tools
- No changes
## rosnode_rtc
- No changes
## rtmbuild
- No changes
## rtmros_common

```
* Improvement on rtm-ros-robot-interface, datalogger-log-parser, samplerobot
* Fix stamp of odom and imu
* Improve dependency: robot_pose_ekf.launch, robot_pose_ekf
* Add depend on std_msgs
* Contributors: Kei Okada, Shunichi Nozawa, YoheiKakiuchi
```
