### PR TITLE
genlisp: 0.4.15-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -387,7 +387,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/genlisp-release.git
-      version: 0.4.14-0
+      version: 0.4.15-0
     source:
       type: git
       url: https://github.com/ros/genlisp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genlisp` to `0.4.15-0`:
- upstream repository: git@github.com:ros/genlisp.git
- release repository: https://github.com/ros-gbp/genlisp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.4.14-0`
