### PR TITLE
mavros: 0.8.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3824,7 +3824,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.8.5-0
+      version: 0.8.6-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.8.6-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.8.5-0`
## libmavconn
- No changes
## mavros

```
* plugin: param: Fix build error #237 <https://github.com/vooon/mavros/issues/237>.
  Master alredy fixed, see #170 <https://github.com/vooon/mavros/issues/170>.
* Contributors: Vladimir Ermakov
```
## mavros_extras
- No changes
