### PR TITLE
object_recognition_core: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4206,7 +4206,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_core-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/wg-perception/object_recognition_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_core` to `0.6.4-0`:
- upstream repository: https://github.com/wg-perception/object_recognition_core.git
- release repository: https://github.com/ros-gbp/object_recognition_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.6.3-0`
## object_recognition_core

```
* fix training pipeline creation
* allow unicode strings
  this should fix https://github.com/wg-perception/reconstruction/issues/1
* Update installation instruction to add ork_visualization
* add the tutorials on the front page
* get code to work with OpenCV3
* OpenCV 3.0 adaptation
* Contributors: Ha Dang, Vincent Rabaud, edgarriba, nlyubova
```
