### PR TITLE
jskeus: 1.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2464,7 +2464,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jskeus-release.git
-      version: 1.0.1-0
+      version: 1.0.1-1
   katana_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.0.1-1`:
- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.0.1-0`
## jskeus

```
* Fix for when euslisp is already installed as deb, if objdir is given from upper script, we use them
* use INSTALL{BIN,LIB,OBJ}DIR  and IRTEUSDIR when euslisp and jskeus is separately installed
* Contributors: Kei Okada
```
