### PR TITLE
Rosdep entry for nvidia-cuda-toolkit on ubuntu and debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2386,8 +2386,8 @@ nvidia-cg:
   gentoo: [media-gfx/nvidia-cg-toolkit]
   ubuntu: [nvidia-cg-toolkit]
 nvidia-cuda:
-  ubuntu: [nvidia-cuda-toolkit]
   debian: [nvidia-cuda-toolkit]
+  ubuntu: [nvidia-cuda-toolkit]
 omniidl:
   debian:
     etch: [omniidl4]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2385,6 +2385,9 @@ nvidia-cg:
   fedora: [Cg]
   gentoo: [media-gfx/nvidia-cg-toolkit]
   ubuntu: [nvidia-cg-toolkit]
+nvidia-cuda:
+  ubuntu: [nvidia-cuda-toolkit]
+  debian: [nvidia-cuda-toolkit]
 omniidl:
   debian:
     etch: [omniidl4]


### PR DESCRIPTION
Well, all in the title. Here is a new rosdep entry for the nvidia-cuda-toolkit package.
