### PR TITLE
lyap_control: 0.0.6-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3552,11 +3552,19 @@ repositories:
       version: toolchain-2.8
     status: maintained
   lyap_control:
+    doc:
+      type: git
+      url: https://AndyZe@bitbucket.org/AndyZe/lyap_control.git
+      version: public
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/AndyZelenak/lyap_control-release.git
-      version: 0.0.1-0
+      version: 0.0.6-2
+    source:
+      type: git
+      url: https://AndyZe@bitbucket.org/AndyZe/lyap_control.git
+      version: public
     status: developed
   m4atx_battery_monitor:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `lyap_control` to `0.0.6-2`:
- upstream repository: https://AndyZe@bitbucket.org/AndyZe/lyap_control.git
- release repository: https://github.com/AndyZelenak/lyap_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.1-0`
## lyap_control

```
* Attempting to update documentation website again.
* Contributors: Andy Zelenak
```
