### PR TITLE
multisense_ros: 3.3.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3976,7 +3976,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
-      version: 3.3.0-0
+      version: 3.3.1-0
     source:
       type: hg
       url: https://bitbucket.org/crl/multisense_ros


### PR DESCRIPTION
Increasing version of package(s) in repository `multisense_ros` to `3.3.1-0`:
- upstream repository: https://bitbucket.org/crl/multisense_ros
- release repository: https://github.com/carnegieroboticsllc/multisense_ros-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `3.3.0-0`
## multisense

```
* Added stamped PPS topic. Updated LibMultiSense to version 3.4 which includes doxygen documentation. Added host time to the PPS header. Improved point cloud publishing speed. Fixed ordered point cloud width and height. Fixed all point cloud row_step fields. Added broadcast parameter to ChangeIpUtility. Removed SSE4 and AVX compilation flags in multisense_ros.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
## multisense_bringup
- No changes
## multisense_cal_check
- No changes
## multisense_description
- No changes
## multisense_lib

```
* Added stamped PPS topic. Updated LibMultiSense to version 3.4 which includes doxygen documentation. Added host time to the PPS header. Improved point cloud publishing speed. Fixed ordered point cloud width and height. Fixed all point cloud row_step fields. Added broadcast parameter to ChangeIpUtility. Removed SSE4 and AVX compilation flags in multisense_ros.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
## multisense_ros

```
* Added stamped PPS topic. Updated LibMultiSense to version 3.4 which includes doxygen documentation. Added host time to the PPS header. Improved point cloud publishing speed. Fixed ordered point cloud width and height. Fixed all point cloud row_step fields. Added broadcast parameter to ChangeIpUtility. Removed SSE4 and AVX compilation flags in multisense_ros.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
