### PR TITLE
homebrew: boost-python is now sepeparate

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -33,8 +33,7 @@ bison:
 boost:
   osx:
     homebrew:
-      options: [--with-python]
-      packages: [boost]
+      packages: [boost, boost-python]
 bullet:
   osx:
     homebrew:


### PR DESCRIPTION
See: https://github.com/ros-infrastructure/rosdep/issues/330
