### PR TITLE
linux_networking: 1.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3414,7 +3414,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/linux_networking-release.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/pr2/linux_networking.git


### PR DESCRIPTION
Increasing version of package(s) in repository `linux_networking` to `1.0.5-0`:
- upstream repository: https://github.com/PR2/linux_networking.git
- release repository: https://github.com/TheDash/linux_networking-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.4-0`
## access_point_control
- No changes
## asmach
- No changes
## asmach_tutorials
- No changes
## ddwrt_access_point
- No changes
## hostapd_access_point
- No changes
## ieee80211_channels
- No changes
## linksys_access_point
- No changes
## linux_networking

```
* Added run_depends for metapackage
* Contributors: TheDash
```
## multi_interface_roam
- No changes
## network_control_tests
- No changes
## network_detector
- No changes
## network_monitor_udp
- No changes
## network_traffic_control
- No changes
