### PR TITLE
Add langpack deps for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -957,8 +957,10 @@ kgraphviewer:
       packages: [media-gfx/kgraphviewer]
   ubuntu: [kgraphviewer]
 language-pack-de:
+  fedora: [filesystem]
   ubuntu: [language-pack-de]
 language-pack-en:
+  fedora: [filesystem]
   ubuntu: [language-pack-en]
 lib32asound2:
   debian: [lib32asound2]


### PR DESCRIPTION
In Fedora, all locale are present in all installs (and are therefore provided by the "filesystem" package)
