### PR TITLE
shape_tools: 0.2.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1013,6 +1013,17 @@ repositories:
       url: https://github.com/ros-gbp/sbpl-release.git
       version: 1.2.0-3
     status: maintained
+  shape_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/shape_tools.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/shape_tools-release.git
+      version: 0.2.1-0
+    status: maintained
   slam_gmapping:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `shape_tools` to `0.2.1-0`:
- upstream repository: git://github.com/ros-planning/shape_tools.git
- release repository: https://github.com/ros-gbp/shape_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
