### PR TITLE
jskeus: 1.0.2-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3205,7 +3205,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jskeus-release.git
-      version: 1.0.2-0
+      version: 1.0.2-1
   katana_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.0.2-1`:
- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.2-0`
## jskeus

```
* Set ${EUSDIR}/irteus as symlink
* Move plot joint min max function to irtmodel.l and define it as method
* Contributors: Kei Okada, Shunichi Nozawa
```
