### PR TITLE
rtmros_nextage: 0.5.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7035,7 +7035,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.5.2-0
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.5.3-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.5.2-0`
## nextage_description
- No changes
## nextage_moveit_config
- No changes
## nextage_ros_bridge

```
* (DIO) Fix #129 <https://github.com/tork-a/rtmros_nextage/issues/129>
* (doc) Move tutorial wiki backup to hironx pkg.
* Move a python module to call DIO via rosservice.
* Contributors: Isaac IY Saito, Akio Ochiai, Daiki Maekawa
```
## rtmros_nextage

```
* (DIO) Fix #129 <https://github.com/tork-a/rtmros_nextage/issues/129>
* (doc) Move tutorial wiki backup to hironx pkg.
* Move a python module to call DIO via rosservice.
* Contributors: Isaac IY Saito, Akio Ochiai, Daiki Maekawa
```
