### PR TITLE
rail_ceiling: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4408,7 +4408,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_ceiling-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_ceiling.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_ceiling` to `0.0.4-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_ceiling.git
- release repository: https://github.com/wpi-rail-release/rail_ceiling-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.3-0`
## rail_ceiling

```
* adds missing dep
* Merge branch 'develop' of github.com:WPI-RAIL/rail_ceiling into develop
* Updated launch for calibration from carl
* Update .travis.yml
* Update .travis.yml
* Contributors: David Kent, Russell Toris
```
