### PR TITLE
pr2_simulator: 2.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5650,7 +5650,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_simulator-release.git
-      version: 2.0.4-1
+      version: 2.0.5-0
     source:
       type: git
       url: https://github.com/PR2/pr2_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_simulator` to `2.0.5-0`:
- upstream repository: https://github.com/pr2/pr2_simulator.git
- release repository: https://github.com/pr2-gbp/pr2_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `2.0.4-1`
## pr2_controller_configuration_gazebo
- No changes
## pr2_gazebo
- No changes
## pr2_gazebo_plugins

```
* Removed dependency on PCL for pr2_Gazebo_plugins
* Contributors: TheDash
```
## pr2_simulator
- No changes
