### PR TITLE
bwi: 0.3.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -538,7 +538,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/bwi-release.git
-      version: 0.2.1-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi` to `0.3.0-0`:
- upstream repository: https://github.com/utexas-bwi/bwi.git
- release repository: https://github.com/utexas-bwi-gbp/bwi-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.1-0`
## bwi_desktop

```
* bwi_desktop: remove obsolete dependencies (#17 <https://github.com/utexas-bwi/bwi/issues/17>)
  also convert to package.xml format two
  also convert and update bwi_desktop_full
* Contributors: Jack O'Quin
```
## bwi_desktop_full

```
* bwi_desktop: remove obsolete dependencies (#17 <https://github.com/utexas-bwi/bwi/issues/17>)
  also convert to package.xml format two
  also convert and update bwi_desktop_full
* Contributors: Jack O'Quin
```
## bwi_launch

```
* bwi_launch: add build dependencies for launch checking references (#16 <https://github.com/utexas-bwi/bwi/issues/16>)
  do not depend on segbot_gazebo twice
* bwi_launch: dependency and launch file cleanup
  partial fix for #16 <https://github.com/utexas-bwi/bwi/issues/16>
* added launch files for segbot v1 and v2 to bwi_launch
* Contributors: Jack O'Quin, Piyush Khandelwal
```
