### PR TITLE
New independent pkg (taken out of mrpt_navigation)

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2372,6 +2372,16 @@ repositories:
       url: https://github.com/lrse/ros-keyboard.git
       version: master
     status: developed
+  kinect_2d_scanner:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/kinect_2d_scanner.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/kinect_2d_scanner.git
+      version: master
+    status: maintained
   kingfisher:
     doc:
       type: git


### PR DESCRIPTION
It didn't make sense to keep this package into mrpt_navigation due to its scope.
