### PR TITLE
rospeex: 2.12.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6944,6 +6944,20 @@ repositories:
       type: git
       url: https://bitbucket.org/rospeex/rospeex.git
       version: master
+    release:
+      packages:
+      - rospeex
+      - rospeex_audiomonitor
+      - rospeex_core
+      - rospeex_if
+      - rospeex_launch
+      - rospeex_msgs
+      - rospeex_samples
+      - rospeex_webaudiomonitor
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://bitbucket.org/rospeex/rospeex-release.git
+      version: 2.12.0-0
     source:
       type: git
       url: https://bitbucket.org/rospeex/rospeex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospeex` to `2.12.0-0`:
- upstream repository: https://bitbucket.org/rospeex/rospeex.git
- release repository: https://bitbucket.org/rospeex/rospeex-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
