### PR TITLE
wpi_jaco: 0.0.17-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9112,7 +9112,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/wpi_jaco-release.git
-      version: 0.0.16-0
+      version: 0.0.17-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/wpi_jaco.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wpi_jaco` to `0.0.17-0`:
- upstream repository: https://github.com/RIVeR-Lab/wpi_jaco.git
- release repository: https://github.com/wpi-rail-release/wpi_jaco-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.16-0`
## jaco_description
- No changes
## jaco_interaction
- No changes
## jaco_moveit_config
- No changes
## jaco_sdk
- No changes
## jaco_teleop
- No changes
## mico_description
- No changes
## mico_moveit_config
- No changes
## wpi_jaco
- No changes
## wpi_jaco_msgs
- No changes
## wpi_jaco_wrapper

```
* CMake typo fix
* install files missing
* Contributors: Russell Toris
```
