### PR TITLE
world_canvas_libs: 0.1.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6513,7 +6513,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/corot/world_canvas_libs-release.git
-      version: 0.1.0-0
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/corot/world_canvas_libs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `world_canvas_libs` to `0.1.0-1`:
- upstream repository: https://github.com/corot/world_canvas_libs.git
- release repository: https://github.com/corot/world_canvas_libs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.1.0-0`
## world_canvas_client_cpp

```
* First release
```
## world_canvas_client_examples

```
* First release
```
## world_canvas_client_py

```
* First release
```
## world_canvas_utils

```
* First release
```
