### PR TITLE
openslam_gmapping: 0.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -584,6 +584,17 @@ repositories:
       url: https://github.com/wg-perception/opencv_candidate.git
       version: master
     status: maintained
+  openslam_gmapping:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/openslam_gmapping-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/openslam_gmapping.git
+      version: master
+    status: maintained
   orocos_kinematics_dynamics:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `openslam_gmapping` to `0.1.0-0`:
- upstream repository: https://github.com/ros-perception/openslam_gmapping
- release repository: https://github.com/ros-gbp/openslam_gmapping-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## openslam_gmapping

```
* Forked from https://openslam.informatik.uni-freiburg.de/data/svn/gmapping/trunk/
* Catkinized and prepared for release into the ROS ecosystem
```
