### PR TITLE
rocon_tutorials: 0.6.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5935,7 +5935,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_tutorials-release.git
-      version: 0.6.4-0
+      version: 0.6.5-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_tutorials` to `0.6.5-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_tutorials.git
- release repository: https://github.com/yujinrobot-release/rocon_tutorials-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `0.6.4-0`
## chatter_concert

```
* revert unused src
* change name of auto enable service argument
* Contributors: dwlee
```
## gazebo_concert

```
* change name of auto enable service argument
* Contributors: dwlee
```
## rocon_app_manager_tutorials
- No changes
## rocon_gateway_tutorials
- No changes
## rocon_tutorials
- No changes
## turtle_concert

```
* change name of auto enable service argument
* Contributors: dwlee
```
