### PR TITLE
cmake_modules: 0.3.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -746,7 +746,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/cmake_modules-release.git
-      version: 0.3.2-0
+      version: 0.3.3-0
     source:
       type: git
       url: https://github.com/ros/cmake_modules.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules` to `0.3.3-0`:
- upstream repository: https://github.com/ros/cmake_modules.git
- release repository: https://github.com/ros-gbp/cmake_modules-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.3.2-0`
## cmake_modules

```
* Added FindPoco.cmake, which migrated from the ros/class_loader repository.
* Update to FindXenomai.cmake
  find_package_handle_standard_args generates all caps variables (XENOMAI_FOUND), while this script is expected to create Xenomai_FOUND.
  This changeset creates the appropriately cased variable, but does not unset the all-caps variant for backwards-compatibility reasons (I typically unset it on new modules).
* Contributors: Adolfo Rodriguez Tsouroukdissian, Esteve Fernandez, William Woodall
```
