### PR TITLE
imu_tools: 1.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2781,7 +2781,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/imu_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.0.3-0`:
- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.0.2-0`
## imu_filter_madgwick

```
* Add std dev parameter to orientation estimate covariance matrix
* Port imu_filter_madgwick to tf2
* Switch to smart pointer
* Contributors: Paul Bovbel, Martin Günther
```
## imu_tools
- No changes
## rviz_imu_plugin
- No changes
