### PR TITLE
people: 1.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3993,6 +3993,18 @@ repositories:
       type: git
       url: https://github.com/wg-perception/people.git
       version: indigo-devel
+    release:
+      packages:
+      - face_detector
+      - leg_detector
+      - people
+      - people_msgs
+      - people_tracking_filter
+      - people_velocity_tracker
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/OSUrobotics/people-release.git
+      version: 1.0.8-0
     source:
       type: git
       url: https://github.com/wg-perception/people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `people` to `1.0.8-0`:
- upstream repository: https://github.com/wg-perception/people.git
- release repository: https://github.com/OSUrobotics/people-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `null`
## face_detector

```
* cleanup formatting with astyle (supersedes #18 <https://github.com/wg-perception/people/issues/18>)
* centrally reference cascade from standalone opencv (addresses #15 <https://github.com/wg-perception/people/issues/15>)
* Contributors: Dan Lazewatsky
```
## leg_detector

```
* cleanup formatting with astyle (supersedes #18 <https://github.com/wg-perception/people/issues/18>)
* Contributors: Dan Lazewatsky
```
## people

```
* moved social_navigation_layers from metapackage
* Contributors: Dan Lazewatsky
```
## people_msgs
- No changes
## people_tracking_filter

```
* cleanup formatting with astyle (supersedes #18 <https://github.com/wg-perception/people/issues/18>)
* Contributors: Dan Lazewatsky
```
## people_velocity_tracker
- No changes
