### PR TITLE
rosjava_core: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6816,6 +6816,17 @@ repositories:
       url: https://github.com/rosjava/rosjava_build_tools.git
       version: indigo
     status: developed
+  rosjava_core:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosjava-release/rosjava_core-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/rosjava/rosjava_core.git
+      version: indigo
+    status: maintained
   rosjava_messages:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_core` to `0.2.1-0`:
- upstream repository: https://github.com/rosjava/rosjava_core
- release repository: https://github.com/rosjava-release/rosjava_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## rosjava_core

```
* allow setting of the talker topic name in pubsub tutorial.
* A more robust ntp provider.
* gradle 1.12 -> 2.2.1
* Add a comment explaining the disabling of SNI.
* Fix SSL connection errors with Java 1.7.
* Adds APIs to check the status of a service connection.
  Fixes bug that caused a disconnected service to be reused.
  Fixes bug in DefaultSubscriber that used the wrong class for logging.
* Changes FrameTransformTree to use GraphName instead of FrameName but still support tf2.
* Removed listAllInetAddress private method.
  Also renamed getAllInetAddressByName to getAllInetAddressesByName.
* Adds newNonLoopbackForNetworkInterface
  This is needed to allow the user to specify the ROS Hostname.
  An example application can: Run the ROS application through a VPN
  connection. The user would like to use the tunnel interface
  to creates the nodes and master.
* Contributors: Damon Kohler, Daniel Stonier, Lucas Chiesa, corot, damonkohler
```
