### PR TITLE
pr2_delivery: 1.0.6-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5133,6 +5133,21 @@ repositories:
       url: https://github.com/pr2/pr2_controllers.git
       version: indigo-devel
     status: maintained
+  pr2_delivery:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_delivery.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_delivery-release.git
+      version: 1.0.6-1
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_delivery.git
+      version: hydro-devel
+    status: maintained
   pr2_gripper_sensor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_delivery` to `1.0.6-1`:
- upstream repository: https://github.com/pr2/pr2_delivery.git
- release repository: https://github.com/pr2-gbp/pr2_delivery-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `null`
