### PR TITLE
jsk_model_tools: 0.1.7-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2383,6 +2383,25 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_common.git
       version: master
     status: developed
+  jsk_model_tools:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_model_tools.git
+      version: master
+    release:
+      packages:
+      - eus_assimp
+      - euscollada
+      - jsk_model_tools
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/jsk_model_tools-release.git
+      version: 0.1.7-1
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_model_tools.git
+      version: master
+    status: developed
   jsk_pr2eus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.1.7-1`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## eus_assimp

```
* fix parsing file extention, in order to use .stlb extention for exporting mesh as STL Binary format
* use tiff file for texture
* Contributors: Yohei Kakiuchi
```
## euscollada

```
* fix parsing sensors from yaml file, sensor_id should be optional
* Get sensor id from sid of sensor tag and sort euslisp sensors by sensor's sid
* Script to compute difference of two urdfs and dump it to yaml file, and apply the yaml file to urdf file as a patch
* add camera model
* Move scripts to euscollada to avoid catkinization of eusurdf
* add sensor coordinates to eus model while converting from urdf model
* add code for viewing convex bodies
* fix order of qhull vertices
* use multiple visual
* update add_sensor_to_collada.py for adding sensor from yaml file
* Merge remote-tracking branch 'origin/master' into use_loadable
* update for compiling on indigo, use liburdfdom and can use yaml-cpp-0.5
* add use_loadable
* fix for using fixed_joint
* fix inertia frame
* remove nan in normal
* (collada2eus.cpp) : Parse multiple translate and rotate tag for sensor definition
* Contributors: Ryohei Ueda, Shunichi Nozawa, Yohei Kakiuchi
```
## jsk_model_tools
- No changes
