### PR TITLE
app_manager: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -73,6 +73,21 @@ repositories:
       type: git
       url: https://github.com/ros/angles.git
       version: master
+  app_manager:
+    doc:
+      type: git
+      url: https://github.com/pr2/app_manager.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/app_manager-release.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/pr2/app_manager.git
+      version: hydro-devel
+    status: maintained
   apriltags_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `app_manager` to `1.0.3-0`:
- upstream repository: https://github.com/pr2/app_manager.git
- release repository: https://github.com/ros-gbp/app_manager-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `null`
## app_manager
- No changes
