### PR TITLE
pr2_common: 1.11.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4639,6 +4639,27 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
       version: master
     status: maintained
+  pr2_common:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_common.git
+      version: indigo-devel
+    release:
+      packages:
+      - pr2_common
+      - pr2_dashboard_aggregator
+      - pr2_description
+      - pr2_machine
+      - pr2_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_common-release.git
+      version: 1.11.8-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_common.git
+      version: indigo-devel
+    status: maintained
   pr2_mechanism_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common` to `1.11.8-0`:
- upstream repository: https://github.com/pr2/pr2_common.git
- release repository: https://github.com/pr2-gbp/pr2_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## pr2_common
- No changes
## pr2_dashboard_aggregator
- No changes
## pr2_description

```
* liburdfdom-dev dep
* Contributors: dash
```
## pr2_machine

```
* package xml
* Contributors: dash
```
## pr2_msgs
- No changes
