### PR TITLE
find_object_2d: 0.5.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1869,6 +1869,13 @@ repositories:
       url: https://github.com/ros/filters.git
       version: hydro-devel
     status: maintained
+  find_object_2d:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/introlab/find_object_2d-release.git
+      version: 0.5.1-0
+    status: maintained
   flir_ptu:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `find_object_2d` to `0.5.1-0`:
- upstream repository: https://find-object.googlecode.com/svn/files/ros/find_object_2d-0.5.1.tar.gz
- release repository: https://github.com/introlab/find_object_2d-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
