### PR TITLE
moveit_ros: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3298,7 +3298,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ros` to `0.6.4-0`:
- upstream repository: https://github.com/ros-planning/moveit_ros.git
- release repository: https://github.com/ros-gbp/moveit_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.6.3-0`
## moveit_ros
- No changes
## moveit_ros_benchmarks

```
* install moveit_benchmark_statistics.py
* Contributors: Michael Ferguson
```
## moveit_ros_benchmarks_gui
- No changes
## moveit_ros_manipulation
- No changes
## moveit_ros_move_group
- No changes
## moveit_ros_perception
- No changes
## moveit_ros_planning

```
* Namespaced "traj_execution" for all trajectory_execution_manager logging
* planning_scene_monitor: add ros parameter for adding a wait-for-transform lookup time
  fixes #465 <https://github.com/ros-planning/moveit_ros/issues/465>
* Contributors: Dave Coleman, Jonathan Bohren
```
## moveit_ros_planning_interface
- No changes
## moveit_ros_robot_interaction
- No changes
## moveit_ros_visualization
- No changes
## moveit_ros_warehouse
- No changes
