### PR TITLE
denso: 0.2.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1223,6 +1223,27 @@ repositories:
       type: git
       url: https://github.com/jizhang-cmu/demo_rgbd.git
       version: indigo
+  denso:
+    doc:
+      type: git
+      url: https://github.com/start-jsk/denso.git
+      version: hydro-devel
+    release:
+      packages:
+      - denso
+      - denso_controller
+      - denso_launch
+      - vs060
+      - vs060_moveit_config
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/start-jsk/denso-release.git
+      version: 0.2.9-0
+    source:
+      type: git
+      url: https://github.com/start-jsk/denso.git
+      version: hydro-devel
+    status: developed
   depthcloud_encoder:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `denso` to `0.2.9-0`:
- upstream repository: https://github.com/start-jsk/denso.git
- release repository: https://github.com/start-jsk/denso-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## denso

```
* Add missing .setup_assistant file, without which moveit_setup_assistant can't open an existing moveit config pkg.
* Check-off query start state from RViz conf.
* Contributors: Isaac IY Saito
```
## denso_controller
- No changes
## denso_launch
- No changes
## vs060
- No changes
## vs060_moveit_config

```
* Add missing .setup_assistant file, without which moveit_setup_assistant can't open an existing moveit config pkg.
* Check-off query start state from RViz conf.
* Contributors: Isaac IY Saito
```
