### PR TITLE
mongodb_store: 0.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3667,7 +3667,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.0.5-0`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.4-0`
## mongodb_log
- No changes
## mongodb_store

```
* Added install target for launch file.
* Fix maintainer in package.xml
* Update package.xml
* Contributors: Chris Burbridge, Marc Hanheide, Nick Hawes
```
## mongodb_store_cpp_client

```
* Fixed typo.
* Added absolute paths to libraries to ensure that dependent projects get correct linking.
* Contributors: Nick Hawes
```
## mongodb_store_msgs
- No changes
