### PR TITLE
jsk_recognition: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2657,6 +2657,10 @@ repositories:
       version: master
     status: developed
   jsk_recognition:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_recognition.git
+      version: master
     release:
       packages:
       - checkerboard_detector
@@ -2669,7 +2673,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_recognition.git
+      version: master
     status: developed
   jsk_robot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.2.2-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.2.1-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros

```
* [jsk_pcl_ros] Add HintedStickFinder to detect stick with human interfaction
* Contributors: Kei Okada, Ryohei Ueda
```
## jsk_perception

```
* [jsk_perception] add posedetection_msgs
* add image_view2 to depends
* Contributors: Kei Okada
```
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## resized_image_transport
- No changes
