### PR TITLE
rospeex: 2.12.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6957,7 +6957,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://bitbucket.org/rospeex/rospeex-release.git
-      version: 2.12.1-0
+      version: 2.12.2-0
     source:
       type: git
       url: https://bitbucket.org/rospeex/rospeex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospeex` to `2.12.2-0`:
- upstream repository: https://bitbucket.org/rospeex/rospeex.git
- release repository: https://bitbucket.org/rospeex/rospeex-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `2.12.1-0`
## rospeex
- No changes
## rospeex_audiomonitor

```
* fix #67
* remove cmake "follow_symlinks"
```
## rospeex_core

```
* fix #66
* fix #66
```
## rospeex_if

```
* fix issue #68
* update version rospeex_if/setup.py
```
## rospeex_launch
- No changes
## rospeex_msgs
- No changes
## rospeex_samples
- No changes
## rospeex_webaudiomonitor
- No changes
