### PR TITLE
icart_mini_navigation: 0.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1924,11 +1924,12 @@ repositories:
     release:
       packages:
       - force_rotate_recovery
+      - icart_mini_navigation
       - waypoints_navigation
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/open-rdc/icart_mini_navigation-release.git
-      version: 0.0.1-0
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/open-rdc/icart_mini_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `icart_mini_navigation` to `0.0.1-1`:
- upstream repository: https://github.com/open-rdc/icart_mini_navigation.git
- release repository: https://github.com/open-rdc/icart_mini_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.1-0`
