### PR TITLE
Simplifying openscenegraph

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1587,17 +1587,7 @@ libopenscenegraph:
   gentoo:
     portage:
       packages: [dev-games/openscenegraph]
-  ubuntu:
-    karmic: [openscenegraph, libopenscenegraph-dev, libopenscenegraph56, libopenthreads-dev, libopenthreads12]
-    lucid: [openscenegraph, libopenscenegraph-dev, libopenscenegraph56, libopenthreads-dev, libopenthreads12]
-    maverick: [openscenegraph, libopenscenegraph-dev, libopenscenegraph65, libopenthreads-dev, libopenthreads13]
-    natty: [openscenegraph, libopenscenegraph-dev, libopenscenegraph65, libopenthreads-dev, libopenthreads13]
-    oneiric: [openscenegraph, libopenscenegraph-dev, libopenscenegraph80, libopenthreads-dev, libopenthreads14]
-    precise: [openscenegraph, libopenscenegraph-dev, libopenscenegraph80, libopenthreads-dev, libopenthreads14]
-    quantal: [openscenegraph, libopenscenegraph-dev, libopenscenegraph80, libopenthreads-dev, libopenthreads14]
-    raring: [openscenegraph, libopenscenegraph-dev, libopenscenegraph80, libopenthreads-dev, libopenthreads14]
-    saucy: [openscenegraph, libopenscenegraph-dev, libopenscenegraph80, libopenthreads-dev, libopenthreads14]
-    trusty: [openscenegraph, libopenscenegraph-dev, libopenscenegraph99, libopenthreads-dev, libopenthreads14]
+  ubuntu: [openscenegraph, libopenscenegraph-dev]
 libosmesa6-dev:
   arch: [mesa]
   debian: [libosmesa6-dev]


### PR DESCRIPTION
After some investigation:

openscenegraph depends on libopenscenegraphNN
libopenscenegraph-dev depends on libopenscenegraphNN
libopenscenegraph-dev depends on libopenthreads-dev
libopenthreads-dev depends on libopenthreadsNN

The original commit was over specified and extended in parallel by several people: https://github.com/ros/rosdistro/commit/7adeda25dce2e0fd06aed353710e6f361b3ab63e
