### PR TITLE
turtlebot_simulator: 2.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6761,6 +6761,26 @@ repositories:
       url: https://github.com/turtlebot/turtlebot_msgs.git
       version: indigo
     status: maintained
+  turtlebot_simulator:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_simulator.git
+      version: indigo
+    release:
+      packages:
+      - turtlebot_gazebo
+      - turtlebot_simulator
+      - turtlebot_stage
+      - turtlebot_stdr
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/turtlebot-release/turtlebot_simulator-release.git
+      version: 2.2.0-0
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_simulator.git
+      version: indigo
+    status: developed
   twist_mux:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_simulator` to `2.2.0-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_simulator.git
- release repository: https://github.com/turtlebot-release/turtlebot_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## turtlebot_gazebo

```
* use env hook to configure gazebo world and map fixes #40 <https://github.com/turtlebot/turtlebot_simulator/issues/40>
* now it uses args to load world. and corridor world is added. #39 <https://github.com/turtlebot/turtlebot_simulator/issues/39>
* disable create gazebo plugin
* Add turtlebot_navigation to turtlebot_gazebo depends
  gmapping_demo.launch depends on it.
* Contributors: Jihoon Lee, Jochen Sprickerhof
```
## turtlebot_simulator

```
* add turtlebot_stdr in meta package fixes #44 <https://github.com/turtlebot/turtlebot_simulator/issues/44>
* add turtlebot_stage
* Contributors: Jihoon Lee
```
## turtlebot_stage

```
* Adds border extension to map to fix map scaling / position in stage
* Added changes in the stage launch file undone before because of the merge
* Merged
* Moved env fold inside stage
* Revert "Stage launch use env variables"
* Small fix for wrong file name of env script
* Added support for map and world file through env variables
* remove annotation and param install rule
* updated rviz configuration for dwa.
* add the trajectory cloud to stage's rviz view.
* stage only permits 'square' robots, so make sure our square fits within
  the turtlebot defined circle otherwise it collides when it normally
  wouldn't.
* redirect all params and launchers at the real turtlebot configuration files and cleanup, #21 <https://github.com/turtlebot/turtlebot_simulator/issues/21>.
* remove unused plugins and add the cost cloud.
* add turtlebot_stage
* Contributors: Alexander Reimann, Daniel Stonier, Jihoon Lee
* Adds border extension to map to fix map scaling / position in stage
* Added changes in the stage launch file undone before because of the merge
* Merged
* Moved env fold inside stage
* Revert "Stage launch use env variables"
* Small fix for wrong file name of env script
* Added support for map and world file through env variables
* remove annotation and param install rule
* updated rviz configuration for dwa.
* add the trajectory cloud to stage's rviz view.
* stage only permits 'square' robots, so make sure our square fits within
  the turtlebot defined circle otherwise it collides when it normally
  wouldn't.
* redirect all params and launchers at the real turtlebot configuration files and cleanup, #21 <https://github.com/turtlebot/turtlebot_simulator/issues/21>.
* remove unused plugins and add the cost cloud.
* add turtlebot_stage
* Contributors: Alexander Reimann, Daniel Stonier, Jihoon Lee
```
## turtlebot_stdr

```
* add installrule for tf_connector and robot directory
* Use default map topic name map after changing stdr's internal map server's topic
* Use only one map topic and remove unused sensors from rviz
* add stdr_resources as run_depend closes #38 <https://github.com/turtlebot/turtlebot_simulator/issues/38>
* correct run_depend for stdr fixes #37 <https://github.com/turtlebot/turtlebot_simulator/issues/37>
* renamed new_map to rviz_map, a map with the right global frame id
* Update turtlebot.yaml
* Update tf_connector.py
* fixed map and costmap misalignement due to wrong frame_id
* fix laser scan min max height for simulation
* added architecture image
* deleted cache file
* added env-hooks folder
* add env-hooks and changed the fixed frame in rviz from map to world
* Cleaned up CMakeLists.txt
* removed param and amcl/movebase modified launch files
* turtlebot_stdr v0.1
* Contributors: Jihoon Lee, Mehdi Tlili
* add installrule for tf_connector and robot directory
* Use default map topic name map after changing stdr's internal map server's topic
* Use only one map topic and remove unused sensors from rviz
* add stdr_resources as run_depend closes #38 <https://github.com/turtlebot/turtlebot_simulator/issues/38>
* correct run_depend for stdr fixes #37 <https://github.com/turtlebot/turtlebot_simulator/issues/37>
* renamed new_map to rviz_map, a map with the right global frame id
* Update turtlebot.yaml
* Update tf_connector.py
* fixed map and costmap misalignement due to wrong frame_id
* fix laser scan min max height for simulation
* added architecture image
* deleted cache file
* added env-hooks folder
* add env-hooks and changed the fixed frame in rviz from map to world
* Cleaned up CMakeLists.txt
* removed param and amcl/movebase modified launch files
* turtlebot_stdr v0.1
* Contributors: Jihoon Lee, Mehdi Tlili
```
