### PR TITLE
world_canvas_msgs: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6481,6 +6481,21 @@ repositories:
       url: https://github.com/RobotWebTools/web_video_server.git
       version: develop
     status: maintained
+  world_canvas_msgs:
+    doc:
+      type: git
+      url: https://github.com/corot/world_canvas_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/corot/world_canvas_msgs-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/corot/world_canvas_msgs.git
+      version: master
+    status: developed
   wpi_jaco:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `world_canvas_msgs` to `0.1.0-0`:
- upstream repository: https://github.com/corot/world_canvas_msgs.git
- release repository: https://github.com/corot/world_canvas_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `null`
## world_canvas_msgs

```
* First release
```
