### PR TITLE
arbotix_ros: 0.10.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -56,6 +56,28 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  arbotix_ros:
+    doc:
+      type: git
+      url: https://github.com/vanadiumlabs/arbotix_ros.git
+      version: indigo-devel
+    release:
+      packages:
+      - arbotix
+      - arbotix_controllers
+      - arbotix_firmware
+      - arbotix_msgs
+      - arbotix_python
+      - arbotix_sensors
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/vanadiumlabs/arbotix_ros-release.git
+      version: 0.10.0-0
+    source:
+      type: git
+      url: https://github.com/vanadiumlabs/arbotix_ros.git
+      version: indigo-devel
+    status: maintained
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `arbotix_ros` to `0.10.0-0`:
- upstream repository: https://github.com/vanadiumlabs/arbotix_ros.git
- release repository: https://github.com/vanadiumlabs/arbotix_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## arbotix
- No changes
## arbotix_controllers

```
* Set queue_size=5 on all publishers
* Check if command exceeds opening limits
* Contributors: Jorge Santos
```
## arbotix_firmware
- No changes
## arbotix_msgs
- No changes
## arbotix_python

```
* Set queue_size=5 on all publishers
* Contributors: Jorge Santos
```
## arbotix_sensors

```
* Set queue_size=5 on all publishers
* Contributors: Jorge Santos
```
