### PR TITLE
rosjava_test_msgs: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6789,6 +6789,17 @@ repositories:
       url: https://github.com/rosjava/rosjava_build_tools.git
       version: indigo
     status: developed
+  rosjava_test_msgs:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosjava-release/rosjava_test_msgs-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/rosjava/rosjava_test_msgs.git
+      version: indigo
+    status: maintained
   roslint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_test_msgs` to `0.2.1-0`:
- upstream repository: https://github.com/rosjava/rosjava_test_msgs.git
- release repository: https://github.com/rosjava-release/rosjava_test_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## rosjava_test_msgs

```
* moved from rosjava_messages (which is now a generator only).
```
