### PR TITLE
perception_pcl: 1.2.6-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -901,7 +901,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/perception_pcl-release.git
-      version: 1.2.6-0
+      version: 1.2.6-1
     source:
       type: git
       url: https://github.com/ros-perception/perception_pcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.2.6-1`:
- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.2.6-0`
## pcl_ros
- No changes
## perception_pcl
- No changes
## pointcloud_to_laserscan

```
* Fix default value for concurrency
* Fix multithreaded lazy pub sub
* Contributors: Paul Bovbel
```
