### PR TITLE
robot_web_tools: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5911,7 +5911,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/robot_web_tools-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/RobotWebTools/robot_web_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_web_tools` to `0.0.3-0`:
- upstream repository: https://github.com/RobotWebTools/robot_web_tools.git
- release repository: https://github.com/RobotWebTools-release/robot_web_tools-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.2-0`
## robot_web_tools

```
* changes to new video server dep
* Contributors: Russell Toris
```
