### PR TITLE
nao_virtual: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4410,7 +4410,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/nao_virtual-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_virtual.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_virtual` to `0.0.4-0`:
- upstream repository: https://github.com/ros-nao/nao_virtual.git
- release repository: https://github.com/ros-naoqi/nao_virtual-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.3-0`
## nao_control

```
* Added foot and pelvis controller in trajectory control launch file in nao_control. Minor cleaning in nao_control
* update repos links
  added run dependencies (not generating warnings)
* Contributors: Konstantinos Chatzilygeroudis, Mikael Arguedas
```
## nao_gazebo_plugin

```
* update repos links
  added run dependencies (not generating warnings)
* Renamed launch files according to nao_description renames..
* remove dependenciesas they generate warnings
  If they are really needed, proper packages should be added one by one
* Contributors: Konstantinos Chatzilygeroudis, Mikael Arguedas, Vincent Rabaud
```
