### PR TITLE
Fix libpq-dev dep for Fedora 21+

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1658,7 +1658,13 @@ libpopt-dev:
 libpq-dev:
   arch: [postgresql-libs]
   debian: [libpq-dev]
-  fedora: [derelict-postgresql-devel, postgresql-devel]
+  fedora:
+    '21': [derelict-PQ-devel, postgresql-devel]
+    '22': [derelict-PQ-devel, postgresql-devel]
+    beefy: [derelict-postgresql-devel, postgresql-devel]
+    heisenbug: [derelict-postgresql-devel, postgresql-devel]
+    schrödinger’s: [derelict-postgresql-devel, postgresql-devel]
+    spherical: [derelict-postgresql-devel, postgresql-devel]
   gentoo:
     portage:
       packages: [dev-libs/libpqxx]


### PR DESCRIPTION
The package name changed in Fedora 21 (and doesn't provide a virtual package under the old name for compatability...boo...)
