### PR TITLE
myahrs_driver: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4038,6 +4038,21 @@ repositories:
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
       version: master
     status: maintained
+  myahrs_driver:
+    doc:
+      type: git
+      url: https://github.com/robotpilot/myahrs_driver.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/robotpilot/myahrs_driver-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/robotpilot/myahrs_driver.git
+      version: master
+    status: maintained
   myo_ros:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `myahrs_driver` to `0.1.1-0`:
- upstream repository: https://github.com/robotpilot/myahrs_driver.git
- release repository: https://github.com/robotpilot/myahrs_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## myahrs_driver

```
* first public release for indigo
```
