### PR TITLE
grizzly_desktop: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1741,6 +1741,24 @@ repositories:
       url: https://github.com/g/grizzly.git
       version: indigo-devel
     status: maintained
+  grizzly_desktop:
+    doc:
+      type: git
+      url: https://github.com/g/grizzly_desktop.git
+      version: indigo-devel
+    release:
+      packages:
+      - grizzly_desktop
+      - grizzly_viz
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/grizzly_desktop-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/g/grizzly_desktop.git
+      version: indigo-devel
+    status: maintained
   grizzly_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly_desktop` to `0.2.1-0`:
- upstream repository: https://github.com/g/grizzly_desktop
- release repository: https://github.com/clearpath-gbp/grizzly_desktop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `null`
## grizzly_desktop
- No changes
## grizzly_viz
- No changes
