### PR TITLE
nao_robot: 0.5.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4286,7 +4286,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-naoqi/nao_robot-release.git
-      version: 0.5.3-0
+      version: 0.5.4-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_robot` to `0.5.4-0`:
- upstream repository: https://github.com/ros-naoqi/nao_robot.git
- release repository: https://github.com/ros-naoqi/nao_robot-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.5.3-0`
## nao_apps
- No changes
## nao_bringup

```
* configure sonars via namespace and params
* Contributors: Karsten Knese
```
## nao_description

```
* restore sensor in naoGazebo.xacro
* Contributors: Mikael Arguedas
```
## nao_pose
- No changes
## nao_robot
- No changes
