### PR TITLE
Add loam_velodyne to index for ROS Indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2377,6 +2377,11 @@ repositories:
       url: https://github.com/clearpathrobotics/lms1xx.git
       version: master
     status: maintained
+  loam_velodyne:
+    doc:
+      type: git
+      url: https://github.com/jizhang-cmu/loam_velodyne.git
+      version: hydro-indigo
   m4atx_battery_monitor:
     doc:
       type: git


### PR DESCRIPTION
Could you add loam_velodyne to index for ROS Indigo. Thanks!
