### PR TITLE
dynamic_reconfigure: 1.5.38-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -82,6 +82,21 @@ repositories:
       url: https://github.com/ros/common_msgs.git
       version: jade-devel
     status: maintained
+  dynamic_reconfigure:
+    doc:
+      type: git
+      url: https://github.com/ros/dynamic_reconfigure.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
+      version: 1.5.38-1
+    source:
+      type: git
+      url: https://github.com/ros/dynamic_reconfigure.git
+      version: master
+    status: maintained
   ecto:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.5.38-1`:
- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## dynamic_reconfigure

```
* Fixes #35 <https://github.com/ros/dynamic_reconfigure/issues/35> by setting queue_size to 10 for publishers.
* Fixes #31 <https://github.com/ros/dynamic_reconfigure/issues/31> by removing boilerplate and copyright info from config header.
* Python 3 Support
* Honor BUILD_SHARED_LIBS and do not force building shared libraries.
* Unicode support
* Contributors: Basheer Subei, Esteve Fernandez, Gary Servin, Kei Okada, Scott K Logan
```
