### PR TITLE
fixing xfs rules. xfs is only available on lucid and precise

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3078,7 +3078,9 @@ xfont-server:
   debian: [xfs]
   fedora: [libXfont]
   macports:
-  ubuntu: [xfs]
+  ubuntu:
+    lucid: [xfs]
+    precise: [xfs]
 xfonts-100dpi:
   debian: [xfonts-100dpi]
   fedora: [xorg-x11-fonts-100dpi]


### PR DESCRIPTION
 packages.ubuntu.com/search?keywords=xfs Fixes #5163
