### PR TITLE
pr2_simulator: 2.0.4-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5452,6 +5452,26 @@ repositories:
       url: https://github.com/PR2/pr2_shield_teleop.git
       version: hydro-devel
     status: maintained
+  pr2_simulator:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_simulator.git
+      version: hydro-devel
+    release:
+      packages:
+      - pr2_controller_configuration_gazebo
+      - pr2_gazebo
+      - pr2_gazebo_plugins
+      - pr2_simulator
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_simulator-release.git
+      version: 2.0.4-1
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_simulator.git
+      version: hydro-devel
+    status: maintained
   prosilica_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_simulator` to `2.0.4-1`:
- upstream repository: https://github.com/pr2/pr2_simulator.git
- release repository: https://github.com/pr2-gbp/pr2_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## pr2_controller_configuration_gazebo
- No changes
## pr2_gazebo
- No changes
## pr2_gazebo_plugins
- No changes
## pr2_simulator
- No changes
