### PR TITLE
geometry: 1.11.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1912,7 +1912,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry-release.git
-      version: 1.11.4-0
+      version: 1.11.5-0
     source:
       type: git
       url: https://github.com/ros/geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry` to `1.11.5-0`:
- upstream repository: https://github.com/ros/geometry.git
- release repository: https://github.com/ros-gbp/geometry-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.11.4-0`
## eigen_conversions
- No changes
## geometry
- No changes
## kdl_conversions
- No changes
## tf

```
* Strip leading slash get parent #79 <https://github.com/ros/geometry/issues/79>
* Make frameExists strip leading slash going into tf2.`#63 <https://github.com/ros/geometry/issues/63>`_
* Update broadcaster.py,  Added ability to use TransformStamped
* update view_frames to use AllFramesAsDot(rospy.time.now()) #77 <https://github.com/ros/geometry/issues/77>
* Contributors: David Lu!!, Gaël Ecorchard, Kei Okada, Tully Foote
```
## tf_conversions
- No changes
