### PR TITLE
rtshell: 3.0.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7462,6 +7462,21 @@ repositories:
       url: https://github.com/tork-a/rtmros_nextage.git
       version: hydro-devel
     status: developed
+  rtshell:
+    doc:
+      type: git
+      url: https://github.com/gbiggs/rtshell.git
+      version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/tork-a/rtshell-release.git
+      version: 3.0.1-1
+    source:
+      type: git
+      url: https://github.com/gbiggs/rtshell.git
+      version: master
+    status: developed
   rtsprofile:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell` to `3.0.1-1`:
- upstream repository: https://github.com/gbiggs/rtshell.git
- release repository: https://github.com/tork-a/rtshell-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
