### PR TITLE
schunk_modular_robotics: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5738,11 +5738,12 @@ repositories:
       - schunk_modular_robotics
       - schunk_powercube_chain
       - schunk_sdh
+      - schunk_sdhx
       - schunk_simulated_tactile_sensors
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/schunk_modular_robotics-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ipa320/schunk_modular_robotics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_modular_robotics` to `0.6.2-0`:
- upstream repository: https://github.com/ipa320/schunk_modular_robotics.git
- release repository: https://github.com/ipa320/schunk_modular_robotics-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.6.1-0`
## schunk_description

```
* added velocity and position controllers
* unify all schunk urdfs
* type error
* defined real limits
* defined real limits
* extend limits for axis 1
* multiple hw-interfaces for lwa4p
* prepare lwa4p for VelocityInterface
* multiple hardwareinterface tags in transmission
* multiple hardwareinterface tags in transmission
* inertia go to hell
* new collision meshes
* improve model - velocity error <0.01
* add new collision meshes
* remove wrong mesh
* Contributors: Florian Weisshardt, ipa-cob4-2, ipa-fmw, ipa-fxm, ipa-nhg
```
## schunk_libm5api

```
* fix minor compiler warnings
* Contributors: ipa-fxm
```
## schunk_modular_robotics

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* sdhx tested
* Contributors: Florian Weisshardt, ipa-nhg
```
## schunk_powercube_chain

```
* add dependencies
* Contributors: ipa-fxm
```
## schunk_sdh
- No changes
## schunk_sdhx

```
* add install tag for recover scipt
* add recover for grippers
* Tries to accelerate the moving acknowledgment
* name space
* merged
* sdhx tested
* Removes log messages
* Stops movement after some seconds to avoid overheating and damage to the finger
* Contributors: ipa-cob4-2, ipa-fmw, ipa-nhg, thiagodefreitas
* add install tag for recover scipt
* add recover for grippers
* Tries to accelerate the moving acknowledgment
* name space
* merged
* sdhx tested
* Removes log messages
* Stops movement after some seconds to avoid overheating and damage to the finger
* Contributors: ipa-cob4-2, ipa-fmw, ipa-nhg, thiagodefreitas
```
## schunk_simulated_tactile_sensors
- No changes
