### PR TITLE
Combined fix for unicode and include fedora 21+ fixes

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1658,7 +1658,13 @@ libpopt-dev:
 libpq-dev:
   arch: [postgresql-libs]
   debian: [libpq-dev]
-  fedora: [derelict-postgresql-devel, postgresql-devel]
+  fedora:
+    '21': [derelict-PQ-devel, postgresql-devel]
+    '22': [derelict-PQ-devel, postgresql-devel]
+    beefy: [derelict-postgresql-devel, postgresql-devel]
+    heisenbug: [derelict-postgresql-devel, postgresql-devel]
+    schrödinger’s: [derelict-postgresql-devel, postgresql-devel]
+    spherical: [derelict-postgresql-devel, postgresql-devel]
   gentoo:
     portage:
       packages: [dev-libs/libpqxx]

--- a/test/test_url_validity.py
+++ b/test/test_url_validity.py
@@ -3,7 +3,7 @@
 from __future__ import print_function
 
 
-from io import BytesIO
+from io import StringIO
 import os
 import subprocess
 import yaml
@@ -51,7 +51,9 @@ def detect_lines(diffstr):
     """Take a diff string and return a dict of
     files with line numbers changed"""
     resultant_lines = {}
-    io = BytesIO(diffstr)
+    # Force utf-8 re: https://github.com/ros/rosdistro/issues/6637
+    encoding = 'utf-8'
+    io = StringIO(unicode(diffstr, encoding))
     udiff = unidiff.PatchSet(io)
     for file in udiff:
         target_lines = []


### PR DESCRIPTION
Replaces #6738  and fixes #6637 
