### PR TITLE
innok_heros_lights: 1.0.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2005,10 +2005,16 @@ repositories:
       type: git
       url: https://github.com/innokrobotics/innok_heros_lights.git
       version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/innokrobotics/innok_heros_lights-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/innokrobotics/innok_heros_lights.git
       version: indigo
+    status: maintained
   interaction_cursor_3d:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `innok_heros_lights` to `1.0.0-1`:
- upstream repository: https://github.com/innokrobotics/innok_heros_lights.git
- release repository: https://github.com/innokrobotics/innok_heros_lights-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `null`
## innok_heros_lights

```
* first version tested on hardware
* Initial commit
* Contributors: Alwin Heerklotz
```
