### PR TITLE
mrpt_navigation: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3208,6 +3208,20 @@ repositories:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
       version: indigo-devel
+    release:
+      packages:
+      - mrpt_bridge
+      - mrpt_localization
+      - mrpt_map
+      - mrpt_msgs
+      - mrpt_navigation
+      - mrpt_rawlog
+      - mrpt_tutorials
+      - pose_cov_ops
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `0.1.1-0`:
- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## mrpt_bridge

```
* First public binary release.
```
## mrpt_localization

```
* First public binary release.
```
## mrpt_map

```
* First public binary release.
```
## mrpt_msgs

```
* First public binary release.
```
## mrpt_navigation

```
* First public binary release.
```
## mrpt_rawlog

```
* First public binary release.
```
## mrpt_tutorials

```
* First public binary release.
```
## pose_cov_ops

```
* First public binary release.
```
