### PR TITLE
razor_imu_9dof: 1.0.5-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5783,7 +5783,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/KristofRobot/razor_imu_9dof-release.git
-      version: 1.0.4-0
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/KristofRobot/razor_imu_9dof.git


### PR DESCRIPTION
Increasing version of package(s) in repository `razor_imu_9dof` to `1.0.5-1`:
- upstream repository: https://github.com/KristofRobot/razor_imu_9dof.git
- release repository: https://github.com/KristofRobot/razor_imu_9dof-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.4-0`
## razor_imu_9dof

```
* Moving scripts from nodes to scripts dir
* Installing files in ``src`` and ``magnetometer_calibration``
* Major cleanup of package.xml and CMakeLists.txt
```
