### PR TITLE
grasping_msgs: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1645,7 +1645,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mikeferguson/grasping_msgs-gbp.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     status: developed
   hector_gazebo:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `grasping_msgs` to `0.3.1-0`:
- upstream repository: git@github.com:mikeferguson/grasping_msgs.git
- release repository: https://github.com/mikeferguson/grasping_msgs-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.3.0-0`
## grasping_msgs

```
* update email
* update description in package.xml
* Contributors: Michael Ferguson
```
