### PR TITLE
jsk_roseus: 1.1.31-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3152,16 +3152,14 @@ repositories:
       version: master
     release:
       packages:
-      - euslisp
-      - geneus
       - jsk_roseus
       - roseus
-      - roseus_msgs
       - roseus_smach
+      - roseus_tutorials
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.30-0
+      version: 1.1.31-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.1.31-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.1.30-0`
## jsk_roseus
- No changes
## roseus

```
* add dynamic_reconfigure
* fix to use catkin-tools
* remove old manifest.xml, fully catkinize
* use originl source (node rosmake proxy package) for euslisp
* add new macro, generate_all_roseus_message() to generate all dependency msgs using new geneus written by python
* enable alpha when converting eus object to ros marker
* [roseus] Fix error of VERSION_LESS around TF2_ROS_VERSION
* Contributors: Kei Okada, Ryohei Ueda, Yusuke Furuta
```
## roseus_smach

```
* remove old manifest.xml, fully catkinize
* Contributors: Kei Okada
```
## roseus_tutorials

```
* remove old manifest.xml, fully catkinize
* Contributors: Kei Okada
```
