### PR TITLE
sophus: 0.9.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7053,7 +7053,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/sophus-release.git
-      version: 0.1.0-0
+      version: 0.9.0-1
     status: maintained
   sparse_bundle_adjustment:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `0.9.0-1`:
- upstream repository: https://github.com/stonier/sophus.git
- release repository: https://github.com/yujinrobot-release/sophus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.0-0`
