### PR TITLE
turtlebot_create_desktop: 2.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8119,7 +8119,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_create_desktop-release.git
-      version: 2.3.0-0
+      version: 2.3.1-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot_create_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_create_desktop` to `2.3.1-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_create_desktop.git
- release repository: https://github.com/turtlebot-release/turtlebot_create_desktop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `2.3.0-0`
## create_dashboard

```
* create_dashboard: Fix some python syntax errors
  Even if this file isn't used, it will be bytecompiled when packaged for Fedora. This will fail if there are syntax errors in the file, so even if it is not used or has functional errors, it needs to be syntactically correct if it is in the repository.
* Contributors: Scott K Logan
```
## create_gazebo_plugins
- No changes
## turtlebot_create_desktop
- No changes
