### PR TITLE
repository_name: 2.0.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6162,6 +6162,14 @@ repositories:
       url: https://github.com/ros-gbp/reflexxes_type2-release.git
       version: 1.2.4-0
     status: maintained
+  repository_name:
+    release:
+      packages:
+      - iiwa
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/stanfordroboticslab/iiwa-release.git
+      version: 2.0.0-1
   retalis:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `repository_name` to `2.0.0-1`:
- upstream repository: https://bitbucket.org/khansari/iiwa.git
- release repository: https://github.com/stanfordroboticslab/iiwa-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
