### PR TITLE
object_recognition_linemod: 0.3.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4212,6 +4212,17 @@ repositories:
       url: https://github.com/wg-perception/object_recognition_core.git
       version: master
     status: maintained
+  object_recognition_linemod:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_linemod-release.git
+      version: 0.3.3-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/linemod.git
+      version: master
+    status: maintained
   object_recognition_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_linemod` to `0.3.3-0`:
- upstream repository: https://github.com/wg-perception/linemod.git
- release repository: https://github.com/ros-gbp/object_recognition_linemod-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## object_recognition_linemod

```
* Fixed input params for training
* use the new renderer API
* Contributors: Vincent Rabaud, nlyubova
```
