### PR TITLE
eml: 1.8.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1481,7 +1481,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/eml-release.git
-      version: 1.8.14-0
+      version: 1.8.15-0
     status: maintained
   epos_hardware:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `eml` to `1.8.15-0`:
- upstream repository: http://pr2packages.clearpathrobotics.com/third-party/eml/eml-r36.tar.gz
- release repository: https://github.com/ros-gbp/eml-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `1.8.14-0`
