### PR TITLE
acado: 1.2.1-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -19,7 +19,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/acado-release.git
-      version: 1.2.1-1
+      version: 1.2.1-3
     source:
       type: git
       url: https://github.com/clearpath-gbp/acado-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `acado` to `1.2.1-3`:
- upstream repository: https://github.com/clearpathrobotics/acado.git
- release repository: https://github.com/clearpath-gbp/acado-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `1.2.1-1`
