### PR TITLE
novatel_span_driver: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4323,6 +4323,24 @@ repositories:
       url: https://github.com/ros/nodelet_core.git
       version: hydro-devel
     status: maintained
+  novatel_span_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/novatel_span_driver.git
+      version: master
+    release:
+      packages:
+      - novatel_msgs
+      - novatel_span_driver
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/novatel_span_driver-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/novatel_span_driver.git
+      version: master
+    status: developed
   object_recognition_capture:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_span_driver` to `0.1.0-0`:
- upstream repository: https://github.com/ros-drivers/novatel_span_driver.git
- release repository: https://github.com/ros-drivers-gbp/novatel_span_driver-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## novatel_msgs

```
* Package mostly unchanged from work done by NovAtel.
* Contributors: Mike Purvis
```
## novatel_span_driver

```
* Consolidation and reorganization of novatelcentral driver prepared by NovAtel
  and published here: https://github.com/NovAtel-inc/rosnovatel
* Contributors: Mike Purvis
```
