### PR TITLE
moveit_ikfast: hydro docs should be build from proper branch.

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3736,7 +3736,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-planning/moveit_ikfast.git
-      version: master
+      version: hydro-devel
     release:
       tags:
         release: release/hydro/{package}/{version}


### PR DESCRIPTION
Branch was recently renamed. `doc` entry was apparently not updated.
