### PR TITLE
ceres_solver: 0.10.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -571,6 +571,13 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: indigo-devel
     status: maintained
+  ceres_solver:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/ceres_solver-release.git
+      version: 0.10.0-1
+    status: maintained
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ceres_solver` to `0.10.0-1`:
- upstream repository: https://github.com/stonier/ceres_solver.git
- release repository: https://github.com/yujinrobot-release/ceres_solver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
