### PR TITLE
innok_heros_lights: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2383,7 +2383,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/innokrobotics/innok_heros_lights-release.git
-      version: 1.0.0-1
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/innokrobotics/innok_heros_lights.git


### PR DESCRIPTION
Increasing version of package(s) in repository `innok_heros_lights` to `1.0.1-0`:
- upstream repository: https://github.com/innokrobotics/innok_heros_lights.git
- release repository: https://github.com/innokrobotics/innok_heros_lights-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.0.0-1`
## innok_heros_lights

```
* fixed installation
* Contributors: Alwin Heerklotz
```
