### PR TITLE
openhrp3: 3.1.7-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3309,7 +3309,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/openhrp3-release.git
-      version: 3.1.7-0
+      version: 3.1.7-1
+    source:
+      type: git
+      url: https://github.com/fkanehiro/openhrp3.git
+      version: master
     status: developed
   openni2_camera:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `openhrp3` to `3.1.7-1`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `3.1.7-0`
