### PR TITLE
rviz: 1.11.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4900,7 +4900,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.11.3-0
+      version: 1.11.3-1
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.11.3-1`:
- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.11.3-0`
## rviz

```
* remove explicit dependency on urdfdom
  urdfdom is provided via urdf and catkin_* CMake variables.
  The current setup was unbalanced anyways because along with urdfdom, urdfdom_headers should have been being depended on and used.
  This precipitated from urdfdom's rosdep key changing as it became a system dependency in Indigo.
* Add ability to delete all markers in Marker plugin
* fix hidden cursor bug
  On some systems loading a pixmap from an svg file can fail.  On these machines
  an empty cursor results, meaning the cursor is invisible inside Rviz.  This
  works around the problem by using an arrow cursor when the desired cursor
  pixmap canot be loaded.
* Install rviz to the global bin
* Added display for sensor_msgs/RelativeHumidity
* Contributors: Acorn Pooley, Adam Leeper, Chad Rockey, Dave Coleman, William Woodall, hersh, trainman419
```
