### PR TITLE
swiftnav: 0.13.0-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6209,7 +6209,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/libswiftnav-release.git
-      version: 0.13.0-1
+      version: 0.13.0-3
     status: maintained
   teleop_twist_joy:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `swiftnav` to `0.13.0-3`:
- upstream repository: https://github.com/swift-nav/libswiftnav.git
- release repository: https://github.com/clearpath-gbp/libswiftnav-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.13.0-1`
