### PR TITLE
apriltags_ros: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -161,6 +161,24 @@ repositories:
       url: https://github.com/clearpathrobotics/applanix_driver.git
       version: hydro-devel
     status: maintained
+  apriltags_ros:
+    doc:
+      type: git
+      url: https://github.com/RIVeR-Lab/apriltags_ros.git
+      version: hydro-devel
+    release:
+      packages:
+      - apriltags
+      - apriltags_ros
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/RIVeR-Lab-release/apriltags_ros-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/RIVeR-Lab/apriltags_ros.git
+      version: hydro-devel
+    status: maintained
   ar_kinect:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltags_ros` to `0.0.1-0`:
- upstream repository: https://github.com/RIVeR-Lab/apriltags_ros.git
- release repository: https://github.com/RIVeR-Lab-release/apriltags_ros-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## apriltags

```
* Initial Commit from release r30 in https://svn.csail.mit.edu/apriltags
```
## apriltags_ros

```
* Initial Version
```
