### PR TITLE
rtabmap: 0.7.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5335,6 +5335,16 @@ repositories:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git
       version: hydro-devel
+  rtabmap:
+    doc:
+      type: git
+      url: https://github.com/introlab/rtabmap.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/introlab/rtabmap-release.git
+      version: 0.7.2-0
   rtt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap` to `0.7.2-0`:
- upstream repository: https://github.com/introlab/rtabmap.git
- release repository: https://github.com/introlab/rtabmap-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `null`
