### PR TITLE
rtmros_gazebo: 0.1.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7322,7 +7322,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_gazebo-release.git
-      version: 0.1.7-0
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_gazebo` to `0.1.8-0`:
- upstream repository: https://github.com/start-jsk/rtmros_gazebo.git
- release repository: https://github.com/tork-a/rtmros_gazebo-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.7-0`
## eusgazebo

```
* fix CHANGELOG order, https://github.com/ros/rosdistro/pull/6794
```
## hrpsys_gazebo_general

```
* fix CHANGELOG order, https://github.com/ros/rosdistro/pull/6794
```
## hrpsys_gazebo_msgs

```
* fix CHANGELOG order, https://github.com/ros/rosdistro/pull/6794
```
