### PR TITLE
epos_hardware: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1578,7 +1578,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RIVeR-Lab-release/epos_hardware-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/epos_hardware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `epos_hardware` to `0.0.2-0`:
- upstream repository: https://github.com/RIVeR-Lab/epos_hardware.git
- release repository: https://github.com/RIVeR-Lab-release/epos_hardware-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.1-0`
## epos_hardware

```
* Fixed so that udev rules file and example launch files are actually installed
* Contributors: Mitchell Wills
```
## epos_library
- No changes
