### PR TITLE
openrtm_aist: 1.1.0-24 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4136,7 +4136,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/openrtm_aist-release.git
-      version: 1.1.0-23
+      version: 1.1.0-24
     status: developed
   openrtm_aist_python:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist` to `1.1.0-24`:
- upstream repository: http://svn.openrtm.org/OpenRTM-aist/tags/RELEASE_1_1_0/OpenRTM-aist/
- release repository: https://github.com/tork-a/openrtm_aist-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.1.0-23`
