### PR TITLE
robot_model: 1.10.21-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5956,7 +5956,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.10.20-0
+      version: 1.10.21-0
     source:
       type: git
       url: https://github.com/ros/robot_model.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.10.21-0`:
- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `1.10.20-0`
## collada_parser

```
* fix rotation of joint axis when oriantation between parent link and child link is differ
* Contributors: YoheiKakiuchi
```
## collada_urdf
- No changes
## joint_state_publisher

```
* Added floating joints to joint types ignored by publisher
* Contributors: Shaun Edwards
```
## kdl_parser
- No changes
## resource_retriever
- No changes
## robot_model
- No changes
## urdf
- No changes
## urdf_parser_plugin
- No changes
