### PR TITLE
mavros: 0.10.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3340,7 +3340,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.9.4-0
+      version: 0.10.0-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.10.0-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.9.4-0`
## libmavconn

```
* libmavconn #154 <https://github.com/vooon/mavros/issues/154>: Stat sum for tcp server mode.
* libmavconn #154 <https://github.com/vooon/mavros/issues/154>: Add IO usage statistics.
  TODO: tcp-l.
* libmavconn: Fix coverity CID 85784 (use of freed object)
* Contributors: Vladimir Ermakov
```
## mavros

```
* mavros #154 <https://github.com/vooon/mavros/issues/154>: Add IO stats to diagnostics.
  Fix #154 <https://github.com/vooon/mavros/issues/154>.
* Add rosindex metadata
* plugin: ftp: init ctor.
* plugin: sts_time: Code cleanup and codestyle fix.
* plugin: command: Quirk for older FCU's (component_id)
  Older FCU's expect that commands addtessed to MAV_COMP_ID_SYSTEM_CONTROL.
  Now there parameter: ~cmd/use_comp_id_system_control
* plugin: rc_io: #185 <https://github.com/vooon/mavros/issues/185> Use synchronized timestamp.
* plugin: gps: #185 <https://github.com/vooon/mavros/issues/185> use synchronized timestamp
  common.xml tells that GPS_RAW_INT have time_usec stamps.
* uas: Fix ros timestamp calculation.
  Issues: #186 <https://github.com/vooon/mavros/issues/186>, #185 <https://github.com/vooon/mavros/issues/185>.
* plugin: add synchronisation to most plugins (fixed)
  Closes #186 <https://github.com/vooon/mavros/issues/186>.
* readme: Add notes about coordinate frame conversions #49 <https://github.com/vooon/mavros/issues/49>
* Contributors: M.H.Kabir, Vladimir Ermakov
```
## mavros_extras

```
* mocap_pose_estimate: Switched from pose to poseStamped.
* Contributors: Tony Baltovski
```
