### PR TITLE
openni2_launch: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4515,7 +4515,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/openni2_launch.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_launch` to `0.2.2-0`:
- upstream repository: https://github.com/ros-drivers/openni2_launch.git
- release repository: https://github.com/ros-gbp/openni2_launch.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.2.1-0`
## openni2_launch

```
* add tf_prefix version, as per #16 <https://github.com/ros-drivers/openni2_launch/issues/16>
* fix #19 <https://github.com/ros-drivers/openni2_launch/issues/19>, reverts #16 <https://github.com/ros-drivers/openni2_launch/issues/16>
* Contributors: Michael Ferguson
```
