### PR TITLE
rospeex: 2.12.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7049,7 +7049,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://bitbucket.org/rospeex/rospeex-release.git
-      version: 2.12.3-1
+      version: 2.12.4-0
     source:
       type: git
       url: https://bitbucket.org/rospeex/rospeex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospeex` to `2.12.4-0`:
- upstream repository: https://bitbucket.org/rospeex/rospeex.git
- release repository: https://bitbucket.org/rospeex/rospeex-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `2.12.3-1`
## rospeex
- No changes
## rospeex_audiomonitor
- No changes
## rospeex_core

```
* Merge branch 'release/2.12.4'
* change application from ffplay to aplay.
```
## rospeex_if

```
* Merge branch 'release/2.12.4'
* change application from ffplay to aplay.
```
## rospeex_launch
- No changes
## rospeex_msgs
- No changes
## rospeex_samples
- No changes
## rospeex_webaudiomonitor
- No changes
