### PR TITLE
husky_control: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2163,7 +2163,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_control-release.git
-      version: 0.0.2-1
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/husky/husky_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_control` to `0.0.3-0`:
- upstream repository: https://github.com/husky/husky_control.git
- release repository: https://github.com/clearpath-gbp/husky_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `0.0.2-1`
## husky_control

```
* Update website
* Add author
* Get rid of chassis_link, switch to base_footprint and base_link
* Turn on 2d mode; future proof robot_localization parameters
* Refactor configuration files into modules
* Re-enable IMU orientation fusion
* Contributors: Paul Bovbel
```
