### PR TITLE
katana_driver: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3034,6 +3034,27 @@ repositories:
       type: git
       url: https://github.com/uos/katana_driver.git
       version: indigo
+    release:
+      packages:
+      - katana
+      - katana_arm_gazebo
+      - katana_description
+      - katana_driver
+      - katana_gazebo_plugins
+      - katana_moveit_ikfast_plugin
+      - katana_msgs
+      - katana_teleop
+      - katana_tutorials
+      - kni
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/uos-gbp/katana_driver-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/uos/katana_driver.git
+      version: indigo_catkin
+    status: developed
   keyboard:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `katana_driver` to `1.0.0-0`:
- upstream repository: https://github.com/uos/katana_driver.git
- release repository: https://github.com/uos-gbp/katana_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## katana

```
* Initial release to Debian packages
* Contributors: Martin Günther, Henning Deeken, Jochen Sprickerhof, Benjamin Reiner, Michael Görner, André Potenza, Frederik Hegger
```
## katana_arm_gazebo

```
* Initial release to Debian packages
* Contributors: Martin Günther, Henning Deeken, Jochen Sprickerhof, Michael Görner, André Potenza, Karl Glatz
```
## katana_description

```
* Initial release to Debian packages
* Contributors: Martin Günther, Henning Deeken, Michael Görner, André Potenza
```
## katana_driver

```
* Initial release to Debian packages
* Contributors: Martin Günther, Henning Deeken, Jochen Sprickerhof, Benjamin Reiner, Michael Görner, André Potenza, Frederik Hegger
```
## katana_gazebo_plugins

```
* Initial release to Debian packages
* Contributors: Martin Günther, Henning Deeken, Jochen Sprickerhof, Michael Görner, André Potenza, Karl Glatz
```
## katana_moveit_ikfast_plugin

```
* Initial release to Debian packages
* Contributors: Martin Günther, Henning Deeken, Michael Görner
```
## katana_msgs

```
* Initial release to Debian packages
* Contributors: Martin Günther, Henning Deeken
```
## katana_teleop

```
* Initial release to Debian packages
* Contributors: Martin Günther, Henning Deeken, Jochen Sprickerhof, André Potenza
```
## katana_tutorials

```
* Initial release to Debian packages
* Contributors: Martin Günther, Henning Deeken, Jochen Sprickerhof, Michael Görner
```
## kni

```
* Initial release to Debian packages
* Contributors: Martin Günther, Henning Deeken, Jochen Sprickerhof, Michael Görner
```
