### PR TITLE
rocon_app_platform: 0.7.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6335,7 +6335,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_app_platform-release.git
-      version: 0.7.7-0
+      version: 0.7.8-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_app_platform` to `0.7.8-0`:
- upstream repository: http://github.com/robotics-in-concert/rocon_app_platform
- release repository: https://github.com/yujinrobot-release/rocon_app_platform-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.7.7-0`
## rocon_app_manager

```
* better warning for preferred rapp selection closes #274 <https://github.com/robotics-in-concert/rocon_app_platform/issues/274>
* clean up launchers #279 <https://github.com/robotics-in-concert/rocon_app_platform/issues/279>
* bugfix robot_naem arg location, fixes #276 <https://github.com/robotics-in-concert/rocon_app_platform/issues/276>.
* set moo as default preferred chirp closes #275 <https://github.com/robotics-in-concert/rocon_app_platform/issues/275>
* change warn to info closes #274 <https://github.com/robotics-in-concert/rocon_app_platform/issues/274>
* Contributors: Daniel Stonier, Jihoon Lee
```
## rocon_app_platform
- No changes
## rocon_app_utilities
- No changes
## rocon_apps
- No changes
