### PR TITLE
ros_canopen: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4857,6 +4857,29 @@ repositories:
       type: git
       url: https://github.com/hbrobotics/ros_arduino_bridge.git
       version: hydro-devel
+  ros_canopen:
+    doc:
+      type: git
+      url: https://github.com/ipa320/ros_canopen.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - canopen_402
+      - canopen_chain_node
+      - canopen_master
+      - canopen_motor_node
+      - canopen_test_utils
+      - ros_canopen
+      - socketcan_interface
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/ros_canopen-release.git
+      version: 0.6.1-0
+    source:
+      type: git
+      url: https://github.com/ipa320/ros_canopen.git
+      version: indigo_dev
+    status: maintained
   ros_comm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.6.1-0`:
- upstream repository: https://github.com/ipa320/ros_canopen.git
- release repository: https://github.com/ipa320/ros_canopen-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `null`
## canopen_402

```
* remove ipa_* and IPA_* prefixes
* added descriptions and authors
* renamed ipa_canopen_402 to canopen_402
* Contributors: Florian Weisshardt, Mathias Lüdtke
```
## canopen_chain_node

```
* remove ipa_* and IPA_* prefixes
* added descriptions and authors
* renamed ipa_canopen_chain_ros to canopen_chain_node
* Contributors: Florian Weisshardt, Mathias Lüdtke
```
## canopen_master

```
* remove ipa_* and IPA_* prefixes
* added descriptions and authors
* renamed ipa_canopen_master to canopen_master
* Contributors: Florian Weisshardt, Mathias Lüdtke
```
## canopen_motor_node

```
* remove ipa_* and IPA_* prefixes
* fixed catkin_lint errors
* added descriptions and authors
* renamed ipa_canopen_motor_control to canopen_motor_node
* Contributors: Florian Weisshardt, Mathias Lüdtke
```
## canopen_test_utils

```
* rename node
* remove ipa_* and IPA_* prefixes
* added descriptions and authors
* renamed ipa_canopen_test to canopen_test_utils
* Contributors: Florian Weisshardt, Mathias Lüdtke
```
## ros_canopen

```
* add metapackage
* Contributors: Florian Weisshardt
```
## socketcan_interface

```
* remove ipa_* and IPA_* prefixes
* fixed catkin_lint errors
* added descriptions and authors
* renamed ipa_can_interface to socketcaninterface
* Contributors: Florian Weisshardt, Mathias Lüdtke
```
