### PR TITLE
rosbridge_suite: 0.7.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5019,10 +5019,11 @@ repositories:
       - rosbridge_library
       - rosbridge_server
       - rosbridge_suite
+      - rosbridge_tools
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.7.0-0
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.7.1-0`:
- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.7.0-0`
## rosapi
- No changes
## rosbridge_library
- No changes
## rosbridge_server

```
* Merge pull request #147 <https://github.com/RobotWebTools/rosbridge_suite/issues/147> from RobotWebTools/migrate_third_parties
  separate tornado and backports from rosbridge_server
* seprate out third party library and ros related script
* remove setup.py
* add rosbridge_tools as rosbridge_server dependency
* remove python-imaging dependency. it is used in rosbridge_library
* Contributors: Jihoon Lee, Russell Toris
```
## rosbridge_suite
- No changes
## rosbridge_tools

```
* seprate out third party library and ros related script
* Contributors: Jihoon Lee
```
