### PR TITLE
libnabo: 1.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3454,7 +3454,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-asl/libnabo-release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/ethz-asl/libnabo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libnabo` to `1.0.6-0`:
- upstream repository: https://github.com/ethz-asl/libnabo.git
- release repository: https://github.com/ethz-asl/libnabo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.5-0`
## libnabo

```
* Reset point indices of results with distances exceeding threshold (#23, #24)
* Fine tune the find_package() capability and add uninstall target (#22)
* Fixed compiler warning (#18)
* Added OpenMP support (#20, #21)
* Build type tuning (#19)
* Fix: terminal comma in enum requires C++11
* Fix UBSAN error calculating maxNodeCount (#16, #17)
* Fixed tiny (yet significant) error in the Python doc strings (#15)
* Compile static lib with PIC (#14)
* Contributors: Francois Pomerleau, François Pomerleau, Gregory Hitz, Gregory Jefferis, Simon Lynen, Stéphane Magnenat
```
