### PR TITLE
openhrp3: 3.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3304,6 +3304,13 @@ repositories:
       url: https://github.com/wg-perception/opencv_candidate.git
       version: master
     status: maintained
+  openhrp3:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/openhrp3-release.git
+      version: 3.1.7-0
+    status: developed
   openni2_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openhrp3` to `3.1.7-0`:
- upstream repository: https://github.com/fkanehiro/openhrp3.git
- release repository: https://github.com/tork-a/openhrp3-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
