### PR TITLE
Adding innok_heros_driver to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2049,6 +2049,15 @@ repositories:
       url: https://github.com/ccny-ros-pkg/imu_tools.git
       version: indigo
     status: developed
+  innok_heros_driver:
+    doc:
+      type: git
+      url: https://github.com/innokrobotics/innok_heros_driver.git
+      version: indigo
+    source:
+      type: git
+      url: https://github.com/innokrobotics/innok_heros_driver.git
+      version: indigo
   innok_heros_lights:
     doc:
       type: git


### PR DESCRIPTION
I'd like innok_heros_driver to be indexed and documented on ros.org for Indigo.
