### PR TITLE
jsk_visualization: 1.0.18-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2691,6 +2691,27 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git
       version: master
     status: maintained
+  jsk_visualization:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_visualization.git
+      version: master
+    release:
+      packages:
+      - jsk_interactive
+      - jsk_interactive_marker
+      - jsk_interactive_test
+      - jsk_rqt_plugins
+      - jsk_rviz_plugins
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/jsk_visualization-release.git
+      version: 1.0.18-1
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_visualization.git
+      version: master
+    status: developed
   jskeus:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.18-1`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## jsk_interactive
- No changes
## jsk_interactive_marker

```
* add link to boost
```
## jsk_interactive_test
- No changes
## jsk_rqt_plugins
- No changes
## jsk_rviz_plugins

```
* add depends to cv_bridge instaed of opencv2
```
