### PR TITLE
rtt_soem: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6556,6 +6556,21 @@ repositories:
       url: https://github.com/orocos/rtt_ros_integration.git
       version: hydro-devel
     status: developed
+  rtt_soem:
+    release:
+      packages:
+      - soem_beckhoff_drivers
+      - soem_ebox
+      - soem_master
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/orocos-gbp/rtt_soem-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/orocos/rtt_soem.git
+      version: master
+    status: maintained
   rtt_typelib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_soem` to `0.1.0-0`:
- upstream repository: https://github.com/orocos/rtt_soem.git
- release repository: https://github.com/orocos-gbp/rtt_soem-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
