### PR TITLE
bfl: documentation in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -381,6 +381,10 @@ repositories:
       version: 1.1.0-0
     status: developed
   bfl:
+    doc:
+      type: git
+      url: https://github.com/ros-gbp/bfl-release.git
+      version: upstream
     release:
       tags:
         release: release/indigo/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `bfl` to `0.7.0-6`:
- upstream repository: http://svn.mech.kuleuven.be/repos/orocos/branches/bfl/branch-0.7/
- release repository: https://github.com/ros-gbp/bfl-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.7.0-6`
