### PR TITLE
navigation_tutorials: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4264,6 +4264,30 @@ repositories:
       url: https://github.com/DLu/navigation_layers.git
       version: indigo
     status: maintained
+  navigation_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation_tutorials.git
+      version: hydro-devel
+    release:
+      packages:
+      - laser_scan_publisher_tutorial
+      - navigation_stage
+      - navigation_tutorials
+      - odometry_publisher_tutorial
+      - point_cloud_publisher_tutorial
+      - robot_setup_tf_tutorial
+      - roomba_stage
+      - simple_navigation_goals_tutorial
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/navigation_tutorials-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/navigation_tutorials.git
+      version: hydro-devel
+    status: maintained
   neo_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_tutorials` to `0.2.0-0`:
- upstream repository: https://github.com/ros-planning/navigation_tutorials.git
- release repository: https://github.com/ros-gbp/navigation_tutorials-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `null`
