### PR TITLE
imu_pipeline: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2331,10 +2331,14 @@ repositories:
       url: https://github.com/ros-perception/imu_pipeline.git
       version: indigo-devel
     release:
+      packages:
+      - imu_pipeline
+      - imu_processors
+      - imu_transformer
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/imu_pipeline-release.git
-      version: 0.1.3-1
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ros-perception/imu_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_pipeline` to `0.2.0-0`:
- upstream repository: https://github.com/ros-perception/imu_pipeline
- release repository: https://github.com/ros-gbp/imu_pipeline-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.3-1`
## imu_pipeline

```
* Remove Chad as a maintainer
* Refactor imu_pipeline into a metapackage
* Contributors: Paul Bovbel
```
## imu_processors

```
* Move misc processors into imu_processors
* Contributors: Paul Bovbel
```
## imu_transformer

```
* Add imu_transformer node/nodelet combination using tf2
* Contributors: Paul Bovbel
```
