### PR TITLE
dynpick_driver: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1217,7 +1217,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/dynpick_driver-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/tork-a/dynpick_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynpick_driver` to `0.0.3-0`:
- upstream repository: https://github.com/tork-a/dynpick_driver.git
- release repository: https://github.com/tork-a/dynpick_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.2-0`
## dynpick_driver

```
* Fix/Typo, this may break downstream packages #7 <https://github.com/tork-a/dynpick_driver/issues/7> from k-okada/fix_typo
* Fix/Install missing resource. #6 <https://github.com/tork-a/dynpick_driver/issues/6> from 130s/fix/install_launch
* Contributors: Kei Okada, Isaac I.Y. Saito
```
