### PR TITLE
husky_description: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2110,7 +2110,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_description-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/husky/husky_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_description` to `0.1.1-0`:
- upstream repository: https://github.com/husky/husky_description.git
- release repository: https://github.com/clearpath-gbp/husky_description-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.0-0`
## husky_description

```
* Remove multirobot changes, experiment later
* Contributors: Paul Bovbel
```
