### PR TITLE
rocon_concert: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5796,13 +5796,14 @@ repositories:
       - concert_service_link_graph
       - concert_service_manager
       - concert_service_utilities
+      - concert_software_farmer
       - concert_utilities
       - rocon_concert
       - rocon_tf_reconstructor
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_concert-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_concert.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_concert` to `0.6.4-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_concert
- release repository: https://github.com/yujinrobot-release/rocon_concert-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `0.6.3-0`
## concert_conductor
- No changes
## concert_master

```
* add graph to stringpublihser closes #270 <https://github.com/robotics-in-concert/rocon_concert/issues/270>
* Merge branch 'indigo' into admin_app_patch
* rename software_manager as software_farmer
* change name of auto enable service argument
* add the concert_name arg in service manager launcher
* Merge branch 'indigo' into software_farm
* draft of software manager
* Contributors: Jihoon Lee, dwlee
```
## concert_schedulers
- No changes
## concert_service_link_graph
- No changes
## concert_service_manager

```
* fixed typo in function name. also print actual error message to make debugging easier. closes #266 <https://github.com/robotics-in-concert/rocon_concert/issues/266>
* do not write enabled field until #258 <https://github.com/robotics-in-concert/rocon_concert/issues/258> get resolved
* convert to string. KeyValue expects value as string
* now solution caches are created under solutions
* fix wrong try/catch
* adjust get rocon friendly name function
* move common util function and fix code as that
* add exception handling at some part
* share logic about load parameter from cahce, file, resource
* revert src
* add code documentation
* change name of auto enable service argument
* change modification checker name
* add extension name checker
* rename and code clear
* fix wrong argument
* add the string strip
* update service manager launch
* update
* update service manager and instance as adding service cache manager
* add function for loading parameter from cache
* create service profile cache manager
* function name change
* create utils.py and create cache maker regarding solution configuration
* Contributors: Jihoon Lee, Piyush Khandelwal, dwlee
```
## concert_service_utilities
- No changes
## concert_software_farmer

```
* add package version software farmer
* fix typo
* add client library closes #264 <https://github.com/robotics-in-concert/rocon_concert/issues/264>
* add client library
* rename software_manager as software_farmer
* Contributors: Jihoon Lee
* add package version software farmer
* fix typo
* add client library closes #264 <https://github.com/robotics-in-concert/rocon_concert/issues/264>
* add client library
* rename software_manager as software_farmer
* Contributors: Jihoon Lee
```
## concert_utilities

```
* conductor graph string publisher for web. and conductor graph dotcode generator code has been migrated
* Contributors: Jihoon Lee
```
## rocon_concert
- No changes
## rocon_tf_reconstructor
- No changes
