### PR TITLE
jsk_common: 1.0.54-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2894,11 +2894,12 @@ repositories:
       - rostwitter
       - sklearn
       - speech_recognition_msgs
+      - virtual_force_publisher
       - voice_text
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.53-0
+      version: 1.0.54-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.54-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.53-0`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## collada_urdf_jsk_patch
- No changes
## depth_image_proc_jsk_patch
- No changes
## downward
- No changes
## dynamic_tf_publisher

```
* Add tf publisher which can be reconfigured by dynamic_reconfigure
* Contributors: Ryohei Ueda
```
## ff
- No changes
## ffha
- No changes
## image_view2
- No changes
## image_view_jsk_patch
- No changes
## jsk_common
- No changes
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_network_tools
- No changes
## jsk_tilt_laser

```
* Added tilt_laser.urdf.xacro to mount on a urdf of TurtleBot.
* Contributors: Tanaka Yoshimaru
```
## jsk_tools
- No changes
## jsk_topic_tools
- No changes
## laser_filters_jsk_patch
- No changes
## libsiftfast
- No changes
## mini_maxwell
- No changes
## multi_map_server
- No changes
## nlopt
- No changes
## openni_tracker_jsk_patch
- No changes
## opt_camera
- No changes
## posedetection_msgs

```
* new srv and changed Object6DPose
* Contributors: Kamada Hitoshi
```
## pr2_groovy_patches
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter

```
* add python-requests
* Contributors: Kei Okada
```
## sklearn
- No changes
## speech_recognition_msgs
- No changes
## virtual_force_publisher

```
* add virtual_force_publisher
* Contributors: Kei Okada
```
## voice_text
- No changes
