### PR TITLE
jsk_pr2eus: 0.1.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2828,10 +2828,11 @@ repositories:
       packages:
       - jsk_pr2eus
       - pr2eus
+      - pr2eus_moveit
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_pr2eus-release.git
-      version: 0.1.7-0
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.1.8-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_pr2eus
- release repository: https://github.com/tork-a/jsk_pr2eus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.1.7-0`
## jsk_pr2eus
- No changes
## pr2eus

```
* Modify wrong maintainer and author name.
* [pr2eus/robot-interface.l] load rosgraph_msgs
* [pr2eus/catkin.cmake] need to call roseus at the end of find_package so that roseus.cmake can read all package files
* Contributors: Kei Okada, Yuto Inagaki
```
