### PR TITLE
innok_heros_driver: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2054,10 +2054,16 @@ repositories:
       type: git
       url: https://github.com/innokrobotics/innok_heros_driver.git
       version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/innokrobotics/innok_heros_driver-release.git
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/innokrobotics/innok_heros_driver.git
       version: indigo
+    status: maintained
   innok_heros_lights:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `innok_heros_driver` to `1.0.0-0`:
- upstream repository: https://github.com/innokrobotics/innok_heros_driver.git
- release repository: https://github.com/innokrobotics/innok_heros_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `null`
## innok_heros_driver

```
* publish battery voltage
* bugfix for host parameter
* eliminated KDL dependency
* Contributors: Alwin Heerklotz
```
