### PR TITLE
rviz: 1.11.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5031,7 +5031,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.11.3-1
+      version: 1.11.4-0
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.11.4-0`:
- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.11.3-1`
## rviz

```
* Fixed stereo support for custom projection matrices
* Fixed read off end of array in triangle_list_marker
* Add dependency on opengl
  rviz calls find_package(OpenGL), so it should have a direct dependency
  on OpenGL. This matters on ARM, where the other packages that rviz
  depends on use OpenGL.ES, and don't provide a transitive dependency on
  OpenGL.
* Update map via QT signal instead of in ros thread
  Resolved issues when running RViz in rqt where the incomingMap callback
  is not issued from RViz's main QThread causing a crash in Ogre. Map
  updates are now handled by emitting a signal to update the map from the
  callback thread.
* fix rainbow color, see #813 <https://github.com/ros-visualization/rviz/issues/813>
* Added TF listener as parameter to constructors of VisualizationManager and FrameManager
* Fix add by topic for Marker and MarkerArray
* Fixed map plugin to only show when active
* stereo: restore camera after rendering (Avoids a segfault)
* fix stereo eye separation
* fix ogre includes
* Contributors: Acorn Pooley, Alex Bencz, Austin, Austin Hendrix, Ben Charrow, Dave Hershberger, Jonathan Bohren, Kei Okada, William Woodall, ZdenekM, v4hn
```
