### PR TITLE
moveit_visual_tools: 2.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2875,7 +2875,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 1.3.0-0
+      version: 2.0.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `2.0.0-0`:
- upstream repository: https://github.com/davetcoleman/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.3.0-0`
## moveit_visual_tools

```
* Updated README
* API Upgrade Notes
* Renamed to have 'MoveIt' prefix in class and file name, moved base functionality to rviz_visual_tools
* Added new publishSphere function and publish_sphere test script
* Created better test script
* Better static_id handling for publishText
* Added mainpage for API docs
* Enabled colors
* Improved integer random num generation
* New publishSpheres functions
* Contributors: Dave Coleman
```
