### PR TITLE
geometry_experimental: 0.5.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -464,7 +464,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/geometry_experimental-release.git
-      version: 0.5.7-0
+      version: 0.5.8-0
     source:
       type: git
       url: https://github.com/ros/geometry_experimental.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_experimental` to `0.5.8-0`:
- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry_experimental-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.5.7-0`
## geometry_experimental
- No changes
## tf2

```
* change from default argument to overload to avoid linking issue #84 <https://github.com/ros/geometry_experimental/issues/84>
* remove useless Makefile files
* Remove unused assignments in max/min functions
* change _allFramesAsDot() -> _allFramesAsDot(double current_time)
* Contributors: Jon Binney, Kei Okada, Tully Foote, Vincent Rabaud
```
## tf2_bullet

```
* remove useless Makefile files
* fix ODR violations
* Contributors: Vincent Rabaud
```
## tf2_geometry_msgs

```
* remove useless Makefile files
* tf2 optimizations
* add conversions of type between tf2 and geometry_msgs
* fix ODR violations
* Contributors: Vincent Rabaud
```
## tf2_kdl

```
* remove useless Makefile files
* fix ODR violations
* Contributors: Vincent Rabaud
```
## tf2_msgs

```
* remove useless Makefile files
* Contributors: Vincent Rabaud
```
## tf2_py
- No changes
## tf2_ros

```
* fix deadlock #79 <https://github.com/ros/geometry_experimental/issues/79>
* break out of loop if ros is shutdown. Fixes #26 <https://github.com/ros/geometry_experimental/issues/26>
* remove useless Makefile files
* Fix static broadcaster with rpy args
* Contributors: Paul Bovbel, Tully Foote, Vincent Rabaud
```
## tf2_sensor_msgs

```
* ODR violation fixes and more conversions
* Fix keeping original pointcloud header in transformed pointcloud
* Contributors: Paul Bovbel, Tully Foote, Vincent Rabaud
```
## tf2_tools

```
* remove useless Makefile files
* Contributors: Vincent Rabaud
```
