### PR TITLE
rail_ceiling: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4165,7 +4165,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_ceiling-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_ceiling.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_ceiling` to `0.0.2-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_ceiling.git
- release repository: https://github.com/wpi-rail-release/rail_ceiling-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.1-0`
## rail_ceiling

```
* Linear interpolation-based method to average quaternions for camera calibration samples
* topic name update
* removed some debugging statements
* CMakeLists install
* Furniture position adjustment
* Organization/Documentation
* Initial positions of furniture can be included in the markers.yaml file, which can be optionally read in when launching the furniture_tracker node
* Added missing dependency
* Documentation and cleanup
* New implementation of furniture tracking for both localization and path planning
* Merge branch 'develop' of https://github.com/WPI-RAIL/rail_ceiling into develop
* Started implementing new furniture tracker with YAML config files
* Update .travis.yml
* Contributors: David Kent, Russell Toris
```
