### PR TITLE
rxparamedit: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7615,6 +7615,21 @@ repositories:
       url: https://github.com/tork-a/rwt_ros.git
       version: hydro-devel
     status: developed
+  rxparamedit:
+    doc:
+      type: git
+      url: https://github.com/dornhege/rxparamedit.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/dornhege/rxparamedit-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/dornhege/rxparamedit.git
+      version: hydro-devel
+    status: maintained
   s3000_laser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rxparamedit` to `1.0.1-0`:
- upstream repository: https://github.com/dornhege/rxparamedit.git
- release repository: https://github.com/dornhege/rxparamedit-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
