### PR TITLE
rospilot_deps: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6330,7 +6330,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rospilot/rospilot_deps-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
+    source:
+      type: git
+      url: https://github.com/rospilot/rospilot_deps.git
+      version: master
     status: developed
   rosprofiler:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot_deps` to `0.0.6-0`:
- upstream repository: https://github.com/rospilot/rospilot_deps.git
- release repository: https://github.com/rospilot/rospilot_deps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.5-0`
## rospilot_deps

```
* Fix library and header exports
* Contributors: Christopher Berner
```
