### PR TITLE
rtsprofile: 3.0.3-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7516,7 +7516,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtsprofile-release.git
-      version: 2.0.0-1
+      version: 3.0.3-2
     status: developed
   rtt:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtsprofile` to `3.0.3-2`:
- upstream repository: https://github.com/gbiggs/rtsprofile.git
- release repository: https://github.com/tork-a/rtsprofile-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `2.0.0-1`
