### PR TITLE
rviz: 1.10.18-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7024,7 +7024,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.10.18-1
+      version: 1.10.18-2
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.10.18-2`:
- upstream repository: git@github.com:ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.10.18-1`
## rviz

```
* Backport fix from Indigo for a warning which fails on the farm.
  Achieved by cherry-picking commit ``12423d1969da5669e6cb0ee698a3483a78ef38dd`` from Indigo.
* Contributors: William Woodall
```
