### PR TITLE
concert_services: 0.1.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -992,7 +992,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/concert_services-release.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/concert_services.git


### PR DESCRIPTION
Increasing version of package(s) in repository `concert_services` to `0.1.6-0`:
- upstream repository: https://github.com/robotics-in-concert/concert_services.git
- release repository: https://github.com/yujinrobot-release/concert_services-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.5-0`
## concert_service_admin
- No changes
## concert_service_gazebo

```
* add robot gazebos as runpdend fixes #36 <https://github.com/robotics-in-concert/concert_services/issues/36>
* update install rule for concert service gazebo fixes #34 <https://github.com/robotics-in-concert/concert_services/issues/34>
* remove topic_relay closes #35 <https://github.com/robotics-in-concert/concert_services/issues/35>
* Contributors: Jihoon Lee
```
## concert_service_indoor_2d_map_prep
- No changes
## concert_service_teleop
- No changes
## concert_service_turtlesim
- No changes
## concert_service_waypoint_navigation
- No changes
## concert_services
- No changes
