### PR TITLE
jsk_model_tools: 0.1.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2478,7 +2478,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.1.7-1
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_model_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.1.8-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.7-1`
## eus_assimp

```
* fix for new euslisp layout
* eus_assimp: build_depend on pkg-config
* Contributors: Scott K Logan, Kei Okada
```
## euscollada
- No changes
## jsk_model_tools
- No changes
