### PR TITLE
jsk_robot: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3118,11 +3118,12 @@ repositories:
       - jsk_robot_startup
       - pepper_bringup
       - pepper_description
+      - peppereus
       - pr2_base_trajectory_action
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_robot-release.git
-      version: 0.0.1-1
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/tork-a/jsk_robot-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `0.0.2-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.1-1`
## baxtereus

```
* add install commands to cmake
* add baxter-moveit.l
* Contributors: Kei Okada, Yuto Inagaki
```
## jsk_baxter_desktop

```
* add install commands to cmake
* Contributors: Kei Okada
```
## jsk_baxter_startup

```
* add install commands to cmake
* remove jtalk voice
* Contributors: Kei Okada, Yuto Inagaki
```
## jsk_baxter_web

```
* add install commands to cmake
* Contributors: Kei Okada
```
## jsk_nao_startup
- No changes
## jsk_pepper_startup

```
* add install commands to cmake
* Contributors: Kei Okada
```
## jsk_pr2_calibration
- No changes
## jsk_pr2_startup

```
* add install commands to cmake
* [jsk_pr2_startup] Disable collider node, it's out of date
* Merge pull request #232 from garaemon/rename-hydro-recognition
  [jsk_pr2_startup] rename hydro_recognition.launch to people_detection.launch and start it up default
* [jsk_pr2_startup] Remove torso_lift_link from self filtering of
  tilt laser to avoid too much filtering of points. And update padding
  of shoulder links to remove veiling noise
* [jsk_pr2_startup] rename hydro_recognition.launch to people_detection.launch
  and start it up in default.
* Merge pull request #230 from garaemon/move-image-processing-to-c2
  [jsk_pr2_startup] Move several image processing to c2 to avoid heavy network communication between c1 and c2
* [jsk_pr2_startup] Move several image processing to c2 to avoid heavy
  network communication between c1 and c2
* [jsk_pr2_startup] Throttle before applying image_view2 to decrease
  CPU load
* use robot-actions.l
* Fix parameter namespace to slow down pr2_gripper_sensor_action
* Use longer priod to check openni soundness
* use rostwitter and python_twoauth
* Contributors: Kei Okada, Ryohei Ueda, Yusuke Furuta
```
## jsk_robot_startup
- No changes
## pepper_bringup

```
* add install commands to cmake
* Contributors: Kei Okada
```
## pepper_description

```
* add install commands to cmake
* Contributors: Kei Okada
```
## peppereus

```
* use package:// for pepper.l
* add .gitignore
* add CMakeLists.txt package.xml pepper-interface.l
* Contributors: Kei Okada
```
## pr2_base_trajectory_action

```
* add install commands to cmake
* Contributors: Kei Okada
```
