### PR TITLE
ackermann_msgs: 0.9.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -11,6 +11,21 @@ release_platforms:
   - utopic
   - vivid
 repositories:
+  ackermann_msgs:
+    doc:
+      type: git
+      url: https://github.com/jack-oquin/ackermann_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/jack-oquin/ackermann_msgs-release.git
+      version: 0.9.1-0
+    source:
+      type: git
+      url: https://github.com/jack-oquin/ackermann_msgs.git
+      version: master
+    status: maintained
   actionlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ackermann_msgs` to `0.9.1-0`:
- upstream repository: https://github.com/jack-oquin/ackermann_msgs.git
- release repository: https://github.com/jack-oquin/ackermann_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## ackermann_msgs

```
* Export architecture_independent flag in package.xml (#3 <https://github.com/jack-oquin/ackermann_msgs/issues/3>), thanks
  to Scott K Logan
```
