### PR TITLE
object_recognition_renderer: 0.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4618,7 +4618,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_renderer-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/ork_renderer.git
+      version: master
     status: maintained
   object_recognition_ros:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_renderer` to `0.2.1-0`:
- upstream repository: https://github.com/wg-perception/ork_renderer.git
- release repository: https://github.com/ros-gbp/object_recognition_renderer-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.2.0-0`
## object_recognition_renderer

```
* use GLUT by default
* clean extensions
* compile on Indigo
* fixed rotation matrix,
  fixed up vector
  additional option to render depth only
* fixed object orientation,
  return distance to an object is added
* build_depend on assimp-dev instead of assimp
* Fix Assimp detection
* Contributors: Scott K Logan, Vincent Rabaud, nlyubova
```
