### PR TITLE
rtmros_common: 1.2.6-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5855,6 +5855,20 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtctree-release.git
       version: 3.0.1-0
+  rtmros_common:
+    release:
+      packages:
+      - hrpsys_ros_bridge
+      - hrpsys_tools
+      - openrtm_ros_bridge
+      - openrtm_tools
+      - rosnode_rtc
+      - rtmbuild
+      - rtmros_common
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/rtmros_common-release.git
+      version: 1.2.6-2
   rtshell:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.2.6-2`:
- upstream repository: https://github.com/start-jsk/rtmros_common.git
- release repository: https://github.com/tork-a/rtmros_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## hrpsys_ros_bridge

```
* set time-limit to 300
* (test-samplerobot.py) fix test case, since /clock is sync with hrpsys time, so we can use more strict settings
* fix test code for changing 0.002
* (rtm-ros-robot-interface) : Add documentation strings for state methods and rearrange it. Add logger documentation.
* Contributors: Kei Okada, Shunichi Nozawa
```
## hrpsys_tools
- No changes
## openrtm_ros_bridge
- No changes
## openrtm_tools
- No changes
## rosnode_rtc
- No changes
## rtmbuild
- No changes
## rtmros_common
- No changes
