### PR TITLE
smart_battery_msgs: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7487,6 +7487,21 @@ repositories:
       url: https://github.com/ros-gbp/slam_karto-release.git
       version: 0.7.1-0
     status: maintained
+  smart_battery_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/smart_battery_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/smart_battery_msgs-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/smart_battery_msgs.git
+      version: master
+    status: maintained
   softkinetic:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `smart_battery_msgs` to `0.1.0-0`:
- upstream repository: https://github.com/ros-drivers/smart_battery_msgs.git
- release repository: https://github.com/ros-gbp/smart_battery_msgs-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## smart_battery_msgs

```
* initial commit
* Contributors: Jihoon Lee
```
