### PR TITLE
genpy: 0.5.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -56,5 +56,20 @@ repositories:
       url: https://github.com/ros/genmsg.git
       version: indigo-devel
     status: maintained
+  genpy:
+    doc:
+      type: git
+      url: https://github.com/ros/genpy.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/genpy-release.git
+      version: 0.5.4-0
+    source:
+      type: git
+      url: https://github.com/ros/genpy.git
+      version: indigo-devel
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.5.4-0`:
- upstream repository: git@github.com:ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## genpy

```
* add support for fixed-width floating-point and integer array values (ros/ros_comm#400 <https://github.com/ros/ros_comm/issues/400>)
* add missing test dependency on yaml
```
