### PR TITLE
abb: 1.1.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -51,7 +51,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-industrial-release/abb-release.git
-      version: 1.1.4-0
+      version: 1.1.5-0
     source:
       type: git
       url: https://github.com/ros-industrial/abb.git
@@ -3321,7 +3321,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/uos-gbp/katana_driver-release.git
-      version: 1.0.1-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/uos/katana_driver.git
@@ -5769,7 +5769,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_metapackages-release.git
-      version: 1.0.5-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/pr2/pr2_metapackages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `abb` to `1.1.5-0`:
- upstream repository: https://github.com/ros-industrial/abb.git
- release repository: https://github.com/ros-industrial-release/abb-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.1.4-0`
## abb

```
* No changes
```
## abb_common

```
* driver: ROS_motionServer.mod was checking for wrong comm type to send reply
  message, causing dirver to quite working after stop command.
  Fix #42 <https://github.com/ros-industrial/abb/issues/42>.
* Contributors: Levi Armstrong
```
## abb_driver

```
* driver: ROS_motionServer.mod was checking for wrong comm type to send reply
  message, causing dirver to quite working after stop command.
  Fix #42 <https://github.com/ros-industrial/abb/issues/42>.
* Contributors: Levi Armstrong
```
## abb_irb2400_moveit_config

```
* moveit_cfg: make warehouse db location user configurable.
  Fix #58 <https://github.com/Aequitas82/abb/issues/58>.
  Released MoveIt configuration packages are installed in non-writable
  locations most of the time. Starting demo.launch or any other launch
  file that starts the mongodb wrapper script results in a 'Permission
  denied' error, as it cannot create the database in those directories.
  These changes allow the user to configure an alternative location
  for the mongodb database by using the db_path argument.
  Essentially a backport of the fix in ros-planning/moveit_setup_assistant #103 <https://github.com/ros-planning/moveit_setup_assistant/issues/103>.
  These fixes have been applied to both the new and the deprecated MoveIt
  configuration packages.
* Contributors: gavanderhoorn
```
## abb_irb2400_moveit_plugins

```
* No changes
```
## abb_irb2400_support

```
* No changes
```
## abb_irb5400_support

```
* No changes
```
## abb_irb6600_support

```
* No changes
```
## abb_irb6640_moveit_config

```
* moveit_cfg: make warehouse db location user configurable.
  Fix #58 <https://github.com/Aequitas82/abb/issues/58>.
  Released MoveIt configuration packages are installed in non-writable
  locations most of the time. Starting demo.launch or any other launch
  file that starts the mongodb wrapper script results in a 'Permission
  denied' error, as it cannot create the database in those directories.
  These changes allow the user to configure an alternative location
  for the mongodb database by using the db_path argument.
  Essentially a backport of the fix in ros-planning/moveit_setup_assistant #103 <https://github.com/ros-planning/moveit_setup_assistant/issues/103>.
  These fixes have been applied to both the new and the deprecated MoveIt
  configuration packages.
* Contributors: gavanderhoorn
```
## abb_moveit_plugins

```
* No changes
```
## irb_2400_moveit_config

```
* moveit_cfg: make warehouse db location user configurable.
  Fix #58 <https://github.com/ros-industrial/abb/issues/58>.
  Released MoveIt configuration packages are installed in non-writable
  locations most of the time. Starting demo.launch or any other launch
  file that starts the mongodb wrapper script results in a 'Permission
  denied' error, as it cannot create the database in those directories.
  These changes allow the user to configure an alternative location
  for the mongodb database by using the db_path argument.
  Essentially a backport of the fix in ros-planning/moveit_setup_assistant #103 <https://github.com/ros-planning/moveit_setup_assistant/issues/103>.
  These fixes have been applied to both the new and the deprecated MoveIt
  configuration packages.
* Contributors: gavanderhoorn
```
## irb_6640_moveit_config

```
* moveit_cfg: make warehouse db location user configurable.
  Fix #58 <https://github.com/Aequitas82/abb/issues/58>.
  Released MoveIt configuration packages are installed in non-writable
  locations most of the time. Starting demo.launch or any other launch
  file that starts the mongodb wrapper script results in a 'Permission
  denied' error, as it cannot create the database in those directories.
  These changes allow the user to configure an alternative location
  for the mongodb database by using the db_path argument.
  Essentially a backport of the fix in ros-planning/moveit_setup_assistant #103 <https://github.com/ros-planning/moveit_setup_assistant/issues/103>.
  These fixes have been applied to both the new and the deprecated MoveIt
  configuration packages.
* Contributors: gavanderhoorn
```
