### PR TITLE
roswww: 0.1.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7184,7 +7184,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/roswww-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/tork-a/roswww.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roswww` to `0.1.5-0`:
- upstream repository: https://github.com/tork-a/roswww.git
- release repository: https://github.com/tork-a/roswww-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.4-0`
## roswww

```
* Install missing launch directory
* Contributors: Jihoon Lee
```
