### PR TITLE
Revert "jsk_roseus: 1.1.27-1 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2471,6 +2471,7 @@ repositories:
       version: master
     release:
       packages:
+      - geneus
       - jsk_roseus
       - roseus
       - roseus_msgs
@@ -2478,7 +2479,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.27-1
+      version: 1.1.27-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
roll back release failing to build #6626 
