### PR TITLE
stage_ros: 1.7.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7026,7 +7026,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/stage_ros-release.git
-      version: 1.7.2-0
+      version: 1.7.3-0
     source:
       type: git
       url: https://github.com/ros-simulation/stage_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `stage_ros` to `1.7.3-0`:
- upstream repository: https://github.com/ros-simulation/stage_ros.git
- release repository: https://github.com/ros-gbp/stage_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.7.2-0`
## stage_ros

```
* Split up ``fltk`` dep into ``libfltk-dev`` and ``fluid``, only ``run_depend``'ing on fluid.
* Now supports multiple robots with multiple sensors.
* Fixed a bug on systems that cannot populate FLTK_INCLUDE_DIRS.
* Updated topurg model from "laser" to "ranger".
* Added -u option to use name property of position models as its namespace instead of "robot_0", "robot_1", etc.
* Contributors: Gustavo Velasco Hernández, Gustavo Velasco-Hernández, Pablo Urcola, Wayne Chang, William Woodall
```
