### PR TITLE
Release the icart_mini metapackage

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1881,58 +1881,29 @@ repositories:
       url: https://github.com/code-iai-release/iai_common_msgs-release.git
       version: 0.0.3-0
     status: developed
-  icart_mini_core:
+  icart_mini:
     doc:
       type: git
-      url: https://github.com/open-rdc/icart_mini_core.git
+      url: https://github.com/open-rdc/icart_mini.git
       version: indigo-devel
     release:
       packages:
       - combine_dr_measurements
+      - force_rotate_recovery
+      - icart_mini
       - icart_mini_control
       - icart_mini_description
       - icart_mini_driver
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/open-rdc/icart_mini_core-release.git
-      version: 0.0.1-1
-    source:
-      type: git
-      url: https://github.com/open-rdc/icart_mini_core.git
-      version: indigo-devel
-    status: developed
-  icart_mini_gazebo:
-    doc:
-      type: git
-      url: https://github.com/open-rdc/icart_mini_gazebo.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/open-rdc/icart_mini_gazebo-release.git
-      version: 0.0.1-1
-    source:
-      type: git
-      url: https://github.com/open-rdc/icart_mini_gazebo.git
-      version: indigo-devel
-    status: developed
-  icart_mini_navigation:
-    doc:
-      type: git
-      url: https://github.com/open-rdc/icart_mini_navigation.git
-      version: indigo-devel
-    release:
-      packages:
-      - force_rotate_recovery
+      - icart_mini_gazebo
       - icart_mini_navigation
       - waypoints_navigation
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/open-rdc/icart_mini_navigation-release.git
-      version: 0.0.1-1
+      url: https://github.com/open-rdc/icart_mini-release.git
+      version: 0.0.3
     source:
       type: git
-      url: https://github.com/open-rdc/icart_mini_navigation.git
+      url: https://github.com/open-rdc/icart_mini.git
       version: indigo-devel
     status: developed
   image_common:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1900,7 +1900,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/open-rdc/icart_mini-release.git
-      version: 0.0.3
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/open-rdc/icart_mini.git


### PR DESCRIPTION
I've modified to manage the icart_mini packages in one place and, release the icart_mini metapackage.
