### PR TITLE
rosbridge_suite: 0.7.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6655,10 +6655,11 @@ repositories:
       - rosbridge_library
       - rosbridge_server
       - rosbridge_suite
+      - rosbridge_tools
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.7.4-0
+      version: 0.7.6-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.7.6-0`:
- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.7.4-0`
## rosapi

```
* 0.7.5
* update changelog
* 0.7.4
* changelog updated
* 0.7.3
* changelog updated
* 0.7.2
* changelog updated
* 0.7.1
* update changelog
* 0.7.0
* changelog updated
* Contributors: Jihoon Lee, Russell Toris
```
## rosbridge_library

```
* 0.7.5
* update changelog
* 0.7.4
* changelog updated
* 0.7.3
* changelog updated
* 0.7.2
* changelog updated
* 0.7.1
* update changelog
* 0.7.0
* changelog updated
* rewrite of advertise service
* cleanup init function
* matches original call_service
* matches original call_service
* service_request --> reuse of call_service (previously defined)
* stop_service --> unadvertise_service
* service_name --> service
* service_type --> type
* removed service_module
* request_id --> id
* Contributors: Jihoon Lee, Russell Toris
```
## rosbridge_server

```
* 0.7.5
* update changelog
* Function in robridge_tools for importing tornado
* Revert "reverts back to internal tornado until fix is ready"
  This reverts commit 49eeb1d97da154213d3170c95169b5677b329d07.
* 0.7.4
* changelog updated
* reverts back to internal tornado until fix is ready
* 0.7.3
* changelog updated
* 0.7.2
* changelog updated
* use alias to import rosbridge_tool tornado
* move modules under rosbridge_tools
* 0.7.1
* update changelog
* Merge pull request #147 from RobotWebTools/migrate_third_parties
  separate tornado and backports from rosbridge_server
* seprate out third party library and ros related script
* remove setup.py
* add rosbridge_tools as rosbridge_server dependency
* remove python-imaging dependency. it is used in rosbridge_library
* 0.7.0
* changelog updated
* Contributors: Jihoon Lee, Jon Binney, Russell Toris
```
## rosbridge_suite

```
* 0.7.5
* update changelog
* 0.7.4
* changelog updated
* 0.7.3
* changelog updated
* 0.7.2
* changelog updated
* 0.7.1
* update changelog
* 0.7.0
* changelog updated
* Contributors: Jihoon Lee, Russell Toris
```
## rosbridge_tools

```
* 0.7.5
* update package version of rosbridge_tool
* update changelog
* Function in robridge_tools for importing tornado
* Remove tornado import aliases
* Revert "reverts back to internal tornado until fix is ready"
  This reverts commit 49eeb1d97da154213d3170c95169b5677b329d07.
* reverts back to internal tornado until fix is ready
* 0.7.3
* changelog updated
* setup.py includes all packages (fixes catkin_make install)
* 0.7.2
* changelog updated
* alias rosbridge_tools.tornado as tornado
* move modules under rosbridge_tools
* 0.7.1
* update changelog
* seprate out third party library and ros related script
* Contributors: Jihoon Lee, Jon Binney, Russell Toris
```
