### PR TITLE
orientus_driver: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4811,6 +4811,24 @@ repositories:
       type: git
       url: https://github.com/ohm-ros-pkg/optris_drivers.git
       version: groovy-devel
+  orientus_driver:
+    doc:
+      type: git
+      url: https://github.com/RIVeR-Lab/orientus_driver.git
+      version: hydro-devel
+    release:
+      packages:
+      - orientus_driver
+      - orientus_sdk_c
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/RIVeR-Lab-release/orientus_driver-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/RIVeR-Lab/orientus_driver.git
+      version: hydro-devel
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orientus_driver` to `0.0.1-0`:
- upstream repository: https://github.com/RIVeR-Lab/orientus_driver.git
- release repository: https://github.com/RIVeR-Lab-release/orientus_driver-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## orientus_driver

```
* Inital version of orientus node
* Contributors: Mitchell Wills
```
## orientus_sdk_c

```
* Added acceleration packet decoder
* initial commit of the Orientus SDK from version 1.1
* Contributors: Mitchell Wills
```
