### PR TITLE
message_generation: 0.2.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -86,6 +86,21 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: indigo-devel
     status: maintained
+  message_generation:
+    doc:
+      type: git
+      url: https://github.com/ros/message_generation.git
+      version: groovy-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/message_generation-release.git
+      version: 0.2.10-0
+    source:
+      type: git
+      url: https://github.com/ros/message_generation.git
+      version: groovy-devel
+    status: maintained
   roscpp_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_generation` to `0.2.10-0`:
- upstream repository: https://github.com/ros/message_generation.git
- release repository: https://github.com/ros-gbp/message_generation-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
