### PR TITLE
genjava: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1730,6 +1730,17 @@ repositories:
       url: https://github.com/jsk-ros-pkg/geneus.git
       version: master
     status: developed
+  genjava:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosjava-release/genjava-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/rosjava/genjava.git
+      version: indigo
+    status: maintained
   genlisp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genjava` to `0.1.1-0`:
- upstream repository: https://github.com/rosjava/genjava.git
- release repository: https://github.com/rosjava-release/genjava-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## genjava

```
* command line tools for building messages from the command line
* cmake api for building messages from catkin
* genjava api for building messages on the fly
* prototype version, builds mini gradle projects for each package
* Contributors: Daniel Stonier
```
