### PR TITLE
openrtm_aist_python: 1.1.0-5 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3435,7 +3435,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/openrtm_aist_python-release.git
-      version: 1.1.0-4
+      version: 1.1.0-5
     status: developed
   openslam_gmapping:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist_python` to `1.1.0-5`:
- upstream repository: http://svn.openrtm.org/OpenRTM-aist-Python/tags/RELEASE_1_1_0_RC1/OpenRTM-aist-Python/
- release repository: https://github.com/tork-a/openrtm_aist_python-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.1.0-4`
