### PR TITLE
geometry_experimental: 0.5.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -273,6 +273,32 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: indigo-devel
     status: maintained
+  geometry_experimental:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry_experimental.git
+      version: indigo-devel
+    release:
+      packages:
+      - geometry_experimental
+      - tf2
+      - tf2_bullet
+      - tf2_geometry_msgs
+      - tf2_kdl
+      - tf2_msgs
+      - tf2_py
+      - tf2_ros
+      - tf2_sensor_msgs
+      - tf2_tools
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/geometry_experimental-release.git
+      version: 0.5.7-0
+    source:
+      type: git
+      url: https://github.com/ros/geometry_experimental.git
+      version: indigo-devel
+    status: maintained
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_experimental` to `0.5.7-0`:
- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry_experimental-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## geometry_experimental
- No changes
## tf2
- No changes
## tf2_bullet

```
* fixing install rules and adding backwards compatible include with #warning
* Contributors: Tully Foote
```
## tf2_geometry_msgs

```
* fixing transitive dependency for kdl. Fixes #53 <https://github.com/ros/geometry_experimental/issues/53>
* Contributors: Tully Foote
```
## tf2_kdl

```
* fixing install rules and adding backwards compatible include with #warning
* Contributors: Tully Foote
```
## tf2_msgs
- No changes
## tf2_py
- No changes
## tf2_ros

```
* Added 6 param transform again
  Yes, using Euler angles is a bad habit. But it is much more convenient if you just need a rotation by 90° somewhere to set it up in Euler angles. So I added the option to supply only the 3 angles.
* Remove tf2_py dependency for Android
* Contributors: Achim Königs, Gary Servin
```
## tf2_sensor_msgs

```
* add support for transforming sensor_msgs::PointCloud2
* Contributors: Vincent Rabaud
```
## tf2_tools
- No changes
