### PR TITLE
husky_viz: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2259,7 +2259,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_viz-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/husky/husky_viz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_viz` to `0.1.1-0`:
- upstream repository: https://github.com/husky/husky_viz.git
- release repository: https://github.com/clearpath-gbp/husky_viz-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `0.1.0-0`
## husky_viz

```
* Update authors and web
* Add IMU viz dependency; Update rviz presets
* Restore interactive marker
* Contributors: Paul Bovbel
```
