### PR TITLE
object_recognition_tod: 0.5.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4807,7 +4807,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_tod-release.git
-      version: 0.5.0-1
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/wg-perception/tod.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_tod` to `0.5.2-0`:
- upstream repository: https://github.com/wg-perception/tod.git
- release repository: https://github.com/ros-gbp/object_recognition_tod-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.5.0-1`
## object_recognition_tod

```
* add opencv_candidate as a dependency
  It is included but just transitively so it's better to have it
  directly
* Revert "remove dependency on opencv_candidate"
  This reverts commit 3a515e48c815b9e0c7f6df20b730b98d0dccd5df.
  The RGBD module from opencv_candidate is indeed needed
* Contributors: Vincent Rabaud
```
