### PR TITLE
rail_collada_models: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5097,7 +5097,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_collada_models-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_collada_models.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_collada_models` to `0.0.2-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_collada_models.git
- release repository: https://github.com/wpi-rail-release/rail_collada_models-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.1-0`
## rail_collada_models

```
* Merge pull request #9 from PeterMitrano/develop
  flipped chairs/table, also not going through floor now
* flipped chairs/table, also not going through floor now
* Contributors: Peter, Russell Toris
```
