### PR TITLE
jskeus: 1.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3239,7 +3239,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jskeus-release.git
-      version: 1.0.2-1
+      version: 1.0.3-0
   katana_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.0.3-0`:
- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.0.2-1`
## jskeus

```
* [PQP.cpp, euspng.c] cast for printf
* [irteus/irtgeo.c] inlucde math.c for function prototype
* output euscomp results to dev/null
* add test code for vplus/vector-mean
* [irteus/irtmath.l] add lms/lmeds and sv-decompose from euslib
* [irtc.c] add ql-decompose and qr-decompose
* Check only {name} and {name}-robot in maek-robot-model-from-name
* Add make-robot-model-from-name function to create instance of
  robot-model from the name of the robot
* Disable DISPLAY environmental variable during compilation
* Contributors: Kei Okada, Ryohei Ueda
```
