### PR TITLE
kinect_aux: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2682,6 +2682,11 @@ repositories:
       type: git
       url: https://github.com/muhrix/kinect_aux.git
       version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/muhrix/kinect_aux-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/muhrix/kinect_aux.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinect_aux` to `0.0.1-0`:
- upstream repository: https://github.com/muhrix/kinect_aux.git
- release repository: https://github.com/muhrix/kinect_aux-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## kinect_aux

```
* Modified way of finding libusb flags
* Added folder name where libusb.h resides
* Updated README.md: added Travis build image
* Added Travis configuration to repo
* Bumped package version
* Added changelog to repo
* Excluding Eclipse project files from repo with .gitignore
* rosdep install now works
* Allow kinect_aux_node to be installed
* The check for system dependency (libusb) is now done properly
* First commit of catkinised working version for ROS Groovy
* Contributors: Murilo F. M.
```
