### PR TITLE
swiftnav: 0.13.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5841,8 +5841,8 @@ repositories:
   swiftnav:
     doc:
       type: git
-      url: https://github.com/swift-nav/libswiftnav.git
-      version: master
+      url: https://github.com/clearpath-gbp/libswiftnav-release.git
+      version: upstream
     release:
       tags:
         release: release/indigo/{package}/{version}

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5838,6 +5838,17 @@ repositories:
       url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator-release.git
       version: 0.2.0-0
     status: developed
+  swiftnav:
+    doc:
+      type: git
+      url: https://github.com/swift-nav/libswiftnav.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/libswiftnav-release.git
+      version: 0.13.0-0
+    status: maintained
   teleop_twist_joy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `swiftnav` to `0.13.0-0`:
- upstream repository: https://github.com/swift-nav/libswiftnav.git
- release repository: https://github.com/clearpath-gbp/libswiftnav-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
