### PR TITLE
rtt_soem: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6565,7 +6565,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_soem-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/orocos/rtt_soem.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_soem` to `0.1.1-0`:
- upstream repository: https://github.com/orocos/rtt_soem.git
- release repository: https://github.com/orocos-gbp/rtt_soem-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.0-0`
