### PR TITLE
ros_comm: 1.10.12-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6459,7 +6459,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.10.11-0
+      version: 1.10.12-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.10.12-0`:
- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.10.11-0`
## message_filters
- No changes
## ros_comm
- No changes
## rosbag

```
* fix delay on detecting a running rosmaster with use_sim_time set (#532 <https://github.com/ros/ros_comm/pull/532>)
```
## rosbag_storage
- No changes
## rosconsole
- No changes
## roscpp
- No changes
## rosgraph
- No changes
## rosgraph_msgs
- No changes
## roslaunch
- No changes
## rosmaster

```
* fix closing sockets properly on node shutdown (#495 <https://github.com/ros/ros_comm/issues/495>)
```
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy

```
* fix infinitely retrying subscriber (#533 <https://github.com/ros/ros_comm/issues/533>)
```
## rosservice
- No changes
## rostest
- No changes
## rostopic
- No changes
## roswtf
- No changes
## std_srvs
- No changes
## topic_tools
- No changes
## xmlrpcpp
- No changes
