### PR TITLE
avt_vimba_camera: 0.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -212,7 +212,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/srv/avt_vimba_camera-release.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/srv/avt_vimba_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `avt_vimba_camera` to `0.0.9-0`:
- upstream repository: https://github.com/srv/avt_vimba_camera.git
- release repository: https://github.com/srv/avt_vimba_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.8-0`
## avt_vimba_camera

```
* Fix #8 <https://github.com/srv/avt_vimba_camera/issues/8>: Constructor delegation and typo in assignment
* added mono camera name
* corrected diagnostics
* fixed sync diagnostic
* improved diagnostics
* better timestamp management
* added command error check
* cleaning stereo prints
* removed old cpp
* fixed merging conflict
* update updater
* added time to tick function
* added getTimestamp
* added reset timestamp command
* changed errors to warnings
* added open/close msgs to diagnostics
* added diagnostics. wip
* bugfixes
* full operative stereo camera
* prepared launchfile for stereo
* auto set packet size
* stereo sync
* preparing for stereo
* added launchfile
* hide first run
* set auto configuration by default
* fix with ptp mode
* Fix dynamic reconfigure error with PTP
* mono camera compiles
* Fix interface type
* Merge pull request #5 <https://github.com/srv/avt_vimba_camera/issues/5> from lucasb-eyer/auto
  Fix names/values of auto settings.
* Fix names/values of auto settings.
* Fix #2 <https://github.com/srv/avt_vimba_camera/issues/2>: Set the highest GeV packet size
* Merge pull request #3 <https://github.com/srv/avt_vimba_camera/issues/3> from pkok/single_identifier
  Allow user to connect by specifying either GUID or IP address.
* Allow user to connect by specifying either GUID or IP address.
* wip
* added testing launchfiles
* added parameters for sync
* Contributors: Miquel Massot, Patrick de Kok, SPENCER-Freiburg Laptop
```
