### PR TITLE
jsk_visualization: 1.0.13-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3016,7 +3016,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.12-0
+      version: 1.0.13-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.13-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.0.12-0`
## jsk_interactive

```
* interactive marker control for hrp2
* publish move time
* Contributors: Yusuke Furuta
```
## jsk_interactive_marker

```
* add tabletop launch file
* Solve inverse kinematics with use-torso t
* do not use ik server for pr2
* add staro interactive marker
* add staro launch file
* add parameter to set menu
* add staro
* add arm ik and torso ik
* set frame id
* check having legs
* interactive marker control for hrp2
* add dependency on jsk_rviz_plugins
* Speed up grasp-pose movement
* add parameter
* rename launch file
* publish first handle pose
* add callback to grasp object
* subscribe initial handle pose
* add bounding box marker name and remove description
* refactor launch file
* do not use old ik-server-function
* move to jsk_interactive_marker and modify spacenav rotate
  add GetPose.srv
* Does not set the name of interactive marker for bounding box, because
  the name is too annoying
* update urdf model with topic
* add launch file to make bounding box interactive marker
* Contributors: Ryohei Ueda, Yuto Inagaki, Eisoku Kuroiwa, Yusuke Furuta
```
## jsk_interactive_test
- No changes
## jsk_rqt_plugins
- No changes
## jsk_rviz_plugins

```
* Add "overtake properties" property to OverlayTextDisplay
* Call queueRender after opening/closing properties in Open/CloseAllTool
* Contributors: Ryohei Ueda
```
