### PR TITLE
removing source part from mtig_driver package in distribution.yaml

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2980,10 +2980,6 @@ repositories:
       type: git
       url: https://github.com/lukscasanova/mtig_driver.git
       version: master
-    source:
-      type: git
-      url: https://github.com/lukscasanova/mtig_driver.git
-      version: master
     status: developed
   multimaster_fkie:
     doc:


### PR DESCRIPTION
Package won't compile because of xsense api dependency. Leaving only the documentation.
