### PR TITLE
pr2_gripper_sensor: 1.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5229,7 +5229,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_gripper_sensor-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/PR2/pr2_gripper_sensor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_gripper_sensor` to `1.0.4-0`:
- upstream repository: https://github.com/PR2/pr2_gripper_sensor.git
- release repository: https://github.com/TheDash/pr2_gripper_sensor-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.3-0`
## pr2_gripper_sensor

```
* Added dependency on rosrt library and updated the CMake structure
* Forgot to make this a metapackage.. oops
* Daily commit
* Contributors: TheDash
```
## pr2_gripper_sensor_action

```
* Fix location of catkin_package to build binary at correct directory
* Contributors: Ryohei Ueda
```
## pr2_gripper_sensor_controller

```
* Added dependency on rosrt library and updated the CMake structure
* Contributors: TheDash
```
## pr2_gripper_sensor_msgs
- No changes
