### PR TITLE
cob_command_tools: 0.6.1-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -610,13 +610,13 @@ repositories:
       - cob_command_tools
       - cob_dashboard
       - cob_interactive_teleop
+      - cob_monitoring
       - cob_script_server
       - cob_teleop
-      - cob_teleop_cob4
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.0-0
+      version: 0.6.1-2
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.1-2`:
- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.6.0-0`
## cob_command_gui

```
* merge
* add nice images to command_gui
* add halt service support
* adapt namespaces to new canopen version
* merge
* Update package.xml
* Contributors: Florian Weisshardt, ipa-fmw
```
## cob_command_tools

```
* merge
* rename finished
* move cob_monitoring
* missed dependency
* Contributors: Florian Weisshardt, ipa-nhg
```
## cob_dashboard

```
* merge
* fix xml syntax
* added dependency
* Contributors: Florian Weisshardt, ipa-fxm, ipa-nhg
```
## cob_interactive_teleop
- No changes
## cob_monitoring

```
* Update battery_monitor.py
* move cob_monitoring to cob_command_tools
* Contributors: Florian Weisshardt, ipa-nhg
```
## cob_script_server

```
* fix traj time calculation
* use default vel instead of default point time
* use 8 sec by default for trajectories
* action and service namespaces are configurable now
* add halt service support
* Missing install tag
* adapt namespaces to new canopen version
* Contributors: Florian Weisshardt, ipa-cob4-2, ipa-fmw
```
## cob_teleop

```
* merge
* adapt teleop_v2 to the new controllers structure
* add gencpp dependency
* rename teleop to teleop_v1
* change maintainer
* rename finished
* rename files from cob4 to v2
* Contributors: Florian Weisshardt, ipa-nhg
```
