### PR TITLE
robot_calibration: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6003,6 +6003,15 @@ repositories:
       url: https://github.com/WPI-RAIL/rmp_msgs.git
       version: develop
     status: maintained
+  robot_calibration:
+    release:
+      packages:
+      - robot_calibration
+      - robot_calibration_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/robot_calibration-release.git
+      version: 0.1.1-0
   robot_localization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.1.1-0`:
- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/fetchrobotics-gbp/robot_calibration-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## robot_calibration

```
* first release
* Contributors: Michael Ferguson
```
## robot_calibration_msgs

```
* split out messages into separate package
* Contributors: Michael Ferguson
```
