### PR TITLE
geneus: 2.0.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1966,6 +1966,12 @@ repositories:
       url: https://github.com/ros/gencpp.git
       version: groovy-devel
     status: maintained
+  geneus:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/tork-a/geneus-release.git
+      version: 2.0.0-1
   genlisp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geneus` to `2.0.0-1`:
- upstream repository: https://github.com/jsk-ros-pkg/geneus
- release repository: https://github.com/tork-a/geneus-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
