### PR TITLE
segway_rmp: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7897,7 +7897,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/segwayrmp/segway_rmp-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/segwayrmp/segway_rmp.git
+      version: master
     status: maintained
   segwayrmp:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `segway_rmp` to `0.1.2-0`:
- upstream repository: https://github.com/segwayrmp/segway-rmp-ros-pkg.git
- release repository: https://github.com/segwayrmp/segway_rmp-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.1-0`
## segway_rmp

```
* Merge pull request #24 <https://github.com/segwayrmp/segway_rmp/issues/24> from segwayrmp/piyushk/parametrize_frame_ids
  allow parametrizing odometry frame id as well (useful for multiple robots)
* Contributors: Piyush Khandelwal
```
