### PR TITLE
kinect_2d_scanner: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2486,6 +2486,11 @@ repositories:
       type: git
       url: https://github.com/mrpt-ros-pkg/kinect_2d_scanner.git
       version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/kinect_2d_scanner-release.git
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/kinect_2d_scanner.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinect_2d_scanner` to `0.1.1-0`:
- upstream repository: https://github.com/mrpt-ros-pkg/kinect_2d_scanner.git
- release repository: https://github.com/mrpt-ros-pkg-release/kinect_2d_scanner-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## kinect_2d_scanner

```
* fix wrong #include's
* Move code from old repository (mrpt_navigation)
* Initial release.
* Contributors: Jose Luis Blanco, Jose-Luis Blanco-Claraco
```
