### PR TITLE
rtmros_hironx: 1.0.28-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7408,12 +7408,11 @@ repositories:
       - hironx_calibration
       - hironx_moveit_config
       - hironx_ros_bridge
-      - hironx_tutorial
       - rtmros_hironx
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.27-0
+      version: 1.0.28-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.28-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `1.0.27-0`
## hironx_calibration
- No changes
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* Add rqt hironx_dashboard.
* Now users can pecify a reference frame with set/get* methods of hrpsys_config.
* Now hironx.py is called from launch file so that hrpsys init process can be completed only by launch file. Also if robot_description_semantic is not found, warn and do not start ros_client.
* Better handling force sensor (See #462 <https://github.com/fkanehiro/hrpsys-base/pull/462>).
* Enormous improvement for QNX installer.
* (doc) Add backup text files of tutorial (http://wiki.ros.org/rtmros_nextage/Tutorials).
* Contributors: Kei Okada, Shunichi Nozawa, Daiki Maekawa, Isaac IY Saito
```
## rtmros_hironx

```
* Add rqt hironx_dashboard.
* Now users can pecify a reference frame with set/get* methods of hrpsys_config.
* Now hironx.py is called from launch file so that hrpsys init process can be completed only by launch file. Also if robot_description_semantic is not found, warn and do not start ros_client.
* Better handling force sensor (See #462 <https://github.com/fkanehiro/hrpsys-base/pull/462>).
* Enormous improvement for QNX installer.
* (doc) Add backup text files of tutorial (http://wiki.ros.org/rtmros_nextage/Tutorials).
* Remove hironx_tutorial pkg (https://github.com/start-jsk/rtmros_hironx/issues/320).
* Contributors: Kei Okada, Shunichi Nozawa, Daiki Maekawa, Isaac IY Saito
```
