### PR TITLE
jsk_recognition: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2656,6 +2656,21 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
       version: master
     status: developed
+  jsk_recognition:
+    release:
+      packages:
+      - checkerboard_detector
+      - imagesift
+      - jsk_pcl_ros
+      - jsk_perception
+      - jsk_recognition
+      - jsk_recognition_msgs
+      - resized_image_transport
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/jsk_recognition-release.git
+      version: 0.2.0-0
+    status: developed
   jsk_roseus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.2.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros
- No changes
## jsk_perception
- No changes
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## resized_image_transport
- No changes
