### PR TITLE
ros_web_video: 0.1.14-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6320,7 +6320,8 @@ repositories:
       type: git
       url: https://github.com/RobotWebTools/ros_web_video.git
       version: develop
-    status: maintained
+    status: end-of-life
+    status_description: Replaced by the web_video_server package.
   rosaria:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6315,7 +6315,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/ros_web_video-release.git
-      version: 0.1.13-0
+      version: 0.1.14-0
     source:
       type: git
       url: https://github.com/RobotWebTools/ros_web_video.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_web_video` to `0.1.14-0`:
- upstream repository: https://github.com/RobotWebTools/ros_web_video.git
- release repository: https://github.com/RobotWebTools-release/ros_web_video-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.13-0`
## ros_web_video

```
* DEPRECATION NOTICE
* Contributors: Russell Toris
```
