### PR TITLE
perception_pcl: 1.1.11-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5169,7 +5169,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/perception_pcl-release.git
-      version: 1.1.10-0
+      version: 1.1.11-0
     source:
       type: git
       url: https://github.com/ros-perception/perception_pcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.1.11-0`:
- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.1.10-0`
## pcl_ros
- No changes
## perception_pcl

```
* clean up package.xml
* Contributors: Paul Bovbel
```
## pointcloud_to_laserscan

```
* add launch tests
* refactor naming and fix nodelet export
* set default target frame to empty
* Contributors: Paul Bovbel
```
