### PR TITLE
jsk_recognition: 0.1.25-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2996,7 +2996,6 @@ repositories:
       packages:
       - checkerboard_detector
       - imagesift
-      - jsk_libfreenect2
       - jsk_pcl_ros
       - jsk_perception
       - jsk_recognition
@@ -3004,7 +3003,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.1.23-0
+      version: 0.1.25-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.1.25-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.23-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros

```
* Add singleton class for tf::TransformListener
* python_sklearn -> python-sklearn, see https://github.com/ros/rosdistro/blob/master/rosdep/python.yaml#L1264
* Merge remote-tracking branch 'origin/master' into add-more-parameter-for-calibration
  Conflicts:
  jsk_pcl_ros/launch/openni2_remote.launch
* Add uv_scale parameter to depth_calibration.cpp and update openni2_remote.launch
  to specify more parameter.
```
## jsk_perception

```
* kalmanfilter
* changed name
* added codes in catkin.cmake
* added cfg
* added color_histogram_mathcer_node
```
## jsk_recognition
- No changes
## resized_image_transport
- No changes
