### PR TITLE
Adding mtig_driver to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2975,6 +2975,16 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
       version: indigo-devel
     status: maintained
+  mtig_driver:
+    doc:
+      type: git
+      url: https://github.com/lukscasanova/mtig_driver
+      version: master
+    source:
+      type: git
+      url: https://github.com/lukscasanova/mtig_driver
+      version: master
+    status: developed
   multimaster_fkie:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2978,11 +2978,11 @@ repositories:
   mtig_driver:
     doc:
       type: git
-      url: https://github.com/lukscasanova/mtig_driver
+      url: https://github.com/lukscasanova/mtig_driver.git
       version: master
     source:
       type: git
-      url: https://github.com/lukscasanova/mtig_driver
+      url: https://github.com/lukscasanova/mtig_driver.git
       version: master
     status: developed
   multimaster_fkie:


### PR DESCRIPTION
I'd like to add mtig_driver to be indexed and documented on ros.org
