### PR TITLE
turtlebot: 2.3.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1051,7 +1051,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/concert_services-release.git
-      version: 0.1.8-0
+      version: 0.1.7-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/concert_services.git
@@ -8030,7 +8030,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot-release.git
-      version: 2.3.5-0
+      version: 2.3.6-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot` to `2.3.6-0`:
- upstream repository: https://github.com/turtlebot/turtlebot.git
- release repository: https://github.com/turtlebot-release/turtlebot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `2.3.5-0`
## turtlebot
- No changes
## turtlebot_bringup

```
* Merge pull request #194 <https://github.com/turtlebot/turtlebot/issues/194> from turtlebot/asus_center
  Configurable 3d sensor
* update urdf. now new position uses asus_xtion_pro. Old position is asus_xtion_pro_offset
* update env hook to  to use centered asus
* add 3dsensor aluncher
* asus is now default
* updates
* Merge branch 'indigo' into 3dsensor_config
* separate launchers for kinect and asus
* Contributors: Daniel Stonier, Jihoon Lee
```
## turtlebot_capabilities
- No changes
## turtlebot_description

```
* add reasons for comment #194 <https://github.com/turtlebot/turtlebot/issues/194>
* update urdf. now new position uses asus_xtion_pro. Old position is asus_xtion_pro_offset
* add asus, mount, and new pole
* add urdf for asus center located version
* Contributors: Jihoon Lee
```
## turtlebot_teleop

```
* remove turtlebot_teleop library from catkin_package call closes #192 <https://github.com/turtlebot/turtlebot/issues/192>
* remove old rosbuild imports no longer necessary
* Contributors: Jihoon Lee, Tully Foote
```
