### PR TITLE
calibration: 0.10.13-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -62,6 +62,33 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: master
     status: maintained
+  calibration:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/calibration.git
+      version: hydro
+    release:
+      packages:
+      - calibration
+      - calibration_estimation
+      - calibration_launch
+      - calibration_msgs
+      - calibration_setup_helper
+      - image_cb_detector
+      - interval_intersection
+      - joint_states_settler
+      - laser_cb_detector
+      - monocam_settler
+      - settlerlib
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/calibration-release.git
+      version: 0.10.13-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/calibration.git
+      version: hydro
+    status: maintained
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `calibration` to `0.10.13-0`:
- upstream repository: http://github.com/ros-perception/calibration.git
- release repository: https://github.com/ros-gbp/calibration-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## calibration
- No changes
## calibration_estimation

```
* Fill previous_pose_guesses by zero if no initial_poses file exists
* Fix to use stream rather than file name to load initial_poses yaml file
* check if frame_id from bagfile and system.yaml is same
* Contributors: Kei Okada, Ryohei Ueda
```
## calibration_launch
- No changes
## calibration_msgs
- No changes
## calibration_setup_helper

```
* add copyright notes
* set k-oakda as maintainer/author
* add calibration_setup_helper program
* Contributors: Kei Okada
* add copyright notes
* set k-oakda as maintainer/author
* add calibration_setup_helper program
* Contributors: Kei Okada
```
## image_cb_detector
- No changes
## interval_intersection
- No changes
## joint_states_settler
- No changes
## laser_cb_detector
- No changes
## monocam_settler
- No changes
## settlerlib
- No changes
