### PR TITLE
iai_common_msgs: 0.0.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1885,16 +1885,19 @@ repositories:
       - grasp_stability_msgs
       - iai_common_msgs
       - iai_content_msgs
+      - iai_control_msgs
       - iai_kinematics_msgs
       - iai_robosherlock_actions
+      - iai_urdf_msgs
       - mln_robosherlock_msgs
+      - person_msgs
       - saphari_msgs
       - scanning_table_msgs
       - sherlock_sim_msgs
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/code-iai-release/iai_common_msgs-release.git
-      version: 0.0.3-0
+      version: 0.0.3-1
     status: developed
   icart_mini:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `iai_common_msgs` to `0.0.3-1`:
- upstream repository: https://github.com/code-iai/iai_common_msgs.git
- release repository: https://github.com/code-iai-release/iai_common_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.0.3-0`
## data_vis_msgs

```
* Added datatype for timeline diagrams (Gantt-Style)
* Contributors: Moritz Tenorth
```
## designator_integration_msgs
- No changes
## dna_extraction_msgs
- No changes
## grasp_stability_msgs
- No changes
## iai_common_msgs

```
* Renamed iai_pancake_perception_action into iai_robosherlock_actions.
* Contributors: Georg Bartels
```
## iai_content_msgs
- No changes
## iai_control_msgs
- No changes
## iai_kinematics_msgs
- No changes
## iai_robosherlock_actions

```
* changed RS action interface to use designator msgs
* Updated changelog of iai_robosherlock_actions.
* Deleted action-definition DetectPancake
* Added action-definition SimplePerceiveObject.
* Renamed iai_pancake_perception_action into iai_robosherlock_actions.
* Contributors: Ferenc Balint-Benczedi, Georg Bartels
```
## iai_urdf_msgs
- No changes
## mln_robosherlock_msgs
- No changes
## person_msgs
- No changes
## saphari_msgs

```
* added constants
* added a message that contains a list equipment messages.
  service will now return that new message instead of a list of equipment messages.
* Contributors: Thiemo Wiedemeyer
```
## scanning_table_msgs
- No changes
## sherlock_sim_msgs
- No changes
