### PR TITLE
naoqi_bridge: 0.4.6-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4379,7 +4379,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_bridge-release.git
-      version: 0.4.5-0
+      version: 0.4.6-1
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge` to `0.4.6-1`:
- upstream repository: https://github.com/ros-naoqi/naoqi_bridge.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.4.5-0`
## naoqi_apps

```
* update wiki ros links
* update repo links in package.xml
* Contributors: Mikael Arguedas
```
## naoqi_bridge

```
* update wiki ros links
* update repo links in package.xml
* Contributors: Mikael Arguedas
```
## naoqi_driver

```
* update repo links in package.xml
* fix the naoqi_logger name
* fix bad nao_logger package
* readd logger
* Contributors: Mikael Arguedas, Vincent Rabaud
```
## naoqi_msgs

```
* update repo links in package.xml
* Contributors: Mikael Arguedas
```
## naoqi_sensors

```
* update repo links in package.xml
* use proper optical frames for the robot
* Contributors: Mikael Arguedas, Vincent Rabaud
```
## naoqi_tools

```
* Update README_run_blender_script.py.rst
* fix for issue 31: to be tested
* update wiki ros links
* update repo links in package.xml
* upload blender scripts
* add optical frames for each camera
* fix typo for inversion of sonars
* Use catkin_install_python macro
* Move generate_urdf.py system bin dir to package bin dir
* Contributors: Arguedas Mikael, Mikael Arguedas, Takashi Ogura, Vincent Rabaud
```
