### PR TITLE
zbar_ros: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -9080,6 +9080,21 @@ repositories:
       url: https://github.com/yujinrobot/yujin_ocs.git
       version: hydro
     status: developed
+  zbar_ros:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/zbar_ros.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/clearpath-gbp/zbar_ros-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/zbar_ros.git
+      version: hydro-devel
+    status: developed
   zeroconf_avahi_suite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `zbar_ros` to `0.0.2-0`:
- upstream repository: https://github.com/clearpathrobotics/zbar_ros.git
- release repository: https://github.com/clearpath-gbp/zbar_ros-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## zbar_ros

```
* update dependencies
* Contributors: Paul Bovbel
```
