### PR TITLE
rtshell: 3.0.1-3 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7482,7 +7482,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtshell-release.git
-      version: 3.0.1-1
+      version: 3.0.1-3
     source:
       type: git
       url: https://github.com/gbiggs/rtshell.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell` to `3.0.1-3`:
- upstream repository: https://github.com/gbiggs/rtshell.git
- release repository: https://github.com/tork-a/rtshell-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `3.0.1-1`
