### PR TITLE
grizzly: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1720,6 +1720,27 @@ repositories:
       url: https://github.com/mikeferguson/grasping_msgs-gbp.git
       version: 0.3.1-0
     status: developed
+  grizzly:
+    doc:
+      type: git
+      url: https://github.com/g/grizzly.git
+      version: indigo-devel
+    release:
+      packages:
+      - grizzly_description
+      - grizzly_motion
+      - grizzly_msgs
+      - grizzly_navigation
+      - grizzly_teleop
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/grizzly-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/g/grizzly.git
+      version: indigo-devel
+    status: maintained
   hector_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly` to `0.3.0-0`:
- upstream repository: https://github.com/g/grizzly.git
- release repository: https://github.com/clearpath-gbp/grizzly-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `null`
## grizzly_description

```
* Fix IMU origin.
* Update physical and collision properties
* update position of wheel's joints
* add hector gps contoller
* add hector imu controller
* change joint names. use rear instead of back
* Aesthetic fixes to grizzly URDF.
* Remove vestigial vcg file.
* Contributors: Mike Purvis, Shokoofeh Pourmehr, dash
```
## grizzly_motion

```
* Replace robot_pose_ekf with robot_localization.
* add front axle publisher.
* added publisher for wheel joints.
* Fix dependency on roboteq_msgs.
* Clarify timeout statemachine logic.
* Use the FindEigen from cmake_modules.
* Contributors: Mike Purvis, Shokoofeh Pourmehr
```
## grizzly_msgs

```
* add front axle publisher.
* Use the FindEigen from cmake_modules.
* Contributors: Mike Purvis, Shokoofeh Pourmehr
```
## grizzly_navigation

```
* Replace robot_pose_ekf with robot_localization.
* Contributors: Shokoofeh Pourmehr, Mike Purvis
```
## grizzly_teleop
- No changes
