### PR TITLE
jsk_roseus: 1.1.30-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2615,12 +2615,11 @@ repositories:
       packages:
       - jsk_roseus
       - roseus
-      - roseus_msgs
       - roseus_smach
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.29-0
+      version: 1.1.30-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.30-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.1.29-0`
## jsk_roseus
- No changes
## roseus

```
* use -L to find symlinked irteusgl
```
## roseus_smach
- No changes
