### PR TITLE
class_loader: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -579,7 +579,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/class_loader-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/ros/class_loader.git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `0.3.1-0`:
- upstream repository: https://github.com/ros/class_loader
- release repository: https://github.com/ros-gbp/class_loader-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.3.0-0`
## class_loader

```
* Depend on boost
* Use FindPoco.cmake from ros/cmake_modules
* Honor BUILD_SHARED_LIBS and do not force building shared libraries.
* Contributors: Esteve Fernandez, Gary Servin, Scott K Logan
```
