### PR TITLE
rosjava_messages: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6800,6 +6800,17 @@ repositories:
       url: https://github.com/rosjava/rosjava_build_tools.git
       version: indigo
     status: developed
+  rosjava_messages:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosjava-release/rosjava_messages-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/rosjava/rosjava_messages.git
+      version: indigo
+    status: developed
   rosjava_test_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_messages` to `0.2.1-0`:
- upstream repository: https://github.com/rosjava/rosjava_messages.git
- release repository: https://github.com/rosjava-release/rosjava_messages-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## rosjava_messages

```
* workaround for move_base_msgs (add roscpp as a msg package).
* dependencies for builds of rosjava/android core and android interactions added.
* restructured as a meta-message artifact generator of core messages only for indigo.
* Contributors: Daniel Stonier, Martin Pecka
```
