### PR TITLE
moveit_visual_tools: 2.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3437,7 +3437,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 2.1.0-0
+      version: 2.2.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `2.2.0-0`:
- upstream repository: https://github.com/davetcoleman/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `2.1.0-0`
## moveit_visual_tools

```
* Code cleanup
* Improved naming
* Joint model bug fix
* Improved speed of sending collision objects to Rviz
  Added Manual planning scene update mode
  Ability to apply colors to all collision objects (YAY)
  API: removed removeAllCollisionObjectsPS function
  Removed loadPlanningPub() function
  Removed publishRemoveAllCollisionObjects() function
* Added backwards compatibile loadCollisionSceneFromFile()
* New publishCollisionRectangle function
  API: Changed loadCollisionSceneFromFile() to accept a pose instead of x,y
* Fix for renamed function
* New publishWorkspaceParameters() function
* Added ability to publish robot states with color
* Fixed install method
* Merge pull request #5 <https://github.com/davetcoleman/moveit_visual_tools/issues/5> from robomakery/feature/fix-collision-objects-test
* Fixes for missing declarations in collision_objects_test.cpp
* Refactored how collision ojects are published
  Created new collision objects test and roslaunch file
  Optimized header file
  Removed loadCollisionPub() function
  Fixed publishCollisionFloor
  Added publishCollisionRectangle
* Contributors: Dave Coleman, Dylan Vaughn
```
