### PR TITLE
iai_common_msgs: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1782,6 +1782,26 @@ repositories:
       url: https://github.com/ahornung/humanoid_msgs.git
       version: devel
     status: maintained
+  iai_common_msgs:
+    release:
+      packages:
+      - data_vis_msgs
+      - designator_integration_msgs
+      - dna_extraction_msgs
+      - grasp_stability_msgs
+      - iai_common_msgs
+      - iai_content_msgs
+      - iai_kinematics_msgs
+      - iai_robosherlock_actions
+      - mln_robosherlock_msgs
+      - saphari_msgs
+      - scanning_table_msgs
+      - sherlock_sim_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/code-iai-release/iai_common_msgs-release.git
+      version: 0.0.3-0
+    status: developed
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iai_common_msgs` to `0.0.3-0`:
- upstream repository: https://github.com/code-iai/iai_common_msgs.git
- release repository: https://github.com/code-iai-release/iai_common_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## data_vis_msgs

```
* Added datatype for timeline diagrams (Gantt-Style)
* Contributors: Moritz Tenorth
```
## designator_integration_msgs
- No changes
## dna_extraction_msgs
- No changes
## grasp_stability_msgs
- No changes
## iai_common_msgs

```
* Renamed iai_pancake_perception_action into iai_robosherlock_actions.
* Contributors: Georg Bartels
```
## iai_content_msgs
- No changes
## iai_kinematics_msgs
- No changes
## iai_robosherlock_actions

```
* changed RS action interface to use designator msgs
* Updated changelog of iai_robosherlock_actions.
* Deleted action-definition DetectPancake
* Added action-definition SimplePerceiveObject.
* Renamed iai_pancake_perception_action into iai_robosherlock_actions.
* Contributors: Ferenc Balint-Benczedi, Georg Bartels
```
## mln_robosherlock_msgs
- No changes
## saphari_msgs

```
* added constants
* added a message that contains a list equipment messages.
  service will now return that new message instead of a list of equipment messages.
* Contributors: Thiemo Wiedemeyer
```
## scanning_table_msgs
- No changes
## sherlock_sim_msgs
- No changes
