### PR TITLE
yocs_msgs: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6472,7 +6472,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/yocs_msgs-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/yujinrobot/yocs_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yocs_msgs` to `0.6.2-0`:
- upstream repository: https://github.com/yujinrobot/yocs_msgs.git
- release repository: https://github.com/yujinrobot-release/yocs_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.6.1-0`
## yocs_msgs

```
* merging waypoint messages
* Merge branch 'indigo-devel' of https://github.com/yujinrobot/yocs_msgs into indigo-devel
* add extra commands to implement later
* add feedback message level
* add localization manager action
* add docking interactor action
* improves comments and adds more states for nav ctrl msgs
* adds new trajectory and nav ctrl messages
* adds Trajectory message
* Merge pull request #4 <https://github.com/yujinrobot/yocs_msgs/issues/4> from yujinrobot/indigo
  Sync with indigo
* add remain_time
* change time from int to float
* add timeout for goal
* add distance field
* add distance variable
* add navigateto action
* updating package info. remove email for author. update maintainer
* Contributors: Jihoon Lee, Marcus Liebhardt
```
