### PR TITLE
cob_control: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -659,13 +659,15 @@ repositories:
       - cob_frame_tracker
       - cob_hardware_interface
       - cob_lookat_controller
+      - cob_model_identifier
+      - cob_omni_drive_controller
       - cob_path_broadcaster
       - cob_trajectory_controller
       - cob_twist_controller
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.6.2-0`:
- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.6.1-0`
## cob_base_velocity_smoother
- No changes
## cob_collision_velocity_filter
- No changes
## cob_control
- No changes
## cob_control_mode_adapter

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* fix cppcheck errors
* set default timeout for switching back to JTC to 0.3sec
* uncommment non default controllers
* moved and fixed switch log message
* switched to enum instead of string
* mutex/locks for thread safety
* moved switch logic to update loop
* init timestamps to zero instead of current time, prevent timing problems at start-up
* Merge pull request #9 <https://github.com/ipa320/cob_control/issues/9> from thiagodefreitas/indigo_new_structure
  More detailed LOG information for the controllers switch
* More detailed LOG information for the controllers switch
* remove timeout and report with ROS_WARN
* Merge pull request #4 <https://github.com/ipa320/cob_control/issues/4> from ipa-fxm/indigo_new_structure
  update dependencies
* update dependencies
* Merge pull request #3 <https://github.com/ipa320/cob_control/issues/3> from ipa-fxm/indigo_new_structure
  Indigo new structure
* extend timeout
* adapt namespaces for cartesian_controller to new structure
* adapt control_mode_adapter to new structure
* merge_cm
* temporary commit
* publish to JointGroup controllers
* null-space syncMM
* cleanup, restructure and fix
* Contributors: Florian Weisshardt, Mathias Lüdtke, ipa-fmw, ipa-fxm, ipa-fxm-cm, thiagodefreitas
```
## cob_footprint_observer
- No changes
## cob_frame_tracker

```
* adapt namespaces for cartesian_controller to new structure
* merge_cm
* temporary commit
* changes in initialization
* temporarily revert to non-feedforward pid_controllers
* null-space syncMM
* Add PID for each translatorial Axes
* Add PID for each translatorial Axes
* Contributors: ipa-fxm, ipa-fxm-cm
```
## cob_hardware_interface

```
* fix cppcheck errors
* Contributors: Florian Weisshardt
```
## cob_lookat_controller

```
* adapt virtual lookat_driver to new datatypes
* Contributors: ipa-fxm
```
## cob_model_identifier

```
* fix cppcheck errors
* few more changes after testing new structure
* merge with fxm-cm
* cleaning up
* add dependencies
* more topic renaming according to new structure
* temporary commit
* fix install tag
* fix compiler warning
* cleanup, restructure and fix
* moved file
* fixed dependency
* merge with fxm
* fixes + latest changes
* add new package cob_model_identifier
* add new package cob_model_identifier
* Contributors: Florian Weisshardt, ipa-fxm, ipa-fxm-cm
* fix cppcheck errors
* few more changes after testing new structure
* merge with fxm-cm
* cleaning up
* add dependencies
* more topic renaming according to new structure
* temporary commit
* fix install tag
* fix compiler warning
* cleanup, restructure and fix
* moved file
* fixed dependency
* merge with fxm
* fixes + latest changes
* add new package cob_model_identifier
* add new package cob_model_identifier
* Contributors: Florian Weisshardt, ipa-fxm, ipa-fxm-cm
```
## cob_omni_drive_controller

```
* added plugin desctiption and install tags
* added plugins
* added GeomController Helper
* further dependencies
* added Boost dependency
* added OdometryTracker
* removed unused member
* added SI function to PlatformState
* added INI file parsing
* added reset to UndercarriageCtrlGeom/::Wheel
* restructured and optimised version
* simplified GetNewCtrlStateSteerDriveSetValues
* got rid of m_dCmdRotVelRadS
* refactored GetActualPltfVelocityVelocity
* downstripped version
* introduced resetController
* version without IniFile and MathSup
* original version of UndercarriageCtrlGeom
* Contributors: Mathias Lüdtke
* added plugin desctiption and install tags
* added plugins
* added GeomController Helper
* further dependencies
* added Boost dependency
* added OdometryTracker
* removed unused member
* added SI function to PlatformState
* added INI file parsing
* added reset to UndercarriageCtrlGeom/::Wheel
* restructured and optimised version
* simplified GetNewCtrlStateSteerDriveSetValues
* got rid of m_dCmdRotVelRadS
* refactored GetActualPltfVelocityVelocity
* downstripped version
* introduced resetController
* version without IniFile and MathSup
* original version of UndercarriageCtrlGeom
* Contributors: Mathias Lüdtke
```
## cob_path_broadcaster

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* few more changes after testing new structure
* cleaning up
* merge_cm
* temporary commit
* Cleaned up and fixed some functions
* Cleaned up and fixed some functions
* Contributors: Florian Weisshardt, ipa-fxm, ipa-fxm-cm
```
## cob_trajectory_controller

```
* fixed preemtion state in run method - trajectory eecution should be stopped if the action is in preemption state
* Contributors: Benjamin Maidel
```
## cob_twist_controller

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* fix twist_control dimensions for any-DoF
* merge with fxm-cm
* merge with fxm-fm
* cleaning up
* branch with features for merging
* topics according to new structure
* remove brics_actuator
* more topic renaming according to new structure
* renaming debug topic
* adapt namespaces for cartesian_controller to new structure
* dynamic reconfigure
* revision of cob_twist_controller
* merge_cm
* merge_fm
* temporary commit
* temporary commit
* changes in initialization
* restructure test_twist publisher scripts
* fix twist_controller to be usable without base again
* able to add base DoFs to Jacobian solver - first tests - needs more debugging
* null-space syncMM
* add test script for twist_stamped
* able to apply twists wrt to various coordinate system orientations
* cleanup, restructure and fix
* missing include
* merge with fxm-fm + clean up
* add twist publisher script
* add output publisher
* cleaning up
* beautify
* Add fixes provided by @ipa-fxm-fm
* fix controller and add damping
* add twist publisher script
* add output publisher
* Add fixes provided by @ipa-fxm-fm
* Contributors: Florian Weisshardt, ipa-fxm, ipa-fxm-cm, ipa-fxm-fm
```
