### PR TITLE
yujin_ocs: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6776,9 +6776,6 @@ repositories:
       version: indigo
     release:
       packages:
-      - yocs_ar_marker_tracking
-      - yocs_ar_pair_approach
-      - yocs_ar_pair_tracking
       - yocs_cmd_vel_mux
       - yocs_controllers
       - yocs_diff_drive_pose_controller
@@ -6789,13 +6786,12 @@ repositories:
       - yocs_safety_controller
       - yocs_velocity_smoother
       - yocs_virtual_sensor
-      - yocs_waypoint_provider
       - yocs_waypoints_navi
       - yujin_ocs
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/yujin_ocs-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/yujinrobot/yujin_ocs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yujin_ocs` to `0.6.3-0`:
- upstream repository: https://github.com/yujinrobot/yujin_ocs.git
- release repository: https://github.com/yujinrobot-release/yujin_ocs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.6.2-0`
## yocs_cmd_vel_mux
- No changes
## yocs_controllers
- No changes
## yocs_diff_drive_pose_controller
- No changes
## yocs_joyop
- No changes
## yocs_keyop
- No changes
## yocs_math_toolkit
- No changes
## yocs_rapps
- No changes
## yocs_safety_controller
- No changes
## yocs_velocity_smoother
- No changes
## yocs_virtual_sensor
- No changes
## yocs_waypoints_navi

```
* Use header frame instead of world_frame for goal
* Contributors: AlexReimann
```
## yujin_ocs
- No changes
