### PR TITLE
fs100_motoman: 0.1.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1872,11 +1872,15 @@ repositories:
       version: hydro-devel
     status: developed
   fs100_motoman:
+    doc:
+      type: git
+      url: https://github.com/DTU-AUT/fs100_motoman.git
+      version: master
     release:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/DTU-AUT/fs100_motoman-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/DTU-AUT/fs100_motoman.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fs100_motoman` to `0.1.4-0`:
- upstream repository: https://github.com/DTU-AUT/fs100_motoman.git
- release repository: https://github.com/DTU-AUT/fs100_motoman-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.1.3-0`
## fs100_motoman
- No changes
