### PR TITLE
pr2_controllers: 1.10.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4659,6 +4659,32 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: indigo-devel
     status: maintained
+  pr2_controllers:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_controllers.git
+      version: indigo-devel
+    release:
+      packages:
+      - ethercat_trigger_controllers
+      - joint_trajectory_action
+      - pr2_calibration_controllers
+      - pr2_controllers
+      - pr2_controllers_msgs
+      - pr2_gripper_action
+      - pr2_head_action
+      - pr2_mechanism_controllers
+      - robot_mechanism_controllers
+      - single_joint_position_action
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_controllers-release.git
+      version: 1.10.12-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_controllers.git
+      version: indigo-devel
+    status: maintained
   pr2_mechanism:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_controllers` to `1.10.12-0`:
- upstream repository: https://github.com/pr2/pr2_controllers.git
- release repository: https://github.com/pr2-gbp/pr2_controllers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## ethercat_trigger_controllers
- No changes
## joint_trajectory_action
- No changes
## pr2_calibration_controllers
- No changes
## pr2_controllers
- No changes
## pr2_controllers_msgs
- No changes
## pr2_gripper_action
- No changes
## pr2_head_action
- No changes
## pr2_mechanism_controllers
- No changes
## robot_mechanism_controllers
- No changes
## single_joint_position_action
- No changes
