### PR TITLE
pr2_kinematics: 1.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5268,6 +5268,10 @@ repositories:
       version: hydro-devel
     status: maintained
   pr2_kinematics:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_kinematics.git
+      version: hydro-devel
     release:
       packages:
       - pr2_arm_kinematics
@@ -5275,7 +5279,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_kinematics-release.git
-      version: 1.0.2-0
+      version: 1.0.4-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_kinematics.git
+      version: hydro-devel
+    status: maintained
   pr2_make_a_map_app:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_kinematics` to `1.0.4-0`:
- upstream repository: https://github.com/PR2/pr2_kinematics.git
- release repository: https://github.com/TheDash/pr2_kinematics-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.2-0`
## pr2_arm_kinematics
- No changes
## pr2_kinematics
- No changes
