### PR TITLE
rqt_paramedit: 1.0.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7274,6 +7274,24 @@ repositories:
       url: https://github.com/OTL/rqt_ez_publisher.git
       version: hydro-devel
     status: maintained
+  rqt_paramedit:
+    doc:
+      type: git
+      url: https://github.com/dornhege/rqt_paramedit.git
+      version: hydro-devel
+    release:
+      packages:
+      - qt_paramedit
+      - rqt_paramedit
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/dornhege/rqt_paramedit-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/dornhege/rqt_paramedit.git
+      version: hydro-devel
+    status: maintained
   rqt_pr2_dashboard:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_paramedit` to `1.0.0-0`:
- upstream repository: https://github.com/dornhege/rqt_paramedit.git
- release repository: https://github.com/dornhege/rqt_paramedit-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
