### PR TITLE
robot_calibration: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6126,7 +6126,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/robot_calibration-release.git
-      version: 0.1.2-0
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/mikeferguson/robot_calibration.git
+      version: indigo-devel
     status: developed
   robot_localization:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.2.0-0`:
- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/fetchrobotics-gbp/robot_calibration-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.2-0`
## robot_calibration

```
* enforce internal consistency between led features
* remove opencv window, add cloud in message option
* update how max error is handled
* extend messages to support multiple sensors
* implement ExtendedCameraInfo
* Contributors: Michael Ferguson
```
## robot_calibration_msgs

```
* extend messages to support multiple sensors
* implement ExtendedCameraInfo
* Contributors: Michael Ferguson
```
