### PR TITLE
hrpsys: 315.3.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2209,7 +2209,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/hrpsys-release.git
-      version: 315.3.0-0
+      version: 315.3.0-1
     source:
       type: git
       url: https://github.com/fkanehiro/hrpsys-base.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys` to `315.3.0-1`:
- upstream repository: https://github.com/fkanehiro/hrpsys-base.git
- release repository: https://github.com/tork-a/hrpsys-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `315.3.0-0`
## hrpsys
- No changes
