### PR TITLE
rosbag_image_compressor: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5172,7 +5172,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rosbag_image_compressor-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/ros/rosbag_image_compressor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_image_compressor` to `0.1.4-0`:
- upstream repository: https://github.com/ros/rosbag_image_compressor.git
- release repository: https://github.com/ros-gbp/rosbag_image_compressor-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.3-0`
## rosbag_image_compressor

```
* fixes #1 <https://github.com/ros/rosbag_image_compressor/issues/1> output parameter crash by importing os.
* Contributors: Basheer Subei
```
