### PR TITLE
hector_quadrotor: 0.3.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2052,7 +2052,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_quadrotor-release.git
-      version: 0.3.3-0
+      version: 0.3.4-0
     status: maintained
   hector_quadrotor_apps:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_quadrotor` to `0.3.4-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_quadrotor-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.3.3-0`
## hector_quadrotor
- No changes
## hector_quadrotor_controller

```
* improved automatic landing detection and shutdown on rollovers
* slightly updated velocity controller limits and gains
* Contributors: Johannes Meyer
```
## hector_quadrotor_controller_gazebo
- No changes
## hector_quadrotor_demo
- No changes
## hector_quadrotor_description
- No changes
## hector_quadrotor_gazebo

```
* added missing run_depend hector_quadrotor_pose_estimation to package.xml
* set pose_estimation/publish_world_nav_transform parameter to true explicitly
* updated package for the latest version of hector_pose_estimation
  * Geographic reference latitude and longitude set to 49.860246N 8.687077E (Lichtwiese).
  * Reenabled auto_elevation, auto_reference and auto_heading parameters for hector_pose_estimation.
  hector_pose_estimation will publish the world->nav transform depending on its reference pose.
* added parameter file for hector_quadrotor_pose_estimation for a simulated quadrotor
  The parameter file disables the auto_elevation, auto_reference, auto_heading modes of hector_pose_estimation and sets the corresponding values
  manually with what is simulated in the gazebo sensor plugins. This simplifies the comparison of estimated poses with ground truth information.
* explicitly set the pose_estimation/nav_frame parameter in spawn_quadrotor.launch
* disabled detection of available plugins in cmake
  The aerodynamics and propulsion plugins are built unconditinally now in hector_quadrotor_gazebo_plugins and the detection is obsolete.
  Additionally we used platform-specific library prefixes and suffixes in find_libary() which caused errors on different platforms.
* Contributors: Johannes Meyer
```
## hector_quadrotor_gazebo_plugins

```
* added dynamic_reconfigure server to gazebo_ros_baro plugin
  See https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/commit/e1698e1c7bfa5fce6a724ab0a922a88bd49c9733 for
  the equivalent commit in hector_gazebo_plugins.
* publish propulsion and aerodynamic wrench as WrenchStamped
  This is primarily for debugging purposes.
  The default topic for the propulsion plugin has been changed to propulsion/wrench.
* disabled detection of available plugins in cmake
  The aerodynamics and propulsion plugins are built unconditinally now in hector_quadrotor_gazebo_plugins and the detection is obsolete.
  Additionally we used platform-specific library prefixes and suffixes in find_libary() which caused errors on different platforms.
* Contributors: Johannes Meyer
```
## hector_quadrotor_model

```
* make models more robust against irregular input values
  Especially on collisions with walls and obstacles Gazebo can output very high
  velocity values for some reason, which caused the propulsion and aerodynamic
  models to output infinite values or NaN as resulting forces and torques, with
  the consequence that Gazebo effectively stopped simulation and showed the quadrotor
  at the origin of the world frame.
  With this patch the simulation is much more stable in case of collisions or
  hard landings.
* disabled quadratic term (CT2s) in propeller speed to performance factor J
  Because of this term the model output a non-zero thrust even if the propeller speed was zero.
  The quadratic term is due to drag and therefore covered in the aerodynamics model.
* Contributors: Johannes Meyer
```
## hector_quadrotor_pose_estimation

```
* added missing install rule for hector_quadrotor_pose_estimation_nodelets.xml
  Many thanks to Bernd Kast for pointing me to this issue.
* update raw baro height as position.z component in sensor pose
  See https://github.com/tu-darmstadt-ros-pkg/hector_localization/commit/bd334f0e30c42fb5833fa8ffa249dfd737d43ddc.
* updated package for the latest version of hector_pose_estimation
  * Geographic reference latitude and longitude set to 49.860246N 8.687077E (Lichtwiese).
  * Reenabled auto_elevation, auto_reference and auto_heading parameters for hector_pose_estimation.
  hector_pose_estimation will publish the world->nav transform depending on its reference pose.
* added parameter file for hector_quadrotor_pose_estimation for a simulated quadrotor
  The parameter file disables the auto_elevation, auto_reference, auto_heading modes of hector_pose_estimation and sets the corresponding values
  manually with what is simulated in the gazebo sensor plugins. This simplifies the comparison of estimated poses with ground truth information.
* shutdown the height subscriber (in favor of topic alitimeter) to not have two height updates
* Contributors: Johannes Meyer
```
## hector_quadrotor_teleop

```
* Add optional parameter to set the joystick device
* Contributors: whoenig
```
## hector_uav_msgs
- No changes
