### PR TITLE
gazebo_ros_pkgs: 2.3.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2019,7 +2019,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.3.7-0
+      version: 2.3.8-0
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.3.8-0`:
- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2.3.7-0`
## gazebo_msgs
- No changes
## gazebo_plugins

```
* Merge pull request #252 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/252> from ros-simulation/pub_joint_trajectory_test_compile_fix
  fix compile error due to missing dependency
* Merge pull request #239 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/239> from ayrton04/hydro-devel
  Fixing handling of non-world frame velocities in setModelState.
* Update CMakeLists.txt
* Fixing set model state method and test
* Adding test for set_model_state
* fix compile error due to missing dependency
* fix compiler warning
* Merge pull request #225 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/225> from ros-simulation/update_header_license_hydro
  update license to Apache 2.0 for hydro
* merging from pull request #192 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/192>
* gazebo_plugins: moveit planning scene publisher
* Contributors: John Hsu, Jonathan Bohren, Jose Luis Rivero, Robert Codd-Downey, Tom Moore, hsu
```
## gazebo_ros

```
* Merge pull request #235 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/235> from ros-simulation/issue_93_set_joint_position_hydro
  add test for issue #93 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/93>, set joint position on spawn_model
* spawn_model: adding joint rosparam
* temporary hack to **fix** the -J joint position option (issue #93 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/93>), sleeping for 1 second to avoid race condition. this branch should only be used for debugging, merge only as a last resort.
* Fixing set model state method and test
* Specify physics engine in args to empty_world.launch
* Fixing handling of non-world frame velocities in setModelState.
* add test for issue #93 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/93>, set joint position on spawn_model
* update license to Apache 2.0 for hydro
* Contributors: John Hsu, Jonathan Bohren, Steven Peters, Tom Moore, ayrton04, hsu
```
## gazebo_ros_control
- No changes
## gazebo_ros_pkgs
- No changes
