### PR TITLE
bond_core: 1.7.16-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -457,7 +457,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/bond_core-release.git
-      version: 1.7.15-0
+      version: 1.7.16-0
     source:
       type: git
       url: https://github.com/ros/bond_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.7.16-0`:
- upstream repository: git://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.7.15-0`
