### PR TITLE
adding retalis to documentation index for hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5865,6 +5865,11 @@ repositories:
       url: https://github.com/ros-gbp/reflexxes_type2-release.git
       version: 1.2.4-0
     status: maintained
+  retalis:
+    doc:
+      type: git
+      url: https://github.com/procrob/retalis.git
+      version: devel
   rgbd_launch:
     doc:
       type: git


### PR DESCRIPTION
I would like retalis to be indexed and documented on ros.org.
