### PR TITLE
eml: 0.36.0-5 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1476,6 +1476,13 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/eigen_stl_containers-release.git
       version: 0.1.4-0
+  eml:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/eml-release.git
+      version: 0.36.0-5
+    status: maintained
   epos_hardware:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eml` to `0.36.0-5`:
- upstream repository: http://pr2packages.clearpathrobotics.com/third-party/eml/eml-r36.tar.gz
- release repository: https://github.com/ros-gbp/eml-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `null`
