### PR TITLE
jsk_common: 1.0.61-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3002,6 +3002,7 @@ repositories:
       - ffha
       - image_view2
       - jsk_common
+      - jsk_data
       - jsk_footstep_msgs
       - jsk_gui_msgs
       - jsk_hark_msgs
@@ -3027,7 +3028,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.60-1
+      version: 1.0.61-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.61-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.0.60-1`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## collada_urdf_jsk_patch
- No changes
## downward
- No changes
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha
- No changes
## image_view2

```
* [image_view2] Add topic interface to emulate mouse event
* [image_view2] Separate main function to another cpp file
* [image_view2] Add std_srvs/Empty interface to change interaction mode
* Contributors: Ryohei Ueda
```
## jsk_common
- No changes
## jsk_data

```
* [jsk_data] catkinize
* Contributors: Ryohei Ueda
```
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_network_tools

```
* [jsk_network_tools] Enable unit test
* [jsk_network_tools] Add unittest about ROS<-->UDP message conversion
* [jsk_network_tools] Fix for uint32 data
* [jsk_network_tools] Fix how to resolve uint8 array
* [jsk_network_tools] Update sample of joint states compressor
* [jsk_network_tools] Fix compressing joint-angles of infinite joint
* Contributors: Ryohei Ueda
```
## jsk_tilt_laser

```
* [jsk_tilt_laser] Add sensor_tf_prefix and not_use_sensor_tf_prefix for the
  robots which has '/left/image_rect_color' sensor frame instead of
  '/multisense/left/image_rect_clor'
* Contributors: Ryohei Ueda
```
## jsk_tools
- No changes
## jsk_topic_tools

```
* [jsk_topic_tools] Fix snapshot to publish first message correctly
* [jsk_topic_tools] Add service interface to change output topic of relay node
* anonymous node
* add flatten mode for array type message
* remove space after ,
* add argument exception handler
* add csv exporter for rosbag
* Contributors: Yuki Furuta, Ryohei Ueda
```
## julius
- No changes
## laser_filters_jsk_patch
- No changes
## libsiftfast
- No changes
## mini_maxwell
- No changes
## multi_map_server
- No changes
## nlopt

```
* install devel files into catkin package destination
* remove install functions,
* change build current directroy to catkin/build, and install lib files to devel/lib
* change build current directroy to catkin/build, and install lib files to devel/lib
* [nlopt] Fix nlopt compilation to export nlopt_cxx correctly.
  * compile libraries under source directory and after that copy to devel space.
  * Use add_custom_command instead of execute_process
* added nlopt_cxx library to catkin_package so that the library will be included by packages that depend on nlopt
* Contributors: Ryohei Ueda, Shintaro Noda, Barrett
```
## opt_camera
- No changes
## posedetection_msgs
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## sklearn
- No changes
## speech_recognition_msgs
- No changes
## virtual_force_publisher
- No changes
## voice_text
- No changes
