### PR TITLE
interactive_world: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2837,6 +2837,27 @@ repositories:
       url: https://github.com/ros-gbp/interactive_markers-release.git
       version: 1.10.2-0
     status: maintained
+  interactive_world:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/interactive_world.git
+      version: master
+    release:
+      packages:
+      - interactive_world
+      - interactive_world_msgs
+      - interactive_world_parser
+      - interactive_world_tools
+      - jinteractiveworld
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/wpi-rail-release/interactive_world-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/interactive_world.git
+      version: develop
+    status: maintained
   ipa_canopen:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_world` to `0.0.1-0`:
- upstream repository: https://github.com/WPI-RAIL/interactive_world.git
- release repository: https://github.com/wpi-rail-release/interactive_world-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `null`
## interactive_world

```
* travis fix
* changelog updated
* load models added
* first pass of new parser
* Contributors: Russell Toris
```
## interactive_world_msgs

```
* travis fix
* changelog updated
* load models added
* connection made using JDBC
* removed old stuff
* data sent to jinteractiveworld
* parser builds msg files
* 0.2.0 jrosbridge used
* first pass of new parser
* Contributors: Russell Toris
```
## interactive_world_parser

```
* travis fix
* changelog updated
* fixed launch install
* load models added
* connection made using JDBC
* first working pipeline or learning
* data sent to jinteractiveworld
* parser builds msg files
* launch file started
* parse and save now service calls
* first pass of new parser
* Contributors: Russell Toris
```
## interactive_world_tools

```
* travis fix
* changelog updated
* load models added
* Contributors: Russell Toris
```
## jinteractiveworld

```
* travis fix
* changelog updated
* load models added
* creates table
* connection made using JDBC
* sigma values addeD
* first working pipeline or learning
* removed old stuff
* data sent to jinteractiveworld
* launch file started
* 0.2.0 jrosbridge used
* small typo
* learner node script added
* catkin builds project now
* import of jinteractiveworld
* Contributors: Russell Toris
```
