### PR TITLE
ros_controllers: 0.9.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4491,11 +4491,12 @@ repositories:
       - joint_trajectory_controller
       - position_controllers
       - ros_controllers
+      - rqt_joint_trajectory_controller
       - velocity_controllers
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.8.1-0
+      version: 0.9.0-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.9.0-0`:
- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.8.1-0`
## diff_drive_controller

```
* Add support for multiple wheels per side
* Odometry computation:
  - New option to compute in open loop fashion
  - New option to skip publishing odom frame to tf
* Remove dependency on angles package
* Buildsystem fixes
* Contributors: Bence Magyar, Lukas Bulwahn, efernandez
```
## effort_controllers

```
* Propagate changes made in forward_command_controller
* Contributors: ipa-fxm
```
## force_torque_sensor_controller

```
* Buildsystem fixes
* Contributors: Dave Coleman
```
## forward_command_controller

```
* ForwardJointGroupCommandController: Class for implementing multi-joint
  command-forwarding controllers
* Contributors: ipa-fxm
```
## gripper_action_controller

```
* Buildsystem fixes
* Contributors: Adolfo Rodriguez Tsouroukdissian, Lukas Bulwahn
```
## imu_sensor_controller

```
* Buildsystem fixes
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## joint_state_controller

```
* Buildsystem fixes
* Contributors: Dave Coleman
```
## joint_trajectory_controller

```
* Check that waypoint times are strictly increasing before accepting a command
* velocity_controllers::JointTrajectoryController: New plugin variant for
  velocity-controlled joints
* Buildsystem fixes
* Contributors: Adolfo Rodriguez Tsouroukdissian, Lukas Bulwahn, ipa-fxm, Dave Coleman
```
## position_controllers

```
* New controller: position_controllers/JointGroupPositionController (multi-joint)
* Hold position when starting JointPositionController and JointGroupPositionController
* Buildsystem fixes
* Contributors: Dave Coleman, ipa-fxm
```
## ros_controllers

```
* Add rqt_joint_trajectory_controller to metapackage
```
## rqt_joint_trajectory_controller

```
* New rqt plugin: joint_trajectory_controller rqt plugin.
  - Allows to select any running joint trajectory controller from any activecontroller manager

    * Two modes:
      - Monitor: Joint display shows actual positions of controller joints
      - Control: Joint display sends controller commands
    * Max joint speed is read from the URDF, but can be scaled down for safety

* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## velocity_controllers

```
* New controller: velocity_controllers/JointGroupVelocityController (multi-joint)
* New controller: velocity_controllers/JointPositionController
* Contributors: ipa-fxm, Dave Coleman
```
