### PR TITLE
rtshell: 3.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5826,6 +5826,12 @@ repositories:
       url: https://github.com/introlab/rtabmap_ros.git
       version: master
     status: maintained
+  rtshell:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/rtshell-release.git
+      version: 3.0.1-1
   rtt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell` to `3.0.1-1`:
- upstream repository: https://github.com/gbiggs/rtshell.git
- release repository: https://github.com/tork-a/rtshell-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
