### PR TITLE
soem: 1.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6880,6 +6880,17 @@ repositories:
       url: https://github.com/ros-drivers/smart_battery_msgs.git
       version: master
     status: maintained
+  soem:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/smits/soem-gbp.git
+      version: 1.3.0-0
+    source:
+      type: git
+      url: https://github.com/smits/soem.git
+      version: master
+    status: maintained
   softkinetic:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `soem` to `1.3.0-0`:
- upstream repository: https://github.com/smits/soem.git
- release repository: https://github.com/smits/soem-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
