### PR TITLE
segbot_simulator: 0.3.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7985,7 +7985,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/segbot_simulator-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/utexas-bwi/segbot_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot_simulator` to `0.3.1-0`:
- upstream repository: https://github.com/utexas-bwi/segbot_simulator.git
- release repository: https://github.com/utexas-bwi-gbp/segbot_simulator-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.3.0-0`
## segbot_gazebo

```
* updated setting amcl laser max range. see segbot_apps`#31 <https://github.com/utexas-bwi/segbot_simulator/issues/31>`_.
* Contributors: Piyush Khandelwal
```
## segbot_simulation_apps
- No changes
## segbot_simulator
- No changes
