### PR TITLE
jsk_common: 1.0.58-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2989,7 +2989,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.57-0
+      version: 1.0.58-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.58-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.57-0`
## assimp_devel
- No changes
## bayesian_belief_networks

```
* check debian_version to see site/dist packages
* Contributors: Kei Okada
```
## collada_urdf_jsk_patch
- No changes
## depth_image_proc_jsk_patch
- No changes
## downward
- No changes
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha
- No changes
## image_view2

```
* [image_view2] Call GUI functions from main thread
* [image_view2] Add new interaction mode to image_view 2 to select
  foreground and background by rectangular region
* [image_view2] add mode to select foreground and background
  for grabcut
* [image_view2] Use opencv2 c++ function to handle window
* [image_view2] add utility function to resolve tf
* [image_view2] refactor to se smaller function
* [image_view2] Use parameter to change mode to select rectangle or
  freeform trajectory instad of "SHIFT KEY"
* [image_view2] Use camel case for methods and functions
* [image_view2] Separate header and cpp file for maintainance
* [image_view2] fix variable name with _ suffix and untabify indents
* [image_view2] Optimize image_view2 to decrease CPU load.
  1) add ~skip_draw_rate to throttle redrawing.
  2) use ros::spin if possible
* Redraw image even though no new message is available
* Add tab-width to image_view2.cpp
* Contributors: Ryohei Ueda
```
## image_view_jsk_patch
- No changes
## jsk_common
- No changes
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_network_tools
- No changes
## jsk_tilt_laser

```
* [jsk_tilt_laser] Use jsk_pcl_ros/TiltLaserListener rather than
  jsk_tilt_laser's snapshotter.
* [jsk_tilt_laser] Add use_robot_description argument to multsense.launch and removed robot_description private param in ros_driver, which is seemed to be unused in multisense_ros/src
* Add document about dynamixel permission on jsk_tilt_laser
* add downsampled points to multisense.launch in jsk_tilt_laser
* Contributors: Ryohei Ueda
```
## jsk_tools

```
* Add more user replacing rules
* Reuse isMasterAlive function across scripts which
  want to check master state
* Add script to change contributors name in CHANGELOG.py
* add roscore_check
* Contributors: Ryohei Ueda, JSK Lab member
```
## jsk_topic_tools

```
* [jsk_topic_tools] Indigo test seems to be broken,
  so skip testing on indigo
* [jsk_topic_tools] Do not implement updateDiagnostic
  as pure virtual method
* Reuse isMasterAlive function across scripts which
  want to check master state
* Contributors: Ryohei Ueda
```
## julius
- No changes
## laser_filters_jsk_patch
- No changes
## libsiftfast
- No changes
## mini_maxwell
- No changes
## multi_map_server
- No changes
## nlopt

```
* [nlopt] Add LIBS='-stdc++' to avoid link error on saucy
* Contributors: Ryohei Ueda
```
## openni_tracker_jsk_patch
- No changes
## opt_camera
- No changes
## posedetection_msgs
- No changes
## pr2_groovy_patches
- No changes
## rospatlite
- No changes
## rosping

```
* [rosping] Do not test on indigo, it seems to be broken
* Contributors: Ryohei Ueda
```
## rostwitter
- No changes
## sklearn
- No changes
## speech_recognition_msgs
- No changes
## virtual_force_publisher
- No changes
## voice_text
- No changes
