### PR TITLE
visp: 2.10.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8780,7 +8780,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 2.9.0-11
+      version: 2.10.0-2
     status: maintained
   visp_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `2.10.0-2`:
- upstream repository: svn://scm.gforge.inria.fr/svnroot/visp/tags/ViSP_2_10_0
- release repository: https://github.com/lagadic/visp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2.9.0-11`
