### PR TITLE
Adding grid_map to documentation index for distro.

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2064,6 +2064,16 @@ repositories:
       url: https://github.com/mikeferguson/grasping_msgs-gbp.git
       version: 0.3.1-0
     status: developed
+  grid_map:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/grid_map.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ethz-asl/grid_map.git
+      version: master
+    status: developed
   grizzly:
     doc:
       type: git


### PR DESCRIPTION
I'd like grid_map to be indexed and documented on ros.org.
