### PR TITLE
turtlebot: 2.3.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8317,7 +8317,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot-release.git
-      version: 2.3.7-0
+      version: 2.3.8-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot` to `2.3.8-0`:
- upstream repository: https://github.com/turtlebot/turtlebot.git
- release repository: https://github.com/turtlebot-release/turtlebot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2.3.7-0`
## turtlebot
- No changes
## turtlebot_bringup

```
* update compatibility for upgrade turtlebot android apps
* Merge pull request #201 <https://github.com/turtlebot/turtlebot/issues/201> from dwlee/indigo_teleop
  Update interaction
* [turtlebot_bringup] fix conflicts in the turtlebot base launchers
* [turtlebot_bringup] doc strings for roslaunch args.
* update android teleop remapping rule and add kitkat in compatibility
* add rapp preferred configuration
* expose the interactions list in a way that conforms to the rest of the turtlebot environment settings.
* doc'ified some url args.
* bugfixes incorrect concert_whitelist arg default, fixes #199 <https://github.com/turtlebot/turtlebot/issues/199>.
* Merge branch 'indigo' of https://github.com/turtlebot/turtlebot into indigo
* visualisation interactions
* add ps3 joystick interactions closes #196 <https://github.com/turtlebot/turtlebot/issues/196>
* Contributors: Daniel Stonier, Jihoon Lee, dwlee
```
## turtlebot_capabilities
- No changes
## turtlebot_description

```
* replace fbx model to open collada model closes #198 <https://github.com/turtlebot/turtlebot/issues/198>
* Contributors: Jihoon Lee
```
## turtlebot_teleop
- No changes
