### PR TITLE
apriltags_ros: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -84,7 +84,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RIVeR-Lab-release/apriltags_ros-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/apriltags_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltags_ros` to `0.1.1-0`:
- upstream repository: https://github.com/RIVeR-Lab/apriltags_ros.git
- release repository: https://github.com/RIVeR-Lab-release/apriltags_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.0-0`
## apriltags

```
* Updated author and website
* Contributors: Mitchell Wills
```
## apriltags_ros

```
* Updated author and website
* Contributors: Mitchell Wills
```
