### PR TITLE
hrpsys: 315.2.8-4 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2133,11 +2133,19 @@ repositories:
       version: 0.1.1-2
     status: maintained
   hrpsys:
+    doc:
+      type: git
+      url: https://github.com/fkanehiro/hrpsys-base.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/hrpsys-release.git
-      version: 315.2.8-3
+      version: 315.2.8-4
+    source:
+      type: git
+      url: https://github.com/fkanehiro/hrpsys-base.git
+      version: master
     status: developed
   humanoid_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys` to `315.2.8-4`:
- upstream repository: https://github.com/fkanehiro/hrpsys-base.git
- release repository: https://github.com/tork-a/hrpsys-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `315.2.8-3`
