### PR TITLE
usb_cam: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7443,7 +7443,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/bosch-ros-pkg-release/usb_cam-release.git
-      version: 0.1.13-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/bosch-ros-pkg/usb_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam` to `0.2.0-0`:
- upstream repository: https://github.com/bosch-ros-pkg/usb_cam.git
- release repository: https://github.com/bosch-ros-pkg-release/usb_cam-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.13-0`
## usb_cam

```
* Bug fix in camera info settings.
* Update .travis.yml
* Merge pull request #27 from bosch-ros-pkg/default_camera_info
  sets default camera info
* sets default camera info
* Contributors: Russell Toris
```
