### PR TITLE
ros_tutorials: 0.5.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5371,7 +5371,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_tutorials-release.git
-      version: 0.5.1-1
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/ros/ros_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `0.5.2-0`:
- upstream repository: git@github.com:ros/ros_tutorials.git
- release repository: https://github.com/ros-gbp/ros_tutorials-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.5.1-1`
## ros_tutorials
- No changes
## roscpp_tutorials
- No changes
## rospy_tutorials

```
* update code style of examples (#18 <https://github.com/ros/ros_tutorials/pull/18>, #19 <https://github.com/ros/ros_tutorials/pull/19>)
```
## turtlesim
- No changes
