### PR TITLE
Fix libmysqlclient-dev deps for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1420,11 +1420,11 @@ libmysqlclient-dev:
   arch: [mariadb]
   debian: [libmysqlclient-dev]
   fedora:
-    '21': [mariadb]
-    beefy: [mysql]
-    heisenbug: [mariadb]
-    schrödinger’s: [mariadb]
-    spherical: [mysql]
+    '21': [mariadb-devel]
+    beefy: [mysql-devel]
+    heisenbug: [mariadb-devel]
+    schrödinger’s: [mariadb-devel]
+    spherical: [mysql-devel]
   gentoo:
     portage:
       packages: [dev-db/mariadb]


### PR DESCRIPTION
Example of break: https://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-librms_binaryrpm_21_x86_64/2/console
