### PR TITLE
ueye_cam: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7911,6 +7911,17 @@ repositories:
       type: git
       url: https://github.com/anqixu/ueye_cam.git
       version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/anqixu/ueye_cam-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/anqixu/ueye_cam.git
+      version: master
+    status: developed
+    status_description: Initial release
   um6:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `1.0.2-0`:
- upstream repository: https://github.com/anqixu/ueye_cam.git
- release repository: https://github.com/anqixu/ueye_cam-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## ueye_cam

```
* switched from rosdep 'opencv2' to 'vision_opencv'
* Contributors: Anqi Xu
```
