### PR TITLE
graph_msgs: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1609,7 +1609,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/graph_msgs-release.git
-      version: 0.0.3-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/graph_msgs.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1604,7 +1604,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/davetcoleman/graph_msgs.git
-      version: master
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -1613,7 +1613,7 @@ repositories:
     source:
       type: git
       url: https://github.com/davetcoleman/graph_msgs.git
-      version: master
+      version: indigo-devel
     status: maintained
   grasping_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `graph_msgs` to `0.1.0-0`:
- upstream repository: https://github.com/davetcoleman/graph_msgs
- release repository: https://github.com/davetcoleman/graph_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.3-0`
## graph_msgs

```
* Added header / timestamp
* Contributors: Dave Coleman
```
