### PR TITLE
ros_comm_msgs: 1.11.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6355,7 +6355,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm_msgs-release.git
-      version: 1.10.3-0
+      version: 1.11.0-0
     source:
       type: git
       url: https://github.com/ros/ros_comm_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm_msgs` to `1.11.0-0`:
- upstream repository: https://github.com/ros/ros_comm_msgs.git
- release repository: https://github.com/ros-gbp/ros_comm_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.10.3-0`
## rosgraph_msgs

```
* bump version to fix hydro-indigo conflict (#3 <https://github.com/ros/ros_comm_msgs/issues/3>)
```
## std_srvs

```
* bump version to fix hydro-indigo conflict (#3 <https://github.com/ros/ros_comm_msgs/issues/3>)
```
