### PR TITLE
async_web_server_cpp: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -201,7 +201,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/async_web_server_cpp-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/async_web_server_cpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_web_server_cpp` to `0.0.2-0`:
- upstream repository: https://github.com/WPI-RAIL/async_web_server_cpp.git
- release repository: https://github.com/wpi-rail-release/async_web_server_cpp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.1-0`
## async_web_server_cpp

```
* Merge pull request #3 from mitchellwills/develop
  Added support for specifying additional headers when creating static request handlers
* Added some comments to the HTTP reply methods
* Added support for specifying additional headers when creating static request handlers
* Contributors: Mitchell Wills, Russell Toris
```
