### PR TITLE
simple_grasping: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7866,6 +7866,21 @@ repositories:
       url: https://github.com/ros-drivers/sicktoolbox_wrapper.git
       version: indigo-devel
     status: maintained
+  simple_grasping:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/simple_grasping.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/simple_grasping-gbp.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/mikeferguson/simple_grasping.git
+      version: master
+    status: developed
   slam_gmapping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_grasping` to `0.2.0-0`:
- upstream repository: https://github.com/mikeferguson/simple_grasping.git
- release repository: https://github.com/fetchrobotics-gbp/simple_grasping-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## simple_grasping

```
* Initial release
* Contributors: Michael Ferguson
```
