### PR TITLE
carl_bot: 0.0.20-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -595,7 +595,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_bot-release.git
-      version: 0.0.19-0
+      version: 0.0.20-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_bot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_bot` to `0.0.20-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_bot.git
- release repository: https://github.com/wpi-rail-release/carl_bot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.19-0`
## carl_bot
- No changes
## carl_bringup

```
* added segmentation topic
* typo in config file name
* added launch for recognition
* Contributors: Russell Toris
```
## carl_description
- No changes
## carl_dynamixel
- No changes
## carl_interactive_manipulation

```
* renamed topic
* Contributors: Russell Toris
```
## carl_phidgets
- No changes
## carl_teleop
- No changes
## carl_tools
- No changes
