### PR TITLE
geneus: 2.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1972,11 +1972,20 @@ repositories:
       version: groovy-devel
     status: maintained
   geneus:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/geneus.git
+      version: master
     release:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/geneus-release.git
-      version: 2.0.0-1
+      version: 2.0.1-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/geneus.git
+      version: master
+    status: developed
   genlisp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geneus` to `2.0.1-0`:
- upstream repository: https://github.com/jsk-ros-pkg/geneus
- release repository: https://github.com/tork-a/geneus-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `2.0.0-1`
## geneus

```
* [scripts/gen_eus.py] set executable
* Contributors: Kei Okada
```
