### PR TITLE
Add the icart_mini packages

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1930,21 +1930,6 @@ repositories:
       url: https://github.com/open-rdc/icart_mini_navigation.git
       version: indigo-devel
     status: developed
-  icart_mini_ros_pkgs:
-    doc:
-      type: git
-      url: https://github.com/open-rdc/icart_mini_ros_pkgs.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/open-rdc/icart_mini_ros_pkgs-release.git
-      version: 0.0.1-0
-    source:
-      type: git
-      url: https://github.com/open-rdc/icart_mini_ros_pkgs.git
-      version: indigo-devel
-    status: developed
   image_common:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1877,6 +1877,59 @@ repositories:
       url: https://github.com/code-iai-release/iai_common_msgs-release.git
       version: 0.0.3-0
     status: developed
+  icart_mini_core:
+    doc:
+      type: git
+      url: https://github.com/open-rdc/icart_mini_core.git
+      version: indigo-devel
+    release:
+      packages:
+      - combine_dr_measurements
+      - icart_mini_control
+      - icart_mini_description
+      - icart_mini_driver
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/open-rdc/icart_mini_core-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/open-rdc/icart_mini_core.git
+      version: indigo-devel
+    status: developed
+  icart_mini_navigation:
+    doc:
+      type: git
+      url: https://github.com/open-rdc/icart_mini_navigation.git
+      version: indigo-devel
+    release:
+      packages:
+      - force_rotate_recovery
+      - waypoints_navigation
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/open-rdc/icart_mini_navigation-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/open-rdc/icart_mini_navigation.git
+      version: indigo-devel
+    status: developed
+  icart_mini_ros_pkgs:
+    doc:
+      type: git
+      url: https://github.com/open-rdc/icart_mini_ros_pkgs.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/open-rdc/icart_mini_ros_pkgs-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/open-rdc/icart_mini_ros_pkgs.git
+      version: indigo-devel
+    status: developed
   image_common:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1897,6 +1897,21 @@ repositories:
       url: https://github.com/open-rdc/icart_mini_core.git
       version: indigo-devel
     status: developed
+  icart_mini_gazebo:
+    doc:
+      type: git
+      url: https://github.com/open-rdc/icart_mini_gazebo.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/open-rdc/icart_mini_gazebo-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/open-rdc/icart_mini_gazebo.git
+      version: indigo-devel
+    status: developed
   icart_mini_navigation:
     doc:
       type: git


### PR DESCRIPTION
I'd like the icart_mini_\* packages to be indexed and documented on ros.org.
