### PR TITLE
rocon_qt_gui: 0.7.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4556,12 +4556,18 @@ repositories:
       version: indigo
     status: developed
   rocon_qt_gui:
+    doc:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_qt_gui.git
+      version: indigo
     release:
       packages:
+      - concert_admin_app
       - concert_conductor_graph
+      - concert_qt_make_a_map
+      - concert_qt_map_annotation
       - concert_qt_service_info
       - concert_qt_teleop
-      - rocon_admin_app
       - rocon_gateway_graph
       - rocon_qt_app_manager
       - rocon_qt_gui
@@ -4573,7 +4579,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_qt_gui-release.git
-      version: 0.7.0-0
+      version: 0.7.2-0
+    source:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_qt_gui.git
+      version: indigo
     status: developed
   rocon_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_qt_gui` to `0.7.2-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_qt_gui.git
- release repository: https://github.com/yujinrobot-release/rocon_qt_gui-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.7.0-0`
## concert_admin_app
- No changes
## concert_conductor_graph
- No changes
## concert_qt_make_a_map
- No changes
## concert_qt_map_annotation
- No changes
## concert_qt_service_info
- No changes
## concert_qt_teleop
- No changes
## rocon_gateway_graph
- No changes
## rocon_qt_app_manager
- No changes
## rocon_qt_gui

```
* add new packages in meta pkg
* Contributors: Jihoon Lee
```
## rocon_qt_library
- No changes
## rocon_qt_listener
- No changes
## rocon_qt_master_info
- No changes
## rocon_qt_teleop
- No changes
## rocon_remocon
- No changes
