### PR TITLE
genlisp: 0.4.14-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -41,6 +41,21 @@ repositories:
       url: https://github.com/ros/gencpp.git
       version: indigo-devel
     status: maintained
+  genlisp:
+    doc:
+      type: git
+      url: https://github.com/ros/genlisp.git
+      version: groovy-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/genlisp-release.git
+      version: 0.4.14-0
+    source:
+      type: git
+      url: https://github.com/ros/genlisp.git
+      version: groovy-devel
+    status: maintained
   genmsg:
     doc:
       type: git
@@ -54,21 +69,6 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/genmsg.git
-      version: indigo-devel
-    status: maintained
-  genpy:
-    doc:
-      type: git
-      url: https://github.com/ros/genpy.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.5.4-0
-    source:
-      type: git
-      url: https://github.com/ros/genpy.git
       version: indigo-devel
     status: maintained
 type: distribution


### PR DESCRIPTION
Increasing version of package(s) in repository `genlisp` to `0.4.14-0`:
- upstream repository: git@github.com:ros/genlisp.git
- release repository: https://github.com/ros-gbp/genlisp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
