### PR TITLE
pr2_tuck_arms_app: 1.0.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5488,6 +5488,21 @@ repositories:
       url: https://github.com/pr2/pr2_teleop_app.git
       version: hydro-devel
     status: maintained
+  pr2_tuck_arms_app:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_tuck_arms_app.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_tuck_arms_app-release.git
+      version: 1.0.3-1
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_tuck_arms_app.git
+      version: hydro-devel
+    status: maintained
   prosilica_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_tuck_arms_app` to `1.0.3-1`:
- upstream repository: https://github.com/PR2/pr2_tuck_arms_app.git
- release repository: https://github.com/pr2-gbp/pr2_tuck_arms_app-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## pr2_tuck_arms_app
- No changes
