### PR TITLE
Adding innok_heros_lights to documenation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2000,6 +2000,15 @@ repositories:
       url: https://github.com/ros-perception/imu_pipeline.git
       version: indigo-devel
     status: maintained
+  innok_heros_lights:
+    doc:
+      type: git
+      url: https://github.com/innokrobotics/innok_heros_lights.git
+      version: indigo
+    source:
+      type: git
+      url: https://github.com/innokrobotics/innok_heros_lights.git
+      version: indigo
   interaction_cursor_3d:
     release:
       packages:


### PR DESCRIPTION
I'd like innok_heros_lights to be indexed and documented on ros.org.
