### PR TITLE
async_web_server_cpp: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -182,6 +182,21 @@ repositories:
       url: https://github.com/ROS-PSE/arni.git
       version: master
     status: maintained
+  async_web_server_cpp:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/async_web_server_cpp.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/async_web_server_cpp-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/async_web_server_cpp.git
+      version: develop
+    status: maintained
   audio_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_web_server_cpp` to `0.0.1-0`:
- upstream repository: https://github.com/WPI-RAIL/async_web_server_cpp.git
- release repository: https://github.com/wpi-rail-release/async_web_server_cpp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## async_web_server_cpp

```
* OCD clenup
* Merge pull request #2 from mitchellwills/develop
  Few small fixes
* Fixed message processing so close message is actually passed through
* Fixed potential memory leak from boost shared_ptr misuse
* Merge pull request #1 from mitchellwills/develop
  Import of initial implementation from webrtc_ros repo
* Fixed install directives
* Added some documentation
* Added more metadata files
* Cleaned up file formatting
* Fixed compilation error on 12.04
* Added boost dependancy
* Added travis configuration
* Package cleanup
* renamed package to async_web_server_cpp
* Initial import of cpp_web_server from webrtc_ros
* Initial commit
* Contributors: Mitchell Wills, Russell Toris
```
