### PR TITLE
pr2_kinematics: 1.0.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5301,7 +5301,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_kinematics-release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/pr2/pr2_kinematics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_kinematics` to `1.0.6-0`:
- upstream repository: https://github.com/PR2/pr2_kinematics.git
- release repository: https://github.com/TheDash/pr2_kinematics-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.5-0`
## pr2_arm_kinematics

```
* Removed mainpage.dox
* Removed mainpage.dox
* Contributors: TheDash, dash
```
## pr2_kinematics
- No changes
