### PR TITLE
robot_upstart: 0.0.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6330,7 +6330,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/robot_upstart-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/robot_upstart.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart` to `0.0.7-0`:
- upstream repository: https://github.com/clearpathrobotics/robot_upstart.git
- release repository: https://github.com/clearpath-gbp/robot_upstart-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.6-0`
## robot_upstart

```
* if logdir does not exist, try to create it, if this fails, fall back to /tmp
* fix invalid range error on grep
* add argument to specify log directory
* Contributors: Eisoku Kuroiwa, Mike Purvis, ipa-mig
```
