### PR TITLE
moveit_ros: 0.5.20-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3974,7 +3974,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.5.19-0
+      version: 0.5.20-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ros` to `0.5.20-0`:
- upstream repository: https://github.com/ros-planning/moveit_ros.git
- release repository: https://github.com/ros-gbp/moveit_ros-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.5.19-0`
## moveit_ros
- No changes
## moveit_ros_benchmarks

```
* Removed PlanningContext clear before planning call
* Contributors: arjungm
```
## moveit_ros_benchmarks_gui
- No changes
## moveit_ros_manipulation

```
* Fix bug in place-planning where attached object was not considered in plan.
* Contributors: Dave Hershberger
```
## moveit_ros_move_group
- No changes
## moveit_ros_perception

```
* Adding missing moveit_occupancy_map_monitor linkage to depth_image_octomap_updater
* Fixed issue with unordered_map and libc++ (LLVM, Mac OS X Mavericks)
* Fixing OpenGL gl.h and glu.h inclusion on Mac OS X
* Bugfix: deadlock race condition in MeshFilterBase, issue #444 <https://github.com/ros-planning/moveit_ros/issues/444>
* Contributors: Ioan A Sucan, Marco Esposito, Tobias Fromm
```
## moveit_ros_planning

```
* Made loading octomap_monitor optional in planning_scene_monitor when using WorldGeometryMonitor
* remove leading '/' from DEFAULT_PLANNING_SCENE_SERVICE; otherwise planning_scene_rviz_plugin fails with 'Failed to call service /get_planning_scene ...' if move_group is in a namespace different from '/'
* Made loading octomap_monitor optional in planning_scene_monitor when using WorldGeometryMonitor
* service must have access to global namespace
* Added capability to set max_planning_attempts in GUI. Parallel planner now plans until either
  the planning_time is reached or until max_planning_attempts are successfull.
* Contributors: Chris Lewis, Dave Coleman, Sachin Chitta, ahb
```
## moveit_ros_planning_interface

```
* Fix spurious warning ("execution should start at current state")
* Add missing variants of place (PlaceLocation, place anywhere) for python interface
* Python wrapper for getEndEffectorTips()
* returning int values
* Contributors: Dave Coleman, Martin Günther, corot
```
## moveit_ros_robot_interaction

```
* Add joystick interface.
* Contributors: Ryohei Ueda, Sachin Chitta
```
## moveit_ros_visualization

```
* Removed installation of removed file
* Better user output, kinematic solver error handling, disclaimer
* Add joystick interface.
* motion_planning_rviz_plugin: add move_group namespace option
* Added capability to set max_planning_attempts in GUI.
* Contributors: Chris Lewis, Dave Coleman, Ioan A Sucan, Jonathan Bohren, Ryohei Ueda, Sachin Chitta
```
## moveit_ros_warehouse
- No changes
