### PR TITLE
openhrp3: 3.1.7-13 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4716,11 +4716,15 @@ repositories:
       version: master
     status: maintained
   openhrp3:
+    doc:
+      type: git
+      url: https://github.com/fkanehiro/openhrp3.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/openhrp3-release.git
-      version: 3.1.7-12
+      version: 3.1.7-13
     source:
       type: git
       url: https://github.com/fkanehiro/openhrp3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openhrp3` to `3.1.7-13`:
- upstream repository: https://github.com/fkanehiro/openhrp3.git
- release repository: https://github.com/tork-a/openhrp3-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `3.1.7-12`
