### PR TITLE
Adding rtabmap and rtabmap_ros to documentation index for hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6985,6 +6985,16 @@ repositories:
       url: https://github.com/ros-visualization/rqt_robot_plugins.git
       version: hydro-devel
     status: maintained
+  rtabmap:
+    doc:
+      type: git
+      url: https://github.com/introlab/rtabmap.git
+      version: master
+  rtabmap_ros:
+    doc:
+      type: git
+      url: https://github.com/introlab/rtabmap_ros.git
+      version: master
   rtmros_common:
     doc:
       type: git


### PR DESCRIPTION
I'd would like rtabmap and rtabmap_ros to be indexed and documented on ros.org.
