### PR TITLE
pr2_plugs: 1.0.12-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5336,6 +5336,7 @@ repositories:
       - checkerboard_pose_estimation
       - outlet_pose_estimation
       - pr2_image_snapshot_recorder
+      - pr2_plugs
       - pr2_plugs_actions
       - pr2_plugs_common
       - pr2_plugs_msgs
@@ -5344,7 +5345,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_plugs-release.git
-      version: 1.0.9-0
+      version: 1.0.12-0
     source:
       type: git
       url: https://github.com/PR2/pr2_plugs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_plugs` to `1.0.12-0`:
- upstream repository: https://github.com/PR2/pr2_plugs.git
- release repository: https://github.com/TheDash/pr2_plugs-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.9-0`
## checkerboard_pose_estimation
- No changes
## outlet_pose_estimation
- No changes
## pr2_image_snapshot_recorder
- No changes
## pr2_plugs
- No changes
## pr2_plugs_actions
- No changes
## pr2_plugs_common
- No changes
## pr2_plugs_msgs
- No changes
## stereo_wall_detection
- No changes
## visual_pose_estimation
- No changes
