### PR TITLE
myo_ros: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3533,6 +3533,18 @@ repositories:
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
       version: master
     status: maintained
+  myo_ros:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/myo_ros-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/myo_ros.git
+      version: master
+    status: maintained
+    status_description: New release. Adding examples planned, but low-priority.
   nanomsg:
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3544,7 +3544,6 @@ repositories:
       url: https://github.com/clearpathrobotics/myo_ros.git
       version: master
     status: maintained
-    status_description: New release. Adding examples planned, but low-priority.
   nanomsg:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `myo_ros` to `0.1.2-0`:
- upstream repository: https://github.com/clearpathrobotics/myo_ros.git
- release repository: https://github.com/clearpath-gbp/myo_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
