### PR TITLE
visualization_tutorials: 0.9.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7714,7 +7714,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/visualization_tutorials-release.git
-      version: 0.9.0-0
+      version: 0.9.1-0
     source:
       type: git
       url: https://github.com/ros-visualization/visualization_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_tutorials` to `0.9.1-0`:
- upstream repository: https://github.com/ros-visualization/visualization_tutorials.git
- release repository: https://github.com/ros-gbp/visualization_tutorials-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.9.0-0`
## interactive_marker_tutorials
- No changes
## librviz_tutorial

```
* Renamed a CMake variable to avoid colliding with built-in name.
* librviz_tutorial now installs it's executable ``myviz``.
* Removed explicit default_plugin library to fix "ld: cannot find -ldefault_plugin" isolated build error
* Contributors: Honore Doktorr, Kei Okada, William Woodall
```
## rviz_plugin_tutorials

```
* Added ``#ifndef Q_MOC_RUN`` guard for compatibility with newer boost versions.
* Contributors: Ryohei Ueda, William Woodall
```
## rviz_python_tutorial
- No changes
## visualization_marker_tutorials

```
* Now checks number of subscribers before publishing any markers.
* Documented the new DELETEALL feature.
* Contributors: Dave Coleman, Victor Lamoine
```
## visualization_tutorials
- No changes
