### PR TITLE
OS X Yosemite (10.10) Rosdep entires for python-vtk and libvtk-java

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -566,7 +566,7 @@ python-support:
       packages: []
 python-vtk:
   osx:
-    pip:
+    homebrew:
       packages: []
 python-yaml:
   osx:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -567,7 +567,7 @@ python-support:
 python-vtk:
   osx:
     homebrew:
-      packages: []
+      depends: [libvtk]
 python-yaml:
   osx:
     pip:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -338,6 +338,11 @@ libvtk:
     homebrew:
       options: [--python, --qt]
       packages: [vtk]
+libvtk-java:
+  osx: 
+    homebrew:
+      options: [--python, --qt]
+      packages: [vtk]
 libx11:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -339,7 +339,7 @@ libvtk:
       options: [--python, --qt]
       packages: [vtk]
 libvtk-java:
-  osx: 
+  osx:
     homebrew:
       packages: []
 libx11:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -341,8 +341,7 @@ libvtk:
 libvtk-java:
   osx: 
     homebrew:
-      options: [--python, --qt]
-      packages: [vtk]
+      packages: []
 libx11:
   osx:
     homebrew:
@@ -562,6 +561,10 @@ python-sphinx:
     pip:
       packages: [Sphinx]
 python-support:
+  osx:
+    pip:
+      packages: []
+python-vtk:
   osx:
     pip:
       packages: []


### PR DESCRIPTION
Clean install of ROS Indigo desktop full as per [instructions](http://wiki.ros.org/indigo/Installation/OSX/Homebrew/Source) fails during ros_pcl build due to the lack of mapping for **libvtk-java** and **python-vtk** (see [Issues 4597](https://github.com/ros/rosdistro/issues/4597)). 

**libvtk** is already mapped to the [homebrew](https://brew.sh) **vtk** package. 

Adding lines for **libvtk-java** and **python-vtk** allows the installation to proceed without issue. Tested on MBP 2010, with Yosemite 10.10 with ROS Indigo. 
