### PR TITLE
ros_tutorials: 0.5.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -265,6 +265,26 @@ repositories:
       url: https://github.com/ros/ros_comm_msgs.git
       version: indigo-devel
     status: maintained
+  ros_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: indigo-devel
+    release:
+      packages:
+      - ros_tutorials
+      - roscpp_tutorials
+      - rospy_tutorials
+      - turtlesim
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/ros_tutorials-release.git
+      version: 0.5.2-0
+    source:
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: indigo-devel
+    status: maintained
   rosbag_migration_rule:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `0.5.2-0`:
- upstream repository: git@github.com:ros/ros_tutorials.git
- release repository: https://github.com/ros-gbp/ros_tutorials-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## ros_tutorials
- No changes
## roscpp_tutorials
- No changes
## rospy_tutorials

```
* update code style of examples (#18 <https://github.com/ros/ros_tutorials/pull/18>, #19 <https://github.com/ros/ros_tutorials/pull/19>)
```
## turtlesim
- No changes
