### PR TITLE
pr2_gripper_sensor: 1.0.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5645,7 +5645,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_gripper_sensor-release.git
-      version: 1.0.4-0
+      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/PR2/pr2_gripper_sensor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_gripper_sensor` to `1.0.6-0`:
- upstream repository: https://github.com/PR2/pr2_gripper_sensor.git
- release repository: https://github.com/TheDash/pr2_gripper_sensor-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.0.4-0`
## pr2_gripper_sensor
- No changes
## pr2_gripper_sensor_action

```
* add install settings for catkin_make
* Contributors: Yuki Furuta
```
## pr2_gripper_sensor_controller

```
* install controller_plugins.xml
* add install settings for catkin_make pr2_gripper_sensor_controller
* Contributors: John Hsu, Yuki Furuta
```
## pr2_gripper_sensor_msgs
- No changes
