### PR TITLE
pr2_navigation: 0.1.23-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5283,6 +5283,10 @@ repositories:
       version: hydro-devel
     status: maintained
   pr2_navigation:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_navigation.git
+      version: hydro-devel
     release:
       packages:
       - laser_tilt_controller_filter
@@ -5299,7 +5303,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_navigation-release.git
-      version: 0.1.22-0
+      version: 0.1.23-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_navigation.git
+      version: hydro-devel
+    status: maintained
   pr2_navigation_apps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_navigation` to `0.1.23-0`:
- upstream repository: https://github.com/PR2/pr2_navigation.git
- release repository: https://github.com/TheDash/pr2_navigation-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.22-0`
## laser_tilt_controller_filter

```
* Updated maintainership
* Contributors: TheDash
```
## pr2_move_base

```
* Updated maintainership
* Contributors: TheDash
```
## pr2_navigation

```
* Updated maintainership
* Contributors: TheDash
```
## pr2_navigation_config

```
* Updated maintainership
* Contributors: TheDash
```
## pr2_navigation_global

```
* Updated maintainership
* Contributors: TheDash
```
## pr2_navigation_local

```
* Updated maintainership
* Contributors: TheDash
```
## pr2_navigation_perception

```
* Updated maintainership
* Contributors: TheDash
```
## pr2_navigation_self_filter

```
* Updated maintainership
* Contributors: TheDash
```
## pr2_navigation_slam

```
* Updated maintainership
* Contributors: TheDash
```
## pr2_navigation_teleop

```
* Updated maintainership
* Contributors: TheDash
```
## semantic_point_annotator

```
* Updated maintainership
* Removed unnecessary package fix
* Contributors: TheDash
```
