### PR TITLE
um6: 1.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7356,7 +7356,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/um6-release.git
-      version: 1.0.0-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/um6.git


### PR DESCRIPTION
Increasing version of package(s) in repository `um6` to `1.1.0-0`:
- upstream repository: https://github.com/ros-drivers/um6.git
- release repository: https://github.com/ros-drivers-gbp/um6-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.0.0-0`
## um6

```
* Parametrize NED->ENU conversion
* Covariance and accel vector fixes
* Added reasonable defaults for std dev
* Scale processed acceleration to SI units
* Add covariances to acceleration and angular velocity
* Clean up private params
* Contributors: Mike Purvis, Paul Bovbel
```
