### PR TITLE
nmea_msgs: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4373,7 +4373,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/nmea_msgs-release.git
-      version: 0.1.0-1
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ros-drivers/nmea_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_msgs` to `0.1.1-0`:
- upstream repository: https://github.com/ros-drivers/nmea_msgs.git
- release repository: https://github.com/ros-drivers-gbp/nmea_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.1.0-1`
## nmea_msgs

```
* Cleanup CMakeLists.txt and package.xml
```
