### PR TITLE
lama_costmap: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2912,7 +2912,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/lama-imr/lama_costmap-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/lama-imr/lama_costmap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lama_costmap` to `0.1.2-0`:
- upstream repository: https://github.com/lama-imr/lama_costmap.git
- release repository: https://github.com/lama-imr/lama_costmap-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.1-0`
## lj_costmap

```
* Fix CGAL libs on Saucy
* Default to compute_dissimilarity
* Contributors: Gaël Ecorchard
```
## nj_costmap

```
* Fix CGAL libs on Saucy
* Contributors: Gaël Ecorchard
```
## nj_oa_costmap

```
* Unchanged
```
