### PR TITLE
euslisp: 9.11.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1752,11 +1752,20 @@ repositories:
       version: hydro_devel
     status: maintained
   euslisp:
+    doc:
+      type: git
+      url: https://github.com/tork-a/euslisp-release.git
+      version: release/hydro/euslisp
     release:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/euslisp-release.git
-      version: 9.1.0-0
+      version: 9.11.0-0
+    source:
+      type: git
+      url: https://github.com/tork-a/euslisp-release.git
+      version: release/hydro/euslisp
+    status: developed
   executive_smach:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `euslisp` to `9.11.0-0`:
- upstream repository: https://github.com/euslisp/EusLisp
- release repository: https://github.com/tork-a/euslisp-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `9.1.0-0`
