### PR TITLE
uwsim_osgocean: 1.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8650,7 +8650,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/uji-ros-pkg/uwsim_osgocean-release.git
-      version: 1.0.2-6
+      version: 1.0.3-0
     status: maintained
   uwsim_osgworks:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_osgocean` to `1.0.3-0`:
- upstream repository: https://github.com/uji-ros-pkg/uwsim_osgocean.git
- release repository: https://github.com/uji-ros-pkg/uwsim_osgocean-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.0.2-6`
