### PR TITLE
async_web_server_cpp: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -263,6 +263,21 @@ repositories:
       type: git
       url: https://github.com/ethz-asl/asctec_mav_framework.git
       version: master
+  async_web_server_cpp:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/async_web_server_cpp.git
+      version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/wpi-rail-release/async_web_server_cpp-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/async_web_server_cpp.git
+      version: develop
+    status: maintained
   audio_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_web_server_cpp` to `0.0.1-0`:
- upstream repository: https://github.com/WPI-RAIL/async_web_server_cpp.git
- release repository: https://github.com/wpi-rail-release/async_web_server_cpp-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## async_web_server_cpp

```
* OCD clenup
* Merge pull request #2 from mitchellwills/develop
  Few small fixes
* Fixed message processing so close message is actually passed through
* Fixed potential memory leak from boost shared_ptr misuse
* Merge pull request #1 from mitchellwills/develop
  Import of initial implementation from webrtc_ros repo
* Fixed install directives
* Added some documentation
* Added more metadata files
* Cleaned up file formatting
* Fixed compilation error on 12.04
* Added boost dependancy
* Added travis configuration
* Package cleanup
* renamed package to async_web_server_cpp
* Initial import of cpp_web_server from webrtc_ros
* Initial commit
* Contributors: Mitchell Wills, Russell Toris
```
