### PR TITLE
turtlebot_interactions: 2.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8426,7 +8426,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_interactions-release.git
-      version: 2.3.0-0
+      version: 2.3.1-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot_interactions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_interactions` to `2.3.1-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_interactions.git
- release repository: https://github.com/turtlebot-release/turtlebot_interactions-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2.3.0-0`
## turtlebot_dashboard
- No changes
## turtlebot_interactions
- No changes
## turtlebot_interactive_markers
- No changes
## turtlebot_rviz_launchers

```
* image_color -> image_rect_color closes #6 <https://github.com/turtlebot/turtlebot_interactions/issues/6>
* Contributors: Jihoon Lee
```
