### PR TITLE
imu_compass: 0.0.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2082,6 +2082,21 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: indigo-devel
     status: maintained
+  imu_compass:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/imu_compass.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/imu_compass-release.git
+      version: 0.0.5-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/imu_compass.git
+      version: master
+    status: maintained
   imu_pipeline:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_compass` to `0.0.5-1`:
- upstream repository: https://github.com/clearpathrobotics/imu_compass
- release repository: https://github.com/clearpath-gbp/imu_compass-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## imu_compass

```
* removing bag references from sample hard-iron calibration output file
* fixing example launch file to reflect changes in param intake in the node
* Contributors: Prasenjit Mukherjee
```
