### PR TITLE
navigation_layers: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3416,10 +3416,11 @@ repositories:
       packages:
       - navigation_layers
       - range_sensor_layer
+      - social_navigation_layers
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wu-robotics/navigation_layers_release.git
-      version: 0.2.1-1
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/DLu/navigation_layers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_layers` to `0.3.0-0`:
- upstream repository: https://github.com/DLu/navigation_layers.git
- release repository: https://github.com/wu-robotics/navigation_layers_release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.2.1-1`
