### PR TITLE
moveit_planners: 0.6.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2787,7 +2787,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_planners-release.git
-      version: 0.6.6-0
+      version: 0.6.7-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_planners.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_planners` to `0.6.7-0`:
- upstream repository: https://github.com/ros-planning/moveit_planners.git
- release repository: https://github.com/ros-gbp/moveit_planners-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.6.6-0`
## moveit_planners
- No changes
## moveit_planners_ompl

```
* Changed OMPL SimpleSetup member variable to shared pointer, passed MotionPlanningRequest to child function
* Simplified number of solve() entry points in moveit_planners_ompl
* Fixed uninitialized ptc_ pointer causing a crash.
* renamed newGoal to new_goal for keeping with formatting
* setting GroupStateValidityCallbackFn member for constraint_sampler member and implementing callbacks for state validity checking
* added functions to check validit of state, and also to act as callback for constraint sampler
* Added copy function from MoveIt! robot_state joint values to ompl state
* fix for demo constraints database linking error
* Namespaced less useful debug output to allow to be easily silenced using ros console
* Contributors: Dave Coleman, Dave Hershberger, Sachin Chitta, arjungm
```
