### PR TITLE
bwi_common: 0.3.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -538,15 +538,19 @@ repositories:
       packages:
       - bwi_common
       - bwi_gazebo_entities
+      - bwi_interruptable_action_server
+      - bwi_kr_execution
       - bwi_mapper
+      - bwi_msgs
       - bwi_planning_common
+      - bwi_tasks
       - bwi_tools
       - bwi_web
       - utexas_gdc
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/bwi_common-release.git
-      version: 0.2.4-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi_common` to `0.3.1-0`:
- upstream repository: https://github.com/utexas-bwi/bwi_common.git
- release repository: https://github.com/utexas-bwi-gbp/bwi_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.4-0`
## bwi_common
- No changes
## bwi_gazebo_entities
- No changes
## bwi_interruptable_action_server
- No changes
## bwi_kr_execution

```
* fixed broken link to costs.asp. costs are not being currently used.
* Contributors: Piyush Khandelwal
```
## bwi_mapper
- No changes
## bwi_msgs
- No changes
## bwi_planning_common
- No changes
## bwi_tasks
- No changes
## bwi_tools
- No changes
## bwi_web
- No changes
## utexas_gdc
- No changes
