### PR TITLE
bwi_common: 0.3.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -565,7 +565,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/bwi_common-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi_common` to `0.3.2-0`:
- upstream repository: https://github.com/utexas-bwi/bwi_common.git
- release repository: https://github.com/utexas-bwi-gbp/bwi_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.3.1-0`
## bwi_common
- No changes
## bwi_gazebo_entities
- No changes
## bwi_interruptable_action_server
- No changes
## bwi_kr_execution

```
* updated Clingo to use the current state correctly.
* removed output that was placed in for debugging. closes #17 <https://github.com/utexas-bwi/bwi_common/issues/17>.
* added missing directory installation. closes #16 <https://github.com/utexas-bwi/bwi_common/issues/16>
* Contributors: Piyush Khandelwal
```
## bwi_mapper
- No changes
## bwi_msgs
- No changes
## bwi_planning_common

```
* removed accidental global script installation. closes #18 <https://github.com/utexas-bwi/bwi_common/issues/18>.
* Contributors: Piyush Khandelwal
```
## bwi_tasks
- No changes
## bwi_tools
- No changes
## bwi_web
- No changes
## utexas_gdc
- No changes
