### PR TITLE
roswww: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6275,16 +6275,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/tork-a/roswww.git
-      version: hydro-devel
+      version: develop
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/roswww-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/tork-a/roswww.git
-      version: hydro-devel
+      version: develop
     status: developed
   rqt:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `roswww` to `0.1.4-0`:
- upstream repository: https://github.com/tork-a/roswww.git
- release repository: https://github.com/tork-a/roswww-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.3-0`
## roswww

```
* example launchfile. update dependency
* configurable package web root
* add parmeter in readme
* classfy roswww webserver. remove ros runtime dependency
* Contributors: Jihoon Lee, Isaac I.Y. Saito
```
