### PR TITLE
cob_simulation: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -868,7 +868,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_simulation-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ipa320/cob_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.6.2-0`:
- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.6.1-0`
## cob_bringup_sim

```
* introduce launchfile argument for -J option of spawn_model
* Contributors: ipa-fxm
```
## cob_gazebo

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* missing dependencies for control plugins
* delete desire
* delete cob3-7
* delete cob3-5
* delete cob3-4
* delete cob3-2
* delete cob3-1
* introduce launchfile argument for -J option of spawn_model
* Contributors: Florian Weisshardt, ipa-fxm
```
## cob_gazebo_objects
- No changes
## cob_gazebo_worlds

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* build depend roslaunch and rostest
* add dependency
* add tests
* added run_dependency
* correct remapping
* add gazebo_ros_control plugin for environment so that real joint_states are published for non-fixed environment joints, i.e. door
* ipa-kitchen includes a door that can passively be pushed open
* changes due to renaming
* fix environment to gazebo world frame + proper interia
* Contributors: Florian Weisshardt, ipa-fxm
```
## cob_simulation
- No changes
