### PR TITLE
freenect_stack: 0.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1541,7 +1541,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/freenect_stack-release.git
-      version: 0.3.2-1
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/freenect_stack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `freenect_stack` to `0.4.0-0`:
- upstream repository: https://github.com/ros-drivers/freenect_stack.git
- release repository: https://github.com/ros-drivers-gbp/freenect_stack-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.3.2-1`
## freenect_camera

```
* Update header file to match libfreenect v0.5.1
* Contributors: Piyush Khandelwal
```
## freenect_launch
- No changes
## freenect_stack
- No changes
