### PR TITLE
rosbridge_suite: 0.7.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5205,11 +5205,10 @@ repositories:
       - rosbridge_library
       - rosbridge_server
       - rosbridge_suite
-      - rosbridge_tools
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.7.3-0
+      version: 0.7.4-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.7.4-0`:
- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.7.3-0`
## rosapi
- No changes
## rosbridge_library
- No changes
## rosbridge_server

```
* reverts back to internal tornado until fix is ready
* Contributors: Russell Toris
```
## rosbridge_suite
- No changes
