### PR TITLE
grizzly_simulator: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1741,6 +1741,25 @@ repositories:
       url: https://github.com/g/grizzly.git
       version: indigo-devel
     status: maintained
+  grizzly_simulator:
+    doc:
+      type: git
+      url: https://github.com/g/grizzly_simulator.git
+      version: indigo-devel
+    release:
+      packages:
+      - grizzly_gazebo
+      - grizzly_gazebo_plugins
+      - grizzly_simulator
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/grizzly_simulator-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/g/grizzly_simulator.git
+      version: indigo-devel
+    status: maintained
   hector_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly_simulator` to `0.2.0-0`:
- upstream repository: https://github.com/g/grizzly_simulator.git
- release repository: https://github.com/clearpath-gbp/grizzly_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `null`
## grizzly_gazebo

```
* replace robot_pose_ekf with robot_localization
* add run dependency to hector_gazebo_plugins
* Add grizzly_navigation dependency.
* Contributors: Mike Purvis, Shokoofeh Pourmehr
```
## grizzly_gazebo_plugins

```
* disable publishing joint states
* fix joint orders and names to match with grizzly drive msg
* update joint names. use rear instead of back.
* Contributors: Mike Purvis, Shokoofeh Pourmehr
```
## grizzly_simulator
- No changes
