### PR TITLE
object_recognition_core: 0.6.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4442,7 +4442,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_core-release.git
-      version: 0.6.4-0
+      version: 0.6.5-0
     source:
       type: git
       url: https://github.com/wg-perception/object_recognition_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_core` to `0.6.5-0`:
- upstream repository: https://github.com/wg-perception/object_recognition_core.git
- release repository: https://github.com/ros-gbp/object_recognition_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.6.4-0`
## object_recognition_core

```
* Properly install test macros
  This fixes #33 <https://github.com/wg-perception/object_recognition_core/issues/33>
* Don't throw when database is empty
  There is no need to throw here.
  The function load_fields_and_attachments works quite nicely
  for an empty database. The only thing it has to do is return...
  This makes it possible to use the rviz plugin OrkObject without
  a valid database (This obviously doesn't show meshes or the name then,
  but it's still useful as it prints confidence values and the object's key.
* Contributors: Michael Görner, Vincent Rabaud
```
