### PR TITLE
navigation: 1.12.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4194,7 +4194,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.11.14-0
+      version: 1.12.0-0
     source:
       type: git
       url: https://github.com/ros-planning/navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.12.0-0`:
- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.11.14-0`
## amcl

```
* update maintainer email
* Contributors: Michael Ferguson
```
## base_local_planner

```
* update maintainer email
* Contributors: Michael Ferguson
```
## carrot_planner

```
* update maintainer email
* Contributors: Michael Ferguson
```
## clear_costmap_recovery

```
* update maintainer email
* Contributors: Michael Ferguson
```
## costmap_2d

```
* update maintainer email
* Contributors: Michael Ferguson
```
## dwa_local_planner

```
* update maintainer email
* Contributors: Michael Ferguson
```
## fake_localization

```
* update maintainer email
* Contributors: Michael Ferguson
```
## global_planner

```
* update maintainer email
* Contributors: Michael Ferguson
```
## map_server

```
* update maintainer email
* Contributors: Michael Ferguson
```
## move_base

```
* update maintainer email
* Contributors: Michael Ferguson
```
## move_base_msgs

```
* update maintainer email
* Contributors: Michael Ferguson
```
## move_slow_and_clear

```
* update maintainer email
* Contributors: Michael Ferguson
```
## nav_core

```
* update maintainer email
* Contributors: Michael Ferguson
```
## navfn

```
* update maintainer email
* Contributors: Michael Ferguson
```
## navigation

```
* update maintainer email
* Contributors: Michael Ferguson
```
## robot_pose_ekf

```
* update maintainer email
* Contributors: Michael Ferguson
```
## rotate_recovery

```
* update maintainer email
* Contributors: Michael Ferguson
```
## voxel_grid

```
* update maintainer email
* Contributors: Michael Ferguson
```
