### PR TITLE
kobuki_soft: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2411,7 +2411,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki_soft-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_soft.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_soft` to `0.1.1-0`:
- upstream repository: https://github.com/yujinrobot/kobuki_soft
- release repository: https://github.com/yujinrobot-release/kobuki_soft-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.1.0-0`
## kobuki_soft
- No changes
## kobuki_softapps

```
* add delta params close #1 <https://github.com/yujinrobot/kobuki_soft/issues/1>
* Contributors: Jihoon Lee
```
## kobuki_softnode
- No changes
