### PR TITLE
Add dfu-util to rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -458,6 +458,10 @@ daemontools:
     portage:
       packages: [sys-process/daemontools]
   ubuntu: [daemontools]
+dfu-util:
+  debian: [dfu-util]
+  fedora: [dfu-util]
+  ubuntu: [dfu-util]
 doxygen:
   arch: [doxygen]
   debian: [doxygen]


### PR DESCRIPTION
Dependency for firmware packages needing this download tool.
