### PR TITLE
add libssl-dev for homebrew

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -269,6 +269,10 @@ libreadline-dev:
   osx:
     homebrew:
       packages: [readline]
+libssl-dev:
+  osx:
+    homebrew:
+      packages: []
 libtbb:
   osx:
     homebrew:


### PR DESCRIPTION
This appears to be right. warehouse_ros depends on libssl-dev, there isn't currently a rosdep key, but it builds without installing anything special on Mavericks/indigo. A quick search shows that openssl is installed by default on newer MacOSX installs.

@wjwwood any additional thoughts?
