### PR TITLE
retalis: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5865,6 +5865,17 @@ repositories:
       url: https://github.com/ros-gbp/reflexxes_type2-release.git
       version: 1.2.4-0
     status: maintained
+  retalis:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/procrob/retalis.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/procrob/retalis.git
+      version: devel
+    status: developed
   rgbd_launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `retalis` to `0.0.1-0`:
- upstream repository: https://github.com/procrob/retalis.git
- release repository: https://github.com/procrob/retalis.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
