### PR TITLE
um7: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8176,6 +8176,15 @@ repositories:
       version: indigo-devel
     status: maintained
   um7:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/um7.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/um7-release.git
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/ros-drivers/um7.git


### PR DESCRIPTION
Increasing version of package(s) in repository `um7` to `0.0.3-0`:
- upstream repository: https://github.com/ros-drivers/um7
- release repository: https://github.com/ros-drivers-gbp/um7-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
