### PR TITLE
moveit_simple_grasps: 1.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2860,7 +2860,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/moveit_simple_grasps-release.git
-      version: 1.2.0-1
+      version: 1.2.1-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_simple_grasps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_simple_grasps` to `1.2.1-0`:
- upstream repository: https://github.com/davetcoleman/moveit_simple_grasps.git
- release repository: https://github.com/davetcoleman/moveit_simple_grasps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.2.0-1`
## moveit_simple_grasps

```
* Refactored for new moveit_visual_tools API
* Fixed package.xml
* Updated README
* Contributors: Dave Coleman
```
