### PR TITLE
geometry: 1.11.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -438,7 +438,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/geometry-release.git
-      version: 1.11.5-0
+      version: 1.11.6-0
     source:
       type: git
       url: https://github.com/ros/geometry.git
@@ -464,7 +464,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/geometry_experimental-release.git
-      version: 0.5.9-0
+      version: 0.5.8-0
     source:
       type: git
       url: https://github.com/ros/geometry_experimental.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry` to `1.11.6-0`:
- upstream repository: https://github.com/ros/geometry.git
- release repository: https://github.com/ros-gbp/geometry-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.11.5-0`
## eigen_conversions
- No changes
## geometry
- No changes
## kdl_conversions
- No changes
## tf

```
* reenable python tests
* Broadcaster: Rospy fix #84 <https://github.com/ros/geometry/issues/84>. Add sendTransformMessage.
* Contributors: Tully Foote, lsouchet
```
## tf_conversions
- No changes
