### PR TITLE
turtlebot_interactions: 2.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6700,6 +6700,26 @@ repositories:
       url: https://github.com/turtlebot/turtlebot_create_desktop.git
       version: indigo
     status: maintained
+  turtlebot_interactions:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_interactions.git
+      version: indigo
+    release:
+      packages:
+      - turtlebot_dashboard
+      - turtlebot_interactions
+      - turtlebot_interactive_markers
+      - turtlebot_rviz_launchers
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/turtlebot-release/turtlebot_interactions-release.git
+      version: 2.3.0-0
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_interactions.git
+      version: indigo
+    status: developed
   turtlebot_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_interactions` to `2.3.0-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_interactions.git
- release repository: https://github.com/turtlebot-release/turtlebot_interactions-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## turtlebot_dashboard
- No changes
## turtlebot_interactions
- No changes
## turtlebot_interactive_markers
- No changes
## turtlebot_rviz_launchers
- No changes
