### PR TITLE
object_recognition_linemod: 0.3.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4585,7 +4585,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_linemod-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/wg-perception/linemod.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_linemod` to `0.3.1-0`:
- upstream repository: https://github.com/wg-perception/linemod.git
- release repository: https://github.com/ros-gbp/object_recognition_linemod-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.3.0-0`
## object_recognition_linemod

```
* fixed object orientation,
  fixed icp,
  added detection of multiple objects,
  added visualization of point clouds
* clean extensions
* update docs
* Updated render function to match latest ork_renderer commit bfcdbc2c74b21ac07b20c953f994269a427eb25c
* fix some runtime behavior
* Contributors: Isura, Vincent Rabaud, nlyubova
```
