### PR TITLE
rocon_qt_gui: 0.7.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6442,7 +6442,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_qt_gui-release.git
-      version: 0.7.7-0
+      version: 0.7.8-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_qt_gui.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_qt_gui` to `0.7.8-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_qt_gui.git
- release repository: https://github.com/yujinrobot-release/rocon_qt_gui-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.7.7-0`
## concert_admin_app
- No changes
## concert_conductor_graph
- No changes
## concert_qt_make_a_map
- No changes
## concert_qt_map_annotation
- No changes
## concert_qt_service_info
- No changes
## concert_qt_teleop
- No changes
## rocon_gateway_graph
- No changes
## rocon_qt_app_manager
- No changes
## rocon_qt_gui
- No changes
## rocon_qt_library
- No changes
## rocon_qt_listener
- No changes
## rocon_qt_master_info
- No changes
## rocon_qt_teleop
- No changes
## rocon_remocon

```
* fix message box argument into parent widget from None
* update QMessage box argument
* update way of interactions status update to remove qt warning message
* fix wrong parsor about ros host name and update shutdown process
* update setup.py to launch rqt_remocon in global
* delete unused resourece
* update api document
* update and test finish in rqt and rocon remocon
* make rqt remocon
* Contributors: dwlee
```
