### PR TITLE
jsk_roseus: 1.2.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -467,7 +467,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.2.5-0
+      version: 1.2.6-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.2.6-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.2.5-0`
## jsk_roseus
- No changes
## roseus

```
* [test-genmsg.sh] fix for latest source code
* [CMakeLists.txt] create symlink from share/roseus -> ../../bin/roseus
* [test-genmsg.sh] fix typo rosun -> rosrun
* [test/test-genmsg.sh] add test for 'manifest should have all depends packages'
* [test/test-genmsg.sh] remove rosbuild settings
* [roseus] Install roseus binary to share directory
* [generate-all-msg-srv] fix msg gen
* Contributors: Yuki Furuta, Kei Okada, Yuto Inagaki
```
