### PR TITLE
kingfisher: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2298,6 +2298,24 @@ repositories:
       url: https://github.com/lrse/ros-keyboard.git
       version: master
     status: developed
+  kingfisher:
+    doc:
+      type: git
+      url: https://github.com/kf/kingfisher.git
+      version: indigo-devel
+    release:
+      packages:
+      - kingfisher_description
+      - kingfisher_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/kingfisher-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/kf/kingfisher.git
+      version: indigo-devel
+    status: maintained
   kobuki:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kingfisher` to `0.1.0-0`:
- upstream repository: http://github.com/kf/kingfisher.git
- release repository: https://github.com/clearpath-gbp/kingfisher-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## kingfisher_description

```
* Add roslaunch file check to kingfisher_description.
* Contributors: Mike Purvis
```
## kingfisher_msgs

```
* Adding a new Power message, to represent charge state info from MCU.
* Contributors: Mike Purvis
```
