### PR TITLE
rail_collada_models: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5703,7 +5703,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_collada_models-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_collada_models.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_collada_models` to `0.0.3-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_collada_models.git
- release repository: https://github.com/wpi-rail-release/rail_collada_models-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.0.2-0`
## rail_collada_models

```
* Merge pull request #10 from PeterMitrano/develop
  turned table
* added surface & turned table
* Merge branch 'develop' of https://github.com/WPI-RAIL/rail_collada_models into develop
* made kitchen table marker farther and correct direction
* Contributors: Peter, Russell Toris
```
