### PR TITLE
aau_multi_robot: 0.1.3-4 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -23,7 +23,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/aau-ros/aau_multi_robot-release.git
-      version: 0.1.3-3
+      version: 0.1.3-4
     source:
       type: git
       url: https://github.com/aau-ros/aau_multi_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aau_multi_robot` to `0.1.3-4`:
- upstream repository: https://github.com/aau-ros/aau_multi_robot.git
- release repository: https://github.com/aau-ros/aau_multi_robot-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.3-3`
