### PR TITLE
concert_services: 0.1.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1051,7 +1051,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/concert_services-release.git
-      version: 0.1.7-0
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/concert_services.git


### PR DESCRIPTION
Increasing version of package(s) in repository `concert_services` to `0.1.8-0`:
- upstream repository: https://github.com/robotics-in-concert/concert_services.git
- release repository: https://github.com/yujinrobot-release/concert_services-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.1.7-0`
## concert_service_admin
- No changes
## concert_service_gazebo

```
* Update link to example in README
  At 6497f837e14672ebc05319534e1c4f8cbeb1860e of the rocon_demos repository
  (https://github.com/robotics-in-concert/rocon_demos), gazebo_solution was
  migrated to the rocon_tutorials repository
  (https://github.com/robotics-in-concert/rocon_tutorials) and renamed to
  "gazebo_concert". Compare with commit c92d9e40938f0b3e75979a7cba7dc52ceaf572c1
  of rocon_tutorials.
* Contributors: Scott Livingston
```
## concert_service_indoor_2d_map_prep
- No changes
## concert_service_teleop
- No changes
## concert_service_turtlesim

```
* provides args for shutdown subscriber closes #41 <https://github.com/robotics-in-concert/concert_services/issues/41>
* Contributors: Jihoon Lee
```
## concert_service_waypoint_navigation
- No changes
## concert_services
- No changes
