### PR TITLE
orogen: 2.8.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4624,10 +4624,15 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/orocos-gbp/orocos_toolchain-release.git
   orogen:
+    doc:
+      type: git
+      url: https://github.com/orocos-toolchain/orogen.git
+      version: toolchain-2.8
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/orocos-gbp/orogen-release.git
+      version: 2.8.0-0
     source:
       type: git
       url: https://github.com/orocos-toolchain/orogen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `orogen` to `2.8.0-0`:
- upstream repository: https://github.com/orocos-toolchain/orogen.git
- release repository: https://github.com/orocos-gbp/orogen-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
