### PR TITLE
universal_robot: 1.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5752,7 +5752,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/universal_robot-release.git
-      version: 1.0.4-0
+      version: 1.1.5-0
     source:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robot` to `1.1.5-0`:
- upstream repository: https://github.com/ros-industrial/universal_robot.git
- release repository: https://github.com/ros-industrial-release/universal_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.4-0`
