### PR TITLE
mavros: 0.8.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2588,12 +2588,13 @@ repositories:
       version: master
     release:
       packages:
+      - libmavconn
       - mavros
       - mavros_extras
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.8.0-0
+      version: 0.8.1-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.8.1-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.8.0-0`
## libmavconn

```
* mavconn #161 <https://github.com/vooon/mavros/issues/161>: try to fix hydro build
* mavconn #161 <https://github.com/vooon/mavros/issues/161>: Move mavconn tests.
* mavconn #161 <https://github.com/vooon/mavros/issues/161>: Fix headers used in mavros. Add readme.
* mavconn #161 <https://github.com/vooon/mavros/issues/161>: Fix mavros build.
* mavconn #161 <https://github.com/vooon/mavros/issues/161>: Move library to its own package
  Also rosconsole replaced by console_bridge, so now library can be used
  without ros infrastructure.
* Contributors: Vladimir Ermakov
```
## mavros

```
* fix build deps for gcs_bridge
* mavconn #161 <https://github.com/vooon/mavros/issues/161>: Enable rosconsole bridge.
* mavconn #161 <https://github.com/vooon/mavros/issues/161>: Move mavconn tests.
* mavconn #161 <https://github.com/vooon/mavros/issues/161>: Fix headers used in mavros. Add readme.
* mavconn #161 <https://github.com/vooon/mavros/issues/161>: Fix mavros build.
* mavconn #161 <https://github.com/vooon/mavros/issues/161>: Move library to its own package
  Also rosconsole replaced by console_bridge, so now library can be used
  without ros infrastructure.
* plugin: sys_time: Set right suffixes to uint64_t constants.
  Issue #156 <https://github.com/vooon/mavros/issues/156>.
* plugin: sys_time: Add time syncronization diag.
  Issue #156 <https://github.com/vooon/mavros/issues/156>.
* plugin: sys_time: Debug result.
  Issue #156 <https://github.com/vooon/mavros/issues/156>.
* plugin: Store time offset in UAS.
  TODO: implement fcu_time().
  Issue #156 <https://github.com/vooon/mavros/issues/156>.
* plugin: sys_time: Fix code style.
  Also reduce class variables count (most not used outside the method).
  Issue #156 <https://github.com/vooon/mavros/issues/156>.
* Update repo links.
  Package moved to mavlink organization.
* Nanosecond fix
* Fix
* Fixes
* Update sys_time.cpp
* Update sys_time.cpp
* Update sys_time.cpp
* Update sys_time.cpp
* Update CMakeLists.txt
* Update mavros_plugins.xml
* Update sys_time.cpp
* Fix build
* sys_time import. Removed all time related stuff from gps and sys_status
* Initial sys_time plugin import
* plugin: ftp: Bytes written now transfered in payload.
* Contributors: Mohammed Kabir, Vladimir Ermakov
```
## mavros_extras

```
* mavconn #161 <https://github.com/vooon/mavros/issues/161>: Fix headers used in mavros. Add readme.
* Update repo links.
  Package moved to mavlink organization.
* Contributors: Vladimir Ermakov
```
