### PR TITLE
cob_gazebo_plugins: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -741,6 +741,24 @@ repositories:
       url: https://github.com/ipa320/cob_extern.git
       version: indigo_dev
     status: maintained
+  cob_gazebo_plugins:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_gazebo_plugins.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_gazebo_plugins
+      - cob_gazebo_ros_control
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/cob_gazebo_plugins-release.git
+      version: 0.6.1-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_gazebo_plugins.git
+      version: indigo_dev
+    status: maintained
   cob_manipulation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_gazebo_plugins` to `0.6.1-0`:
- upstream repository: https://github.com/ipa320/cob_gazebo_plugins.git
- release repository: https://github.com/ipa320/cob_gazebo_plugins-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `null`
## cob_gazebo_plugins

```
* new gazebo_ros_control_plugin supporting multiple hardwareinterfaces and switch on controller_switching
* Contributors: ipa-fxm
```
## cob_gazebo_ros_control

```
* Update README.md
* Update README.md
* Update README.md
* Update README.md
* Update README.md
* enable joint filtering for multi_hwi_gazebo plugin
* remove support for X_PID control_methods for simplicity (obsolete anyway)
* unify ROS STREAM output
* ignore 'robotSimType'
* Update README.md
* Update README.md
* add README for new plugin
* correctly reset all interfaces in doSwitchHWInterface
* new gazebo_ros_control_plugin supporting multiple hardwareinterfaces and switch on controller_switching
* Contributors: Felix Messmer, ipa-fxm
```
