### PR TITLE
rosdep: add python-catkin-tools

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -194,7 +194,7 @@ python-catkin-pkg:
 python-catkin-tools:
   osx:
     pip:
-      packages: [catkin-tools]
+      packages: [catkin_tools]
   ubuntu: [python-catkin-tools]
 python-cherrypy:
   fedora: [python-cherrypy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -191,6 +191,11 @@ python-catkin-pkg:
     trusty_python3: [python3-catkin-pkg]
     utopic: [python-catkin-pkg]
     vivid: [python-catkin-pkg]
+python-catkin-tools:
+  osx:
+    pip:
+      packages: [catkin-tools]
+  ubuntu: [python-catkin-tools]
 python-cherrypy:
   fedora: [python-cherrypy]
   ubuntu:


### PR DESCRIPTION
This allows ROS packages to depend on catkin_tools.
