### PR TITLE
husky_control: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2056,6 +2056,21 @@ repositories:
       url: https://github.com/ahornung/humanoid_msgs.git
       version: devel
     status: maintained
+  husky_control:
+    doc:
+      type: git
+      url: https://github.com/husky/husky_control.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/husky_control-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/husky/husky_control.git
+      version: indigo-devel
+    status: maintained
   husky_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_control` to `0.0.1-0`:
- upstream repository: https://github.com/husky/husky_control.git
- release repository: https://github.com/clearpath-gbp/husky_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## husky_control

```
* Initial development of husky_control for Husky indigo release
* Contributors: Paul Bovbel
```
