### PR TITLE
rocon_app_platform: 0.7.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4997,7 +4997,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_app_platform-release.git
-      version: 0.7.5-0
+      version: 0.7.6-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_app_platform` to `0.7.6-0`:
- upstream repository: http://github.com/robotics-in-concert/rocon_app_platform
- release repository: https://github.com/yujinrobot-release/rocon_app_platform-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.7.5-0`
## rocon_app_manager

```
* add log and typo fix
* use auto_rapp_installation param to enable disable installer
* disabl installer logic
* Contributors: Jihoon Lee
```
## rocon_app_platform
- No changes
## rocon_app_utilities

```
* remove custom platform checker and use rospkg.os_detect in dependency checker closes #269 <https://github.com/robotics-in-concert/rocon_app_platform/issues/269>
* Contributors: Jihoon Lee
```
## rocon_apps
- No changes
