### PR TITLE
Add qtmobility to rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2509,6 +2509,11 @@ qt4-qmake:
   ubuntu: [qt4-qmake]
 qt5-qmake:
   ubuntu: [qt5-qmake]
+qtmobility-dev:
+  arch: [qtmobility]
+  debian: [qtmobility-dev]
+  fedora: [qt-mobility-devel]
+  ubuntu: [qtmobility-dev]
 readline-dev:
   arch: [readline]
   debian: [libreadline-dev]


### PR DESCRIPTION
For buiding Rospeex (cloud-based multilingual communication package for robots), qtmobility is required so it is added to rosdep/base.yaml.
