### PR TITLE
pr2_metapackages: 1.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5238,6 +5238,25 @@ repositories:
       url: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
       version: 1.8.0-0
     status: maintained
+  pr2_metapackages:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_metapackages.git
+      version: hydro-devel
+    release:
+      packages:
+      - pr2
+      - pr2_base
+      - pr2_desktop
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_metapackages-release.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_metapackages.git
+      version: hydro-devel
+    status: maintained
   pr2_navigation:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_metapackages` to `1.0.3-0`:
- upstream repository: https://github.com/pr2/pr2_metapackages.git
- release repository: https://github.com/pr2-gbp/pr2_metapackages-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## pr2
- No changes
## pr2_base
- No changes
## pr2_desktop
- No changes
