### PR TITLE
object_recognition_tod: 0.5.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -821,6 +821,17 @@ repositories:
       url: https://github.com/wg-perception/ork_renderer.git
       version: master
     status: maintained
+  object_recognition_tod:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_tod-release.git
+      version: 0.5.2-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/tod.git
+      version: master
+    status: maintained
   opencv3:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_tod` to `0.5.2-0`:
- upstream repository: https://github.com/wg-perception/tod.git
- release repository: https://github.com/ros-gbp/object_recognition_tod-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## object_recognition_tod

```
* add opencv_candidate as a dependency
  It is included but just transitively so it's better to have it
  directly
* Revert "remove dependency on opencv_candidate"
  This reverts commit 3a515e48c815b9e0c7f6df20b730b98d0dccd5df.
  The RGBD module from opencv_candidate is indeed needed
* Contributors: Vincent Rabaud
```
