### PR TITLE
carl_moveit: 0.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -617,7 +617,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_moveit-release.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_moveit` to `0.0.8-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_moveit.git
- release repository: https://github.com/wpi-rail-release/carl_moveit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.7-0`
## carl_moveit

```
* Updated IK and MoveToPose to use stamped poses instead of base_footprint frame poses
* Removed run dependency on moveit visualization
* Update CMakeLists.txt
* Update .travis.yml
* lift server start
* Planning-based hand lift
* Output message when arm is already retracted
* retract bug fix
* Added check if arm is already retracted before performing a home->retract action
* Cancel retract if home fails
* Better failure detection on joint pose goal planning and moving
* Merge branch 'develop' of github.com:WPI-RAIL/carl_moveit into develop
* Error code debugging on failed moveToPose
* Contributors: David Kent, Russell Toris
```
