### PR TITLE
navigation: 1.12.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4388,7 +4388,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.12.0-0
+      version: 1.12.1-0
     source:
       type: git
       url: https://github.com/ros-planning/navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.12.1-0`:
- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.12.0-0`
## amcl

```
* amcl_node will now save latest pose on shutdown
* Contributors: iandanforth
```
## base_local_planner
- No changes
## carrot_planner
- No changes
## clear_costmap_recovery
- No changes
## costmap_2d

```
* fixed issue with voxel_layer and obstacle_layer both deleting the same dynamic_reconfigure::Server and causing segfaults
* Fixing various memory freeing operations
* Fix indexing error in OccupancyGridUpdate callback function.
* Contributors: Alex Bencz, David V. Lu!!, James Servos, Julse, Kaijen Hsiao
```
## dwa_local_planner

```
* link only libraries found with find_package
* Contributors: Lukas Bulwahn
```
## fake_localization
- No changes
## global_planner

```
* Fixing various memory freeing operations
* Add Orientation Filter to Global Planner
* Contributors: Alex Bencz, David V. Lu!!, James Servos, Michael Ferguson
```
## map_server
- No changes
## move_base

```
* Fixing various memory freeing operations
* Contributors: Alex Bencz
```
## move_base_msgs

```
* Remove unused dependencies in move_base_msgs
* Contributors: Daniel Stonier
```
## move_slow_and_clear
- No changes
## nav_core
- No changes
## navfn
- No changes
## navigation
- No changes
## robot_pose_ekf
- No changes
## rotate_recovery
- No changes
## voxel_grid
- No changes
