### PR TITLE
multisense_ros: 3.3.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2911,7 +2911,7 @@ repositories:
     doc:
       type: hg
       url: https://bitbucket.org/crl/multisense_ros
-      version: master
+      version: default
     release:
       packages:
       - multisense
@@ -2927,7 +2927,7 @@ repositories:
     source:
       type: hg
       url: https://bitbucket.org/crl/multisense_ros
-      version: master
+      version: default
     status: developed
   nanomsg:
     release:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2908,6 +2908,10 @@ repositories:
       version: indigo-devel
     status: maintained
   multisense_ros:
+    doc:
+      type: hg
+      url: https://bitbucket.org/crl/multisense_ros
+      version: master
     release:
       packages:
       - multisense
@@ -2919,7 +2923,12 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
-      version: 3.3.2-0
+      version: 3.3.3-0
+    source:
+      type: hg
+      url: https://bitbucket.org/crl/multisense_ros
+      version: master
+    status: developed
   nanomsg:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `multisense_ros` to `3.3.3-0`:
- upstream repository: https://bitbucket.org/crl/multisense_ros
- release repository: https://github.com/carnegieroboticsllc/multisense_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `3.3.2-0`
## multisense
- No changes
## multisense_bringup
- No changes
## multisense_cal_check
- No changes
## multisense_description
- No changes
## multisense_lib

```
* Updated CMakeLists.txt to resolve linker errors with Jenkins.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
## multisense_ros

```
* Updated CMakeLists.txt to resolve linker errors with Jenkins.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
