### PR TITLE
ueye_cam: 1.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8197,7 +8197,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/anqixu/ueye_cam-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/anqixu/ueye_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `1.0.4-0`:
- upstream repository: https://github.com/anqixu/ueye_cam.git
- release repository: https://github.com/anqixu/ueye_cam-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `1.0.3-0`
## ueye_cam

```
* Switching to DownloadUEyeDriversUnofficial.cmake (based on ueye ROS package) until IDS grants official permission
* Contributors: Anqi Xu
```
