### PR TITLE
leap_motion: 0.0.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3431,7 +3431,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/leap_motion-release.git
-      version: 0.0.4-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/ros-drivers/leap_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leap_motion` to `0.0.7-0`:
- upstream repository: https://github.com/ros-drivers/leap_motion
- release repository: https://github.com/ros-gbp/leap_motion-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.4-0`
## leap_motion

```
* Build some binaries only when SDK is installed (Fix to https://github.com/ros-drivers/leap_motion/issues/7).
* Contributors: Isaac I.Y. Saito, Yu Ohara
```
