### PR TITLE
wifi_ddwrt: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8430,6 +8430,21 @@ repositories:
       url: https://github.com/ros-drivers/wge100_driver.git
       version: hydro-devel
     status: maintained
+  wifi_ddwrt:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/wifi_ddwrt.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/wifi_ddwrt-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/wifi_ddwrt.git
+      version: hydro-devel
+    status: maintained
   willow_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wifi_ddwrt` to `0.2.0-0`:
- upstream repository: https://github.com/ros-drivers/wifi_ddwrt.git
- release repository: https://github.com/ros-gbp/wifi_ddwrt-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
