### PR TITLE
jsk_common: 1.0.62-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3028,7 +3028,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.61-0
+      version: 1.0.62-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.62-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.0.61-0`
## assimp_devel
- No changes
## bayesian_belief_networks

```
* [bayesian_belief_networks] Fix setup.py for install python
* Contributors: Yuto Inagaki
```
## collada_urdf_jsk_patch

```
* [collada_urdf_jsk_patch] Remove urdf and urdfdom from package.xml
  because it should be resolved via collada_urdf package
* Contributors: Ryohei Ueda
```
## downward
- No changes
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha
- No changes
## image_view2

```
* [image_view2] Add utility script to scale mouse event from image_view2
  for resized image
* [image_view2] Initialize window_selection_ and font_ variable even in
  no-window mode
* [image_view2] Publish rectangular region infromation even in grabcut_rect mode
* [image_view2] Reset rectangle region when changing mode
* [image_view2] Add none mode to ignore any interaction with the user
* [image_view2] Add new flag: ratio_scale to pecify size of text by ratio
  to the size of image
* [image_view2] Add left_up_origin flag to ImageMarker2 to draw text from left up origin
* Contributors: Ryohei Ueda
```
## jsk_common
- No changes
## jsk_data
- No changes
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_network_tools

```
* [jsk_network_tools] Add ~packet_interval to highspeed streamer to avoid
  consuming too much bandwidth
* [jsk_network_tools] latch output of joint-state-decompressor.l
* [jsk_network_tools] Support messages which has longer joints than robot model
* [jsk_network_tools] Publish the last time to send/receive messages
* Contributors: Ryohei Ueda
```
## jsk_tilt_laser

```
* [jsk_tilt_laser] Add another argument to disable robot_state_publisher and
  robot_description perfectly
* Contributors: Ryohei Ueda
```
## jsk_tools

```
* [jsk_tools] Add script to see rosout in terminal
  Fix syntax
* [jsk_tools] Add more user to rename
* [jsk_tools] Install bin directory to lib directory
* Contributors: Ryohei Ueda
```
## jsk_topic_tools

```
* [jsk_topic_tools] Add ~latch option to snapshot nodelet
* Contributors: Ryohei Ueda
```
## julius
- No changes
## laser_filters_jsk_patch
- No changes
## libsiftfast
- No changes
## mini_maxwell
- No changes
## multi_map_server
- No changes
## nlopt

```
* corrected install locations
* flipped lib and include on install directive
* include files weren't properly included and the pattern matching for nlopt libraries needed to be fixed
* Contributors: C. Barrett Ames
```
## opt_camera
- No changes
## posedetection_msgs
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## sklearn
- No changes
## speech_recognition_msgs
- No changes
## virtual_force_publisher
- No changes
## voice_text
- No changes
