### PR TITLE
hector_quadrotor: 0.3.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2222,7 +2222,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_quadrotor-release.git
-      version: 0.3.4-0
+      version: 0.3.5-0
     status: maintained
   hector_quadrotor_apps:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_quadrotor` to `0.3.5-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_quadrotor-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.3.4-0`
## hector_quadrotor
- No changes
## hector_quadrotor_controller

```
* updated angular/z controller parameters
* Remove redundant callback queue in twist_controller, use root_nh queue as per ros_control API
* Add controller timeout to allow faster shutdown of spawner
* Contributors: Johannes Meyer, Paul Bovbel
```
## hector_quadrotor_controller_gazebo
- No changes
## hector_quadrotor_demo
- No changes
## hector_quadrotor_description
- No changes
## hector_quadrotor_gazebo
- No changes
## hector_quadrotor_gazebo_plugins
- No changes
## hector_quadrotor_model
- No changes
## hector_quadrotor_pose_estimation
- No changes
## hector_quadrotor_teleop
- No changes
## hector_uav_msgs
- No changes
