### PR TITLE
husky_control: 0.0.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2096,7 +2096,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_control-release.git
-      version: 0.0.2-0
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/husky/husky_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_control` to `0.0.2-1`:
- upstream repository: https://github.com/husky/husky_control.git
- release repository: https://github.com/clearpath-gbp/husky_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.2-0`
## husky_control

```
* Use odom position for ekf
* Update wheel separation multiplier for slippage
* Restore teleop twist joy
* Set 2D mode, and add move_base cmd channel
* Contributors: Paul Bovbel
```
