### PR TITLE
brew formula changes for vtk

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -340,7 +340,7 @@ libv4l-dev:
 libvtk:
   osx:
     homebrew:
-      options: [--python, --qt]
+      options: [--with-qt]
       packages: [vtk]
 libvtk-java:
   osx:


### PR DESCRIPTION
the homebrew formula for `vtk` does not have the `--python` option anymore.
Because of this the installation fails, by removing the option `vtk` installs
