### PR TITLE
gencpp: 0.5.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1543,7 +1543,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/gencpp-release.git
-      version: 0.5.2-0
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/ros/gencpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gencpp` to `0.5.3-0`:
- upstream repository: git@github.com:ros/gencpp.git
- release repository: https://github.com/ros-gbp/gencpp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.5.2-0`
## gencpp

```
* remove copyright header from generated code (#20 <https://github.com/ros/gencpp/issues/20>)
```
