### PR TITLE
pointgrey_camera_driver: 0.11.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3868,7 +3868,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
-      version: 0.10.0-0
+      version: 0.11.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/pointgrey_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointgrey_camera_driver` to `0.11.0-0`:
- upstream repository: https://github.com/ros-drivers/pointgrey_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.10.0-0`
## image_exposure_msgs
- No changes
## pointgrey_camera_driver

```
* Change approach to downloading flycapture SDK.
  The logic which fetches and extracts the archive from ptgrey.com
  has been moved to a more reasonable and comprehensible python script.
  This should better pave the way for better future ARM support in this
  driver.
* Use dh_installudev for udev rules.
* The raw and mono pixel formats (raw8, raw16, mono8, mono16) can be selected from dynamic reconfigure with every video mode (while before it was hard coded that only mono pixel formats could be used with mode1 and mode2).
* Binning information removed from camera_info published by the nodelet.
* Add image_proc as dependency.
* Removed changes to binning_x and binning_y in camera info messages (otherwise image_proc node would performs a further downsampling).
* Now the wrapper allows to set raw and mono pixel formats with any mode.
* Added possibility to set GigE packet delay as launch/conf parameter.
* Changed 'auto_packet_size' to 'true' as default.
* Added possibility to change GigE packet size for GigE cameras.
* For GigE cameras, automatically discover best packet size.
* Fix launch file syntax error (XML comments neither nest nor continue).
* Contributors: Aaron Denney, Jeff Schmidt, Matteo Munaro, Mike Purvis
```
## statistics_msgs
- No changes
## wfov_camera_msgs
- No changes
