### PR TITLE
rqt_robot_plugins: 0.4.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6940,7 +6940,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-      version: 0.3.7-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins` to `0.4.0-0`:
- upstream repository: https://github.com/ros-visualization/rqt_robot_plugins.git
- release repository: https://github.com/ros-gbp/rqt_robot_plugins-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.3.7-0`
## rqt_moveit

```
* update script to use full plugin name
```
## rqt_nav_view

```
* update script to use full plugin name
```
## rqt_pose_view

```
* update script to use full plugin name
```
## rqt_robot_dashboard
- No changes
## rqt_robot_monitor

```
* rewrite rqt_robot_monitor (#3 <https://github.com/ros-visualization/rqt_robot_plugins/issues/3>, #9 <https://github.com/ros-visualization/rqt_robot_plugins/issues/9>, #32 <https://github.com/ros-visualization/rqt_robot_plugins/issues/32>, #33 <https://github.com/ros-visualization/rqt_robot_plugins/issues/33>, #71 <https://github.com/ros-visualization/rqt_robot_plugins/issues/71>)
* make diagnostics_agg a relative topic (#32 <https://github.com/ros-visualization/rqt_robot_plugins/issues/32>)
* add rqt_bag plugin
* update script to use full plugin name
```
## rqt_robot_plugins
- No changes
## rqt_robot_steering

```
* update script to use full plugin name
```
## rqt_runtime_monitor

```
* avoid marking items as stale when using sim time (#69 <https://github.com/ros-visualization/rqt_robot_plugins/issues/69>)
* allow remapping diagnostics topic
* update script to use full plugin name
```
## rqt_rviz

```
* update script to use full plugin name
```
## rqt_tf_tree

```
* update script to use full plugin name
```
