### PR TITLE
husky_navigation: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2131,6 +2131,21 @@ repositories:
       url: https://github.com/husky/husky_msgs.git
       version: indigo-devel
     status: maintained
+  husky_navigation:
+    doc:
+      type: git
+      url: https://github.com/husky/husky_navigation.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/husky_navigation-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/husky/husky_navigation.git
+      version: indigo-devel
+    status: maintained
   husky_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_navigation` to `0.1.0-0`:
- upstream repository: https://github.com/husky/husky_navigation.git
- release repository: https://github.com/clearpath-gbp/husky_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## husky_navigation

```
* Add exploration demo
* Indigo release refactor
* adding prebuilt maps for playpen, slightly more representative map then willowgarage world
* Contributors: Paul Bovbel, Prasenjit Mukherjee
```
