### PR TITLE
Use RPM macros in Fedora deps for g++-multilib, gcc-multilib and lib32asound2

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -643,7 +643,7 @@ ftdi-eeprom:
   fedora: [libftdi-devel, libftdi-c++-devel]
   ubuntu: [ftdi-eeprom]
 g++-multilib:
-  fedora: [gcc-c++, glibc-devel, glibc-devel(x86-32), glibc-static, glibc-static(x86-32), libstdc++-devel, libstdc++-devel(x86-32), libstdc++-static, libstdc++-static(x86-32)]
+  fedora: [gcc-c++, glibc-devel, 'glibc-devel(%{__isa_name}-32)', glibc-static, 'glibc-static(%{__isa_name}-32)', libstdc++-devel, 'libstdc++-devel(%{__isa_name}-32)', libstdc++-static, 'libstdc++-static(%{__isa_name}-32)']
   ubuntu: [g++-multilib]
 gawk:
   fedora: [gawk]
@@ -664,7 +664,7 @@ gcc-avr:
   gentoo: [cross-avr/gcc]
   ubuntu: [gcc-avr]
 gcc-multilib:
-  fedora: [gcc, glibc-devel, glibc-devel(x86-32), glibc-static, glibc-static(x86-32)]
+  fedora: [gcc, glibc-devel, 'glibc-devel(%{__isa_name}-32)', glibc-static, 'glibc-static(%{__isa_name}-32)']
   ubuntu: [gcc-multilib]
 gccxml:
   arch: [gccxml-git]
@@ -962,7 +962,7 @@ language-pack-en:
   ubuntu: [language-pack-en]
 lib32asound2:
   debian: [lib32asound2]
-  fedora: [alsa-lib(x86-32), alsa-lib]
+  fedora: ['alsa-lib(%{__isa_name}-32)', alsa-lib]
   ubuntu: [lib32asound2]
 libann-dev:
   arch: [ann]


### PR DESCRIPTION
Support for macros was added in rosdep 0.10.33 by https://github.com/ros-infrastructure/rosdep/commit/e43b325117fdbd3b178db77851c29fe6fb41b41f

This is needed to add support for non-x86 platforms to any packages which depend on these keys (namely ARM).

See https://github.com/ros-infrastructure/rosdep/pull/357 for details.
