### PR TITLE
jsk_recognition: 0.1.32-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3110,7 +3110,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.1.31-0
+      version: 0.1.32-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.1.32-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.31-0`
## checkerboard_detector

```
* [jsk_pcl_ros, checkerboard_detector] Fix offset from checker board
* Contributors: Ryohei Ueda
```
## imagesift
- No changes
## jsk_pcl_ros

```
* add Torus.msg and TorusArrray.msg
* [jsk_pcl_ros, checkerboard_detector] Fix offset from checker board
* [jsk_pcl_ros] Use pcl::LINEMOD in LINEMODDetector for memory efficiency
* [jsk_pcl_ros] Use linemod class when training linemod template
* [jsk_pcl_ros] tune parameter of multi plane based object detection using
  spindle laser
* Contributors: Ryohei Ueda, Yuto Inagaki
```
## jsk_perception
- No changes
## jsk_recognition
- No changes
## resized_image_transport
- No changes
