### PR TITLE
ros_openlighting: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4760,7 +4760,7 @@ repositories:
     source:
       type: git
       url: https://github.com/sevenbitbyte/ros_openlighting.git
-      version: 0.1.1
+      version: indigo
     status: developed
   ros_statistics_msgs:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4747,6 +4747,21 @@ repositories:
       url: https://github.com/WPI-RAIL/ros_ethernet_rmp.git
       version: develop
     status: maintained
+  ros_openlighting:
+    release:
+      packages:
+      - lighting_msgs
+      - lighting_tools
+      - ola_ros
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/sevenbitbyte/ros_openlighting-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/sevenbitbyte/ros_openlighting.git
+      version: 0.1.1
+    status: developed
   ros_statistics_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_openlighting` to `0.1.1-0`:
- upstream repository: https://github.com/sevenbitbyte/ros_openlighting.git
- release repository: https://github.com/sevenbitbyte/ros_openlighting-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
