### PR TITLE
naoqi_bridge: 0.4.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4551,7 +4551,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_bridge-release.git
-      version: 0.4.6-1
+      version: 0.4.7-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge` to `0.4.7-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_bridge.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.4.6-1`
## naoqi_apps
- No changes
## naoqi_bridge
- No changes
## naoqi_driver

```
* MOVETO: transform moveTo commands in /base_footprint frame.
* Contributors: lsouchet
```
## naoqi_msgs
- No changes
## naoqi_sensors

```
* install octomap_python
* Contributors: Vincent Rabaud
```
## naoqi_tools
- No changes
