### PR TITLE
Adding tinkerforge_laser_transform to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8048,6 +8048,16 @@ repositories:
       url: https://github.com/wcaarls/threemxl.git
       version: master
     status: maintained
+  tinkerforge_laser_transform:
+    doc:
+      type: git
+      url: https://github.com/gus484/ros.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/gus484/ros.git
+      version: indigo-devel
+    status: developed
   topic_proxy:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8052,11 +8052,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/gus484/ros.git
-      version: indigo-devel
+      version: master
     source:
       type: git
       url: https://github.com/gus484/ros.git
-      version: indigo-devel
+      version: master
     status: developed
   topic_proxy:
     doc:


### PR DESCRIPTION
I'd like tinkerforge_laser_transform to be indexed and documented on ros.org.
