### PR TITLE
rail_collada_models: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5903,7 +5903,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_collada_models-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_collada_models.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_collada_models` to `0.0.4-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_collada_models.git
- release repository: https://github.com/wpi-rail-release/rail_collada_models-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.3-0`
## rail_collada_models

```
* Merge pull request #12 from PeterMitrano/develop
  Fixed surfaces on kitchen table and coffee table
* flipped table surface. added chair surfaces
* Merge branch 'develop' of https://github.com/WPI-RAIL/rail_collada_models into develop
* moved table marker closer
* added sizes of surfaces
* marker too close for arm
* added surfaces with macro
* Contributors: Peter, Russell Toris
```
