### PR TITLE
lama: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3106,7 +3106,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/lama-imr/lama-release.git
-      version: 0.1.1-4
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/lama-imr/lama.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lama` to `0.1.3-0`:
- upstream repository: https://github.com/lama-imr/lama.git
- release repository: https://github.com/lama-imr/lama-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.17`
- previous version for package: `0.1.1-4`
## lama_core

```
* Unchanged
```
## lama_interfaces

```
* debug instead of info
* more robust default engine
* change test target name
* remove unused test_interfaces.py
* add missing target dependency
* fix import in graph_builder.py
* Contributors: Gaël Ecorchard
```
## lama_jockeys

```
* lama_jockeys: cosmetic changes
* Contributors: Gaël Ecorchard
```
## lama_msgs

```
* Unchanged
```
