### PR TITLE
ros_control: 0.9.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4468,7 +4468,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.8.2-0
+      version: 0.9.0-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.9.0-0`:
- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.8.2-0`
## controller_interface
- No changes
## controller_manager

```
* Spawner script: adding shutdown timeout to prevent deadlocks
* Documentation fixes
* Contributors: Jonathan Bohren, shadowmanos
```
## controller_manager_msgs

```
* Add Python helpers for:
  - Getting all active controller managers.
  - Determining if a namespace contains the controller manager ROS API.
  - Filtering the output of the 'list_controllers' service bytype, name, state, hardware_interface and claimed resources.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## controller_manager_tests

```
* Tests for Python helpers added to controller_manager_msgs
* Buildsystem and documentation fixes
* Contributors: Adolfo Rodriguez Tsouroukdissian, Lukas Bulwahn, shadowmanos
```
## hardware_interface

```
* Add PosVel and PosVelAcc command interfaces
* Documentation fixes
* Contributors: Igorec, shadowmanos
```
## joint_limits_interface

```
* Buildsystem and documentation fixes
* Add inline keyword to free header functions
* Contributors: Adolfo Rodriguez Tsouroukdissian, Lukas Bulwahn, shadowmanos
```
## ros_control
- No changes
## rqt_controller_manager
- No changes
## transmission_interface

```
* Buildsystem and documentation fixes
* Contributors: Adolfo Rodriguez Tsouroukdissian, shadowmanos
```
