### PR TITLE
openhrp3: 3.1.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4917,7 +4917,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/openhrp3-release.git
-      version: 3.1.5-6
+      version: 3.1.7-0
     source:
       type: git
       url: https://github.com/start-jsk/openhrp3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openhrp3` to `3.1.7-0`:
- upstream repository: https://github.com/fkanehiro/openhrp3.git
- release repository: https://github.com/tork-a/openhrp3-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `3.1.5-6`
