### PR TITLE
acado: 1.2.1-3 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -57,6 +57,21 @@ repositories:
       url: https://github.com/ros-industrial/abb.git
       version: hydro
     status: developed
+  acado:
+    doc:
+      type: git
+      url: https://github.com/clearpath-gbp/acado-release.git
+      version: upstream-patched
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/clearpath-gbp/acado-release.git
+      version: 1.2.1-3
+    source:
+      type: git
+      url: https://github.com/clearpath-gbp/acado-release.git
+      version: upstream-patched
+    status: maintained
   ackermann_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `acado` to `1.2.1-3`:
- upstream repository: https://github.com/clearpathrobotics/acado.git
- release repository: https://github.com/clearpath-gbp/acado-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
