### PR TITLE
rail_pick_and_place: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6051,7 +6051,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_pick_and_place.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_pick_and_place` to `1.0.3-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_pick_and_place.git
- release repository: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.2-0`
## graspdb

```
* correct dev added
* added select all to database
* repub of recognized objects addedg
* Contributors: Russell Toris
```
## rail_grasp_collection

```
* debug is now latched
* starting to cleanup model generator
* Contributors: Russell Toris
```
## rail_pick_and_place
- No changes
## rail_pick_and_place_msgs

```
* starting to cleanup model generator
* Contributors: Russell Toris
```
## rail_pick_and_place_tools

```
* starting to cleanup model generator
* refactor of point cloud recognizer
* Contributors: Russell Toris
```
## rail_recognition

```
* debug is now latched
* checks for empty point cloud
* starting to cleanup model generator
* fix in launch
* refactor of point cloud recognizer
* added select all to database
* repub of recognized objects addedg
* Contributors: Russell Toris
```
