### PR TITLE
rosdep: add vivid entry for python-sip-dev

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1316,6 +1316,7 @@ python-sip:
     trusty: [python-sip-dev]
     trusty_python3: [python3-sip-dev]
     utopic: [python-sip-dev]
+    vivid: [python-sip-dev]
 python-sip4:
   fedora: [sip]
   macports: [py27-sip4]


### PR DESCRIPTION
required for releasing orocos_kinematics_dynamics into jade

Signed-off-by: Ruben Smits ruben.smits@intermodalics.eu
