### PR TITLE
common_msgs: 1.12.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -202,7 +202,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.12.0-0
+      version: 1.12.1-0
     source:
       type: git
       url: https://github.com/ros/common_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.12.1-0`:
- upstream repository: git@github.com:ros/common_msgs.git
- release repository: https://github.com/ros-gbp/common_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.12.0-0`
## actionlib_msgs

```
* updating outdated urls. fixes #52 <https://github.com/ros/common_msgs/issues/52>.
* Contributors: Tully Foote
```
## common_msgs

```
* updating outdated urls. fixes #52 <https://github.com/ros/common_msgs/issues/52>.
* Contributors: Tully Foote
```
## diagnostic_msgs

```
* updating outdated urls. fixes #52 <https://github.com/ros/common_msgs/issues/52>.
* Contributors: Tully Foote
```
## geometry_msgs

```
* updating outdated urls. fixes #52 <https://github.com/ros/common_msgs/issues/52>.
* Contributors: Tully Foote
```
## nav_msgs

```
* updating outdated urls. fixes #52 <https://github.com/ros/common_msgs/issues/52>.
* Adds a SetMap service message to support swap maps functionality in amcl
* Contributors: Tully Foote, liz-murphy
```
## sensor_msgs
- No changes
## shape_msgs

```
* updating outdated urls. fixes #52 <https://github.com/ros/common_msgs/issues/52>.
* Contributors: Tully Foote
```
## stereo_msgs

```
* updating outdated urls. fixes #52 <https://github.com/ros/common_msgs/issues/52>.
* Contributors: Tully Foote
```
## trajectory_msgs

```
* updating outdated urls. fixes #52 <https://github.com/ros/common_msgs/issues/52>.
* Contributors: Tully Foote
```
## visualization_msgs
- No changes
