### PR TITLE
husky_control: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2204,7 +2204,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_control-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/husky/husky_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_control` to `0.0.4-0`:
- upstream repository: https://github.com/husky/husky_control.git
- release repository: https://github.com/clearpath-gbp/husky_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.0.3-0`
## husky_control

```
* Namespace fixes
* Contributors: Paul Bovbel
```
