### PR TITLE
graph_msgs: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2063,7 +2063,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/davetcoleman/graph_msgs-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/davetcoleman/graph_msgs.git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2058,7 +2058,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/davetcoleman/graph_msgs.git
-      version: master
+      version: hydro-devel
     release:
       tags:
         release: release/hydro/{package}/{version}
@@ -2067,7 +2067,7 @@ repositories:
     source:
       type: git
       url: https://github.com/davetcoleman/graph_msgs.git
-      version: master
+      version: hydro-devel
     status: developed
   grasping_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `graph_msgs` to `0.0.3-0`:
- upstream repository: https://github.com/davetcoleman/graph_msgs
- release repository: https://github.com/davetcoleman/graph_msgs-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.2-0`
## graph_msgs

```
* Release to indigo
* Spelling fix
* Contributors: Dave Coleman
```
