### PR TITLE
pcan_topics: 1.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4360,6 +4360,20 @@ repositories:
       url: https://github.com/allenh1/p2os-release.git
       version: 1.0.11-0
     status: developed
+  pcan_topics:
+    doc:
+      type: git
+      url: https://github.com/najkirdneh/pcan_topics.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/najkirdneh/pcan_topics-release.git
+      version: 1.0.7-0
+    source:
+      type: git
+      url: https://github.com/najkirdneh/pcan_topics.git
+      version: master
   pcl_conversions:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcan_topics` to `1.0.7-0`:
- upstream repository: https://github.com/najkirdneh/pcan_topics.git
- release repository: https://github.com/najkirdneh/pcan_topics-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## pcan_topics

```
* Added a system dependency
* Contributors: Hendrik Meijdam
```
