### PR TITLE
orocos_kinematics_dynamics: 1.3.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -369,6 +369,21 @@ repositories:
       url: https://github.com/wg-perception/opencv_candidate.git
       version: master
     status: maintained
+  orocos_kinematics_dynamics:
+    release:
+      packages:
+      - orocos_kdl
+      - orocos_kinematics_dynamics
+      - python_orocos_kdl
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/smits/orocos-kdl-release.git
+      version: 1.3.0-0
+    source:
+      type: git
+      url: https://github.com/orocos/orocos_kinematics_dynamics.git
+      version: master
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kinematics_dynamics` to `1.3.0-0`:
- upstream repository: https://github.com/orocos/orocos_kinematics_dynamics.git
- release repository: https://github.com/smits/orocos-kdl-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
