### PR TITLE
cob_driver: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -685,6 +685,7 @@ repositories:
       - cob_generic_can
       - cob_head_axis
       - cob_light
+      - cob_mimic
       - cob_phidgets
       - cob_relayboard
       - cob_sick_lms1xx
@@ -696,7 +697,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.6.2-0`:
- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.6.1-0`
## cob_base_drive_chain

```
* remove joint_states publisher for simulation - using JointStateController anyway
* Contributors: ipa-fxm
```
## cob_camera_sensors
- No changes
## cob_canopen_motor
- No changes
## cob_driver
- No changes
## cob_generic_can
- No changes
## cob_head_axis
- No changes
## cob_light

```
* fix warning message
* Merge pull request #188 <https://github.com/ipa320/cob_driver/issues/188> from ipa-bnm/feature/newCircleMode
  feature/new-circle-mode and bugfixes
* Merge branch 'feature/newCircleMode' of https://github.com/ipa-bnm/cob_driver into indigo_new_structure
* change default frequency and fix breath mode
* Merge branch 'indigo_dev' of https://github.com/ipa-nhg/cob_driver into ipa-nhg-indigo_dev
* added circle color mode test script
* fixed circle color mode
* implemented new circular mode
* defined 1Hz startup frecuency
* frequency corresponds to choosen mode
* fix
* removed debug output
* fixes to stagedriver and some refactoring
* write stageprofi colors for all dmx channels within one command
* cleanup
* queue messages
* added concurrent queue
* merge conflict
* typo fix
* Tested on cob4-2 for all modes
* Changes for the LED driver without led numbers
* Tested on cob4-2
* Temporary commit for tests
* CHanges for array of leds
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_driver into indigo_dev
  Conflicts:
  cob_light/ros/src/ms35.cpp
* Removed unecessary debug
* fix minor compiler warning
* new line at end of file
* Changes formatting
* Support for the StageProfi board on cob_light
* Contributors: Benjamin Maidel, Florian Weisshardt, bnm, ipa-cob4-2, ipa-fmw, ipa-fxm, ipa-nhg, thiagodefreitas
```
## cob_mimic

```
* new names for mimic
* use wallpaper instead of fullscreen
* add tired mimic
* delete outdated bored mimic and add default
* final faces
* new mimic files
* add action for mimic node
* new faces
* update mimic videos
* delete outdated gifs
* install tags
* new faces
* fixed circle color mode
* the rate can  be a float
* tested on cob4-2
* redo cob_mimic
* removed pygame dependency
* updated cob_mimic
* rewrite script using os.system
* new package cob_mimic - First Version
* Contributors: Florian Weisshardt, bnm, ipa-cob4-2, ipa-fmw, ipa-nhg
* new names for mimic
* use wallpaper instead of fullscreen
* add tired mimic
* delete outdated bored mimic and add default
* final faces
* new mimic files
* add action for mimic node
* new faces
* update mimic videos
* delete outdated gifs
* install tags
* new faces
* fixed circle color mode
* the rate can  be a float
* tested on cob4-2
* redo cob_mimic
* removed pygame dependency
* updated cob_mimic
* rewrite script using os.system
* new package cob_mimic - First Version
* Contributors: Florian Weisshardt, bnm, ipa-cob4-2, ipa-fmw, ipa-nhg
```
## cob_phidgets
- No changes
## cob_relayboard
- No changes
## cob_sick_lms1xx
- No changes
## cob_sick_s300
- No changes
## cob_sound

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* missed dependency
* missed dependency
* Contributors: Florian Weisshardt, ipa-cob4-2, ipa-nhg
```
## cob_undercarriage_ctrl
- No changes
## cob_utilities
- No changes
## cob_voltage_control

```
* fix install tag
* Tested on cob4-2
* make record current and voltage generic
* Contributors: ipa-cob4-2
```
