### PR TITLE
Adding tf_splitter to documentation index for Groovy

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4588,6 +4588,21 @@ repositories:
       url: https://github.com/RobotWebTools/tf2_web_republisher.git
       version: develop
     status: maintained
+  tf_splitter:
+    doc:
+      type: git
+      url: https://github.com/yzrobot/tf_splitter.git
+      version: master
+    release:
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/yzrobot/tf_splitter.git
+      version: 0.0.1
+    source:
+      type: git
+      url: https://github.com/yzrobot/tf_splitter.git
+      version: develop
+    status: maintained
   topic_proxy:
     doc:
       type: git


### PR DESCRIPTION
I'd like tf_splitter to be indexed and documented on ros.org.
