### PR TITLE
sbpl: 1.2.0-3 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -984,6 +984,13 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: indigo-devel
     status: maintained
+  sbpl:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/sbpl-release.git
+      version: 1.2.0-3
+    status: maintained
   slam_gmapping:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `sbpl` to `1.2.0-3`:
- upstream repository: https://github.com/sbpl/sbpl
- release repository: https://github.com/ros-gbp/sbpl-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
