### PR TITLE
cmake_modules: 0.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -525,7 +525,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/cmake_modules-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/ros/cmake_modules.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules` to `0.3.2-0`:
- upstream repository: https://github.com/ros/cmake_modules.git
- release repository: https://github.com/ros-gbp/cmake_modules-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.3.1-0`
## cmake_modules

```
* Added CMake module for finding the UUID libraries
* Changed prepend of CMAKE_MODULE_PATH to append behaviour in order to allow prepending of external CMake modules.
* Added CMake module for finding GSL
* Contributors: Esteve Fernandez, Peter Lehner, William Woodall, v01d
```
