### PR TITLE
rocon_qt_gui: 0.7.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5051,7 +5051,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_qt_gui-release.git
-      version: 0.7.3-0
+      version: 0.7.4-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_qt_gui.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_qt_gui` to `0.7.4-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_qt_gui.git
- release repository: https://github.com/yujinrobot-release/rocon_qt_gui-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.7.3-0`
## concert_admin_app
- No changes
## concert_conductor_graph
- No changes
## concert_qt_make_a_map
- No changes
## concert_qt_map_annotation
- No changes
## concert_qt_service_info
- No changes
## concert_qt_teleop
- No changes
## rocon_gateway_graph
- No changes
## rocon_qt_app_manager
- No changes
## rocon_qt_gui
- No changes
## rocon_qt_library

```
* update setup.py to install submodules fixes #173 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/173>
* Contributors: Jihoon Lee
```
## rocon_qt_listener
- No changes
## rocon_qt_master_info
- No changes
## rocon_qt_teleop
- No changes
## rocon_remocon
- No changes
