### PR TITLE
linux_peripheral_interfaces: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2523,7 +2523,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/linux_peripheral_interfaces-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ros-drivers/linux_peripheral_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `linux_peripheral_interfaces` to `0.1.1-0`:
- upstream repository: https://github.com/ros-drivers/linux_peripheral_interfaces.git
- release repository: https://github.com/ros-gbp/linux_peripheral_interfaces-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.0-0`
## laptop_battery_monitor

```
* Added using hostname as diagnostic hardware id for laptop battery monitor
* Contributors: Mitchell Wills
```
## linux_peripheral_interfaces
- No changes
