### PR TITLE
fix repo name

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2874,7 +2874,7 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_common.git
       version: master
     status: developed
-  jsk_control-release:
+  jsk_control:
     doc:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_control.git


### PR DESCRIPTION
I'm not sure but I have commited with wrong name (jsk_congtrol-release), this should be jsk_control
