### PR TITLE
jsk_common: 1.0.48-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2024,6 +2024,47 @@ repositories:
       url: https://github.com/ros-gbp/joystick_drivers-release.git
       version: 1.10.0-0
     status: maintained
+  jsk_common:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common.git
+      version: master
+    release:
+      packages:
+      - bayesian_belief_networks
+      - downward
+      - dynamic_tf_publisher
+      - ff
+      - ffha
+      - image_view2
+      - jsk_common
+      - jsk_footstep_msgs
+      - jsk_gui_msgs
+      - jsk_hark_msgs
+      - jsk_network_tools
+      - jsk_tilt_laser
+      - jsk_tools
+      - jsk_topic_tools
+      - libsiftfast
+      - multi_map_server
+      - nlopt
+      - opt_camera
+      - posedetection_msgs
+      - rospatlite
+      - rosping
+      - rostwitter
+      - sklearn
+      - speech_recognition_msgs
+      - voice_text
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/jsk_common-release.git
+      version: 1.0.48-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common.git
+      version: master
+    status: developed
   jsk_pr2eus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.48-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## bayesian_belief_networks
- No changes
## downward

```
* use tgz to download source
* Contributors: Kei Okada
```
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha
- No changes
## image_view2

```
* remove depends to opencv2, since indigo depends on libopencv-dev, so we depends on cv_bridge whcih both hydro/indigo depends on it
* Contributors: Kei Okada
```
## jsk_common
- No changes
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_network_tools
- No changes
## jsk_tilt_laser

```
* add cmake_modules for indigo compile
* Contributors: Kei Okada
```
## jsk_tools
- No changes
## jsk_topic_tools
- No changes
## libsiftfast
- No changes
## multi_map_server
- No changes
## nlopt
- No changes
## opt_camera
- No changes
## posedetection_msgs
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## sklearn
- No changes
## speech_recognition_msgs
- No changes
## voice_text
- No changes
