### PR TITLE
openhrp3: 3.1.7-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3309,7 +3309,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/openhrp3-release.git
-      version: 3.1.7-2
+      version: 3.1.7-3
     source:
       type: git
       url: https://github.com/fkanehiro/openhrp3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openhrp3` to `3.1.7-3`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `3.1.7-2`
