### PR TITLE
Fix for broken dependencies in Saucy

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2290,9 +2290,10 @@ mrpt:
     precise: [libmrpt-dev]
     quantal: [libmrpt-dev]
     raring: [libmrpt-dev, mrpt-apps]
-    saucy: [libmrpt-dev]
+    saucy: [libmrpt-dev, mrpt-apps]
     trusty: [libmrpt-dev]
     utopic: [libmrpt-dev]
+    vivid: [libmrpt-dev]
 muparser:
   fedora: [muParser-devel]
   ubuntu: [libmuparser-dev]


### PR DESCRIPTION
All this is caused by missing Debian dependencies in old libmrpt-dev packages.
When saucy gets old enough, all lines will collapse to the unique right dependency (libmrpt-dev), but as long as saucy is supported we must add the other packages manually.
