### PR TITLE
ros: 1.11.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5095,7 +5095,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.11.5-0
+      version: 1.11.6-0
     source:
       type: git
       url: https://github.com/ros/ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.11.6-0`:
- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.11.5-0`
## mk
- No changes
## rosbash

```
* match behaviour of 'roscd' in zsh with bash (#73 <https://github.com/ros/ros/pull/73>)
* improve rosbag zsh tab completion for bag files (#70 <https://github.com/ros/ros/issues/70>)
```
## rosboost_cfg
- No changes
## rosbuild

```
* fix dry clean-test-results target (#71 <https://github.com/ros/ros/issues/71>)
```
## rosclean
- No changes
## roscreate
- No changes
## roslang
- No changes
## roslib

```
* consider std_msgs/Header to be a valid header in rosbuild-based messages (#67 <https://github.com/ros/ros/pull/67>)
```
## rosmake
- No changes
## rosunit

```
* fix OSError handling (#69 <https://github.com/ros/ros/pull/69>, regression since 1.11.1)
```
