### PR TITLE
hrpsys: 315.2.8-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2539,7 +2539,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/hrpsys-release.git
-      version: 315.2.8-0
+      version: 315.2.8-1
     source:
       type: git
       url: https://github.com/start-jsk/hrpsys.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys` to `315.2.8-1`:
- upstream repository: https://github.com/fkanehiro/hrpsys-base.git
- release repository: https://github.com/tork-a/hrpsys-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `315.2.8-0`
