### PR TITLE
actionlib: 1.11.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -11,6 +11,21 @@ release_platforms:
   - utopic
   - vivid
 repositories:
+  actionlib:
+    doc:
+      type: git
+      url: https://github.com/ros/actionlib.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/actionlib-release.git
+      version: 1.11.3-0
+    source:
+      type: git
+      url: https://github.com/ros/actionlib.git
+      version: indigo-devel
+    status: maintained
   angles:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.11.3-0`:
- upstream repository: https://github.com/ros/actionlib.git
- release repository: https://github.com/ros-gbp/actionlib-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## actionlib

```
* Increase queue sizes to match Python client publishers.
* Adjust size of client publishers in Python
* Contributors: Esteve Fernandez, Michael Ferguson
```
