### PR TITLE
geometry_experimental: 0.5.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1947,7 +1947,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry_experimental-release.git
-      version: 0.5.8-0
+      version: 0.5.9-0
     source:
       type: git
       url: https://github.com/ros/geometry_experimental.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_experimental` to `0.5.9-0`:
- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry_experimental-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.5.8-0`
## geometry_experimental
- No changes
## tf2

```
* fixing edge case where two no frame id lookups matched in getLatestCommonTime
* Contributors: Tully Foote
```
## tf2_bullet
- No changes
## tf2_geometry_msgs
- No changes
## tf2_kdl
- No changes
## tf2_msgs
- No changes
## tf2_py
- No changes
## tf2_ros

```
* changed queue_size in Python transform boradcaster to match that in c++
* Contributors: mrath
```
## tf2_sensor_msgs
- No changes
## tf2_tools
- No changes
