### PR TITLE
jackal: 0.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2349,13 +2349,12 @@ repositories:
       packages:
       - jackal_control
       - jackal_description
-      - jackal_diff_drive_controller
       - jackal_msgs
       - jackal_navigation
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.4.1-0`:
- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.4.0-0`
## jackal_control

```
* Remove fork of diff_drive_controller.
* Contributors: Mike Purvis
```
## jackal_description
- No changes
## jackal_msgs
- No changes
## jackal_navigation
- No changes
