### PR TITLE
rtsprofile: 2.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5819,18 +5819,18 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtctree-release.git
       version: 3.0.1-0
-  rtsprofile:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/tork-a/rtsprofile-release.git
-      version: 2.0.0-0
   rtshell:
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtshell-release.git
       version: 3.0.1-1
+  rtsprofile:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/rtsprofile-release.git
+      version: 2.0.0-0
   rtt:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5826,6 +5826,12 @@ repositories:
       url: https://github.com/introlab/rtabmap_ros.git
       version: master
     status: maintained
+  rtsprofile:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/rtsprofile-release.git
+      version: 2.0.0-0
   rtt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtsprofile` to `2.0.0-0`:
- upstream repository: https://github.com/gbiggs/rtsprofile.git
- release repository: https://github.com/tork-a/rtsprofile-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
