### PR TITLE
husky_navigation: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2159,7 +2159,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_navigation-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/husky/husky_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_navigation` to `0.1.1-0`:
- upstream repository: https://github.com/husky/husky_navigation.git
- release repository: https://github.com/clearpath-gbp/husky_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.0-0`
## husky_navigation

```
* Update web and maintainers
* More meaningful name for mapless navigation demo
* Add missing dependencies
* Contributors: Paul Bovbel
```
