### PR TITLE
applanix_driver: 0.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -155,7 +155,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/applanix_driver-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/applanix_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `applanix_driver` to `0.0.5-0`:
- upstream repository: https://github.com/clearpathrobotics/applanix_driver.git
- release repository: https://github.com/clearpath-gbp/applanix_driver-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.4-0`
## applanix_bridge

```
* Origin now includes the z dimension or altitude so that the odometry msgs are w.r.t. the current surface and not the sea level. quaternion assignment in tf broadcaster had a bug which is fixed now.
* Fixing typo in publisher.py, we Transfrom != Transform
* Contributors: Vaibhav Kumar Mehta
```
## applanix_driver
- No changes
## applanix_msgs
- No changes
