### PR TITLE
(leap_motion) update releaese repository URL.

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3356,7 +3356,7 @@ repositories:
     release:
       tags:
         release: release/hydro/{package}/{version}
-      url: https://github.com/ros-gbp/rosleapmotion-release.git
+      url: https://github.com/ros-gbp/leap_motion-release.git
       version: 0.0.4-0
     source:
       type: git


### PR DESCRIPTION
Discussed in https://github.com/ros/rosdistro/pull/6285#discussion_r20483502
