### PR TITLE
yujin_ocs: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8387,22 +8387,28 @@ repositories:
       version: indigo
     release:
       packages:
+      - yocs_ar_marker_tracking
+      - yocs_ar_pair_approach
+      - yocs_ar_pair_tracking
       - yocs_cmd_vel_mux
       - yocs_controllers
       - yocs_diff_drive_pose_controller
       - yocs_joyop
       - yocs_keyop
+      - yocs_localization_manager
       - yocs_math_toolkit
+      - yocs_navigator
       - yocs_rapps
       - yocs_safety_controller
       - yocs_velocity_smoother
       - yocs_virtual_sensor
+      - yocs_waypoint_provider
       - yocs_waypoints_navi
       - yujin_ocs
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/yujin_ocs-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/yujinrobot/yujin_ocs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yujin_ocs` to `0.6.4-0`:
- upstream repository: https://github.com/yujinrobot/yujin_ocs.git
- release repository: https://github.com/yujinrobot-release/yujin_ocs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `0.6.3-0`
## yocs_ar_marker_tracking

```
* fix yaml-cpp dependency closes #63 <https://github.com/yujinrobot/yujin_ocs/issues/63>
* Contributors: Jihoon Lee
```
## yocs_ar_pair_approach

```
* Merge remote-tracking branch 'origin/indigo' into update_ar_pair_approach
* ar pair update
* now base target frame is on odom frame
* add queue_size
* updates
* updates
* base tf publisher
* now diff drive pose controller receives target frame as topic
* ar pair approach publishes target frame now
* Contributors: Jihoon Lee
```
## yocs_ar_pair_tracking
- No changes
## yocs_cmd_vel_mux
- No changes
## yocs_controllers
- No changes
## yocs_diff_drive_pose_controller

```
* clean up debug messages #72 <https://github.com/yujinrobot/yujin_ocs/issues/72>
* Merge remote-tracking branch 'origin/indigo' into update_ar_pair_approach
* comment out debug messages
* wrap heading. bounding rotational speed. replace atan to atan2
* updates
* base tf publisher
* now diff drive pose controller receives target frame as topic
* Contributors: Jihoon Lee
```
## yocs_joyop
- No changes
## yocs_keyop
- No changes
## yocs_localization_manager

```
* comment out debug messages
* add ar target offset param
* updates
* updates
* base tf publisher
* ar pair approach publishes target frame now
* add sleep to publish tf properly
* Contributors: Jihoon Lee
```
## yocs_math_toolkit
- No changes
## yocs_navigator

```
* convert yocs_navigator
* add backward function
* add slow_backward function
* Contributors: Jihoon Lee
```
## yocs_rapps
- No changes
## yocs_safety_controller
- No changes
## yocs_velocity_smoother
- No changes
## yocs_virtual_sensor
- No changes
## yocs_waypoint_provider

```
* fix yaml-cpp dependency closes #63 <https://github.com/yujinrobot/yujin_ocs/issues/63>
* Contributors: Jihoon Lee
```
## yocs_waypoints_navi
- No changes
## yujin_ocs
- No changes
