### PR TITLE
pr2_navigation_apps: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5816,7 +5816,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_navigation_apps-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/PR2/pr2_navigation_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_navigation_apps` to `1.0.2-0`:
- upstream repository: https://github.com/PR2/pr2_navigation_apps.git
- release repository: https://github.com/TheDash/pr2_navigation_apps-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.0.1-0`
## pr2_2dnav

```
* Updated pr2_2dnav to install launch files and remove unecessary rosbuild files
* Contributors: TheDash
```
## pr2_2dnav_local

```
* Removed rosbuild files, added install for launch files
* Contributors: TheDash
```
## pr2_2dnav_slam

```
* Removed rosbuild files, added install for launch files
* Contributors: TheDash
```
## pr2_navigation_apps
- No changes
