### PR TITLE
Adding pcan_topics to documentation index for fuerte

### DIFF
--- a/doc/fuerte/pcan_topics.rosinstall
+++ b/doc/fuerte/pcan_topics.rosinstall
@@ -1,0 +1,3 @@
+- git:
+      local-name: pcan_topics
+      uri: https://github.com/najkirdneh/pcan_topics.git


### PR DESCRIPTION
I created a small node so CAN communication in ROS can be visualized easily. I will also submit this node for other ROS versions in the future. 
