### PR TITLE
[rosdep] Add the libx264 library

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2027,6 +2027,10 @@ libx11-dev:
   fedora: [libX11-devel]
   gentoo: [x11-libs/libX11]
   ubuntu: [libx11-dev]
+libx264-dev:
+  debian: [libx264-dev]
+  fedora: [x264-devel]
+  ubuntu: [libx264-dev]
 libxaw:
   arch: [libxaw]
   debian: [libxaw7-dev]


### PR DESCRIPTION
I need this for compilation of an image_transport plugin and thought it could be useful for others as well.
