### PR TITLE
rail_ceiling: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4169,7 +4169,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_ceiling-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_ceiling.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_ceiling` to `0.0.3-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_ceiling.git
- release repository: https://github.com/wpi-rail-release/rail_ceiling-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.2-0`
## rail_ceiling

```
* old YAML syntax fix 2
* syntax fix for old YAML versions
* Merge branch 'develop' of github.com:WPI-RAIL/rail_ceiling into develop
* Added support for previous YAML versions, removed unused bundles
* Update .travis.yml
* Merge branch 'develop' of github.com:WPI-RAIL/rail_ceiling into develop
* corrected the ratio for the slerp averaging; it was originally backwards
* Contributors: David Kent, Russell Toris
```
