### PR TITLE
zbar_ros: 0.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -9112,7 +9112,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/zbar_ros-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/zbar_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zbar_ros` to `0.0.4-0`:
- upstream repository: https://github.com/clearpathrobotics/zbar_ros.git
- release repository: https://github.com/clearpath-gbp/zbar_ros-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.3-0`
## zbar_ros

```
* Style fixes
* Fix naming and debug messages
* Update node->nodelet wrapper
* Contributors: Paul Bovbel
```
