### PR TITLE
pr2_common: 1.11.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5120,7 +5120,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_common-release.git
-      version: 1.11.8-0
+      version: 1.11.9-0
     source:
       type: git
       url: https://github.com/pr2/pr2_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common` to `1.11.9-0`:
- upstream repository: https://github.com/pr2/pr2_common.git
- release repository: https://github.com/pr2-gbp/pr2_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.11.8-0`
## pr2_common
- No changes
## pr2_dashboard_aggregator
- No changes
## pr2_description

```
* Updated maintainership
* Contributors: TheDash
```
## pr2_machine
- No changes
## pr2_msgs
- No changes
