### PR TITLE
Revert "Removing wet kdl"

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3061,6 +3061,17 @@ repositories:
       type: git
       url: https://github.com/RCPRG-ros-pkg/orocos_controllers.git
       version: electric
+  orocos_kdl:
+    release:
+      packages:
+      - kdl
+      - orocos_kdl
+      - orocos_kinematics_dynamics
+      - python_orocos_kdl
+      tags:
+        release: release/{package}/{upstream_version}
+      url: https://github.com/ros-gbp/orocos_kdl-release.git
+      version: 1.1.99-13
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#4302

I am proposing to revert this since the farm will never turn on this again, but restoring this will likely fix building Groovy from source.

I am going to merge it (as soon as CI catches up) and then try building from source. If it works then I would say we should keep it. Otherwise we can revert it.
