### PR TITLE
rocon_tools: 0.1.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6276,7 +6276,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_tools-release.git
-      version: 0.1.15-0
+      version: 0.1.16-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_tools` to `0.1.16-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_tools.git
- release repository: https://github.com/yujinrobot-release/rocon_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.15-0`
## rocon_bubble_icons
- No changes
## rocon_console
- No changes
## rocon_ebnf
- No changes
## rocon_icons
- No changes
## rocon_interactions
- No changes
## rocon_launch
- No changes
## rocon_master_info
- No changes
## rocon_python_comms

```
* use exceptions informative way #79 <https://github.com/robotics-in-concert/rocon_tools/issues/79>
* update logic of find_service_namespace #79 <https://github.com/robotics-in-concert/rocon_tools/issues/79>
* rename is_valid_service
* rename is_valid_service to service_is_available
* update namespace finder and service validation checker
* Contributors: Jihoon Lee, dwlee
```
## rocon_python_redis
- No changes
## rocon_python_utils
- No changes
## rocon_python_wifi
- No changes
## rocon_semantic_version
- No changes
## rocon_tools
- No changes
## rocon_uri
- No changes
