### PR TITLE
wpi_jaco: 0.0.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8993,15 +8993,18 @@ repositories:
       packages:
       - jaco_description
       - jaco_interaction
+      - jaco_moveit_config
       - jaco_sdk
       - jaco_teleop
+      - mico_description
+      - mico_moveit_config
       - wpi_jaco
       - wpi_jaco_msgs
       - wpi_jaco_wrapper
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/wpi_jaco-release.git
-      version: 0.0.15-0
+      version: 0.0.16-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/wpi_jaco.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wpi_jaco` to `0.0.16-0`:
- upstream repository: https://github.com/RIVeR-Lab/wpi_jaco.git
- release repository: https://github.com/wpi-rail-release/wpi_jaco-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.15-0`
## jaco_description

```
* copied old meshes. manual texturing failed on web.
* Minor fixes for better placement of items.
  Also:
  - Actually launches joint controllers in the Gazebo launch
  - Allows the robot to be specified, this allows mounting the Jaco arm on
  a variety of bases using the same gazebo launch.
* Added Gazebo support.
  Added necessary elements for Gazebo simulation:
  - Mass (currently made up)
  - Inertia (currently made up)
  - Joint controllers for the Gazebo robot using ROS Control
  - Transmissions on necessary joints
  - Gripper tag to support grasping (may need tuning)
* Contributors: Alex Henning, Peter
```
## jaco_interaction

```
* Fixed retract position from interactive marker call so that the arm doesn't bump itself
* travis edit and some naming cleanup
* Updated jaco interaction to use the new rail_manipulation_msgs
* Contributors: David Kent
```
## jaco_moveit_config

```
* changelogs updated
* Moved jaco_gazebo to its own package
* Updated package documentation
* Updated jaco controllers list for moveit configuration, added install to CMakeLists, and other general cleanup
* Added moveit support for the standalone Jaco arm
* Contributors: Alex Henning, David Kent, Russell Toris
* Moved jaco_gazebo to its own package
* Updated package documentation
* Updated jaco controllers list for moveit configuration, added install to CMakeLists, and other general cleanup
* Added moveit support for the standalone Jaco arm
* Contributors: Alex Henning, David Kent
```
## jaco_sdk

```
* Updated Kinova libraries
* Fix for compatibilty with catkin_tools build system
* Contributors: Dave Coleman, David Kent
```
## jaco_teleop
- No changes
## mico_description

```
* changelogs updated
* Added mico_description
* Contributors: Mathijs de Langen, Russell Toris
* Added mico_description
* Contributors: Mathijs de Langen
```
## mico_moveit_config

```
* changelogs updated
* Added newline
* Added Mico MoveIt! configuration
* Contributors: Mathijs de Langen, Russell Toris
* Added newline
* Added Mico MoveIt! configuration
* Contributors: Mathijs de Langen
```
## wpi_jaco

```
* Moved jaco_gazebo to its own package
* Updated jaco controllers list for moveit configuration, added install to CMakeLists, and other general cleanup
* Contributors: David Kent
```
## wpi_jaco_msgs

```
* Removed redundant messages
* Contributors: David Kent
```
## wpi_jaco_wrapper

```
* Removed some debugging output
* Put back the remapping
* Removed the *0.8 for testing
* Added some comments for the parameters
* finger_threshold, made error counting for mico depend on two/three fingers
* added finger_error_threshold as configurable parameter
* added finger_error_threshold as configurable parameter
* Moved the } two lines to below (WRONG MERGE:/)
* removed space
* recommented stuff
* for loops for the fingers
* newline
* Newlines at end of file
* Load params for each node
* Deal with different number of fingers
* Removed test code
* private nodehandle not needed
* Made num finger joints configurable
* added parameters, fixed typo
* forgotten nodehandle
* actionlib typedefs, made actionlib constructs pointer so parameters can be loaded first
* Synced all topics names with arm_name_
* conversions topic uses arm name parameter
* made loadParameters a const function
* Renamed variables to follow ROS naming conventions
* Topic renaming
* Renamed topics
* Made jaco_arm_trajectory_node configurable
* Configurable parameters via #defines added
* Missing a lock in the gripper action server, should fix a potential crash with the jaco
* Changed gripper action success conditions to better reflect reality
* Removed redundant messages
* Updated jaco interaction to use the new rail_manipulation_msgs
* Switched jaco_manipulation to use rail_manipulation_msgs
* Contributors: David Kent, Mathijs de Langen
```
