### PR TITLE
rtmros_gazebo: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6825,7 +6825,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_gazebo-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_gazebo` to `0.1.2-0`:
- upstream repository: https://github.com/start-jsk/rtmros_gazebo.git
- release repository: https://github.com/tork-a/rtmros_gazebo-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.1.1-0`
## eusgazebo

```
* add gazebo_ros, gazebo_msgs, and gazebo_plugins to dependency of hrpsys_gazebo_general, eusgaebo.
* Contributors: Masaki Murooka
```
## hrpsys_gazebo_general

```
* add gazebo_ros, gazebo_msgs, and gazebo_plugins to dependency of hrpsys_gazebo_general, eusgaebo.
* Merge pull request #111 from k-okada/hrpEC_with_hrpIo_gazebo
  compile hrpEC liked with hrpIo_gazebo
* add COMPILE_DEFINITIONS for hrpEC
* Contributors: Kei Okada, Yohei Kakiuchi, Masaki Murooka
```
## hrpsys_gazebo_msgs
- No changes
