### PR TITLE
interactive_world: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2578,7 +2578,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/interactive_world-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/interactive_world.git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_world` to `0.0.5-0`:
- upstream repository: https://github.com/WPI-RAIL/interactive_world.git
- release repository: https://github.com/wpi-rail-release/interactive_world-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.0.4-0`
## interactive_world
- No changes
## interactive_world_msgs
- No changes
## interactive_world_parser
- No changes
## interactive_world_tools
- No changes
## jinteractiveworld
- No changes
## spatial_world_model

```
* missing msg dep added
* Contributors: Russell Toris
```
