### PR TITLE
spur: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8077,6 +8077,26 @@ repositories:
       url: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
       version: 0.3.2-0
     status: maintained
+  spur:
+    doc:
+      type: git
+      url: https://github.com/tork-a/spur.git
+      version: master
+    release:
+      packages:
+      - spur
+      - spur_controller
+      - spur_description
+      - spur_gazebo
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/spur-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/tork-a/spur.git
+      version: master
+    status: developed
   sql_database:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `spur` to `0.1.0-0`:
- upstream repository: https://github.com/tork-a/spur.git
- release repository: https://github.com/tork-a/spur-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## spur
- No changes
## spur_controller
- No changes
## spur_description
- No changes
## spur_gazebo
- No changes
