### PR TITLE
rtmros_nextage: 0.6.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7433,7 +7433,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.5.3-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.6.0-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `0.5.3-0`
## nextage_description

```
* VRML stored location inside qnx is now NEXTAGE specific.
* (launch) Accept more as an argument. Remove a redundant collada file.
* Contributors: Isaac IY Saito
```
## nextage_moveit_config

```
* Remove non-existent eef groups.
* Contributors: Isaac IY Saito
```
## nextage_ros_bridge

```
* [nextage_ros_bridge] Fix path for catkin build
* VRML stored location inside qnx is now NEXTAGE specific.
* (launch) Accept more as an argument. Remove a redundant collada file.
* Contributors: Isaac IY Saito, Ryohei Ueda
```
## rtmros_nextage

```
* (IMPORTANT) VRML stored location inside qnx is now NEXTAGE specific. From now on, controller on QNX should be updated. Please open a ticket at https://github.com/tork-a/rtmros_nextage/issues if you have any convern.
* Adjust to catkin build
* Contributors: Isaac IY Saito, Ryohei Ueda
```
