### PR TITLE
icart_mini: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1915,7 +1915,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/open-rdc/icart_mini-release.git
-      version: 0.0.3-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/open-rdc/icart_mini.git


### PR DESCRIPTION
Increasing version of package(s) in repository `icart_mini` to `0.0.5-0`:
- upstream repository: https://github.com/open-rdc/icart_mini.git
- release repository: https://github.com/open-rdc/icart_mini-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.3-0`
