### PR TITLE
mavros: 0.11.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3723,7 +3723,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.10.2-0
+      version: 0.11.0-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.11.0-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.10.2-0`
## libmavconn

```
* readme: fix links
* license #242 <https://github.com/vooon/mavros/issues/242>: add license files
* license #242 <https://github.com/vooon/mavros/issues/242>: update libmavconn headers
* libmavconn: Fix logging (now all connections use same log name)
  Before i got several names: URL, serial0..
  But severity only changes if i changed first registered tag (URL).
  Now all debug will be enabled by one tag: ros.rosconsole_bridge.mavconn
  And because its only used for debugging that was ok.
* Contributors: Vladimir Ermakov
```
## mavros

```
* plugin: setpoint_position #247 <https://github.com/vooon/mavros/issues/247>: rename topic
* launch #257 <https://github.com/vooon/mavros/issues/257>: rename blacklist.yaml to pluginlists.yaml
* node #257 <https://github.com/vooon/mavros/issues/257>: implement while list.
* plugin: actuator_control #247 <https://github.com/vooon/mavros/issues/247>: update topic name.
* mavros: Initialize UAS before connecting plugin routing.
  Inspired by #256 <https://github.com/vooon/mavros/issues/256>.
* plugin: sys_status: Check sender id.
  Inspired by #256 <https://github.com/vooon/mavros/issues/256>.
* plugin: sys_status: Use WARN severity for unknown levels
* uas: Add UAS::is_my_target()
  Inspired by #256 <https://github.com/vooon/mavros/issues/256>.
* plugin: global_position: Fill status and covariance if no raw_fix.
  Additional fix for #252 <https://github.com/vooon/mavros/issues/252>.
* launch: change apm target component id
  APM uses 1/1 (sys/comp) by default.
* plugin: sys_status: publish state msg after updating uas
  Before this commit, the custom mode string published in the
  state message was computed using the autopilot type from the
  previous heartbeat message--*not* the autopilot type from the
  current hearbeat message.
  Normally that isn't a problem, but when running a GCS and mavros
  concurrently, both connected to an FCU that routes mavlink packets
  (such as APM), then this causes the custom mode to be computed
  incorrectly, because the mode string for the GCS's hearbeat packet
  will be computed using the FCU's autopilot type, and the mode string
  for the FCU's heartbeat packet will be computed using the GCS's
  autopilot type.
* plugin: global_position: fix nullptr crash
  This fixes a crash in cases where a GLOBAL_POSITION_INT message
  is received before a GPS_RAW_INT message, causing the gps_fix
  pointer member to be dereferenced before it has been set.
* msgs: fix spelling, add version rq.
* coverity: init ctor in 3dr_radio
* launch fix #249 <https://github.com/vooon/mavros/issues/249>: update apm blacklist
* launch: rename APM2 to APM.
* launch #211 <https://github.com/vooon/mavros/issues/211>: update configs
* plugin: gps: remove unused param
* plugin: sys_time: remove unused param
* launch fix #248 <https://github.com/vooon/mavros/issues/248>: remove radio launch
* plugin: 3dr_radio #248 <https://github.com/vooon/mavros/issues/248>: add/remove diag conditionally
* plugin: sys_status: move connection params to ns
* plugin: sys_time: fix #206 <https://github.com/vooon/mavros/issues/206> (param ns)
* node: Inform what dialect built-in node
* plugin: sys_status: Conditionaly add APM diag
* plugin: sys_status: fix #244 <https://github.com/vooon/mavros/issues/244>
* uas #244 <https://github.com/vooon/mavros/issues/244>: add enum lookups
* package: update lic
* license #242 <https://github.com/vooon/mavros/issues/242>: update mavros headers
* plugin: local_positon: use auto
* plugin: imu_pub: Update UAS store.
* plugin: gps: remove diag class, change UAS storage API.
* plugin api #241 <https://github.com/vooon/mavros/issues/241>: move diag updater to UAS.
* plugin api #241 <https://github.com/vooon/mavros/issues/241>: remove global private node handle.
  Now all plugins should define their local node handle (see dummy.cpp).
  Also partially does #233 <https://github.com/vooon/mavros/issues/233> (unmerge setpoint topic namespace).
* plugin api #241 <https://github.com/vooon/mavros/issues/241>: remove get_name()
* package: mavros now has any-link proxy, not only UDP
* Update years. I left gpl header, but it is BSD too.
* Add BSD license option #220 <https://github.com/vooon/mavros/issues/220>
* plugin: sys_status: AUTOPILOT_VERSION support.
  Fix #96 <https://github.com/vooon/mavros/issues/96>.
* mavros fix #235 <https://github.com/vooon/mavros/issues/235>: Use AsyncSpinner to allow plugins chat.
  Old single-threaded spinner have a dead-lock if you tried to call
  a service from for example timer callback.
  For now i hardcoded thread count (4).
* uncrustify: actuator_control
* Merge branch 'master' of github.com:mstuettgen/Mavros
* fixed missing ;
* code cosmetics
* further removed unneeded white spaces and minor code cosmetics
* fixed timestamp and commented in the not-working function call
* code cosmetics, removed whitespaces and re-ordered function signatures
* more code comment cosmetic
* code comment cosmetic
* uncrustify: fix style
* readme: add contributing notes
* uncrustify: mavros base plugins
* uncrustify: mavros lib
* uncrustify: mavros headers
* tools: add uncrustify cfg for fixing codestyle
  Actually it different from my codestyle,
  but much closer than others.
* added more const to function calls to ensure data consistency
* modified code to fit new message
* added group_mix to ActuatorControl.msg and a link to mixing-wiki
* plugin: rc_io: Add override support warning
* REALLY added ActuatorControl.msg
* added ActuatorControl.msg
* fixed latest compiler error
* renamed cpp file to actuator_control.cpp and added the new plugin to mavros_plugins.xml
* removed unneeded Mixinx and reverse_throttle, and unneeded variables in function signatures
* inital draft for set_actuator_control plugin
* launch: enable setpoint plugins for APM
  As of ArduCopter 3.2, APM supports position and velocity setpoints via SET_POSITION_TARGET_LOCAL_NED.
* plugin: setpoint_velocity: Fix vx setpoint
  vz should have been vx.
* Contributors: Clay McClure, Marcel Stuettgen, Marcel Stüttgen, Vladimir Ermakov
```
## mavros_extras

```
* extras: vision_pose #247 <https://github.com/vooon/mavros/issues/247>: rename topic
* extras: launch #257 <https://github.com/vooon/mavros/issues/257>: use white list for px4flow.
  Also updates config #211 <https://github.com/vooon/mavros/issues/211>.
* uncrustify and fix #207 <https://github.com/vooon/mavros/issues/207>
* uncrustify extras
* package: update lic
* license #242 <https://github.com/vooon/mavros/issues/242>: update mavros_extras headers
* plugin api #241 <https://github.com/vooon/mavros/issues/241>: move diag updater to UAS.
* plugin api #241 <https://github.com/vooon/mavros/issues/241>: remove global private node handle.
  Now all plugins should define their local node handle (see dummy.cpp).
  Also partially does #233 <https://github.com/vooon/mavros/issues/233> (unmerge setpoint topic namespace).
* plugin api #241 <https://github.com/vooon/mavros/issues/241>: remove get_name()
* Add BSD license option #220 <https://github.com/vooon/mavros/issues/220>
* uncrustify: mocap plugin
* Switched from mavlink VICON_POSITION_ESTIMATE to ATT_POS_MOCAP.
* Contributors: Tony Baltovski, Vladimir Ermakov
```
