### PR TITLE
ueye: 0.0.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8544,7 +8544,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/kmhallen/ueye-release.git
-      version: 0.0.4-0
+      version: 0.0.6-0
     source:
       type: hg
       url: https://bitbucket.org/kmhallen/ueye


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye` to `0.0.6-0`:
- upstream repository: https://bitbucket.org/kmhallen/ueye
- release repository: https://github.com/kmhallen/ueye-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.0.4-0`
## ueye

```
* SDK downloads point to download.ros.org to support the legacy build-farm
* Contributors: Kevin Hallenbeck
```
