### PR TITLE
apriltags_ros: 0.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -173,7 +173,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RIVeR-Lab-release/apriltags_ros-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/apriltags_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltags_ros` to `0.0.4-0`:
- upstream repository: https://github.com/RIVeR-Lab/apriltags_ros.git
- release repository: https://github.com/RIVeR-Lab-release/apriltags_ros-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.3-0`
## apriltags

```
* Updated author and website
* Contributors: Mitchell Wills
```
## apriltags_ros

```
* Updated author and website
* Contributors: Mitchell Wills
```
