### PR TITLE
rail_segmentation: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5751,7 +5751,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_segmentation.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_segmentation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_segmentation` to `0.0.5-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_segmentation.git
- release repository: https://github.com/wpi-rail-release/rail_segmentation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.0.4-0`
## rail_segmentation

```
* Fixed a possible exception thrown due to transforming a point cloud at an invalid time
* Merge branch 'develop' of github.com:WPI-RAIL/rail_segmentation into develop
* Added an automatic segmentation service which will determine how best to segment based on camera angle
* Contributors: David Kent
```
