### PR TITLE
pcan_topics: 1.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4487,7 +4487,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/najkirdneh/pcan_topics-release.git
-      version: 1.0.7-0
+      version: 1.0.9-0
     source:
       type: git
       url: https://github.com/najkirdneh/pcan_topics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcan_topics` to `1.0.9-0`:
- upstream repository: https://github.com/najkirdneh/pcan_topics.git
- release repository: https://github.com/najkirdneh/pcan_topics-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.0.7-0`
## pcan_topics
- No changes
