### PR TITLE
pr2_props_stack: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5247,24 +5247,6 @@ repositories:
       url: https://github.com/PR2/pr2_hack_the_future.git
       version: hydro-devel
     status: maintained
-  pr2_kinematics:
-    doc:
-      type: git
-      url: https://github.com/pr2/pr2_kinematics.git
-      version: hydro-devel
-    release:
-      packages:
-      - pr2_arm_kinematics
-      - pr2_kinematics
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/pr2-gbp/pr2_kinematics-release.git
-      version: 1.0.7-1
-    source:
-      type: git
-      url: https://github.com/pr2/pr2_kinematics.git
-      version: hydro-devel
-    status: maintained
   pr2_make_a_map_app:
     doc:
       type: git
@@ -5278,21 +5260,6 @@ repositories:
     source:
       type: git
       url: https://github.com/PR2/pr2_make_a_map_app.git
-      version: hydro-devel
-    status: maintained
-  pr2_map_navigation_app:
-    doc:
-      type: git
-      url: https://github.com/PR2/pr2_map_navigation_app.git
-      version: hydro-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/pr2-gbp/pr2_map_navigation_app-release.git
-      version: 1.0.2-0
-    source:
-      type: git
-      url: https://github.com/PR2/pr2_map_navigation_app.git
       version: hydro-devel
     status: maintained
   pr2_mechanism:
@@ -5399,6 +5366,23 @@ repositories:
     source:
       type: git
       url: https://github.com/PR2/pr2_props_app.git
+      version: hydro-devel
+    status: maintained
+  pr2_props_stack:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_props_stack.git
+      version: hydro-devel
+    release:
+      packages:
+      - pr2_props
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_props_stack-release.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_props_stack.git
       version: hydro-devel
     status: maintained
   prosilica_camera:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_props_stack` to `1.0.3-0`:
- upstream repository: https://github.com/pr2/pr2_props_stack.git
- release repository: https://github.com/pr2-gbp/pr2_props_stack-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## pr2_props
- No changes
