### PR TITLE
hrpsys: 315.2.8-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2036,7 +2036,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/hrpsys-release.git
-      version: 315.2.8-1
+      version: 315.2.8-2
     status: developed
   humanoid_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys` to `315.2.8-2`:
- upstream repository: https://github.com/fkanehiro/hrpsys-base.git
- release repository: https://github.com/tork-a/hrpsys-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `315.2.8-1`
