### PR TITLE
jsk_common: 1.0.54-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2151,11 +2151,12 @@ repositories:
       - rostwitter
       - sklearn
       - speech_recognition_msgs
+      - virtual_force_publisher
       - voice_text
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.53-0
+      version: 1.0.54-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.54-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.53-0`
## bayesian_belief_networks
- No changes
## downward
- No changes
## dynamic_tf_publisher

```
* Add tf publisher which can be reconfigured by dynamic_reconfigure
* Contributors: Ryohei Ueda
```
## ff
- No changes
## ffha
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_network_tools
- No changes
## jsk_tilt_laser

```
* Added tilt_laser.urdf.xacro to mount on a urdf of TurtleBot.
* Contributors: Tanaka Yoshimaru
```
## jsk_tools
- No changes
## jsk_topic_tools
- No changes
## libsiftfast
- No changes
## mini_maxwell
- No changes
## multi_map_server
- No changes
## nlopt
- No changes
## opt_camera
- No changes
## posedetection_msgs

```
* new srv and changed Object6DPose
* Contributors: Kamada Hitoshi
```
## rospatlite
- No changes
## rosping
- No changes
## rostwitter

```
* add python-requests
* Contributors: Kei Okada
```
## sklearn
- No changes
## speech_recognition_msgs
- No changes
## virtual_force_publisher

```
* add virtual_force_publisher
* Contributors: Kei Okada
```
## voice_text
- No changes
