### PR TITLE
typelib: 2.8.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7345,10 +7345,15 @@ repositories:
       version: indigo-devel
     status: maintained
   typelib:
+    doc:
+      type: git
+      url: https://github.com/orocos-toolchain/typelib.git
+      version: toolchain-2.8
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/orocos-gbp/typelib-release.git
+      version: 2.8.0-0
     source:
       type: git
       url: https://github.com/orocos-toolchain/typelib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `typelib` to `2.8.0-0`:
- upstream repository: https://github.com/orocos-toolchain/typelib.git
- release repository: https://github.com/orocos-gbp/typelib-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
