### PR TITLE
metaruby: 1.0.0-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3439,7 +3439,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/orocos-gbp/metaruby-release.git
-      version: 1.0.0-2
+      version: 1.0.0-3
     status: maintained
   microstrain_3dmgx2_imu:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `metaruby` to `1.0.0-3`:
- upstream repository: https://github.com/rock-core/tools-metaruby.git
- release repository: https://github.com/orocos-gbp/metaruby-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.0.0-2`
