### PR TITLE
wpi_jaco: 0.0.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7004,7 +7004,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/wpi_jaco-release.git
-      version: 0.0.10-0
+      version: 0.0.11-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/wpi_jaco.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wpi_jaco` to `0.0.11-0`:
- upstream repository: https://github.com/RIVeR-Lab/wpi_jaco.git
- release repository: https://github.com/wpi-rail-release/wpi_jaco-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.10-0`
## jaco_description

```
* minify script
* Contributors: Russell Toris
```
## jaco_interaction
- No changes
## jaco_sdk
- No changes
## jaco_teleop

```
* Changed teleop to use angular commands for finger movement; this will allow finger control even near/in arm singularities
* Contributors: David Kent
```
## wpi_jaco
- No changes
## wpi_jaco_msgs

```
* Changed teleop to use angular commands for finger movement; this will allow finger control even near/in arm singularities
* Contributors: David Kent
```
## wpi_jaco_wrapper
- No changes
