### PR TITLE
moveit_visual_tools: 2.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2913,7 +2913,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 2.0.0-0
+      version: 2.1.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `2.1.0-0`:
- upstream repository: https://github.com/davetcoleman/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `2.0.0-0`
## moveit_visual_tools

```
* Fix for upstream change of RvizVisualTools
* Set animation speed of grasps
* Fix publishing end effector
* New publishCollisionObjectMsg() function
* New getSharedRobotState() accessor function
* Consolidated publish marker functions
* Fixed loadEEMarker() to be called more than once
* Contributors: Dave Coleman
```
