### PR TITLE
geometry: 1.11.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -273,6 +273,27 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: indigo-devel
     status: maintained
+  geometry:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry.git
+      version: indigo-devel
+    release:
+      packages:
+      - eigen_conversions
+      - geometry
+      - kdl_conversions
+      - tf
+      - tf_conversions
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/geometry-release.git
+      version: 1.11.4-0
+    source:
+      type: git
+      url: https://github.com/ros/geometry.git
+      version: indigo-devel
+    status: maintained
   geometry_experimental:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry` to `1.11.4-0`:
- upstream repository: https://github.com/ros/geometry.git
- release repository: https://github.com/ros-gbp/geometry-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## eigen_conversions
- No changes
## geometry

```
* Update package.xml
* Contributors: David Lu!!
```
## kdl_conversions

```
* Update package.xml
* Contributors: David Lu!!
```
## tf

```
* Install static lib and remove test for Android
* Larger default queue size in broadcaster
  With queue_size=1 when two transforms are sent in quick succession,
  the second is often lost. The C++ code uses a default queue_size of
  100, so switch to that default here as well. If that is not appropriate,
  a queue_size constructor argument is provided.
* Update package.xml
* add rate parameter to tf_echo
* Added check for normalized quaternion in roswtf plugin
* Contributors: David Lu!!, Gary Servin, Kevin Hallenbeck, Stephan Wirth, contradict
```
## tf_conversions

```
* Update package.xml
* Contributors: David Lu!!
```
