### PR TITLE
python-colorama is only available on trusty

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -215,7 +215,16 @@ python-clearsilver:
     trusty: [python-clearsilver]
 python-colorama:
   fedora: [python-colorama]
-  ubuntu: [python-colorama]
+  ubuntu:
+    lucid: []
+    maverick: []
+    natty: []
+    oneiric: []
+    precise: []
+    quantal: []
+    raring: []
+    saucy: []
+    trusty: [python-colorama]
 python-couchdb:
   debian: [python-couchdb]
   fedora: [python-couchdb]


### PR DESCRIPTION
see http://packages.ubuntu.com/search?lang=en&suite=trusty&searchon=names&keywords=python-colorama

or did you intened to install via pip?
