### PR TITLE
carl_safety: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -537,7 +537,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_safety-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_safety.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_safety` to `0.0.2-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_safety.git
- release repository: https://github.com/wpi-rail-release/carl_safety-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.1-0`
## carl_safety

```
* Changed int param to bool
* Parameter, topic, and launch file cleanup for consistency
* Merge pull request #2 <https://github.com/WPI-RAIL/carl_safety/issues/2> from bhetherman/develop
  changes to make teleop safety and arm noise able to toggle on and off with launch paramater
* changes to make teleop safety and arm noise able to toggle on and off with launch paramater
* Update .travis.yml
* Update package.xml
* merged
* Added dependency on wpi_jaco_msgs for safe nav
* Implemented /move_base_safe to retract the arm before navigation
* Contributors: Brian Hetherman, David Kent, Russell Toris
```
