### PR TITLE
jsk_recognition: 0.1.29-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3078,7 +3078,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.1.28-0
+      version: 0.1.29-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.1.29-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.28-0`
## checkerboard_detector

```
* Move multisense specific lines from capture.launch to capture_multisense_training_data.launch
* Added new nodelet to capture training data of stereo camera to
  jsk_pcl_ros and update launch files to capture training data of multisense
* Add launch file to capture training data with two-checker-boarded table
* Add launch file for capture board: publishing center of the capture
  board calculated from two checker board
* Hotfix for mulformed multisense camera_info. Their K and R matrix and
  distirtion parameter is not set
* Add script to estimate position of the camera using two checker boards
* Stabilize color inverted asymetrical circle detection
  1) use cv::bitwise_not to invert color
  2) use cv::CALIB_CB_CLUSTERING when detecting circlesGrid
* Use OpenCV C++ API in checkerboard_detector
* Support color inversion to distinguish white-black circle pattern
  and black-white circle pattern
* Support ciecle and acircle pattern
* Contributors: Ryohei Ueda
```
## imagesift
- No changes
## jsk_pcl_ros

```
* Add document about IntermittentImageAnnotator
* [LINEMODDetector] Do not use small templates
* [CaptureStereoSynchronizer] Does not capture near samples
* Add IntermittentImageAnnotator to select ROI out of several snapshots
* [LINEMODDetector] Use glob to specify template files for linemod
* [LINEMODTrainer] Simulate samples rotating around z-axis
* Add projective ICP registration
* Write PCD file as binary compressed in LINEMODTrainer
* Load linemod training data from pcd and sqmmt files and use OpenMP
  to speed-up it
* Synchronize reference pointcloud and input pointcloud in icp registration
  to refine result of other recognition
* LINEMODDetector: add documentation and load template after setting
  parameters and publish the result of recognition as pointcloud
* Add LINEMODDetector and implement LINEMODTrainer and LINEMODDetector in
  one linemod_nodelet.cpp
* fix transform mistake
* Fix linemod template format. lmt is just a tar file of pcd and sqmm files
* rotate pose of box acoording to looking direction
* Add launch file to reconstruct 3d pointcloud from captured by CaptureStereoSynchronizer
* Add nodelet to train linemod
* Move multisense specific lines from capture.launch to capture_multisense_training_data.launch
* Added new nodelet to capture training data of stereo camera to
  jsk_pcl_ros and update launch files to capture training data of multisense
* Add new nodelet to generate mask image from PointIndices
* Clip Pointcloud and publish the indices inside of a box in AttentionClipper
* Added topic interface to specify the region by jsk_pcl_ros::BoundingBox
* add parameter to choose keeping organized
* Add utility launch file to resize pointcloud and fix initial value of
  use_indices_ in resize_points_publisher_nodelet.cpp
* Support pointclouds include nan in EuclideanClustering
* Remove diagnostic_nodelet.{cpp,h} and connection_based_nodelet.{cpp,h}
  of jsk_pcl_ros and use them of jsk_topic_tools
* Use jsk_topic_tools::ConnectionBasedNodelet in DepthImageError, EdgeDepthReginement, EdgebasedCubeFinder, EuclideanClusterExtraction and GridSampler
* add parameter
* print handle estimation
* use handle_estimator.l instead of nodelet version
* add euslisp handle estimator
* handle_estimator : change condition or to and
* Contributors: Ryohei Ueda, Yusuke Furuta, Chi Wun Au, Yuto Inagaki
```
## jsk_perception

```
* added some more parameters for detection
* Contributors: Yu Ohara
```
## jsk_recognition
- No changes
## resized_image_transport
- No changes
