### PR TITLE
roboteq: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4953,7 +4953,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/roboteq-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/g/roboteq.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roboteq` to `0.1.2-0`:
- upstream repository: https://github.com/g/roboteq.git
- release repository: https://github.com/clearpath-gbp/roboteq-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.1-0`
## roboteq_diagnostics

```
* Add queue_size, fixes #4 <https://github.com/g/roboteq//issues/4>
* Contributors: Mike Purvis
```
## roboteq_driver
- No changes
## roboteq_msgs
- No changes
