### PR TITLE
ros_web_video: 0.1.13-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6247,7 +6247,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/ros_web_video-release.git
-      version: 0.1.12-0
+      version: 0.1.13-0
     source:
       type: git
       url: https://github.com/RobotWebTools/ros_web_video.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_web_video` to `0.1.13-0`:
- upstream repository: https://github.com/RobotWebTools/ros_web_video.git
- release repository: https://github.com/RobotWebTools-release/ros_web_video-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.12-0`
## ros_web_video

```
* Merge pull request #6 from mitchellwills/develop
  Fix ros_web_video  HTTP header generation
* Fixed ROS_INFO argument mismatch
* Fixed HTTP Header generation
* Contributors: Mitchell Wills, Russell Toris
```
