### PR TITLE
common_msgs: 1.11.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1036,7 +1036,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.11.6-0
+      version: 1.11.7-0
     source:
       type: git
       url: https://github.com/ros/common_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.11.7-0`:
- upstream repository: https://github.com/ros/common_msgs.git
- release repository: https://github.com/ros-gbp/common_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.11.6-0`
## actionlib_msgs
- No changes
## common_msgs
- No changes
## diagnostic_msgs
- No changes
## geometry_msgs

```
* Add Accel, AccelStamped, AccelWithCovariance, AccelWithCovarianceStamped message definitions
* Add Inertia and InertiaStamped messages
* Contributors: Jonathan Bohren, Paul Bovbel
```
## nav_msgs

```
* change type of initial_pose in SetMap service to PoseWithCovarianceStamped
* Adds a SetMap service message to support swap maps functionality in amcl
* Contributors: Stephan Wirth, liz-murphy
```
## sensor_msgs
- No changes
## shape_msgs
- No changes
## stereo_msgs
- No changes
## trajectory_msgs
- No changes
## visualization_msgs
- No changes
