### PR TITLE
moveit_ros: 0.6.3-0 in 'indigo/distribution.yaml'[manual]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3022,7 +3022,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_ros.git


### PR DESCRIPTION
Bloom failed with

```
This generated pull request modifies a repository entry other than the one being released.
This likely occurred because the upstream rosdistro changed during this release.
This pull request will abort, please re-run this command with the -p option to try again.
```

running with -p option then fails with:

```
==> Generating pull request to distro file located at 'https://raw.github.com/ros/rosdistro/master/indigo/distribution.yaml'
This release resulted in no changes to the ROS distro file...
The release of your packages was successful, but the pull request failed.
Please manually open a pull request by editing the file here: 'https://raw.github.com/ros/rosdistro/master/indigo/distribution.yaml'
<== No pull request opened.
```
