### PR TITLE
jsk_common: 1.0.56-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2953,6 +2953,7 @@ repositories:
       - jsk_tilt_laser
       - jsk_tools
       - jsk_topic_tools
+      - julius
       - laser_filters_jsk_patch
       - libsiftfast
       - mini_maxwell
@@ -2972,7 +2973,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.55-0
+      version: 1.0.56-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.56-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.55-0`
## assimp_devel
- No changes
## bayesian_belief_networks

```
* modify bayseian setup.py
* Contributors: aginika
```
## collada_urdf_jsk_patch

```
* add patch for removing old gazebo settings
* Contributors: YoheiKakiuchi
```
## depth_image_proc_jsk_patch
- No changes
## downward
- No changes
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha
- No changes
## image_view2
- No changes
## image_view_jsk_patch
- No changes
## jsk_common
- No changes
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_network_tools

```
* plot multiple lines
* add network plot
* Contributors: tarukosu
```
## jsk_tilt_laser
- No changes
## jsk_tools

```
* Use ping with 10 seconds timeout to check master aliveness
* add battery full capacity summary script
* Contributors: Ryohei Ueda, aginika
```
## jsk_topic_tools
- No changes
## julius

```
* catkinize julius
* Contributors: Furushchev
```
## laser_filters_jsk_patch
- No changes
## libsiftfast
- No changes
## mini_maxwell
- No changes
## multi_map_server
- No changes
## nlopt
- No changes
## openni_tracker_jsk_patch
- No changes
## opt_camera
- No changes
## posedetection_msgs
- No changes
## pr2_groovy_patches
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## sklearn
- No changes
## speech_recognition_msgs
- No changes
## virtual_force_publisher
- No changes
## voice_text
- No changes
