### PR TITLE
rtmros_gazebo: 0.1.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6871,7 +6871,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_gazebo-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_gazebo` to `0.1.3-0`:
- upstream repository: https://github.com/start-jsk/rtmros_gazebo.git
- release repository: https://github.com/tork-a/rtmros_gazebo-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.2-0`
## eusgazebo
- No changes
## hrpsys_gazebo_general

```
* set CMAKE_BUILD_TYPE to install, also support RelWithDebInfo for deb release
* install files
* add compile_robot_model_for_gazebo.cmake and generate model and launch file for samplerobot simulation.
* Contributors: Kei Okada, Masaki Murooka
```
## hrpsys_gazebo_msgs
- No changes
