### PR TITLE
rtmros_hironx: 1.0.26-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6846,7 +6846,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.25-0
+      version: 1.0.26-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.26-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.25-0`
## hironx_calibration
- No changes
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* (hironx_calient.py) check if rmfo is defined in HrpsysConfigurator
* (hironx_ros_bridge) Add hrpiob files under multi-license.
* (hironx_ros_bridge) add missing run_depend package.
* Contributors: Hiroaki Yaguchi, Isaac IY Saito, Kei Okada
```
## hironx_tutorial
- No changes
## rtmros_hironx
- No changes
