### PR TITLE
lama_test: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2981,10 +2981,16 @@ repositories:
       type: git
       url: https://github.com/lama-imr/lama_test.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/lama-imr/lama_test-release.git
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/lama-imr/lama_test.git
       version: indigo-devel
+    status: developed
   lama_utilities:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lama_test` to `0.1.2-0`:
- upstream repository: https://github.com/lama-imr/lama_test.git
- release repository: https://github.com/lama-imr/lama_test-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## lama_test

```
* set dissimilarity server name
* Remove random_walker.py
* Contributors: Gaël Ecorchard
```
