### PR TITLE
genmsg: 0.4.26-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1876,7 +1876,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/genmsg-release.git
-      version: 0.4.25-0
+      version: 0.4.26-0
     source:
       type: git
       url: https://github.com/ros/genmsg.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.4.26-0`:
- upstream repository: git@github.com:ros/genmsg.git
- release repository: https://github.com/ros-gbp/genmsg-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.4.25-0`
## genmsg

```
* fix interpreter globals collision with multiple message templates or modules (#53 <https://github.com/ros/genmsg/issues/53>)
```
