### PR TITLE
common_msgs: 1.12.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -202,7 +202,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.12.1-0
+      version: 1.12.2-0
     source:
       type: git
       url: https://github.com/ros/common_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.12.2-0`:
- upstream repository: git@github.com:ros/common_msgs.git
- release repository: https://github.com/ros-gbp/common_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.12.1-0`
## actionlib_msgs
- No changes
## common_msgs
- No changes
## diagnostic_msgs
- No changes
## geometry_msgs

```
* Add Accel, AccelStamped, AccelWithCovariance, AccelWithCovarianceStamped message definitions
* Add Inertia and InertiaStamped messages
* Contributors: Jonathan Bohren, Paul Bovbel
```
## nav_msgs

```
* change type of initial_pose in SetMap service to PoseWithCovarianceStamped
* Contributors: Stephan Wirth
```
## sensor_msgs
- No changes
## shape_msgs
- No changes
## stereo_msgs
- No changes
## trajectory_msgs
- No changes
## visualization_msgs
- No changes
