### PR TITLE
pr2_apps: 0.5.17-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5040,6 +5040,29 @@ repositories:
       url: https://github.com/fetchrobotics-gbp/power_msgs-release.git
       version: 0.1.2-0
     status: developed
+  pr2_apps:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_apps.git
+      version: hydro-devel
+    release:
+      packages:
+      - pr2_app_manager
+      - pr2_apps
+      - pr2_mannequin_mode
+      - pr2_position_scripts
+      - pr2_teleop
+      - pr2_teleop_general
+      - pr2_tuckarm
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_apps-release.git
+      version: 0.5.17-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_apps.git
+      version: hydro-devel
+    status: maintained
   pr2_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_apps` to `0.5.17-0`:
- upstream repository: https://github.com/PR2/pr2_apps.git
- release repository: https://github.com/pr2-gbp/pr2_apps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `null`
