### PR TITLE
rosserial: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5035,7 +5035,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rosserial-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/ros-drivers/rosserial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial` to `0.6.3-0`:
- upstream repository: https://github.com/ros-drivers/rosserial.git
- release repository: https://github.com/ros-gbp/rosserial-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.6.2-0`
## rosserial
- No changes
## rosserial_arduino

```
* Fix for Arduino upload path issue.
* Contributors: Mike Purvis
```
## rosserial_client

```
* Move avr serialization logic to Msg class, add gtest to exercise it.
* Fixed the deserialization of avr64bit in order to support negative numbers.
* Contributors: Martin Gerdzhev, Mike Purvis
```
## rosserial_embeddedlinux

```
* Miscellaneous tidying in EmbeddedLinuxHardware.
* Rename header.
* Automatic astyle fixes.
* portName as const char*, eliminate strtok.
* Contributors: Mike Purvis
```
## rosserial_msgs
- No changes
## rosserial_python
- No changes
## rosserial_server

```
* Add more log output, don't end the session for certain write errors.
* Contributors: Mike Purvis
```
## rosserial_windows
- No changes
## rosserial_xbee
- No changes
