### PR TITLE
rtabmap and rtabmap_ros: 0.8.0 in hydro/indigo

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7179,7 +7179,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.7.3-1
+      version: 0.8.0-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -7194,7 +7194,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.7.3-1
+      version: 0.8.0-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5553,7 +5553,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.7.3-0
+      version: 0.8.0-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -5568,7 +5568,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.7.3-0
+      version: 0.8.0-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repositories `rtabmap` and  `rtabmap_ros` to `0.8.0` both for Hydro and Indigo distributions.
- `rtabmap`
  - upstream repository: https://github.com/introlab/rtabmap.git
  - release repository: https://github.com/introlab/rtabmap-release.git
- `rtabmap_ros`
  - upstream repository: https://github.com/introlab/rtabmap_ros.git
  - release repository: https://github.com/introlab/rtabmap_ros-release.git
