### PR TITLE
ros_package_web_server: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5488,6 +5488,13 @@ repositories:
       url: https://github.com/sevenbitbyte/ros_openlighting.git
       version: indigo
     status: developed
+  ros_package_web_server:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RIVeR-Lab-release/ros_package_web_server-release.git
+      version: 0.0.1-0
+    status: maintained
   ros_statistics_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_package_web_server` to `0.0.1-0`:
- upstream repository: https://github.com/RIVeR-Lab/ros_package_web_server.git
- release repository: https://github.com/RIVeR-Lab-release/ros_package_web_server-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## ros_package_web_server

```
* Initial Release
* Contributors: Mitchell Wills
```
