### PR TITLE
Change source and doc branch for mavros.

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3579,7 +3579,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/mavlink/mavros.git
-      version: master
+      version: hydro-devel
     release:
       packages:
       - libmavconn
@@ -3592,8 +3592,8 @@ repositories:
     source:
       type: git
       url: https://github.com/mavlink/mavros.git
-      version: master
-    status: developed
+      version: hydro-devel
+    status: maintained
   maxwell:
     doc:
       type: git


### PR DESCRIPTION
Hydro now splitted from master to hydro-devel.
