### PR TITLE
lama_utilities: 0.1.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2921,7 +2921,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/lama-imr/lama_utilities-release.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/lama-imr/lama_utilities.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lama_utilities` to `0.1.6-0`:
- upstream repository: https://github.com/lama-imr/lama_utilities.git
- release repository: https://github.com/lama-imr/lama_utilities-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.5-0`
## crossing_detector

```
* remove Python bindings libs from catkin_package
* Contributors: Gaël Ecorchard
```
## dfs_explorer

```
* Unchanged
```
## goto_crossing

```
* Unchanged
```
## lama_common

```
* Unchanged
```
## local_map

```
* Unchanged
```
## map_ray_caster

```
* Unchanged
```
## nj_escape_crossing

```
* Unchanged
```
## nlj_dummy

```
* Unchanged
```
