### PR TITLE
husky_metapackages: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2237,7 +2237,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_metapackages-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/husky/husky_metapackages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_metapackages` to `0.1.1-0`:
- upstream repository: https://github.com/husky/husky_metapackages.git
- release repository: https://github.com/clearpath-gbp/husky_metapackages-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.1.0-0`
## husky_desktop

```
* Update description and docs
* Contributors: Paul Bovbel
```
## husky_robot

```
* Remove navigation
* Update description and docs
* Contributors: Paul Bovbel
```
