### PR TITLE
rtctree: 3.0.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7364,6 +7364,21 @@ repositories:
       url: https://github.com/introlab/rtabmap_ros.git
       version: master
     status: maintained
+  rtctree:
+    doc:
+      type: git
+      url: https://github.com/gbiggs/rtctree.git
+      version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/tork-a/rtctree-release.git
+      version: 3.0.1-1
+    source:
+      type: git
+      url: https://github.com/gbiggs/rtctree.git
+      version: master
+    status: developed
   rtmros_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtctree` to `3.0.1-1`:
- upstream repository: https://github.com/gbiggs/rtctree.git
- release repository: https://github.com/tork-a/rtctree-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `null`
