### PR TITLE
nodelet_core: 1.9.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3263,7 +3263,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.9.1-0
+      version: 1.9.2-0
     source:
       type: git
       url: https://github.com/ros/nodelet_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.2-0`:
- upstream repository: git://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.9.1-0`
## nodelet

```
* Fix dependency version
* Contributors: Esteve Fernandez
```
## nodelet_core
- No changes
## nodelet_topic_tools
- No changes
