### PR TITLE
jsk_robot: 0.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3157,7 +3157,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_robot-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `0.0.4-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.3-0`
## baxtereus

```
* currently we do not generate baxter.l from baxter_description on the fly
* [baxtereus] add wait key for stop-grasp in baxter-interface.l
* add groupname for baxter-interface.l
```
## jsk_baxter_desktop
- No changes
## jsk_baxter_startup
- No changes
## jsk_baxter_web

```
* do not generate baxter_description if baxter_description is not found
* [jsk_baxter_web] Do not depend on rwt_ros (meta package)
* Delete rospack find and use the result of find package
```
## jsk_nao_startup
- No changes
## jsk_pepper_startup
- No changes
## jsk_pr2_calibration
- No changes
## jsk_pr2_startup

```
* [jsk_pr2_startup] Remove unrequired return-from in pr2-compressed-angle-vector-interface
* rename pr2-compressed-angle-vector-interface.l
* use string to set data
* fix typo
* update to work
* add jsk_pr2_teleop
```
## jsk_robot_startup
- No changes
## pepper_bringup
- No changes
## pepper_description
- No changes
## peppereus
- No changes
## pr2_base_trajectory_action
- No changes
