### PR TITLE
rtabmap_ros: 0.8.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7279,7 +7279,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.8.0-0
+      version: 0.8.1-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.8.1-0`:
- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.8.0-0`
