### PR TITLE
rosjava: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6827,11 +6827,19 @@ repositories:
       version: master
     status: maintained
   rosjava:
+    doc:
+      type: git
+      url: https://github.com/rosjava/rosjava.git
+      version: indigo
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rosjava-release/rosjava-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/rosjava/rosjava.git
+      version: indigo
     status: maintained
   rosjava_bootstrap:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava` to `0.2.1-0`:
- upstream repository: https://github.com/rosjava/rosjava.git
- release repository: https://github.com/rosjava-release/rosjava-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.2.0-0`
## rosjava

```
* added rocon_rosjava_core to the dependencies.
```
