### PR TITLE
geometry_tutorials: 0.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2079,10 +2079,12 @@ repositories:
       packages:
       - geometry_tutorials
       - turtle_tf
+      - turtle_tf2
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/geometry_tutorials-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
+    status: maintained
   google_glass_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_tutorials` to `0.2.1-0`:
- upstream repository: https://github.com/ros/geometry_tutorials
- release repository: https://github.com/ros-gbp/geometry_tutorials-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.2.0-0`
## geometry_tutorials

```
* Added new tutorial for tf2
* Contributors: Denis Štogl
```
## turtle_tf

```
* continuing on error instead of executing the rest of the block. Fixes #13 <https://github.com/ros/geometry_tutorials/issues/13>
* merging conflicting pull requests
* catch tf.ExtrapolationException
  see http://answers.ros.org/question/12024/tftutorials-demo-problem-ros-electric/, this still happens in hydro
* Fixes for "Using sensor messages with tf" tutorial.
* add start_debug_demo.launch, that is introduced in http://wiki.ros.org/tf/Tutorials/Debugging%20tf%20problems
* Fix wrong order of arguments to q.setRPY in commit 82964f6.
* Fix wrong order of arguments to q.setRPY in commit 82964f6.
  The API shows the order is:
  void    setRPY (const tfScalar &roll, const tfScalar &pitch, const tfScalar &yaw)
  Line 14 should read:
  q.setRPY(0, 0, msg->theta);
  This fault breaks this tutorial:
  http://wiki.ros.org/tf/Tutorials/Writing%20a%20tf%20broadcaster%20%28C%2B%2B%29
  In a way that doesn't show up until the subsequent tutorial, where the
  follower doesn't follow. The fix to line 14 proposed above fixes the
  subsequent tutorial.
  The problem is discussed in this thread:
  http://answers.ros.org/question/45884/turtle-tf-tutorial-fails-to-work/?answer=47845#post-id-47845
  and an incorrect fix was applied to the wiki. The note in the wiki under
  the code, which says the code should read:
  transform.setRotation( tf::Quaternion(0, 0, msg->theta) );
  is wrong - it should say transform.setRPY.
* Added queue size for Publisher to avoid warning.
* add queue_size argument to rospy.Publisher
  ros/ros_comm#169 <https://github.com/ros/ros_comm/issues/169>
* add queue_size argument to rospy publisher
  ros/ros_comm#169 <https://github.com/ros/ros_comm/issues/169>
* add queue_size
  ros/ros_comm#169 <https://github.com/ros/ros_comm/issues/169>
* Adding queue_size argument to publisher
  ros/ros_comm#169 <https://github.com/ros/ros_comm/issues/169>
* Contributors: Denis Štogl, K.mura, Kei Okada, Paul Bouchier, Tully Foote, spourmehr
```
## turtle_tf2

```
* fixing install rules for turtle_tf2 fixes #15 <https://github.com/ros/geometry_tutorials/issues/15>
* adding cpp launcher for testing
* fixing exceptions and making turtle name a parameter
* Removed debug-output
* Added launch files for cpp example and cpp code update to work
* Ingnoring exceptions from lookup_transform
* Errors corrected after testing
* parameterize turtlename and fix theta setting, yaw not roll
* fix frame_id names and don't execute on error
* Added new tutorial for tf2
* Contributors: Denis Štogl, Tully Foote
```
