### PR TITLE
jsk_robot: 0.0.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3084,6 +3084,34 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git
       version: master
     status: maintained
+  jsk_robot:
+    doc:
+      type: git
+      url: https://github.com/tork-a/jsk_robot-release.git
+      version: master
+    release:
+      packages:
+      - baxtereus
+      - jsk_baxter_desktop
+      - jsk_baxter_startup
+      - jsk_baxter_web
+      - jsk_nao_startup
+      - jsk_pepper_startup
+      - jsk_pr2_calibration
+      - jsk_pr2_startup
+      - jsk_robot_startup
+      - pepper_bringup
+      - pepper_description
+      - pr2_base_trajectory_action
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/tork-a/jsk_robot-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/tork-a/jsk_robot-release.git
+      version: master
+    status: developed
   jsk_roseus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `0.0.1-1`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## baxtereus

```
* fix version number
* add wait time for suction
* get baxter hand type property
* fix baxter endcoords and rotate 90
* add action joint client left_w2 right_w2
* do not disable joint-action-enable if gripper action is not found, gazebo did not provide gripper joint action for now
* add tuck-pose and untuck-pose, thanks to wkentaro, iory
* update baxter.yaml (add wrist yaw, head end-coords) baxter.l
* add baxter nod function (send *ri* :nod)
* update baxtereus to use gripper action server
* add reset-manip-pose
* add baxter eus sample
* add :set-baxter-face interface
* do not generate baxter.l if already exists
* add start-grasp and stop-grasp for baxter
* depent to pr2eus speak.l
* add camera interface
* add sound tools and eus speak-en
* fix end-coords
* add baxter.l since baxter_simple.urdf is not released yet
* add code to use baxter_simple.urdf
* add roseus/preus to rundepend
* fix cmake syntax error
* fix for baxter_description is installed
* add missing depends
* change the reset pose
* add baxter-interface.l, validated with 73B2 baxter
* add depends to collada2eus
* use _simple model for smaller dae/lisp files
* add jsk_baxter_robot
* Contributors: Kei Okada, Kentaro Wada, Ryohei Ueda, Tomoya Yoshizawa, Yuto Inagaki, Shintaro Noda
```
## jsk_baxter_desktop

```
* repair desktop icon
* add jsk baxter desktop
* Contributors: Yuto Inagaki
```
## jsk_baxter_startup

```
* fix typo in baxter_tweet
* add time singal in baxter startup
* move twitter related program to robot_common from jsk_pr2_startup
* repair mongodb.launch and add param
* add gripper action server
* add camera info fixer launch in baxter.launch
* use face_recognition package(procrob_functional)
* add camera_info_fixer, camera_info_std publishes with original param and roi, and camera_info publishes cropped image with same roi, it seems something wrong...
* remove unnecessary components
* add wrench publisher
* add depends
* add image saver
* add sound tools and eus speak-en
* modify params
* modify package name
* add baxter tweet
* mv catkin.cmake to CMakeLists.txt
* fix jsk_baxter_startup/package.xml
* remove baxter_interface and baxter_tools from find_package, they do not need to load as COMPONENTS
* remove unneeded lines
* delete objectdetection_tf_publisher and use checker_board_detector's
* add baxter_description
* update kinect.launch
* delete files correctly
* delete voice directory and move file
* delete text2wave and modify voice_echo.l
* Update jsk_baxter_startup
  We added files in jsk_baxter_sensors
  - for kinect.launch
  - add voice set
  - change joy device name
* add baxter joy dir and launch
* add baxter rviz config file for default baxter nodes
* update manifest
* add tmp groovy manifest file
* one more openni => openni_launch space
* update and add catkin.cmake (just rename CMakeLists.txt to catkin.cmake)
* add baxter startup launch file
* Contributors: Kei Okada, Tomoya Yoshizawa, Yuto Inagaki
```
## jsk_baxter_web

```
* debug the loop of link problem
  update to Copy Correctly
* add urdf_viewer for real robot
* delte rwt_ros from find_package
* update .rosinstall to include rwt_ros
* add jsk baxter web
* Contributors: Yuto Inagaki
```
## jsk_nao_startup

```
* nao_vision and audio launch added
* update nao_driver -> naoqi_driver
* add jsk_nao_startup
* Contributors: Yuki Furuta, Kanae Kochigami
```
## jsk_pepper_startup

```
* add depends to pepper_bringup
* fix launch file as of Dec 14
* use jsk_pepper_bringup and now naoqi repos
* add more depends
* tweet when imu is learge
* deleted displaying installed behaviors (only it was test)
* conversation added to face recognition
* remove nao_driver from depends
* add comment to how to modify voices
* add learn face example
* check timestamp to publish images
* add nao_interaction_msgs
* update sample, without face recognition
* use all cameras (top/bottom/depeth)
* use key for recognize-word
* use naoqi_sensors
* add simple demo code
* add nao_dashboard
* add sample/sample.l
* fix package.xml
* move tweet.l under nodes directory, listen /pepper_tweet
* some voice added
* some bugs fixed
* pepper speaking function added
* add jsk_peper_robot (add CMakeLists.txt launch/jsk_pepper_startup.launch package.xml tweet.l)
* Contributors: Kanae Kochigami, Kei Okada
```
## jsk_pr2_calibration

```
* Remove generate file
* Add utility package to generate JSK-style pr2 urdf
* Contributors: Ryohei Ueda
```
## jsk_pr2_startup

```
* Restarting kinect paranoiac
  1) usb reset
  2) kill nodelet manager
  3) kill child processing
  4) restart openni.launch (hardcoded!)
* Add rviz_mouse_point_to_tablet.py to pr2.launch
* Use larger value to detect gound object by PR2 to avoid small noises
* Add sound when launching pr2.launch
* kill nodelet manager and processes rather than killing openni/driver
* Say something at the end of pr2.launch
* Use low framerate for gripper sensors to avoid high load
* move twitter related program to robot_common from jsk_pr2_startup
* modify launch file for gazebo
* add yaml file for gazebo
* delete LaserScanIntensityFilter
* modify sensors_kinect and add sensors
* move pr2 related package under jsk_pr2_robot
* Contributors: Ryohei Ueda, Yuto Inagaki, Yusuke Furuta
```
## jsk_robot_startup

```
* check joint state and set movep for odom disable robot
* Add sound when launching pr2.launch
* Say something at the end of pr2.launch
* move twitter related program to robot_common from jsk_pr2_startup
* add ros-info
* robot time signal
* add tweet.l, see jsk_nao_startup.launch for example
* repiar mongodb.launch
* repair mongodb.launch and add param
* add jsk_robot_common/jsk_robot_startup
* Contributors: Kanae Kochigami, Ryohei Ueda, Yuto Inagaki, Yusuke Furuta
```
## pepper_bringup

```
* add pepper_bringup, add CMakeLists.txt package.xml launch/pepper.launch
* Contributors: Kei Okada
```
## pepper_description

```
* add pepper_description/.gitignore
* add pepper_description, just cmakefile to convert xml model file simulator to urdf, you need latest assimp
* Contributors: Kei Okada
```
## pr2_base_trajectory_action

```
* fix version number
* move pr2 related package under jsk_pr2_robot
* Contributors: Kei Okada, Yuto Inagaki
```
