### PR TITLE
multimaster_fkie: 0.3.17-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4156,7 +4156,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.3.16-0
+      version: 0.3.17-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.3.17-0`:
- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.3.16-0`
## default_cfg_fkie
- No changes
## master_discovery_fkie

```
* master_discovery_fkie: fixed discovery support for ipv6
* Contributors: Alexander Tiderko
```
## master_sync_fkie
- No changes
## multimaster_fkie
- No changes
## multimaster_msgs_fkie
- No changes
## node_manager_fkie

```
* node_manager_fkie: switch to local monitoring after connection problems to local master_discovery
* node_manager_fkie: added an update procedure to refresh discovered masters
  In same cases the messages, which are send on the shutdown of the
  master_discovery are not received by node_manager. To update the
  discovered list in node_manager the complete list of discoevered hosts
  will be requested, if the localhost master is added as new master.
* node_manager_fkie: fixed error while publishing to 'std_msgs/Empty'
* Contributors: Alexander Tiderko
```
