### PR TITLE
willow_maps: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8026,6 +8026,21 @@ repositories:
       url: https://github.com/RobotWebTools/web_video_server.git
       version: develop
     status: maintained
+  willow_maps:
+    doc:
+      type: git
+      url: https://github.com/pr2/willow_maps.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/willow_maps-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/pr2/willow_maps.git
+      version: hydro-devel
+    status: maintained
   world_canvas:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `willow_maps` to `1.0.2-0`:
- upstream repository: https://github.com/pr2/willow_maps.git
- release repository: https://github.com/ros-gbp/willow_maps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `null`
## willow_maps
- No changes
