### PR TITLE
Fedora 21 support

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4,6 +4,7 @@
 ---
 release_platforms:
   fedora:
+  - '21'
   - heisenbug
   ubuntu:
   - saucy

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -903,6 +903,7 @@ joystick:
   arch: [linuxconsole]
   debian: [joystick]
   fedora:
+    '21': [linuxconsoletools]
     beefy: [joystick]
     heisenbug: [linuxconsoletools]
     schrödinger’s: [linuxconsoletools]
@@ -1414,6 +1415,7 @@ libmysqlclient-dev:
   arch: [mariadb]
   debian: [libmysqlclient-dev]
   fedora:
+    '21': [mariadb]
     beefy: [mysql]
     heisenbug: [mariadb]
     schrödinger’s: [mariadb]
@@ -2013,6 +2015,7 @@ libusb-1.0:
   arch: [libusbx]
   debian: [libusb-1.0-0]
   fedora:
+    '21': [libusbx]
     beefy: [libusb1]
     heisenbug: [libusbx]
     schrödinger’s: [libusbx]
@@ -2024,6 +2027,7 @@ libusb-1.0-dev:
   arch: [libusbx]
   debian: [libusb-1.0-0-dev]
   fedora:
+    '21': [libusbx-devel]
     beefy: [libusb1-devel]
     heisenbug: [libusbx-devel]
     schrödinger’s: [libusbx-devel]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -356,6 +356,7 @@ python-espeak:
     trusty_python3: [python3-espeak]
 python-flake8:
   fedora:
+    '21': [python-flake8]
     heisenbug: [python-flake8]
   ubuntu:
     trusty: [python-flake8]
@@ -450,6 +451,7 @@ python-imaging:
   arch: [python2-pillow]
   debian: [python-imaging]
   fedora:
+    '21': [python-pillow, python-pillow-qt]
     beefy: [python-imaging]
     heisenbug: [python-pillow, python-pillow-qt]
     schrödinger’s: [python-pillow, python-pillow-qt]


### PR DESCRIPTION
As a note, `rosdep` requires that the OS version number be a string (similar to the way Bloom does [1]). All of Fedora 21+ will be indexed in this way, as there are no longer codenames for each release [2].

Unfortunately, Fedora 21 shipped with `rosdep` 0.10.32, and won't function correctly with anything less than 0.10.33. An update to Fedora 21 is currently pushing to stable to introduce 0.10.33 [3].

If anyone has `rosdep` resolution errors citing a missing `rosdep` key for os version "Twenty", please update to `rosdep` 0.10.33 to resolve the problem.

As with Fedora 20 support in the distribution.yaml, I will use workaround repos for those packages which have not generated a `.spec` for f21.

Thanks,

--scott

[1] https://github.com/ros/rosdistro/issues/6435#issuecomment-65871198
[2] https://github.com/ros-infrastructure/rosdep/pull/349
[3] https://admin.fedoraproject.org/updates/FEDORA-2014-16190/python-catkin_lint-1.3.8-1.fc21,python-rosdep-0.10.33-1.fc21,python-bloom-0.5.14-1.fc21,python-rosdistro-0.3.7-1.fc21
