### PR TITLE
roscpp_core: 0.5.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5460,7 +5460,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.5.4-0
+      version: 0.5.5-0
     source:
       type: git
       url: https://github.com/ros/roscpp_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.5.5-0`:
- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.5.4-0`
## cpp_common
- No changes
## roscpp_serialization
- No changes
## roscpp_traits
- No changes
## rostime

```
* move implementation of Duration(Rate) constructor (#30 <https://github.com/ros/roscpp_core/issues/30>)
* fix Duration initialization from seconds for negative values  (#29 <https://github.com/ros/roscpp_core/pull/29>)
```
