### PR TITLE
add urdfdom_py to jade

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -695,6 +695,13 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  urdfdom_py:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/urdfdom_py-release.git
+      version: 0.3.0-1
+    status: maintained
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
I failed to get a pull request (I had played with my git config too much) but things were released using bloom-release, no worries.
