### PR TITLE
rtmros_gazebo: 0.1.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7322,7 +7322,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_gazebo-release.git
-      version: 0.1.6-0
+      version: 0.1.7-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_gazebo` to `0.1.7-0`:
- upstream repository: https://github.com/start-jsk/rtmros_gazebo.git
- release repository: https://github.com/tork-a/rtmros_gazebo-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.6-0`
## eusgazebo

```
* add trajectory_msgs
* 0.1.6
* update CHANGELOG.rst
* update CHANGELOG.rst
* 0.1.5
* 0.1.4
* update CHANGELOG.rst
* Contributors: Kei Okada
```
## hrpsys_gazebo_general

```
* add pthread for link only for raling 64bit
* 0.1.6
* update CHANGELOG.rst
* update CHANGELOG.rst
* add dl to target_link_libraries
* add SPAWN_MODEL and fix for PAUSE
* change model name when spawning robot model
* update setup.sh
* fix using SPAWN_MODEL argument
* udpate PubQueue.h for matching gazebo_ros_pkgs
* 0.1.5
* enable to select launching dashboard or not. default is false.
* add SampleRobot.conf for unstable rtc and call that conf file.
* 0.1.4
* update CHANGELOG.rst
* install compile-robot-model-for-gazebo.cmake
* add world for using cfm parameter
* fix parameter of gazebo launch
* initialize flag and counter
* fixed bag: removed duplicate lines in compile_robot_model_for_gazebo.cmake.
* deletece unnecessary file. added xacro file
* Contributors: Kei Okada, YoheiKakiuchi, mmurooka
```
## hrpsys_gazebo_msgs

```
* 0.1.6
* update CHANGELOG.rst
* update CHANGELOG.rst
* 0.1.5
* 0.1.4
* update CHANGELOG.rst
* Contributors: Kei Okada
```
