### PR TITLE
roswww: 0.1.3-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7065,7 +7065,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/roswww-release.git
-      version: 0.1.2-1
+      version: 0.1.3-2
     source:
       type: git
       url: https://github.com/tork-a/roswww.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roswww` to `0.1.3-2`:
- upstream repository: https://github.com/tork-a/roswww.git
- release repository: https://github.com/tork-a/roswww-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.2-1`
## roswww

```
* Separate webserver.py into module and script files (quick fix to #10 <https://github.com/tork-a/roswww/issues/10>).
* Contributors: Isaac I.Y. Saito, Jihoon Lee
```
