### PR TITLE
perception_oru: 1.0.26-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5054,7 +5054,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tstoyanov/perception_oru-release.git
-      version: 1.0.25-0
+      version: 1.0.26-0
     source:
       type: git
       url: https://github.com/tstoyanov/perception_oru-release.git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5037,7 +5037,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/tstoyanov/perception_oru-release.git
-      version: release-hydro-source
+      version: release-source
     release:
       packages:
       - ndt_costmap
@@ -5058,7 +5058,7 @@ repositories:
     source:
       type: git
       url: https://github.com/tstoyanov/perception_oru-release.git
-      version: release-hydro-source
+      version: release-source
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_oru` to `1.0.26-0`:
- upstream repository: /home/tsv/code/workspace-hydro/src/perception_oru
- release repository: https://github.com/tstoyanov/perception_oru-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.25-0`
## ndt_costmap
- No changes
## ndt_feature_reg
- No changes
## ndt_fuser

```
* small fix to package.xmls and an update of visualization
* Contributors: Todor Stoyanov
```
## ndt_map
- No changes
## ndt_map_builder
- No changes
## ndt_mcl
- No changes
## ndt_registration
- No changes
## ndt_rviz_visualisation
- No changes
## ndt_visualisation

```
* small fix to package.xmls and an update of visualization
* Contributors: Todor Stoyanov
```
## perception_oru
- No changes
## sdf_tracker
- No changes
