### PR TITLE
pr2_metapackages: 1.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5769,7 +5769,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_metapackages-release.git
-      version: 1.0.3-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/pr2/pr2_metapackages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_metapackages` to `1.0.5-0`:
- upstream repository: https://github.com/pr2/pr2_metapackages.git
- release repository: https://github.com/pr2-gbp/pr2_metapackages-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.0.3-0`
## pr2

```
* Updated changelogs
* Contributors: TheDash
```
## pr2_base

```
* Collapsed pr2 moveit deps
* Updated changelogs
* Added dependency for warehouse_ros
* Contributors: TheDash
* Added dependency for warehouse_ros
* Contributors: TheDash
```
## pr2_desktop

```
* Updated changelogs
* change maintainer
* Contributors: Dirk Thomas, TheDash
* change maintainer
* Contributors: Dirk Thomas
```
