### PR TITLE
pr2_apps: 0.5.15-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5331,7 +5331,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_apps-release.git
-      version: 0.5.14-0
+      version: 0.5.15-0
     source:
       type: git
       url: https://github.com/pr2/pr2_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_apps` to `0.5.15-0`:
- upstream repository: https://github.com/PR2/pr2_apps.git
- release repository: https://github.com/TheDash/pr2_apps-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.5.14-0`
## pr2_app_manager
- No changes
## pr2_apps
- No changes
## pr2_mannequin_mode
- No changes
## pr2_position_scripts
- No changes
## pr2_teleop

```
* Added target locations to pr2_teleop libs and execs
* Added installs for pr2_teleop_general and pr2_teleop
* Added installs for pr2_teleop binaries
* Contributors: dash
```
## pr2_teleop_general

```
* Bugfix for pr2_teleop_general. Added destinations for targets
* Added target locations to pr2_teleop libs and execs
* Added installs for pr2_teleop_general and pr2_teleop
* Contributors: dash
```
## pr2_tuckarm
- No changes
