### PR TITLE
rviz: 1.11.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7245,7 +7245,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.11.5-0
+      version: 1.11.6-0
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.11.6-0`:
- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.11.5-0`
## rviz

```
* Fixed a mesh memory leak in ogre_helpers/mesh_shape.h/.cpp
  This fixes a memory leak which is caused due to no meshes ever being
  destroyed without removing the mesh from the mesh manager.
  This gets really bad when drawing meshes with 50K triangles at 10Hz,
  resulting in a leak rate @ ~60MB/sec.
* Add a simple 'About' dialog to the help menu.
* Contributors: Jonathan Bohren, William Woodall, gavanderhoorn
```
