### PR TITLE
yaml_cpp_0_3: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8134,7 +8134,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/yaml_cpp_0_3-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/stonier/yaml_cpp_0_3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_0_3` to `0.3.1-0`:
- upstream repository: https://github.com/stonier/yaml_cpp_0_3.git
- release repository: https://github.com/yujinrobot-release/yaml_cpp_0_3-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.3.0-0`
## yaml_cpp_0_3

```
* refactored the actual library namespace (previously just renamed the library)
```
