### PR TITLE
genmsg: 0.5.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -26,5 +26,20 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: indigo-devel
     status: maintained
+  genmsg:
+    doc:
+      type: git
+      url: https://github.com/ros/genmsg.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/genmsg-release.git
+      version: 0.5.6-0
+    source:
+      type: git
+      url: https://github.com/ros/genmsg.git
+      version: indigo-devel
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.5.6-0`:
- upstream repository: git@github.com:ros/genmsg.git
- release repository: https://github.com/ros-gbp/genmsg-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## genmsg

```
* fix interpreter globals collision with multiple message templates or modules (#53 <https://github.com/ros/genmsg/issues/53>)
```
