### PR TITLE
crsm_slam: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -942,6 +942,17 @@ repositories:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/cpp_introspection.git
       version: master
+  crsm_slam:
+    doc:
+      type: git
+      url: https://github.com/etsardou/crsm-slam-ros-pkg.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/etsardou/crsm-slam-ros-pkg-release.git
+      version: 1.0.3-0
+    status: maintained
   cv_backports:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `crsm_slam` to `1.0.3-0`:
- upstream repository: https://github.com/etsardou/crsm-slam-ros-pkg.git
- release repository: https://github.com/etsardou/crsm-slam-ros-pkg-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## crsm_slam

```
* Compliance with ROS REP 117
```
