### PR TITLE
genlisp: 0.4.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1878,7 +1878,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/genlisp-release.git
-      version: 0.4.14-0
+      version: 0.4.15-0
     source:
       type: git
       url: https://github.com/ros/genlisp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genlisp` to `0.4.15-0`:
- upstream repository: git@github.com:ros/genlisp.git
- release repository: https://github.com/ros-gbp/genlisp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.4.14-0`
