### PR TITLE
Adding pixy_ros to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3821,6 +3821,25 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: indigo-devel
     status: maintained
+  pixy_ros:
+    doc:
+      type: git
+      url: https://github.com/jeskesen/pixy_ros.git
+      version: indigo-devel
+    release:
+      packages:
+      - pixy_msgs
+      - pixy_node
+      - pixy_ros
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/pixy_ros-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/jeskesen/pixy_ros.git
+      version: indigo-devel
+    status: developed
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add my new repository, pixy_ros, to ros.org.
