### PR TITLE
rail_pick_and_place: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6026,16 +6026,16 @@ repositories:
       version: master
     release:
       packages:
+      - graspdb
       - rail_grasp_collection
-      - rail_grasping
       - rail_pick_and_place
       - rail_pick_and_place_msgs
-      - rail_pick_and_place_wrapper
+      - rail_pick_and_place_tools
       - rail_recognition
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
-      version: 0.0.2-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_pick_and_place.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_pick_and_place` to `1.0.0-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_pick_and_place.git
- release repository: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.2-0`
## graspdb

```
* minor cleanup
* delete functions added
* load functions for grasp models
* added check for libpqxx version
* add grasp added
* grasp model class added
* grasp data type added
* grasp_models.unique
* ID returned from add
* typo fixed in SQL
* major refactor
* creates models table
* virtual added to destructor
* model added
* ref ref ref
* moved to internal PointCloud2 message
* fixed bug in fixed frame constructor
* bug fixes after initial testing
* allow for copy of client
* get array of objects based on object name
* extract from database added for demonstrations
* added node to load and publish grasps
* new message for grasp demo
* travis fix
* minor edits
* added mutex for list
* more comments
* comments for graspdb
* comments for grasp demonstration
* comments for pose
* comments for position and orientation
* first pass of new collector
* consty const const const
* insert grasp added
* graspdb started (creates tables)
* Contributors: Russell Toris
```
## rail_grasp_collection

```
* minor cleanup
* small fix
* Updated rail recognition to use the database, fixed a point cloud transform bug in grasp collection
* Switched registration to use the graspdb, fixed point cloud selection in grasp collector
* minor bug fixes
* include cleanup
* fixed default link
* global database params
* load functions for grasp models
* add grasp added
* ID returned from add
* major refactor
* virtual added to destructor
* model added
* Moved rviz panels to rail_pick_and_place_tools, added an rviz panel for grasp collection
* typo
* adds back private node handle
* removes unused members
* bug fixes after initial testing
* small edits
* small edits
* merge conflict
* allow for copy of client
* get array of objects based on object name
* extract from database added for demonstrations
* Updated to reflect moving some messages from rail_segmentation to rail_manipulation_messages
* added node to load and publish grasps
* Updated to use the new rail_manipulation_msgs
* travis fix
* missing dep
* minor edits
* added param for segmented object topic
* launch file added
* added mutex for list
* more comments
* first pass of new collector
* consty const const const
* insert grasp added
* graspdb started (creates tables)
* all but storing in the SQL database redone for grasp collection
* Contributors: David Kent, Russell Toris
```
## rail_pick_and_place

```
* minor cleanup
* Moved rviz panels to rail_pick_and_place_tools, added an rviz panel for grasp collection
* Contributors: David Kent, Russell Toris
```
## rail_pick_and_place_msgs

```
* Removed unused messages
* grasp model class added
* ID returned from add
* major refactor
* model added
* added node to load and publish grasps
* new message for grasp demo
* travis fix
* missing dep
* minor edits
* all but storing in the SQL database redone for grasp collection
* Contributors: David Kent, Russell Toris
```
## rail_pick_and_place_tools

```
* Moved actions from recognition to msgs
* edits
* Updated vision rviz panel to use the new recognize all action
* Added a recognition listener that allows for shared recognition of a list of detected objects
* Added refresh button to the model generation panel
* Removed some unused stuff from recognition
* Updates to rviz panels
* Switched registration to use the graspdb, fixed point cloud selection in grasp collector
* Added a vision panel that can handle segmentation and recognition, minor documentation updates to other panels
* Moved rviz panels to rail_pick_and_place_tools, added an rviz panel for grasp collection
* Contributors: David Kent, Russell Toris
```
## rail_recognition

```
* object recognition listener now checks if segmentation passes in updated information vs. new object information
* Moved actions from recognition to msgs
* Removed unused messages
* Message generation dependency
* Removed some unused imports
* Added a recognition listener that allows for shared recognition of a list of detected objects
* Removed some unused stuff from recognition
* Updated rail recognition to use the database, fixed a point cloud transform bug in grasp collection
* Updates to rviz panels
* Switched registration to use the graspdb, fixed point cloud selection in grasp collector
* Added a vision panel that can handle segmentation and recognition, minor documentation updates to other panels
* Moved rviz panels to rail_pick_and_place_tools, added an rviz panel for grasp collection
* Updated grasp requests to use stamped poses instead of base_footprint frame poses
* Switched model generation from a service to an action, and updated the rviz plugin so that it does not freeze during the model generation call
* Updated to reflect moving some messages from rail_segmentation to rail_manipulation_messages
* rviz plugin launch/install, new models, and some general cleanup
* Rviz plugin updates
* Initial rviz plugin for model generation
* Contributors: David Kent
```
