### PR TITLE
perception_oru: 1.0.22-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4987,19 +4987,21 @@ repositories:
       version: release-hydro-source
     release:
       packages:
+      - ndt_costmap
+      - ndt_feature_reg
       - ndt_fuser
       - ndt_map
       - ndt_map_builder
       - ndt_mcl
       - ndt_registration
+      - ndt_rviz_visualisation
       - ndt_visualisation
       - perception_oru
-      - pointcloud_vrml
       - sdf_tracker
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tstoyanov/perception_oru-release.git
-      version: 1.0.18-0
+      version: 1.0.22-0
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_oru` to `1.0.22-0`:
- upstream repository: /home/tsv/code/workspace-hydro/src/perception_oru
- release repository: https://github.com/tstoyanov/perception_oru-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.18-0`
