### PR TITLE
carl_safety: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -608,7 +608,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_safety-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_safety.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_safety` to `0.0.3-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_safety.git
- release repository: https://github.com/wpi-rail-release/carl_safety-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `0.0.2-0`
## carl_safety

```
* message generation dependency
* Split launch file into basic safety nodes that should always be on and nodes that only affect safety when using an external interface
* launch file for tipping safety
* Launch file updated with tipping safety
* Tuned nav safety thresholds and added tipping safety to stop the robot when tipping is detected
* Changed manual and auto nav safety to allow movement when the arm is within CARL's navigation footprint
* Removed some debugging statements
* Manual base movement override if arm is not retracted
* Contributors: David Kent
```
