### PR TITLE
rosbridge_suite: 0.7.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6596,10 +6596,11 @@ repositories:
       - rosbridge_library
       - rosbridge_server
       - rosbridge_suite
+      - rosbridge_tools
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.7.0-0
+      version: 0.7.2-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.7.2-0`:
- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.7.0-0`
## rosapi

```
* 0.7.1
* update changelog
* Contributors: Jihoon Lee
```
## rosbridge_library

```
* 0.7.1
* update changelog
* Contributors: Jihoon Lee
```
## rosbridge_server

```
* use alias to import rosbridge_tool tornado
* move modules under rosbridge_tools
* 0.7.1
* update changelog
* Merge pull request #147 from RobotWebTools/migrate_third_parties
  separate tornado and backports from rosbridge_server
* seprate out third party library and ros related script
* remove setup.py
* add rosbridge_tools as rosbridge_server dependency
* remove python-imaging dependency. it is used in rosbridge_library
* Contributors: Jihoon Lee, Russell Toris
```
## rosbridge_suite

```
* 0.7.1
* update changelog
* Contributors: Jihoon Lee
```
## rosbridge_tools

```
* alias rosbridge_tools.tornado as tornado
* move modules under rosbridge_tools
* 0.7.1
* update changelog
* seprate out third party library and ros related script
* Contributors: Jihoon Lee
```
