### PR TITLE
jaco_gazebo: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2772,6 +2772,21 @@ repositories:
       url: https://github.com/jackal/jackal_simulator.git
       version: indigo-devel
     status: developed
+  jaco_gazebo:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/jaco_gazebo.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/jaco_gazebo-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/jaco_gazebo.git
+      version: develop
+    status: maintained
   joystick_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jaco_gazebo` to `0.0.1-0`:
- upstream repository: https://github.com/WPI-RAIL/jaco_gazebo.git
- release repository: https://github.com/wpi-rail-release/jaco_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## jaco_gazebo

```
* release cleanup
* initial commit
* Contributors: David Kent, Russell Toris
```
