### PR TITLE
ueye_cam: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5477,6 +5477,22 @@ repositories:
       url: https://bitbucket.org/kmhallen/ueye
       version: default
     status: maintained
+  ueye_cam:
+    doc:
+      type: git
+      url: https://github.com/anqixu/ueye_cam.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/anqixu/ueye_cam-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/anqixu/ueye_cam.git
+      version: master
+    status: developed
+    status_description: Initial release
   um6:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `1.0.2-0`:
- upstream repository: https://github.com/anqixu/ueye_cam.git
- release repository: https://github.com/anqixu/ueye_cam-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## ueye_cam

```
* switched from rosdep 'opencv2' to 'vision_opencv'
* Contributors: Anqi Xu
```
