### PR TITLE
object_recognition_renderer: 0.2.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -488,6 +488,17 @@ repositories:
       url: https://github.com/wg-perception/object_recognition_msgs.git
       version: master
     status: maintained
+  object_recognition_renderer:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_renderer-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/ork_renderer.git
+      version: master
+    status: maintained
   opencv_candidate:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_renderer` to `0.2.1-0`:
- upstream repository: https://github.com/wg-perception/ork_renderer.git
- release repository: https://github.com/ros-gbp/object_recognition_renderer-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## object_recognition_renderer

```
* use GLUT by default
* clean extensions
* compile on Indigo
* fixed rotation matrix,
  fixed up vector
  additional option to render depth only
* fixed object orientation,
  return distance to an object is added
* build_depend on assimp-dev instead of assimp
* Fix Assimp detection
* Contributors: Scott K Logan, Vincent Rabaud, nlyubova
```
