### PR TITLE
teleop_tools: 0.1.2-0 in 'indigo/distribution.yaml'

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7778,6 +7778,15 @@ repositories:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git
       version: indigo-devel
+    release:
+      packages:
+      - joy_teleop
+      - key_teleop
+      - teleop_tools
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/teleop_tools-release.git
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git


### PR DESCRIPTION
I had some network issues at the end of bloom release so had to the PR by hand.
