### PR TITLE
rqt_graphprofiler: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4871,7 +4871,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_graphprofiler-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/osrf/rqt_graphprofiler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graphprofiler` to `0.1.1-0`:
- upstream repository: https://github.com/osrf/rqt_graphprofiler.git
- release repository: https://github.com/ros-gbp/rqt_graphprofiler-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.0-0`
## rqt_graphprofiler

```
* deactivates nosetest because of broken dep on flake8
* add architecture independence as suggested by #29 <https://github.com/osrf/rqt_graphprofiler/issues/29>
* fix build farm compilation
* Contributors: Vincent Rabaud, dan brooks
```
