### PR TITLE
rtmros_hironx: 1.0.27-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6990,7 +6990,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.26-0
+      version: 1.0.27-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.27-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.26-0`
## hironx_calibration
- No changes
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* fix roobt-script-date.tgz name
* (hrpiob) Add missing files.
* Contributors: Isaac IY Saito, Kei Okada
```
## hironx_tutorial

```
* Add more sample scripts (https://github.com/tork-a/hironx_tutorial/pull/10).
* Contributors: Isaac IY Saito
```
## rtmros_hironx

```
* Add more sample scripts (https://github.com/tork-a/hironx_tutorial/pull/10).
* (hrpiob) Add missing files.
* Contributors: Kei Okada, Isaac IY Saito
```
