### PR TITLE
pr2_plugs: 1.0.14-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5354,7 +5354,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_plugs-release.git
-      version: 1.0.13-0
+      version: 1.0.14-0
     source:
       type: git
       url: https://github.com/PR2/pr2_plugs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_plugs` to `1.0.14-0`:
- upstream repository: https://github.com/PR2/pr2_plugs.git
- release repository: https://github.com/TheDash/pr2_plugs-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.13-0`
## checkerboard_pose_estimation

```
* Fixing orocos bug
* Contributors: TheDash
```
## outlet_pose_estimation
- No changes
## pr2_image_snapshot_recorder
- No changes
## pr2_plugs
- No changes
## pr2_plugs_actions
- No changes
## pr2_plugs_common

```
* Fixing orocos bug
* fixed orocos-kdl
* Contributors: TheDash
```
## pr2_plugs_msgs
- No changes
## stereo_wall_detection
- No changes
## visual_pose_estimation

```
* Fixing orocos bug
* Contributors: TheDash
```
