### PR TITLE
icart_mini_core: 0.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1895,7 +1895,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/open-rdc/icart_mini_core-release.git
-      version: 0.0.1-0
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/open-rdc/icart_mini_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `icart_mini_core` to `0.0.1-1`:
- upstream repository: https://github.com/open-rdc/icart_mini_core.git
- release repository: https://github.com/open-rdc/icart_mini_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.1-0`
