### PR TITLE
hrpsys: 315.2.8-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1769,7 +1769,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/hrpsys-release.git
-      version: 315.2.8-0
+      version: 315.2.8-1
     status: developed
   humanoid_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys` to `315.2.8-1`:
- upstream repository: https://github.com/fkanehiro/hrpsys-base.git
- release repository: https://github.com/tork-a/hrpsys-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `315.2.8-0`
