### PR TITLE
geneus: 2.1.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -313,7 +313,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/geneus-release.git
-      version: 2.1.0-0
+      version: 2.1.1-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/geneus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geneus` to `2.1.1-0`:
- upstream repository: https://github.com/jsk-ros-pkg/geneus
- release repository: https://github.com/tork-a/geneus-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `2.1.0-0`
## geneus

```
* [geneus_main.py] use rospack to find build(only package have msg/src) dependency
* [.travis.yml] add test code to check work with roseus
* [src/geneus/geneus_main.py] add comments
* fix ros::load-ros-package order by dependencies
* Contributors: Kei Okada, Yuki Furuta
```
