### PR TITLE
bfl: 0.7.0-2 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -78,6 +78,13 @@ repositories:
       url: https://github.com/vanadiumlabs/arbotix_ros.git
       version: indigo-devel
     status: maintained
+  bfl:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/bfl-release.git
+      version: 0.7.0-2
+    status: maintained
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bfl` to `0.7.0-2`:
- upstream repository: http://svn.mech.kuleuven.be/repos/orocos/branches/bfl/branch-0.7/
- release repository: https://github.com/ros-gbp/bfl-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
