### PR TITLE
rtctree: 3.0.3-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7411,7 +7411,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtctree-release.git
-      version: 3.0.1-1
+      version: 3.0.3-2
     status: developed
   rtmros_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtctree` to `3.0.3-2`:
- upstream repository: https://github.com/gbiggs/rtctree.git
- release repository: https://github.com/tork-a/rtctree-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `3.0.1-1`
