### PR TITLE
rtabmap_ros: 0.7.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7004,6 +7004,15 @@ repositories:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git
       version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/introlab/rtabmap_ros-release.git
+      version: 0.7.1-0
+    source:
+      type: git
+      url: https://github.com/introlab/rtabmap_ros.git
+      version: master
   rtmros_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.7.1-0`:
- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
