### PR TITLE
naoqi_bridge: 0.4.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4317,13 +4317,15 @@ repositories:
       version: master
     release:
       packages:
+      - naoqi_bridge
       - naoqi_driver
       - naoqi_msgs
       - naoqi_sensors
+      - naoqi_tools
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_bridge-release.git
-      version: 0.4.3-1
+      version: 0.4.4-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge` to `0.4.4-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_bridge.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.4.3-1`
## naoqi_bridge
- No changes
## naoqi_driver
- No changes
## naoqi_msgs
- No changes
## naoqi_sensors

```
* cleanup some installs
* change default 3d frame
* configure sonars via external params
  launch multiple sonars via diff namespaces
  see launching cameras for this
* Contributors: Karsten Knese, Vincent Rabaud
```
## naoqi_tools
- No changes
