### PR TITLE
Updated indexing info of package kinect_aux

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -2048,6 +2048,11 @@ repositories:
       type: git
       url: https://github.com/muhrix/kinect_aux.git
       version: groovy
+    source:
+      type: git
+      url: https://github.com/muhrix/kinect_aux.git
+      version: groovy
+    status: maintained
   knowrob:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3228,6 +3228,11 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/muhrix/kinect_aux-release.git
       version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/muhrix/kinect_aux.git
+      version: hydro
+    status: maintained
   kingfisher:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2677,6 +2677,16 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/kinect_2d_scanner.git
       version: master
     status: maintained
+  kinect_aux:
+    doc:
+      type: git
+      url: https://github.com/muhrix/kinect_aux.git
+      version: indigo
+    source:
+      type: git
+      url: https://github.com/muhrix/kinect_aux.git
+      version: indigo
+    status: maintained
   kingfisher:
     doc:
       type: git


### PR DESCRIPTION
Updated indexing information of ROS package `kinect_aux` for currently maintained distributions (Groovy, Hydro and Indigo).
