### PR TITLE
Fix lua-dev dep for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2273,7 +2273,13 @@ log4cxx:
 lua-dev:
   arch: [lua]
   debian: [liblua5.1-0-dev]
-  fedora: [lua-devel]
+  fedora:
+    '21': [compat-lua-devel]
+    '22': [compat-lua-devel]
+    beefy: [lua-devel]
+    heisenbug: [compat-lua-devel]
+    schrödinger’s: [lua-devel]
+    spherical: [lua-devel]
   macports: [lua51]
   ubuntu: [liblua5.1-0-dev]
 lz4:


### PR DESCRIPTION
Fedora 20+ have Lua 5.2 which is not fully API compatible with Lua 5.1. However, Lua 5.1 is available in f20+ as the compat-lua package.

Example build break: https://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-ocl_binaryrpm_21_x86_64/2/consoleFull

Kudos to @jpgr87 for discovering this fix
