### PR TITLE
stage_ros: 1.7.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -968,6 +968,21 @@ repositories:
       url: https://github.com/ros-gbp/stage-release.git
       version: 4.1.1-1
     status: maintained
+  stage_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-simulation/stage_ros.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/stage_ros-release.git
+      version: 1.7.3-0
+    source:
+      type: git
+      url: https://github.com/ros-simulation/stage_ros.git
+      version: master
+    status: maintained
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stage_ros` to `1.7.3-0`:
- upstream repository: https://github.com/ros-simulation/stage_ros.git
- release repository: https://github.com/ros-gbp/stage_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## stage_ros

```
* Split up ``fltk`` dep into ``libfltk-dev`` and ``fluid``, only ``run_depend``'ing on fluid.
* Now supports multiple robots with multiple sensors.
* Fixed a bug on systems that cannot populate FLTK_INCLUDE_DIRS.
* Updated topurg model from "laser" to "ranger".
* Added -u option to use name property of position models as its namespace instead of "robot_0", "robot_1", etc.
* Contributors: Gustavo Velasco Hernández, Gustavo Velasco-Hernández, Pablo Urcola, Wayne Chang, William Woodall
```
