### PR TITLE
husky_metapackages: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2116,6 +2116,24 @@ repositories:
       url: https://github.com/husky/husky_description.git
       version: indigo-devel
     status: maintained
+  husky_metapackages:
+    doc:
+      type: git
+      url: https://github.com/husky/husky_metapackages.git
+      version: indigo-devel
+    release:
+      packages:
+      - husky_desktop
+      - husky_robot
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/husky_metapackages-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/husky/husky_metapackages.git
+      version: indigo-devel
+    status: maintained
   husky_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_metapackages` to `0.1.0-0`:
- upstream repository: https://github.com/husky/husky_metapackages.git
- release repository: https://github.com/clearpath-gbp/husky_metapackages-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## husky_desktop

```
* Update descriptions, dependencies, and maintainer
* Add common message dependencies to desktop metapackage.
* Contributors: Mike Purvis, Paul Bovbel
```
## husky_robot

```
* Update descriptions, dependencies, and maintainer
* Contributors: Paul Bovbel
* RP-264 Update descriptions, dependencies, and maintainer
* Contributors: Paul Bovbel
```
