### PR TITLE
dynpick_driver: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1199,6 +1199,21 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/arebgun/dynamixel_motor-release.git
       version: 0.4.0-0
+  dynpick_driver:
+    doc:
+      type: git
+      url: https://github.com/tork-a/dynpick_driver.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/dynpick_driver-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/tork-a/dynpick_driver.git
+      version: master
+    status: maintained
   ecl_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynpick_driver` to `0.0.2-0`:
- upstream repository: https://github.com/tork-a/dynpick_driver.git
- release repository: https://github.com/tork-a/dynpick_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## dynpick_driver

```
* Initial commit
* Add doc
* Contributors: Kei Okada, Isaac I.Y. Saito
```
