### PR TITLE
Add python-flake8 dep for Fedora 20

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -328,6 +328,8 @@ python-espeak:
     trusty: [python-espeak]
     trusty_python3: [python3-espeak]
 python-flake8:
+  fedora:
+    heisenbug: [python-flake8]
   ubuntu:
     trusty: [python-flake8]
     trusty_python3: [python3-flake8]


### PR DESCRIPTION
python-flake8 only exists for f20+
