### PR TITLE
rosjava_build_tools: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6775,6 +6775,17 @@ repositories:
       url: https://github.com/OSUrobotics/rosh_robot_plugins.git
       version: master
     status: maintained
+  rosjava_build_tools:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosjava-release/rosjava_build_tools-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/rosjava/rosjava_build_tools.git
+      version: indigo
+    status: developed
   roslint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_build_tools` to `0.2.1-0`:
- upstream repository: https://github.com/rosjava/rosjava_build_tools.git
- release repository: https://github.com/rosjava-release/rosjava_build_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## rosjava_build_tools

```
* upgrade catkin create scripts for indigo
* support modules for genjava
* deprecated create msg package scripts
* minor bugfixes and improvements.
* Contributors: Benjamin Chrétien, Daniel Stonier, Martin Pecka
```
