### PR TITLE
jsk_roseus: 1.1.27-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2424,7 +2424,6 @@ repositories:
       version: master
     release:
       packages:
-      - euslisp
       - geneus
       - jsk_roseus
       - roseus
@@ -2433,7 +2432,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.26-0
+      version: 1.1.27-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.27-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.1.26-0`
## geneus
- No changes
## jsk_roseus
- No changes
## roseus

```
* update body's worldcoords before using its faces
* add logger and level key param to ros::roseus
* fix typo of ros::coords->pose
* add :anonymous to ros::roseus
* add set_logger_level func
* modified typo ros::rosinfo => ros::ros-info
* add warning if id is set
* update param-test.l for testing parameter handling by roseus
* add code for reading dictionary type parameter to roseus
```
## roseus_msgs
- No changes
## roseus_smach

```
* remove cmake file for rosbuild
* not use executive_smach as deps directly; remove manifest.xml
```
