### PR TITLE
segbot_simulator: 0.3.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7985,7 +7985,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/segbot_simulator-release.git
-      version: 0.2.1-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/utexas-bwi/segbot_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot_simulator` to `0.3.0-0`:
- upstream repository: https://github.com/utexas-bwi/segbot_simulator.git
- release repository: https://github.com/utexas-bwi-gbp/segbot_simulator-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.1-0`
## segbot_gazebo

```
* use the updated segbot_v1 hokuyo only launch file as default.
* now set yaw correctly for true localization as well
* use different eband parameters in simulation.
* allow changing the move base server.
* Contributors: Piyush Khandelwal
```
## segbot_simulation_apps

```
* added missing dependency on multi_level_map_msgs.
* migrated DoorHandlerInterface from segbot_simulation_apps to bwi_msgs in the bwi_common repository.
* updated door handler to use new multimap.
* Contributors: Piyush Khandelwal
```
## segbot_simulator
- No changes
