### PR TITLE
icart_mini: 0.1.1-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1945,7 +1945,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/open-rdc/icart_mini-release.git
-      version: 0.0.5-0
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/open-rdc/icart_mini.git


### PR DESCRIPTION
Increasing version of package(s) in repository `icart_mini` to `0.1.1-2`:
- upstream repository: https://github.com/open-rdc/icart_mini.git
- release repository: https://github.com/open-rdc/icart_mini-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.0.5-0`
