### PR TITLE
utilrb: 2.8.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7511,10 +7511,15 @@ repositories:
       version: develop
     status: maintained
   utilrb:
+    doc:
+      type: git
+      url: https://github.com/orocos-toolchain/utilrb.git
+      version: toolchain-2.8
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/orocos-gbp/utilrb-release.git
+      version: 2.8.0-0
     source:
       type: git
       url: https://github.com/orocos-toolchain/utilrb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `utilrb` to `2.8.0-0`:
- upstream repository: https://github.com/orocos-toolchain/utilrb.git
- release repository: https://github.com/orocos-gbp/utilrb-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
