### PR TITLE
cob_control: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -668,7 +668,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.6.2-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.6.4-0`:
- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.6.2-0`
## cob_base_velocity_smoother
- No changes
## cob_collision_velocity_filter
- No changes
## cob_control
- No changes
## cob_control_mode_adapter
- No changes
## cob_footprint_observer
- No changes
## cob_frame_tracker
- No changes
## cob_hardware_interface
- No changes
## cob_lookat_controller
- No changes
## cob_model_identifier
- No changes
## cob_omni_drive_controller

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* update deps
* Contributors: Florian Weisshardt
```
## cob_path_broadcaster
- No changes
## cob_trajectory_controller
- No changes
## cob_twist_controller
- No changes
