### PR TITLE
twist_mux: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8008,7 +8008,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/twist_mux-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
   twist_mux_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux` to `0.0.2-0`:
- upstream repository: https://github.com/ros-teleop/twist_mux.git
- release repository: https://github.com/ros-gbp/twist_mux-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.1-0`
## twist_mux

```
* Add diagnostic_updater dependency
* Contributors: Enrique Fernández
```
