### PR TITLE
husky_description: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2086,6 +2086,21 @@ repositories:
       url: https://github.com/husky/husky_control.git
       version: indigo-devel
     status: maintained
+  husky_description:
+    doc:
+      type: git
+      url: https://github.com/husky/husky_description.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/husky_description-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/husky/husky_description.git
+      version: indigo-devel
+    status: maintained
   husky_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_description` to `0.1.0-0`:
- upstream repository: https://github.com/husky/husky_description.git
- release repository: https://github.com/clearpath-gbp/husky_description-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## husky_description

```
* Major refactor for indigo release:
  * base_link is now located on the ground plane, while chassis_link
  * refactored joint names for consistency with Jackal and Grizzly for ros_control
  * moved plugins requiring gazebo dependencies to husky_gazebo (imu, gps, lidar, ros_control)
  * initial prefixing for multirobot
* Contributors: Alex Bencz, James Servos, Mike Purvis, Paul Bovbel, Prasenjit Mukherjee, y22ma
```
