### PR TITLE
carl_bot: 0.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -470,12 +470,13 @@ repositories:
       - carl_description
       - carl_dynamixel
       - carl_interactive_manipulation
+      - carl_phidgets
       - carl_teleop
       - carl_tools
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_bot-release.git
-      version: 0.0.11-0
+      version: 0.0.12-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_bot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_bot` to `0.0.12-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_bot.git
- release repository: https://github.com/wpi-rail-release/carl_bot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.11-0`
## carl_bot

```
* cleanup of cmake
* Contributors: Russell Toris
```
## carl_bringup

```
* Orientation filter ignores accelerometer measurements when anything more than the gravity vector is detected
* Contributors: David Kent
```
## carl_description

```
* Orientation filter ignores accelerometer measurements when anything more than the gravity vector is detected
* Added joints to CARL urdf to allow for orientation adjustments from IMU data, implemented a static orientation correction from accelerometer data
* Contributors: David Kent
```
## carl_dynamixel

```
* cleanup of cmake
* Contributors: Russell Toris
```
## carl_interactive_manipulation
- No changes
## carl_phidgets

```
* cleanup of cmake
* Orientation filter ignores accelerometer measurements when anything more than the gravity vector is detected
* IMU filter for top sensor strut orientation
* Filter tuning
* Filtering for base IMU initial commit
* sign error
* Update README.md
* Fixed sign error
* sign error
* swapped pitch/roll
* Added joints to CARL urdf to allow for orientation adjustments from IMU data, implemented a static orientation correction from accelerometer data
* Update README.md
* Updated readme and removed unused nodelet stuff
* Added launch file to startup both of CARL's IMUs
* Parameterized device selection for using multiple IMUs
* fixed install issue
* carl_phidgets initial commit
* Contributors: David Kent, Russell Toris
```
## carl_teleop
- No changes
## carl_tools
- No changes
