### PR TITLE
Adding crom_common and crom_sim to documentation index for hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1240,6 +1240,26 @@ repositories:
       url: https://github.com/cram-code/cram_core.git
       version: master
     status: maintained
+  crom_common:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/crom_common.git
+      version: hydro-devel
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/crom_common.git
+      version: hydro-devel
+    status: maintained
+  crom_sim:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/crom_sim.git
+      version: hydro-devel
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/crom_sim.git
+      version: hydro-devel
+    status: maintained
   crsm_slam:
     doc:
       type: git


### PR DESCRIPTION
I'd like crom_common and crom_sim to be indexed or ros.org
