### PR TITLE
rail_maps: 0.2.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3451,21 +3451,6 @@ repositories:
       url: https://github.com/ethz-asl/libpointmatcher.git
       version: master
     status: developed
-  librms:
-    doc:
-      type: git
-      url: https://github.com/WPI-RAIL/librms.git
-      version: master
-    release:
-      tags:
-        release: release/hydro/{package}/{version}
-      url: https://github.com/wpi-rail-release/librms-release.git
-      version: 0.0.1-0
-    source:
-      type: git
-      url: https://github.com/WPI-RAIL/librms.git
-      version: develop
-    status: maintained
   libsegwayrmp:
     doc:
       type: git
@@ -5826,7 +5811,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_maps-release.git
-      version: 0.2.4-0
+      version: 0.2.5-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_maps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_maps` to `0.2.5-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_maps.git
- release repository: https://github.com/wpi-rail-release/rail_maps-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.2.4-0`
## rail_maps

```
* Rail lab with no furniture, for navigation that handles the furniture dynamically
* Contributors: David Kent
```
