### PR TITLE
sophus: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6874,6 +6874,13 @@ repositories:
       url: https://github.com/ipa320/softkinetic.git
       version: indigo_dev
     status: maintained
+  sophus:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/sophus-release.git
+      version: 0.1.0-0
+    status: maintained
   sparse_bundle_adjustment:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `0.1.0-0`:
- upstream repository: https://github.com/stonier/sophus.git
- release repository: https://github.com/yujinrobot-release/sophus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
