### PR TITLE
jsk_common: 1.0.59-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2635,7 +2635,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.58-0
+      version: 1.0.59-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.59-1`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.58-0`
## assimp_devel

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## bayesian_belief_networks

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## downward

```
* Remove rosbuild files
* [downward] Remove multilib from it's dependency
* use jsk-ros-pkg/archives for download tgz
* downward: Use native bitwidth when compiling
  Previous behavior is to always compile 32-bit binaries
* [downward] Ignore error when building downward.
* Contributors: Ryohei Ueda, Scott K Logan, Kei Okada
```
## dynamic_tf_publisher

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## ff

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## ffha

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## image_view2

```
* Remove rosbuild files
* [image_view2] Add service to change interaction mode
* [image_view2] Support continuous publishing in line selection mode
* [image_view2] Fix timing to publish points selected in line mode
* [image_view2] Add new interaction mode to select line
* [image_view2] Do not publish region outside of the image
* [image_view2] Add ~region_continuous_publish parameter and if it's true,
  image_view2 will keep publishing region selected by user
* [image_view2] Do not show image if no image is available
* [image_view2] Do not use time difference to detect point or rectangle
* Contributors: Ryohei Ueda
```
## jsk_common

```
* [pr2_groovy_patches] Remove pr2_groovy_patches, it's no longer needed
* Contributors: Ryohei Ueda
```
## jsk_footstep_msgs

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## jsk_gui_msgs

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## jsk_hark_msgs

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## jsk_network_tools

```
* [jsk_network_tools] Add euslisp script to compress/decompres joint
  states. Originally implemented in jsk_pr2_startup by Y.Furuta
* [jsk_topic_tools] Add pesimistic mode for highspeed receiver
* add param to set rate
* [jsk_network_tools] Support run silverhammer_highspeed_receiver.py
  without topic_prefix
* [jsk_network_tools] Add script to check size in lowspeed network
* [jsk_network_tools] Add openni2 sample for highspeed streaming using
  silverhammer toolkit and recover message if possible of missing packets
* [jsk_network_tools] use png images for documentation
* [jsk_network_tools] Simpler implementation of lowspeed communication and
  update document. Bang Bang!
* [jsk_network_tools] Add documentation about limited network communication
* [jsk_network_tools] Script for DRC-highspeed-link communication
* [jsk_network_tools] Fix typo: OSC -> OCS
* [jsk_network_tools] for Low-bandwidth environment, add silverhammer
  toolset.
  You can communicate between two ROS-neworks over low-bandwidth network
  like DRC final.
* Contributors: Ryohei Ueda, Yusuke Furuta
```
## jsk_tilt_laser

```
* [jsk_tilt_laser] Update multisense.launch according to the latest update
  1) use multisense.launch, it support launch_robot_state_publisher argument
  2) fix name to change speed of spindle laser
* Remove rosbuild files
* [jsk_tilt_laser] Add ~overwrap_angle parameter to multisense.launch
* [jsk_tilt_laser] Add scan_to_cloud_chain to multisense.launch to get
  one-scan pointcloud. We use ~high_fidelity=true in order to avoid
  laser_geometry's bug to produce large sphere pointcloud
* Merge pull request #691 <https://github.com/jsk-ros-pkg/jsk_common/issues/691> from garaemon/laser-filter
  [jsk_tilt_laser] Add laser_filters to multisense
* [jsk_tilt_laser] Add laser_filters to multisense
* update multisense launch for using with real robot
* Contributors: Ryohei Ueda, Yohei Kakiuchi
```
## jsk_tools

```
* Remove rosbuild files
* [jsk_tools] Add new replace rule to force_to_rename_changelog_user.py
* add error message when percol is not installed
* [jsk_tools] Add percol utility
* update to use rossetmaster in functions
* [jsk_tools] Add progress bar to force_to_rename_changelog_user.py
* [jsk_tools] Add more name conevrsion rule to force_to_rename_changelog_user.py
* [jsk_tools] install bin directory
* Contributors: Ryohei Ueda, Kei Okada
```
## jsk_topic_tools

```
* [jsk_topic_tools] Add document about nodelet utility classes
* [jsk_topic_tools] Fix license: WillowGarage -> JSK Lab
* [jsk_topic_tools] Add documentation about color_utils.h
* Remove rosbuild files
* [jsk_topic_tools] Return true in service callback of snapshot nodelet
* [jsk_topci_tools] Fix heatColor function to return std_msgs::ColorRGBA
* [jsk_topic_tools] Add new utility to take snapshot of topic
* Contributors: Ryohei Ueda
```
## julius

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## libsiftfast

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## mini_maxwell

```
* Remove rosbuild files
* [mini_maxwell] Publish status of mini maxwell in drc_2015_environment.py
* [mini_maxwell] Fix minimaxwell configuration not to drop all the
  packets :)
* [mini_maxwell] Support 'disable_network_limitation' and add launch file
* [mini_maxwell] Add udp mode to simple test server
* [mini_maxwell] Add script to test like DRC-final-2015
* [mini_maxwell] Use struct module to make message with fixed size
* [mini_maxwell] Add simple echo server to debug mini maxwell settings
* Contributors: Ryohei Ueda
```
## multi_map_server

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## nlopt

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## opt_camera

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## posedetection_msgs

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## rospatlite

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## rosping

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## rostwitter

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## sklearn
- No changes
## speech_recognition_msgs

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
## virtual_force_publisher
- No changes
## voice_text

```
* Remove rosbuild files
* Contributors: Ryohei Ueda
```
