### PR TITLE
perception_pcl: 1.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3689,10 +3689,11 @@ repositories:
       packages:
       - pcl_ros
       - perception_pcl
+      - pointcloud_to_laserscan
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/perception_pcl-release.git
-      version: 1.2.1-0
+      version: 1.2.2-0
     source:
       type: git
       url: https://github.com/ros-perception/perception_pcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.2.2-0`:
- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.2.1-0`
## pcl_ros

```
* Adding target_frame
  [Ability to specify frame in bag_to_pcd ](https://github.com/ros-perception/perception_pcl/issues/55)
* Update pcl_nodelets.xml
  Included missing closing library tag.  This was causing the pcl/Filter nodelets below the missing nodelet tag to not be exported correctly.
* Contributors: Matt Derry, Paul Bovbel, Ruffin
```
## perception_pcl
- No changes
## pointcloud_to_laserscan

```
* clean up package.xml
* Fix header reference
* Fix flow
* Fix pointer assertion
* Finalize pointcloud to laserscan
* Initial pointcloud to laserscan commit
* Contributors: Paul Bovbel
```
