### PR TITLE
nodelet_core: 1.8.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4341,7 +4341,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.8.4-0
+      version: 1.8.5-0
     source:
       type: git
       url: https://github.com/ros/nodelet_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.8.5-0`:
- upstream repository: git://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.8.4-0`
## nodelet

```
* Use FindUUID.cmake from cmake-modules to find the UUID libraries
* Contributors: Esteve Fernandez
```
## nodelet_core
- No changes
## nodelet_topic_tools
- No changes
