### PR TITLE
geometry: 1.11.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1645,7 +1645,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry-release.git
-      version: 1.11.3-1
+      version: 1.11.4-0
     source:
       type: git
       url: https://github.com/ros/geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry` to `1.11.4-0`:
- upstream repository: https://github.com/ros/geometry.git
- release repository: https://github.com/ros-gbp/geometry-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.11.3-1`
## eigen_conversions
- No changes
## geometry

```
* Update package.xml
* Contributors: David Lu!!
```
## kdl_conversions

```
* Update package.xml
* Contributors: David Lu!!
```
## tf

```
* Install static lib and remove test for Android
* Larger default queue size in broadcaster
  With queue_size=1 when two transforms are sent in quick succession,
  the second is often lost. The C++ code uses a default queue_size of
  100, so switch to that default here as well. If that is not appropriate,
  a queue_size constructor argument is provided.
* Update package.xml
* add rate parameter to tf_echo
* Added check for normalized quaternion in roswtf plugin
* Contributors: David Lu!!, Gary Servin, Kevin Hallenbeck, Stephan Wirth, contradict
```
## tf_conversions

```
* Update package.xml
* Contributors: David Lu!!
```
