### PR TITLE
(hydro, leap_motion) Update repository info.

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3315,8 +3315,18 @@ repositories:
   leap_motion:
     doc:
       type: git
-      url: https://github.com/mirzashah/rosleapmotion.git
+      url: https://github.com/ros-drivers/leap_motion.git
       version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/rosleapmotion-release.git
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/leap_motion.git
+      version: master
+    status: maintained
   libccd:
     release:
       tags:
@@ -6535,14 +6545,6 @@ repositories:
       url: https://github.com/rosjava/rosjava_messages.git
       version: hydro
     status: developed
-  rosleapmotion:
-    release:
-      packages:
-      - leap_motion
-      tags:
-        release: release/hydro/{package}/{version}
-      url: https://github.com/ros-gbp/rosleapmotion-release.git
-      version: 0.0.4-0
   roslint:
     doc:
       type: git


### PR DESCRIPTION
Once https://github.com/ros-gbp/rosleapmotion-release/issues/1 gets addressed, I'll make a pull request for releasing its new version.

Although I don't know how things worked, the name of DEB available is `ros-hydro-leap-motion` instead of `rosleapmotion`. And its upstream is now https://github.com/ros-drivers/leap_motion (see [here](https://github.com/warp1337/rosleapmotion/issues/4#issuecomment-46400766)). So `leap_motion` should be used.
@mirzashah 
