### PR TITLE
head_pose_estimation: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2176,6 +2176,21 @@ repositories:
       url: https://github.com/atenpas/handle_detector.git
       version: master
     status: maintained
+  head_pose_estimation:
+    doc:
+      type: git
+      url: https://github.com/OSUrobotics/ros-head-tracking.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/OSUrobotics/head_pose_estimation-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/OSUrobotics/ros-head-tracking.git
+      version: hydro-devel
+    status: maintained
   hector_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `head_pose_estimation` to `1.0.1-0`:
- upstream repository: https://github.com/OSUrobotics/ros-head-tracking.git
- release repository: https://github.com/OSUrobotics/head_pose_estimation-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## head_pose_estimation

```
* catkinize and cleanup in preparation for release
* Contributors: Dan Lazewatsky
```
