### PR TITLE
add debian defs for indigo deps

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1008,6 +1008,7 @@ libcoin80-dev:
   ubuntu: [libcoin80-dev]
 libconsole-bridge-dev:
   arch: [console-bridge]
+  debian: [libconsole-bridge-dev]
   fedora: [console-bridge-devel]
   ubuntu:
     saucy: [libconsole-bridge-dev]
@@ -1451,6 +1452,7 @@ libois-dev:
   ubuntu: [libois-dev]
 libopencv-dev:
   arch: [opencv]
+  debian: [libopencv-dev]
   fedora: [opencv-devel]
   gentoo: [media-libs/opencv]
   macports: [opencv]
@@ -1925,12 +1927,14 @@ libunwind-dev:
     trusty: [libunwind8-dev]
 liburdfdom-dev:
   arch: [urdfdom]
+  debian: [liburdfdom-dev]
   fedora: [urdfdom-devel]
   ubuntu:
     saucy: [liburdfdom-dev]
     trusty: [liburdfdom-dev]
 liburdfdom-headers-dev:
   arch: [urdfdom-headers]
+  debian: [liburdfdom-headers-dev]
   fedora: [urdfdom-headers-devel]
   ubuntu:
     saucy: [liburdfdom-headers-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -148,6 +148,7 @@ python-bluez:
     saucy: [python-bluez]
     trusty: [python-bluez]
 python-cairo:
+  debian: [python-cairo]
   fedora: [pycairo]
   ubuntu:
     lucid: [python-cairo]
@@ -638,6 +639,7 @@ python-omniorb:
     trusty: [python-omniorb, python-omniorb-omg, omniidl-python]
 python-opencv:
   arch: [opencv]
+  debian: [python-opencv]
   fedora: [opencv-python]
   ubuntu:
     saucy: [python-opencv]


### PR DESCRIPTION
Adding Debians definitions for packages that have been released separately for indigo.  Needed for rosdep to install all dependencies for compiling ROS from source on Debian (or Raspbian).
