### PR TITLE
carl_navigation: 0.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -522,7 +522,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_navigation-release.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_navigation` to `0.0.8-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_navigation.git
- release repository: https://github.com/wpi-rail-release/carl_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.7-0`
## carl_navigation

```
* Update .travis.yml
* travis now pull source
* topic name update
* propagated furniture obstacle information to local costmap as well as the global costmap
* message generation dependency
* Fixed a race condition on geting the initial furniture positions
* Adjustments to inflation amount and publisher/subscriber initialization order for the furniture_layer
* Organization/Documentation
* Navigation can now be launched to use layered costmaps for localization and navigation based on fixed furniture positions, marker-tracked furniture positions, or the original non-layered version.
* Documentation and cleanup
* Layered costmap implementation for dynamic furniture tracking
* Contributors: David Kent, Russell Toris
```
