### PR TITLE
OS X Yosemite (10.10) Rosdep entries for vtk and gazebo2

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -98,7 +98,7 @@ freetype:
 gazebo:
   osx:
     homebrew:
-      packages: [gazebo]
+      packages: [gazebo2]
 gccxml:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -336,7 +336,7 @@ libv4l-dev:
 libvtk:
   osx:
     homebrew:
-      options: [--python, --qt]
+      options: [--with-qt]
       packages: [vtk]
 libvtk-java:
   osx:


### PR DESCRIPTION
#### Homebrew VTK Update

Recent updates to the homebrew/science/vtk brew have created issues for ROS Indigo install on OSX. 
This can be fixed by removing the **--python** and **--qt** options and replacing them with **--with-qt** on the vtk homebrew dependency.
#### ROS & Gazebo

As noted on the [Which combination of ROS/Gazebo versions to use](http://gazebosim.org/tutorials?tut=ros_wrapper_versions&cat=connect_ros) page, ROS Indigo is only compatible with the Gazebo 2.x branch.  
