### PR TITLE
husky_bringup: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2071,6 +2071,21 @@ repositories:
       url: https://github.com/husky/husky_base.git
       version: indigo-devel
     status: maintained
+  husky_bringup:
+    doc:
+      type: git
+      url: https://github.com/husky/husky_bringup.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/husky_bringup-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/husky/husky_bringup.git
+      version: indigo-devel
+    status: maintained
   husky_control:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_bringup` to `0.1.0-0`:
- upstream repository: https://github.com/husky/husky_bringup.git
- release repository: https://github.com/clearpath-gbp/husky_bringup-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## husky_bringup

```
* Port to robot_localization, gyro only pending um6 fixes
* changed the launch file to match parameter namespace changes in the imu_compass node
* ported kingfisher compass calibration to husky
* Added Microstrain device condition - Looks for an attached Microstrain device and installs the necessary launch files from the microstrain_config directory.
* Update sick.launch - Fixed binary name
* Change default IP for LIDAR to 192.168.1.14
* Add launcher for sick LIDAR.
* Added Microstrain launch file and udev rule.
* Contributors: Jeff Schmidt, Mike Purvis, Paul Bovbel, Prasenjit Mukherjee
```
