### PR TITLE
ros: 1.10.11-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6406,7 +6406,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.10.10-0
+      version: 1.10.11-0
     source:
       type: git
       url: https://github.com/ros/ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.10.11-0`:
- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.10.10-0`
## mk
- No changes
## rosbash

```
* match behaviour of 'roscd' in zsh with bash (#73 <https://github.com/ros/ros/pull/73>)
```
## rosboost_cfg
- No changes
## rosbuild

```
* fix dry clean-test-results target (#71 <https://github.com/ros/ros/issues/71>)
```
## rosclean
- No changes
## roscreate
- No changes
## roslang
- No changes
## roslib

```
* consider std_msgs/Header to be a valid header in rosbuild-based messages (#67 <https://github.com/ros/ros/pull/67>)
```
## rosmake
- No changes
## rosunit
- No changes
