### PR TITLE
rocon_app_platform: 0.7.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4945,7 +4945,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_app_platform-release.git
-      version: 0.7.3-0
+      version: 0.7.4-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_app_platform` to `0.7.4-0`:
- upstream repository: http://github.com/robotics-in-concert/rocon_app_platform
- release repository: https://github.com/yujinrobot-release/rocon_app_platform-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.7.3-0`
## rocon_app_manager

```
* ignore unncessay remapping rule #265 <https://github.com/robotics-in-concert/rocon_app_platform/issues/265>
* Contributors: Jihoon Lee
```
## rocon_app_platform
- No changes
## rocon_app_utilities
- No changes
## rocon_apps

```
* volume is now configurable
* Contributors: Jihoon Lee
```
