### PR TITLE
pr2_apps: 0.5.18-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5099,7 +5099,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_apps-release.git
-      version: 0.5.17-0
+      version: 0.5.18-0
     source:
       type: git
       url: https://github.com/pr2/pr2_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_apps` to `0.5.18-0`:
- upstream repository: https://github.com/PR2/pr2_apps.git
- release repository: https://github.com/pr2-gbp/pr2_apps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.5.17-0`
## pr2_app_manager

```
* Merge branch 'hydro-devel' of https://github.com/PR2/pr2_apps into hydro-devel
* Updated maintainership
* fix install destination
* Contributors: Furushchev, TheDash
```
## pr2_apps
- No changes
## pr2_mannequin_mode

```
* fix install destination
* Contributors: Furushchev
```
## pr2_position_scripts

```
* Merge branch 'hydro-devel' of https://github.com/PR2/pr2_apps into hydro-devel
* Updated maintainership
* Contributors: TheDash
```
## pr2_teleop

```
* fix install destination
* Contributors: Furushchev
```
## pr2_teleop_general
- No changes
## pr2_tuckarm

```
* Merge branch 'hydro-devel' of https://github.com/PR2/pr2_apps into hydro-devel
* Updated maintainership
* Contributors: TheDash
```
