### PR TITLE
husky_msgs: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2144,7 +2144,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_msgs-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/husky/husky_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_msgs` to `0.0.2-0`:
- upstream repository: https://github.com/husky/husky_msgs.git
- release repository: https://github.com/clearpath-gbp/husky_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.1-0`
## husky_msgs

```
* Update description and maintainer
* Contributors: Paul Bovbel
```
