### PR TITLE
moveit_ros: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3022,7 +3022,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ros` to `0.6.3-0`:
- upstream repository: https://github.com/ros-planning/moveit_ros.git
- release repository: https://github.com/ros-gbp/moveit_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.6.2-0`
## moveit_ros
- No changes
## moveit_ros_benchmarks

```
* Add missing include of scoped_ptr
* Contributors: v4hn
```
## moveit_ros_benchmarks_gui
- No changes
## moveit_ros_manipulation

```
* trivial fixes for warnings
* use named logging for manipulation components
* Contributors: Michael Ferguson
```
## moveit_ros_move_group
- No changes
## moveit_ros_perception

```
* port #445 <https://github.com/ros-planning/moveit_ros/issues/445> to indigo
* disable test that needs display when no display defined
* GL_TYPE() is a function in newer versions of OpenGL, this fixes tests on Ubuntu 14.04
* Contributors: Michael Ferguson
```
## moveit_ros_planning

```
* add plugin interface for collision detectors
* fix missing return value
* trivial fixes for warnings
* Contributors: Michael Ferguson
```
## moveit_ros_planning_interface

```
* include correct boost::*_ptr class for boost 1.57.
* Contributors: v4hn
```
## moveit_ros_robot_interaction
- No changes
## moveit_ros_visualization

```
* fix duplicate planning attempt box, also fix warning about name
* Contributors: Michael Ferguson
```
## moveit_ros_warehouse
- No changes
