### PR TITLE
rocon_concert: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4970,7 +4970,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_concert-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_concert.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_concert` to `0.6.3-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_concert
- release repository: https://github.com/yujinrobot-release/rocon_concert-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.6.2-0`
## concert_conductor
- No changes
## concert_master
- No changes
## concert_schedulers

```
* update install rule fixes #253 <https://github.com/robotics-in-concert/rocon_concert/issues/253>
* Contributors: Jihoon Lee
```
## concert_service_link_graph
- No changes
## concert_service_manager
- No changes
## concert_service_utilities
- No changes
## concert_utilities
- No changes
## rocon_concert
- No changes
## rocon_tf_reconstructor
- No changes
