### PR TITLE
pr2_sith: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5521,7 +5521,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_sith-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/PR2/pr2_sith.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_sith` to `1.0.2-0`:
- upstream repository: https://github.com/PR2/pr2_sith.git
- release repository: https://github.com/TheDash/pr2_sith-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.1-0`
## pr2_sith

```
* Updated CMakeLists to pass catkin_make install
* Contributors: TheDash
```
