### PR TITLE
common_tutorials: 0.1.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -885,7 +885,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/common_tutorials-release.git
-      version: 0.1.7-0
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/ros/common_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_tutorials` to `0.1.8-0`:
- upstream repository: https://github.com/ros/common_tutorials.git
- release repository: https://github.com/ros-gbp/common_tutorials-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.7-0`
## actionlib_tutorials

```
* update package maintainer.
* Use _EXPORTED_TARGETS target suffix instead of _generate_messages_cpp
* Contributors: Daniel Stonier, Esteve Fernandez
```
## common_tutorials

```
* update package maintainer.
* Contributors: Daniel Stonier
```
## nodelet_tutorial_math

```
* update package maintainer.
* Contributors: Daniel Stonier
```
## pluginlib_tutorials

```
* update package maintainer.
* Contributors: Daniel Stonier
```
## turtle_actionlib

```
* update package maintainer.
* Use _EXPORTED_TARGETS target suffix instead of _generate_messages_cpp
* changed shape_server code to run with the hydro mversion of turtlesim ("geometry_msgs/Twist" nad cmd_vel)
* Contributors: Benjamin Brieber, Daniel Stonier, Esteve Fernandez
```
