### PR TITLE
orientus_driver: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3652,6 +3652,24 @@ repositories:
       type: git
       url: https://github.com/ohm-ros-pkg/optris_drivers.git
       version: groovy-devel
+  orientus_driver:
+    doc:
+      type: git
+      url: https://github.com/RIVeR-Lab/orientus_driver.git
+      version: hydro-devel
+    release:
+      packages:
+      - orientus_driver
+      - orientus_sdk_c
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RIVeR-Lab-release/orientus_driver-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/RIVeR-Lab/orientus_driver.git
+      version: hydro-devel
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orientus_driver` to `0.0.3-0`:
- upstream repository: https://github.com/RIVeR-Lab/orientus_driver.git
- release repository: https://github.com/RIVeR-Lab-release/orientus_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## orientus_driver

```
* Added website, issue tracker, and repository to package.xml
* Contributors: Mitchell Wills
```
## orientus_sdk_c

```
* Added website, issue tracker, and repository to package.xml
* Contributors: Mitchell Wills
```
