### PR TITLE
jsk_recognition: 0.1.31-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3094,7 +3094,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.1.30-0
+      version: 0.1.31-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.1.31-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.30-0`
## checkerboard_detector

```
* [checkerboard_detector] Fix compilation warning of
  objectdetection_transform_echo about tf exception
* [checkerboard_detector] Force to ubscribe topic if ~display is True
* [checkerboard_detector] Add modeline for emacs to keep coding style
* something have changed in updatream (maybe cv_bridge), added image_geometry as depends
```
## imagesift

```
* [imagesift] Add warning message if size of mask and image are different
* [imagesift] support mask image
* [imagesift] Add warning message if size of mask and image are different
* [imagesift] support mask image
* [imagesift] Fix order of subscription and advertisation
```
## jsk_pcl_ros

```
* Merge pull request #563 from garaemon/no-indices-for-multi-plane-extraction
  [jsk_pcl_ros] Parameter to disable indices in MultiPlaneExtraction
* [jsk_pcl_ros] Do not use indices in MultiPlaneExtraction
* Merge pull request #562 from garaemon/add-plane-concatenator
  [jsk_pcl_ros] PlaneConcatenator: nodelet to concatenate near planes
* [jsk_pcl_ros] PlaneConcatenator: nodelet to concatenate near planes
* Merge pull request #561 from garaemon/add-clear-cache-service
  [jsk_pcl_ros] Add ~clear_cache service to TiltLaserListener
* [jsk_pcl_ros] Add ~clear_cache service to restart collecting
  laser data in TiltLaserListener
* [jsk_pcl_ros] Support multiple interest region in AttentionClipper
* [jsk_pcl_ros] Support initial pose of AttentionClipper
* [jsk_pcl_ros/LINEMODTrainer] Use wildcard in compressing data to
  generate ltm
* [jsk_pcl_ros] Multithread safe LINEMODTrainer by avoiding
  pcl::RangeImage non-thread safe initialization
* [jsk_pcl_ros] Do not publish range image (It's not stable under OpenMP)
  and use directory rather than filename when calling tar
* [jsk_pcl_ros] Train linemod with OpenMP and publish range image
  with color
* [jsk_pcl_ros] Utility launch file and scripts to training LINEMOD from
  bag file
* [jsk_pcl_ros] Add image for LINEMODTrainer documentation
* [jsk_pcl_ros] Decrease memory usage when training LINEMOD
* [jsk_pcl_ros] Sampling viewpoint to generate training data
  for LINEMOD
* [jsk_pcl_ros] Remove linemod rotation quantization
* [jsk_pcl_ros] Use triangle decomposition to check a point is inside
  or not of polygon
* [jsk_pcl_ros] Add picture of LINEMODDetector
* [jsk_pcl_ros] SupervoxelSegmentation: new nodelet to wrap
  pcl::SupervoxelClustering
* [jsk_pcl_ros] Refine Model by ICP in IncrementalModelRegistration
* [jsk_pcl_ros] Add simple icp service to ICPRegistration
* [jsk_pcl_ros] add utility launch file to capture training data from multisense
* [jsk_pcl_ros] Publish the number of samples from CaptureStereoSynchronizer
* [jsk_pcl_ros] Fix when ROI is outside of the image in AttentionClipper
* [jsk_pcl_ros] Fix when ROI is outside of the image in AttentionClipper
* Merge pull request #532 from garaemon/add-mask-image-to-point-indices
  [jsk_pcl_ros] Add MaskImageToPointIndices
* Merge pull request #531 from garaemon/add-incremental-pointcloud-registration
  [jsk_pcl_ros] IncrementalModelRegistration Add new nodelet to build full 3d model from sequentially captured pointcloud
* fix to compile on indigo #529
* [jsk_pcl_ros] MaskImageToPointIndices: add nodelet to convert mask image to point indices
* [jsk_pcl_ros] Add new nodelet to build full 3d model from
  sequentially captured pointcloud: IncrementalModelRegistration
* [jsk_pcl_ros] untabify icp_registration_nodelet.cpp
* [jsk_pcl_ros] update document of IntermittentImageAnnotator
* [jsk_pcl_ros] Storing pointcloud and publish pointcloud inside
  of ROI specified
* [jsk_pcl_ros] Visualize selected ROI as marker in IntermittentImageAnnotator
* [jsk_pcl_ros] Add ~rate parameter to throttle image publishing from IntermittentImageAnnotator
* add camera frame param to handle_estimator.l
```
## jsk_perception

```
* [jsk_perception] Add parameter to select seed policy (definitely
  back/foreground or probably back/foreground) to GrabCut
* adapt attention-clipper for fridge demo
* [jsk_perception] Publish mask image of grabcut result
* [jsk_perception] add GrabCut nodelet
* Remove roseus from build dependency of jsk_perception
* added debug pub
```
## jsk_recognition
- No changes
## resized_image_transport

```
* not include image prosessing config
* add log polar sample
* add include directory
* implement resize image processing
* implement log-polar processing
* add base class for processing image
* add sample launch file
* add LogPolar.cfg
* add first sample
```
