### PR TITLE
leap_motion: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3366,6 +3366,21 @@ repositories:
       url: https://github.com/ros-perception/laser_proc.git
       version: indigo-devel
     status: maintained
+  leap_motion:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/leap_motion.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/leap_motion-release.git
+      version: 0.0.7-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/leap_motion.git
+      version: master
+    status: maintained
   libccd:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `leap_motion` to `0.0.7-0`:
- upstream repository: https://github.com/ros-drivers/leap_motion
- release repository: https://github.com/ros-gbp/leap_motion-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## leap_motion

```
* Build some binaries only when SDK is installed (Fix to https://github.com/ros-drivers/leap_motion/issues/7).
* Contributors: Isaac I.Y. Saito, Yu Ohara
```
