### PR TITLE
naoqi_bridge: 0.4.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4334,6 +4334,7 @@ repositories:
       version: master
     release:
       packages:
+      - naoqi_apps
       - naoqi_bridge
       - naoqi_driver
       - naoqi_msgs
@@ -4342,7 +4343,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_bridge-release.git
-      version: 0.4.4-0
+      version: 0.4.5-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge` to `0.4.5-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_bridge.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.4.4-0`
## naoqi_apps

```
* add naoqi_apps
* Contributors: Vincent Rabaud
* add naoqi_apps
* Contributors: Vincent Rabaud
```
## naoqi_bridge
- No changes
## naoqi_driver

```
* DRIVER: Add node to send motion moveTo via rviz.
* propper install of the nodes
* Contributors: Vincent Rabaud, lsouchet
```
## naoqi_msgs
- No changes
## naoqi_sensors

```
* Update nodelet names in log messages
* Update names in nodelet launchfiles
* Update camera nodelet names in comments
* Update the xml for the camera nodelet
  During the restructuring the nodelet was renamed, but the metadata in the
  xml file was not updated. This breaks loading of the nodelet. Here the
  metadata is updated. Packages that use the nodelet will need to update
  their launchfiles.
* SENSORS: Publish octomap and sonars only when subscribed.
  Signed-off-by: lsouchet <mailto:lsouchet@aldebaran-robotics.com>
* remove debug line
* add raw depth support
* Contributors: Jon Dybeck, Vincent Rabaud, lsouchet
```
## naoqi_tools
- No changes
