### PR TITLE
jsk_recognition: 0.2.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3128,7 +3128,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.2.3-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.2.2-0`
## checkerboard_detector

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## imagesift

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## jsk_pcl_ros

```
* [jsk_pcl_ros] Add ~min_inliers and ~cylinder_fitting_trial parameter to
  try cylinder fitting severeal times in HintedStickFinder
* [jsk_pcl_ros] Implement utility function to generate cylinder marker
  from cylinder object
* [jsk_pcl_ros] FIx mis-publishing of coefficients of HintedStickFInder
* [jsk_pcl_ros, jsk_perception] Move mask image operation to jsk_perception
* [jsk_pcl_ros] Publish inliers and coefficients from HintedStickFinder
* Remove rosbuild files
* [jsk_perception] Add DilateMaskImage
* Contributors: Ryohei Ueda
```
## jsk_perception

```
* [jsk_pcl_ros, jsk_perception] Move mask image operation to jsk_perception
* Remove rosbuild files
* [jsk_perception] Add ErodeMaskImage nodelet
* [jsk_perception] Add DilateMaskImage
* Contributors: Ryohei Ueda
```
## jsk_recognition
- No changes
## jsk_recognition_msgs

```
* add CATKIN_DEPENDS
* [jsk_recognition_msgs] Add new message for occupancy grid for more
  simple usage
* Contributors: Ryohei Ueda, Kei Okada
```
## resized_image_transport

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
