### PR TITLE
world_canvas: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6481,6 +6481,23 @@ repositories:
       url: https://github.com/RobotWebTools/web_video_server.git
       version: develop
     status: maintained
+  world_canvas:
+    doc:
+      type: git
+      url: https://github.com/corot/world_canvas.git
+      version: master
+    release:
+      packages:
+      - world_canvas_server
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/corot/world_canvas-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/corot/world_canvas.git
+      version: master
+    status: developed
   world_canvas_libs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `world_canvas` to `0.1.0-0`:
- upstream repository: https://github.com/corot/world_canvas.git
- release repository: https://github.com/corot/world_canvas-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `null`
## world_canvas_server

```
* First release
```
