### PR TITLE
lama_featurenav: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2745,10 +2745,19 @@ repositories:
       type: git
       url: https://github.com/lama-imr/lama_featurenav.git
       version: indigo-devel
+    release:
+      packages:
+      - anj_featurenav
+      - featurenav_base
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/lama-imr/lama_featurenav-release.git
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/lama-imr/lama_featurenav.git
       version: indigo-devel
+    status: developed
   lama_laser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lama_featurenav` to `0.1.1-0`:
- upstream repository: https://github.com/lama-imr/lama_featurenav.git
- release repository: https://github.com/lama-imr/lama_featurenav-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## anj_featurenav

```
* First public release
* Contributors: Gaël Ecorchard
```
## featurenav_base

```
* First public release
* Contributors: Gaël Ecorchard, Karel Košnar, Vladimír Petrík, Tomáš Krajnìk
```
