### PR TITLE
lama_polygon_matcher: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2890,10 +2890,20 @@ repositories:
       type: git
       url: https://github.com/lama-imr/lama_polygon_matcher.git
       version: indigo-devel
+    release:
+      packages:
+      - pm_fourier
+      - pm_mcc
+      - polygon_matcher
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/lama-imr/lama_polygon_matcher-release.git
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/lama-imr/lama_polygon_matcher.git
       version: indigo-devel
+    status: developed
   lama_test:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lama_polygon_matcher` to `0.1.1-0`:
- upstream repository: https://github.com/lama-imr/lama_polygon_matcher.git
- release repository: https://github.com/lama-imr/lama_polygon_matcher-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## pm_fourier

```
* First public release for Indigo
* Contributors: Gaël Ecorchard, Karel Košnar
```
## pm_mcc

```
* First public release for Indigo
* Contributors: Gaël Ecorchard, Karel Košnar
```
## polygon_matcher

```
* First public release for Indigo
* Contributors: Gaël Ecorchard, Karel Košnar
```
