### PR TITLE
ubiquity_motor: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8526,6 +8526,13 @@ repositories:
       url: https://github.com/orocos-toolchain/typelib.git
       version: toolchain-2.7
     status: maintained
+  ubiquity_motor:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
+      version: 0.1.0-0
+    status: developed
   ublox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ubiquity_motor` to `0.1.0-0`:
- upstream repository: https://github.com/UbiquityRobotics/ubiquity_motor.git
- release repository: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
