### PR TITLE
ps4eye: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5812,6 +5812,21 @@ repositories:
       url: https://github.com/ros-drivers-gbp/prosilica_gige_sdk-release.git
       version: 1.26.2-0
     status: maintained
+  ps4eye:
+    doc:
+      type: git
+      url: https://github.com/longjie/ps4eye.git
+      version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/tork-a/ps4eye-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/longjie/ps4eye.git
+      version: master
+    status: developed
   pysdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ps4eye` to `0.0.2-0`:
- upstream repository: https://github.com/longjie/ps4eye.git
- release repository: https://github.com/tork-a/ps4eye-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## ps4eye

```
* use param to set camera_info
* add run_depends
* add arg for camera_info and camera_transformation
* add install rule
* add license and author
* Update README.md
  ps4eys_init は ps4_init.py ??? -> https://github.com/ps4eye/ps4eye/tree/master/python
* Contributors: Kei Okada, Ron Tajima
```
