### PR TITLE
segbot: 0.3.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7837,7 +7837,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/segbot-release.git
-      version: 0.2.1-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/utexas-bwi/segbot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot` to `0.3.0-0`:
- upstream repository: https://github.com/utexas-bwi/segbot.git
- release repository: https://github.com/utexas-bwi-gbp/segbot-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.1-0`
## segbot

```
* added platform independent tag to metapackage.
* Contributors: Piyush Khandelwal
```
## segbot_bringup

```
* fixed default depth_registered flag to allow kinect to work properly.
* use different filters for segbot v1 and segbot v2 due to differences between different laser models.
* added launch file for segbot v2.
* fixed some issues with frame ids for multi robot setup.
* Changed the value of "depth_only" to "true" so that the published point cloud contains color information as well.
* Contributors: Jivko Sinapov, Piyush Khandelwal
```
## segbot_description

```
* modified simple robot model in gazebo to be more accurate while still being able to detect other robots.
* temp update to change range of hokuyo in simulation.
* added the kinect.dae mesh that was missing in the meshes folder of segbot_description package
* Contributors: Jivko Sinapov, Piyush Khandelwal
```
## segbot_firmware

```
* new arduino firmware for segbot v2.
* Contributors: Jack O'Quin
```
## segbot_sensors

```
* use different list of filters for segbot v1 and segbot v2 due to differences between different laser models.
* added a launch file for ethernet hokuyo for segbot v2.
* added some code to process low battery messages. The robots will now attempt to send an email if they're reaching
  low battery levels.
* big rework of all the arduino code to support the sensors on the new mounting plate.
* added some diagnostic publications.
* removed hack in nan_to_inf filter that was setting values to max_range - epsilon.
* Contributors: Jack O'Quin, Jivko Sinapov, Maxwell Svetlik, Piyush Khandelwal
```
