### PR TITLE
gazebo_ros_pkgs: 2.4.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1775,7 +1775,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.4.7-1
+      version: 2.4.8-0
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.4.8-0`:
- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2.4.7-1`
## gazebo_msgs
- No changes
## gazebo_plugins

```
* fixed mistake at calculation of joint velocity
* [gazebo_ros_diff_drive] force call SetMaxForce since this Joint::Reset in gazebo/physics/Joint.cc reset MaxForce to zero and ModelPlugin::Reset is called after Joint::Reset
* add PointCloudCutoffMax
* Contributors: Kei Okada, Michael Ferguson, Sabrina Heerklotz
```
## gazebo_ros

```
* Specify physics engine in args to empty_world.launch
* Contributors: Steven Peters
```
## gazebo_ros_control

```
* Merge pull request #244 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/244> from cottsay/control-urdf-fix
  gazebo_ros_control: add urdf to downstream catkin deps
* Added emergency stop support.
* Contributors: Adolfo Rodriguez Tsouroukdissian, Jim Rothrock, Scott K Logan
```
## gazebo_ros_pkgs
- No changes
