### PR TITLE
pr2_self_test: 1.0.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5634,7 +5634,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_self_test-release.git
-      version: 1.0.6-0
+      version: 1.0.7-0
     source:
       type: git
       url: https://github.com/PR2/pr2_self_test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_self_test` to `1.0.7-0`:
- upstream repository: https://github.com/PR2/pr2_self_test.git
- release repository: https://github.com/TheDash/pr2_self_test-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `1.0.6-0`
