### PR TITLE
navigation: 1.11.15-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4427,7 +4427,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.11.14-0
+      version: 1.11.15-0
     source:
       type: git
       url: https://github.com/ros-planning/navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.11.15-0`:
- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.11.14-0`
## amcl
- No changes
## base_local_planner

```
* Add ARCHIVE_DESTINATION for static builds
* Contributors: Gary Servin
```
## carrot_planner

```
* Add ARCHIVE_DESTINATION for static builds
* Contributors: Gary Servin
```
## clear_costmap_recovery

```
* Add ARCHIVE_DESTINATION for static builds
* Contributors: Gary Servin
```
## costmap_2d

```
* Add ARCHIVE_DESTINATION for static builds
* Contributors: Gary Servin
```
## dwa_local_planner

```
* Add ARCHIVE_DESTINATION for static builds
* Contributors: Gary Servin
```
## fake_localization
- No changes
## global_planner
- No changes
## map_server
- No changes
## move_base

```
* Disable global planner when resetting state.
* Mark move_base headers for installation
* Add ARCHIVE DESTINATION for move_base
* Break infinite loop when tolerance 0 is used
* remove partial usage of <tab> in the code
* Contributors: Gary Servin, Michael Ferguson, ohendriks, v4hn
```
## move_base_msgs
- No changes
## move_slow_and_clear

```
* Add ARCHIVE_DESTINATION for static builds
* Contributors: Gary Servin
```
## nav_core
- No changes
## navfn

```
* Add ARCHIVE_DESTINATION for static builds
* Contributors: Gary Servin
```
## navigation
- No changes
## robot_pose_ekf

```
* Fix bfl includes in robot_pose_ekf
* Contributors: Jochen Sprickerhof
```
## rotate_recovery

```
* Add ARCHIVE_DESTINATION for static builds
* Contributors: Gary Servin
```
## voxel_grid

```
* Add ARCHIVE_DESTINATION for static builds
* Contributors: Gary Servin
```
