### PR TITLE
applanix_driver: 0.0.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -160,7 +160,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/applanix_driver-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/applanix_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `applanix_driver` to `0.0.6-0`:
- upstream repository: https://github.com/clearpathrobotics/applanix_driver.git
- release repository: https://github.com/clearpath-gbp/applanix_driver-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.5-0`
## applanix_bridge

```
* Gams param max_heading_error_rms has to be assigned to 3.0 degrees default and cannot be zero.
* Contributors: Vaibhav Kumar Mehta
```
## applanix_driver
- No changes
## applanix_msgs
- No changes
