### PR TITLE
ros_realtime: 1.0.24-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6320,7 +6320,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/ros_realtime-release.git
-      version: 1.0.23-0
+      version: 1.0.24-0
     source:
       type: git
       url: https://github.com/ros/ros_realtime.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_realtime` to `1.0.24-0`:
- upstream repository: https://github.com/ros/ros_realtime.git
- release repository: https://github.com/TheDash/ros_realtime-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.23-0`
## ros_realtime
- No changes
