### PR TITLE
bwi: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -434,6 +434,25 @@ repositories:
       type: git
       url: https://github.com/voxel-dot-at/bta_ros.git
       version: master
+  bwi:
+    doc:
+      type: git
+      url: https://github.com/utexas-bwi/bwi.git
+      version: master
+    release:
+      packages:
+      - bwi_desktop
+      - bwi_desktop_full
+      - bwi_launch
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/utexas-bwi-gbp/bwi-release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/utexas-bwi/bwi.git
+      version: master
+    status: developed
   bwi_common:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi` to `0.3.1-0`:
- upstream repository: https://github.com/utexas-bwi/bwi.git
- release repository: https://github.com/utexas-bwi-gbp/bwi-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## bwi_desktop
- No changes
## bwi_desktop_full

```
* removed rosemacs-el from bwi_desktop_full dependency list. closes #18 <https://github.com/utexas-bwi/bwi/issues/18>.
* Contributors: Piyush Khandelwal
```
## bwi_launch

```
* updated launch files to account for upcoming amcl.launch change.
* updated launch file to automatically start the planner/reasoner in simulation mode.
* Contributors: Piyush Khandelwal
```
