### PR TITLE
Fix java deps for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -900,7 +900,12 @@ jasper:
 java:
   arch: [jdk7-openjdk]
   debian: [openjdk-6-jdk]
-  fedora: [java-1.8.0-openjdk, java-1.7.0-openjdk]
+  fedora:
+    '21': [java-1.8.0-openjdk]
+    beefy: [java-1.7.0-openjdk]
+    heisenbug: [java-1.8.0-openjdk, java-1.7.0-openjdk]
+    schrödinger’s: [java-1.8.0-openjdk, java-1.7.0-openjdk]
+    spherical: [java-1.7.0-openjdk]
   freebsd: [openjdk6]
   gentoo: [dev-java/sun-jdk]
   ubuntu: [default-jdk]


### PR DESCRIPTION
This is probably going to break like https://github.com/ros/rosdistro/pull/6619 did, but I'll forget if I don't open the PR :stuck_out_tongue: 
