### PR TITLE
Adding debian targets to mongodb and libsensors4-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1879,6 +1879,7 @@ libreadline-java:
   ubuntu: [libreadline-java]
 libsensors4-dev:
   arch: [lm_sensors]
+  debian: [libsensors4-dev]
   fedora: [lm_sensors-devel]
   ubuntu: [libsensors4-dev]
 libsimage-dev:
@@ -2322,6 +2323,7 @@ meshlab:
   fedora: [meshlab]
   ubuntu: [meshlab]
 mongodb:
+  debian: [mongodb]
   fedora: [mongodb]
   ubuntu: [mongodb]
 mongodb-dev:


### PR DESCRIPTION
Adding targets I needed to be able to build the arbotix package on a debian jessie running on a Raspberry Pi. Tested locally according to recommendations found in http://docs.ros.org/independent/api/rosdep/html/contributing_rules.html
rosdep completed with out further complaints and the subsequent build and install succeeded without incident.
