### PR TITLE
Removed pr2_ethercat_drivers from distribution.yaml. Will fix and releas...

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5060,26 +5060,6 @@ repositories:
       url: https://github.com/pr2/pr2_controllers.git
       version: indigo-devel
     status: maintained
-  pr2_ethercat_drivers:
-    doc:
-      type: git
-      url: https://github.com/pr2/pr2_ethercat_drivers.git
-      version: indigo-devel
-    release:
-      packages:
-      - eml
-      - ethercat_hardware
-      - fingertip_pressure
-      - pr2_ethercat_drivers
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/pr2-gbp/pr2_ethercat_drivers-release.git
-      version: 1.8.13-1
-    source:
-      type: git
-      url: https://github.com/pr2/pr2_ethercat_drivers.git
-      version: indigo-devel
-    status: maintained
   pr2_mechanism:
     doc:
       type: git


### PR DESCRIPTION
Regarding actions to be taken from this issue https://github.com/PR2/pr2_ethercat_drivers/issues/68, pr2_ethercat_drivers will be removed. Once tested in Indigo and eml is released as a third party, this package will re-release. Will this effect packages that depend on these catkin packages being inside the distribution.yaml? Do those also have to be removed?
