### PR TITLE
open_industrial_ros_controllers: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4806,6 +4806,24 @@ repositories:
       url: https://github.com/davetcoleman/ompl_visual_tools.git
       version: indigo-devel
     status: developed
+  open_industrial_ros_controllers:
+    doc:
+      type: git
+      url: https://github.com/start-jsk/open_industrial_ros_controllers.git
+      version: hydro-devel
+    release:
+      packages:
+      - open_controllers_interface
+      - open_industrial_ros_controllers
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/start-jsk/open_industrial_ros_controllers-release.git
+      version: 0.1.4-0
+    source:
+      type: git
+      url: https://github.com/start-jsk/open_industrial_ros_controllers.git
+      version: hydro-devel
+    status: developed
   open_karto:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_industrial_ros_controllers` to `0.1.4-0`:
- upstream repository: https://github.com/start-jsk/open-industrial-ros-controllers.git
- release repository: https://github.com/start-jsk/open_industrial_ros_controllers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## open_controllers_interface

```
* remove unused %s, this causes segfault as reported on #14
* Contributors: Wataru Yasuda
```
## open_industrial_ros_controllers

```
* remove unused %s, this causes segfault as reported on #14
* Contributors: Wataru Yasuda
```
