### PR TITLE
husky: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2323,7 +2323,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.2.1-0`:
- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.0-0`
## husky_control

```
* Update control params with base_link
* Contributors: Paul Bovbel
```
## husky_description

```
* Port *.stl to *.dae format, removing material/gazebo colours
* Make base_footprint a child of base_link
* Contributors: Paul Bovbel
```
## husky_msgs
- No changes
## husky_navigation
- No changes
## husky_ur5_moveit_config

```
* remove temp files
* Contributors: Paul Bovbel
```
