### PR TITLE
Updated termcolor and netaddr python rosdep to include additional platforms via pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -601,7 +601,40 @@ python-multicast:
   ubuntu:
     pip: [py-multicast]
 python-netaddr:
-  ubuntu: [python-netaddr]
+  debian:
+    pip:
+      packages: [netaddr]
+  fedora:
+    pip:
+      packages: [netaddr]
+  osx:
+    pip:
+      packages: [netaddr]
+  ubuntu:
+    lucid: [python-netaddr]
+    maverick:
+      pip:
+        packages: [netaddr]
+    natty:
+      pip:
+        packages: [netaddr]
+    oneiric:
+      pip:
+        packages: [netaddr]
+    precise: [python-netaddr]
+    quantal:
+      pip:
+        packages: [netaddr]
+    raring:
+      pip:
+        packages: [netaddr]
+    saucy:
+      pip:
+        packages: [netaddr]
+    trusty: [python-netaddr]
+    trusty_python3: [python3-netaddr]
+    utopic: [python-netaddr]
+    vivid: [python-netaddr]
 python-netifaces:
   arch: [python2-netifaces]
   debian: [python-netifaces]
@@ -1360,7 +1393,44 @@ python-sympy:
     saucy: [python-sympy]
     trusty: [python-sympy]
 python-termcolor:
-  ubuntu: [python-termcolor]
+  debian:
+    pip:
+      packages: [termcolor]
+  fedora:
+    pip:
+      packages: [termcolor]
+  osx:
+    pip:
+      packages: [termcolor]
+  ubuntu:
+    lucid:
+      pip:
+        packages: [termcolor]
+    maverick:
+      pip:
+        packages: [termcolor]
+    natty:
+      pip:
+        packages: [termcolor]
+    oneiric:
+      pip:
+        packages: [termcolor]
+    precise:
+      pip:
+        packages: [termcolor]
+    quantal:
+      pip:
+        packages: [termcolor]
+    raring:
+      pip:
+        packages: [termcolor]
+    saucy:
+      pip:
+        packages: [termcolor]
+    trusty: [python-termcolor]
+    trusty_python3: [python3-termcolor]
+    utopic: [python-termcolor]
+    vivid: [python-termcolor]
 python-tftpy:
   fedora: [python-tftpy]
   ubuntu: [python-tftpy]


### PR DESCRIPTION
In response to discussion in #6750 
