### PR TITLE
librms: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3486,7 +3486,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/wpi-rail-release/librms-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/librms.git


### PR DESCRIPTION
Increasing version of package(s) in repository `librms` to `0.0.2-0`:
- upstream repository: https://github.com/WPI-RAIL/librms.git
- release repository: https://github.com/wpi-rail-release/librms-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.0.1-0`
## librms

```
* fix for header installs
* Contributors: Russell Toris
```
