### PR TITLE
rqt_pr2_dashboard: 0.2.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6873,7 +6873,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
-      version: 0.2.5-0
+      version: 0.2.6-0
     status: maintained
   rqt_robot_plugins:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_pr2_dashboard` to `0.2.6-0`:
- upstream repository: https://github.com/ros-visualization/rqt_pr2_dashboard.git
- release repository: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12-issue211`
- previous version for package: `0.2.5-0`
## rqt_pr2_dashboard

```
* update maintainer (#16 <https://github.com/PR2/rqt_pr2_dashboard/issues/16>)
```
