### PR TITLE
add trusty to the platforms for jade

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -7,6 +7,7 @@ release_platforms:
   - '21'
   - '22'
   ubuntu:
+  - trusty
   - utopic
   - vivid
 repositories:


### PR DESCRIPTION
We forgot this on the first pass, see: https://github.com/ros-infrastructure/rep/pull/89#issuecomment-67087151
