### PR TITLE
husky, husky_desktop, husky_robot, husky_simulator: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2297,112 +2297,62 @@ repositories:
       url: https://github.com/ahornung/humanoid_msgs.git
       version: devel
     status: maintained
-  husky_base:
+  husky:
     doc:
       type: git
-      url: https://github.com/husky/husky_base.git
+      url: https://github.com/husky/husky.git
       version: indigo-devel
     release:
+      packages:
+      - husky_control
+      - husky_description
+      - husky_msgs
+      - husky_navigation
+      - husky_ur5_moveit_config
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/clearpath-gbp/husky_base-release.git
-      version: 0.1.5-0
+      url: https://github.com/clearpath-gbp/husky-release.git
+      version: 0.2.0-0
     source:
       type: git
-      url: https://github.com/husky/husky_base.git
+      url: https://github.com/husky/husky.git
       version: indigo-devel
     status: maintained
-  husky_bringup:
+  husky_desktop:
     doc:
       type: git
-      url: https://github.com/husky/husky_bringup.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/clearpath-gbp/husky_bringup-release.git
-      version: 0.1.2-0
-    source:
-      type: git
-      url: https://github.com/husky/husky_bringup.git
-      version: indigo-devel
-    status: maintained
-  husky_control:
-    doc:
-      type: git
-      url: https://github.com/husky/husky_control.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/clearpath-gbp/husky_control-release.git
-      version: 0.0.4-0
-    source:
-      type: git
-      url: https://github.com/husky/husky_control.git
-      version: indigo-devel
-    status: maintained
-  husky_description:
-    doc:
-      type: git
-      url: https://github.com/husky/husky_description.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/clearpath-gbp/husky_description-release.git
-      version: 0.1.2-0
-    source:
-      type: git
-      url: https://github.com/husky/husky_description.git
-      version: indigo-devel
-    status: maintained
-  husky_metapackages:
-    doc:
-      type: git
-      url: https://github.com/husky/husky_metapackages.git
+      url: https://github.com/husky/husky_desktop.git
       version: indigo-devel
     release:
       packages:
       - husky_desktop
+      - husky_viz
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/husky_desktop-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/husky/husky_desktop.git
+      version: indigo-devel
+    status: maintained
+  husky_robot:
+    doc:
+      type: git
+      url: https://github.com/husky/husky_robot.git
+      version: indigo-devel
+    release:
+      packages:
+      - husky_base
+      - husky_bringup
       - husky_robot
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/clearpath-gbp/husky_metapackages-release.git
-      version: 0.1.1-0
+      url: https://github.com/clearpath-gbp/husky_robot-release.git
+      version: 0.2.0-0
     source:
       type: git
-      url: https://github.com/husky/husky_metapackages.git
-      version: indigo-devel
-    status: maintained
-  husky_msgs:
-    doc:
-      type: git
-      url: https://github.com/husky/husky_msgs.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/clearpath-gbp/husky_msgs-release.git
-      version: 0.0.2-0
-    source:
-      type: git
-      url: https://github.com/husky/husky_msgs.git
-      version: indigo-devel
-    status: maintained
-  husky_navigation:
-    doc:
-      type: git
-      url: https://github.com/husky/husky_navigation.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/clearpath-gbp/husky_navigation-release.git
-      version: 0.1.2-0
-    source:
-      type: git
-      url: https://github.com/husky/husky_navigation.git
+      url: https://github.com/husky/husky_robot.git
       version: indigo-devel
     status: maintained
   husky_simulator:
@@ -2421,21 +2371,6 @@ repositories:
     source:
       type: git
       url: https://github.com/husky/husky_simulator.git
-      version: indigo-devel
-    status: maintained
-  husky_viz:
-    doc:
-      type: git
-      url: https://github.com/husky/husky_viz.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/clearpath-gbp/husky_viz-release.git
-      version: 0.1.1-0
-    source:
-      type: git
-      url: https://github.com/husky/husky_viz.git
       version: indigo-devel
     status: maintained
   iai_common_msgs:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2417,7 +2417,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_simulator-release.git
-      version: 0.1.4-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/husky/husky_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.2.0-0`

Increasing version of package(s) in repository `husky_desktop` to `0.2.0-0`

Increasing version of package(s) in repository `husky_robot` to `0.2.0-0`

Increasing version of package(s) in repository `husky_simulator` to `0.2.0-0`:
- upstream repository: https://github.com/husky/husky_simulator.git
- release repository: https://github.com/clearpath-gbp/husky_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.4-0`
## husky_gazebo

```
* Refactor URDF
* Add UR5 and Kinect simulation
* Contributors: Paul Bovbel, TheDash
```
## husky_simulator
- No changes
