### PR TITLE
rosauth: 0.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4976,7 +4976,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rosauth-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rosauth.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosauth` to `0.1.5-0`:
- upstream repository: https://github.com/WPI-RAIL/rosauth.git
- release repository: https://github.com/wpi-rail-release/rosauth-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.4-0`
## rosauth

```
* Merge pull request #6 from forouher/develop
  add missing catkin dependencies
* add missing catkin dependencies
* Now runs hydro and groovy
* fixed dox file
* Contributors: Dariush Forouher, Russell Toris
```
