### PR TITLE
roscpp_core: 0.5.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -71,5 +71,26 @@ repositories:
       url: https://github.com/ros/genmsg.git
       version: indigo-devel
     status: maintained
+  roscpp_core:
+    doc:
+      type: git
+      url: https://github.com/ros/roscpp_core.git
+      version: indigo-devel
+    release:
+      packages:
+      - cpp_common
+      - roscpp_core
+      - roscpp_serialization
+      - roscpp_traits
+      - rostime
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/roscpp_core-release.git
+      version: 0.5.5-0
+    source:
+      type: git
+      url: https://github.com/ros/roscpp_core.git
+      version: indigo-devel
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.5.5-0`:
- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## cpp_common
- No changes
## roscpp_serialization
- No changes
## roscpp_traits
- No changes
## rostime

```
* move implementation of Duration(Rate) constructor (#30 <https://github.com/ros/roscpp_core/issues/30>)
* fix Duration initialization from seconds for negative values  (#29 <https://github.com/ros/roscpp_core/pull/29>)
```
