### PR TITLE
rosjava_bootstrap: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6775,6 +6775,17 @@ repositories:
       url: https://github.com/OSUrobotics/rosh_robot_plugins.git
       version: master
     status: maintained
+  rosjava_bootstrap:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosjava-release/rosjava_bootstrap-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/rosjava/rosjava_bootstrap.git
+      version: indigo
+    status: maintained
   rosjava_build_tools:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_bootstrap` to `0.2.1-0`:
- upstream repository: https://github.com/rosjava/rosjava_bootstrap
- release repository: https://github.com/rosjava-release/rosjava_bootstrap-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## rosjava_bootstrap

```
* minor bugfixes and improvements.
* java source compatibility for java 1.6 -> 1.7
* centralised buildscript for java packages.
* add eclipse and idea plugins for easy ide support.
* Add support of UTF-8!
* update to the latest gradle plugin.
* single interface generator for genjava.
* Fix SSL connection errors with Java 1.7.
* Contributors: Damon Kohler, Daniel Stonier, Mickael Gaillard, talregev
```
