### PR TITLE
libsegwayrmp: 0.2.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3572,6 +3572,13 @@ repositories:
       url: https://github.com/WPI-RAIL/librms.git
       version: develop
     status: maintained
+  libsegwayrmp:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/segwayrmp/libsegwayrmp-release.git
+      version: 0.2.10-0
+    status: maintained
   libuvc:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libsegwayrmp` to `0.2.10-0`:
- upstream repository: https://github.com/segwayrmp/libsegwayrmp.git
- release repository: https://github.com/segwayrmp/libsegwayrmp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## libsegwayrmp

```
* The segwayrmp_gui is now installed so it is available from binaries
```
