### PR TITLE
pr2_hack_the_future: 1.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5210,6 +5210,30 @@ repositories:
       url: https://github.com/PR2/pr2_gripper_sensor.git
       version: hydro-devel
     status: maintained
+  pr2_hack_the_future:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_hack_the_future.git
+      version: hydro-devel
+    release:
+      packages:
+      - hack_the_web_program_executor
+      - pr2_hack_the_future
+      - pr2_joint_teleop
+      - pr2_simple_interface
+      - program_queue
+      - queue_web
+      - rviz_backdrop
+      - slider_gui
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_hack_the_future-release.git
+      version: 1.0.9-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_hack_the_future.git
+      version: hydro-devel
+    status: maintained
   pr2_mechanism:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_hack_the_future` to `1.0.9-0`:
- upstream repository: https://github.com/PR2/pr2_hack_the_future.git
- release repository: https://github.com/pr2-gbp/pr2_hack_the_future-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## hack_the_web_program_executor
- No changes
## pr2_hack_the_future
- No changes
## pr2_joint_teleop
- No changes
## pr2_simple_interface
- No changes
## program_queue
- No changes
## queue_web
- No changes
## rviz_backdrop
- No changes
## slider_gui
- No changes
