### PR TITLE
object_recognition_capture: 0.3.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -451,6 +451,17 @@ repositories:
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel
     status: maintained
+  object_recognition_capture:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_capture-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/capture.git
+      version: master
+    status: maintained
   object_recognition_core:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_capture` to `0.3.0-0`:
- upstream repository: https://github.com/wg-perception/capture.git
- release repository: https://github.com/ros-gbp/object_recognition_capture-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## object_recognition_capture

```
* make sure doc works with the latest ecto
* no need for stack.xml
* drop Fuerte support
* update website
* Added argument -p for preview.
  This is frequently used argument so it's good to have a short form.
* Corrected errors in parsing arguments --input and --matches.
* Contributors: Denis Štogl, Vincent Rabaud
```
