### PR TITLE
visp: 2.10.0-2 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -4962,7 +4962,7 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 2.9.0-3
+      version: 2.10.0-2
     status: maintained
   visualization:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `2.10.0-2`:
- upstream repository: svn://scm.gforge.inria.fr/svnroot/visp/tags/ViSP_2_10_0
- release repository: https://github.com/lagadic/visp-release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2.9.0-3`
