### PR TITLE
Updated indexing info of package phidgets_drivers

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3225,6 +3225,7 @@ repositories:
       type: git
       url: https://github.com/ccny-ros-pkg/phidgets_drivers.git
       version: groovy
+    status: maintained
   physics_ode:
     doc:
       type: svn

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5189,6 +5189,7 @@ repositories:
       type: git
       url: https://github.com/ccny-ros-pkg/phidgets_drivers.git
       version: hydro
+    status: maintained
   pi_tracker:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4642,6 +4642,16 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: indigo-devel
     status: maintained
+  phidgets_drivers:
+    doc:
+      type: git
+      url: https://github.com/ccny-ros-pkg/phidgets_drivers.git
+      version: indigo
+    source:
+      type: git
+      url: https://github.com/ccny-ros-pkg/phidgets_drivers.git
+      version: indigo
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Updated indexing information of ROS package `phidgets_drivers` for currently maintained distributions (Groovy, Hydro and Indigo).
