### PR TITLE
hector_gazebo: 0.3.5-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2350,7 +2350,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
-      version: 0.3.4-0
+      version: 0.3.5-1
     status: maintained
   hector_localization:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_gazebo` to `0.3.5-1`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.3.4-0`
## hector_gazebo
- No changes
## hector_gazebo_plugins

```
* fixed simulated IMU calibration
* fill position_covariance in sensor_msgs/NavSatFix message from position error model in gazebo_ros_gps (fix #17)
* added dynamic_reconfigure servers to gps, magneto and sonar plugins
  The GPS plugin allows to configure the status and server flags in the output message,
  additionally to the error characteristics. This allows to simulate GPS dropouts.
* added dynamic_reconfigure server for IMU sensor model parameters
* fixed invocation of sensor model in gazebo_ros_imu and gazebo_ros_sonar to also respect the scale error
* calculate angular rate from quaternion difference directly
  This seems to be numerically more stable and removes the jitter in the angular rate signal.
* added initial bias
* added bias publisher to gazebo_ros_imu
  ...to compare hector_pose_estimation estimates with ground truth.
  Also renamed heading to yaw in gazebo_ros_imu and updated pseudo AHRS orientation calculation.
* added scale error to the sensor model and removed linearization in drift update
  The scale error is assumed to be constant and its value is loaded from the scaleError plugin parameter.
  The default scale error is 1.0 (no scale error).
  The value returned by the model is (real_value * scale_error) + offset + drift + noise.
* fixed wrong calculation of reference earth magnetic field vector if declination!=0
* Contributors: Johannes Meyer
```
## hector_gazebo_thermal_camera
- No changes
## hector_gazebo_worlds

```
* Change drc qual 4 settings to be same as current Atlas default
* Add drc final qual step block world and launch file
* 

    * Adjusted lighting

* 

    * Update world

* -Add inner block with stations model
* -Add complete sick robot day 2014 outer ring with stations
* -Add two target panel examples to world
* -Update world file
* -Add complete sick robot day 2014 target stations
* -Add inner block to world
* -Add inner block for sick robot day 2014
* -Add target model to sick robot day 2014 world
* -Add sick robot day target model
* Contributors: Stefan Kohlbrecher
```
## hector_sensors_gazebo
- No changes
