### PR TITLE
rosbridge_suite: 0.6.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4543,7 +4543,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.6.4-0
+      version: 0.6.5-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.6.5-0`:
- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.6.4-0`
## rosapi

```
* 0.6.4
* update changelog
* 0.6.3
* update change log
* Contributors: Jihoon Lee
```
## rosbridge_library

```
* 0.6.4
* update changelog
* modify tests
  less duplicated code, some other changes to (hopefully) improve reliability. Tested locally about 30 times without encountering any failures.
* Change the behavior of MessageHandler.transition()
  Now reflects usage in the tests, i.e. a QueueMessageHandler only needs queue_length to be defined, not throttle_rate.
* 0.6.3
* update change log
* install util python module to fix #128
* Contributors: Jihoon Lee, Nils Berg
```
## rosbridge_server

```
* 0.6.4
* update changelog
* add backports to setup.py, so backports.ssl_match_hostname can be properly resolved
* 0.6.3
* update change log
* Contributors: Jihoon Lee, Nils Berg
```
## rosbridge_suite

```
* 0.6.4
* update changelog
* 0.6.3
* update change log
* Contributors: Jihoon Lee
```
