### PR TITLE
teleop_tools: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7793,6 +7793,15 @@ repositories:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git
       version: hydro-devel
+    release:
+      packages:
+      - joy_teleop
+      - key_teleop
+      - teleop_tools
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/teleop_tools-release.git
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `0.1.1-0`:
- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros-gbp/teleop_tools-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## joy_teleop

```
* Change maintainer
* checks for index out of bounds in buttons list
  buttons is a list, not a dict
  Filter out buttons not available
* Check for b in buttons
* Check for IndexError
* joy_teleop: add action server auto-refresh
* Move everything to joy_teleop subfolder
* Contributors: Bence Magyar, Enrique Fernández Perdomo, Paul Mathieu
```
## key_teleop

```
* Change maintainer
* Remove rosbuild legacy
* Merge key_teleop into teleop_tools
* Contributors: Bence Magyar, Paul Mathieu
```
## teleop_tools

```
* Change maintainer
* Add key_teleop to metapackage
* Add teleop_tools metapackage
* Contributors: Bence Magyar, Paul Mathieu
```
