### PR TITLE
moveit_core: 0.6.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2910,7 +2910,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_core-release.git
-      version: 0.6.11-0
+      version: 0.6.12-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_core` to `0.6.12-0`:
- upstream repository: https://github.com/ros-planning/moveit_core.git
- release repository: https://github.com/ros-gbp/moveit_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.6.11-0`
## moveit_core

```
* Merge pull request #214 <https://github.com/ros-planning/moveit_core/issues/214> from mikeferguson/collision_plugin
  moveit_core components of collision plugins
* Merge pull request #210 <https://github.com/ros-planning/moveit_core/issues/210> from davetcoleman/debug_model
  Fix truncated debug message
* Fixed a number of tests, all are now passing on buildfarm
* Merge pull request #208 <https://github.com/ros-planning/moveit_core/issues/208> from mikeferguson/update_fcl_api
  update to use non-deprecated call
* Contributors: Dave Coleman, Ioan A Sucan, Michael Ferguson
```
