### PR TITLE
pr2_robot: 1.6.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5446,6 +5446,30 @@ repositories:
       url: https://github.com/PR2/pr2_ps3_joystick_app.git
       version: hydro-devel
     status: maintained
+  pr2_robot:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_robot.git
+      version: hydro-devel
+    release:
+      packages:
+      - imu_monitor
+      - pr2_bringup
+      - pr2_camera_synchronizer
+      - pr2_computer_monitor
+      - pr2_controller_configuration
+      - pr2_ethercat
+      - pr2_robot
+      - pr2_run_stop_auto_restart
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_robot-release.git
+      version: 1.6.7-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_robot.git
+      version: hydro-devel
+    status: maintained
   pr2_shield_teleop:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_robot` to `1.6.7-0`:
- upstream repository: https://github.com/pr2/pr2_robot.git
- release repository: https://github.com/pr2-gbp/pr2_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## imu_monitor
- No changes
## pr2_bringup

```
* Updated mainpage.dox
* Contributors: TheDash
```
## pr2_camera_synchronizer

```
* Updated mainpage.dox
* Contributors: TheDash
```
## pr2_computer_monitor

```
* Reverted changes
* Added dependencies in catkin
* Added catkin_package() to pr2_robot
* Updated mainpage.dox
* Fix binary location of network_detector
* Contributors: Ryohei Ueda, TheDash
```
## pr2_controller_configuration

```
* Updated mainpage.dox
* Corrected typo in description of pr2 effort controllers.
* Contributors: Georg Bartels, TheDash
```
## pr2_ethercat

```
* Updated mainpage.dox
* Contributors: TheDash
```
## pr2_robot
- No changes
## pr2_run_stop_auto_restart

```
* Compile pr2_run_stop_auto_restart after generating pr2_msgs c++ codes
* Contributors: Ryohei Ueda
```
