### PR TITLE
pr2_calibration: 1.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5056,7 +5056,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_calibration-release.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/PR2/pr2_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_calibration` to `1.0.5-0`:
- upstream repository: https://github.com/PR2/pr2_calibration.git
- release repository: https://github.com/TheDash/pr2_calibration-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.4-0`
## dense_laser_assembler

```
* Changed lib destination for dense_laser_snapshotter
* Removed mainpage.dox for *
* Contributors: TheDash
```
## laser_joint_processor

```
* Removed mainpage.dox for *
* Contributors: TheDash
```
## laser_joint_projector

```
* Removed mainpage.dox for *
* Contributors: TheDash
```
## pr2_calibration

```
* Added package.xml run depends for pr2_calibration
* Contributors: dash
```
## pr2_calibration_launch

```
* Removed mainpage.dox for *
* fix for catkin make
* Contributors: JSK applications, TheDash
```
## pr2_dense_laser_snapshotter

```
* Removed mainpage.dox for *
* Fixed pr2_dense_laser_snapshotter
* Contributors: TheDash
```
## pr2_se_calibration_launch

```
* Removed mainpage.dox for *
* Contributors: TheDash
```
