### PR TITLE
industrial_core: 0.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2622,7 +2622,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/industrial_core-release.git
-      version: 0.3.4-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/ros-industrial/industrial_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_core` to `0.4.0-0`:
- upstream repository: https://github.com/ros-industrial/industrial_core.git
- release repository: https://github.com/ros-industrial-release/industrial_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.3.4-0`
## industrial_core

```
* No changes
```
## industrial_deprecated

```
* No changes
```
## industrial_msgs

```
* No changes
```
## industrial_robot_client

```
* Fill stamp of the RobotStatus message Fix: #97 <https://github.com/shaun-edwards/industrial_core/issues/97>
  Just edited on a github didn't test it.
* Only accept goals after reception of controller feedback. Fix #85 <https://github.com/shaun-edwards/industrial_core/issues/85>.
* robot_client: workaround for #46 <https://github.com/shaun-edwards/industrial_core/issues/46>. Fix #67 <https://github.com/shaun-edwards/industrial_core/issues/67>.
  This is an updated version of the workaround committed in 9df46977. Instead
  of requiring dependent packages to invoke the function defined in the
  CFG_EXTRAS cmake snippet, the snippet now sets up the linker path directly.
  Dependent packages now only need to remember to explicitly list their
  dependency on industrial_robot_client and simple_message in their
  add_library(..) statements.
* Contributors: Libor Wagner, gavanderhoorn
```
## industrial_robot_simulator

```
* Fixed roslaunch test dependency and build depends for robot simulator package
* Corrected roslaunch test and added rospy depends to industrial_robot_simulator package
* Removed extraneous dependencies.  Re-enable launch test
* robot_simulator: add TU Delft copyright as well.
* robot_simulator: add BSD license header. Fix #90 <https://github.com/shaun-edwards/industrial_core/issues/90>.
* robot_simulator: set explicit queue size in Publishers. Fix #99 <https://github.com/shaun-edwards/industrial_core/issues/99>.
  Queue size of 1 is most likely sufficient for these topics.
* robot_simulator: add GetRobotInfo svc server.
* robot_simulator: quiet down node (use logdebug()).
* Merge pull request #88 <https://github.com/shaun-edwards/industrial_core/issues/88> from gavanderhoorn/rob_sim_robot_status
  Add RobotStatus publishing to robot simulator node
* robot_simulator: remove redundant load_manifest(). Fix #63 <https://github.com/shaun-edwards/industrial_core/issues/63>.
* robot_simulator: update manifest (depend on industrial_msgs).
* robot_simulator: publish RobotStatus msgs as well.
* robot_simulator: make initial joint state configurable. Fix #73 <https://github.com/shaun-edwards/industrial_core/issues/73>.
* Contributors: Shaun Edwards, gavanderhoorn
```
## industrial_trajectory_filters

```
* Added a smoothing filter as a planning request adapter plugin
* Contributors: Chris Lewis
```
## industrial_utils

```
* Silent warnings
* Contributors: Victor Lamoine
```
## simple_message

```
* Moved common socket contstructor code to simple_socket base class
* Updated simple message header to reflect vendor ranges specified in REP-I0004
* Correctly initialized connected state for udp connections
* Fixed issue #48 <https://github.com/shaun-edwards/industrial_core/issues/48>, logSocketError is now passed errno
* Merge pull request #70 <https://github.com/shaun-edwards/industrial_core/issues/70> from gt-ros-pkg/hydro-devel
  Fixing receiveBytes for UDP
* Macro'ed out GETHOSTBYNAME, and fixed if-statement braces to be on a new line for consistency
* Added support for gethostbyname, for passing host names in addition to IP addresses.
* Making setConnected protected again, adding setDisconnected to public methods so that that method can be used to flag the connection as disconnected.
* Putting back in timeout for receiveBytes
* More formal fix for UDP communication.
  This should now make UDP sockets act almost exactly like the
  TCP sockets.
* Fixing receiveBytes for UDP
* robot_client: workaround for #46 <https://github.com/shaun-edwards/industrial_core/issues/46>. Fix #67 <https://github.com/shaun-edwards/industrial_core/issues/67>.
  This is an updated version of the workaround committed in 9df46977. Instead
  of requiring dependent packages to invoke the function defined in the
  CFG_EXTRAS cmake snippet, the snippet now sets up the linker path directly.
  Dependent packages now only need to remember to explicitly list their
  dependency on industrial_robot_client and simple_message in their
  add_library(..) statements.
* Contributors: Fred Proctor, Kelsey, Shaun Edwards, gavanderhoorn
```
