### PR TITLE
rtt_ros_integration: 2.8.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7520,7 +7520,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_ros_integration-release.git
-      version: 2.8.0-0
+      version: 2.8.1-0
     source:
       type: git
       url: https://github.com/orocos/rtt_ros_integration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_ros_integration` to `2.8.1-0`:
- upstream repository: https://github.com/orocos/rtt_ros_integration.git
- release repository: https://github.com/orocos-gbp/rtt_ros_integration-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2.8.0-0`
