### PR TITLE
stage: 4.1.1-2 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1189,7 +1189,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/stage-release.git
-      version: 4.1.1-1
+      version: 4.1.1-2
     status: maintained
   stage_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `stage` to `4.1.1-2`:
- upstream repository: https://github.com/rtv/Stage.git
- release repository: https://github.com/ros-gbp/stage-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `4.1.1-1`
