### PR TITLE
geometry_experimental: 0.5.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1666,11 +1666,12 @@ repositories:
       - tf2_msgs
       - tf2_py
       - tf2_ros
+      - tf2_sensor_msgs
       - tf2_tools
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry_experimental-release.git
-      version: 0.5.6-0
+      version: 0.5.7-0
     source:
       type: git
       url: https://github.com/ros/geometry_experimental.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_experimental` to `0.5.7-0`:
- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry_experimental-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.5.6-0`
## geometry_experimental
- No changes
## tf2
- No changes
## tf2_bullet

```
* fixing install rules and adding backwards compatible include with #warning
* Contributors: Tully Foote
```
## tf2_geometry_msgs

```
* fixing transitive dependency for kdl. Fixes #53 <https://github.com/ros/geometry_experimental/issues/53>
* Contributors: Tully Foote
```
## tf2_kdl

```
* fixing install rules and adding backwards compatible include with #warning
* Contributors: Tully Foote
```
## tf2_msgs
- No changes
## tf2_py
- No changes
## tf2_ros

```
* Added 6 param transform again
  Yes, using Euler angles is a bad habit. But it is much more convenient if you just need a rotation by 90° somewhere to set it up in Euler angles. So I added the option to supply only the 3 angles.
* Remove tf2_py dependency for Android
* Contributors: Achim Königs, Gary Servin
```
## tf2_sensor_msgs

```
* add support for transforming sensor_msgs::PointCloud2
* Contributors: Vincent Rabaud
```
## tf2_tools
- No changes
