### PR TITLE
turtlebot_msgs: 2.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5893,6 +5893,21 @@ repositories:
       url: https://github.com/turtlebot/turtlebot_arm.git
       version: indigo-devel
     status: developed
+  turtlebot_msgs:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_msgs.git
+      version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/turtlebot-release/turtlebot_msgs-release.git
+      version: 2.2.0-0
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_msgs.git
+      version: indigo
+    status: maintained
   twist_mux:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_msgs` to `2.2.0-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_msgs.git
- release repository: https://github.com/turtlebot-release/turtlebot_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## turtlebot_msgs

```
* Changelog added
```
