### PR TITLE
rtshell: 3.0.1-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6850,11 +6850,20 @@ repositories:
       version: hydro-devel
     status: developed
   rtshell:
+    doc:
+      type: git
+      url: https://github.com/gbiggs/rtshell.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtshell-release.git
-      version: 3.0.1-1
+      version: 3.0.1-2
+    source:
+      type: git
+      url: https://github.com/gbiggs/rtshell.git
+      version: master
+    status: developed
   rtsprofile:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell` to `3.0.1-2`:
- upstream repository: https://github.com/gbiggs/rtshell.git
- release repository: https://github.com/tork-a/rtshell-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `3.0.1-1`
