### PR TITLE
openrtm_aist: 1.1.0-26 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4784,11 +4784,19 @@ repositories:
       url: https://github.com/ros-drivers/openni_launch.git
       version: indigo-devel
   openrtm_aist:
+    doc:
+      type: git
+      url: https://github.com/tork-a/openrtm_aist-release.git
+      version: release/indigo/openrtm_aist
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/openrtm_aist-release.git
-      version: 1.1.0-25
+      version: 1.1.0-26
+    source:
+      type: git
+      url: https://github.com/tork-a/openrtm_aist-release.git
+      version: release/indigo/openrtm_aist
     status: developed
   openrtm_aist_python:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist` to `1.1.0-26`:
- upstream repository: http://svn.openrtm.org/OpenRTM-aist/tags/RELEASE_1_1_0/OpenRTM-aist/
- release repository: https://github.com/tork-a/openrtm_aist-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.1.0-25`
