### PR TITLE
moveit_setup_assistant: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3010,11 +3010,19 @@ repositories:
       version: indigo-devel
     status: maintained
   moveit_setup_assistant:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_setup_assistant.git
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
-      version: 0.5.9-0
+      version: 0.6.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_setup_assistant.git
+      version: indigo-devel
     status: maintained
   moveit_simple_grasps:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_setup_assistant` to `0.6.0-0`:
- upstream repository: https://github.com/ros-planning/moveit_setup_assistant.git
- release repository: https://github.com/ros-gbp/moveit_setup_assistant-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.5.9-0`
## moveit_setup_assistant

```
* Values are now read from kinematics.yaml correctly.
* Simplified the inputKinematicsYAML() code.
* Debug and octomap improvements in launch file templates
* Values are now read from kinematics.yaml correctly. Previously, keys such
  as "kinematics_solver" were not found.
* Added clear octomap service to move_group launch file template
* Added gdb debug helper that allows easier break point addition
* Add launch file for joystick control of MotionPlanningPlugin
* Joint limits comments
* Removed velocity scaling factor
* Added a new 'velocity_scaling_factor' parameter to evenly reduce max joint velocity for all joints. Added documentation.
* Simply renamed kin_model to robot_model for more proper naming convension
* Added new launch file for controll Rviz with joystick
* use relative instead of absolute names for topics (to allow for namespaces)
* Added planner specific parameters to ompl_planning.yaml emitter.
* Added space after every , in function calls
  Added either a space or a c-return before opening {
  Moved & next to the variable in the member function declarations
* Added planner specific parameters to ompl_planning.yaml emitter.
  Each parameter is set to current defaults. This is fragile, as defaults may change.
* Contributors: Chris Lewis, Dave Coleman, Ioan A Sucan, Jim Rothrock, ahb, hersh
```
