### PR TITLE
rail_pick_and_place: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3821,6 +3821,24 @@ repositories:
       url: https://github.com/WPI-RAIL/rail_maps.git
       version: develop
     status: maintained
+  rail_pick_and_place:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_pick_and_place.git
+      version: master
+    release:
+      packages:
+      - rail_pick_and_place
+      - rail_pick_and_place_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_pick_and_place.git
+      version: develop
+    status: maintained
   rail_segmentation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_pick_and_place` to `0.0.1-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_pick_and_place.git
- release repository: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## rail_pick_and_place

```
* prep for release
* Initial commit
* Contributors: David Kent, Russell Toris
```
## rail_pick_and_place_msgs

```
* prep for release
* Initial commit
* Contributors: David Kent, Russell Toris
```
