### PR TITLE
ntpd_driver: 1.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -602,6 +602,21 @@ repositories:
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel
     status: maintained
+  ntpd_driver:
+    doc:
+      type: git
+      url: https://github.com/vooon/ntpd_driver.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/vooon/ntpd_driver-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/vooon/ntpd_driver.git
+      version: master
+    status: maintained
   object_recognition_capture:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ntpd_driver` to `1.0.2-0`:
- upstream repository: https://github.com/vooon/ntpd_driver.git
- release repository: https://github.com/vooon/ntpd_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## ntpd_driver

```
* Add example launch script.
* Add rosindex metadata.
* Contributors: Vladimir Ermakov
```
