### PR TITLE
geometry_tutorials: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1896,7 +1896,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry_tutorials-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/ros/geometry_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_tutorials` to `0.2.2-0`:
- upstream repository: https://github.com/ros/geometry_tutorials
- release repository: https://github.com/ros-gbp/geometry_tutorials-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.1-0`
## geometry_tutorials
- No changes
## turtle_tf

```
* remove old roslib invocations
* Contributors: Tully Foote
```
## turtle_tf2

```
* homogenizing install rules and script locations with older versions
* remove old roslib invocations
* Contributors: Tully Foote
```
