### PR TITLE
jsk_common: 1.0.49-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2051,16 +2051,12 @@ repositories:
       version: master
     release:
       packages:
-      - assimp_devel
       - bayesian_belief_networks
-      - collada_urdf_jsk_patch
-      - depth_image_proc_jsk_patch
       - downward
       - dynamic_tf_publisher
       - ff
       - ffha
       - image_view2
-      - image_view_jsk_patch
       - jsk_common
       - jsk_footstep_msgs
       - jsk_gui_msgs
@@ -2069,14 +2065,11 @@ repositories:
       - jsk_tilt_laser
       - jsk_tools
       - jsk_topic_tools
-      - laser_filters_jsk_patch
       - libsiftfast
       - multi_map_server
       - nlopt
-      - openni_tracker_jsk_patch
       - opt_camera
       - posedetection_msgs
-      - pr2_groovy_patches
       - rospatlite
       - rosping
       - rostwitter

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2051,12 +2051,16 @@ repositories:
       version: master
     release:
       packages:
+      - assimp_devel
       - bayesian_belief_networks
+      - collada_urdf_jsk_patch
+      - depth_image_proc_jsk_patch
       - downward
       - dynamic_tf_publisher
       - ff
       - ffha
       - image_view2
+      - image_view_jsk_patch
       - jsk_common
       - jsk_footstep_msgs
       - jsk_gui_msgs
@@ -2065,11 +2069,14 @@ repositories:
       - jsk_tilt_laser
       - jsk_tools
       - jsk_topic_tools
+      - laser_filters_jsk_patch
       - libsiftfast
       - multi_map_server
       - nlopt
+      - openni_tracker_jsk_patch
       - opt_camera
       - posedetection_msgs
+      - pr2_groovy_patches
       - rospatlite
       - rosping
       - rostwitter
@@ -2079,7 +2086,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.48-0
+      version: 1.0.49-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.49-0`:
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `1.0.48-0`
## bayesian_belief_networks
- No changes
## downward
- No changes
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_footstep_msgs

```
* Add optional parameters for visualization to jsk_footstep_msgs/Footstep
* Contributors: Ryohei Ueda
```
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_network_tools
- No changes
## jsk_tilt_laser
- No changes
## jsk_tools

```
* Add script to kill/respawn automatically according to roscore status
* Contributors: Ryohei Ueda
```
## jsk_topic_tools

```
* Fix location of catkin_package of jsk_topic_tools
* Contributors: Ryohei Ueda
```
## libsiftfast
- No changes
## multi_map_server
- No changes
## nlopt
- No changes
## opt_camera
- No changes
## posedetection_msgs
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## sklearn
- No changes
## speech_recognition_msgs
- No changes
## voice_text
- No changes
