### PR TITLE
cob_robots: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -843,12 +843,11 @@ repositories:
       - cob_controller_configuration_gazebo
       - cob_default_robot_config
       - cob_hardware_config
-      - cob_monitoring
       - cob_robots
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.6.1-0`:
- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.6.0-0`
## cob_bringup

```
* merge
* rename canopen launch files and fix roslaunch test errors
* delete cob3-3
* cob3-9
* Update cob3-9.xml
* setup cob3-9
* comment mimic
* cob3-9
* add recover for grippers
* add light and sdhx to cob4-2
* add namespace for light launch file. needed for cob4-2
* default config for gripper_left
* config for gripper right
* add cob4 to tests
* Delete phidgets_monitor.launch
* Update base_solo.launch
* Update base_solo.launch
* Update teleop_v2.xml
* Update teleop_v1.xml
* Merge pull request #23 <https://github.com/ipa320/cob_robots/issues/23> from ipa-cob4-2/indigo_dev
  actual version cob4-2
* actual version cob4-2
* test raw3-3
* Update env.sh
* merge
* add robot arg to imageflip
* use teleop v1 and add light to bringup
* remove launch prefix
* Merge pull request #3 <https://github.com/ipa320/cob_robots/issues/3> from ipa-fmw/indigo_new_structure
  Indigo new structure
* update cob4-2 launch file
* updates on cob4-2
* add lookat components to cob4-2
* added temporary topic_relays for base - v1.5
* indigo_new_structure
* indigo_new_structure
* launch and yaml file base according to new structure
* adapt teleop to v2
* delete desire
* delete cob3-8
* delete cob3-7
* delete cob3-5
* delete cob3-4
* delete cob3-2
* delete cob3-1
* switch parameter namespaces due to BRIDE private nodehandle
* new ros_canopen driver version, adapted bringup configuration
* add parameter for max_X_velocity to launch file
* new parameter files
* Merge pull request #226 <https://github.com/ipa320/cob_robots/issues/226> from ipa-nhg/indigo_test
  bringup tests
* bringup tests
* moved msgs
* set locahost as default parameter
* set locahost as default parameter
* add monitor scripts to replace pr2_computer_monitor
* Contributors: Florian Weisshardt, Nadia Hammoudeh García, ipa-cob3-9, ipa-cob4-2, ipa-fmw, ipa-fxm, ipa-nhg
```
## cob_controller_configuration_gazebo

```
* merge
* remove unused dep
* add depdendencies
* add dependency
* delete cob3-3
* delete cob3-3
* cleanup: cob4-1 with torso and head; cob4-2 without torso and head
* setup cob3-9 simulation
* cob3-9
* add cob4 to tests
* Merge pull request #18 <https://github.com/ipa320/cob_robots/issues/18> from ipa-fxm/indigo_dev
  add lookat components to cob4-2
* add lookat components to cob4-2
* merge
* new structure for cob4-1 and cob4-2
* added temporary topic_relays for base - v1.5
* launch and yaml file base according to new structure
* adapt teleop to v2
* delete desire
* delete cob3-8
* delete cob3-7
* delete cob3-5
* delete cob3-4
* delete cob3-2
* delete cob3-1
* uses forward command controller for all simulated bases
* Contributors: Florian Weisshardt, ipa-fxm, ipa-nhg
```
## cob_default_robot_config

```
* delete cob3-3
* adapt default velocity
* speedup default vel
* cleanup: cob4-1 with torso and head; cob4-2 without torso and head
* deleted sound.yaml
* cob3-9
* setup cob3-9 simulation
* setup cob3-9
* add service_ns for base
* cob3-9
* merge
* add grippers to dashboard
* update cob4-2 config
* updated command_gui buttons
* added accion_name and service_ns parameters
* default config for gripper_left
* default config for gripper_left
* added gripper_right
* config for gripper right
* added accion_name and service_ns parameters
* test raw3-3
* add side configuration and update folded configuration
* switch axis for arm_1 joints
* add parameters for action and service namespace to sss
* updates on cob4-2
* delete desire
* delete cob3-8
* delete cob3-7
* delete cob3-5
* delete cob3-4
* delete cob3-2
* delete cob3-1
* new ros_canopen driver version, adapted bringup configuration
* Contributors: Florian Weisshardt, ipa-cob3-9, ipa-cob4-2, ipa-fmw, ipa-nhg
```
## cob_hardware_config

```
* merge
* rename canopen launch files and fix roslaunch test errors
* delete cob3-3
* cleanup: cob4-1 with torso and head; cob4-2 without torso and head
* cob3-9
* setup cob3-9 simulation
* setup cob3-9
* cob3-9
* set cores for toros pcs
* add namespace for light launch file. needed for cob4-2
* add namespace for light launch file. needed for cob4-2
* led rule
* config for gripper right
* disable launch tests
* set teleop config for cob4-2
* Rename teleop_v1.yaml to teleop.yaml
* test raw3-3
* Finger configuration files
* set default mode for light
* merge
* add phidget config for cob4-2
* support for vel mode
* Merge pull request #3 <https://github.com/ipa320/cob_robots/issues/3> from ipa-fmw/indigo_new_structure
  Indigo new structure
* use static head and torso for cob4-2
* fix arm mounting positions
* add lookat components to cob4-2
* new structure for cob4-1 and cob4-2
* indigo_new_structure
* adapt teleop to v2
* delete desire
* delete cob3-8
* delete cob3-7
* delete cob3-5
* delete cob3-4
* delete cob3-2
* delete cob3-1
* new ros_canopen driver version, adapted bringup configuration
* Adds light configuration for cob4-2
* new parameter files
* added pc monitor config files for cob4-1
* Contributors: Florian Weisshardt, ipa-cob3-9, ipa-cob4-1, ipa-cob4-2, ipa-fmw, ipa-fxm, ipa-nhg, thiagodefreitas
```
## cob_robots

```
* merge
* move cob_monitoring to cob_command_tools
* Contributors: Florian Weisshardt, ipa-nhg
```
