### PR TITLE
segway_rmp: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7738,6 +7738,13 @@ repositories:
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git
       version: master
     status: maintained
+  segway_rmp:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/segwayrmp/segway_rmp-release.git
+      version: 0.1.2-0
+    status: maintained
   sentis_tof_m100:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `segway_rmp` to `0.1.2-0`:
- upstream repository: https://github.com/segwayrmp/segway-rmp-ros-pkg.git
- release repository: https://github.com/segwayrmp/segway_rmp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## segway_rmp

```
* Merge pull request #24 <https://github.com/segwayrmp/segway_rmp/issues/24> from segwayrmp/piyushk/parametrize_frame_ids
  allow parametrizing odometry frame id as well (useful for multiple robots)
* Contributors: Piyush Khandelwal
```
