### PR TITLE
ros_web_video: 0.1.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4620,7 +4620,8 @@ repositories:
       type: git
       url: https://github.com/RobotWebTools/ros_web_video.git
       version: develop
-    status: maintained
+    status: end-of-life
+    status_description: Replaced by the web_video_server package.
   rosauth:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4615,7 +4615,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/ros_web_video-release.git
-      version: 0.1.13-0
+      version: 0.1.14-0
     source:
       type: git
       url: https://github.com/RobotWebTools/ros_web_video.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_web_video` to `0.1.14-0`:
- upstream repository: https://github.com/RobotWebTools/ros_web_video.git
- release repository: https://github.com/RobotWebTools-release/ros_web_video-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.13-0`
## ros_web_video

```
* DEPRECATION NOTICE
* Contributors: Russell Toris
```
