### PR TITLE
rqt_graphprofiler: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4871,7 +4871,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_graphprofiler-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/osrf/rqt_graphprofiler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graphprofiler` to `0.1.2-0`:
- upstream repository: https://github.com/osrf/rqt_graphprofiler.git
- release repository: https://github.com/ros-gbp/rqt_graphprofiler-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.1-0`
## rqt_graphprofiler

```
* removes std_msgs from CMakeLists (it does not have a build_depend in
  package.xml)
* Contributors: dan brooks
```
