### PR TITLE
yocs_msgs: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8359,7 +8359,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/yocs_msgs-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/yujinrobot/yocs_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yocs_msgs` to `0.6.3-0`:
- upstream repository: https://github.com/yujinrobot/yocs_msgs.git
- release repository: https://github.com/yujinrobot-release/yocs_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `0.6.2-0`
## yocs_msgs

```
* Merge branch 'indigo' into update
* add distortion
* add more commands
* Contributors: Jihoon Lee
```
