### PR TITLE
jskeus: 1.0.4-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -541,7 +541,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jskeus-release.git
-      version: 1.0.3-0
+      version: 1.0.4-1
     status: developed
   korg_nanokontrol:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.0.4-1`:
- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.0.3-0`
## jskeus

```
* add closed-loop support
* make support-polygon in init-endinghttps://github.com/euslisp/jskeus/pull/177/files
* Utility function to choose good color for 10 and 20 categories https://github.com/euslisp/jskeus/pull/178
* misc updates
* Contributors: Kei Okada, Ryohei Ueda, Shunichi Nozawa
```
