### PR TITLE
jsk_common: 1.0.56-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2293,6 +2293,7 @@ repositories:
       - jsk_tilt_laser
       - jsk_tools
       - jsk_topic_tools
+      - julius
       - libsiftfast
       - mini_maxwell
       - multi_map_server
@@ -2309,7 +2310,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.55-1
+      version: 1.0.56-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.56-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.0.55-1`
## assimp_devel
- No changes
## bayesian_belief_networks

```
* modify bayseian setup.py
* Contributors: aginika
```
## downward
- No changes
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_network_tools

```
* plot multiple lines
* add network plot
* Contributors: tarukosu
```
## jsk_tilt_laser
- No changes
## jsk_tools

```
* Use ping with 10 seconds timeout to check master aliveness
* add battery full capacity summary script
* Contributors: Ryohei Ueda, aginika
```
## jsk_topic_tools
- No changes
## julius

```
* catkinize julius
* Contributors: Furushchev
```
## libsiftfast
- No changes
## mini_maxwell
- No changes
## multi_map_server
- No changes
## nlopt
- No changes
## opt_camera
- No changes
## posedetection_msgs
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## sklearn
- No changes
## speech_recognition_msgs
- No changes
## virtual_force_publisher
- No changes
## voice_text
- No changes
