### PR TITLE
cob_common: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -634,12 +634,11 @@ repositories:
       - cob_description
       - cob_msgs
       - cob_srvs
-      - desire_description
       - raw_description
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.6.2-0`:
- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.6.1-0`
## brics_actuator
- No changes
## cob_common

```
* merge
* delete desire_description
* Contributors: Florian Weisshardt, ipa-fxm
```
## cob_description

```
* fix syntax
* added velocity and position controllers
* more output for urdf test
* static versions for torso and head
* set limit for sensorring
* prepare cob4 component descriptions for new structure
* new reduced stl collision meshes
* use VelocityJointInterface hardware interfaces for simulation of all bases
* Contributors: Florian Weisshardt, ipa-cob4-2, ipa-fmw, ipa-fxm, ipa-nhg
```
## cob_msgs

```
* add new msgs
* Contributors: ipa-nhg
```
## cob_srvs
- No changes
## raw_description

```
* use VelocityJointInterface hardware interfaces for simulation of all bases
* Contributors: ipa-fxm
```
