### PR TITLE
bond_core: 1.7.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -267,7 +267,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/bond_core-release.git
-      version: 1.7.14-1
+      version: 1.7.15-0
     source:
       type: git
       url: https://github.com/ros/bond_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.7.15-0`:
- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.7.14-1`
