### PR TITLE
add python-oauth2 for debian/fedra

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -618,6 +618,8 @@ python-numpy:
     trusty: [python-numpy]
     trusty_python3: [python3-numpy]
 python-oauth2:
+  debian: [python-oauth2]
+  fedora: [python-oauth2]
   ubuntu: [python-oauth2]
 python-omniorb:
   arch: [omniorbpy]


### PR DESCRIPTION
fedra and debian information for python-oauth2 (https://github.com/ros/rosdistro/pull/5824)

see https://apps.fedoraproject.org/packages/python-oauth2, https://packages.debian.org/search?suite=all&searchon=names&keywords=python-oauth2
