### PR TITLE
acado: 1.2.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14,7 +14,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/clearpath-gbp/acado-release.git
-      version: release/indigo/acado
+      version: upstream-patched
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -23,7 +23,7 @@ repositories:
     source:
       type: git
       url: https://github.com/clearpath-gbp/acado-release.git
-      version: release/indigo/acado
+      version: upstream-patched
     status: maintained
   ackermann_msgs:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10,6 +10,21 @@ release_platforms:
   - saucy
   - trusty
 repositories:
+  acado:
+    doc:
+      type: git
+      url: https://github.com/clearpath-gbp/acado-release.git
+      version: release/indigo/acado
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/acado-release.git
+      version: 1.2.1-1
+    source:
+      type: git
+      url: https://github.com/clearpath-gbp/acado-release.git
+      version: release/indigo/acado
+    status: maintained
   ackermann_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `acado` to `1.2.1-1`:
- upstream repository: https://github.com/acado/acado.git
- release repository: https://github.com/clearpath-gbp/acado-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
