### PR TITLE
Adding o3d3xx to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3546,6 +3546,11 @@ repositories:
       url: https://github.com/vooon/ntpd_driver.git
       version: master
     status: developed
+  o3d3xx:
+    doc:
+      type: git
+      url: https://github.com/lovepark/o3d3xx-ros.git
+      version: master
   object_recognition_capture:
     release:
       tags:


### PR DESCRIPTION
I'd like to add my `o3d3xx'  repository to be indexed and documented on ros.org
