### PR TITLE
openrtm_aist: 1.1.0-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4988,6 +4988,21 @@ repositories:
       url: https://github.com/ros-gbp/openni_tracker-release.git
       version: 0.2.0-1
     status: maintained
+  openrtm_aist:
+    doc:
+      type: svn
+      url: http://svn.openrtm.org/OpenRTM-aist/tags/RELEASE_1_1_0/OpenRTM-aist/
+      version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/tork-a/openrtm_aist-release.git
+      version: 1.1.0-2
+    source:
+      type: svn
+      url: http://svn.openrtm.org/OpenRTM-aist/tags/RELEASE_1_1_0/OpenRTM-aist/
+      version: master
+    status: developed
   openslam_gmapping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist` to `1.1.0-2`:
- upstream repository: http://svn.openrtm.org/OpenRTM-aist/tags/RELEASE_1_1_0/OpenRTM-aist/
- release repository: https://github.com/tork-a/openrtm_aist-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
