### PR TITLE
catkin: 0.6.10-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -20,7 +20,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.6.10-0
+      version: 0.6.10-1
     source:
       type: git
       url: https://github.com/ros/catkin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.6.10-1`:
- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.6.10-0`
## catkin

```
* check changes to -D args CATKIN_DEVEL_PREFIX / CMAKE_INSTALL_PREFIX when considering to reinvoke cmake (#700 <https://github.com/ros/catkin/issues/700>)
* add --use-ninja option to catkin_make(_isolated) to use ninja instead of make (#693 <https://github.com/ros/catkin/issues/693>)
* remove 'emulate sh' from setup.zsh (#686 <https://github.com/ros/catkin/issues/686>)
* set terminal title only when isatty (#687 <https://github.com/ros/catkin/issues/687>)
* add description to catkin_make for ignoring packages
* add suggestion to use catkin_make_isolated for non-homogeneous workspaces
* refactor code from run_tests.py into Python module (#678 <https://github.com/ros/catkin/issues/678>)
```
