### PR TITLE
genjava: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1735,7 +1735,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rosjava-release/genjava-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/rosjava/genjava.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genjava` to `0.1.4-0`:
- upstream repository: https://github.com/rosjava/genjava.git
- release repository: https://github.com/rosjava-release/genjava-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.1.3-0`
## genjava

```
* generate_rosjava_messages cmake api needs the rosjava environment.
* Contributors: Daniel Stonier
```
