### PR TITLE
segbot: 0.3.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7940,7 +7940,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/segbot-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/utexas-bwi/segbot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot` to `0.3.2-0`:
- upstream repository: https://github.com/utexas-bwi/segbot.git
- release repository: https://github.com/utexas-bwi-gbp/segbot-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.3.1-0`
## segbot
- No changes
## segbot_bringup
- No changes
## segbot_description

```
* added sensor plate and sonars to tf tree for segbot v2.
* make standoff urdf more generic. dropped the 632 suffix and added radius as a parameter
* Contributors: Piyush Khandelwal
```
## segbot_firmware
- No changes
## segbot_sensors
- No changes
