### PR TITLE
robot_model: 1.11.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4369,7 +4369,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.11.5-0
+      version: 1.11.6-0
     source:
       type: git
       url: https://github.com/ros/robot_model.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.11.6-0`:
- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `1.11.5-0`
## collada_parser

```
* fix rotation of joint axis when oriantation between parent link and child link is differ
* Contributors: YoheiKakiuchi
```
## collada_urdf
- No changes
## joint_state_publisher

```
* Added floating joints to joint types ignored by publisher
* warn when joints have no limits
* add queue_size for publisher
* Contributors: Jihoon Lee, Michael Ferguson, Shaun Edwards
```
## kdl_parser

```
* add version dependency on orocos_kdl >= 1.3.0
* Contributors: William Woodall
```
## robot_model
- No changes
## urdf

```
* Add install for static libs needed for Android cross-compilation
* Contributors: Gary Servin
```
## urdf_parser_plugin
- No changes
