### PR TITLE
zeroconf_jmdns_suite: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8933,6 +8933,17 @@ repositories:
       url: https://github.com/stonier/zeroconf_avahi_suite.git
       version: indigo
     status: developed
+  zeroconf_jmdns_suite:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosjava-release/zeroconf_jmdns_suite-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/rosjava/zeroconf_jmdns_suite.git
+      version: indigo
+    status: maintained
   zeroconf_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `zeroconf_jmdns_suite` to `0.2.1-0`:
- upstream repository: https://github.com/rosjava/zeroconf_jmdns_suite.git
- release repository: https://github.com/rosjava-release/zeroconf_jmdns_suite-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## zeroconf_jmdns_suite

```
* gradle 1.8 -> 2.2.1
* Contributors: Daniel Stonier
```
