### PR TITLE
removed ira_photonfocus_driver release repo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2035,11 +2035,6 @@ repositories:
       version: indigo_dev
     status: maintained
   ira_photonfocus_driver:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/iralabdisco/ira_photonfocus_driver-release.git
-      version: 1.0.0-3
     source:
       type: git
       url: https://github.com/iralabdisco/ira_photonfocus_driver.git


### PR DESCRIPTION
due to some problems with building the package on the ros farm (we don't know how to replicate a build farm locally for making corrections to the package, and using the official one remotely takes too much time and efforts)
