### PR TITLE
mavros: 0.10.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3606,7 +3606,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.10.1-0
+      version: 0.10.2-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.10.2-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.10.1-0`
## libmavconn

```
* mavconn: fix readme link
* mavconn: Licensed under BSD 3-clause too, update headers for LGPLv3.
  PX4 team asked me to support BSD license.
* Contributors: Vladimir Ermakov
```
## mavros

```
* Document launch files
* launch: Fix vim modelines #213 <https://github.com/vooon/mavros/issues/213>
* launch #210 <https://github.com/vooon/mavros/issues/210>: blacklist image_pub by px4 default.
  Fix #210 <https://github.com/vooon/mavros/issues/210>.
* Contributors: Clay McClure, Vladimir Ermakov
```
## mavros_extras

```
* launch: Fix vim modelines #213 <https://github.com/vooon/mavros/issues/213>
* Contributors: Vladimir Ermakov
```
