### PR TITLE
bride: 0.3.3-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -460,7 +460,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/bride-release.git
-      version: 0.3.3-0
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/ipa320/bride.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bride` to `0.3.3-1`:
- upstream repository: https://github.com/ipa320/bride.git
- release repository: https://github.com/ipa320/bride-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.3.3-0`
