### PR TITLE
turtlebot_apps: 2.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6637,6 +6637,32 @@ repositories:
       url: https://github.com/turtlebot/turtlebot.git
       version: indigo
     status: developed
+  turtlebot_apps:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_apps.git
+      version: indigo
+    release:
+      packages:
+      - pano_core
+      - pano_py
+      - pano_ros
+      - turtlebot_actions
+      - turtlebot_apps
+      - turtlebot_calibration
+      - turtlebot_follower
+      - turtlebot_navigation
+      - turtlebot_panorama
+      - turtlebot_rapps
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/turtlebot-release/turtlebot_apps-release.git
+      version: 2.3.1-0
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_apps.git
+      version: indigo
+    status: developed
   turtlebot_arm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_apps` to `2.3.1-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_apps.git
- release repository: https://github.com/turtlebot-release/turtlebot_apps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## pano_core
- No changes
## pano_py
- No changes
## pano_ros
- No changes
## turtlebot_actions
- No changes
## turtlebot_apps

```
* remove turtlebot_telop from meta package
* Contributors: Jihoon Lee
```
## turtlebot_calibration
- No changes
## turtlebot_follower
- No changes
## turtlebot_navigation
- No changes
## turtlebot_panorama
- No changes
## turtlebot_rapps
- No changes
