### PR TITLE
end-of-life for ipa_canopen 

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2163,24 +2163,11 @@ repositories:
       version: develop
     status: maintained
   ipa_canopen:
-    doc:
-      type: git
-      url: https://github.com/ipa320/ipa_canopen.git
-      version: indigo_release_candidate
-    release:
-      packages:
-      - ipa_canopen
-      - ipa_canopen_core
-      - ipa_canopen_ros
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ipa320/ipa_canopen-release.git
-      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/ipa320/ipa_canopen.git
       version: indigo_dev
-    status: maintained
+    status: end-of-life
   ira_photonfocus_driver:
     release:
       tags:


### PR DESCRIPTION
is substituted by ros_canopen
