### PR TITLE
segbot: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7776,6 +7776,27 @@ repositories:
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git
       version: master
     status: maintained
+  segbot:
+    doc:
+      type: git
+      url: https://github.com/utexas-bwi/segbot.git
+      version: master
+    release:
+      packages:
+      - segbot
+      - segbot_bringup
+      - segbot_description
+      - segbot_firmware
+      - segbot_sensors
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/utexas-bwi-gbp/segbot-release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/utexas-bwi/segbot.git
+      version: master
+    status: developed
   segway_rmp:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot` to `0.3.1-0`:
- upstream repository: https://github.com/utexas-bwi/segbot.git
- release repository: https://github.com/utexas-bwi-gbp/segbot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## segbot
- No changes
## segbot_bringup

```
* removed redundant segbot v1 models.
* updated segbot v2 model to use correct URDF.
* Contributors: Piyush Khandelwal
```
## segbot_description

```
* removed redundant segbot v1 models.
* added new segbot v2 model URDF.
* Contributors: Piyush Khandelwal
```
## segbot_firmware
- No changes
## segbot_sensors
- No changes
