### PR TITLE
Adding my_repo_name to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1285,6 +1285,17 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/eigen_stl_containers-release.git
       version: 0.1.4-0
+  epuck_driver:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/verlab-ros-pkg/epuck_drive-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/verlab-ros-pkg/epuck_driver.git
+      version: indigo-devel
+    status: maintained
   executive_smach:
     release:
       packages:


### PR DESCRIPTION
I would like epuck_driver to be indexed and documented on ros.org
