### PR TITLE
moveit_ros: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2876,7 +2876,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ros` to `0.6.1-0`:
- upstream repository: https://github.com/ros-planning/moveit_ros.git
- release repository: https://github.com/ros-gbp/moveit_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.6.0-0`
## moveit_ros
- No changes
## moveit_ros_benchmarks
- No changes
## moveit_ros_benchmarks_gui
- No changes
## moveit_ros_manipulation
- No changes
## moveit_ros_move_group
- No changes
## moveit_ros_perception

```
* fix linking error on OSX
* Contributors: Michael Ferguson
```
## moveit_ros_planning

```
* re-add libqt4 dependency (previously came from pcl-all)
* Contributors: Michael Ferguson
```
## moveit_ros_planning_interface
- No changes
## moveit_ros_robot_interaction
- No changes
## moveit_ros_visualization

```
* Fixed joystick documentation
* Joystick documentation and queue_size addition
* Contributors: Dave Coleman
```
## moveit_ros_warehouse
- No changes
