### PR TITLE
lama_utilities: 0.1.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2831,10 +2831,25 @@ repositories:
       type: git
       url: https://github.com/lama-imr/lama_utilities.git
       version: indigo-devel
+    release:
+      packages:
+      - crossing_detector
+      - dfs_explorer
+      - goto_crossing
+      - lama_common
+      - local_map
+      - map_ray_caster
+      - nj_escape_crossing
+      - nlj_dummy
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/lama-imr/lama_utilities-release.git
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/lama-imr/lama_utilities.git
       version: indigo-devel
+    status: developed
   laser_assembler:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lama_utilities` to `0.1.1-1`:
- upstream repository: https://github.com/lama-imr/lama_utilities.git
- release repository: https://github.com/lama-imr/lama_utilities-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## crossing_detector

```
* First public release for Indigo
* Contributors: Gaël Ecorchard
```
## dfs_explorer

```
* First public release for Indigo
* Contributors: Gaël Ecorchard
```
## goto_crossing

```
* First public release for Indigo
* Contributors: Gaël Ecorchard
```
## lama_common

```
* First public release for Indigo
* Contributors: Gaël Ecorchard
```
## local_map

```
* First public release for Indigo
* Contributors: Gaël Ecorchard
```
## map_ray_caster

```
* First public release for Indigo
* Contributors: Gaël Ecorchard
```
## nj_escape_crossing

```
* First public release for Indigo
* Contributors: Gaël Ecorchard
```
## nlj_dummy

```
* First public release for Indigo
* Contributors: Gaël Ecorchard
```
