### PR TITLE
jsk_visualization: 1.0.15-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3119,7 +3119,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.14-0
+      version: 1.0.15-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.15-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.14-0`
## jsk_interactive

```
* use robot-joint-interface in move bounding box
* add grasp hand method
* use moveit
* Contributors: Ryohei Ueda, Yusuke Furuta
```
## jsk_interactive_marker

```
* use robot-joint-interface in move bounding box
* add service request index to choose box from other program
* added config for show or not show controlls
* added spaces infront and behind equal
* update interactive marker controller for hrp2w
* changed dyn_reconfogure_effect_trigger_to_switch
* add interface to send joint trajectory
* add grasp hand method
* use moveit
* add JointTrajectoryPointWithType.msg
* Contributors: Ryohei Ueda, Yu Ohara, Yuto Inagaki, Yu Ohara, Yusuke Furuta
```
## jsk_interactive_test
- No changes
## jsk_rqt_plugins
- No changes
## jsk_rviz_plugins

```
* Add new plugin and message to display array of pictograms
* Remove pictogram when the display is disabled
* Fix policy to move head using rviz: Do not consider movement of mouse,
  just use the position of the mouse. Because we cannot ignore
  network latency
* Fix several parameters suitable for surface
* Add panel for tablet demonstration
* Add view_controller_msgs
* Compute difference to mouse position
* Add TabletViewController to control robot from tablet using rviz
* Check texture is available or not when initializing CameraInfo
* Paster image on the bottom of the camera parameter pyramid
* Contributors: Ryohei Ueda
```
