### PR TITLE
object_recognition_tod: 0.5.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4822,7 +4822,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_tod-release.git
-      version: 0.5.2-0
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/wg-perception/tod.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_tod` to `0.5.3-0`:
- upstream repository: https://github.com/wg-perception/tod.git
- release repository: https://github.com/ros-gbp/object_recognition_tod-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.5.2-0`
## object_recognition_tod

```
* use OpenCV and not opencv_candidate for LSH
* Contributors: Vincent Rabaud
```
