### PR TITLE
uwsim_osgocean: 1.0.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5786,7 +5786,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uji-ros-pkg/uwsim_osgocean-release.git
-      version: 1.0.2-0
+      version: 1.0.2-1
     status: maintained
   uwsim_osgworks:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_osgocean` to `1.0.2-1`:
- upstream repository: https://github.com/uji-ros-pkg/uwsim_osgocean.git
- release repository: https://github.com/uji-ros-pkg/uwsim_osgocean-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.2-0`
