### PR TITLE
perception_oru: 1.0.27-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5055,7 +5055,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tstoyanov/perception_oru-release.git
-      version: 1.0.26-0
+      version: 1.0.27-0
     source:
       type: git
       url: https://github.com/tstoyanov/perception_oru-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_oru` to `1.0.27-0`:
- upstream repository: /home/tsv/code/workspace-hydro/src/perception_oru
- release repository: https://github.com/tstoyanov/perception_oru-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.26-0`
## ndt_costmap
- No changes
## ndt_feature_reg

```
* fixes to package.xml files
* Contributors: Todor Stoyanov
```
## ndt_fuser
- No changes
## ndt_map
- No changes
## ndt_map_builder
- No changes
## ndt_mcl
- No changes
## ndt_registration
- No changes
## ndt_rviz_visualisation
- No changes
## ndt_visualisation

```
* fixes to package.xml files
* Contributors: Todor Stoyanov
```
## perception_oru
- No changes
## sdf_tracker
- No changes
