### PR TITLE
ueye: 0.0.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -755,6 +755,21 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  ueye:
+    doc:
+      type: hg
+      url: https://bitbucket.org/kmhallen/ueye
+      version: default
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/kmhallen/ueye-release.git
+      version: 0.0.4-0
+    source:
+      type: hg
+      url: https://bitbucket.org/kmhallen/ueye
+      version: default
+    status: maintained
   ueye_cam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye` to `0.0.4-0`:
- upstream repository: https://bitbucket.org/kmhallen/ueye
- release repository: https://github.com/kmhallen/ueye-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `null`
## ueye

```
* Allow discrete-only pixelclocks cameras
* Contributors: Kevin Hallenbeck, Fran Real
```
