### PR TITLE
joint_state_publisher_js: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2973,6 +2973,21 @@ repositories:
       url: https://github.com/Kinovarobotics/jaco-ros.git
       version: hydro-devel
     status: maintained
+  joint_state_publisher_js:
+    doc:
+      type: git
+      url: https://github.com/DLu/joint_state_publisher_js.git
+      version: hydro
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/wu-robotics/joint_state_publisher_js_release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/DLu/joint_state_publisher_js.git
+      version: hydro
+    status: developed
   joy_teleop:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joint_state_publisher_js` to `0.0.1-0`:
- upstream repository: https://github.com/DLu/joint_state_publisher_js.git
- release repository: https://github.com/wu-robotics/joint_state_publisher_js_release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
