### PR TITLE
cob_calibration_data: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -593,7 +593,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_calibration_data-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/ipa320/cob_calibration_data.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_calibration_data` to `0.6.1-0`:
- upstream repository: https://github.com/ipa320/cob_calibration_data.git
- release repository: https://github.com/ipa320/cob_calibration_data-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.6.0-0`
## cob_calibration_data

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* delete cob3-3
* Merge pull request #72 <https://github.com/ipa320/cob_calibration_data/issues/72> from ipa-fmw/indigo_dev
  cleanup: cob4-1 with torso and head; cob4-2 without torso and head
* cleanup: cob4-1 with torso and head; cob4-2 without torso and head
* Merge pull request #71 <https://github.com/ipa320/cob_calibration_data/issues/71> from ipa-nhg/cob3-9
  Cob3 9
* cob3-9
* cob3-9
* Merge pull request #70 <https://github.com/ipa320/cob_calibration_data/issues/70> from ipa-fmw/delete_unsupported_robots
  [indigo] Delete unsupported robots
* delete desire
* delete cob3-8
* delete cob3-7
* delete cob3-5
* delete cob3-4
* delete cob3-2
* delete cob3-1
* Merge pull request #2 <https://github.com/ipa320/cob_calibration_data/issues/2> from ipa320/indigo_dev
  Indigo dev
* Contributors: Florian Weisshardt, Nadia Hammoudeh García, ipa-nhg
```
