### PR TITLE
power_msgs: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4827,6 +4827,17 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
       version: master
     status: maintained
+  power_msgs:
+    doc:
+      type: git
+      url: https://github.com/fetchrobotics/power_msgs.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/power_msgs-release.git
+      version: 0.1.1-0
+    status: developed
   pr2_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `power_msgs` to `0.1.1-0`:
- upstream repository: https://github.com/fetchrobotics/power_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/power_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## power_msgs

```
* add BreakerCommand
* Contributors: Michael Ferguson
```
