### PR TITLE
object_recognition_renderer: 0.2.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -493,7 +493,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_renderer-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/wg-perception/ork_renderer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_renderer` to `0.2.2-0`:
- upstream repository: https://github.com/wg-perception/ork_renderer.git
- release repository: https://github.com/ros-gbp/object_recognition_renderer-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.2.1-0`
## object_recognition_renderer

```
* fixed mesh path
* use a pimpl to not let the user decide between GLUT or OSMesa
* remove legacy CMake
* Contributors: Vincent Rabaud, nlyubova
```
