### PR TITLE
geneus: 2.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1583,11 +1583,20 @@ repositories:
       version: indigo-devel
     status: maintained
   geneus:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/geneus.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/geneus-release.git
-      version: 0.1.0-0
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/geneus.git
+      version: master
+    status: developed
   genlisp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geneus` to `2.0.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/geneus
- release repository: https://github.com/tork-a/geneus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.0-0`
