### PR TITLE
grizzly: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1828,7 +1828,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/grizzly-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/g/grizzly.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly` to `0.3.1-0`:
- upstream repository: https://github.com/g/grizzly.git
- release repository: https://github.com/clearpath-gbp/grizzly-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.3.0-0`
## grizzly_description

```
* Find includes in URDF relative to package locations.
* Remove unneeded joint_state_publisher dependency.
* fix imu topic in simulator
* In navigation pkg, rename config and launch files to localization
* set imu frame ID as imu_link
* Contributors: Mike Purvis, Shokoofeh Pourmehr
```
## grizzly_motion

```
* Fix grizzly_motion/tests bugs
* Contributors: Shokoofeh Pourmehr
```
## grizzly_msgs
- No changes
## grizzly_navigation

```
* fix imu topic
* change imu topic to imu/data_combined
* In navigation pkg, rename config and launch files to localization
* Contributors: Shokoofeh Pourmehr
```
## grizzly_teleop

```
* Add modified sixpair to grizzly_teleop.
  This version supports the Navigation controller, and a wrapper
  is included which allows it to be run easily from ROS while
  wrapped in sudo.
* Add queue_size to rospy.Publisher.
* Contributors: Mike Purvis
```
