### PR TITLE
carl_safety: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -608,7 +608,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_safety-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_safety.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_safety` to `0.0.4-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_safety.git
- release repository: https://github.com/wpi-rail-release/carl_safety-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.0.3-0`
## carl_safety

```
* Adjusted finger current thresholds
* Fixed output message for finger joints on arm safety
* Adjustments for finger safety threshold
* Merge branch 'develop' of https://github.com/WPI-RAIL/carl_safety into develop
* Arm safety threshold tuning
* Contributors: David Kent
```
