### PR TITLE
segbot_simulator: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7853,6 +7853,25 @@ repositories:
       url: https://github.com/utexas-bwi/segbot_apps.git
       version: master
     status: developed
+  segbot_simulator:
+    doc:
+      type: git
+      url: https://github.com/utexas-bwi/segbot_simulator.git
+      version: master
+    release:
+      packages:
+      - segbot_gazebo
+      - segbot_simulation_apps
+      - segbot_simulator
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/utexas-bwi-gbp/segbot_simulator-release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/utexas-bwi/segbot_simulator.git
+      version: master
+    status: developed
   segway_rmp:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot_simulator` to `0.3.1-0`:
- upstream repository: https://github.com/utexas-bwi/segbot_simulator.git
- release repository: https://github.com/utexas-bwi-gbp/segbot_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## segbot_gazebo

```
* updated setting amcl laser max range. see segbot_apps`#31 <https://github.com/utexas-bwi/segbot_simulator/issues/31>`_.
* Contributors: Piyush Khandelwal
```
## segbot_simulation_apps
- No changes
## segbot_simulator
- No changes
