### PR TITLE
moveit_ikfast: 3.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3735,7 +3735,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ikfast-release.git
-      version: 3.0.7-0
+      version: 3.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_ikfast.git
+      version: hydro-devel
     status: developed
   moveit_metapackages:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ikfast` to `3.1.0-0`:
- upstream repository: https://github.com/ros-planning/moveit_ikfast
- release repository: https://github.com/ros-gbp/moveit_ikfast-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `3.0.7-0`
## moveit_ikfast

```
* Search for cheapest IK solution
* Specify search mode during code generation
* Fix issue: min_count must be negative (negative direction was ignored!)
* Added G.A. vd. Hoorn as second package maintainer
* Fix for issue #34 <https://github.com/davetcoleman/moveit_ikfast/issues/34>: add liblapack-dev dependency to generated pkg manifest
* scripts: add dependency on liblapack-dev to generated pkg manifest. Fix #34 <https://github.com/davetcoleman/moveit_ikfast/issues/34>.
* Use getIkType() in getPositionIK()
* Added support for the Translation3D-type IK
* Fix for missing run_depends in generated pkg manifest
* Make sure run_depends get added to pkg manifest as well. Fix #30 <https://github.com/davetcoleman/moveit_ikfast/issues/30>.
  Short-circuit evaluation of the statement determining the value of
  'modified_pkg' caused the second call to update_deps(.., 'run_depend', ..)
  to never happen. Using binary or to work around that.
* Fixes for 23, 27 and 28
* Eigen is not actually a dependency anymore, so remove build_dep on cmake_modules.
* Remove dependency on deprecated tip_frame_ variable
* scripts: any change to run or build depends should trigger manifest updating.
* templates: include planning group name in plugin desc install rule. Fix #28 <https://github.com/davetcoleman/moveit_ikfast/issues/28>.
* templates: remove superfluous link_directories(). Fix #23 <https://github.com/davetcoleman/moveit_ikfast/issues/23>.
* templates: cmake_modules provides FindEigen, so explicitly depend on it. Fix #27 <https://github.com/davetcoleman/moveit_ikfast/issues/27>.
  Also change order of find_package(..) statements to reflect this and
  update dependency checking in pkg generator script to allow for different
  run and build depends (cmake_modules is only a build_depend).
* Remove dependency on deprecated tip_frame_ variable (now supports multiple tip frames)
* Added support for the Translation3D-type IK
  Modified the ikfast moveit template to work with OpenRAVE's
  Translation3D-type IK. This is useful for manipulators with few DOF
  (i.e., 3 or 4) that just want to go to a certain position without caring
  so much about the end effector's orientation.
* Contributors: Dave Coleman, G.A. vd. Hoorn, Ioan A Sucan, Nicolas Alt, Steve Levine, gavanderhoorn, nalt
```
