### PR TITLE
convex_decomposition: 0.1.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1028,6 +1028,21 @@ repositories:
       url: https://github.com/ros-controls/control_toolbox.git
       version: indigo-devel
     status: maintained
+  convex_decomposition:
+    doc:
+      type: git
+      url: https://github.com/ros/convex_decomposition.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/convex_decomposition-release.git
+      version: 0.1.10-0
+    source:
+      type: git
+      url: https://github.com/ros/convex_decomposition.git
+      version: indigo-devel
+    status: maintained
   cpp_introspection:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `convex_decomposition` to `0.1.10-0`:
- upstream repository: https://github.com/ros/convex_decomposition.git
- release repository: https://github.com/ros-gbp/convex_decomposition-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## convex_decomposition

```
* Added tag 0.1.9 for changeset c7c2984fc16f
* Contributors: Dirk Thomas
```
