### PR TITLE
rail_pick_and_place: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5731,12 +5731,16 @@ repositories:
       version: master
     release:
       packages:
+      - rail_grasp_collection
+      - rail_grasping
       - rail_pick_and_place
       - rail_pick_and_place_msgs
+      - rail_pick_and_place_wrapper
+      - rail_recognition
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_pick_and_place.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_pick_and_place` to `0.0.2-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_pick_and_place.git
- release repository: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.0.1-0`
## rail_grasp_collection

```
* catkin cleanup
* Updated metapackage
* Grasp collection, model building, basic recognition and grasping
* Contributors: David Kent, Russell Toris
```
## rail_grasping

```
* catkin cleanup
* Updated metapackage
* Grasp collection, model building, basic recognition and grasping
* Contributors: David Kent, Russell Toris
```
## rail_pick_and_place

```
* Updated metapackage
* Contributors: David Kent
```
## rail_pick_and_place_msgs

```
* catkin cleanup
* Contributors: Russell Toris
```
## rail_pick_and_place_wrapper

```
* catkin cleanup
* Updated metapackage
* Grasp collection, model building, basic recognition and grasping
* Contributors: David Kent, Russell Toris
```
## rail_recognition

```
* catkin cleanup
* Updated metapackage
* Grasp collection, model building, basic recognition and grasping
* Contributors: David Kent, Russell Toris
```
