### PR TITLE
message_multiplexing: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3654,6 +3654,7 @@ repositories:
       version: indigo
     release:
       packages:
+      - message_multiplexing
       - mm_core_msgs
       - mm_eigen_msgs
       - mm_messages
@@ -3663,7 +3664,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/message_multiplexing-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/stonier/message_multiplexing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_multiplexing` to `0.2.1-0`:
- upstream repository: https://github.com/stonier/message_multiplexing.git
- release repository: https://github.com/yujinrobot-release/message_multiplexing-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.2.0-0`
## message_multiplexing

```
* metapacakge added
```
