### PR TITLE
screenrun: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7673,6 +7673,21 @@ repositories:
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git
       version: master
     status: maintained
+  screenrun:
+    doc:
+      type: git
+      url: https://github.com/dornhege/screenrun.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/dornhege/screenrun-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/dornhege/screenrun.git
+      version: hydro-devel
+    status: maintained
   scriptable_monitoring:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `screenrun` to `1.0.1-0`:
- upstream repository: https://github.com/dornhege/screenrun.git
- release repository: https://github.com/dornhege/screenrun-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
