### PR TITLE
jsk_roseus: 1.2.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -432,6 +432,24 @@ repositories:
       url: https://github.com/ros-perception/image_pipeline.git
       version: indigo
     status: maintained
+  jsk_roseus:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_roseus.git
+      version: master
+    release:
+      packages:
+      - jsk_roseus
+      - roseus
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/jsk_roseus-release.git
+      version: 1.2.3-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_roseus.git
+      version: master
+    status: developed
   jskeus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.2.3-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## jsk_roseus
- No changes
## roseus

```
* find package if not messages path is not found
* [roseus] Fix typo
* euslisp is now non-catkin package
```
