### PR TITLE
care_o_bot: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -450,12 +450,13 @@ repositories:
     release:
       packages:
       - care_o_bot
+      - care_o_bot_desktop
       - care_o_bot_robot
       - care_o_bot_simulation
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/care-o-bot-release.git
-      version: 0.6.0-0
+      version: 0.6.3-0
     status: maintained
   carl_bot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `care_o_bot` to `0.6.3-0`:
- upstream repository: https://github.com/ipa320/care-o-bot.git
- release repository: https://github.com/ipa320/care-o-bot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.6.0-0`
## care_o_bot
- No changes
## care_o_bot_desktop
- No changes
## care_o_bot_robot

```
* modify deps
* Contributors: Florian Weisshardt
```
## care_o_bot_simulation
- No changes
