### PR TITLE
remove OpenCV3 on Hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5085,13 +5085,6 @@ repositories:
       url: https://github.com/ros-gbp/opencv2_doc-release.git
       version: 2.4.6-0
     status: maintained
-  opencv3:
-    release:
-      tags:
-        release: release/hydro/{package}/{version}
-      url: https://github.com/vrabaud/opencv3-release.git
-      version: 2.9.4-1
-    status: maintained
   opencv_candidate:
     release:
       tags:


### PR DESCRIPTION
It does not compile on Precise because of a gcc bug and I don't
want to patch it.
