### PR TITLE
geneus: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1540,6 +1540,12 @@ repositories:
       url: https://github.com/ros/gencpp.git
       version: indigo-devel
     status: maintained
+  geneus:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/geneus-release.git
+      version: 0.1.0-0
   genlisp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geneus` to `0.1.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/geneus
- release repository: https://github.com/tork-a/geneus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## geneus

```
* rewrite everything only depends on genmsg
* Contributors: Kei Okada
```
