### PR TITLE
rospack: 2.2.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -177,6 +177,21 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: indigo-devel
     status: maintained
+  rospack:
+    doc:
+      type: git
+      url: https://github.com/ros/rospack.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/rospack-release.git
+      version: 2.2.5-0
+    source:
+      type: git
+      url: https://github.com/ros/rospack.git
+      version: indigo-devel
+    status: maintained
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.2.5-0`:
- upstream repository: https://github.com/ros/rospack.git
- release repository: https://github.com/ros-gbp/rospack-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## rospack

```
* support tags defined in package format 2 (#43 <https://github.com/ros/rospack/issues/43>)
```
