### PR TITLE
find_object_2d: 0.5.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1655,6 +1655,17 @@ repositories:
       url: https://github.com/ros/filters.git
       version: hydro-devel
     status: maintained
+  find_object_2d:
+    doc:
+      type: svn
+      url: https://find-object.googlecode.com/svn/trunk/ros-pkg/find_object_2d
+      version: HEAD
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/introlab/find_object_2d-release.git
+      version: 0.5.1-0
+    status: maintained
   flir_ptu:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `find_object_2d` to `0.5.1-0`:
- upstream repository: https://find-object.googlecode.com/svn/files/ros/find_object_2d-0.5.1.tar.gz
- release repository: https://github.com/introlab/find_object_2d-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
