### PR TITLE
turtlebot_apps: 2.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7159,7 +7159,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_apps-release.git
-      version: 2.3.1-0
+      version: 2.3.2-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_apps` to `2.3.2-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_apps.git
- release repository: https://github.com/turtlebot-release/turtlebot_apps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `2.3.1-0`
## pano_core
- No changes
## pano_py
- No changes
## pano_ros
- No changes
## turtlebot_actions
- No changes
## turtlebot_apps
- No changes
## turtlebot_calibration
- No changes
## turtlebot_follower
- No changes
## turtlebot_navigation
- No changes
## turtlebot_panorama
- No changes
## turtlebot_rapps

```
* add robot_pose_publisher as run depend closes #131 <https://github.com/turtlebot/turtlebot_apps/issues/131>
* Contributors: Jihoon Lee
```
