### PR TITLE
rtabmap and rtabmap_ros: 0.7.3 in hydro/indigo

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7085,11 +7085,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.7.1-1
+      version: 0.7.3-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
       version: master
+    status: maintained
   rtabmap_ros:
     doc:
       type: git
@@ -7099,11 +7100,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.7.1-0
+      version: 0.7.3-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git
       version: master
+    status: maintained
   rtmros_common:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5410,7 +5410,12 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.7.2-0
+      version: 0.7.3-0
+    source:
+      type: git
+      url: https://github.com/introlab/rtabmap.git
+      version: master
+    status: maintained
   rtabmap_ros:
     doc:
       type: git
@@ -5420,7 +5425,12 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.7.2-0
+      version: 0.7.3-0
+    source:
+      type: git
+      url: https://github.com/introlab/rtabmap_ros.git
+      version: master
+    status: maintained
   rtt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repositories `rtabmap` and  `rtabmap_ros` to `0.7.3` both for Hydro and Indigo distributions.
- upstream repository: https://github.com/introlab/rtabmap.git
- release repository: https://github.com/introlab/rtabmap-release.git
- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
