### PR TITLE
rtmros_nextage: 0.5.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7010,7 +7010,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.5.1-0
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.5.2-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.5.1-0`
## nextage_description
- No changes
## nextage_moveit_config
- No changes
## nextage_ros_bridge

```
* Improvement on camera launch file (add binning arg in nextage_ueye_stereo.launch)
* DIO
* Contributors: Isaac IY Saito, Yutaka Kondo
```
## rtmros_nextage

```
* Improvement on camera launch file (add binning arg in nextage_ueye_stereo.launch)
* DIO
* Contributors: Isaac IY Saito, Yutaka Kondo
```
