### PR TITLE
pr2_kinematics: 1.0.7-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5247,6 +5247,24 @@ repositories:
       url: https://github.com/PR2/pr2_hack_the_future.git
       version: hydro-devel
     status: maintained
+  pr2_kinematics:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_kinematics.git
+      version: hydro-devel
+    release:
+      packages:
+      - pr2_arm_kinematics
+      - pr2_kinematics
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_kinematics-release.git
+      version: 1.0.7-1
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_kinematics.git
+      version: hydro-devel
+    status: maintained
   pr2_make_a_map_app:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_kinematics` to `1.0.7-1`:
- upstream repository: https://github.com/PR2/pr2_kinematics.git
- release repository: https://github.com/pr2-gbp/pr2_kinematics-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## pr2_arm_kinematics

```
* Fix pr2_arm_kinematics for indigo by adding cmake_modules
* Add dependency to cmake_modules to solve Eigen depdency on indigo
* Contributors: Ryohei Ueda
```
## pr2_kinematics
- No changes
