### PR TITLE
librms: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2565,6 +2565,21 @@ repositories:
       url: https://github.com/ethz-asl/libpointmatcher.git
       version: master
     status: developed
+  librms:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/librms.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/librms-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/librms.git
+      version: develop
+    status: maintained
   libuvc:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `librms` to `0.0.1-0`:
- upstream repository: https://github.com/WPI-RAIL/librms.git
- release repository: https://github.com/wpi-rail-release/librms-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## librms

```
* first working version of librms
* studies and conditions
* Initial commit
* Contributors: Russell Toris
```
