### PR TITLE
jsk_control: 0.1.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3006,6 +3006,7 @@ repositories:
       - eus_qp
       - eus_qpoases
       - joy_mouse
+      - jsk_calibration
       - jsk_footstep_controller
       - jsk_footstep_planner
       - jsk_ik_server
@@ -3013,7 +3014,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_control-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_control` to `0.1.5-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_control.git
- release repository: https://github.com/tork-a/jsk_control-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.4-0`
## eus_nlopt

```
* remove engin from build_depend
* remove find_package(Eigen)
* Contributors: Kei Okada
```
## eus_qp
- No changes
## eus_qpoases

```
* Get qpOASES status from argument
* Update patch for qpoases shared object (https://github.com/jsk-ros-pkg/jsk_control/issues/180)
* Contributors: Shunichi Nozawa
```
## joy_mouse

```
* [joy_mouse] Use name of kensington mouse and remove dev file
  specification.
  [jsk_teleop_joy] Remove DEV argument
* [joy_mouse] Add name API to lookup device by name like
  "TPPS/2 IBM TrackPoint"
* Contributors: Ryohei Ueda
```
## jsk_calibration

```
* Add utility script to test a lot of calibration parameters
* Reduce sampling poses to 30
* Sampling pose with configuration space and update sampling space of
  leg poses
* Add legs to calibrate hrp2jsknt
* Self Collisoin with small changes on joint angles to get stable position
* Add calibration document
* Select different poses with probability computation
* Select good calibration sample from a lot of mother samples
* Use dual arm to calibrate HRP2JSKNT
* Filtering not good poses for calibration
* Do not use gripper joint on HRP2JSKNT
* Add rviz config to see pose_guesses marker
* rename make-calibration-pose.l -> calibration.l and separate hrp2
  specific setting to hrp2-calibration.l
* Remove unused file
* Update calibration for hrp2jsknt
* Add motion files for hrp2jsknt and implement several methods to generate yamls and launches
* Generate motion with more strict collision check and add test method on real robot
* Update parameters for hrp2jsknt
* Add special reset-pose for leg calibration
* Remove unused files
* Add hrp2jsknt_calibration directory just copied from hironx_calibration
* Add board to collision check and refine motion with interpolated angle vectors
* Add method to check collision of interpolated motions
* Add more depends
* add legs motion
* Implement hrp2 motion generation
* Depends on pr2_msgs and pr2_controllers_msgs
* Add jsk_calibration package for hand-eye calibration
* Contributors: Ryohei Ueda
```
## jsk_footstep_controller

```
* Update drcmodel for current planner
* Fix poping-up cancel window by broadcasting canceled information
* Change threshold according to the footsteps respectively
* Wait until contact state is stable during interrubtible-walking
* Check contact state is stable or not in footcoords.cpp
* Apply low-pass filter to force sensor values
* Add script to compute stats about contact_states
* Add text publisher about single/double stance phase
* Merge remote-tracking branch 'origin/master' into add-breakpoint-text
  Conflicts:
  jsk_footstep_controller/euslisp/footstep-controller.l
  jsk_footstep_controller/launch/hrp2jsknt_real_full.launch
* Add text publishing when checking breakpoint
* Update forth threshold to 25N to regard the leg is on floor
* Add z-error to contact_state of footcoords
* check tf2::ExtrapolationException in footcoords
* Change walking orbit and the height of the root link according to the plans
* Use snapit to snap the goal of footstep to the planes
* Change the color of footsteps if there is no planning result
* Update footstep parameter for climing up stairs:
  larger footstep and smaller footprint
* Publish usage of footstep planner joy
* Publish conctact state and angular error between two legs as topic
* Publish support leg information to diagnostic
* During single support phace, ground should on the end effector coordinates
* Add documentation about footcoords
* Publish /odom_on_ground and /ground tf frame from footcoords
* Fix indent of footcoords
* Display footstep parameter on rviz
* Move down 50 mm during walking and use more larger step for walking
* Fix calculation of roll difference
* Separate roll and pitch angles to calculate angular difference between
  footstep to be refined
* Fix refinment of footstep by using relative transformation to the
  previous footstep
* Refine result of footstep planning by filtering goal of actionlib interface
  of footstep planner.
* Reset to reset-manip-pose after look around the ground
* Contributors: Ryohei Ueda
```
## jsk_footstep_planner

```
* renamed make_sumple function
* added make-coords-list function
* added inverse_reachablity_with_given_coords
* Update drcmodel for current planner
* Add sample to compare heuristic functions
* add api to change successor
* Merge remote-tracking branch 'origin/master' into add-breakpoint-text
  Conflicts:
  jsk_footstep_controller/euslisp/footstep-controller.l
  jsk_footstep_controller/launch/hrp2jsknt_real_full.launch
* Add text publishing when checking breakpoint
* Do not allow step over 250mm stride
* Supress x-transition after z-transition. All the threshold is hard-coded
* Update footstep parameter for climing up stairs:
  larger footstep and smaller footprint
* Add dimensions of footsteps to the result of footstep planner
* Visualize footstep successors
* roseus only needs runtime
* Contributors: Kei Okada, Ryohei Ueda, Yu Ohara
```
## jsk_ik_server

```
* pass warnp as argument in :fullbody-ik-main
* remove sample robot test
* Merge branch 'master' into update-samplerobot-in-ik-server
* use unix:usleep because hrpsys stops clock
* use hrpsys sample robot for ik server
* Contributors: HRP2, leus, tarukosu
```
## jsk_teleop_joy

```
* [joy_mouse] Use name of kensington mouse and remove dev file
  specification.
  [jsk_teleop_joy] Remove DEV argument
* add script to publish pose stamped with spacenav
* Fix poping-up cancel window by broadcasting canceled information
* add api to change successor
* Add text publishing when checking breakpoint
* Publish usage of footstep planner joy
* disable/enable head control with trackball buttons, move head joint continuously.
* Contributors: Masaki Murooka, Ryohei Ueda, Yusuke Furuta
```
