### PR TITLE
rosdep: fixing osxbrew -> osx platform key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1320,7 +1320,7 @@ python-sip:
   gentoo: [dev-python/sip]
   macports: [py27-sip]
   opensuse: [python-sip-devel]
-  osxbrew:
+  osx:
     homebrew:
       packages: [sip]
   rhel: [sip-devel]


### PR DESCRIPTION
This is the only one like it, is this a valid platform key?
