### PR TITLE
mjpeg_server: 1.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2690,7 +2690,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/mjpeg_server-release.git
-      version: 1.1.1-0
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/RobotWebTools/mjpeg_server.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2695,7 +2695,8 @@ repositories:
       type: git
       url: https://github.com/RobotWebTools/mjpeg_server.git
       version: develop
-    status: maintained
+    status: end-of-life
+    status_description: Replaced by the web_video_server package.
   ml_classifiers:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `mjpeg_server` to `1.1.2-0`:
- upstream repository: https://github.com/RobotWebTools/mjpeg_server.git
- release repository: https://github.com/RobotWebTools-release/mjpeg_server-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.1.1-0`
## mjpeg_server

```
* ROS_WARN added
* DEPRECATION NOTICE
* Contributors: Russell Toris
```
