### PR TITLE
orocos_toolchain: 2.8.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4619,10 +4619,16 @@ repositories:
       version: master
     status: maintained
   orocos_toolchain:
+    doc:
+      type: git
+      url: https://github.com/orocos-toolchain/orocos_toolchain.git
+      version: toolchain-2.8
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/orocos-gbp/orocos_toolchain-release.git
+      version: 2.8.0-0
+    status: maintained
   orogen:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_toolchain` to `2.8.0-0`:
- upstream repository: https://github.com/orocos-toolchain/orocos_toolchain.git
- release repository: https://github.com/orocos-gbp/orocos_toolchain-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
