### PR TITLE
carl_moveit: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -520,7 +520,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_moveit-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_moveit` to `0.0.4-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_moveit.git
- release repository: https://github.com/wpi-rail-release/carl_moveit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.3-0`
## carl_moveit

```
* Launched carl_moveit_wrapper with full launch file
* Update .travis.yml
* Added Cartesian path planning, experimental Cartesian control using a Jacobian pseudoinverse, and some general cleanup
* Contributors: David Kent
```
