### PR TITLE
rtmros_common: 1.2.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7302,7 +7302,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.2.7-0
+      version: 1.2.8-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.2.8-0`:
- upstream repository: https://github.com/start-jsk/rtmros_common.git
- release repository: https://github.com/tork-a/rtmros_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.2.7-0`
## hrpsys_ros_bridge

```
* [hrpsys_ros_bridge] Do not run collada_to_urdf parallel. In order to
  avoid parallel execution of collada_to_urdf, add tricky dependency
* Add graspless manip mode euslisp interface
* [test-*.py] test name could not contain minus? any changet to underscore (http://answers.ros.org/question/197377/rostest-not-finding-the-actual-test/)
* [test-samplerobot.py] fix syntax error on loadPattern
* update for legged robot
* Sample.pos is not installed via deb package, see https://github.com/fkanehiro/openhrp3/issues/46
* Fix rmfo sensor argument
* copy rtmlaunch,rtmtest to global_bin when compile
* Add method to calculate go-velocity param from velocity center offset
* Add menus for unstable rtcs (not used by default)
* Add setting for HrpsysConfigurator in hrpsys dashboard and apply it to servoOn/Off menu (disabled by default).
* Remove unused initial leg offsetting because this is implemented AutoBalancer's setFootSteps
* [hrpsys_ros_bridge] Refactor compile_robot_model.cmake
* Use ee name for impedance methods
* [hrpsys_ros_bridge] collision_state.py:  need to wait for activate
* [hrpsys_ros_bridge] sensor_ros_bridge_connect.py: wait for sh, sometimes we can not find them
* Update impedance start/stop methods
* [hrpsys_ros_bridge] Do not call export_collada in parallel
* Update :reset-force-moment-offset funcs and add documents
* Update documentation strings for ImpedanceController and Ref forces
* [hrpsys_ros_bridge] Fix path for catkin build
* pass :rarm instead of 'rhsensor' or 'rasensor' to :set-forcemoment-offset-param
* Add seq base pos and rpy methods
* Remove duplicated method and fix argument passing for imp methods
* Contributors: Kei Okada, Ryohei Ueda, Shunichi Nozawa, Eisoku Kuroiwa
```
## hrpsys_tools

```
* [test-*.py] test name could not contain minus? any changet to underscore (http://answers.ros.org/question/197377/rostest-not-finding-the-actual-test/)
* (diagnosis info) Renamed a script to show respect for the great ROS ancestors.
* (diagnosis info) Obtain package versions in a more generic way.
* (diagnosis info) Catch error stream.
* (diagnosis info) Variablize corba hostname and port.
* Add a very simple tool for recording system diagnosis info.
* Contributors: Isaac IY Saito, Kei Okada
```
## openrtm_ros_bridge

```
* [openrtm_ros_bridge] Fix path to rtmbuild cmake
* Contributors: Ryohei Ueda
```
## openrtm_tools

```
* [test-*.py] test name could not contain minus? any changet to underscore (http://answers.ros.org/question/197377/rostest-not-finding-the-actual-test/)
* [FIXME][rtshell-setup.sh] source bash_completion, since shell_suport is not working for now
* search rtshell path from CMAKE_PREFIX_PATH
* [openrtm_tools] rtshell-setup.sh: fix shell_support location
* Contributors: Kei Okada
```
## rosnode_rtc
- No changes
## rtmbuild

```
* fix for when hrp_idldir is null, hope this solves indigo ros buildfirm problem
* Contributors: Kei Okada
```
## rtmros_common
- No changes
