### PR TITLE
jsk_control: 0.1.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2893,7 +2893,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_control-release.git
-      version: 0.1.3-1
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_control` to `0.1.4-0`:
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.9`
- previous version for package: `0.1.3-1`
## eus_nlopt

```
* add eigen
```
## eus_qp

```
* add eigen to depend
```
## eus_qpoases

```
* trust server ssl
```
## joy_mouse
- No changes
## jsk_footstep_controller

```
* Refine footsteps to snapped to plane
* Add simple motion to look around the floor near from legs and
  update minor stuff for the latest EnvironmentPlaneModeling
```
## jsk_footstep_planner
- No changes
## jsk_ik_server

```
* support hrp2jsknts in ik-server
* adding hrp2w-ik-server.l
```
## jsk_teleop_joy

```
* Merge pull request #112 from mmurooka/overwrite-write-command-in-midi-player
  Overwrite writing command in midi_config_player.py
* overwrite writing command in midi_config_player.py
* add pr2_relay.launch
* publish joy topic only when midi state is changed.
* add feedback config to b-control.yaml
```
