### PR TITLE
rviz: 1.10.19-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7591,7 +7591,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.10.18-4
+      version: 1.10.19-0
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.10.19-0`:
- upstream repository: git@github.com:ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.10.18-4`
## rviz

```
* Fixed a mesh memory leak in ogre_helpers/mesh_shape.h/.cpp
  This fixes a memory leak which is caused due to no meshes ever being destroyed without removing the mesh from the mesh manager.
  This gets really bad when drawing meshes with 50K triangles at 10Hz, resulting in a leak rate @ ~60MB/sec.
* Map via QT signal instead of in ros thread
  Resolved issues when running RViz in rqt where the incoming Map callback is not issued from RViz's main QThread causing a crash in Ogre.
  Map updates are now handled by emitting a signal to update the map from the callback thread.
* Fixed read off end of array in triangle_list_marker.
* Fix add by topic for Marker and MarkerArray
* Contributors: Alex Bencz, Ben Charrow, Dave Hershberger, Jonathan Bohren, William Woodall
```
