### PR TITLE
hector_gazebo: 0.3.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2090,7 +2090,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
-      version: 0.3.5-0
+      version: 0.3.6-0
     status: maintained
   hector_localization:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_gazebo` to `0.3.6-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.3.5-0`
## hector_gazebo
- No changes
## hector_gazebo_plugins

```
* allow negative offsets in SensorModel dynamic_reconfigure config
* fixed sporadic NaN values in gazebo_ros_imu's angular_velocity output (fix #20)
* reintroduced orientation bias due to accelerometer and yaw sensor drift
  This orientation bias was removed in 74b21b7, but there is no need for this.
  The IMU can have a mounting offset and a bias error. To remove the bias error, set the accelerationDrift and yawDrift parameters to 0.
* interpret parameters xyzOffset and rpyOffset as pure mounting offsets and not as induced by accelerometer bias (fix #18)
  Obviously the SDF conversion assumes that all sensor plugins interpret the <xyzOffset> and <rpyOffset> parameters in the same way as an
  additional sensor link which is connected with a static joint to the real parent frame. I was not aware that this is a requirement.
  hector_gazebo_ros_imu interpreted the roll and pitch part of <rpyOffset> as an orientation offset caused by a (small) accelerometer bias.
  This patch completely removes the bias error on the orientation output in the Imu message and the orientation quaternion in the bias message
  is set to zero.
* Contributors: Johannes Meyer
```
## hector_gazebo_thermal_camera
- No changes
## hector_gazebo_worlds
- No changes
## hector_sensors_gazebo
- No changes
