### PR TITLE
moveit_pr2: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3590,7 +3590,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_pr2-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_pr2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_pr2` to `0.6.1-0`:
- upstream repository: https://github.com/ros-planning/moveit_pr2.git
- release repository: https://github.com/ros-gbp/moveit_pr2-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.6.0-0`
## moveit_pr2

```
* update maintainer while debugging build errors
* Contributors: Michael Ferguson
```
## pr2_moveit_config
- No changes
## pr2_moveit_plugins

```
* update maintainer while debugging build errors
* add build depend on cmake_modules
* Contributors: Michael Ferguson
```
## pr2_moveit_tutorials

```
* update maintainer while debugging build errors
* Contributors: Michael Ferguson
```
