### PR TITLE
perception_pcl: 1.2.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -855,6 +855,25 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: indigo-devel
     status: maintained
+  perception_pcl:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: indigo-devel
+    release:
+      packages:
+      - pcl_ros
+      - perception_pcl
+      - pointcloud_to_laserscan
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/perception_pcl-release.git
+      version: 1.2.6-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: indigo-devel
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.2.6-0`:
- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## pcl_ros
- No changes
## perception_pcl
- No changes
## pointcloud_to_laserscan

```
* Fix default value for concurrency
* Fix multithreaded lazy pub sub
* Contributors: Paul Bovbel
```
