### PR TITLE
kobuki_desktop: 0.4.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3090,7 +3090,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki_desktop-release.git
-      version: 0.4.1-0
+      version: 0.4.2-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_desktop` to `0.4.2-0`:
- upstream repository: https://github.com/yujinrobot/kobuki_desktop.git
- release repository: https://github.com/yujinrobot-release/kobuki_desktop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.4.1-0`
## kobuki_dashboard
- No changes
## kobuki_desktop
- No changes
## kobuki_gazebo
- No changes
## kobuki_gazebo_plugins

```
* kobuki_gazebo_plugins: Resolve IMU sensor using fully scoped name
  This ensures uniqueness among multiple models in which the sensor has the
  same name. In this case, our specific motivation is the Kobuki Gazebo
  plugin being spawned multiple times using kobuki_gazebo.urdf.xacro in the
  package kobuki_description.
* Contributors: Scott Livingston
```
## kobuki_qtestsuite
- No changes
## kobuki_rviz_launchers
- No changes
