### PR TITLE
aau_multi_robot: 0.1.3-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -19,11 +19,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/aau-ros/aau_multi_robot-release.git
-      version: 0.1.3-0
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/aau-ros/aau_multi_robot.git
       version: hydro
+    status: developed
   abb:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aau_multi_robot` to `0.1.3-1`:
- upstream repository: https://github.com/aau-ros/aau_multi_robot.git
- release repository: https://github.com/aau-ros/aau_multi_robot-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.1.3-0`
