### PR TITLE
turtlebot_create_desktop: 2.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6084,6 +6084,25 @@ repositories:
       url: https://github.com/turtlebot/turtlebot_create.git
       version: indigo
     status: maintained
+  turtlebot_create_desktop:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_create_desktop.git
+      version: indigo
+    release:
+      packages:
+      - create_dashboard
+      - create_gazebo_plugins
+      - turtlebot_create_desktop
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/turtlebot-release/turtlebot_create_desktop-release.git
+      version: 2.3.0-0
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_create_desktop.git
+      version: indigo
+    status: maintained
   turtlebot_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_create_desktop` to `2.3.0-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_create_desktop.git
- release repository: https://github.com/turtlebot-release/turtlebot_create_desktop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `null`
## create_dashboard
- No changes
## create_gazebo_plugins

```
* Update contact manager for Gazebo 2.0
* add catkin_ignore due to the compile error. remove this when it is ready go
* -Fix instantaneous odom getting computed, but not published (would alway publish 0 before)
* Fix compilation on OS X (at least 10.9)
  - without this, linking fails.
* replace deprecated shared_dynamic_cast (fixes #9 <https://github.com/turtlebot/turtlebot_create_desktop/issues/9>)
* fixes gazebo header paths (refs #7 <https://github.com/turtlebot/turtlebot_create_desktop/issues/7>)
* Contributors: Jihoon Lee, Marcus Liebhardt, Nikolaus Demmel, Samir Benmendil, Stefan Kohlbrecher, trainman419
```
## turtlebot_create_desktop
- No changes
