### PR TITLE
jsk_roseus: 1.1.25-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2058,7 +2058,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.24-0
+      version: 1.1.25-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.25-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.1.24-0`
## euslisp

```
* Merge pull request #157 from k-okada/fix_rpath
  use ORIGIN to set rpath
* enabel euslisp_INCLUDE_DIRS
* use ORIGIN to set rpath
```
## geneus

```
* Do not generate message/service files which are already generated
* Merge remote-tracking branch 'refs/remotes/origin/master' into not-invoke-many-eus-when-genmsg
* Do not invoke many eus when generating ros message files
```
## jsk_roseus
- No changes
## roseus
- No changes
## roseus_msgs

```
* Merge pull request #160 from k-okada/add_jsk_visualization
  add jsk_visualization
* add jsk_visualization
```
## roseus_smach
- No changes
