### PR TITLE
jackal_simulator: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2551,7 +2551,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_simulator-release.git
-      version: 0.2.3-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/jackal/jackal_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_simulator` to `0.3.0-0`:
- upstream repository: https://github.com/jackal/jackal_simulator
- release repository: https://github.com/clearpath-gbp/jackal_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.2.3-0`
## jackal_gazebo

```
* Add small hack to continue supporting the front_laser:=true arg, since that was prominently documented.
* Change from individual accessory args to a single "config" arg.
* Contributors: Mike Purvis
```
## jackal_simulator
- No changes
