### PR TITLE
mrpt_navigation: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3422,16 +3422,18 @@ repositories:
     release:
       packages:
       - mrpt_bridge
+      - mrpt_local_obstacles
       - mrpt_localization
       - mrpt_map
       - mrpt_msgs
       - mrpt_navigation
       - mrpt_rawlog
+      - mrpt_reactivenav2d
       - mrpt_tutorials
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `0.1.4-0`:
- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.3-0`
## mrpt_bridge

```
* Solved some old 'TODO' comments
* Removed 'mrpt' dep from catkin_package().
  I *think* this is giving problems to dependant pkgs and is not needed...
* Start new pkg mrpt_local_obstacles.
  Fixes in package.xml's
* Better doxygen docs
* localization: New param to configure sensor sources in a flexible way
* Contributors: Jose Luis Blanco
```
## mrpt_local_obstacles

```
* First working version of the package
* Contributors: Jose Luis Blanco
```
## mrpt_localization

```
* dont publish if numSubscribers()==0
* fixes for mrpt 1.3.0
* Removed 'mrpt' dep from catkin_package().
  I *think* this is giving problems to dependant pkgs and is not needed...
* pose_cov_ops removed from mrpt_navigation metapkg
* localization: New param to configure sensor sources in a flexible way
* Contributors: Jose Luis Blanco
```
## mrpt_map

```
* Removed 'mrpt' dep from catkin_package().
  I *think* this is giving problems to dependant pkgs and is not needed...
* localization: New param to configure sensor sources in a flexible way
* Contributors: Jose Luis Blanco
```
## mrpt_msgs
- No changes
## mrpt_navigation

```
* Start new pkg mrpt_local_obstacles.
  Fixes in package.xml's
* pose_cov_ops removed from mrpt_navigation metapkg
* Contributors: Jose Luis Blanco
```
## mrpt_rawlog

```
* Removed 'mrpt' dep from catkin_package().
  I *think* this is giving problems to dependant pkgs and is not needed...
* localization: New param to configure sensor sources in a flexible way
* Contributors: Jose Luis Blanco
```
## mrpt_reactivenav2d

```
* First working version of the reactive navigator
* Contributors: Jose Luis Blanco
```
## mrpt_tutorials
- No changes
