### PR TITLE
fcl: 0.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1338,7 +1338,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/fcl-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     status: maintained
   filters:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `fcl` to `0.3.2-0`:
- upstream repository: https://github.com/flexible-collision-library/fcl.git
- release repository: https://github.com/ros-gbp/fcl-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.3.1-0`
