### PR TITLE
orientus_driver: 0.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4832,7 +4832,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RIVeR-Lab-release/orientus_driver-release.git
-      version: 0.0.2-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/orientus_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `orientus_driver` to `0.0.4-0`:
- upstream repository: https://github.com/RIVeR-Lab/orientus_driver.git
- release repository: https://github.com/RIVeR-Lab-release/orientus_driver-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.2-0`
## orientus_driver

```
* Updated author and website
* Contributors: Mitchell Wills
```
## orientus_sdk_c

```
* Updated author and website
* Contributors: Mitchell Wills
```
