### PR TITLE
Add http://wiki.ros.org/arni

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -158,6 +158,12 @@ repositories:
       type: git
       url: https://github.com/voxel-dot-at/argos3d_p100_ros_pkg.git
       version: master
+  arni:
+    source:
+      type: git
+      url: https://github.com/ROS-PSE/arni.git
+      version: master
+    status: maintained
   audio_common:
     doc:
       type: git
@@ -1350,7 +1356,7 @@ repositories:
       version: hydro-devel
     status: maintained
   gazebo2rviz:
-    doc:
+    source:
       type: git
       url: https://github.com/andreasBihlmaier/gazebo2rviz.git
       version: master
@@ -3570,7 +3576,7 @@ repositories:
       version: hydro-devel
     status: maintained
   pysdf:
-    doc:
+    source:
       type: git
       url: https://github.com/andreasBihlmaier/pysdf.git
       version: master


### PR DESCRIPTION
While at it: fix confusion of doc vs source repository for pysdf and gazebo2rviz
