### PR TITLE
moveit_metapackages: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3526,7 +3526,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_metapackages-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     status: maintained
   moveit_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_metapackages` to `0.6.1-0`:
- upstream repository: https://github.com/ros-planning/moveit_metapackages.git
- release repository: https://github.com/ros-gbp/moveit_metapackages-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.6.0-0`
## moveit_full

```
* add maintainer so I catch build failures
* Contributors: Michael Ferguson
```
## moveit_full_pr2

```
* add maintainer so I catch build failures
* Contributors: Michael Ferguson
```
