### PR TITLE
razor_imu_9dof: 1.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6088,7 +6088,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/KristofRobot/razor_imu_9dof-release.git
-      version: 1.0.5-1
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/KristofRobot/razor_imu_9dof.git


### PR DESCRIPTION
Increasing version of package(s) in repository `razor_imu_9dof` to `1.1.0-0`:
- upstream repository: https://github.com/KristofRobot/razor_imu_9dof.git
- release repository: https://github.com/KristofRobot/razor_imu_9dof-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.5-1`
## razor_imu_9dof

```
* Resolving bug in exiting display_3D_visualization (#15 <https://github.com/KristofRobot/razor_imu_9dof/issues/15>)
* Adding dynamic reconfigure for yaw calibration (Paul Bouchier)
* Moving calibration values from firmware to ROS yaml file (#13 <https://github.com/KristofRobot/razor_imu_9dof/issues/13>)Note: this is a BREAKING CHANGE - requires firmware update (updated firmware provided)
* Refactoring code: moved scripts to nodes, renamed node.py to imu_node.py (Paul Bouchier)
* Adding diagnostic status reporting (Paul Bouchier)
```
