### PR TITLE
razor_imu_9dof: 1.1.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5922,7 +5922,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/KristofRobot/razor_imu_9dof-release.git
-      version: 1.1.0-0
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/KristofRobot/razor_imu_9dof.git


### PR DESCRIPTION
Increasing version of package(s) in repository `razor_imu_9dof` to `1.1.0-1`:
- upstream repository: https://github.com/KristofRobot/razor_imu_9dof.git
- release repository: https://github.com/KristofRobot/razor_imu_9dof-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.1.0-0`
## razor_imu_9dof

```
* Resolving bug in exiting display_3D_visualization (#15 <https://github.com/KristofRobot/razor_imu_9dof/issues/15>)
* Adding dynamic reconfigure for yaw calibration (Paul Bouchier)
* Moving calibration values from firmware to ROS yaml file (#13 <https://github.com/KristofRobot/razor_imu_9dof/issues/13>)Note: this is a BREAKING CHANGE - requires firmware update (updated firmware provided)
* Refactoring code: moved scripts to nodes, renamed node.py to imu_node.py (Paul Bouchier)
* Adding diagnostic status reporting (Paul Bouchier)
```
