### PR TITLE
iiwa: 2.0.0-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2792,6 +2792,12 @@ repositories:
       url: https://github.com/code-iai/iai_common_msgs.git
       version: master
     status: developed
+  iiwa:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/stanfordroboticslab/iiwa-release.git
+      version: 2.0.0-1
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iiwa` to `2.0.0-1`:
- upstream repository: https://bitbucket.org/khansari/iiwa.git
- release repository: https://github.com/stanfordroboticslab/iiwa-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
