### PR TITLE
fs100_motoman: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1859,6 +1859,12 @@ repositories:
       url: https://github.com/paulbovbel/frontier_exploration.git
       version: hydro-devel
     status: developed
+  fs100_motoman:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/DTU-AUT/fs100_motoman-release.git
+      version: 0.1.0-0
   gazebo2rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fs100_motoman` to `0.1.0-0`:
- upstream repository: https://github.com/DTU-AUT/fs100_motoman.git
- release repository: https://github.com/DTU-AUT/fs100_motoman-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `null`
