### PR TITLE
cmake_modules: 0.4.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -26,6 +26,21 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: indigo-devel
     status: maintained
+  cmake_modules:
+    doc:
+      type: git
+      url: https://github.com/ros/cmake_modules.git
+      version: 0.4-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/cmake_modules-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/ros/cmake_modules.git
+      version: 0.4-devel
+    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules` to `0.4.0-0`:
- upstream repository: https://github.com/ros/cmake_modules.git
- release repository: https://github.com/ros-gbp/cmake_modules-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `null`
## cmake_modules

```
* The Eigen module provided by this package has been deprecated.
  There is now a CMake warning to encourage people to use the Module provided by Eigen instead.
* Contributors: William Woodall
```
