### PR TITLE
mjpeg_server: 1.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3671,7 +3671,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/mjpeg_server-release.git
-      version: 1.1.1-0
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/RobotWebTools/mjpeg_server.git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3676,7 +3676,8 @@ repositories:
       type: git
       url: https://github.com/RobotWebTools/mjpeg_server.git
       version: develop
-    status: maintained
+    status: end-of-life
+    status_description: Replaced by the web_video_server package.
   ml_classifiers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mjpeg_server` to `1.1.2-0`:
- upstream repository: https://github.com/RobotWebTools/mjpeg_server.git
- release repository: https://github.com/RobotWebTools-release/mjpeg_server-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.1.1-0`
## mjpeg_server

```
* ROS_WARN added
* DEPRECATION NOTICE
* Contributors: Russell Toris
```
