### PR TITLE
python_trep: 0.93.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3985,6 +3985,21 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: groovy-devel
     status: maintained
+  python_trep:
+    doc:
+      type: git
+      url: https://github.com/MurpheyLab/trep-release.git
+      version: release/indigo/python_trep
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/MurpheyLab/trep-release.git
+      version: 0.93.0-2
+    source:
+      type: git
+      url: https://github.com/MurpheyLab/trep.git
+      version: master
+    status: developed
   qt_gui_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_trep` to `0.93.0-2`:
- upstream repository: https://github.com/MurpheyLab/trep.git
- release repository: https://github.com/MurpheyLab/trep-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
