### PR TITLE
segbot_apps: 0.3.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7960,7 +7960,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/segbot_apps-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/utexas-bwi/segbot_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot_apps` to `0.3.1-0`:
- upstream repository: https://github.com/utexas-bwi/segbot_apps.git
- release repository: https://github.com/utexas-bwi-gbp/segbot_apps-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.3.0-0`
## segbot_apps

```
* added architecture_independent flag to segbot_apps metapackage. Closes #24 <https://github.com/utexas-bwi/segbot_apps/issues/24>
* Contributors: Piyush Khandelwal
```
## segbot_gui
- No changes
## segbot_logical_translator

```
* Closes #29 <https://github.com/utexas-bwi/segbot_apps/issues/29>
  - Get latest version of move_base to get fix introduced in https://github.com/ros-planning/navigation/pull/295
  This allows setting tolerance to 0 when calling make_plan from segbot_logical_translator.
  - Don't use any tolerance when testing whether a door was open or not.
  - Don't clear costmap around robot when testing for an open door.
* fixed issue where the logical translator was returning beside and facing for two different doors. closes #30 <https://github.com/utexas-bwi/segbot_apps/issues/30>.
* segbot_logical_navigator now checks for costmap updates to test whether the map has changed between door/no-door versions. closes #28 <https://github.com/utexas-bwi/segbot_apps/issues/28>
* removed segbot_gazebo dependency. closes #27 <https://github.com/utexas-bwi/segbot_apps/issues/27>.
* Contributors: Piyush Khandelwal
```
## segbot_navigation

```
* Allow explicit amcl laser max range paramter instantiation. closes #31 <https://github.com/utexas-bwi/segbot_apps/issues/31>.
* Closes #29 <https://github.com/utexas-bwi/segbot_apps/issues/29>
  - Get latest version of move_base to get fix introduced in https://github.com/ros-planning/navigation/pull/295
  This allows setting tolerance to 0 when calling make_plan from segbot_logical_translator.
  - Don't use any tolerance when testing whether a door was open or not.
  - Don't clear costmap around robot when testing for an open door.
* Increase local costmap size to 8m x 8m. Increasing obstacle and raytrace range for primary laser to match. Closes #26 <https://github.com/utexas-bwi/segbot_apps/issues/26>.
* updated planner frequency to 1.0. Closes #25 <https://github.com/utexas-bwi/segbot_apps/issues/25>
* Contributors: Piyush Khandelwal
```
