### PR TITLE
multisense_ros: 3.3.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3976,7 +3976,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
-      version: 3.3.1-0
+      version: 3.3.2-0
     source:
       type: hg
       url: https://bitbucket.org/crl/multisense_ros


### PR DESCRIPTION
Increasing version of package(s) in repository `multisense_ros` to `3.3.2-0`:
- upstream repository: https://bitbucket.org/crl/multisense_ros
- release repository: https://github.com/carnegieroboticsllc/multisense_ros-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `3.3.1-0`
## multisense

```
* Added colorized laser point cloud topic. Removed LIDAR streaming frequency warning. Updated build dependencies for Bloom. General interface cleanup.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
## multisense_bringup

```
* Added colorized laser point cloud topic. Removed LIDAR streaming frequency warning. Updated build dependencies for Bloom. General interface cleanup.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
## multisense_cal_check

```
* Added colorized laser point cloud topic. Removed LIDAR streaming frequency warning. Updated build dependencies for Bloom. General interface cleanup.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
## multisense_description

```
* Added colorized laser point cloud topic. Removed LIDAR streaming frequency warning. Updated build dependencies for Bloom. General interface cleanup.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
## multisense_lib

```
* Added colorized laser point cloud topic. Removed LIDAR streaming frequency warning. Updated build dependencies for Bloom. General interface cleanup.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
## multisense_ros

```
* Added colorized laser point cloud topic. Removed LIDAR streaming frequency warning. Updated build dependencies for Bloom. General interface cleanup.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
