### PR TITLE
libfreenect: 0.5.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3202,8 +3202,8 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ros-drivers-gbp/libfreenect-release.git
-      version: 0.1.2-2
+      url: https://github.com/ros-drivers-gbp/libfreenect-ros-release.git
+      version: 0.5.1-0
     status: maintained
   libg2o:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `libfreenect` to `0.5.1-0`:
- upstream repository: https://github.com/ros-drivers/libfreenect.git
- release repository: https://github.com/ros-drivers-gbp/libfreenect-ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.2-2`
