### PR TITLE
ivcon: 0.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2341,6 +2341,17 @@ repositories:
       url: https://github.com/iralabdisco/ira_photonfocus_driver.git
       version: master
     status: maintained
+  ivcon:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/ivcon-release.git
+      version: 0.1.5-0
+    source:
+      type: git
+      url: https://github.com/ros/ivcon.git
+      version: indigo-devel
+    status: maintained
   jackal:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ivcon` to `0.1.5-0`:
- upstream repository: https://github.com/ros/ivcon.git
- release repository: https://github.com/ros-gbp/ivcon-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## ivcon

```
* Indigo devel
* Added tag 0.1.4 for changeset 4f7be6010df7
* Contributors: Ioan Sucan, dash
```
