### PR TITLE
Removes interactive_world form hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2837,27 +2837,6 @@ repositories:
       url: https://github.com/ros-gbp/interactive_markers-release.git
       version: 1.10.2-0
     status: maintained
-  interactive_world:
-    doc:
-      type: git
-      url: https://github.com/WPI-RAIL/interactive_world.git
-      version: master
-    release:
-      packages:
-      - interactive_world
-      - interactive_world_msgs
-      - interactive_world_parser
-      - interactive_world_tools
-      - jinteractiveworld
-      tags:
-        release: release/hydro/{package}/{version}
-      url: https://github.com/wpi-rail-release/interactive_world-release.git
-      version: 0.0.1-0
-    source:
-      type: git
-      url: https://github.com/WPI-RAIL/interactive_world.git
-      version: develop
-    status: maintained
   ipa_canopen:
     doc:
       type: git


### PR DESCRIPTION
Package developed on Indigo and originally thought it would be backwards compatible; turns out I was wrong! Removes package from distribution.yaml (package is not yet on public sync so minimal impact).
