### PR TITLE
imu_tools: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2776,7 +2776,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/imu_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.0.2-0`:
- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.0.1-0`
## imu_filter_madgwick

```
* fix tf publishing (switch parent + child frames)
  The orientation is between a fixed inertial frame (``fixed_frame_``) and
  the frame that the IMU is mounted in (``imu_frame_``). Also,
  ``imu_msg.header.frame`` should be ``imu_frame_``, but the corresponding TF
  goes from ``fixed_frame_`` to ``imu_frame_``. This commit fixes that; for
  the ``reverse_tf`` case, it was already correct.
  Also see http://answers.ros.org/question/50870/what-frame-is-sensor_msgsimuorientation-relative-to/.
  Note that tf publishing should be enabled for debug purposes only, since we can only
  provide the orientation, not the translation.
* Add ~reverse_tf parameter for the robots which does not have IMU on root-link
* Log mag bias on startup to assist with debugging.
* add boost depends to CMakeLists
  All non-catkin things that we expose in our headers should be added to
  the DEPENDS, so that packages which depend on our package will also
  automatically link against it.
* Contributors: Martin Günther, Mike Purvis, Ryohei Ueda
```
## imu_tools
- No changes
## rviz_imu_plugin
- No changes
