### PR TITLE
lama_utilities: 0.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2906,7 +2906,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/lama-imr/lama_utilities-release.git
-      version: 0.1.1-1
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/lama-imr/lama_utilities.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lama_utilities` to `0.1.5-0`:
- upstream repository: https://github.com/lama-imr/lama_utilities.git
- release repository: https://github.com/lama-imr/lama_utilities-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.1-1`
## crossing_detector

```
* Unchanged
```
## dfs_explorer

```
* Unchanged
```
## goto_crossing

```
* Unchanged
```
## lama_common

```
* Fix SimplifyPlaceProfile with last point excluded
* Contributors: Gaël Ecorchard
```
## local_map

```
* Unchanged
```
## map_ray_caster

```
* Unchanged
```
## nj_escape_crossing

```
* Unchanged
```
## nlj_dummy

```
* Unchanged
```
