### PR TITLE
opencv_candidate: 0.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4992,7 +4992,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/opencv_candidate-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/wg-perception/opencv_candidate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `opencv_candidate` to `0.2.4-0`:
- upstream repository: https://github.com/wg-perception/opencv_candidate.git
- release repository: https://github.com/ros-gbp/opencv_candidate-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.3-0`
## opencv_candidate

```
* get features2d to compile with OpenCV3
* do not compile RGBD for OpenCV3 as there should be an opencv_contrib module anyway
* remove Python bindings of data matrix
* remove LSH as it is now upstream
* get datamatrix to compile with OpenCV3
* Updating namespaces
* Contributors: Vincent Rabaud, edgarriba
```
