### PR TITLE
pr2_map_navigation_app: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5246,6 +5246,21 @@ repositories:
       url: https://github.com/PR2/pr2_hack_the_future.git
       version: hydro-devel
     status: maintained
+  pr2_map_navigation_app:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_map_navigation_app.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_map_navigation_app-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_map_navigation_app.git
+      version: hydro-devel
+    status: maintained
   pr2_mechanism:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_map_navigation_app` to `1.0.2-0`:
- upstream repository: https://github.com/PR2/pr2_map_navigation_app.git
- release repository: https://github.com/pr2-gbp/pr2_map_navigation_app-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## pr2_map_navigation_app

```
* Fixes
* Contributors: TheDash
```
