### PR TITLE
pr2_shield_teleop: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5418,6 +5418,21 @@ repositories:
       url: https://github.com/PR2/pr2_ps3_joystick_app.git
       version: hydro-devel
     status: maintained
+  pr2_shield_teleop:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_shield_teleop.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_shield_teleop-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_shield_teleop.git
+      version: hydro-devel
+    status: maintained
   prosilica_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_shield_teleop` to `1.0.2-0`:
- upstream repository: https://github.com/PR2/pr2_shield_teleop.git
- release repository: https://github.com/pr2-gbp/pr2_shield_teleop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## pr2_shield_teleop
- No changes
