### PR TITLE
eband_local_planner: 0.2.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1482,11 +1482,19 @@ repositories:
       version: master
     status: maintained
   eband_local_planner:
+    doc:
+      type: git
+      url: https://github.com/utexas-bwi/eband_local_planner.git
+      version: master
     release:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/eband_local_planner-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
+    source:
+      type: git
+      url: https://github.com/utexas-bwi/eband_local_planner.git
+      version: master
     status: developed
   ecl_core:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `eband_local_planner` to `0.2.2-0`:
- upstream repository: https://github.com/utexas-bwi/eband_local_planner.git
- release repository: https://github.com/utexas-bwi-gbp/eband_local_planner-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.1-0`
## eband_local_planner

```
* fixed catkin lint warnings in preparation for v0.2.2 release
* added a bit more paramterization of the algorithm to help navigation in simulation. all changes are backwards
  compatible. #17 <https://github.com/utexas-bwi/eband_local_planner/issues/17> from utexas-bwi/piyushk/fix_simulation_navigation
* made some changes for a future Indigo release. fixed Eigen dependency (#16 <https://github.com/utexas-bwi/eband_local_planner/issues/16>)
* Contributors: Jack O'Quin, Piyush Khandelwal
```
