### PR TITLE
rocon_app_platform: 0.7.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4396,7 +4396,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_app_platform-release.git
-      version: 0.7.2-0
+      version: 0.7.3-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_app_platform` to `0.7.3-0`:
- upstream repository: http://github.com/robotics-in-concert/rocon_app_platform
- release repository: https://github.com/yujinrobot-release/rocon_app_platform-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.7.2-0`
## rocon_app_manager

```
* Merge pull request #263 <https://github.com/robotics-in-concert/rocon_app_platform/issues/263> from robotics-in-concert/sim_param
  simulated robot support in app manager
* rename sim to simulation
* add sim param in standalone launcher
* sim parameter passing
* process sim param
* add sim param
* [rocon_app_manager] permit esoteric names once more.
* [rocon_app_manager] bugfix stray hub whitelist param, lower casing base topic names, catching the right exception
* bugfix stopping of rapps after virtual implementation upgrade.
* Contributors: Daniel Stonier, Jihoon Lee
```
## rocon_app_platform
- No changes
## rocon_app_utilities

```
* rename sim to simulation
* sim parameter passing
* [rocon_app_manager] bugfix stray hub whitelist param, lower casing base topic names, catching the right exception
* Contributors: Daniel Stonier, Jihoon Lee
```
## rocon_apps

```
* migrate teleop implementation rapps to yujin_ocs
* add waypoint navigation app in package.xml
* [rocon_apps] waypoint navigation meta-rapp.
* Contributors: Daniel Stonier, Jihoon Lee
```
