### PR TITLE
lama_laser: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2950,7 +2950,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/lama-imr/lama_laser-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/lama-imr/lama_laser.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lama_laser` to `0.1.3-0`:
- upstream repository: https://github.com/lama-imr/lama_laser.git
- release repository: https://github.com/lama-imr/lama_laser-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.2-0`
## lj_laser

```
* Fix CGAL libs on Saucy
* Default to compute_dissimilarity
* Contributors: Gaël Ecorchard
```
## lj_laser_heading

```
* Fix CGAL libs on Saucy
* Default to compute_dissimilarity
* Contributors: Gaël Ecorchard
```
## nj_laser

```
* Fix CGAL libs on Saucy
* Contributors: Gaël Ecorchard
```
## nj_oa_laser

```
* Unchanged
```
