### PR TITLE
sbpl: 1.2.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5628,6 +5628,13 @@ repositories:
       url: https://github.com/davetcoleman/rviz_visual_tools.git
       version: indigo-devel
     status: developed
+  sbpl:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/sbpl-release.git
+      version: 1.2.0-1
+    status: maintained
   schunk_modular_robotics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbpl` to `1.2.0-1`:
- upstream repository: https://github.com/sbpl/sbpl
- release repository: https://github.com/ros-gbp/sbpl-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `null`
