### PR TITLE
roslint: 0.9.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5622,7 +5622,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/roslint-release.git
-      version: 0.9.2-1
+      version: 0.9.3-0
     source:
       type: git
       url: https://github.com/ros/roslint.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslint` to `0.9.3-0`:
- upstream repository: https://github.com/ros/roslint.git
- release repository: https://github.com/ros-gbp/roslint-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.9.2-1`
## roslint

```
* Don't hang on header outside "include" dir.
* Contributors: Mike Purvis
```
