### PR TITLE
mavros: 0.8.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3582,12 +3582,13 @@ repositories:
       version: master
     release:
       packages:
+      - libmavconn
       - mavros
       - mavros_extras
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.8.0-0
+      version: 0.8.2-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.8.2-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.8.0-0`
## libmavconn

```
* mavconn #162 <https://github.com/vooon/mavros/issues/162>: fix console_bridge package name.
  In Hydro console bridge not released as system dependency.
* Contributors: Vladimir Ermakov
```
## mavros
- No changes
## mavros_extras
- No changes
