### PR TITLE
rosbridge_suite: 0.7.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6655,11 +6655,10 @@ repositories:
       - rosbridge_library
       - rosbridge_server
       - rosbridge_suite
-      - rosbridge_tools
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.7.6-0
+      version: 0.7.7-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.7.7-0`:
- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.7.6-0`
## rosapi
- No changes
## rosbridge_library
- No changes
## rosbridge_server

```
* remove rosbridge_tools from dependency #163 <https://github.com/RobotWebTools/rosbridge_suite/issues/163>
* reverting back the changes
* Contributors: Jihoon Lee
```
## rosbridge_suite
- No changes
