### PR TITLE
pr2_common_actions: 0.0.3-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5171,6 +5171,10 @@ repositories:
       version: hydro-devel
     status: maintained
   pr2_common_actions:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_common_actions.git
+      version: hydro-devel
     release:
       packages:
       - joint_trajectory_action_tools
@@ -5183,7 +5187,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_common_actions-release.git
-      version: 0.0.3-0
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_common_actions.git
+      version: hydro-devel
+    status: maintained
   pr2_controllers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common_actions` to `0.0.3-1`:
- upstream repository: https://github.com/PR2/pr2_common_actions.git
- release repository: https://github.com/TheDash/pr2_common_actions-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.3-0`
## joint_trajectory_action_tools
- No changes
## joint_trajectory_generator
- No changes
## pr2_arm_move_ik
- No changes
## pr2_common_action_msgs
- No changes
## pr2_common_actions
- No changes
## pr2_tilt_laser_interface
- No changes
## pr2_tuck_arms_action

```
* Added install exports
* Contributors: TheDash
```
