### PR TITLE
sick_tim: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7801,7 +7801,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uos-gbp/sick_tim-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/uos/sick_tim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_tim` to `0.0.4-0`:
- upstream repository: https://github.com/uos/sick_tim
- release repository: https://github.com/uos-gbp/sick_tim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.3-0`
## sick_tim

```
* Tim561: Make sick_tim551 node work with TiM561.

    * The TiM561 has a angular resolution of 0.33°, which leads to 811 points per scan.
    * Add warning if time_increment is inconsistent. This happens on the TiM561,
      which reports an incorrect measurement frequency.
    * Add ros params to override a few values, including time_increment
      (#24 <https://github.com/uos/sick_tim/issues/24> ).

* All scanners: Split datagrams up before handing them to parse_datagram.
  This finally fixes the warning on datagrams of invalid length
  each time multiple datagrams are read. (#21 <https://github.com/uos/sick_tim/issues/21>)
* All scanners: add subscribing to datagram topic.
  If subscribe_datagram is set, all nodes will now process the datagrams
  published on the datagram topic instead of reading from the physical
  device. Useful for debugging.
* Contributors: Jochen Sprickerhof, Martin Günther, Michael Ferguson, Michael Görner
```
