### PR TITLE
robot_web_tools: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5863,7 +5863,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/robot_web_tools-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/RobotWebTools/robot_web_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_web_tools` to `0.0.2-0`:
- upstream repository: https://github.com/RobotWebTools/robot_web_tools.git
- release repository: https://github.com/RobotWebTools-release/robot_web_tools-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.1-0`
## robot_web_tools

```
* updated deps for non-meta package dep
* Contributors: Russell Toris
```
