### PR TITLE
rospilot_deps: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6983,7 +6983,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rospilot/rospilot_deps-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/rospilot/rospilot_deps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot_deps` to `0.0.7-0`:
- upstream repository: https://github.com/rospilot/rospilot_deps.git
- release repository: https://github.com/rospilot/rospilot_deps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.6-0`
## rospilot_deps

```
* Add Exynos MFC library
* Contributors: Christopher Berner
```
