### PR TITLE
twist_mux: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5877,7 +5877,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/twist_mux-release.git
-      version: 0.0.1-0
+      version: 1.0.2-0
   twist_mux_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux` to `1.0.2-0`:
- upstream repository: https://github.com/ros-teleop/twist_mux.git
- release repository: https://github.com/ros-gbp/twist_mux-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.1-0`
## twist_mux

```
* Increase version to 1.0.1 for indigo release
* Add diagnostic_updater dependency
* Contributors: Enrique Fernández
```
