### PR TITLE
pr2_kinematics: 1.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5299,7 +5299,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_kinematics-release.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/pr2/pr2_kinematics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_kinematics` to `1.0.5-0`:
- upstream repository: https://github.com/PR2/pr2_kinematics.git
- release repository: https://github.com/TheDash/pr2_kinematics-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.4-0`
## pr2_arm_kinematics

```
* Added install target for pr2_kinematics_node to archive and lib dests
* Contributors: TheDash
```
## pr2_kinematics
- No changes
