### PR TITLE
jsk_robot: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3139,7 +3139,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_robot-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/tork-a/jsk_robot-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `0.0.3-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.2-0`
## baxtereus
- No changes
## jsk_baxter_desktop

```
* change to pure catkin package
```
## jsk_baxter_startup
- No changes
## jsk_baxter_web
- No changes
## jsk_nao_startup
- No changes
## jsk_pepper_startup
- No changes
## jsk_pr2_calibration
- No changes
## jsk_pr2_startup
- No changes
## jsk_robot_startup
- No changes
## pepper_bringup
- No changes
## pepper_description
- No changes
## peppereus
- No changes
## pr2_base_trajectory_action
- No changes
