### PR TITLE
jskeus: 1.0.2-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -432,6 +432,21 @@ repositories:
       url: https://github.com/ros-perception/image_pipeline.git
       version: indigo
     status: maintained
+  jskeus:
+    doc:
+      type: git
+      url: https://github.com/euslisp/jskeus.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/jskeus-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/euslisp/jskeus.git
+      version: master
+    status: developed
   message_generation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.0.2-1`:
- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `null`
## jskeus

```
* Set ${EUSDIR}/irteus as symlink
* Move plot joint min max function to irtmodel.l and define it as method
* Contributors: Kei Okada, Shunichi Nozawa
```
