### PR TITLE
moveit_ros: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2876,7 +2876,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ros` to `0.6.2-0`:
- upstream repository: https://github.com/ros-planning/moveit_ros.git
- release repository: https://github.com/ros-gbp/moveit_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.6.1-0`
## moveit_ros
- No changes
## moveit_ros_benchmarks
- No changes
## moveit_ros_benchmarks_gui
- No changes
## moveit_ros_manipulation
- No changes
## moveit_ros_move_group

```
* Merge pull request #522 <https://github.com/ros-planning/moveit_ros/issues/522> from mikeferguson/indigo-devel
  add dependency on std_srvs (part of octomap clearing service)
* add dependency on std_srvs (part of octomap clearing service)
* Contributors: Ioan A Sucan, Michael Ferguson
```
## moveit_ros_perception
- No changes
## moveit_ros_planning
- No changes
## moveit_ros_planning_interface
- No changes
## moveit_ros_robot_interaction
- No changes
## moveit_ros_visualization
- No changes
## moveit_ros_warehouse
- No changes
