### PR TITLE
sick_tim: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7808,7 +7808,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/uos-gbp/sick_tim-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/uos/sick_tim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_tim` to `0.0.3-0`:
- upstream repository: https://github.com/uos/sick_tim
- release repository: https://github.com/uos-gbp/sick_tim-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.2-0`
## sick_tim

```
* Merge pull request #20 <https://github.com/uos/sick_tim/issues/20> from jspricke/fix_19
  Fixes for #19 <https://github.com/uos/sick_tim/issues/19>
* Increase get_datagram timout to 1 second, Closes: #19 <https://github.com/uos/sick_tim/issues/19>
* Add ROS param for TCP port (defaults to 2112)
* fix dependencies in CMakeLists
  All non-catkin things that we expose in our headers should be added to
  the DEPENDS, so that packages which depend on our package will also
  automatically link against it.
  Also see: http://answers.ros.org/question/58498/what-is-the-purpose-of-catkin_depends/#58593 <https://github.com/uos/sick_tim/issues/58593>
* Contributors: Jochen Sprickerhof, Martin Günther
```
