### PR TITLE
turtlebot: 2.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6020,6 +6020,26 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/topic_proxy-release.git
       version: 0.1.1-0
     status: maintained
+  turtlebot:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot.git
+      version: indigo
+    release:
+      packages:
+      - turtlebot
+      - turtlebot_bringup
+      - turtlebot_capabilities
+      - turtlebot_description
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/turtlebot-release/turtlebot-release.git
+      version: 2.3.0-0
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot.git
+      version: indigo
+    status: developed
   turtlebot_arm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot` to `2.3.0-0`:
- upstream repository: https://github.com/turtlebot/turtlebot.git
- release repository: https://github.com/turtlebot-release/turtlebot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `null`
## turtlebot

```
* migrate linux_hardware as linux_peripheral_interfaces repo
* adds turtlebot_capabilities package and related changes
* Contributors: Jihoon Lee, Marcus Liebhardt
```
## turtlebot_bringup

```
* removing unused args
* move out turtlebot map file environment variable to turtlebot_navigation, refs #163 <https://github.com/turtlebot/turtlebot/issues/163>.
* fixing typo in concert_client.launch
* add interaction icons to fix #162 <https://github.com/turtlebot/turtlebot/issues/162>
* migrate linux_hardware as linux_peripheral_interfaces repo
* Revert "Adding the rosbridge setting for using rosbridge on pairing mode"
* align the arg
* add the rosbridge setting for using rosbridge on pairing mode
* Change env-vars to not overwrite already set vars
* concert version turtlebot
* proper remappings and use video_teleop virtual rapp
* Merge pull request #148 <https://github.com/turtlebot/turtlebot/issues/148> from turtlebot/irdevel
  Update to use environment hooks for turtlebot_bringup / Android pairing updates
* Move robot name and type to environment variable as mentioned in #134 <https://github.com/turtlebot/turtlebot/issues/134>
* Fix compatibility uri's to filter out PC interactions on Android
* Split Android and PC Pairing into seperate roles
* Update to use env-hooks for Turtlebot
* Initial Android fixes
* Update to account for turtlebot_rapps/teleop change to implement rocon_apps/teleop
* cleanup legacy install rule. and remove concert directory which is not valid anymore
* Rolled android and qt make_a_map and map_nav into one
* Remove unncessary launchers as app manager and capabilities are rolled into minimal now
* Enable capabilities server for turtlebot on indigo
* Fix mapping for Qt teleop
* Bugfix changes - small
* Added more interactions
* Added interactions to Turtlebot on indigo, collapsed minimal_with_appmanager into just minimal
* better acceleration defaults after experimental observations.
* refactor turtlebot_core_apps -> turtlebot_rapps
* Remap cmd_vel for the calibration script
  It needs to match the turtlebot node in order to monitor for changes
* Load calibration on turtlebot bringup
* add depth argument to configure scan_processing. With this configuration scan works for both depth_regratation false and true
* add blacklist argument
* compatible with new app manager
* rapp exporting for new rocon_app_manager
* patches to keep the consistency of arguments #114 <https://github.com/turtlebot/turtlebot/issues/114>
* Merge pull request #114 <https://github.com/turtlebot/turtlebot/issues/114> from mayrjohannes/hydro-devel
  Added serial port as parameter to launch files (Issue https://github.com/turtlebot/turtlebot/issues/111)
* Fixing "Error with diagnostics.yaml for roomba #110 <https://github.com/turtlebot/turtlebot/issues/110>"
* updates capabilities-specific rosinstaller
* adds turtlebot_capabilities package and related changes
* Trivial comment spelling fix rhoomba -> roomba
* turtlebot_bringup: adds capabilities (server + default provider configs)
* adding name for rapp list
* Added serial port as parameter to launch files
  modified:   create/mobile_base.launch.xml
  modified:   kobuki/mobile_base.launch.xml
  modified:   mobile_base.launch.xml
  modified:   roomba/mobile_base.launch.xml
  modified:   ../minimal.launch
  Committer: mayrjohannes <mailto:joh.mayr@jku.at>
  Author: mayrjohannes <mailto:joh.mayr@jku.at>
* Contributors: Daniel Stonier, DongWook Lee, Jihoon Lee, Kenneth Bogert, Luka Čehovin, Marcus Liebhardt, Yujin, kentsommer, wheeled_robin
```
## turtlebot_capabilities

```
* Enable capabilities server for turtlebot on indigo
* adds turtlebot_capabilities package and related changes
* Contributors: Marcus Liebhardt, kentsommer
* Enable capabilities server for turtlebot on indigo
* adds turtlebot_capabilities package and related changes
* Contributors: Marcus Liebhardt, kentsommer
```
## turtlebot_description

```
* Check if unit-testing is enabled
  CATKIN_ENABLE_TESTING is a late addtion to catkin. This updates the
  package to comply with the strict checking rule.
* Contributors: Adam Lee
```
