### PR TITLE
iai_common_msgs: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2540,7 +2540,7 @@ repositories:
       - iai_common_msgs
       - iai_content_msgs
       - iai_kinematics_msgs
-      - iai_pancake_perception_action
+      - iai_robosherlock_actions
       - mln_robosherlock_msgs
       - saphari_msgs
       - scanning_table_msgs
@@ -2548,7 +2548,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/code-iai-release/iai_common_msgs-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/code-iai/iai_common_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `iai_common_msgs` to `0.0.3-0`:
- upstream repository: https://github.com/code-iai/iai_common_msgs.git
- release repository: https://github.com/code-iai-release/iai_common_msgs-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.2-0`
## data_vis_msgs

```
* Added datatype for timeline diagrams (Gantt-Style)
* Contributors: Moritz Tenorth
```
## designator_integration_msgs
- No changes
## dna_extraction_msgs
- No changes
## grasp_stability_msgs
- No changes
## iai_common_msgs

```
* Renamed iai_pancake_perception_action into iai_robosherlock_actions.
* Contributors: Georg Bartels
```
## iai_content_msgs
- No changes
## iai_kinematics_msgs
- No changes
## iai_robosherlock_actions

```
* changed RS action interface to use designator msgs
* Updated changelog of iai_robosherlock_actions.
* Deleted action-definition DetectPancake
* Added action-definition SimplePerceiveObject.
* Renamed iai_pancake_perception_action into iai_robosherlock_actions.
* Contributors: Ferenc Balint-Benczedi, Georg Bartels
```
## mln_robosherlock_msgs
- No changes
## saphari_msgs

```
* added constants
* added a message that contains a list equipment messages.
  service will now return that new message instead of a list of equipment messages.
* Contributors: Thiemo Wiedemeyer
```
## scanning_table_msgs
- No changes
## sherlock_sim_msgs
- No changes
