### PR TITLE
pr2_apps: 0.5.18-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5538,7 +5538,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_apps-release.git
-      version: 0.5.15-0
+      version: 0.5.18-0
     source:
       type: git
       url: https://github.com/pr2/pr2_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_apps` to `0.5.18-0`:
- upstream repository: https://github.com/PR2/pr2_apps.git
- release repository: https://github.com/TheDash/pr2_apps-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.5.15-0`
## pr2_app_manager

```
* Merge branch 'hydro-devel' of https://github.com/PR2/pr2_apps into hydro-devel
* Updated maintainership
* fix install destination
* Contributors: Furushchev, TheDash
```
## pr2_apps
- No changes
## pr2_mannequin_mode

```
* fix install destination
* Contributors: Furushchev
```
## pr2_position_scripts

```
* Merge branch 'hydro-devel' of https://github.com/PR2/pr2_apps into hydro-devel
* Updated maintainership
* Contributors: TheDash
```
## pr2_teleop

```
* fix install destination
* Contributors: Furushchev
```
## pr2_teleop_general
- No changes
## pr2_tuckarm

```
* Merge branch 'hydro-devel' of https://github.com/PR2/pr2_apps into hydro-devel
* Updated maintainership
* Contributors: TheDash
```
