### PR TITLE
add rosdep key for python-pymongo on OSX

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -876,6 +876,9 @@ python-pymodbus:
 python-pymongo:
   debian: [python-pymongo]
   fedora: [python-pymongo]
+  osx:
+    pip:
+      packages: [pymongo]
   ubuntu:
     lucid: [python-pymongo]
     maverick: [python-pymongo]


### PR DESCRIPTION
I don't actually know how to test that the warehouse_ros stuff actually works, but this at least satisfies the rosdep requirement for this package so that MoveIt can be installed on OSX, and this pip package does contain the same files that are in the associated python package on Ubuntu.
