### PR TITLE
actionlib: 1.11.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -53,7 +53,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.11.2-0
+      version: 1.11.3-0
     source:
       type: git
       url: https://github.com/ros/actionlib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.11.3-0`:
- upstream repository: git@github.com:ros/actionlib.git
- release repository: https://github.com/ros-gbp/actionlib-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.11.2-0`
## actionlib

```
* Increase queue sizes to match Python client publishers.
* Adjust size of client publishers in Python
* Contributors: Esteve Fernandez, Michael Ferguson
```
