### PR TITLE
graft: 0.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2219,7 +2219,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/graft-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     status: developed
   graph_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `graft` to `0.2.1-0`:
- upstream repository: https://github.com/ros-perception/graft.git
- release repository: https://github.com/ros-gbp/graft-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.0-0`
## graft

```
* update package.xml to have an actual description
* Inintialize covariances in topics
  Publish state relative to node name
* graft sensors: style cleanup
* parameter manager: factor out rosparam array loading, style cleanup
* Contributors: Michael Ferguson, Austin Hendrix
```
