### PR TITLE
visp: 2.10.0-3 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1334,7 +1334,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 2.10.0-2
+      version: 2.10.0-3
     status: maintained
   xacro:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `2.10.0-3`:
- upstream repository: svn://scm.gforge.inria.fr/svnroot/visp/tags/ViSP_2_10_0
- release repository: https://github.com/lagadic/visp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2.10.0-2`
