### PR TITLE
carl_navigation: 0.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -523,7 +523,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_navigation-release.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_navigation` to `0.0.9-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_navigation.git
- release repository: https://github.com/wpi-rail-release/carl_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.8-0`
## carl_navigation

```
* rviz update
* launches ilab URDF
* Update .travis.yml
* Update .travis.yml
* Update .travis.yml
* Contributors: Russell Toris
```
