### PR TITLE
rosbridge_suite: 0.7.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6521,7 +6521,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.6.8-0
+      version: 0.7.0-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.7.0-0`:
- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.6.8-0`
## rosapi
- No changes
## rosbridge_library

```
* rewrite of advertise service
* cleanup init function
* matches original call_service
* matches original call_service
* service_request --> reuse of call_service (previously defined)
* stop_service --> unadvertise_service
* service_name --> service
* service_type --> type
* removed service_module
* request_id --> id
* Contributors: Russell Toris
```
## rosbridge_server
- No changes
## rosbridge_suite
- No changes
