### PR TITLE
carl_bot: 0.0.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -462,7 +462,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_bot-release.git
-      version: 0.0.9-0
+      version: 0.0.10-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_bot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_bot` to `0.0.10-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_bot.git
- release repository: https://github.com/wpi-rail-release/carl_bot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.9-0`
## carl_bot

```
* deleted everything
* intial commit from rail computer
* Contributors: Peter
```
## carl_bringup

```
* deleted everything
* Parameter, topic, and launch file cleanup for consistency
* changes to make teleop safety able to toggle on and off with launch paramater
* Contributors: Brian Hetherman, David Kent, Peter
```
## carl_description

```
* reverted rviz
* fixed rear struts. also rebuild urdf
* rebuild urdf
* fixed front cover and back strut
* removed stls
* reverted to original rviz
* removed stls
* ran xacro
* removed screenshot
* fixed castor plate. added screenshot
* finished collision models. creative camera,mount,topplate,jacomount,camera lift
* caster
* servo arm, caster plate
* servo
* base, rear struts<
  >
* wheels, front cover, camera, hokuyo
* used cylinder for wheel collision model
* Contributors: Peter
```
## carl_dynamixel

```
* deleted everything
* Contributors: Peter
```
## carl_interactive_manipulation
- No changes
## carl_teleop

```
* deleted everything
* Parameter, topic, and launch file cleanup for consistency
* changes to make teleop safety able to toggle on and off with launch paramater
* Contributors: Brian Hetherman, David Kent, Peter
```
