### PR TITLE
dynpick_driver: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1450,6 +1450,21 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/dynamixel_pro_moveit_controller-release.git
       version: 0.8.1-0
+  dynpick_driver:
+    doc:
+      type: git
+      url: https://github.com/tork-a/dynpick_driver.git
+      version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/tork-a/dynpick_driver-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/tork-a/dynpick_driver.git
+      version: master
+    status: maintained
   eband_local_planner:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dynpick_driver` to `0.0.2-0`:
- upstream repository: https://github.com/tork-a/dynpick_driver.git
- release repository: https://github.com/tork-a/dynpick_driver-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## dynpick_driver

```
* Initial commit
* Add doc
* Contributors: Kei Okada, Isaac I.Y. Saito
```
