### PR TITLE
angles: 1.9.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -11,6 +11,21 @@ release_platforms:
   - utopic
   - vivid
 repositories:
+  angles:
+    doc:
+      type: git
+      url: https://github.com/ros/angles.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/geometry_angles_utils-release.git
+      version: 1.9.10-0
+    source:
+      type: git
+      url: https://github.com/ros/angles.git
+      version: master
+    status: maintained
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `angles` to `1.9.10-0`:
- upstream repository: https://github.com/ros/angles.git
- release repository: https://github.com/ros-gbp/geometry_angles_utils-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## angles

```
* Export architecture_independent flag in package.xml
* Simply and improve performance of shortest_angular_distance(). adding two unit test cases
* check for CATKIN_ENABLE_TESTING
* Contributors: Derek King, Lukas Bulwahn, Scott K Logan, Tully Foote
```
