### PR TITLE
xacro: 1.9.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7660,7 +7660,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.9.2-0
+      version: 1.9.3-0
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.9.3-0`:
- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.9.2-0`
## xacro

```
* merge test cases
* add a snapshot of the pr2 model to the test directory. add a test case which verifies that the pr2 model is parsed equal to a 'golden' parse of it.
* add more tests
* add default arg tests
* Allow default values for substitution args
* Fix up comments
* Allow xacro macros to have default parameters
* Contributors: Paul Bovbel, Morgan Quigley
```
