### PR TITLE
yaml_cpp_0_3: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8087,6 +8087,17 @@ repositories:
       url: https://github.com/rohbotics/xv_11_laser_driver.git
       version: indigo-devel
     status: maintained
+  yaml_cpp_0_3:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/yaml_cpp_0_3-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/stonier/yaml_cpp_0_3.git
+      version: indigo
+    status: maintained
   yocs_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_0_3` to `0.3.0-0`:
- upstream repository: https://github.com/stonier/yaml_cpp_0_3.git
- release repository: https://github.com/yujinrobot-release/yaml_cpp_0_3-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## yaml_cpp_0_3

```
* renamespaced library and headers (yaml->yaml-0.3) to avoid system v0.5 conflict
```
