### PR TITLE
Add rosdep key for gcc/g++ which includes static libs

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -675,6 +675,9 @@ ftdi-eeprom:
 g++-multilib:
   fedora: [gcc-c++, glibc-devel, 'glibc-devel(%{__isa_name}-32)', glibc-static, 'glibc-static(%{__isa_name}-32)', libstdc++-devel, 'libstdc++-devel(%{__isa_name}-32)', libstdc++-static, 'libstdc++-static(%{__isa_name}-32)']
   ubuntu: [g++-multilib]
+g++-static:
+  fedora: [gcc-c++, glibc-devel, glibc-static, libstdc++-devel, libstdc++-static]
+  ubuntu: [g++]
 gawk:
   fedora: [gawk]
   ubuntu: [gawk]
@@ -696,6 +699,9 @@ gcc-avr:
 gcc-multilib:
   fedora: [gcc, glibc-devel, 'glibc-devel(%{__isa_name}-32)', glibc-static, 'glibc-static(%{__isa_name}-32)']
   ubuntu: [gcc-multilib]
+gcc-static:
+  fedora: [gcc, glibc-devel, glibc-static]
+  ubuntu: [gcc]
 gccxml:
   arch: [gccxml-git]
   debian: [gccxml]


### PR DESCRIPTION
From what I can tell, glibc/stdc++ packages in Ubuntu also provide the static versions of the libraries. In Fedora, this is not the case, and such libraries are not allowed in packages that do not end in `-static`.

These keys should essentially be "noops" for Ubuntu, but will ensure the static libs are present when indicated in the appropriate `package.xml`s.

Example failure: http://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-downward_binaryrpm_heisenbug_x86_64/25/consoleFull

Thanks,

--scott
