### PR TITLE
rospack: 2.1.25-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6598,7 +6598,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
-      version: 2.1.24-0
+      version: 2.1.25-0
     source:
       type: git
       url: https://github.com/ros/rospack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.1.25-0`:
- upstream repository: https://github.com/ros/rospack
- release repository: https://github.com/ros-gbp/rospack-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `2.1.24-0`
## rospack

```
* fix find_package(PythonLibs ...) with CMake 3 (#42 <https://github.com/ros/rospack/issues/42>)
```
