### PR TITLE
phidgets_drivers: 0.2.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5436,7 +5436,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/muhrix/phidgets_drivers-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/phidgets_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `0.2.2-0`:
- upstream repository: https://github.com/ccny-ros-pkg/phidgets_drivers.git
- release repository: https://github.com/muhrix/phidgets_drivers-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.1-0`
## phidgets_api

```
* phidgets_api: updated build/installation rules to use 3rd party libphdigets ROS package
* phidgets_api: updated package details
* phidgets_api: added copy of udev rule to package and updated path in script
* phidgets_api: updated path to libphidgets header file
* phidgets_api: removed license and header file of phidgets library
* Contributors: Murilo FM
```
## phidgets_drivers
- No changes
## phidgets_imu

```
* Merge pull request #18 from ccny-ros-pkg/libphidgets
  Merge libphidgets branch into indigo
* set orientation_covariance[0] to -1
  from Imu.msg:
  > If you have no estimate for one of the data elements (e.g. your IMU doesn't produce an orientation
  > estimate), please set element 0 of the associated covariance matrix to -1.
* phidgets_imu: fixed issue #9
* Contributors: Martin Günther, Murilo FM
```
## phidgets_ir
- No changes
