### PR TITLE
openrtm_aist_python: 1.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5003,6 +5003,21 @@ repositories:
       url: http://svn.openrtm.org/OpenRTM-aist/tags/RELEASE_1_1_0/OpenRTM-aist/
       version: master
     status: developed
+  openrtm_aist_python:
+    doc:
+      type: svn
+      url: http://svn.openrtm.org/OpenRTM-aist-Python/tags/RELEASE_1_1_0_RC1/OpenRTM-aist-Python/
+      version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/tork-a/openrtm_aist_python-release.git
+      version: 1.1.0-0
+    source:
+      type: svn
+      url: http://svn.openrtm.org/OpenRTM-aist-Python/tags/RELEASE_1_1_0_RC1/OpenRTM-aist-Python/
+      version: master
+    status: developed
   openslam_gmapping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist_python` to `1.1.0-0`:
- upstream repository: http://svn.openrtm.org/OpenRTM-aist-Python/tags/RELEASE_1_1_0_RC1/OpenRTM-aist-Python/
- release repository: https://github.com/tork-a/openrtm_aist_python-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
