### PR TITLE
husky_viz: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2149,6 +2149,21 @@ repositories:
       url: https://github.com/husky/husky_simulator.git
       version: indigo-devel
     status: maintained
+  husky_viz:
+    doc:
+      type: git
+      url: https://github.com/husky/husky_viz.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/husky_viz-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/husky/husky_viz.git
+      version: indigo-devel
+    status: maintained
   iai_common_msgs:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_viz` to `0.1.0-0`:
- upstream repository: https://github.com/husky/husky_viz.git
- release repository: https://github.com/clearpath-gbp/husky_viz-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## husky_viz

```
* Update visualizations for indigo release
* update maintainer and dependencies
* Remove husky_interactive_markers, switch to generic.
* Add front_laser arg to view_model launcher.
* Default fixed frame for the model viewer should be base_link.
* viewing more options for navigation.rviz
* Contributors: Mike Purvis, Paul Bovbel, Prasenjit Mukherjee
```
