### PR TITLE
power_msgs: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4847,7 +4847,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/power_msgs-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     status: developed
   pr2_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `power_msgs` to `0.1.2-0`:
- upstream repository: https://github.com/fetchrobotics/power_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/power_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.1-0`
## power_msgs

```
* add limits, documentation (breaks MD5)
* Contributors: Michael Ferguson
```
