### PR TITLE
multimaster_fkie: 0.3.15-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4054,7 +4054,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.3.14-0
+      version: 0.3.15-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.3.15-0`:
- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.3.14-0`
## default_cfg_fkie

```
* multimaster_fkie: removed some python mistakes
* Contributors: Alexander Tiderko
```
## master_discovery_fkie

```
* multimaster_fkie: added queue_size argumet to the publishers
* multimaster_fkie: removed some python mistakes
* Contributors: Alexander Tiderko
```
## master_sync_fkie

```
* multimaster_fkie: added queue_size argumet to the publishers
* multimaster_fkie: removed some python mistakes
* Contributors: Alexander Tiderko
```
## multimaster_fkie
- No changes
## multimaster_msgs_fkie
- No changes
## node_manager_fkie

```
* node_manager_fkie: fixed sync button handling
* multimaster_fkie: removed some python mistakes
* node_manager_fkie: removed some python mistakes
* node_manager_fkie: fixed node selection in description dock
* node_manager_fkie: some icons changed
* node_manager_fkie: 'autoupdate' parameter added
  The autoupdate parameter disables the automatic requests. It is usefull
  for low bandwidth networks.
* node_manager_fkie: reduced remote parameter requests
* node_manager_fkie: added a republish functionality
  This function is accessible in extended info widget.
* node_manager_fkie: fix publish with rate slower one
  Updated the topic info. Added constants to message definition view.
* node_manager_fkie: restores the view of expanded capability groups after reload of a launch file
* node_managef_fkie: fix sidebar parameter selection
* node_manager_fkie: fixes in parameter dialog
  * fixed filter in parameter dialog
  * fixed parser of the list values
  * update only changed values in ROS parameter server
* Contributors: Alexander Tiderko
```
