### PR TITLE
lama_costmap: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2904,10 +2904,20 @@ repositories:
       type: git
       url: https://github.com/lama-imr/lama_costmap.git
       version: indigo-devel
+    release:
+      packages:
+      - lj_costmap
+      - nj_costmap
+      - nj_oa_costmap
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/lama-imr/lama_costmap-release.git
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/lama-imr/lama_costmap.git
       version: indigo-devel
+    status: developed
   lama_featurenav:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lama_costmap` to `0.1.1-0`:
- upstream repository: https://github.com/lama-imr/lama_costmap.git
- release repository: https://github.com/lama-imr/lama_costmap-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## lj_costmap

```
* First public release for Indigo
* Contributors: Gaël Ecorchard
```
## nj_costmap

```
* First public release for Indigo
* Contributors: Gaël Ecorchard
```
## nj_oa_costmap

```
* First public release for Indigo
* Contributors: Gaël Ecorchard
```
