### PR TITLE
jsk_roseus: 1.2.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -444,7 +444,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.2.4-0
+      version: 1.2.5-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.2.5-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.2.4-0`
## jsk_roseus
- No changes
## roseus

```
* [roseus.cmake] add more condition
* [roseus] Add class to synchronize multiple topics with the same timestamp like message_filters
* Contributors: Kei Okada, Ryohei Ueda
```
