### PR TITLE
ros_canopen: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4931,13 +4931,12 @@ repositories:
       - canopen_chain_node
       - canopen_master
       - canopen_motor_node
-      - canopen_test_utils
       - ros_canopen
       - socketcan_interface
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/ros_canopen-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ipa320/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.6.2-0`:
- upstream repository: https://github.com/ipa320/ros_canopen.git
- release repository: https://github.com/ipa320/ros_canopen-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.6.1-0`
## canopen_402
- No changes
## canopen_chain_node
- No changes
## canopen_master
- No changes
## canopen_motor_node
- No changes
## ros_canopen

```
* remove canopen_test_utils from metapackage
* Contributors: Florian Weisshardt
```
## socketcan_interface
- No changes
