### PR TITLE
ros_comm: 1.11.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -158,6 +158,53 @@ repositories:
       url: https://github.com/ros/ros.git
       version: jade-devel
     status: maintained
+  ros_comm:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_comm.git
+      version: indigo-devel
+    release:
+      packages:
+      - message_filters
+      - ros_comm
+      - rosbag
+      - rosbag_storage
+      - rosconsole
+      - roscpp
+      - rosgraph
+      - roslaunch
+      - roslz4
+      - rosmaster
+      - rosmsg
+      - rosnode
+      - rosout
+      - rosparam
+      - rospy
+      - rosservice
+      - rostest
+      - rostopic
+      - roswtf
+      - test_rosbag
+      - test_rosbag_storage
+      - test_roscpp
+      - test_rosgraph
+      - test_roslaunch
+      - test_roslib_comm
+      - test_rosmaster
+      - test_rosparam
+      - test_rospy
+      - test_rosservice
+      - topic_tools
+      - xmlrpcpp
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/ros_comm-release.git
+      version: 1.11.10-0
+    source:
+      type: git
+      url: https://github.com/ros/ros_comm.git
+      version: indigo-devel
+    status: maintained
   ros_comm_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.10-0`:
- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## message_filters
- No changes
## ros_comm
- No changes
## rosbag

```
* add option to specify the minimum disk space at which recording is stopped (#500 <https://github.com/ros/ros_comm/pull/500>)
* add convenience API to Python rosbag (#508 <https://github.com/ros/ros_comm/issues/508>)
* fix delay on detecting a running rosmaster with use_sim_time set (#532 <https://github.com/ros/ros_comm/pull/532>)
```
## rosbag_storage

```
* fix various defects reported by coverity
```
## rosconsole

```
* fix various defects reported by coverity
```
## roscpp

```
* fix various defects reported by coverity
* fix comment (#529 <https://github.com/ros/ros_comm/issues/529>)
* improve Android support (#518 <https://github.com/ros/ros_comm/pull/518>)
```
## rosgraph

```
* rosconsole format for rospy (#517 <https://github.com/ros/ros_comm/issues/517>)
* fix exception at roscore startup if python has IPv6 disabled (#515 <https://github.com/ros/ros_comm/issues/515>)
```
## roslaunch

```
* fix exception at roscore startup if python has IPv6 disabled (#515 <https://github.com/ros/ros_comm/issues/515>)
* fix error handling (#516 <https://github.com/ros/ros_comm/pull/516>)
* fix compatibility with paramiko 1.10.0 (#498 <https://github.com/ros/ros_comm/pull/498>)
```
## roslz4

```
* disable lz4 Python bindings on Android (#521 <https://github.com/ros/ros_comm/pull/521>)
```
## rosmaster

```
* fix closing sockets properly on node shutdown (#495 <https://github.com/ros/ros_comm/issues/495>)
```
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy

```
* add specific exception for time jumping backwards (#485 <https://github.com/ros/ros_comm/issues/485>)
* make param functions thread-safe (#523 <https://github.com/ros/ros_comm/pull/523>)
* fix infinitely retrying subscriber (#533 <https://github.com/ros/ros_comm/issues/533>)
* fix removal of QueuedConnection leading to wrong subscriber count (#526 <https://github.com/ros/ros_comm/issues/526>)
* fix TCPROS header validation when callerid header is not set (#522 <https://github.com/ros/ros_comm/issues/522>, regression from 1.11.1)
* fix memory leak when using subcriber statistics (#520 <https://github.com/ros/ros_comm/issues/520>)
* fix reported traffic in bytes from Python nodes (#501 <https://github.com/ros/ros_comm/issues/501>)
```
## rosservice
- No changes
## rostest
- No changes
## rostopic

```
* add support for fixed-width floating-point and integer array values (#400 <https://github.com/ros/ros_comm/issues/400>)
```
## roswtf
- No changes
## topic_tools
- No changes
## xmlrpcpp

```
* improve Android support (#537 <https://github.com/ros/ros_comm/pull/537>)
* fix various defects reported by coverity
```
