### PR TITLE
interactive_markers: 1.10.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2835,11 +2835,19 @@ repositories:
       version: hydro-devel
     status: developed
   interactive_markers:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: hydro-devel
     release:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/interactive_markers-release.git
-      version: 1.10.2-0
+      version: 1.10.3-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: hydro-devel
     status: maintained
   ipa_canopen:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `1.10.3-0`:
- upstream repository: https://github.com/ros-visualization/interactive_markers
- release repository: https://github.com/ros-gbp/interactive_markers-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `1.10.2-0`
## interactive_markers

```
* Fixed a SEGFAULT in setPose reported in #18 <https://github.com/ros-visualization/interactive_markers/issues/18>
  Previously, calling setPose() on an interactive marker causes a SEGFAULT
  if applyChanges() was not called on the server at least once since the
  marker was created. I traced the actual SEGFAULT to the doSetPose
  function. The value of header passed from setPose() is invalid because,
  in this case, marker_context_it = marker_contexts_.end().
  I added a check for this case and, if there is no marker is present,
  instead use the header from the pending update.
* Addressed some threading related bugs.
  Fix locking of data structures shared across threads.
* Contributors: Acorn Pooley, Mike Koval, William Woodall, hersh
```
