### PR TITLE
object_recognition_core: 0.6.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -424,6 +424,17 @@ repositories:
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel
     status: maintained
+  object_recognition_core:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_core-release.git
+      version: 0.6.3-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/object_recognition_core.git
+      version: master
+    status: maintained
   object_recognition_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_core` to `0.6.3-0`:
- upstream repository: https://github.com/wg-perception/object_recognition_core.git
- release repository: https://github.com/ros-gbp/object_recognition_core-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## object_recognition_core

```
* Merge pull request #27 <https://github.com/wg-perception/object_recognition_core/issues/27> from cottsay/master
  Always include ecto.hpp first
* Always include ecto.hpp first
  ecto.hpp includes Python.hpp, which must always come before system includes
* adapt docs for ROS distribution
* improve install instructions
  This fixes #25 <https://github.com/wg-perception/object_recognition_core/issues/25> by only taking non-redundant information
* Contributors: Scott K Logan, Vincent Rabaud
```
