### PR TITLE
interactive_world: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2461,10 +2461,11 @@ repositories:
       - interactive_world_parser
       - interactive_world_tools
       - jinteractiveworld
+      - spatial_world_model
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/interactive_world-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/interactive_world.git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_world` to `0.0.3-0`:
- upstream repository: https://github.com/WPI-RAIL/interactive_world.git
- release repository: https://github.com/wpi-rail-release/interactive_world-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.2-0`
## interactive_world
- No changes
## interactive_world_msgs

```
* spatial world model added
* Contributors: Russell Toris
```
## interactive_world_parser
- No changes
## interactive_world_tools
- No changes
## jinteractiveworld
- No changes
## spatial_world_model

```
* spatial world model added
* Contributors: Russell Toris
```
