### PR TITLE
mvsim: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3494,6 +3494,11 @@ repositories:
       type: git
       url: https://github.com/ual-arm-ros-pkg/multivehicle-simulator.git
       version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ual-arm-ros-pkg/multivehicle-simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.1.1-0`:
- upstream repository: https://github.com/ual-arm-ros-pkg/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## mvsim

```
* First public release.
* Contributors: Jose Luis Blanco
```
