### PR TITLE
bwi_common: 0.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -434,6 +434,29 @@ repositories:
       type: git
       url: https://github.com/voxel-dot-at/bta_ros.git
       version: master
+  bwi_common:
+    release:
+      packages:
+      - bwi_common
+      - bwi_gazebo_entities
+      - bwi_interruptable_action_server
+      - bwi_kr_execution
+      - bwi_mapper
+      - bwi_msgs
+      - bwi_planning_common
+      - bwi_tasks
+      - bwi_tools
+      - bwi_web
+      - utexas_gdc
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/utexas-bwi-gbp/bwi_common-release.git
+      version: 0.3.2-0
+    source:
+      type: git
+      url: https://github.com/utexas-bwi/bwi_common.git
+      version: master
+    status: developed
   calibration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi_common` to `0.3.2-0`:
- upstream repository: https://github.com/utexas-bwi/bwi_common.git
- release repository: https://github.com/utexas-bwi-gbp/bwi_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## bwi_common
- No changes
## bwi_gazebo_entities
- No changes
## bwi_interruptable_action_server
- No changes
## bwi_kr_execution

```
* updated Clingo to use the current state correctly.
* removed output that was placed in for debugging. closes #17 <https://github.com/utexas-bwi/bwi_common/issues/17>.
* added missing directory installation. closes #16 <https://github.com/utexas-bwi/bwi_common/issues/16>
* Contributors: Piyush Khandelwal
```
## bwi_mapper
- No changes
## bwi_msgs
- No changes
## bwi_planning_common

```
* removed accidental global script installation. closes #18 <https://github.com/utexas-bwi/bwi_common/issues/18>.
* Contributors: Piyush Khandelwal
```
## bwi_tasks
- No changes
## bwi_tools
- No changes
## bwi_web
- No changes
## utexas_gdc
- No changes
