### PR TITLE
rocon_qt_gui: 0.7.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5883,7 +5883,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_qt_gui-release.git
-      version: 0.7.4-0
+      version: 0.7.5-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_qt_gui.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_qt_gui` to `0.7.5-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_qt_gui.git
- release repository: https://github.com/yujinrobot-release/rocon_qt_gui-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `0.7.4-0`
## concert_admin_app

```
* fix return value regarding service profile update function
* update ros service and subscriber init function
* Contributors: dwlee
```
## concert_conductor_graph

```
* migrate concert conductor dotcode generator to new base closes #176 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/176>
* Contributors: Jihoon Lee
```
## concert_qt_make_a_map
- No changes
## concert_qt_map_annotation
- No changes
## concert_qt_service_info
- No changes
## concert_qt_teleop
- No changes
## rocon_gateway_graph
- No changes
## rocon_qt_app_manager

```
* icon enable disable works
* support remapping
* start stop works
* ui sortof look good
* rapp dialog getting ready
* icon view ready
* Contributors: Jihoon Lee
```
## rocon_qt_gui
- No changes
## rocon_qt_library

```
* fix name typo
* ann use pose covariance
* rocon_qt_library convert table to waypoint
* Contributors: Jihoon Lee
```
## rocon_qt_listener
- No changes
## rocon_qt_master_info
- No changes
## rocon_qt_teleop
- No changes
## rocon_remocon

```
* restore rocon_remocon src
* update ros service and subscriber init function
* make test brach
* Contributors: dwlee
```
