### PR TITLE
install freeglut for rosdep key glut on osx

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -114,7 +114,7 @@ git:
 glut:
   osx:
     homebrew:
-      packages: []
+      packages: [freeglut]
 gperftools:
   osx:
     homebrew:


### PR DESCRIPTION
I'm not 100% sure this is correct, but:
- This key was last updated in 2012.
- On Mavericks, I had to install freeglut in order to compile moveit_ros_perception, which depends on glut. Specific file/line that was problematic is https://github.com/ros-planning/moveit_ros/blob/indigo-devel/perception/mesh_filter/src/gl_renderer.cpp#L44
- On Ubuntu (and all other linux distros), glut translates to freeglut.

@ahendrix @wjwwood Any thoughts?
