### PR TITLE
jsk_roseus: 1.2.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3172,7 +3172,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.1.33-0
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.2.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.1.33-0`
## jsk_roseus
- No changes
## roseus

```
* [roseus] If user return invalid instance in service callback, print error message
* use EUSDIR insted of using rospack find euslisp
* Contributors: Kei Okada, Ryohei Ueda
```
## roseus_smach
- No changes
## roseus_tutorials
- No changes
