### PR TITLE
jsk_roseus: 1.2.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3183,7 +3183,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.2.3-0
+      version: 1.2.4-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.2.4-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.2.3-0`
## jsk_roseus
- No changes
## roseus

```
* do not run upstream message generation on buildfirm
* fir for generating manifest for packages does not have depends
* add test code for geneus
* more fix to generate-all-msg-srv
* fit for generating msgs
* add target package those who does not have msg files
* [roseus] generate-all-msgs-srv.sh fix for new geneus package
* roseus messages under home-dir is nolonger supported
* [roseus] add more debug messages ros message generation
* [roseus] test/test-genmsg.sh, fix typo start-from -> start-with for catkin-tools
* Contributors: Kei Okada
```
## roseus_smach
- No changes
## roseus_tutorials
- No changes
