### PR TITLE
pr2_navigation: 0.1.25-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5182,6 +5182,33 @@ repositories:
       url: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
       version: 1.8.0-0
     status: maintained
+  pr2_navigation:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_navigation.git
+      version: hydro-devel
+    release:
+      packages:
+      - laser_tilt_controller_filter
+      - pr2_move_base
+      - pr2_navigation
+      - pr2_navigation_config
+      - pr2_navigation_global
+      - pr2_navigation_local
+      - pr2_navigation_perception
+      - pr2_navigation_self_filter
+      - pr2_navigation_slam
+      - pr2_navigation_teleop
+      - semantic_point_annotator
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_navigation-release.git
+      version: 0.1.25-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_navigation.git
+      version: hydro-devel
+    status: maintained
   pr2_power_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_navigation` to `0.1.25-0`:
- upstream repository: https://github.com/PR2/pr2_navigation.git
- release repository: https://github.com/pr2-gbp/pr2_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `null`
## laser_tilt_controller_filter

```
* Add library now called after catkin_package
* Changed install from global to local install for the lib
* Contributors: TheDash
```
## pr2_move_base
- No changes
## pr2_navigation
- No changes
## pr2_navigation_config
- No changes
## pr2_navigation_global
- No changes
## pr2_navigation_local
- No changes
## pr2_navigation_perception
- No changes
## pr2_navigation_self_filter
- No changes
## pr2_navigation_slam
- No changes
## pr2_navigation_teleop
- No changes
## semantic_point_annotator
- No changes
