### PR TITLE
rtabmap: 0.8.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7264,7 +7264,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.8.0-0
+      version: 0.8.1-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap` to `0.8.1-0`:
- upstream repository: https://github.com/introlab/rtabmap.git
- release repository: https://github.com/introlab/rtabmap-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.8.0-0`
