### PR TITLE
razor_imu_9dof: 1.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4135,7 +4135,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/KristofRobot/razor_imu_9dof-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/KristofRobot/razor_imu_9dof.git


### PR DESCRIPTION
Increasing version of package(s) in repository `razor_imu_9dof` to `1.0.4-0`:
- upstream repository: https://github.com/KristofRobot/razor_imu_9dof.git
- release repository: https://github.com/KristofRobot/razor_imu_9dof-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.3-0`
## razor_imu_9dof

```
* Adding press 'a' to align feature
* Moving magnetometer calibration sketches under dedicated ``magnetometer_calibration`` directory
* Adding magnetometer calibration sketches for Processing and Matlab (Paul Bouchier)
* Setting default USB port to /dev/ttyUSB0 in all files
* Adding graceful exit in case USB port not found
* Adding queue_size=1
* Fixing x linear accelerations sign
```
