### PR TITLE
wpi_jaco: 0.0.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8047,7 +8047,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/wpi_jaco-release.git
-      version: 0.0.12-0
+      version: 0.0.13-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/wpi_jaco.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wpi_jaco` to `0.0.13-0`:
- upstream repository: https://github.com/RIVeR-Lab/wpi_jaco.git
- release repository: https://github.com/wpi-rail-release/wpi_jaco-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.12-0`
## jaco_description

```
* fixed catkin install bug
* min
* remin
* moved to .jpg
* fixed small ring & minified
* Merge remote-tracking branch 'upstream/develop' into manual-texturing
* finished retexturing
* link 4,5,small ring. swapped colors
* link 2
* finished link 1
* large ring complete
* textred large ring manually
* added materials
* changed to .jpg
* changed to jpegs
* minifinified and fixed textures
* replaced with recolored dae's
* added materials
* Contributors: Peter, Russell Toris
```
## jaco_interaction
- No changes
## jaco_sdk
- No changes
## jaco_teleop
- No changes
## wpi_jaco
- No changes
## wpi_jaco_msgs
- No changes
## wpi_jaco_wrapper

```
* Result on gripper control action server now reports correctly.
* Initial adjustment of gripper action server to fix result feedback
* Contributors: David Kent
```
