### PR TITLE
carl_bot: 0.0.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -533,7 +533,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_bot-release.git
-      version: 0.0.15-0
+      version: 0.0.16-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_bot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_bot` to `0.0.16-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_bot.git
- release repository: https://github.com/wpi-rail-release/carl_bot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.0.15-0`
## carl_bot
- No changes
## carl_bringup
- No changes
## carl_description
- No changes
## carl_dynamixel

```
* Fixed a timestamp problem for tf lookups
* Documentation
* Asus servo commands to look at point or look at frame
* Contributors: David Kent
```
## carl_interactive_manipulation

```
* Update package.xml
* Merge pull request #25 from PeterMitrano/develop
  moved carl_parking to carl_interactive markers
* removed timeout and added intsallation
* Adjusted finger current thresholds
* Put a small threshold on executing an arm interactive marker recovery behavior to prevent it from activating on accidental clicks
* Adjustments for finger safety threshold.
* Lengthened distance of arm recovery behavior
* Documentation
* moved ros spin
* conformed to conventions
* Safety override for interactive marker control
* mend
* improved oop-ness
* removed unnessecary dependancy
* parking spots correctly appear
* improved oop structure. no statics
* oop works, but is really bad oop
* working on initializing static member
* made ParkingSpots class
* moved carl_parking to carl_interactive markers
* Contributors: David Kent, Peter, Russell Toris
```
## carl_phidgets
- No changes
## carl_teleop

```
* Changed teleop segment call to segment_auto
* Contributors: David Kent
```
## carl_tools

```
* Documentation
* Safety override for interactive marker control
* Contributors: David Kent
```
