### PR TITLE
openhab_bridge has no indigo-devel branch

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4478,7 +4478,7 @@ repositories:
     source:
       type: git
       url: https://github.com/corb555/openhab_bridge.git
-      version: indigo-devel
+      version: master
     status: maintained
   openhrp3:
     release:


### PR DESCRIPTION
Not sure why I was getting build failure emails (I have nothing to do with this repo) but it was building quite constantly since there was no indigo-devel branch
