### PR TITLE
jsk_robot: 0.0.4-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2671,6 +2671,35 @@ repositories:
       url: https://github.com/tork-a/jsk_recognition-release.git
       version: 0.2.1-0
     status: developed
+  jsk_robot:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_robot.git
+      version: master
+    release:
+      packages:
+      - baxtereus
+      - jsk_baxter_desktop
+      - jsk_baxter_startup
+      - jsk_baxter_web
+      - jsk_nao_startup
+      - jsk_pepper_startup
+      - jsk_pr2_calibration
+      - jsk_pr2_startup
+      - jsk_robot_startup
+      - pepper_bringup
+      - pepper_description
+      - peppereus
+      - pr2_base_trajectory_action
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/jsk_robot-release.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_robot.git
+      version: master
+    status: developed
   jsk_roseus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `0.0.4-1`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## baxtereus

```
* currently we do not generate baxter.l from baxter_description on the fly
* [baxtereus] add wait key for stop-grasp in baxter-interface.l
* add groupname for baxter-interface.l
```
## jsk_baxter_desktop
- No changes
## jsk_baxter_startup
- No changes
## jsk_baxter_web

```
* do not generate baxter_description if baxter_description is not found
* [jsk_baxter_web] Do not depend on rwt_ros (meta package)
* Delete rospack find and use the result of find package
```
## jsk_nao_startup
- No changes
## jsk_pepper_startup
- No changes
## jsk_pr2_calibration
- No changes
## jsk_pr2_startup

```
* [jsk_pr2_startup] Remove unrequired return-from in pr2-compressed-angle-vector-interface
* rename pr2-compressed-angle-vector-interface.l
* use string to set data
* fix typo
* update to work
* add jsk_pr2_teleop
```
## jsk_robot_startup
- No changes
## pepper_bringup
- No changes
## pepper_description
- No changes
## peppereus
- No changes
## pr2_base_trajectory_action
- No changes
