### PR TITLE
euslisp: 9.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1378,6 +1378,12 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/eigen_stl_containers-release.git
       version: 0.1.4-0
+  euslisp:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/euslisp-release.git
+      version: 9.1.0-0
   executive_smach:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `euslisp` to `9.1.0-0`:
- upstream repository: https://github.com/euslisp/EusLisp
- release repository: https://github.com/tork-a/euslisp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
