### PR TITLE
twist_mux_msgs: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5872,6 +5872,12 @@ repositories:
       url: https://github.com/turtlebot/turtlebot_arm.git
       version: indigo-devel
     status: developed
+  twist_mux_msgs:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/twist_mux_msgs-release.git
+      version: 0.0.1-0
   typelib:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux_msgs` to `0.0.1-0`:
- upstream repository: https://github.com/ros-teleop/twist_mux_msgs.git
- release repository: https://github.com/ros-gbp/twist_mux_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## twist_mux_msgs

```
* Add twist_mux msgs
* Contributors: Enrique Fernandez, Siegfried Gevatter, Paul Mathieu
```
