### PR TITLE
Manually remove release pkg from old metapkg

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3394,7 +3394,6 @@ repositories:
       - mrpt_navigation
       - mrpt_rawlog
       - mrpt_tutorials
-      - pose_cov_ops
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git


### PR DESCRIPTION
Package pose_cov_ops was formerly in "mrpt_navigation". I must delete it for bloom to allow its publication as a separate pkg.
