### PR TITLE
roscpp_core: 0.4.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6695,7 +6695,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.4.3-0
+      version: 0.4.4-0
     source:
       type: git
       url: https://github.com/ros/roscpp_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.4.4-0`:
- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.4.3-0`
## cpp_common
- No changes
## roscpp_serialization
- No changes
## roscpp_traits
- No changes
## rostime

```
* move implementation of Duration(Rate) constructor (#30 <https://github.com/ros/roscpp_core/issues/30>)
* fix Duration initialization from seconds for negative values  (#29 <https://github.com/ros/roscpp_core/pull/29>)
```
