### PR TITLE
visp: 2.10.0-2 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1311,6 +1311,13 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: indigo
     status: maintained
+  visp:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/lagadic/visp-release.git
+      version: 2.10.0-2
+    status: maintained
   xacro:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `2.10.0-2`:
- upstream repository: svn://scm.gforge.inria.fr/svnroot/visp/tags/ViSP_2_10_0
- release repository: https://github.com/lagadic/visp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
