### PR TITLE
mongodb_store: 0.1.3-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3672,7 +3672,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.1.3-0
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.3-1`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.3-0`
## mongodb_log
- No changes
## mongodb_store

```
* added mongodb-dev as run depend
  to force inclusion in Debian dependencies
* Contributors: Marc Hanheide
```
## mongodb_store_msgs
- No changes
