### PR TITLE
srdfdom: 0.2.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1038,6 +1038,17 @@ repositories:
       url: https://github.com/ros-perception/slam_gmapping.git
       version: hydro-devel
     status: developed
+  srdfdom:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/srdfdom-release.git
+      version: 0.2.7-0
+    status: maintained
   stage:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `0.2.7-0`:
- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/ros-gbp/srdfdom-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## srdfdom

```
* fixing dependencies for https://github.com/ros/rosdistro/issues/4633
* added travis build status indicator in README.md
* added travis support
* use FindTinyXML from cmake_module
* Contributors: Dave Coleman, Dave Hershberger, Ioan Sucan, Tully Foote
```
