### PR TITLE
lama_utilities: 0.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3002,7 +3002,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/lama-imr/lama_utilities-release.git
-      version: 0.1.6-0
+      version: 0.1.7-0
     source:
       type: git
       url: https://github.com/lama-imr/lama_utilities.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lama_utilities` to `0.1.7-0`:
- upstream repository: https://github.com/lama-imr/lama_utilities.git
- release repository: https://github.com/lama-imr/lama_utilities-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.6-0`
## crossing_detector

```
* crossing_detector: solve CGAL cmake on Saucy
* Contributors: Gaël Ecorchard
```
## dfs_explorer

```
* Unchanged
```
## goto_crossing

```
* Unchanged
```
## lama_common

```
* Unchanged
```
## local_map

```
* Unchanged
```
## map_ray_caster

```
* Unchanged
```
## nj_escape_crossing

```
* Unchanged
```
## nlj_dummy

```
* nlj_dummy: remove setup.py
* nlj_dummy: fix publishing before initializing
  add random_walker.py and associated launch file
  add test similar to random_walker.py
* nlj_dummy: rename test for interfaces
* Contributors: Gaël Ecorchard
```
