### PR TITLE
multisense_ros: 3.3.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2947,7 +2947,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
-      version: 3.3.3-0
+      version: 3.3.4-0
     source:
       type: hg
       url: https://bitbucket.org/crl/multisense_ros


### PR DESCRIPTION
Increasing version of package(s) in repository `multisense_ros` to `3.3.4-0`:
- upstream repository: https://bitbucket.org/crl/multisense_ros
- release repository: https://github.com/carnegieroboticsllc/multisense_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `3.3.3-0`
## multisense
- No changes
## multisense_bringup

```
* Added sensor_msgs::Imu message publishing. No orientation information is published. Updated URDF models to have consistent accelerometer, magnetometer, and gyroscope frame_ids.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
## multisense_cal_check
- No changes
## multisense_description

```
* Added sensor_msgs::Imu message publishing. No orientation information is published. Updated URDF models to have consistent accelerometer, magnetometer, and gyroscope frame_ids.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
## multisense_lib
- No changes
## multisense_ros

```
* Added sensor_msgs::Imu message publishing. No orientation information is published. Updated URDF models to have consistent accelerometer, magnetometer, and gyroscope frame_ids.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
