### PR TITLE
Updated rtabmap and rtabmap_ros packages to version 0.8.3

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7334,7 +7334,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.8.2-0
+      version: 0.8.3-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -7349,7 +7349,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.8.1-0
+      version: 0.8.3-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6760,7 +6760,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.8.0-0
+      version: 0.8.3-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -6775,7 +6775,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.8.0-0
+      version: 0.8.3-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repositories rtabmap and rtabmap_ros to 0.8.3 both for Hydro and Indigo distributions.

upstream repository: https://github.com/introlab/rtabmap.git
release repository: https://github.com/introlab/rtabmap-release.git
upstream repository: https://github.com/introlab/rtabmap_ros.git
release repository: https://github.com/introlab/rtabmap_ros-release.git
