### PR TITLE
husky_bringup: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2081,7 +2081,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_bringup-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/husky/husky_bringup.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_bringup` to `0.1.1-0`:
- upstream repository: https://github.com/husky/husky_bringup.git
- release repository: https://github.com/clearpath-gbp/husky_bringup-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.0-0`
## husky_bringup

```
* Update website and authors
* Add transform to transfer IMU data to base_link frame
* Make ROBOT_NETWORK optional
* Switch to robot_upstart python API
* Switch to debhelper install method for udeb rules
* Switch to env-hook for file storage
* Switch to new calibration method for um6; switch to imu_filter_magwick
* Contributors: Paul Bovbel
```
