### PR TITLE
multisense_ros: 3.3.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3127,7 +3127,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
-      version: 3.3.7-1
+      version: 3.3.8-0
     source:
       type: hg
       url: https://bitbucket.org/crl/multisense_ros


### PR DESCRIPTION
Increasing version of package(s) in repository `multisense_ros` to `3.3.8-0`:
- upstream repository: https://bitbucket.org/crl/multisense_ros
- release repository: https://github.com/carnegieroboticsllc/multisense_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `3.3.7-1`
## multisense
- No changes
## multisense_bringup
- No changes
## multisense_cal_check
- No changes
## multisense_description
- No changes
## multisense_lib
- No changes
## multisense_ros

```
* Added stereo_msgs/DisparityImage publishing for both left and right disparity images. Added latched default camera_info publishing for all image topics. Updated rosbuild multisense_ros CMakeLists.txt to build color_laser_publisher.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
