### PR TITLE
lyap_control: 0.0.7-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3607,7 +3607,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/AndyZelenak/lyap_control-release.git
-      version: 0.0.6-2
+      version: 0.0.7-1
     source:
       type: git
       url: https://AndyZe@bitbucket.org/AndyZe/lyap_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lyap_control` to `0.0.7-1`:
- upstream repository: https://bitbucket.org/AndyZe/lyap_control.git
- release repository: https://github.com/AndyZelenak/lyap_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.6-2`
## lyap_control

```
* Still futzing to get documentation and author info right.
* Contributors: Andy Zelenak
```
