### PR TITLE
nao_robot: 0.5.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4194,7 +4194,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/nao_robot-release.git
-      version: 0.5.5-0
+      version: 0.5.6-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_robot` to `0.5.6-0`:
- upstream repository: https://github.com/ros-naoqi/nao_robot.git
- release repository: https://github.com/ros-naoqi/nao_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.5.5-0`
## nao_apps

```
* Cleanup and rename launch files
* Contributors: Karsten Knese
```
## nao_bringup

```
* Cleanup and rename launch files
* Contributors: Karsten Knese
```
## nao_description

```
* properly fix 535d34474d9f64ddb60f6f163656c10fcdf92774
  The automatic generator was used to generate inertia
* dirty fix for naoqi_bridge/issues/31
* Minor fix to load RViz config file in display.launch
* fixing typo
* Cleanup and rename launch files
* Contributors: Karsten Knese, Konstantinos Chatzilygeroudis, Mikael Arguedas, Vincent Rabaud
```
## nao_pose
- No changes
## nao_robot
- No changes
