### PR TITLE
carl_bot: 0.0.17-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -572,7 +572,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_bot-release.git
-      version: 0.0.16-0
+      version: 0.0.17-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_bot.git
@@ -617,7 +617,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_moveit-release.git
-      version: 0.0.8-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_moveit.git
@@ -5903,7 +5903,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_collada_models-release.git
-      version: 0.0.4-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_collada_models.git
@@ -5970,7 +5970,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_segmentation.git
-      version: 0.1.0-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_segmentation.git
@@ -6838,7 +6838,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rosauth-release.git
-      version: 0.1.6-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rosauth.git
@@ -8993,18 +8993,15 @@ repositories:
       packages:
       - jaco_description
       - jaco_interaction
-      - jaco_moveit_config
       - jaco_sdk
       - jaco_teleop
-      - mico_description
-      - mico_moveit_config
       - wpi_jaco
       - wpi_jaco_msgs
       - wpi_jaco_wrapper
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/wpi_jaco-release.git
-      version: 0.0.16-0
+      version: 0.0.15-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/wpi_jaco.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_bot` to `0.0.17-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_bot.git
- release repository: https://github.com/wpi-rail-release/carl_bot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.16-0`
## carl_bot
- No changes
## carl_bringup

```
* limited output on phidgets initialization, added moveit stuff to carl_bringup launch
* Contributors: David Kent
```
## carl_description

```
* Added an end effector frame for the JACO
* Contributors: David Kent
```
## carl_dynamixel
- No changes
## carl_interactive_manipulation

```
* Added new recognition calls to carl_interactive_manipulation (note that pickup is still in progress and will not currently work)
* updted message
* Updated to reflect moving some messages from rail_segmentation to rail_manipulation_messages
* Switched im to use new rail_manipulation_msgs
* Contributors: David Kent, Russell Toris
```
## carl_phidgets

```
* limited output on phidgets initialization, added moveit stuff to carl_bringup launch
* Contributors: David Kent
```
## carl_teleop
- No changes
## carl_tools
- No changes
