### PR TITLE
eband_local_planner: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1414,6 +1414,21 @@ repositories:
       url: https://github.com/tork-a/dynpick_driver.git
       version: master
     status: maintained
+  eband_local_planner:
+    doc:
+      type: git
+      url: https://github.com/utexas-bwi/eband_local_planner.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/utexas-bwi-gbp/eband_local_planner-release.git
+      version: 0.2.2-0
+    source:
+      type: git
+      url: https://github.com/utexas-bwi/eband_local_planner.git
+      version: master
+    status: maintained
   ecl_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eband_local_planner` to `0.2.2-0`:
- upstream repository: https://github.com/utexas-bwi/eband_local_planner.git
- release repository: https://github.com/utexas-bwi-gbp/eband_local_planner-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## eband_local_planner

```
* fixed catkin lint warnings in preparation for v0.2.2 release
* added a bit more paramterization of the algorithm to help navigation in simulation. all changes are backwards
  compatible. #17 <https://github.com/utexas-bwi/eband_local_planner/issues/17> from utexas-bwi/piyushk/fix_simulation_navigation
* made some changes for a future Indigo release. fixed Eigen dependency (#16 <https://github.com/utexas-bwi/eband_local_planner/issues/16>)
* Contributors: Jack O'Quin, Piyush Khandelwal
```
