### PR TITLE
pr2_navigation: 0.1.26-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5260,7 +5260,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_navigation-release.git
-      version: 0.1.25-0
+      version: 0.1.26-0
     source:
       type: git
       url: https://github.com/pr2/pr2_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_navigation` to `0.1.26-0`:
- upstream repository: https://github.com/PR2/pr2_navigation.git
- release repository: https://github.com/pr2-gbp/pr2_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.1.25-0`
## laser_tilt_controller_filter
- No changes
## pr2_move_base
- No changes
## pr2_navigation

```
* Merge branch 'hydro-devel' of https://github.com/PR2/pr2_navigation into hydro-devel
* Updated maintanership
* Contributors: TheDash
```
## pr2_navigation_config
- No changes
## pr2_navigation_global
- No changes
## pr2_navigation_local
- No changes
## pr2_navigation_perception

```
* Updated maintanership
* Contributors: TheDash
```
## pr2_navigation_self_filter

```
* Updated maintanership
* Contributors: TheDash
```
## pr2_navigation_slam
- No changes
## pr2_navigation_teleop
- No changes
## semantic_point_annotator
- No changes
