### PR TITLE
rosdoc_lite: 0.2.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6731,7 +6731,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rosdoc_lite-release.git
-      version: 0.2.4-0
+      version: 0.2.5-0
     source:
       type: git
       url: https://github.com/ros-infrastructure/rosdoc_lite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosdoc_lite` to `0.2.5-0`:
- upstream repository: https://github.com/ros-infrastructure/rosdoc_lite.git
- release repository: https://github.com/ros-gbp/rosdoc_lite-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.4-0`
## rosdoc_lite

```
* Add autodoc to sphinx config.
* Use generator specific output folder.
* Move import to local scope, since when the new API is being invoked
  from jenkins_scripts genmsg is not on the Python path.
* Add API to provide generator specific output folders.
* Run epydoc in the package folder.
* Print output from epydoc invocation (fix #50 <https://github.com/ros-infrastructure/rosdoc_lite/issues/50>).
* Update doxygen template to disable external groups and pages.
* Update doxygen template to 1.8.6.
* Contributors: Dirk Thomas, Jack O'Quin, Jonathan Bohren
```
