### PR TITLE
wpi_jaco: 0.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7775,7 +7775,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/wpi_jaco-release.git
-      version: 0.0.11-0
+      version: 0.0.12-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/wpi_jaco.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wpi_jaco` to `0.0.12-0`:
- upstream repository: https://github.com/RIVeR-Lab/wpi_jaco.git
- release repository: https://github.com/wpi-rail-release/wpi_jaco-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.11-0`
## jaco_description
- No changes
## jaco_interaction
- No changes
## jaco_sdk
- No changes
## jaco_teleop
- No changes
## wpi_jaco
- No changes
## wpi_jaco_msgs
- No changes
## wpi_jaco_wrapper

```
* Tuned finger position controller, added detection and termination if the fingers are blocked from reaching their goal
* Finger position control test
* Removed unused debug statement
* Adjusted angular and cartesian command callbacks to correctly execute finger position commands when arm joint commands are not specified
* Contributors: David Kent
```
