### PR TITLE
industrial_core: 0.3.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2600,6 +2600,20 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/industrial_core.git
       version: indigo
+    release:
+      packages:
+      - industrial_core
+      - industrial_deprecated
+      - industrial_msgs
+      - industrial_robot_client
+      - industrial_robot_simulator
+      - industrial_trajectory_filters
+      - industrial_utils
+      - simple_message
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-industrial-release/industrial_core-release.git
+      version: 0.3.4-0
     source:
       type: git
       url: https://github.com/ros-industrial/industrial_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_core` to `0.3.4-0`:
- upstream repository: https://github.com/ros-industrial/industrial_core.git
- release repository: https://github.com/ros-industrial-release/industrial_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## industrial_core

```
* Fix #67 <https://github.com/ros-industrial/industrial_core/issues/67>.
```
## industrial_deprecated

```
* No change
```
## industrial_msgs

```
* No change
```
## industrial_robot_client

```
* robot_client: workaround for #46 <https://github.com/shaun-edwards/industrial_core/issues/46>. Fix #67 <https://github.com/shaun-edwards/industrial_core/issues/67>.
  This is an updated version of the workaround committed in 9df46977. Instead
  of requiring dependent packages to invoke the function defined in the
  CFG_EXTRAS cmake snippet, the snippet now sets up the linker path directly.
  Dependent packages now only need to remember to explicitly list their
  dependency on industrial_robot_client and simple_message in their
  add_library(..) statements.
* Contributors: gavanderhoorn
```
## industrial_robot_simulator

```
* No change
```
## industrial_trajectory_filters

```
* No change
```
## industrial_utils

```
* No change
```
## simple_message

```
* robot_client: workaround for #46 <https://github.com/shaun-edwards/industrial_core/issues/46>. Fix #67 <https://github.com/shaun-edwards/industrial_core/issues/67>.
  This is an updated version of the workaround committed in 9df46977. Instead
  of requiring dependent packages to invoke the function defined in the
  CFG_EXTRAS cmake snippet, the snippet now sets up the linker path directly.
  Dependent packages now only need to remember to explicitly list their
  dependency on industrial_robot_client and simple_message in their
  add_library(..) statements.
* Contributors: gavanderhoorn
```
