### PR TITLE
roswww: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5401,6 +5401,21 @@ repositories:
       url: https://github.com/ros-drivers/rosserial.git
       version: indigo-devel
     status: maintained
+  roswww:
+    doc:
+      type: git
+      url: https://github.com/tork-a/roswww.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/roswww-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/tork-a/roswww.git
+      version: hydro-devel
+    status: developed
   rqt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roswww` to `0.1.2-0`:
- upstream repository: https://github.com/tork-a/roswww.git
- release repository: https://github.com/tork-a/roswww-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `null`
## roswww

```
* Re-release into ROS (addresses #1 <https://github.com/tork-a/roswww/issues/3>)
* Remove tornado (this dependency is supposed to be taken from rosbridge). Move webserver.py to src folder to follow more common python style (fix #1 <https://github.com/tork-a/roswww/issues/1>)
* Add dependency on rosbridge, webserver.py installation.
* Remove roswww_pkg metapkg and roswww_pack that doesn't seem to be used. Remove redundant hierarchy.
* Code cleaning, conform to PEP8, refactor method names. Add docroot.
* Contributors: Isaac IY Saito
```
