### PR TITLE
rail_manipulation_msgs: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5909,6 +5909,21 @@ repositories:
       url: https://github.com/WPI-RAIL/rail_collada_models.git
       version: develop
     status: maintained
+  rail_manipulation_msgs:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_manipulation_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/rail_manipulation_msgs-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_manipulation_msgs.git
+      version: develop
+    status: maintained
   rail_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_manipulation_msgs` to `0.0.1-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_manipulation_msgs.git
- release repository: https://github.com/wpi-rail-release/rail_manipulation_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## rail_manipulation_msgs

```
* added image to segmented
* added marker and centroid to objects
* added readmes and such
* initial messages
* Contributors: Russell Toris
```
