### PR TITLE
rtt_typelib: 2.8.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6546,10 +6546,15 @@ repositories:
       version: hydro-devel
     status: developed
   rtt_typelib:
+    doc:
+      type: git
+      url: https://github.com/orocos-toolchain/rtt_typelib.git
+      version: toolchain-2.8
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_typelib-release.git
+      version: 2.8.0-0
     source:
       type: git
       url: https://github.com/orocos-toolchain/rtt_typelib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_typelib` to `2.8.0-0`:
- upstream repository: https://github.com/orocos-toolchain/rtt_typelib.git
- release repository: https://github.com/orocos-gbp/rtt_typelib-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
