### PR TITLE
foo: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1457,6 +1457,23 @@ repositories:
       url: https://github.com/ros-drivers/flir_ptu.git
       version: master
     status: developed
+  foo:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/imu_compass.git
+      version: master
+    release:
+      packages:
+      - imu_compass
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/imu_compass-release.git
+      version: 0.0.5-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/imu_compass.git
+      version: master
+    status: maintained
   freenect_stack:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `foo` to `0.0.5-0`:
- upstream repository: https://github.com/clearpathrobotics/imu_compass
- release repository: https://github.com/clearpath-gbp/imu_compass-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## imu_compass

```
* removing bag references from sample hard-iron calibration output file
* fixing example launch file to reflect changes in param intake in the node
* Contributors: Prasenjit Mukherjee
```
