### PR TITLE
moveit_pr2: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3503,6 +3503,26 @@ repositories:
       url: https://github.com/ros-planning/moveit_plugins.git
       version: indigo-devel
     status: maintained
+  moveit_pr2:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_pr2.git
+      version: indigo-devel
+    release:
+      packages:
+      - moveit_pr2
+      - pr2_moveit_config
+      - pr2_moveit_plugins
+      - pr2_moveit_tutorials
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_pr2-release.git
+      version: 0.6.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_pr2.git
+      version: indigo-devel
+    status: maintained
   moveit_python:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_pr2` to `0.6.0-0`:
- upstream repository: https://github.com/ros-planning/moveit_pr2.git
- release repository: https://github.com/ros-gbp/moveit_pr2-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## moveit_pr2
- No changes
## pr2_moveit_config

```
* deleted duplicate debug xml tag in launchfile
* Contributors: arjungm
```
## pr2_moveit_plugins

```
* build system fix
* Fix deprecated class loader call, renamed global variables to have _, cleaned up launch files
* Contributors: Dave Coleman, Ioan Sucan
```
## pr2_moveit_tutorials

```
* Fixed launch file name in api_tutorial doc.
* Added missing dependency on moveit_fake_controller_manager to tutorial.
* Contributors: Dave Hershberger
```
