### PR TITLE
pr2_self_test: 1.0.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5598,12 +5598,13 @@ repositories:
       - joint_qualification_controllers
       - pr2_bringup_tests
       - pr2_counterbalance_check
+      - pr2_motor_diagnostic_tool
       - pr2_self_test
       - pr2_self_test_msgs
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_self_test-release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/PR2/pr2_self_test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_self_test` to `1.0.6-0`:
- upstream repository: https://github.com/PR2/pr2_self_test.git
- release repository: https://github.com/TheDash/pr2_self_test-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `1.0.5-0`
## pr2_motor_diagnostic_tool

```
* Added pr2_motor_diagnostic_tool
* Contributors: TheDash
```
