### PR TITLE
rtmros_gazebo: 0.1.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7286,10 +7286,11 @@ repositories:
       - eusgazebo
       - hrpsys_gazebo_general
       - hrpsys_gazebo_msgs
+      - staro_moveit_config
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_gazebo-release.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_gazebo` to `0.1.6-0`:
- upstream repository: https://github.com/start-jsk/rtmros_gazebo.git
- release repository: https://github.com/tork-a/rtmros_gazebo-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.5-0`
## eusgazebo

```
* update CHANGELOG.rst
* Contributors: Kei Okada
```
## hrpsys_gazebo_general

```
* update CHANGELOG.rst
* add dl to target_link_libraries
* add SPAWN_MODEL and fix for PAUSE
* change model name when spawning robot model
* update setup.sh
* fix using SPAWN_MODEL argument
* udpate PubQueue.h for matching gazebo_ros_pkgs
* Contributors: Kei Okada, YoheiKakiuchi
```
## hrpsys_gazebo_msgs

```
* update CHANGELOG.rst
* Contributors: Kei Okada
```
