### PR TITLE
gazebo_ros_pkgs: 2.4.7-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1512,7 +1512,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.4.7-0
+      version: 2.4.7-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.4.7-1`:
- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `2.4.7-0`
## gazebo_msgs

```
* Update Gazebo/ROS tutorial URL
* Contributors: Jose Luis Rivero
```
## gazebo_plugins

```
* Merge pull request #276 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/276> from ros-simulation/gazebo_ogre_compile_flag_fix
  fix missing ogre flags: removed from gazebo default (5.x.x candidate) cmake config
* Merge pull request #238 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/238> from ayrton04/indigo-devel
  Fixing handling of non-world frame velocities in setModelState.
* fix missing ogre flags (removed from gazebo cmake config)
* change header to use opencv2/opencv.hpp issue #274 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/274>
* Update Gazebo/ROS tutorial URL
* Merge pull request #237 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/237> from ros-simulation/update_header_license
  Update header license for Indigo
* Contributors: John Hsu, Jose Luis Rivero, Robert Codd-Downey, Tom Moore, hsu
```
## gazebo_ros

```
* temporary hack to **fix** the -J joint position option (issue #93 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/93>), sleeping for 1 second to avoid race condition. this branch should only be used for debugging, merge only as a last resort.
* Fixing set model state method and test
* Extended the fix for #246 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/246> also to debug, gazebo, gzclient and perf scripts.
* Update Gazebo/ROS tutorial URL
* [gazebo_ros] Fix for #246 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/246>
  Fixing issue #246 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/246> in gzserver.
* Fixing handling of non-world frame velocities in setModelState.
* update headers to apache 2.0 license
* update headers to apache 2.0 license
* Contributors: John Hsu, Jose Luis Rivero, Martin Pecka, Tom Moore, ayrton04
```
## gazebo_ros_control

```
* move declaration for DefaultRobotHWSim to header file
* Contributors: ipa-fxm
```
## gazebo_ros_pkgs

```
* Update Gazebo/ROS tutorial URL
* Contributors: Jose Luis Rivero
```
