### PR TITLE
bond_core: 1.7.16-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -26,6 +26,28 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  bond_core:
+    doc:
+      type: git
+      url: https://github.com/ros/bond_core.git
+      version: master
+    release:
+      packages:
+      - bond
+      - bond_core
+      - bondcpp
+      - bondpy
+      - smclib
+      - test_bond
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/bond_core-release.git
+      version: 1.7.16-0
+    source:
+      type: git
+      url: https://github.com/ros/bond_core.git
+      version: master
+    status: maintained
   catkin:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -38,7 +38,6 @@ repositories:
       - bondcpp
       - bondpy
       - smclib
-      - test_bond
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/bond_core-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.7.16-0`:
- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
