### PR TITLE
rail_segmentation: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5970,7 +5970,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_segmentation.git
-      version: 0.0.5-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_segmentation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_segmentation` to `0.1.0-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_segmentation.git
- release repository: https://github.com/wpi-rail-release/rail_segmentation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.5-0`
## rail_segmentation

```
* added RGB image to message
* average RGB on marker
* uses indices instead of new PCs
* Merge pull request #1 from WPI-RAIL/refactor
  Refactor
* merge conflicts
* Revert "plane detection refactored"
  This reverts commit 7160b0b12e55755451ec5c8a9318e05552924cc6.
* doc added
* cleanup of old files
* first pass of new segmentation node
* plane detection refactored
* Added a recognize all action which gives feedback throughout the recognition process; the recognize all server remains for compatibility, but it's recommended to use the action server instead.
* Edited .travis.yml
* Merge branch 'develop' of github.com:WPI-RAIL/rail_segmentation into develop
* Updated to reflect moving some messages from rail_segmentation to rail_manipulation_messages
* Contributors: David Kent, Russell Toris
```
