### PR TITLE
cob_calibration_data: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -593,7 +593,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_calibration_data-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ipa320/cob_calibration_data.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_calibration_data` to `0.6.2-0`:
- upstream repository: https://github.com/ipa320/cob_calibration_data.git
- release repository: https://github.com/ipa320/cob_calibration_data-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.6.1-0`
## cob_calibration_data

```
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_calibration_data into indigo_dev
* remove cob3-3
* Merge pull request #73 <https://github.com/ipa320/cob_calibration_data/issues/73> from ipa320/indigo_release_candidate
  Indigo release candidate
* Contributors: Florian Weisshardt
```
