### PR TITLE
mavros: 0.10.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -506,6 +506,25 @@ repositories:
       url: https://github.com/mavlink/mavlink-gbp-release.git
       version: 2015.2.25-0
     status: maintained
+  mavros:
+    doc:
+      type: git
+      url: https://github.com/mavlink/mavros.git
+      version: master
+    release:
+      packages:
+      - libmavconn
+      - mavros
+      - mavros_extras
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/mavlink/mavros-release.git
+      version: 0.10.2-0
+    source:
+      type: git
+      url: https://github.com/mavlink/mavros.git
+      version: master
+    status: developed
   message_generation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.10.2-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## libmavconn

```
* mavconn: fix readme link
* mavconn: Licensed under BSD 3-clause too, update headers for LGPLv3.
  PX4 team asked me to support BSD license.
* Contributors: Vladimir Ermakov
```
## mavros

```
* Document launch files
* launch: Fix vim modelines #213 <https://github.com/vooon/mavros/issues/213>
* launch #210 <https://github.com/vooon/mavros/issues/210>: blacklist image_pub by px4 default.
  Fix #210 <https://github.com/vooon/mavros/issues/210>.
* Contributors: Clay McClure, Vladimir Ermakov
```
## mavros_extras

```
* launch: Fix vim modelines #213 <https://github.com/vooon/mavros/issues/213>
* Contributors: Vladimir Ermakov
```
