### PR TITLE
husky_simulator: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2244,7 +2244,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_simulator-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/husky/husky_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_simulator` to `0.1.3-0`:
- upstream repository: https://github.com/husky/husky_simulator.git
- release repository: https://github.com/clearpath-gbp/husky_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `0.1.2-0`
## husky_gazebo

```
* Fix installing
* Contributors: Paul Bovbel
```
## husky_simulator
- No changes
