### PR TITLE
multi_level_map: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4195,6 +4195,26 @@ repositories:
       url: https://github.com/lukscasanova/mtig_driver.git
       version: master
     status: developed
+  multi_level_map:
+    doc:
+      type: git
+      url: https://github.com/utexas-bwi/multi_level_map.git
+      version: master
+    release:
+      packages:
+      - multi_level_map
+      - multi_level_map_msgs
+      - multi_level_map_server
+      - multi_level_map_utils
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/utexas-bwi-gbp/multi_level_map-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/utexas-bwi/multi_level_map.git
+      version: master
+    status: developed
   multimaster_fkie:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `multi_level_map` to `0.1.1-0`:
- upstream repository: https://github.com/utexas-bwi/multi_level_map.git
- release repository: https://github.com/utexas-bwi-gbp/multi_level_map-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## multi_level_map
- No changes
## multi_level_map_msgs
- No changes
## multi_level_map_server
- No changes
## multi_level_map_utils

```
* removed unnecessary script installation which installs in global bin instead of package bin. closes #4 <https://github.com/utexas-bwi/multi_level_map/issues/4>.
* Contributors: Piyush Khandelwal
```
