### PR TITLE
rocon_concert: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1100,7 +1100,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/concert_services-release.git
-      version: 0.1.9-0
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/concert_services.git
@@ -6361,7 +6361,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_concert-release.git
-      version: 0.6.5-0
+      version: 0.6.6-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_concert.git
@@ -6442,7 +6442,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_qt_gui-release.git
-      version: 0.7.8-0
+      version: 0.7.7-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_qt_gui.git
@@ -8317,7 +8317,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot-release.git
-      version: 2.3.8-0
+      version: 2.3.7-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_concert` to `0.6.6-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_concert
- release repository: https://github.com/yujinrobot-release/rocon_concert-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.6.5-0`
## concert_conductor
- No changes
## concert_master
- No changes
## concert_schedulers
- No changes
## concert_service_link_graph
- No changes
## concert_service_manager
- No changes
## concert_service_utilities
- No changes
## concert_software_farmer

```
* [rocon_concert] remove debugging prints.
* Contributors: Daniel Stonier
```
## concert_utilities

```
* [rocon_concert] remove debugging prints.
* [concert_utilities] fuchsia->magenta, fixes #275 <https://github.com/robotics-in-concert/rocon_concert/issues/275>.
* fuschia->fuchsia, fixes #275 <https://github.com/robotics-in-concert/rocon_concert/issues/275>.
* Contributors: Daniel Stonier
```
## rocon_concert
- No changes
## rocon_tf_reconstructor
- No changes
