### PR TITLE
novatel_span_driver: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3442,6 +3442,14 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/novatel_span_driver.git
       version: master
+    release:
+      packages:
+      - novatel_msgs
+      - novatel_span_driver
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/novatel_span_driver-release.git
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/novatel_span_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_span_driver` to `1.0.0-0`:
- upstream repository: https://github.com/ros-drivers/novatel_span_driver.git
- release repository: https://github.com/ros-drivers-gbp/novatel_span_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.13`
- previous version for package: `null`
## novatel_msgs

```
* Fix velx/y mixup, add diagnostic publisher.
* BESTPOSB -> BESTPOS, add diagnostic constants.
* Update messages to include header, fix header to match documentation.
* Contributors: Mike Purvis
```
## novatel_span_driver

```
* Add capture from INS PPP, default value for IMU rate, fix test, add docs to example launcher.
* Throttle wheelvelocity commands to 1Hz, as recommended by Novatel.
* Fix velx/y mixup, add diagnostic publisher.
* BESTPOSB -> BESTPOS, add diagnostic constants and shim class.
* Treat altitude as positive-up.
* Update messages to include header, fix header to match documentation.
* Add wheel velocity handler.
* Contributors: Mike Purvis
```
