### PR TITLE
stage: 4.1.1-4 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8099,7 +8099,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/stage-release.git
-      version: 4.1.1-3
+      version: 4.1.1-4
     status: maintained
   stage_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `stage` to `4.1.1-4`:
- upstream repository: https://github.com/rtv/Stage.git
- release repository: https://github.com/ros-gbp/stage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `4.1.1-3`
