### PR TITLE
jsk_planning: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2642,6 +2642,27 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_model_tools.git
       version: master
     status: developed
+  jsk_planning:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_planning.git
+      version: master
+    release:
+      packages:
+      - jsk_planning
+      - pddl_msgs
+      - pddl_planner
+      - pddl_planner_viewer
+      - task_compiler
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/jsk_planning-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_planning.git
+      version: master
+    status: developed
   jsk_pr2eus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_planning` to `0.1.3-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_planning
- release repository: https://github.com/tork-a/jsk_planning-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## jsk_planning
- No changes
## pddl_msgs

```
* remove rosbuild stuff, change to pure catkin packages
* Contributors: Kei Okada
```
## pddl_planner

```
* remove rosbuild stuff, change to pure catkin packages
* use rosrun instead of find_package to search pddl planner
* not use roslib in hydro
* add planner option for downward
* Contributors: Yuki Furuta, Kei Okada
```
## pddl_planner_viewer

```
* remove rosbuild stuff, change to pure catkin packages
* not use roslib in hydro
* Contributors: Yuki Furuta, Kei Okada
```
## task_compiler

```
* remove rosbuild stuff, change to pure catkin packages
* remove rosbuild stuff, change to pure catkin packages
* also removed from build_depend
* pddl_planner and roseus_smach is not used in cmake
* add option result success and fail
* support failure plan
* add planner option for downward
* Contributors: Yuki Furuta, Kei Okada
```
