### PR TITLE
lyap_control: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3551,6 +3551,13 @@ repositories:
       url: https://github.com/orocos-toolchain/log4cpp.git
       version: toolchain-2.8
     status: maintained
+  lyap_control:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/AndyZelenak/lyap_control-release.git
+      version: 0.0.1-0
+    status: developed
   m4atx_battery_monitor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lyap_control` to `0.0.1-0`:
- upstream repository: https://AndyZe@bitbucket.org/AndyZe/lyap_control.git
- release repository: https://github.com/AndyZelenak/lyap_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## lyap_control

```
* Pre-release commit.
* Contributors: Andy Zelenak
```
