### PR TITLE
rtmros_common: 1.2.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6846,7 +6846,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.2.5-2
+      version: 1.2.6-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.2.6-0`:
- upstream repository: https://github.com/start-jsk/rtmros_common.git
- release repository: https://github.com/tork-a/rtmros_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.2.5-2`
## hrpsys_ros_bridge

```
* set time-limit to 300
* (test-samplerobot.py) fix test case, since /clock is sync with hrpsys time, so we can use more strict settings
* fix test code for changing 0.002
* (rtm-ros-robot-interface) : Add documentation strings for state methods and rearrange it. Add logger documentation.
* Contributors: Kei Okada, Shunichi Nozawa
```
## hrpsys_tools
- No changes
## openrtm_ros_bridge
- No changes
## openrtm_tools
- No changes
## rosnode_rtc
- No changes
## rtmbuild
- No changes
## rtmros_common
- No changes
