### PR TITLE
vision_visp: 0.8.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -9114,7 +9114,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.7.5-0
+      version: 0.8.0-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.8.0-0`:
- upstream repository: https://github.com/lagadic/vision_visp.git
- release repository: https://github.com/lagadic/vision_visp-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.7.5-0`
## vision_visp

```
* Merge branch 'hydro-devel' into hydro
* Merge branch 'master' into hydro-devel
* Fix doc url location
* hydro-0.7.5
* Contributors: Fabien Spindler
```
## visp_auto_tracker

```
* Merge branch 'hydro-devel' into hydro
* Reintroduce link_directories() requested to work with ros-hydro-visp-2.4.9
* Merge branch 'master' into hydro-devel
* Remove catkin_lint issues and warnings
* Fix doc url location
* Update launch files
* Comment viewer node. Only interesting when visp_auto_tracker debug_display param is False
* Improve pose computation using Lagrange and Dementhon methods as initialisation
* Increase quality value to avoid keypoint detection on the black part of the target
* Introduce code_message parameter as a comment to show how to use.
* New parameter "code_message" to specify the target to track from the code message.
  If this parameter is not set, the code that is tracked is the largest in the image.
* Add frame_size parameter to the tracker client and viewer nodes that allow to specify
  the lenght (in meter) of the frame axis
* Publish the code message of the tracked target on /visp_auto_tracker/code_message topic.
  If no target is tracked, publish an empty message.
  Remove fps printing
* Fix to publish covariance matrix associated to the pose estimation
* Fix to publish an empty list of moving edges and klt points on their respective topics when
  the tracker fails
* Makes sure klt points that are sent via ros are from visible polygons.
* Show how to use the viewer with visp_auto_tracker
* Consider also .cao file to describe the cad model of the object to track with the hybrid
  model-based tracker
* Remove useless include
* Fix issue https://github.com/lagadic/vision_visp/issues/45 to take into account
  model_name parameter set in the launch file.
* Changes done to use flash code detectors introduced in ViSP 2.10.0 rather than the
  one in visp_auto_tracker/flashcode_mbt/detectors.
* Fix to publish camera_info with the images
* Fix to avoid an OpenCV exception when the object roi is outside the image
* Fix to run the viewer node
* Fix compat with ViSP 2.10.0
* Fix to avoid an OpenCV exception when the object roi is outside the image
* Fix to run the viewer node
* Fix to publish camera_info with the images
* Fix compat with ViSP 2.10.0
* hydro-0.7.5
* Prepare changelogs
* Contributors: Aurelien Yol, Fabien Spindler, Riccardo Spica
```
## visp_bridge

```
* Merge branch 'hydro-devel' into hydro
* Reintroduce link_directories() requested to work with ros-hydro-visp-2.4.9
* Merge branch 'master' into hydro-devel
* Remove catkin_lint issues and warnings
* Fix doc url location
* Revert previous commit that breaks compat
* hydro-0.7.5
* Prepare changelogs
* Revert previous commit that breaks compat
* Contributors: Fabien Spindler, Riccardo Spica
```
## visp_camera_calibration

```
* Merge branch 'hydro-devel' into hydro
* Reintroduce link_directories() requested to work with ros-hydro-visp-2.4.9
* Remove catkin_lint issues and warnings
* Fix doc url location
* hydro-0.7.5
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_hand2eye_calibration

```
* Merge branch 'hydro-devel' into hydro
* Reintroduce link_directories() requested to work with ros-hydro-visp-2.4.9
* Merge branch 'master' into hydro-devel
* Remove catkin_lint issues and warnings
* Fix doc url location
* hydro-0.7.5
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_tracker

```
* Merge branch 'hydro-devel' into hydro
* Reintroduce link_directories() requested to work with ros-hydro-visp-2.4.9
* Merge branch 'master' into hydro-devel
* Remove catkin_lint issues and warnings
* Fix doc url location
* Fix hard coded "protected to public" for Model based trackers parameters.
* Change warning message when viewer is waiting for initialization.
* Change default quality value of KLT points detection.
* Add config files for dynamic reconfigure of Edge and KLT Model based trackers.
* Fix dynamic reconfigure for bother client and tracker.
  Add forgotten mutex.unlock() when catching errors.
* Remove "bad suppress value" message and improve suppress state detection based on ViSP enum
* Add frame_size parameter to the tracker client and viewer nodes that allow to
  specify the lenght (in meter) of the frame axis
* Fix compat with ViSP-2.9.0
* Fix to save/read initial pose from /tmp/${USER}/${model_name}.0.pos file
* Show optional help file during initialization. To this end 2
  options are possible:
  1/ If visp_tracker_client has help_image_path parameter, we
  use this setting to display the corresponding image. Extension
  could be jpeg, not only ppm. For example, in the launch file we can have:
  <node pkg="visp_tracker" type="visp_tracker_client" name="tracker_mbt_client">
  <param name="model_path" value="package://visp_tracker/models" />
  <param name="model_name" value="laas-box" />
  <param name="help_image_path" value="/home/user/laas-box.ppm"/>
  In that case we will open a display windows with /home/user/laas-box.ppm image.
  2/ If the previous parameter is not set, we consider
  model_path/model_name/model_name + .ppm extension as image full name and path.
  Following previous example, we will display
  package://visp_tracker/models/laas-box/laas-box.ppm
* Adapt visp_tracker to handle new message for trackers common parameters.
  Add mutex_lock() in visp_tracker_client to fix dynamic reconfigure utilisation.
  Modify ModelBasedSettings.cfg for better usage of dynamic reconfigure.
* Add new message for trackers common parameters.
* Show object frame
* Introduce bug fix when tracker viewer reads wrong /model_description value.
* Support not only wrml but also cao model files.
* Allow to read comments in init file.
* Remove useless debug messages.
* Fix to set Klt config at initialization.
  To check if really necessary.
* Merge branch 'master' of https://github.com/lagadic/vision_visp
* From /model_decription parameter decode the type of model that is used (vrml or cao)
  to be able to consider both descriptions in the viewer
* Tracker client and viewer can now consider not only /camera_prefix but also
  /node_name/camera_prefix parameters
* Introduce comment arround /camera_prefix parameter
* Rename model file name parameter to be generic.
  Delete useless setPose().
  Add other forgotten setPose().
* Rename model name variable to be generic.
* Add comment to the model
* Sync with ViSP 2.10.0
* Fix compat with ViSP 2.10.0
* Fix compat with ViSP 2.10.0
* hydro-0.7.5
* Prepare changelogs
* Contributors: Aurelien Yol, Fabien Spindler
```
