### PR TITLE
turtlebot_create: 2.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6044,6 +6044,26 @@ repositories:
       url: https://github.com/turtlebot/turtlebot_arm.git
       version: indigo-devel
     status: developed
+  turtlebot_create:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_create.git
+      version: indigo
+    release:
+      packages:
+      - create_description
+      - create_driver
+      - create_node
+      - turtlebot_create
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/turtlebot-release/turtlebot_create-release.git
+      version: 2.3.0-0
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_create.git
+      version: indigo
+    status: maintained
   turtlebot_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_create` to `2.3.0-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_create.git
- release repository: https://github.com/turtlebot-release/turtlebot_create-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `null`
## create_description

```
* -Fix extreme slipping of create base in gazebo by using same parameters that kobuki uses
* Contributors: Stefan Kohlbrecher
```
## create_driver
- No changes
## create_node

```
* Set queue size
* Actually use provided configuration
* Contributors: Kenneth Bogert, trainman419
```
## turtlebot_create
- No changes
