### PR TITLE
rtabmap: 0.7.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6990,6 +6990,15 @@ repositories:
       type: git
       url: https://github.com/introlab/rtabmap.git
       version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/introlab/rtabmap-release.git
+      version: 0.7.1-1
+    source:
+      type: git
+      url: https://github.com/introlab/rtabmap.git
+      version: master
   rtabmap_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap` to `0.7.1-1`:
- upstream repository: https://github.com/introlab/rtabmap.git
- release repository: https://github.com/introlab/rtabmap-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
