### PR TITLE
rosdep: split fltk into fltk-dev and fluid

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -632,6 +632,15 @@ fltk:
   macports: [fltk]
   opensuse: [fltk-devel]
   ubuntu: [fluid, libfltk1.1-dev]
+fluid:
+  arch: [fltk]
+  debian: [libfltk1.1-dev]
+  fedora: [fltk-fluid]
+  freebsd: [fltk]
+  gentoo: [=x11-libs/fltk-1*]
+  macports: [fltk]
+  opensuse: [fltk-devel]
+  ubuntu: [fluid]
 freeimage:
   arch: [freeimage]
   debian: [libfreeimage-dev]
@@ -1161,6 +1170,15 @@ libflann-dev:
       packages: [sci-libs/flann]
   macports: [flann]
   ubuntu: [libflann-dev]
+libfltk-dev:
+  arch: [fltk]
+  debian: [libfltk1.1-dev]
+  fedora: [fltk-devel]
+  freebsd: [fltk]
+  gentoo: [=x11-libs/fltk-1*]
+  macports: [fltk]
+  opensuse: [fltk-devel]
+  ubuntu: [libfltk1.1-dev]
 libfreenect-dev:
   arch: [libfreenect]
   debian: [libfreenect-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -623,7 +623,7 @@ flex:
   gentoo: [sys-devel/flex]
   macports: [flex]
   ubuntu: [flex]
-fltk:
+fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
   arch: [fltk]
   debian: [libfltk1.1-dev]
   fedora: [fltk-devel, fltk-fluid]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -91,6 +91,10 @@ fltk:
   osx:
     homebrew:
       packages: [fltk]
+fluid:
+  osx:
+    homebrew:
+      packages: [fltk]
 freeimage:
   osx:
     homebrew:
@@ -163,6 +167,10 @@ libflann-dev:
   osx:
     homebrew:
       packages: [flann]
+libfltk-dev:
+  osx:
+    homebrew:
+      packages: [fltk]
 libftdi-dev:
   osx:
     homebrew:


### PR DESCRIPTION
This splits the `fltk` rosdep key into a dev and runtime part, `libfltk-dev` and `fluid` respectively. This is to resolve https://github.com/ros-simulation/stage_ros/pull/9. I'll leave `fltk` for backwards compatibility.
