### PR TITLE
Update unidiff usage and merge fedora rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2273,7 +2273,13 @@ log4cxx:
 lua-dev:
   arch: [lua]
   debian: [liblua5.1-0-dev]
-  fedora: [lua-devel]
+  fedora:
+    '21': [compat-lua-devel]
+    '22': [compat-lua-devel]
+    beefy: [lua-devel]
+    heisenbug: [compat-lua-devel]
+    schrödinger’s: [lua-devel]
+    spherical: [lua-devel]
   macports: [lua51]
   ubuntu: [liblua5.1-0-dev]
 lz4:

--- a/test/test_url_validity.py
+++ b/test/test_url_validity.py
@@ -56,10 +56,11 @@ def detect_lines(diffstr):
     """Take a diff string and return a dict of
     files with line numbers changed"""
     resultant_lines = {}
+    # diffstr is already utf-8 encoded
+    io = StringIO(diffstr)
     # Force utf-8 re: https://github.com/ros/rosdistro/issues/6637
     encoding = 'utf-8'
-    io = StringIO(unicode(diffstr, encoding))
-    udiff = unidiff.PatchSet(io)
+    udiff = unidiff.PatchSet(io, encoding)
     for file in udiff:
         target_lines = []
         # if file.path in TARGET_FILES:


### PR DESCRIPTION
unidiff 0.5.1 added support for encoding, the default argument was None so ascii which broke our utf-8 encoded files. 

This has the fix for encoding as well as the commit from the previously failing pull-request: https://github.com/ros/rosdistro/pull/6959
