### PR TITLE
laser_geometry: 1.6.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -554,6 +554,17 @@ repositories:
       url: https://github.com/ros-drivers/korg_nanokontrol.git
       version: master
     status: maintained
+  laser_geometry:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/laser_geometry-release.git
+      version: 1.6.3-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: indigo-devel
+    status: maintained
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `1.6.3-0`:
- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros-gbp/laser_geometry-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## laser_geometry

```
* provide support for tf2
* Contributors: Vincent Rabaud
```
