### PR TITLE
rocon_rosjava_core: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6221,6 +6221,17 @@ repositories:
       url: https://github.com/robotics-in-concert/rocon_qt_gui.git
       version: indigo
     status: developed
+  rocon_rosjava_core:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/rocon_rosjava_core-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_rosjava_core.git
+      version: indigo
+    status: developed
   rocon_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_rosjava_core` to `0.2.0-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_rosjava_core.git
- release repository: https://github.com/yujinrobot-release/rocon_rosjava_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## rocon_rosjava_core

```
* First build on indigo
```
