### PR TITLE
rtmros_nextage: 0.6.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7490,7 +7490,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.6.1-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.6.0-0`
## nextage_description
- No changes
## nextage_moveit_config
- No changes
## nextage_ros_bridge

```
* Start ROS clinent when the script begins
* Contributors: Kei Okada
```
## rtmros_nextage

```
* Start ROS clinent when the script begins
* Contributors: Kei Okada
```
