### PR TITLE
rosbridge_suite: 0.7.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6919,7 +6919,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.7.10-0
+      version: 0.7.11-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.7.11-0`:
- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.7.10-0`
## rosapi

```
* rename rosapi script to rosapi_node to address #170 <https://github.com/RobotWebTools/rosbridge_suite/issues/170>
* Contributors: Jihoon Lee
```
## rosbridge_library
- No changes
## rosbridge_server

```
* rename rosapi script to rosapi_node to address #170 <https://github.com/RobotWebTools/rosbridge_suite/issues/170>
* Enabled TCP nodelay in Websocket handler
* Contributors: Jihoon Lee, Sebastien Mamessier
```
## rosbridge_suite
- No changes
