### PR TITLE
lyap_control: 0.0.6-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3556,7 +3556,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/AndyZelenak/lyap_control-release.git
-      version: 0.0.1-0
+      version: 0.0.6-1
+    source:
+      type: git
+      url: https://AndyZe@bitbucket.org/AndyZe/lyap_control.git
+      version: 0.0.6
     status: developed
   m4atx_battery_monitor:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `lyap_control` to `0.0.6-1`:
- upstream repository: https://AndyZe@bitbucket.org/AndyZe/lyap_control.git
- release repository: https://github.com/AndyZelenak/lyap_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.1-0`
## lyap_control

```
* Attempting to update documentation website again.
* Contributors: Andy Zelenak
```
