### PR TITLE
linux_peripheral_interfaces: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2945,11 +2945,12 @@ repositories:
     release:
       packages:
       - laptop_battery_monitor
+      - libsensors_monitor
       - linux_peripheral_interfaces
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/linux_peripheral_interfaces-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/ros-drivers/linux_peripheral_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `linux_peripheral_interfaces` to `0.1.2-0`:
- upstream repository: https://github.com/ros-drivers/linux_peripheral_interfaces.git
- release repository: https://github.com/ros-gbp/linux_peripheral_interfaces-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.1-0`
## laptop_battery_monitor
- No changes
## libsensors_monitor

```
* Import libsensors_monitor node from diagnostic_common_diagnostics
* Contributors: Mitchell Wills
* Import libsensors_monitor node from diagnostic_common_diagnostics
* Contributors: Mitchell Wills
```
## linux_peripheral_interfaces

```
* add libsensors_monitor in metapackage #4 <https://github.com/ros-drivers/linux_peripheral_interfaces/issues/4>
* Contributors: Jihoon Lee
```
