### PR TITLE
pcl_conversions: 0.2.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -825,6 +825,21 @@ repositories:
       url: https://github.com/orocos/orocos_kinematics_dynamics.git
       version: master
     status: maintained
+  pcl_conversions:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/pcl_conversions.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/pcl_conversions-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/pcl_conversions.git
+      version: indigo-devel
+    status: maintained
   pcl_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_conversions` to `0.2.0-0`:
- upstream repository: https://github.com/ros-perception/pcl_conversions.git
- release repository: https://github.com/ros-gbp/pcl_conversions-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## pcl_conversions

```
* Added conversions for stamp types
* update maintainer info, add eigen dependency
* fix Eigen dependency
* Make pcl_conversions run_depend on libpcl-all-dev
* Contributors: Brice Rebsamen, Paul Bovbel, Scott K Logan, William Woodall
```
