### PR TITLE
stage_ros: 1.7.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7911,7 +7911,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/stage_ros-release.git
-      version: 1.7.3-0
+      version: 1.7.4-0
     source:
       type: git
       url: https://github.com/ros-simulation/stage_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `stage_ros` to `1.7.4-0`:
- upstream repository: https://github.com/ros-simulation/stage_ros.git
- release repository: https://github.com/ros-gbp/stage_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.7.3-0`
## stage_ros

```
* Added missing -ldl flag on newer versions of Ubuntu
* Contributors: William Woodall
```
