### PR TITLE
rocon_qt_gui: 0.7.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6215,7 +6215,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_qt_gui-release.git
-      version: 0.7.5-0
+      version: 0.7.6-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_qt_gui.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_qt_gui` to `0.7.6-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_qt_gui.git
- release repository: https://github.com/yujinrobot-release/rocon_qt_gui-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.7.5-0`
## concert_admin_app

```
* fix return values of  setting configuration in admin app
* Contributors: dwlee
```
## concert_conductor_graph
- No changes
## concert_qt_make_a_map
- No changes
## concert_qt_map_annotation
- No changes
## concert_qt_service_info
- No changes
## concert_qt_teleop
- No changes
## rocon_gateway_graph
- No changes
## rocon_qt_app_manager
- No changes
## rocon_qt_gui
- No changes
## rocon_qt_library
- No changes
## rocon_qt_listener
- No changes
## rocon_qt_master_info
- No changes
## rocon_qt_teleop
- No changes
## rocon_remocon

```
* reverting the master checking process #180 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/180>
* check all cached master status when it starts up. closes #180 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/180>
* Contributors: Jihoon Lee
```
