### PR TITLE
rocon_tutorials: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1051,7 +1051,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/concert_services-release.git
-      version: 0.1.8-0
+      version: 0.1.7-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/concert_services.git
@@ -6266,7 +6266,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_tutorials-release.git
-      version: 0.6.5-0
+      version: 0.6.6-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_tutorials` to `0.6.6-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_tutorials.git
- release repository: https://github.com/yujinrobot-release/rocon_tutorials-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.6.5-0`
## chatter_concert

```
* disable zeroconf option
* Contributors: Jihoon Lee
```
## gazebo_concert
- No changes
## rocon_app_manager_tutorials
- No changes
## rocon_gateway_tutorials
- No changes
## rocon_tutorials
- No changes
## turtle_concert

```
* default values for request turtle closes #58 <https://github.com/robotics-in-concert/rocon_tutorials/issues/58>
* Contributors: Jihoon Lee
```
