### PR TITLE
rocon_msgs: 0.7.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5829,7 +5829,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-      version: 0.7.8-0
+      version: 0.7.9-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs` to `0.7.9-0`:
- upstream repository: http://github.com/robotics-in-concert/rocon_msgs.git
- release repository: https://github.com/yujinrobot-release/rocon_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `0.7.8-0`
## concert_msgs

```
* remove enabled field closes #107 <https://github.com/robotics-in-concert/rocon_msgs/issues/107>
* merge from indigo branch
* fix indent
* separate profile message and instance message. they are carrying different info
* updates
* delete unused property and type and name change of parameter_detail
  create update service config service msg and fix profile msg type
  fix type
* add real data field regarding parameter, interaction, launch
* rename requester to user
* add requester
* add software list msg
* add allocate software srv
* add software namespace
* remove launcher type
* add resource name
* replace interface with namespace
* add software profile
* Contributors: Jihoon Lee, dwlee
```
## concert_service_msgs
- No changes
## gateway_msgs
- No changes
## rocon_app_manager_msgs
- No changes
## rocon_device_msgs

```
* change hue color name
* delete unused pre-defined color
* update cmake #101 <https://github.com/robotics-in-concert/rocon_msgs/issues/101>
* clean up message as modification of rocon hue
* Contributors: Jihoon Lee, dwlee
```
## rocon_interaction_msgs
- No changes
## rocon_msgs
- No changes
## rocon_service_pair_msgs
- No changes
## rocon_std_msgs

```
* merge indigo
* add softwre farm tag
* Contributors: Jihoon Lee
```
## rocon_tutorial_msgs
- No changes
## scheduler_msgs
- No changes
