### PR TITLE
cmvision: 0.4.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -757,7 +757,8 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/cmvision-release.git
-      version: 0.4.1-0
+      version: 0.4.2-0
+    status: maintained
   cmvision_3d:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cmvision` to `0.4.2-0`:
- upstream repository: https://github.com/utexas-bwi/cmvision.git
- release repository: https://github.com/utexas-bwi-gbp/cmvision-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.4.1-0`
## cmvision

```
* Merge pull request #2 <https://github.com/utexas-bwi/cmvision/issues/2> from OSUrobotics/hydro-devel
  Include color name in the blob message.
* Contributors: Alex Hubers
```
