### PR TITLE
husky_bringup: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2189,7 +2189,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_bringup-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/husky/husky_bringup.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_bringup` to `0.1.2-0`:
- upstream repository: https://github.com/husky/husky_bringup.git
- release repository: https://github.com/clearpath-gbp/husky_bringup-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.1.1-0`
## husky_bringup

```
* Namespace fixes
* Contributors: Paul Bovbel
```
