### PR TITLE
novatel_span_driver: 0.2.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4359,7 +4359,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-drivers-gbp/novatel_span_driver-release.git
-      version: 0.1.0-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/novatel_span_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_span_driver` to `0.2.0-0`:
- upstream repository: https://github.com/ros-drivers/novatel_span_driver.git
- release repository: https://github.com/ros-drivers-gbp/novatel_span_driver-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.1.0-0`
## novatel_msgs

```
* Remove a bunch of unused messages.
* Add WHEELVELOCITY msg.
* Contributors: Mike Purvis
```
## novatel_span_driver

```
* Re-work the publisher class.
* Add a pcap for a SPAN fix.
* Tweaks to topic names.
* Add working rostest, fixes from pepify.
* Add roslaunch file check for example launcher.
* Add roslint test.
* Contributors: Mike Purvis
```
