### PR TITLE
multimaster_fkie: 0.3.14-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3959,7 +3959,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.3.13-0
+      version: 0.3.14-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.3.14-0`:
- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.3.13-0`
## default_cfg_fkie

```
* node_manager_fkie: added support of $(find ...) statement to add images in decription of capabilities
```
## master_discovery_fkie
- No changes
## master_sync_fkie

```
* master_sync_fkie: reduced update notifications after registration of a subscriber
```
## multimaster_fkie
- No changes
## multimaster_msgs_fkie
- No changes
## node_manager_fkie

```
* node_manager_fkie: added a warning to capability table, if multiple configurations for the same node are loaded
* node_manager_fkie: remove now the configuration in capability table after a host was removed
* node_manager_fkie: fixed error while navigate in description panel
* node_manager_fkie: changed sidebar parameter handling (for start host dialog)
* node_manager_fkie: changed the handling on click the sync button in master list
* node_manager_fkie: fixed tooltip for recent loaded files
* node_manager_fkie: fixed problems in capability table with multi-launch-files for the same host and group
* CapabilityHeader: Keep indices of _data and controlWidget in sync when inserting new capabilities
* Fixed crash in master_list_model if IPv6 addresses are present on the host
* node_manager_fkie:manual link added
* node_manager_fkie: added args and remaps to change detection after reload a launch file
* node_manager_fkie: ignore namespace while display the Capabilities in Capabilities table
* node_manager_fkie: fixed some template tags in xml editor
* node_manager_fkie: stop nodes first while restart nodes after loading a launch file
* node_manager_fkie: added support of $(find ...) statement to add images in decription of capabilities
* node_manager_fkie: xmleditor - ask for save by pressing ESC
* node_manager_fkie: changed the update strategy for description dock
* node_manager_fkie: changed the update strategy for description dock
* node_manager_fkie: changed name creation for default configuration node
* node_manager_fkie: fixed blocked focus if a xmleditor was open
* node_manager_fkie: fixed highlighter problem in pyqt
* node_manager_fkie: improved respawn script
* node_manager_fkie: fixed handling of history files
* node_manager_fkie: mark line with problems in launch editor
* Contributors: Alexander, Alexander Tiderko, Stefan Oßwald, Timo Röhling
```
