### PR TITLE
husky_simulator: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2116,6 +2116,24 @@ repositories:
       url: https://github.com/husky/husky_msgs.git
       version: indigo-devel
     status: maintained
+  husky_simulator:
+    doc:
+      type: git
+      url: https://github.com/husky/husky_simulator.git
+      version: indigo-devel
+    release:
+      packages:
+      - husky_gazebo
+      - husky_simulator
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/husky_simulator-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/husky/husky_simulator.git
+      version: indigo-devel
+    status: maintained
   iai_common_msgs:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_simulator` to `0.1.0-0`:
- upstream repository: https://github.com/husky/husky_simulator.git
- release repository: https://github.com/clearpath-gbp/husky_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## husky_gazebo

```
* Major refactor for indigo:
  * All gazebo plugins moved to urdf/description.gazebo.xacro from husky_description
  * Ported to ros_control
* Contributors: James Servos, Mike Purvis, Paul Bovbel, Prasenjit Mukherjee, y22ma
```
## husky_simulator

```
* Removed husky_gazebo_plugins in favor of ros_control
* Contributors: Paul Bovbel
```
