### PR TITLE
eband_local_planner: 0.3.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1548,7 +1548,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/eband_local_planner-release.git
-      version: 0.2.2-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/utexas-bwi/eband_local_planner.git


### PR DESCRIPTION
Increasing version of package(s) in repository `eband_local_planner` to `0.3.0-0`:
- upstream repository: https://github.com/utexas-bwi/eband_local_planner.git
- release repository: https://github.com/utexas-bwi-gbp/eband_local_planner-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.2-0`
## eband_local_planner

```
* slow down trajectory controller while close to goal. closes #19 <https://github.com/utexas-bwi/eband_local_planner/issues/19>.
* convert info message to debug. closes #18 <https://github.com/utexas-bwi/eband_local_planner/issues/18>.
* clear local costmap if global plan cannot be converted to band even on first attempt. see #5 <https://github.com/utexas-bwi/eband_local_planner/issues/5>
* Contributors: Piyush Khandelwal
```
