### PR TITLE
zbar_ros: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7493,7 +7493,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/zbar_ros-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/zbar_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zbar_ros` to `0.0.3-0`:
- upstream repository: https://github.com/clearpathrobotics/zbar_ros.git
- release repository: https://github.com/clearpath-gbp/zbar_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.2-0`
## zbar_ros

```
* remove stray tf in cmake
* Contributors: Paul Bovbel
```
