### PR TITLE
lama_laser: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2930,10 +2930,21 @@ repositories:
       type: git
       url: https://github.com/lama-imr/lama_laser.git
       version: indigo-devel
+    release:
+      packages:
+      - lj_laser
+      - lj_laser_heading
+      - nj_laser
+      - nj_oa_laser
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/lama-imr/lama_laser-release.git
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/lama-imr/lama_laser.git
       version: indigo-devel
+    status: developed
   lama_polygon_matcher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lama_laser` to `0.1.2-0`:
- upstream repository: https://github.com/lama-imr/lama_laser.git
- release repository: https://github.com/lama-imr/lama_laser-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## lj_laser

```
* Solve issue with CGAL linking
* Add polygon_matcher dependency
* Contributors: Gaël Ecorchard
```
## lj_laser_heading

```
* Solve issue with CGAL linking
* Contributors: Gaël Ecorchard
```
## nj_laser

```
* Solve issue with CGAL linking
* Contributors: Gaël Ecorchard
```
## nj_oa_laser

```
* nj_oa_laser: robot_radius instead of robot_width
* Contributors: Gaël Ecorchard
```
