### PR TITLE
Adding "find_object_2d" package to documentation index

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1870,6 +1870,10 @@ repositories:
       version: hydro-devel
     status: maintained
   find_object_2d:
+    doc:
+      type: svn
+      url: https://find-object.googlecode.com/svn/trunk/ros-pkg/find_object_2d
+      version: HEAD
     release:
       tags:
         release: release/hydro/{package}/{version}


### PR DESCRIPTION
I'd like find_object_2d to be indexed on ros.org
