### PR TITLE
Add python-docopt

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -295,6 +295,11 @@ python-deap-pip:
     pip: [deap]
   ubuntu:
     pip: [deap]
+python-docopt:
+  debian:
+    pip: [docopt]
+  ubuntu:
+    pip: [docopt]
 python-docutils:
   debian: [python-docutils]
   fedora: [python-docutils]


### PR DESCRIPTION
Pythonic command line arguments parser, that will make you smile http://docopt.org

This is the output of the check_rosdep script:

```
$ ./scripts/check_rosdep.py rosdep/python.yaml
checking for trailing spaces...
checking for incorrect indentation...
checking for non-bracket package lists...
checking for item order...
building yaml dict...
```
