### PR TITLE
ueye_cam: 1.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8298,7 +8298,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/anqixu/ueye_cam-release.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/anqixu/ueye_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `1.0.5-0`:
- upstream repository: https://github.com/anqixu/ueye_cam.git
- release repository: https://github.com/anqixu/ueye_cam-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `1.0.4-0`
## ueye_cam

```
* fixed/improved unofficial driver install; added warning messages during compile- & run-time to note that unofficially-installed drivers will allow ueye_cam to be compiled, but will not detect any cameras during runtime (since IDS camera daemon is not packaged in unofficial driver download)
* Contributors: Anqi Xu
```
