### PR TITLE
Revert "(Indigo) Add Nextage package"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7108,26 +7108,6 @@ repositories:
       url: https://github.com/start-jsk/rtmros_hironx.git
       version: hydro-devel
     status: developed
-  rtmros_nextage:
-    doc:
-      type: git
-      url: https://github.com/tork-a/rtmros_nextage.git
-      version: hydro-devel
-    release:
-      packages:
-      - nextage_description
-      - nextage_moveit_config
-      - nextage_ros_bridge
-      - rtmros_nextage
-      tags:
-        release: release/hydro/{package}/{version}
-      url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.6.0-0
-    source:
-      type: git
-      url: https://github.com/tork-a/rtmros_nextage.git
-      version: hydro-devel
-    status: developed
   rtshell:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#7286

Reviewing this content change this was released as hydro not indigo into the indigo rosdistro. 

The upstream can be the same, but it must be rereleased for indigo. 
@130s 
