### PR TITLE
abb: 1.1.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -51,7 +51,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-industrial-release/abb-release.git
-      version: 1.1.4-0
+      version: 1.1.6-0
     source:
       type: git
       url: https://github.com/ros-industrial/abb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `abb` to `1.1.6-0`:
- upstream repository: https://github.com/ros-industrial/abb.git
- release repository: https://github.com/ros-industrial-release/abb-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.1.4-0`
## abb

```
* No changes
```
## abb_common

```
* Fix typos and links in CHANGELOG.rst
* Contributors: Levi Armstrong
```
## abb_driver

```
* Fix typos and links in CHANGELOG.rst
* Contributors: Levi Armstrong
```
## abb_irb2400_moveit_config

```
* Fix typos and links in CHANGELOG.rst
* Contributors: Levi Armstrong
```
## abb_irb2400_moveit_plugins

```
* No changes
```
## abb_irb2400_support

```
* No changes
```
## abb_irb5400_support

```
* No changes
```
## abb_irb6600_support

```
* No changes
```
## abb_irb6640_moveit_config

```
* Fix typos and links in CHANGELOG.rst
* Contributors: Levi Armstrong
```
## abb_moveit_plugins

```
* No changes
```
## irb_2400_moveit_config

```
* No changes
```
## irb_6640_moveit_config

```
* Fix typos and links in CHANGELOG.rst
* Contributors: Levi Armstrong
```
