### PR TITLE
denso: 0.2.9-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1306,7 +1306,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/start-jsk/denso-release.git
-      version: 0.2.8-0
+      version: 0.2.9-0
     source:
       type: git
       url: https://github.com/start-jsk/denso.git


### PR DESCRIPTION
Increasing version of package(s) in repository `denso` to `0.2.9-0`:
- upstream repository: https://github.com/start-jsk/denso.git
- release repository: https://github.com/start-jsk/denso-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.8-0`
## denso

```
* Add missing .setup_assistant file, without which moveit_setup_assistant can't open an existing moveit config pkg.
* Check-off query start state from RViz conf.
* Contributors: Isaac IY Saito
```
## denso_controller
- No changes
## denso_launch
- No changes
## vs060
- No changes
## vs060_moveit_config

```
* Add missing .setup_assistant file, without which moveit_setup_assistant can't open an existing moveit config pkg.
* Check-off query start state from RViz conf.
* Contributors: Isaac IY Saito
```
