### PR TITLE
rosbridge_suite: 0.7.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5150,7 +5150,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.7.1-0
+      version: 0.7.3-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.7.3-0`:
- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.7.1-0`
## rosapi
- No changes
## rosbridge_library
- No changes
## rosbridge_server
- No changes
## rosbridge_suite
- No changes
## rosbridge_tools

```
* setup.py includes all packages (fixes catkin_make install)
* Contributors: Russell Toris
```
