### PR TITLE
moveit_metapackages: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3455,6 +3455,20 @@ repositories:
       url: https://github.com/ros-planning/moveit_ikfast.git
       version: indigo-devel
     status: maintained
+  moveit_metapackages:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_metapackages.git
+      version: master
+    release:
+      packages:
+      - moveit_full
+      - moveit_full_pr2
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_metapackages-release.git
+      version: 0.6.0-0
+    status: maintained
   moveit_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_metapackages` to `0.6.0-0`:
- upstream repository: https://github.com/ros-planning/moveit_metapackages.git
- release repository: https://github.com/ros-gbp/moveit_metapackages-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## moveit_full
- No changes
## moveit_full_pr2
- No changes
