### PR TITLE
map_store: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2605,6 +2605,21 @@ repositories:
       type: git
       url: https://github.com/ethz-asl/map_msgs.git
       version: master
+  map_store:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/map_store.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/map_store-release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/map_store.git
+      version: hydro-devel
+    status: maintained
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `map_store` to `0.3.1-0`:
- upstream repository: git@github.com:ros-planning/map_store.git
- release repository: https://github.com/ros-gbp/map_store-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
