### PR TITLE
pr2_calibration: 1.0.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5207,7 +5207,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_calibration-release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/PR2/pr2_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_calibration` to `1.0.6-0`:
- upstream repository: https://github.com/PR2/pr2_calibration.git
- release repository: https://github.com/TheDash/pr2_calibration-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `1.0.5-0`
## dense_laser_assembler

```
* Changelogs
* Contributors: TheDash
```
## laser_joint_processor

```
* Changelogs
* Revert "Fix dependency of laser_joint_processor"
* Fix dependency of laser_joint_processor
* Contributors: Devon Ash, Ryohei Ueda, TheDash
```
## laser_joint_projector

```
* Changelogs
* Contributors: TheDash
```
## pr2_calibration

```
* Changelogs
* Contributors: TheDash
```
## pr2_calibration_launch

```
* Changelogs
* Fix PR2 calibration by using hacked version of urdf_parser_py by
  overwriting PYTHONPATH in the shell scripts.
* Contributors: Ryohei Ueda, TheDash
```
## pr2_dense_laser_snapshotter

```
* Changelogs
* Contributors: TheDash
```
## pr2_se_calibration_launch

```
* Changelogs
* Contributors: TheDash
```
