### PR TITLE
phidgets_drivers: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4685,6 +4685,16 @@ repositories:
       type: git
       url: https://github.com/ccny-ros-pkg/phidgets_drivers.git
       version: indigo
+    release:
+      packages:
+      - phidgets_api
+      - phidgets_drivers
+      - phidgets_imu
+      - phidgets_ir
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/muhrix/phidgets_drivers-release.git
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/phidgets_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `0.2.1-0`:
- upstream repository: https://github.com/ccny-ros-pkg/phidgets_drivers.git
- release repository: https://github.com/muhrix/phidgets_drivers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## phidgets_api

```
* phidgets_api: add libusb dependency
  This caused Jenkins CI tests to fail.
* phidgets_api: fix case in CMakeLists
* phidgets_api: added GNU LGPLv3 copy (phidget21.h)
* phidgets_api: updated license and author information
* phidgets_api: added script to setup udev rules for Phidgets devices
* phidgets_api: added libphidget21 dependency as cmake external project
* phidgets_api: updated path to libphidget header file
* phidgets_api: added libphidget header file to package
* phidgets_api: removed phidgets_c_api dependency
* Deleted comments within files of all packages
* Catkinised packages
* added missing cmakelists
* added api, imu and ir
* removed deps directory
* initial commit
* Contributors: Ivan Dryanovski, Martin Günther, Murilo FM
```
## phidgets_drivers

```
* phidgets_drivers: removed phidgets_c_api dependency
* Updated version, maintainer and author information
* Deleted comments within files of all packages
* phidgets_drivers: converted stack into metapackage
* Contributors: Murilo FM
```
## phidgets_imu

```
* add boost depends to CMakeLists
  All non-catkin things that we expose in our headers should be added to
  the DEPENDS, so that packages which depend on our package will also
  automatically link against it.
  Also see: http://answers.ros.org/question/58498/what-is-the-purpose-of-catkin_depends/#58593
* improve error output when setting compass corr params
  The previous implementation didn't catch a number of error codes
  (EPHIDGET_INVALIDARG, EPHIDGET_NOTATTACHED, EPHIDGET_UNEXPECTED), and
  the new one is more elegant and consistent with the previous code anyway.
* Set compass correction params on the device
  Tested with a Phidget Spatial 3/3/3 1044.
* phidgets_imu: install phidgets_imu_nodelet.xml
* phidgets_imu: not exporting nodelet as library anymore
* Updated version, maintainer and author information
* phidgets_imu: added install rule to launch files
* phidgets_imu: removed unnecessary dependency
* Deleted comments within files of all packages
* Catkinised packages
* Merge pull request #1 from uos/fix_imu_time_lag
  fix IMU time lag
* add some hints to error message
  I just spent 30 minutes trying to figure out why the IMU works on one
  computer and doesn't on another one. Felt a little foolish when I found
  out that the udev rules weren't installed; maybe providing some more
  info in the error message helps others.
* use ros::Time::now() if time lag exceeds threshold
* added warning if IMU time lags behind ROS time
* renamed rate parameter to period
* added timestamp in imu data
* fixed cmakelists by including lib to compile on electric
* adding missing imu_ros h file
* adding missing imu_ros cpp file
* added api, imu and ir
* initial commit
* Contributors: Ivan Dryanovski, Martin Günther, Murilo FM
```
## phidgets_ir

```
* Updated version, maintainer and author information
* phidgets_ir: added dependency to phidgets_api package
* Deleted comments within files of all packages
* Catkinised packages
* updated manifest of phidgets IR
* fixed cmakelists by including lib to compile on electric
* added api, imu and ir
* Contributors: Ivan Dryanovski, Murilo FM
```
