### PR TITLE
jsk_common: 1.0.55-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2944,7 +2944,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.54-0
+      version: 1.0.55-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.55-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.54-0`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## collada_urdf_jsk_patch

```
* fix compiling jsk_ros_patch for indigo
* Contributors: Yohei Kakiuchi
```
## depth_image_proc_jsk_patch
- No changes
## downward

```
* fix downward copy directory
* Contributors: Yuki Furuta
```
## dynamic_tf_publisher

```
* import empty srv
* add pubish tf service
* Contributors: Yusuke Furuta
```
## ff
- No changes
## ffha
- No changes
## image_view2
- No changes
## image_view_jsk_patch
- No changes
## jsk_common

```
* Add more dependency to jsk_common
* Contributors: Ryohei Ueda
```
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs

```
* delete Imu and DeviceSensorAll msgs
* Contributors: Yuto Inagaki
```
## jsk_hark_msgs
- No changes
## jsk_network_tools

```
* fix msg error in heartbeat
* add description
* add parameter to set hz
* Contributors: Yusuke Furuta
```
## jsk_tilt_laser

```
* Added parameter configuration for fps and spindle_speed of multisense and fixed urdf name
* Contributors: Terasawa
```
## jsk_tools

```
* Add document about roscore_regardless.py
* Check master is reachable before chcking master is alive
* Merge pull request #613 <https://github.com/jsk-ros-pkg/jsk_common/issues/613> from k-okada/show_ip
  show ROS_IP in prompt
* Merge pull request #612 <https://github.com/jsk-ros-pkg/jsk_common/issues/612> from k-okada/rename_rossetrobot
  rename rossetrobot -> rossetmaster
* show ROS_IP in prompt
* rename rossetrobot -> rossetmaster, keep rossetrobot for backword compatibility
* add: zshrc.ros (Change emacs mode configuration: Shell-script -> shell-script)
* add: zshrc.ros
* fix prompt when rossetlocal is called.
* Contributors: Kei Okada, Kentaro Wada, Masaki Murooka, Ryohei Ueda
```
## jsk_topic_tools

```
* added topic_buffer_periodic_test.launch and added argument to topic_buffer_client/server_sample.launch
* add mutex lock in callback and thread function
* enable to select periodic mode from server param
* enable to select periodic mode from server param
* send request periodic publish from client when rosparam is set
* add update periodically function
* Contributors: Yuki Furuta, Masaki Murooka
```
## laser_filters_jsk_patch
- No changes
## libsiftfast
- No changes
## mini_maxwell

```
* add install macro
* add mini maxwell scripts instead of downloading them
* Contributors: Yusuke Furuta
```
## multi_map_server
- No changes
## nlopt
- No changes
## openni_tracker_jsk_patch
- No changes
## opt_camera
- No changes
## posedetection_msgs
- No changes
## pr2_groovy_patches

```
* remove safe_teleop_base.patcj
* Contributors: Yuto Inagaki
```
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## sklearn
- No changes
## speech_recognition_msgs
- No changes
## virtual_force_publisher

```
* fix a mistack of transformation
* add launch file for virtual_force_publisher
* use pseudo-inv-jacobian to calc forces, add low pass filter ,use tf to transform forces to if proper coords
* Contributors: Chi Wun Au
```
## voice_text
- No changes
