### PR TITLE
ecto_opencv: 0.5.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1596,7 +1596,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ecto_opencv-release.git
-      version: 0.5.4-0
+      version: 0.5.5-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto_opencv` to `0.5.5-0`:
- upstream repository: https://github.com/plasmodic/ecto_opencv.git
- release repository: https://github.com/ros-gbp/ecto_opencv-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.5.4-0`
## ecto_opencv

```
* compile with the latest opencv_candidate
* use OpenCV's LSH
* remove useless file
* clean extensions
* Contributors: Vincent Rabaud
```
