### PR TITLE
ueye_cam: 1.0.9-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -755,6 +755,21 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  ueye_cam:
+    doc:
+      type: git
+      url: https://github.com/anqixu/ueye_cam.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/anqixu/ueye_cam-release.git
+      version: 1.0.9-0
+    source:
+      type: git
+      url: https://github.com/anqixu/ueye_cam.git
+      version: master
+    status: developed
   urdfdom_py:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `1.0.9-0`:
- upstream repository: https://github.com/anqixu/ueye_cam.git
- release repository: https://github.com/anqixu/ueye_cam-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `null`
## ueye_cam

```
* fixed lagged changes to flip_upd and flip_lr via rqt_reconfigure
* Support discrete-only pixelclocks cameras
* Ask if gainboost is supported first
* Switched to jbohren's version of the file(GENERATE...) fix
* Contributors: Anqi Xu, Fran Real, Jonathan Bohren
```
