### PR TITLE
euslisp: 9.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -251,6 +251,21 @@ repositories:
       url: https://github.com/plasmodic/ecto_ros.git
       version: master
     status: maintained
+  euslisp:
+    doc:
+      type: git
+      url: https://github.com/euslisp/EusLisp.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/euslisp-release.git
+      version: 9.1.0-0
+    source:
+      type: git
+      url: https://github.com/euslisp/EusLisp.git
+      version: master
+    status: developed
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `euslisp` to `9.1.0-0`:
- upstream repository: https://github.com/euslisp/EusLisp
- release repository: https://github.com/tork-a/euslisp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `null`
