### PR TITLE
rosjava: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6794,6 +6794,13 @@ repositories:
       url: https://github.com/OSUrobotics/rosh_robot_plugins.git
       version: master
     status: maintained
+  rosjava:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosjava-release/rosjava-release.git
+      version: 0.2.0-0
+    status: maintained
   rosjava_bootstrap:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava` to `0.2.0-0`:
- upstream repository: https://github.com/rosjava/rosjava.git
- release repository: https://github.com/rosjava-release/rosjava-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## rosjava

```
* updated dependencies for indigo
```
