### PR TITLE
ompl_visual_tools: 2.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3503,7 +3503,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/ompl_visual_tools-release.git
-      version: 2.1.1-0
+      version: 2.2.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/ompl_visual_tools.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3498,7 +3498,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/davetcoleman/ompl_visual_tools.git
-      version: hydro-devel
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -3507,7 +3507,7 @@ repositories:
     source:
       type: git
       url: https://github.com/davetcoleman/ompl_visual_tools.git
-      version: hydro-devel
+      version: indigo-devel
     status: developed
   open_karto:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl_visual_tools` to `2.2.0-0`:
- upstream repository: https://github.com/davetcoleman/ompl_rviz_viewer.git
- release repository: https://github.com/davetcoleman/ompl_visual_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `2.1.1-0`
## ompl_visual_tools

```
* Fix for RvizVisualTools
* Upgrade to new moveit_visual_tools API
* API changes for moveit_visual_tools
* Added gitignore
* New publishState() functions
* New publishRobotState function
* Formatting, new callback parameter
* Deprecated publishSamples functions
* Added publishSpheres functions to correspond to moveit_visual_tools ones
* Improved visualizationStateCallback
* New publishRobotGraph function
* New convertRobotStatesToTipPoints function
* Fixing display database mode
* Made publish functions return bool
* Disable 3D option
* publish cost map with non-static ID numbers
* New publishSampleIDs function. Restructured publishSamples interface to use moveit_visual_tools version
* Updated publishSampels() functions
* Reduced size of published spheres
* Contributors: Dave Coleman
```
