### PR TITLE
rtmros_nextage: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7127,6 +7127,26 @@ repositories:
       url: https://github.com/start-jsk/rtmros_hironx.git
       version: hydro-devel
     status: developed
+  rtmros_nextage:
+    doc:
+      type: git
+      url: https://github.com/tork-a/rtmros_nextage.git
+      version: hydro-devel
+    release:
+      packages:
+      - nextage_description
+      - nextage_moveit_config
+      - nextage_ros_bridge
+      - rtmros_nextage
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/rtmros_nextage-release.git
+      version: 0.6.0-0
+    source:
+      type: git
+      url: https://github.com/tork-a/rtmros_nextage.git
+      version: hydro-devel
+    status: maintained
   rtshell:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.6.0-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## nextage_description

```
* VRML stored location inside qnx is now NEXTAGE specific.
* (launch) Accept more as an argument. Remove a redundant collada file.
* Contributors: Isaac IY Saito
```
## nextage_moveit_config

```
* Remove non-existent eef groups.
* Contributors: Isaac IY Saito
```
## nextage_ros_bridge

```
* [nextage_ros_bridge] Fix path for catkin build
* VRML stored location inside qnx is now NEXTAGE specific.
* (launch) Accept more as an argument. Remove a redundant collada file.
* Contributors: Isaac IY Saito, Ryohei Ueda
```
## rtmros_nextage

```
* (IMPORTANT) VRML stored location inside qnx is now NEXTAGE specific. From now on, controller on QNX should be updated. Please open a ticket at https://github.com/tork-a/rtmros_nextage/issues if you have any convern.
* Adjust to catkin build
* Contributors: Isaac IY Saito, Ryohei Ueda
```
