### PR TITLE
ueye: 0.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8484,7 +8484,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/kmhallen/ueye-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: hg
       url: https://bitbucket.org/kmhallen/ueye


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye` to `0.0.4-0`:
- upstream repository: https://bitbucket.org/kmhallen/ueye
- release repository: https://github.com/kmhallen/ueye-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.3-0`
## ueye

```
* Allow discrete-only pixelclocks cameras
* Contributors: Kevin Hallenbeck, Fran Real
```
