### PR TITLE
Added orocos toolchain 2.8 repositories to indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2534,6 +2534,16 @@ repositories:
       type: git
       url: https://github.com/jizhang-cmu/loam_velodyne.git
       version: hydro-indigo
+  log4cpp:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/orocos-gbp/log4cpp-release.git
+    source:
+      type: git
+      url: https://github.com/orocos-toolchain/log4cpp.git
+      version: toolchain-2.8
+    status: maintained
   m4atx_battery_monitor:
     doc:
       type: git
@@ -2688,6 +2698,11 @@ repositories:
       url: https://github.com/ros-gbp/metapackages-release.git
       version: 1.1.3-0
     status: maintained
+  metaruby:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/orocos-gbp/metaruby-release.git
   microstrain_3dmgx2_imu:
     doc:
       type: git
@@ -3429,6 +3444,20 @@ repositories:
       url: https://github.com/wg-perception/transparent_objects.git
       version: master
     status: maintained
+  ocl:
+    doc:
+      type: git
+      url: https://github.com/orocos-toolchain/ocl.git
+      version: toolchain-2.8
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/orocos-gbp/ocl-release.git
+    source:
+      type: git
+      url: https://github.com/orocos-toolchain/ocl.git
+      version: toolchain-2.8
+    status: maintained
   octomap:
     doc:
       type: git
@@ -3688,6 +3717,21 @@ repositories:
       type: git
       url: https://github.com/orocos/orocos_kinematics_dynamics.git
       version: master
+    status: maintained
+  orocos_toolchain:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/orocos-gbp/orocos_toolchain-release.git
+  orogen:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/orocos-gbp/orogen-release.git
+    source:
+      type: git
+      url: https://github.com/orocos-toolchain/orogen.git
+      version: toolchain-2.8
     status: maintained
   p2os:
     release:
@@ -4087,6 +4131,20 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/resource_retriever-release.git
       version: 1.11.0-2
+  rfsm:
+    doc:
+      type: git
+      url: https://github.com/orocos/rFSM.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/orocos-gbp/rfsm-release.git
+    source:
+      type: git
+      url: https://github.com/orocos/rFSM.git
+      version: master
+    status: developed
   rgbd_launch:
     doc:
       type: git
@@ -5098,6 +5156,90 @@ repositories:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git
       version: groovy-devel
+  rtt:
+    doc:
+      type: git
+      url: https://github.com/orocos-toolchain/rtt.git
+      version: toolchain-2.8
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/orocos-gbp/rtt-release.git
+    source:
+      type: git
+      url: https://github.com/orocos-toolchain/rtt.git
+      version: toolchain-2.8
+    status: maintained
+  rtt_geometry:
+    doc:
+      type: git
+      url: https://github.com/orocos/rtt_geometry.git
+      version: hydro-devel
+    release:
+      packages:
+      - eigen_typekit
+      - kdl_typekit
+      - rtt_geometry
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/orocos-gbp/rtt_geometry-release.git
+    source:
+      type: git
+      url: https://github.com/orocos/rtt_geometry.git
+      version: hydro-devel
+    status: developed
+  rtt_ros_integration:
+    doc:
+      type: git
+      url: https://github.com/orocos/rtt_ros_integration.git
+      version: hydro-devel
+    release:
+      packages:
+      - rtt_actionlib
+      - rtt_actionlib_msgs
+      - rtt_common_msgs
+      - rtt_diagnostic_msgs
+      - rtt_dynamic_reconfigure
+      - rtt_geometry_msgs
+      - rtt_kdl_conversions
+      - rtt_nav_msgs
+      - rtt_ros
+      - rtt_ros_comm
+      - rtt_ros_integration
+      - rtt_ros_msgs
+      - rtt_rosclock
+      - rtt_roscomm
+      - rtt_rosdeployment
+      - rtt_rosgraph_msgs
+      - rtt_rosnode
+      - rtt_rospack
+      - rtt_rosparam
+      - rtt_sensor_msgs
+      - rtt_shape_msgs
+      - rtt_std_msgs
+      - rtt_std_srvs
+      - rtt_stereo_msgs
+      - rtt_tf
+      - rtt_trajectory_msgs
+      - rtt_visualization_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/orocos-gbp/rtt_ros_integration-release.git
+    source:
+      type: git
+      url: https://github.com/orocos/rtt_ros_integration.git
+      version: hydro-devel
+    status: developed
+  rtt_typelib:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/orocos-gbp/rtt_typelib-release.git
+    source:
+      type: git
+      url: https://github.com/orocos-toolchain/rtt_typelib.git
+      version: toolchain-2.8
+    status: maintained
   rviz:
     doc:
       type: git
@@ -5672,6 +5814,16 @@ repositories:
       url: https://github.com/turtlebot/turtlebot_arm.git
       version: indigo-devel
     status: developed
+  typelib:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/orocos-gbp/typelib-release.git
+    source:
+      type: git
+      url: https://github.com/orocos-toolchain/typelib.git
+      version: toolchain-2.8
+    status: maintained
   ublox:
     doc:
       type: git
@@ -5844,6 +5996,26 @@ repositories:
       type: git
       url: https://github.com/bosch-ros-pkg/usb_cam.git
       version: develop
+    status: maintained
+  utilmm:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/orocos-gbp/utilmm-release.git
+    source:
+      type: git
+      url: https://github.com/orocos-toolchain/utilmm.git
+      version: toolchain-2.8
+    status: maintained
+  utilrb:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/orocos-gbp/utilrb-release.git
+    source:
+      type: git
+      url: https://github.com/orocos-toolchain/utilrb.git
+      version: toolchain-2.8
     status: maintained
   uwsim_bullet:
     release:


### PR DESCRIPTION
This pull request adds some repositories that belong to the [Orocos Toolchain](http://www.orocos.org) and related ROS integration to the indigo distribution file in preparation for the upcoming 2.8 release.
One 3rd-party dependency, metaruby, was added compared to the hydro release.
