### PR TITLE
industrial_core: 0.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2568,7 +2568,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/industrial_core-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/ros-industrial/industrial_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_core` to `0.4.1-0`:
- upstream repository: https://github.com/ros-industrial/industrial_core.git
- release repository: https://github.com/ros-industrial-release/industrial_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.4.0-0`
## industrial_core

```
* No changes
```
## industrial_deprecated

```
* Fixed changelog links to point to main repo
* Contributors: Shaun Edwards
```
## industrial_msgs

```
* Fixed changelog links to point to main repo
* Contributors: Shaun Edwards
```
## industrial_robot_client

```
* Fixed changelog links to point to main repo
* Contributors: Shaun Edwards
```
## industrial_robot_simulator

```
* Fixed changelog links to point to main repo
* Contributors: Shaun Edwards
```
## industrial_trajectory_filters

```
* No changes
```
## industrial_utils

```
* Fixed changelog links to point to main repo
* Contributors: Shaun Edwards
```
## simple_message

```
* Fixed changelog links to point to main repo
* Contributors: Shaun Edwards
```
