### PR TITLE
jackal_desktop: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2527,7 +2527,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_desktop-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/jackal/jackal_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_desktop` to `0.3.1-0`:
- upstream repository: https://github.com/jackal/jackal_desktop.git
- release repository: https://github.com/clearpath-gbp/jackal_desktop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.3.0-0`
## jackal_desktop

```
* Add version number blocks.
* Contributors: Mike Purvis
```
## jackal_viz

```
* Add version number blocks.
* Switch view_model to use optenv-style URDF parameterization.
* Contributors: Mike Purvis
```
