### PR TITLE
ros_realtime: 1.0.25-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6049,6 +6049,27 @@ repositories:
       url: https://github.com/RIVeR-Lab-release/ros_package_web_server-release.git
       version: 0.0.1-0
     status: maintained
+  ros_realtime:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_realtime.git
+      version: hydro-devel
+    release:
+      packages:
+      - allocators
+      - lockfree
+      - ros_realtime
+      - rosatomic
+      - rosrt
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/ros_realtime-release.git
+      version: 1.0.25-0
+    source:
+      type: git
+      url: https://github.com/ros/ros_realtime.git
+      version: hydro-devel
+    status: maintained
   ros_statistics_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_realtime` to `1.0.25-0`:
- upstream repository: https://github.com/ros/ros_realtime.git
- release repository: https://github.com/ros-gbp/ros_realtime-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `null`
## ros_realtime
- No changes
