### PR TITLE
ueye_cam: 1.0.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8420,7 +8420,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/anqixu/ueye_cam-release.git
-      version: 1.0.7-0
+      version: 1.0.8-0
     source:
       type: git
       url: https://github.com/anqixu/ueye_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `1.0.8-0`:
- upstream repository: https://github.com/anqixu/ueye_cam.git
- release repository: https://github.com/anqixu/ueye_cam-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.0.7-0`
## ueye_cam

```
* switched from cmake's file(GENERATE ...) to execute_command(cp ...), to accommodate cmake 2.8.x on Saucy
* Contributors: Anqi Xu
```
