### PR TITLE
rfsm: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5234,6 +5234,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/orocos-gbp/rfsm-release.git
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/orocos/rFSM.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rfsm` to `1.0.0-0`:
- upstream repository: https://github.com/orocos/rFSM.git
- release repository: https://github.com/orocos-gbp/rfsm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
