### PR TITLE
apriltags_ros: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -72,6 +72,24 @@ repositories:
       type: git
       url: https://github.com/ros/angles.git
       version: master
+  apriltags_ros:
+    doc:
+      type: git
+      url: https://github.com/RIVeR-Lab/apriltags_ros.git
+      version: indigo-devel
+    release:
+      packages:
+      - apriltags
+      - apriltags_ros
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RIVeR-Lab-release/apriltags_ros-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/RIVeR-Lab/apriltags_ros.git
+      version: indigo-devel
+    status: maintained
   ar_sys:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltags_ros` to `0.1.0-0`:
- upstream repository: https://github.com/RIVeR-Lab/apriltags_ros.git
- release repository: https://github.com/RIVeR-Lab-release/apriltags_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## apriltags

```
* Updated dependancies for indigo
* Contributors: Mitchell Wills
```
## apriltags_ros

```
* Updated dependancies for indigo
* Contributors: Mitchell Wills
```
