### PR TITLE
ros_control: 0.7.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6185,7 +6185,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.7.2-1
+      version: 0.7.3-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.7.3-0`:
- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.7.2-1`
## controller_interface
- No changes
## controller_manager

```
* Spawner: adding shutdown timeout to prevent deadlocks
* Create README.md
* Contributors: Adolfo Rodriguez Tsouroukdissian, Jonathan Bohren
```
## controller_manager_msgs
- No changes
## controller_manager_tests

```
* make rostest in CMakeLists optional
* controller_manager_tests: fix library linking
* Contributors: Lukas Bulwahn, Paul Mathieu
```
## hardware_interface
- No changes
## joint_limits_interface

```
* make rostest in CMakeLists optional.
* Add hardware_interface to CATKIN_DEPENDS.
* Fix generation of rostests in catkin.
* Contributors: Adolfo Rodriguez Tsouroukdissian, Lukas Bulwahn
```
## ros_control
- No changes
## rqt_controller_manager
- No changes
## transmission_interface
- No changes
