### PR TITLE
pr2_ethercat_drivers: 1.8.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4659,6 +4659,26 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: indigo-devel
     status: maintained
+  pr2_ethercat_drivers:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_mechanism.git
+      version: indigo-devel
+    release:
+      packages:
+      - eml
+      - ethercat_hardware
+      - fingertip_pressure
+      - pr2_ethercat_drivers
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_ethercat_drivers-release.git
+      version: 1.8.13-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_mechanism.git
+      version: indigo-devel
+    status: maintained
   pr2_mechanism_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_ethercat_drivers` to `1.8.13-0`:
- upstream repository: https://github.com/pr2/pr2_ethercat_drivers.git
- release repository: https://github.com/pr2-gbp/pr2_ethercat_drivers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## eml
- No changes
## ethercat_hardware
- No changes
## fingertip_pressure
- No changes
## pr2_ethercat_drivers
- No changes
