### PR TITLE
carl_demos: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -478,7 +478,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_demos-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_demos.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_demos` to `0.0.4-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_demos.git
- release repository: https://github.com/wpi-rail-release/carl_demos-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.3-0`
## carl_demos

```
* travis fix
* adds nav to demo
* Update .travis.yml
* added web_video_server to web demo launch
* Contributors: David Kent, Russell Toris
```
