### PR TITLE
Add GLM (OpenGL math library) to rosdep.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1260,6 +1260,11 @@ libglib-dev:
     portage:
       packages: [dev-libs/glib]
   ubuntu: [libglib2.0-dev]
+libglm-dev:
+  arch: [glm]
+  debian: [libglm-dev]
+  fedora: [glm]
+  ubuntu: [libglm-dev]
 libglui-dev:
   arch: [glui]
   debian: [libglui-dev]


### PR DESCRIPTION
This adds [GLM, an OpenGL math library](http://glm.g-truc.net/) to rosdep.
