### PR TITLE
jskeus: 1.0.4-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3331,7 +3331,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jskeus-release.git
-      version: 1.0.3-0
+      version: 1.0.4-1
   katana_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.0.4-1`:
- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.0.3-0`
## jskeus

```
* add closed-loop support
* make support-polygon in init-endinghttps://github.com/euslisp/jskeus/pull/177/files
* Utility function to choose good color for 10 and 20 categories https://github.com/euslisp/jskeus/pull/178
* misc updates
* Contributors: Kei Okada, Ryohei Ueda, Shunichi Nozawa
```
