### PR TITLE
navigation: 1.13.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -667,6 +667,39 @@ repositories:
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
       version: master
     status: maintained
+  navigation:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation.git
+      version: jade-devel
+    release:
+      packages:
+      - amcl
+      - base_local_planner
+      - carrot_planner
+      - clear_costmap_recovery
+      - costmap_2d
+      - dwa_local_planner
+      - fake_localization
+      - global_planner
+      - map_server
+      - move_base
+      - move_slow_and_clear
+      - nav_core
+      - navfn
+      - navigation
+      - robot_pose_ekf
+      - rotate_recovery
+      - voxel_grid
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/navigation-release.git
+      version: 1.13.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/navigation.git
+      version: jade-devel
+    status: maintained
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.13.0-0`:
- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## amcl

```
* amcl_node will now save latest pose on shutdown
* Contributors: Ian Danforth
```
## base_local_planner

```
* remove previously deprecated param
* Contributors: Michael Ferguson
```
## carrot_planner
- No changes
## clear_costmap_recovery
- No changes
## costmap_2d

```
* fixed issue with voxel_layer and obstacle_layer both deleting the same dynamic_reconfigure::Server and causing segfaults
* Fixing various memory freeing operations
* static_layer: Fix indexing error in OccupancyGridUpdate callback function.
* Contributors: Alex Bencz, David V. Lu!!, James Servos, Julse, Kaijen Hsiao
```
## dwa_local_planner

```
* link only libraries found with find_package
* Contributors: Lukas Bulwahn
```
## fake_localization
- No changes
## global_planner

```
* Fixing various memory freeing operations
* Add Orientation Filter to Global Planner
* Contributors: Alex Bencz, David V. Lu!!, James Servos, Michael Ferguson
```
## map_server

```
* rename image_loader library, fixes #208 <https://github.com/ros-planning/navigation/issues/208>
* Contributors: Michael Ferguson
```
## move_base

```
* Fixing various memory freeing operations
* Contributors: Alex Bencz
```
## move_slow_and_clear
- No changes
## nav_core

```
* adding makePlan function with returned cost to base_global_planner
* Contributors: phil0stine
```
## navfn
- No changes
## navigation
- No changes
## robot_pose_ekf
- No changes
## rotate_recovery
- No changes
## voxel_grid
- No changes
