### PR TITLE
multimaster_fkie: 0.3.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3206,7 +3206,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.3.15-0
+      version: 0.3.16-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.3.16-0`:
- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.3.15-0`
## default_cfg_fkie
- No changes
## master_discovery_fkie
- No changes
## master_sync_fkie
- No changes
## multimaster_fkie
- No changes
## multimaster_msgs_fkie
- No changes
## node_manager_fkie

```
* node_manager_fkie: fixed a problem with screen view
  The node_manager uses the /usr/bin/x-terminal-emulator to show the
  screen content of the nodes. To execute a command with arguments
  'konsole', 'xterm' uses -e, 'terminator', 'gnome-terminal' or
  'xfce4-terminal'use '-x'.
* Contributors: Alexander Tiderko
```
