### PR TITLE
mavlink: 2015.2.25-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -495,6 +495,17 @@ repositories:
       url: https://github.com/ros-drivers/korg_nanokontrol.git
       version: master
     status: maintained
+  mavlink:
+    doc:
+      type: git
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: release/jade/mavlink
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: 2015.2.25-0
+    status: maintained
   message_generation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2015.2.25-0`:
- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/mavlink/mavlink-gbp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
