### PR TITLE
rviz: 1.11.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7188,7 +7188,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.11.4-0
+      version: 1.11.5-0
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.11.5-0`:
- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.11.4-0`
## rviz

```
* Tools (on the toolbar) can now indicate if they need access to keypresses by setting the ``access_all_keys_`` attribute.
  The handling of keypresses in tools has also been refactored. See: pull request #838 <https://github.com/ros-visualization/rviz/issues/838>
* Path display now has an additional display style called "Billboards" which allows to set the line width of the paths.
  It also now has an offset property to shift the path with regard to the fixed frame origin.
  See: pull request #842 <https://github.com/ros-visualization/rviz/issues/842>
* Meshes now have their ambient values scaled by 0.5 which gives a softer look, which is more in line with Gazebo's look and feel.
  See: pull request #841 <https://github.com/ros-visualization/rviz/issues/841>
* The default ambient color for meshes is now 0,0,0, down from 0.5,0.5,0.5.
  See: pull request #837 <https://github.com/ros-visualization/rviz/issues/837>
* Triangle-list markers are now shaded like other objects.
  See: pull request #833 <https://github.com/ros-visualization/rviz/issues/833>
* Color is now applied to all visuals of the line class, closes #820 <https://github.com/ros-visualization/rviz/issues/820>.
  See: pull request #827 <https://github.com/ros-visualization/rviz/issues/827>
* The find_package logic for assimp/yamlcpp has been moved to before add_library for librviz to fix building on OS X.
  See: pull request #825 <https://github.com/ros-visualization/rviz/issues/825>
* Fixed moc generation errors with boost >= 1.57.
  See: pull request #826 <https://github.com/ros-visualization/rviz/issues/826>
* Contributors: Daniel Stonier, Dave Hershberger, Henning Deeken, Michael Ferguson, Timm Linder, William Woodall, v4hn
```
