### PR TITLE
pid: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5138,6 +5138,21 @@ repositories:
       url: https://github.com/ccny-ros-pkg/phidgets_drivers.git
       version: indigo
     status: maintained
+  pid:
+    doc:
+      type: git
+      url: https://AndyZe@bitbucket.org/AndyZe/pid.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/AndyZelenak/pid-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://AndyZe@bitbucket.org/AndyZe/pid.git
+      version: master
+    status: developed
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pid` to `0.0.1-0`:
- upstream repository: https://AndyZe@bitbucket.org/AndyZe/pid.git
- release repository: https://github.com/AndyZelenak/pid-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## pid

```
* Fixing various minor bugs related to user input.
* Pre-release commit.
* It WORKS!
* It's talking with the plant sim now. Just the PID programming remains.
* Making progress with the command line input.
* Rough outline of the program. Need to take inputs on the command line next.
* Initial commit
* Contributors: Andy Zelenak
```
