### PR TITLE
utilrb: 2.8.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7540,7 +7540,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/orocos-gbp/utilrb-release.git
-      version: 2.8.0-0
+      version: 2.8.0-1
     source:
       type: git
       url: https://github.com/orocos-toolchain/utilrb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `utilrb` to `2.8.0-1`:
- upstream repository: https://github.com/orocos-toolchain/utilrb.git
- release repository: https://github.com/orocos-gbp/utilrb-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `2.8.0-0`
