### PR TITLE
pr2_gripper_sensor: 1.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5110,6 +5110,26 @@ repositories:
       url: https://github.com/pr2/pr2_controllers.git
       version: indigo-devel
     status: maintained
+  pr2_gripper_sensor:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_gripper_sensor.git
+      version: hydro-devel
+    release:
+      packages:
+      - pr2_gripper_sensor
+      - pr2_gripper_sensor_action
+      - pr2_gripper_sensor_controller
+      - pr2_gripper_sensor_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_gripper_sensor-release.git
+      version: 1.0.5-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_gripper_sensor.git
+      version: hydro-devel
+    status: maintained
   pr2_mechanism:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_gripper_sensor` to `1.0.5-0`:
- upstream repository: https://github.com/PR2/pr2_gripper_sensor.git
- release repository: https://github.com/pr2-gbp/pr2_gripper_sensor-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `null`
## pr2_gripper_sensor
- No changes
## pr2_gripper_sensor_action
- No changes
## pr2_gripper_sensor_controller

```
* Removed the lib dir from sensor_controller
* Add publish_skip parameter to supress high-frequency publishing of gripper sensor data
* Contributors: Ryohei Ueda, TheDash
```
## pr2_gripper_sensor_msgs
- No changes
