### PR TITLE
roslint: 0.9.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -528,6 +528,21 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: indigo-devel
     status: maintained
+  roslint:
+    doc:
+      type: git
+      url: https://github.com/ros/roslint.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/roslint-release.git
+      version: 0.9.3-0
+    source:
+      type: git
+      url: https://github.com/ros/roslint.git
+      version: master
+    status: maintained
   roslisp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslint` to `0.9.3-0`:
- upstream repository: https://github.com/ros/roslint.git
- release repository: https://github.com/ros-gbp/roslint-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `null`
## roslint

```
* Don't hang on header outside "include" dir.
* Contributors: Mike Purvis
```
