### PR TITLE
change urls in rosdep default list to use raw.githubusercontent.com

### DIFF
--- a/rosdep/sources.list.d/20-default.list
+++ b/rosdep/sources.list.d/20-default.list
@@ -1,10 +1,10 @@
 # os-specific listings first
-yaml https://github.com/ros/rosdistro/raw/master/rosdep/osx-homebrew.yaml osx
+yaml https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/osx-homebrew.yaml osx
 
 # generic
-yaml https://github.com/ros/rosdistro/raw/master/rosdep/base.yaml
-yaml https://github.com/ros/rosdistro/raw/master/rosdep/python.yaml
-yaml https://github.com/ros/rosdistro/raw/master/rosdep/ruby.yaml
-gbpdistro https://github.com/ros/rosdistro/raw/master/releases/fuerte.yaml fuerte
+yaml https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml
+yaml https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/python.yaml
+yaml https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/ruby.yaml
+gbpdistro https://raw.githubusercontent.com/ros/rosdistro/master/releases/fuerte.yaml fuerte
 
 # newer distributions (Groovy, Hydro, ...) must not be listed anymore, they are being fetched from the rosdistro index.yaml instead


### PR DESCRIPTION
As recommended by GitHub some time ago.

@esteve @tfoote @wjwwood Please review.
