### PR TITLE
openrtm_aist: 1.1.0-12 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4984,7 +4984,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/openrtm_aist-release.git
-      version: 1.1.0-11
+      version: 1.1.0-12
     source:
       type: git
       url: https://github.com/tork-a/openrtm_aist-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist` to `1.1.0-12`:
- upstream repository: http://svn.openrtm.org/OpenRTM-aist/tags/RELEASE_1_1_0/OpenRTM-aist/
- release repository: https://github.com/tork-a/openrtm_aist-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.1.0-11`
