### PR TITLE
rosjava_extras: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6827,6 +6827,17 @@ repositories:
       url: https://github.com/rosjava/rosjava_core.git
       version: indigo
     status: maintained
+  rosjava_extras:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosjava-release/rosjava_extras-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/rosjava/rosjava_extras.git
+      version: indigo
+    status: maintained
   rosjava_messages:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_extras` to `0.2.1-0`:
- upstream repository: https://github.com/rosjava/rosjava_extras.git
- release repository: https://github.com/rosjava-release/rosjava_extras-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## rosjava_extras

```
* gradle 1.8 -> 2.2.1
* Contributors: Daniel Stonier
```
