### PR TITLE
pr2_ethercat_drivers: 1.8.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5188,6 +5188,25 @@ repositories:
       url: https://github.com/pr2/pr2_delivery.git
       version: hydro-devel
     status: maintained
+  pr2_ethercat_drivers:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_ethercat_drivers.git
+      version: hydro-devel
+    release:
+      packages:
+      - ethercat_hardware
+      - fingertip_pressure
+      - pr2_ethercat_drivers
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_ethercat_drivers-release.git
+      version: 1.8.14-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_ethercat_drivers.git
+      version: hydro-devel
+    status: maintained
   pr2_gripper_sensor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_ethercat_drivers` to `1.8.14-0`:
- upstream repository: https://github.com/pr2/pr2_ethercat_drivers.git
- release repository: https://github.com/pr2-gbp/pr2_ethercat_drivers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
