### PR TITLE
jskeus: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2568,7 +2568,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jskeus-release.git
-      version: 1.0.1-1
+      version: 1.0.2-0
   katana_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.0.2-0`:
- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.0.1-1`
## jskeus

```
* Set ${EUSDIR}/irteus as symlink
* Move plot joint min max function to irtmodel.l and define it as method
* Contributors: Kei Okada, Shunichi Nozawa
```
