### PR TITLE
segbot: 0.3.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7940,7 +7940,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/segbot-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/utexas-bwi/segbot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot` to `0.3.1-0`:
- upstream repository: https://github.com/utexas-bwi/segbot.git
- release repository: https://github.com/utexas-bwi-gbp/segbot-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.3.0-0`
## segbot
- No changes
## segbot_bringup

```
* removed redundant segbot v1 models.
* updated segbot v2 model to use correct URDF.
* Contributors: Piyush Khandelwal
```
## segbot_description

```
* removed redundant segbot v1 models.
* added new segbot v2 model URDF.
* Contributors: Piyush Khandelwal
```
## segbot_firmware
- No changes
## segbot_sensors
- No changes
