### PR TITLE
Addind bta_ros to documentation index for hydro and indigo

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -382,6 +382,11 @@ repositories:
       type: svn
       url: https://brown-ros-pkg.googlecode.com/svn/trunk/distribution/brown_remotelab
       version: HEAD
+  bta_ros:
+    doc:
+      type: git
+      url: https://github.com/voxel-dot-at/bta_ros.git
+      version: master
   bullet:
     doc:
       type: hg

--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -382,11 +382,6 @@ repositories:
       type: svn
       url: https://brown-ros-pkg.googlecode.com/svn/trunk/distribution/brown_remotelab
       version: HEAD
-  bta_ros:
-    doc:
-      type: git
-      url: https://github.com/voxel-dot-at/bta_ros.git
-      version: master
   bullet:
     doc:
       type: hg

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -485,6 +485,11 @@ repositories:
       url: https://github.com/ipa320/bride.git
       version: develop
     status: developed
+  bta_ros:
+    doc:
+      type: git
+      url: https://github.com/voxel-dot-at/bta_ros.git
+      version: master
   bwi:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -290,6 +290,11 @@ repositories:
       url: https://github.com/ipa320/bride.git
       version: develop
     status: developed
+  bta_ros:
+    doc:
+      type: git
+      url: https://github.com/voxel-dot-at/bta_ros.git
+      version: master
   calibration:
     doc:
       type: git


### PR DESCRIPTION
I'd like bta_ros indexed and documented on ros.org.
