### PR TITLE
fanuc: 0.3.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1781,14 +1781,30 @@ repositories:
       - fanuc
       - fanuc_assets
       - fanuc_driver
+      - fanuc_lrmate200ic5h_moveit_config
+      - fanuc_lrmate200ic5l_moveit_config
+      - fanuc_lrmate200ic_moveit_config
+      - fanuc_lrmate200ic_moveit_plugins
+      - fanuc_lrmate200ic_support
+      - fanuc_m10ia_moveit_config
+      - fanuc_m10ia_moveit_plugins
       - fanuc_m10ia_support
+      - fanuc_m16ib20_moveit_config
+      - fanuc_m16ib_moveit_plugins
       - fanuc_m16ib_support
+      - fanuc_m20ia10l_moveit_config
+      - fanuc_m20ia_moveit_config
+      - fanuc_m20ia_moveit_plugins
+      - fanuc_m20ia_support
+      - fanuc_m430ia2f_moveit_config
+      - fanuc_m430ia2p_moveit_config
+      - fanuc_m430ia_moveit_plugins
       - fanuc_m430ia_support
       - fanuc_resources
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-industrial-release/fanuc-release.git
-      version: 0.2.0-1
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/ros-industrial/fanuc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fanuc` to `0.3.0-0`:
- upstream repository: https://github.com/ros-industrial/fanuc.git
- release repository: https://github.com/ros-industrial-release/fanuc-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.2.0-1`
## fanuc

```
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_assets

```
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* add a shared constants xacro.
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_driver

```
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* Karel driver updates:

    * explicit socket close on ABORT (#27 <https://github.com/ros-industrial/fanuc/issues/27>)
    * improve use of Karel built-in routines and constants (math, IO, TP keys) (#50 <https://github.com/ros-industrial/fanuc/issues/50>)
    * update translator directives and header documentation
    * update copyright notices and Karel library versions
    * introduce include dir
    * include trajectory relay program status in 'motion_possible' calculation (#108 <https://github.com/ros-industrial/fanuc/issues/108>)
    * fixup use of underscore suffixes to convey routine & variable scope

* explicitly declare dependencies of roslaunch tests (#70 <https://github.com/ros-industrial/fanuc/issues/70>).
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_lrmate200ic5h_moveit_config

```
* first Hydro release of this package.
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_lrmate200ic5l_moveit_config

```
* first Hydro release of this package.
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_lrmate200ic_moveit_config

```
* first Hydro release of this package.
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_lrmate200ic_moveit_plugins

```
* first Hydro release of this package.
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_lrmate200ic_support

```
* first Hydro release of this package.
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* add info on specific config used for urdf/xacro (#26 <https://github.com/ros-industrial/fanuc/issues/26>).
* explicitly declare dependencies of roslaunch tests (#70 <https://github.com/ros-industrial/fanuc/issues/70>).
* update urdfs based on DH data (#54 <https://github.com/ros-industrial/fanuc/issues/54> and #63 <https://github.com/ros-industrial/fanuc/issues/63>).
* add 'base' link (transform to World Coordinates) (#101 <https://github.com/ros-industrial/fanuc/issues/101>).
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_m10ia_moveit_config

```
* first Hydro release of this package.
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_m10ia_moveit_plugins

```
* first Hydro release of this package.
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_m10ia_support

```
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* add info on specific config used for urdf/xacro (#26 <https://github.com/ros-industrial/fanuc/issues/26>).
* explicitly declare dependencies of roslaunch tests (#70 <https://github.com/ros-industrial/fanuc/issues/70>).
* add 'base' link (transform to World Coordinates) (#101 <https://github.com/ros-industrial/fanuc/issues/101>).
* update urdfs based on DH data (#54 <https://github.com/ros-industrial/fanuc/issues/54> and #63 <https://github.com/ros-industrial/fanuc/issues/63>).
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_m16ib20_moveit_config

```
* first Hydro release of this package.
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_m16ib_moveit_plugins

```
* first Hydro release of this package.
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_m16ib_support

```
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* explicitly declare dependencies of roslaunch tests (#70 <https://github.com/ros-industrial/fanuc/issues/70>).
* add 'base' link (transform to World Coordinates) (#101 <https://github.com/ros-industrial/fanuc/issues/101>).
* update urdfs based on DH data (#54 <https://github.com/ros-industrial/fanuc/issues/54> and #63 <https://github.com/ros-industrial/fanuc/issues/63>).
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_m20ia10l_moveit_config

```
* first Hydro release of this package.
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_m20ia_moveit_config

```
* first Hydro release of this package.
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_m20ia_moveit_plugins

```
* first Hydro release of this package.
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_m20ia_support

```
* first Hydro release of this package.
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* explicitly declare dependencies of roslaunch tests (#70 <https://github.com/ros-industrial/fanuc/issues/70>).
* add 'base' link (transform to World Coordinates) (#101 <https://github.com/ros-industrial/fanuc/issues/101>).
* update urdfs based on DH data (#54 <https://github.com/ros-industrial/fanuc/issues/54> and #63 <https://github.com/ros-industrial/fanuc/issues/63>).
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_m430ia2f_moveit_config

```
* first Hydro release of this package.
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_m430ia2p_moveit_config

```
* first Hydro release of this package.
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_m430ia_moveit_plugins

```
* first Hydro release of this package.
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_m430ia_support

```
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* explicitly declare dependencies of roslaunch tests (#70 <https://github.com/ros-industrial/fanuc/issues/70>).
* add 'base' link (transform to World Coordinates) (#101 <https://github.com/ros-industrial/fanuc/issues/101>).
* update urdfs based on DH data (#54 <https://github.com/ros-industrial/fanuc/issues/54> and #63 <https://github.com/ros-industrial/fanuc/issues/63>).
* fix mirrored meshes (#109 <https://github.com/ros-industrial/fanuc/issues/109>).
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
## fanuc_resources

```
* promote experimental packages for M-10iA, M-16iB, M-20iA, M-430iA and LR Mate 200iC to main repository.
* add a shared constants xacro.
* for a complete list of changes see the commit log for 0.3.0 <https://github.com/ros-industrial/fanuc/compare/0.2.0...0.3.0>
```
