### PR TITLE
Adding crazyflie to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -947,6 +947,12 @@ repositories:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/cpp_introspection.git
       version: master
+  crazyflie:
+    doc:
+      type: git
+      url: https://github.com/whoenig/crazyflie_ros.git
+      version: master
+    status: maintained
   crsm_slam:
     doc:
       type: git


### PR DESCRIPTION
I'd like crazyflie to be indexed and documented on ros.org.
