### PR TITLE
robot_web_tools: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4143,7 +4143,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/robot_web_tools-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/RobotWebTools/robot_web_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_web_tools` to `0.0.3-0`:
- upstream repository: https://github.com/RobotWebTools/robot_web_tools.git
- release repository: https://github.com/RobotWebTools-release/robot_web_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.2-0`
## robot_web_tools

```
* changes to new video server dep
* Contributors: Russell Toris
```
