### PR TITLE
bfl: documentation in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -79,6 +79,10 @@ repositories:
       version: indigo-devel
     status: maintained
   bfl:
+    doc:
+      type: git
+      url: https://github.com/ros-gbp/bfl-release.git
+      version: upstream
     release:
       tags:
         release: release/jade/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `bfl` to `0.7.0-2`:
- upstream repository: http://svn.mech.kuleuven.be/repos/orocos/branches/bfl/branch-0.7/
- release repository: https://github.com/ros-gbp/bfl-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.7.0-2`
