### PR TITLE
cmake_modules: 0.3.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -701,7 +701,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/cmake_modules-release.git
-      version: 0.2.1-1
+      version: 0.3.2-0
+    source:
+      type: git
+      url: https://github.com/ros/cmake_modules.git
+      version: 0.3-devel
+    status: maintained
   cmvision:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules` to `0.3.2-0`:
- upstream repository: https://github.com/ros/cmake_modules.git
- release repository: https://github.com/ros-gbp/cmake_modules-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.2.1-1`
## cmake_modules

```
* Added CMake module for finding the UUID libraries
* Changed prepend of CMAKE_MODULE_PATH to append behaviour in order to allow prepending of external CMake modules.
* Added CMake module for finding GSL
* Contributors: Esteve Fernandez, Peter Lehner, William Woodall, v01d
```
