### PR TITLE
lama: 0.1.1-4 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2716,10 +2716,21 @@ repositories:
       type: git
       url: https://github.com/lama-imr/lama.git
       version: indigo-devel
+    release:
+      packages:
+      - lama_core
+      - lama_interfaces
+      - lama_jockeys
+      - lama_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/lama-imr/lama-release.git
+      version: 0.1.1-4
     source:
       type: git
       url: https://github.com/lama-imr/lama.git
       version: indigo-devel
+    status: developed
   lama_costmap:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lama` to `0.1.1-4`:
- upstream repository: https://github.com/lama-imr/lama.git
- release repository: https://github.com/lama-imr/lama-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## lama_core
- No changes
## lama_interfaces

```
* lama_interfaces, lama_jockeys: update install
* all: move some messages from lama_interfaces to lama_msgs
  lama_interfaces: update install script
* Contributors: Gaël Ecorchard
```
## lama_jockeys

```
* lama_interfaces, lama_jockeys: update install
* all: move some messages from lama_interfaces to lama_msgs
  lama_interfaces: update install script
* Contributors: Gaël Ecorchard
```
## lama_msgs

```
* all: move some messages from lama_interfaces to lama_msgs
  lama_interfaces: update install script
* Contributors: Gaël Ecorchard
```
