### PR TITLE
ros_ethernet_rmp: 0.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6202,7 +6202,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/ros_ethernet_rmp-release.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/ros_ethernet_rmp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ethernet_rmp` to `0.0.8-0`:
- upstream repository: https://github.com/WPI-RAIL/ros_ethernet_rmp.git
- release repository: https://github.com/wpi-rail-release/ros_ethernet_rmp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `0.0.7-0`
## ros_ethernet_rmp

```
* Changed args in launch file so that they can be overriden
* Contributors: David Kent
```
