### PR TITLE
rail_segmentation: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5327,7 +5327,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_segmentation.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_segmentation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_segmentation` to `0.0.4-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_segmentation.git
- release repository: https://github.com/wpi-rail-release/rail_segmentation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `0.0.3-0`
## rail_segmentation

```
* Update .travis.yml
* visualized object list initialization
* Contributors: David Kent, Russell Toris
```
