### PR TITLE
cob_robots: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -859,7 +859,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.6.2-0`:
- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.6.1-0`
## cob_bringup
- No changes
## cob_controller_configuration_gazebo

```
* fix diagnostics
* Contributors: Florian Weisshardt
```
## cob_default_robot_config
- No changes
## cob_hardware_config

```
* add missing dep
* Contributors: Florian Weisshardt
```
## cob_robots
- No changes
