### PR TITLE
mrpt_navigation: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3344,7 +3344,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `0.1.3-0`:
- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.2-0`
## mrpt_bridge
- No changes
## mrpt_localization

```
* Fix many missing install files
* Contributors: Jose Luis Blanco
```
## mrpt_map

```
* Fix many missing install files
* Contributors: Jose Luis Blanco
```
## mrpt_msgs
- No changes
## mrpt_navigation
- No changes
## mrpt_rawlog

```
* Fix many missing install files
* Contributors: Jose Luis Blanco
```
## mrpt_tutorials

```
* Fix many missing install files
* Contributors: Jose Luis Blanco
```
## pose_cov_ops

```
* Fix many missing install files
* Contributors: Jose Luis Blanco
```
