### PR TITLE
pr2_precise_trajectory: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5182,6 +5182,21 @@ repositories:
       url: https://github.com/pr2/pr2_power_drivers.git
       version: indigo-devel
     status: maintained
+  pr2_precise_trajectory:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_precise_trajectory.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_precise_trajectory-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_precise_trajectory.git
+      version: hydro-devel
+    status: maintained
   prosilica_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_precise_trajectory` to `1.0.2-0`:
- upstream repository: https://github.com/PR2/pr2_precise_trajectory.git
- release repository: https://github.com/pr2-gbp/pr2_precise_trajectory-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `null`
## pr2_precise_trajectory
- No changes
