### PR TITLE
wpi_jaco: 0.0.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8589,7 +8589,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/wpi_jaco-release.git
-      version: 0.0.14-0
+      version: 0.0.15-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/wpi_jaco.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wpi_jaco` to `0.0.15-0`:
- upstream repository: https://github.com/RIVeR-Lab/wpi_jaco.git
- release repository: https://github.com/wpi-rail-release/wpi_jaco-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.0.14-0`
## jaco_description
- No changes
## jaco_interaction

```
* Updated interactive marker to use erase_trajectories service when the marker is released, giving the arm a more consistent stop
* Contributors: David Kent
```
## jaco_sdk
- No changes
## jaco_teleop
- No changes
## wpi_jaco
- No changes
## wpi_jaco_msgs
- No changes
## wpi_jaco_wrapper

```
* Documentation
* adjustment to erase trajectories service
* Merge branch 'develop' of https://github.com/RIVeR-Lab/wpi_jaco into develop
* Added some minor service calls to support some other packages
* Contributors: David Kent
```
