### PR TITLE
ecto_ros: 0.4.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1649,7 +1649,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ecto_ros-release.git
-      version: 0.4.5-0
+      version: 0.4.6-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto_ros` to `0.4.6-0`:
- upstream repository: /home/vrabaud/workspace/recognition_kitchen/src/ecto_ros
- release repository: https://github.com/ros-gbp/ecto_ros-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `0.4.5-0`
## ecto_ros

```
* do not install files from devel
  fixes #16 <https://github.com/plasmodic/ecto_ros/issues/16>
* clean extensions
* Contributors: Vincent Rabaud
```
