### PR TITLE
orocos_toolchain: 2.8.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4619,20 +4619,21 @@ repositories:
       version: master
     status: maintained
   orocos_toolchain:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/orocos-gbp/orocos_toolchain-release.git
-  orogen:
     doc:
       type: git
-      url: https://github.com/orocos-toolchain/orogen.git
+      url: https://github.com/orocos-toolchain/orocos_toolchain.git
       version: toolchain-2.8
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/orocos-gbp/orogen-release.git
+      url: https://github.com/orocos-gbp/orocos_toolchain-release.git
       version: 2.8.0-0
+    status: maintained
+  orogen:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/orocos-gbp/orogen-release.git
     source:
       type: git
       url: https://github.com/orocos-toolchain/orogen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_toolchain` to `2.8.0-0`:
- upstream repository: https://github.com/orocos-toolchain/orocos_toolchain.git
- release repository: https://github.com/orocos-gbp/orocos_toolchain-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
