### PR TITLE
rocon_msgs: 0.7.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4448,7 +4448,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-      version: 0.7.7-1
+      version: 0.7.8-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs` to `0.7.8-0`:
- upstream repository: http://github.com/robotics-in-concert/rocon_msgs.git
- release repository: https://github.com/yujinrobot-release/rocon_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.7.7-1`
## concert_msgs
- No changes
## concert_service_msgs

```
* replace captureteop with captureresource
* returns topic names when it allocates resource
* Contributors: Jihoon Lee
```
## gateway_msgs
- No changes
## rocon_app_manager_msgs

```
* new error code for stopping a rapp that is not listed.
* Contributors: Daniel Stonier
```
## rocon_device_msgs

```
* fixed make rule
* create hue set color message
* Contributors: dwlee
```
## rocon_interaction_msgs
- No changes
## rocon_msgs
- No changes
## rocon_service_pair_msgs
- No changes
## rocon_std_msgs

```
* strings for os
* add gazebo robot type for export
* Contributors: Jihoon Lee
```
## rocon_tutorial_msgs
- No changes
## scheduler_msgs
- No changes
