### PR TITLE
wge100_driver: 1.8.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8403,6 +8403,25 @@ repositories:
       url: https://github.com/RobotWebTools/web_video_server.git
       version: develop
     status: maintained
+  wge100_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/wge100_driver.git
+      version: hydro-devel
+    release:
+      packages:
+      - wge100_camera
+      - wge100_camera_firmware
+      - wge100_driver
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/wge100_driver-release.git
+      version: 1.8.2-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/wge100_driver.git
+      version: hydro-devel
+    status: maintained
   willow_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wge100_driver` to `1.8.2-0`:
- upstream repository: https://github.com/ros-drivers/wge100_driver.git
- release repository: https://github.com/ros-drivers-gbp/wge100_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
