### PR TITLE
openni2_camera: 0.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4666,7 +4666,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `0.2.3-0`:
- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros-gbp/openni2_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.2.2-0`
## openni2_camera

```
* Explicitly ask for serial number when trying to resolve device URI instead of doing it once on device connected, fixes #24 <https://github.com/ros-drivers/openni2_camera/issues/24>
* Contributors: Michael Ferguson, Stephan Wirth
```
