### PR TITLE
unique_identifier: 1.0.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1013,6 +1013,25 @@ repositories:
       url: https://github.com/anqixu/ueye_cam.git
       version: master
     status: developed
+  unique_identifier:
+    doc:
+      type: git
+      url: https://github.com/ros-geographic-info/unique_identifier.git
+      version: master
+    release:
+      packages:
+      - unique_id
+      - unique_identifier
+      - uuid_msgs
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-geographic-info/unique_identifier-release.git
+      version: 1.0.4-0
+    source:
+      type: git
+      url: https://github.com/ros-geographic-info/unique_identifier.git
+      version: master
+    status: maintained
   urdfdom_py:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `unique_identifier` to `1.0.4-0`:
- upstream repository: https://github.com/ros-geographic-info/unique_identifier.git
- release repository: https://github.com/ros-geographic-info/unique_identifier-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## unique_id
- No changes
## unique_identifier
- No changes
## uuid_msgs
- No changes
