### PR TITLE
freenect_stack: 0.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1652,7 +1652,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/freenect_stack-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/ros-drivers/freenect_stack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `freenect_stack` to `0.4.1-0`:
- upstream repository: https://github.com/ros-drivers/freenect_stack.git
- release repository: https://github.com/ros-drivers-gbp/freenect_stack-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.4.0-0`
## freenect_camera
- No changes
## freenect_launch

```
* fix tf_prefix leading slash issue #13 <https://github.com/ros-drivers/freenect_stack/issues/13>
* Contributors: Jihoon Lee, Piyush Khandelwal
```
## freenect_stack
- No changes
