### PR TITLE
perception_oru: 1.0.24-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5000,7 +5000,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tstoyanov/perception_oru-release.git
-      version: 1.0.23-0
+      version: 1.0.24-0
+    source:
+      type: git
+      url: https://github.com/tstoyanov/perception_oru-release.git
+      version: release-hydro-source
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_oru` to `1.0.24-0`:
- upstream repository: /home/tsv/code/workspace-hydro/src/perception_oru
- release repository: https://github.com/tstoyanov/perception_oru-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.23-0`
## ndt_costmap

```
* small fix with install targets
* Contributors: Todor Stoyanov
```
## ndt_feature_reg
- No changes
## ndt_fuser
- No changes
## ndt_map
- No changes
## ndt_map_builder

```
* small fix with install targets
* Contributors: Todor Stoyanov
```
## ndt_mcl
- No changes
## ndt_registration

```
* small fix with install targets
* Contributors: Todor Stoyanov
```
## ndt_rviz_visualisation
- No changes
## ndt_visualisation
- No changes
## perception_oru
- No changes
## sdf_tracker
- No changes
