### PR TITLE
web_video_server: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -9008,7 +9008,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/RobotWebTools-release/web_video_server-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/RobotWebTools/web_video_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `web_video_server` to `0.0.2-0`:
- upstream repository: https://github.com/RobotWebTools/web_video_server.git
- release repository: https://github.com/RobotWebTools-release/web_video_server-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.0.1-0`
## web_video_server

```
* Merge pull request #10 from mitchellwills/develop
  Added option to specify server address
* Added option to specify server address
* Merge pull request #3 from mitchellwills/develop
  Remove old http_server implementation and replace it with async_web_server_cpp package
* Moved from using built in http server to new async_web_server_cpp package
* Did some cleanup of streamers
* Update package.xml
* Contributors: Mitchell Wills, Russell Toris
```
