### PR TITLE
ueye_cam: 1.0.9-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8528,7 +8528,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/anqixu/ueye_cam-release.git
-      version: 1.0.8-0
+      version: 1.0.9-0
     source:
       type: git
       url: https://github.com/anqixu/ueye_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `1.0.9-0`:
- upstream repository: https://github.com/anqixu/ueye_cam.git
- release repository: https://github.com/anqixu/ueye_cam-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.0.8-0`
## ueye_cam

```
* fixed lagged changes to flip_upd and flip_lr via rqt_reconfigure
* Support discrete-only pixelclocks cameras
* Ask if gainboost is supported first
* Switched to jbohren's version of the file(GENERATE...) fix
* Contributors: Anqi Xu, Fran Real, Jonathan Bohren
```
