### PR TITLE
nodelet_core: 1.9.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3263,7 +3263,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.9.0-0
+      version: 1.9.1-0
     source:
       type: git
       url: https://github.com/ros/nodelet_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.1-0`:
- upstream repository: git://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.9.0-0`
## nodelet

```
* Use FindUUID.cmake from cmake-modules to find the UUID libraries
* nodelet: Loader: do not call impl->refresh_classes_ if not available
* Contributors: Esteve Fernandez, Max Schwarz
```
## nodelet_core
- No changes
## nodelet_topic_tools
- No changes
