### PR TITLE
epos_hardware: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1434,6 +1434,24 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/eigen_stl_containers-release.git
       version: 0.1.4-0
+  epos_hardware:
+    doc:
+      type: git
+      url: https://github.com/RIVeR-Lab/epos_hardware.git
+      version: indigo-devel
+    release:
+      packages:
+      - epos_hardware
+      - epos_library
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RIVeR-Lab-release/epos_hardware-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/RIVeR-Lab/epos_hardware.git
+      version: indigo-devel
+    status: maintained
   euslisp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `epos_hardware` to `0.0.1-0`:
- upstream repository: https://github.com/RIVeR-Lab/epos_hardware.git
- release repository: https://github.com/RIVeR-Lab-release/epos_hardware-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## epos_hardware

```
* Initial release of epos_hardware
* Contributors: Mitchell Wills
```
## epos_library

```
* initial release of 64-bit EPOS Linux libraries
* Contributors: Mitchell Wills
```
