### PR TITLE
pr2_simulator: 2.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5448,10 +5448,11 @@ repositories:
       - pr2_controller_configuration_gazebo
       - pr2_gazebo
       - pr2_gazebo_plugins
+      - pr2_simulator
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/pr2_simulator-release.git
-      version: 2.0.2-0
+      version: 2.0.3-0
     source:
       type: git
       url: https://github.com/PR2/pr2_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_simulator` to `2.0.3-0`:
- upstream repository: https://github.com/PR2/pr2_simulator.git
- release repository: https://github.com/ros-gbp/pr2_simulator-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `2.0.2-0`
## pr2_controller_configuration_gazebo

```
* Changelogs
* Changelogs
* Corrected typo in configuration of pr2-joint-effort-controllers.
* Contributors: Georg Bartels, TheDash
* Changelogs
* Corrected typo in configuration of pr2-joint-effort-controllers.
* Contributors: Georg Bartels, TheDash
* Corrected typo in configuration of pr2-joint-effort-controllers.
* Contributors: Georg Bartels
```
## pr2_gazebo

```
* Changelogs
* Changelogs
* Bug fix thanks to vovakkk @github
* Contributors: TheDash
* Changelogs
* Bug fix thanks to vovakkk @github
* Contributors: TheDash
* Bug fix thanks to vovakkk @github
* Contributors: TheDash
```
## pr2_gazebo_plugins

```
* Changelogs
* Changelogs
* Contributors: TheDash
* Changelogs
* Contributors: TheDash
```
## pr2_simulator

```
* Changelogs
* New vers
* Changelogs
* Updated metapackage
* Contributors: TheDash
* New vers
* Changelogs
* Updated metapackage
* Contributors: TheDash
* Updated metapackage
* Contributors: TheDash
```
