### PR TITLE
multisense_ros: 3.3.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3017,7 +3017,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
-      version: 3.3.5-0
+      version: 3.3.6-0
     source:
       type: hg
       url: https://bitbucket.org/crl/multisense_ros


### PR DESCRIPTION
Increasing version of package(s) in repository `multisense_ros` to `3.3.6-0`:
- upstream repository: https://bitbucket.org/crl/multisense_ros
- release repository: https://github.com/carnegieroboticsllc/multisense_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `3.3.5-0`
## multisense
- No changes
## multisense_bringup
- No changes
## multisense_cal_check
- No changes
## multisense_description
- No changes
## multisense_lib
- No changes
## multisense_ros

```
* Added libturbojpeg dependency to multisense_ros. Based on pull request https://bitbucket.org/crl/multisense_ros/pull-request/5/added-libturbojpeg-to-dependencies-for/diff
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
