### PR TITLE
husky_base: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2066,7 +2066,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_base-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/husky/husky_base.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_base` to `0.1.2-0`:
- upstream repository: https://github.com/husky/husky_base.git
- release repository: https://github.com/clearpath-gbp/husky_base-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.1-0`
## husky_base

```
* Fix library install location
* Contributors: Paul Bovbel
```
