### PR TITLE
rosdep: add NumPy dependency for Arch's python-opencv dependency.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -752,7 +752,7 @@ python-omniorb:
     saucy: [python-omniorb, python-omniorb-omg, omniidl-python]
     trusty: [python-omniorb, python-omniorb-omg, omniidl-python]
 python-opencv:
-  arch: [opencv]
+  arch: [opencv, python2-numpy]
   debian: [python-opencv]
   fedora: [opencv-python]
   ubuntu:


### PR DESCRIPTION
Arch only has one [opencv](https://www.archlinux.org/packages/extra/x86_64/opencv/) package with NumPy as an optional dependency for its Python bindings.

(cf. ros-perception/vision_opencv#47)
