### PR TITLE
jsk_control: 0.1.3-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2892,7 +2892,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_control-release.git
-      version: 0.1.1-0
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_control` to `0.1.3-1`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.1-0`
## eus_nlopt

```
* Use deb files to install jsk programs
* Fix path to find nlopt headers and libraries
```
## eus_qp
- No changes
## eus_qpoases
- No changes
## joy_mouse
- No changes
## jsk_footstep_controller

```
* Add footcoords to jsk_footstep_controller to compute tf like "/odom on ground"
  by monitoring foot force sensors
* do not run foot_contact_monitor in hrp2jsknt_real.launch. that script will be launched in default startup launch file
```
## jsk_footstep_planner
- No changes
## jsk_ik_server

```
* add ik-server wait function, in travis, ik-server is slow to start
* install euslisp in share directory
* change ik-server files all exectable
* add :ik-server-name args, smaple robot has name with - charactre
* forbit to use copy-object of link cascoords object
```
## jsk_teleop_joy

```
* add b_control_status.py
* add config file of b-control
* Add joystick interface for jsk_pcl_ros/EnvironmentPlaneModeling
* use scripts/head_control_by_trackball.py for general robot. implimented launch file for pr2 and hrp2
* Merge branch 'master' into select-menu-with-analog-stick
* autorepeat joy input
* check analog input
* remap tf
* test analog check
* get argument  for set pose
```
