### PR TITLE
rosprofiler: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4632,7 +4632,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rosprofiler-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/osrf/rosprofiler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosprofiler` to `0.1.2-0`:
- upstream repository: https://github.com/osrf/rosprofiler.git
- release repository: https://github.com/ros-gbp/rosprofiler-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.1-0`
## rosprofiler

```
* Implements more robust automatic node name creation
* Handles exceptions in rospy timer
* Contributors: dan brooks
```
