### PR TITLE
head_pose_estimation: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2185,7 +2185,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/OSUrobotics/head_pose_estimation-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/OSUrobotics/ros-head-tracking.git


### PR DESCRIPTION
Increasing version of package(s) in repository `head_pose_estimation` to `1.0.2-0`:
- upstream repository: https://github.com/OSUrobotics/ros-head-tracking.git
- release repository: https://github.com/OSUrobotics/head_pose_estimation-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.1-0`
## head_pose_estimation

```
* add kdl dep
* Contributors: Dan Lazewatsky
```
