### PR TITLE
moveit_core: 0.6.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2770,7 +2770,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_core-release.git
-      version: 0.6.10-0
+      version: 0.6.11-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_core` to `0.6.11-0`:
- upstream repository: https://github.com/ros-planning/moveit_core.git
- release repository: https://github.com/ros-gbp/moveit_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.6.10-0`
## moveit_core

```
* Merge pull request #204 <https://github.com/ros-planning/moveit_core/issues/204> from mikeferguson/indigo-devel
  forward port #198 <https://github.com/ros-planning/moveit_core/issues/198> to indigo
* forward port #198 <https://github.com/ros-planning/moveit_core/issues/198> to indigo
* Contributors: Ioan A Sucan, Michael Ferguson
```
