### PR TITLE
perception_pcl: 1.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4426,7 +4426,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/perception_pcl-release.git
-      version: 1.2.2-0
+      version: 1.2.3-0
     source:
       type: git
       url: https://github.com/ros-perception/perception_pcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.2.3-0`:
- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.2.2-0`
## pcl_ros

```
* Update common.py
  Extended filter limits up to ±100000.0 in order to support intensity channel filtering.
* Contributors: Dani Carbonell
```
## perception_pcl

```
* clean up package.xml
* Contributors: Paul Bovbel
```
## pointcloud_to_laserscan

```
* add launch tests
* refactor naming and fix nodelet export
* set default target frame to empty
* clean up package.xml
* Contributors: Paul Bovbel
```
