### PR TITLE
rocon_concert: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4421,7 +4421,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_concert-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_concert.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_concert` to `0.6.1-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_concert
- release repository: https://github.com/yujinrobot-release/rocon_concert-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.6.0-0`
## concert_conductor

```
* [rocon_concert] permit esoteric names once more.
* Contributors: Daniel Stonier
```
## concert_master

```
* add option to start rosbridge with concert.
* add arg comments for all command. fix typo #247 <https://github.com/robotics-in-concert/rocon_concert/issues/247>
* now auto enable services are selectable
* Contributors: Jihoon Lee
```
## concert_schedulers

```
* [rocon_concert] permit esoteric names once more.
* Contributors: Daniel Stonier
```
## concert_service_link_graph
- No changes
## concert_service_manager

```
* now it properly prints not auto enabled service. #247 <https://github.com/robotics-in-concert/rocon_concert/issues/247>
* add arg comments for all command. fix typo #247 <https://github.com/robotics-in-concert/rocon_concert/issues/247>
* add all to enable all services
* now auto enable services are selectable
* Contributors: Jihoon Lee
```
## concert_service_utilities

```
* typo fix
* resource pimp working
* Contributors: Jihoon Lee
```
## concert_utilities
- No changes
## rocon_concert
- No changes
## rocon_tf_reconstructor

```
* adding params for spin rate configuration. default spin rate 10hz Fix #240 <https://github.com/robotics-in-concert/rocon_concert/issues/240>
* Contributors: Jihoon Lee
```
