### PR TITLE
jackal: 0.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2185,10 +2185,11 @@ repositories:
       - jackal_description
       - jackal_diff_drive_controller
       - jackal_msgs
+      - jackal_navigation
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.3.0-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.4.0-0`:
- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.3.0-0`
## jackal_control

```
* added joystick argumant.
* Adding imu0_differential setting (=true) to control.yaml
* Add dep for joint state controller.
* Contributors: Mike Purvis, Shokoofeh Pourmehr, Tom Moore
```
## jackal_description

```
* add pointgrey camera
* Removed inertial and geometry of the base_link.
* hector gazebo plugin for gps is added.
* hector gazebo plugin for imu sensor is added
* Contributors: Mike Purvis, spourmehr
```
## jackal_diff_drive_controller
- No changes
## jackal_msgs

```
* Add hardware string to Status message.
* Contributors: Mike Purvis
```
## jackal_navigation

```
* Removed redundant local and global costmaps.
* Fixed location of non-demo launch files in roslaunch-file-check in CMakeList
* Moved rviz configurations to jackal_viz.
* Changed config/ to params/. Moved non-demo launch files to launch/include.
* Added gps_transform.launch for transforming GPS data to robot's world frame. Also added gps_integration_demo.launch for fusing GPS data with odomtery data. This node generates map->odom transform.
* Modified AMCL's parameters, map and demo for Jackal.
* Modified slam_gmapping parameters for Jackal for building a map.
* Modified costmap and base planner parameters for the navigation without map with obstacle avoidance using laser scanner.
* Contributors: Mike Purvis, Shokoofeh Pourmehr
```
