### PR TITLE
Define package names for python-sphinx in Jade.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1390,6 +1390,8 @@ python-sphinx:
     saucy: [python-sphinx]
     trusty: [python-sphinx]
     trusty_python3: [python3-sphinx]
+    utopic: [python-sphinx]
+    vivid: [python-sphinx]
 python-sqlalchemy:
   debian: [python-sqlalchemy]
   fedora: [python-sqlalchemy]


### PR DESCRIPTION
Define Utopic and Vivid package names for python-sphinx.
