### PR TITLE
genlisp: 0.4.15-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2093,11 +2093,12 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/genlisp-release.git
-      version: 0.4.14-0
+      version: 0.4.15-0
     source:
       type: git
       url: https://github.com/ros/genlisp.git
       version: groovy-devel
+    status: maintained
   genmsg:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genlisp` to `0.4.15-0`:
- upstream repository: git@github.com:ros/genlisp.git
- release repository: https://github.com/ros-gbp/genlisp-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.4.14-0`
