### PR TITLE
turtlebot: 2.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6627,10 +6627,11 @@ repositories:
       - turtlebot_bringup
       - turtlebot_capabilities
       - turtlebot_description
+      - turtlebot_teleop
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot-release.git
-      version: 2.3.0-0
+      version: 2.3.2-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot` to `2.3.2-0`:
- upstream repository: https://github.com/turtlebot/turtlebot.git
- release repository: https://github.com/turtlebot-release/turtlebot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `2.3.0-0`
## turtlebot

```
* cleanup metapackage. add teleop and remove laptop battery_monitor
* Contributors: Jihoon Lee
```
## turtlebot_bringup
- No changes
## turtlebot_capabilities
- No changes
## turtlebot_description
- No changes
## turtlebot_teleop
- No changes
