### PR TITLE
roboteq: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4597,6 +4597,25 @@ repositories:
       url: https://github.com/RobotWebTools/robot_web_tools.git
       version: develop
     status: maintained
+  roboteq:
+    doc:
+      type: git
+      url: https://github.com/g/roboteq.git
+      version: master
+    release:
+      packages:
+      - roboteq_diagnostics
+      - roboteq_driver
+      - roboteq_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/roboteq-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/g/roboteq.git
+      version: master
+    status: maintained
   robotiq:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roboteq` to `0.1.1-0`:
- upstream repository: https://github.com/g/roboteq.git
- release repository: https://github.com/clearpath-gbp/roboteq-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `null`
## roboteq_diagnostics

```
* Fix name of python node to install.
```
## roboteq_driver
- No changes
## roboteq_msgs
- No changes
