### PR TITLE
tf2_web_republisher: 0.3.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8049,7 +8049,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/tf2_web_republisher-release.git
-      version: 0.2.2-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/RobotWebTools/tf2_web_republisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_web_republisher` to `0.3.0-0`:
- upstream repository: https://github.com/RobotWebTools/tf2_web_republisher.git
- release repository: https://github.com/RobotWebTools-release/tf2_web_republisher-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.2.2-0`
## tf2_web_republisher

```
* Merge pull request #16 from T045T/tf2_republisher_service
  Tf2 republisher service
* add back action server functionality
* modularize code that can be used by both the action and service implementation
* remove test folder
* change terminology to reflect the fact that this is now a service, rather than an Action server
  also remove some high-frequency debug output
* change TFArray member name from data to transforms
* change tf2_web_republisher to use a service and dynamically advertised topics instead of an action call
  TODO: testing
* consistent 2 space indentation
* Contributors: Nils Berg, Russell Toris
```
