### PR TITLE
rocon_tutorials: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4613,6 +4613,7 @@ repositories:
     release:
       packages:
       - chatter_concert
+      - gazebo_concert
       - rocon_app_manager_tutorials
       - rocon_gateway_tutorials
       - rocon_tutorials
@@ -4620,7 +4621,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_tutorials-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_tutorials` to `0.6.2-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_tutorials.git
- release repository: https://github.com/yujinrobot-release/rocon_tutorials-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.6.1-0`
## chatter_concert

```
* updating compatibility of webapps and weburls closes #50 <https://github.com/robotics-in-concert/rocon_tutorials/issues/50>
* [chatter_concert] unit test esoteric names.
* auto_enable_services now use all instead of bool
* Contributors: Daniel Stonier, Jihoon Lee
```
## gazebo_concert

```
* update gazebo_concert package version
* update package.xml
* local client is now argument
* remove initialisation service
* add kobuki
* add prameters for gazebo
* fix install rule
* add world_canvas
* gazebo concert ready
* add gazebo_concert init
* Contributors: Jihoon Lee
* update gazebo_concert package version
* update package.xml
* local client is now argument
* remove initialisation service
* add kobuki
* add prameters for gazebo
* fix install rule
* add world_canvas
* gazebo concert ready
* add gazebo_concert init
* Contributors: Jihoon Lee
```
## rocon_app_manager_tutorials
- No changes
## rocon_gateway_tutorials
- No changes
## rocon_tutorials

```
* update package.xml
* Contributors: Jihoon Lee
```
## turtle_concert

```
* updating compatibility of webapps and weburls closes #50 <https://github.com/robotics-in-concert/rocon_tutorials/issues/50>
* auto_enable_services now use all instead of bool
* Contributors: Jihoon Lee
```
