### PR TITLE
rviz_visual_tools: 1.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5056,6 +5056,21 @@ repositories:
       url: https://github.com/ros-visualization/rviz_fixed_view_controller.git
       version: indigo-devel
     status: developed
+  rviz_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/rviz_visual_tools.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/davetcoleman/rviz_visual_tools-release.git
+      version: 1.3.1-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/rviz_visual_tools.git
+      version: indigo-devel
+    status: developed
   schunk_modular_robotics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `1.3.1-0`:
- upstream repository: https://github.com/davetcoleman/rviz_visual_tools.git
- release repository: https://github.com/davetcoleman/rviz_visual_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## rviz_visual_tools

```
* Added new publishSpheres function
* Renamed rviz_colors to colors and rviz_scales to scales
* Initial commit, forked from moveit_visual_tools
* Contributors: Dave Coleman
```
