### PR TITLE
Added rosdep key rake-compiler to ruby.yaml

### DIFF
--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -85,6 +85,11 @@ rake:
   macports: [rb-rake]
   ubuntu:
     apt: [rake]
+rake-compiler:
+  arch: [ruby-rake-compiler]
+  fedora: [rubygem-rake-compiler]
+  ubuntu:
+    apt: [rake-compiler]
 rdoc:
   arch: [ruby]
   fedora: [rubygem-rdoc]


### PR DESCRIPTION
The newest version of [orogen](https://github.com/orocos-toolchain/orogen/tree/toolchain-2.8) now depend on `rake` and `rake-compiler` and we would need the new key for release in indigo.
@cottsay already added the `rubygem-rake-compiler` package to the `rake` key in d01c285282604f17bed03801d82ccd62f6d2a1f3, but only for Fedora.
