### PR TITLE
gencpp: 0.5.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -26,6 +26,21 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: indigo-devel
     status: maintained
+  gencpp:
+    doc:
+      type: git
+      url: https://github.com/ros/gencpp.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/gencpp-release.git
+      version: 0.5.3-0
+    source:
+      type: git
+      url: https://github.com/ros/gencpp.git
+      version: indigo-devel
+    status: maintained
   genmsg:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gencpp` to `0.5.3-0`:
- upstream repository: git@github.com:ros/gencpp.git
- release repository: https://github.com/ros-gbp/gencpp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## gencpp

```
* remove copyright header from generated code (#20 <https://github.com/ros/gencpp/issues/20>)
```
