### PR TITLE
korg_nanokontrol: 0.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -488,6 +488,21 @@ repositories:
       url: https://github.com/tork-a/jskeus-release.git
       version: release/jade/jskeus
     status: developed
+  korg_nanokontrol:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/korg_nanokontrol.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/korg_nanokontrol-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/korg_nanokontrol.git
+      version: master
+    status: maintained
   message_generation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `korg_nanokontrol` to `0.1.2-0`:
- upstream repository: https://github.com/ros-drivers/korg_nanokontrol.git
- release repository: https://github.com/ros-gbp/korg_nanokontrol-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
