### PR TITLE
fanuc: 0.3.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1804,7 +1804,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-industrial-release/fanuc-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/ros-industrial/fanuc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fanuc` to `0.3.1-0`:
- upstream repository: https://github.com/ros-industrial/fanuc.git
- release repository: https://github.com/ros-industrial-release/fanuc-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.3.0-0`
## fanuc

```
* no changes.
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_assets

```
* no changes.
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_driver

```
* no changes.
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_lrmate200ic5h_moveit_config

```
* make warehouse db location user configurable (#142 <https://github.com/ros-industrial/fanuc/issues/142>).
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_lrmate200ic5l_moveit_config

```
* make warehouse db location user configurable (#142 <https://github.com/ros-industrial/fanuc/issues/142>).
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_lrmate200ic_moveit_config

```
* make warehouse db location user configurable (#142 <https://github.com/ros-industrial/fanuc/issues/142>).
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_lrmate200ic_moveit_plugins

```
* no changes.
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_lrmate200ic_support

```
* no changes.
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_m10ia_moveit_config

```
* make warehouse db location user configurable (#142 <https://github.com/ros-industrial/fanuc/issues/142>).
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_m10ia_moveit_plugins

```
* no changes.
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_m10ia_support

```
* no changes.
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_m16ib20_moveit_config

```
* make warehouse db location user configurable (#142 <https://github.com/ros-industrial/fanuc/issues/142>).
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_m16ib_moveit_plugins

```
* no changes.
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_m16ib_support

```
* no changes.
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_m20ia10l_moveit_config

```
* make warehouse db location user configurable (#142 <https://github.com/ros-industrial/fanuc/issues/142>).
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_m20ia_moveit_config

```
* make warehouse db location user configurable (#142 <https://github.com/ros-industrial/fanuc/issues/142>).
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_m20ia_moveit_plugins

```
* no changes.
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_m20ia_support

```
* no changes.
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_m430ia2f_moveit_config

```
* make warehouse db location user configurable (#142 <https://github.com/ros-industrial/fanuc/issues/142>).
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_m430ia2p_moveit_config

```
* make warehouse db location user configurable (#142 <https://github.com/ros-industrial/fanuc/issues/142>).
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_m430ia_moveit_plugins

```
* no changes.
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_m430ia_support

```
* no changes.
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
## fanuc_resources

```
* no changes.
* for a complete list of changes see the commit log for 0.3.1 <https://github.com/ros-industrial/fanuc/compare/0.3.0...0.3.1>
```
