### PR TITLE
carl_moveit: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -460,6 +460,21 @@ repositories:
       url: https://github.com/WPI-RAIL/carl_estop.git
       version: develop
     status: maintained
+  carl_moveit:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/carl_moveit.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/carl_moveit-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/carl_moveit.git
+      version: develop
+    status: maintained
   carl_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_moveit` to `0.0.1-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_moveit.git
- release repository: https://github.com/wpi-rail-release/carl_moveit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## carl_moveit

```
* mongo fix
* travis test
* cleanup for release
* updates for pick and place
* initial commit
* Contributors: Russell Toris, dekent
```
