### PR TITLE
read_omni_dataset: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5918,6 +5918,17 @@ repositories:
       url: https://bitbucket.org/rbdl/rbdl
       version: default
     status: developed
+  read_omni_dataset:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/aamirahmad/read_omni_dataset-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/aamirahmad/read_omni_dataset.git
+      version: master
+    status: developed
   realtime_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `read_omni_dataset` to `0.0.2-0`:
- upstream repository: https://github.com/aamirahmad/read_omni_dataset.git
- release repository: https://github.com/aamirahmad/read_omni_dataset-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `null`
## read_omni_dataset
- No changes
