### PR TITLE
openhrp3: 3.1.7-7 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3420,7 +3420,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/openhrp3-release.git
-      version: 3.1.7-6
+      version: 3.1.7-7
     source:
       type: git
       url: https://github.com/fkanehiro/openhrp3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openhrp3` to `3.1.7-7`:
- upstream repository: https://github.com/fkanehiro/openhrp3.git
- release repository: https://github.com/tork-a/openhrp3-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `3.1.7-6`
