### PR TITLE
jsk_common: 1.0.64-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3149,7 +3149,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.63-0
+      version: 1.0.64-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.64-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `1.0.63-0`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## collada_urdf_jsk_patch
- No changes
## downward
- No changes
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha

```
* use jsk-ros-pkg/archives for downloading ffha source
* Contributors: Yuki Furuta
```
## image_view2

```
* [image_view2] Clear poly mode caches when image_view2 is resetted
* [image_view2] Support poly mode to select polygonal region on image
* [image_view2] Check if input image is valid and skip if the input is invalid
* [image_view2] Do not show warning message when scale is 0
* Contributors: Ryohei Ueda
```
## jsk_common
- No changes
## jsk_data

```
* [jsk_data] Utility script to save/load robot_description
* Contributors: Ryohei Ueda
```
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_network_tools

```
* [jsk_network_tools] Fix typos
* [jsk_network_tools] Add dynamic_reconfigure interface to specify
  bandwidth of highspeed streamer
* [jsk_network_tools] Defaults to 280 Mbps
* [jsk_network_tools] Decide interval between sending packets based on bandwidth
* [jsk_network_tools] Do not load unused robot models when
  compress/decompress joint_states
* [jsk_network_tools] Publish the last received time as std_msgs/Time from silverhammer receivers
* [jsk_network_tools] Force to be within 0-255 when compressing joint angles
* [jsk_network_tools] Add diagnostics information to lowspeed streamer and receiver
* [jsk_network_tools] Add diagnostics information to highspeed streamer/receiver
* [jsk_network_tools] Add event_driven mode to lowspeed streamer
* [jsk_network_tools] Add event-driven mode to lowspeed streamer
* Contributors: Ryohei Ueda
```
## jsk_tilt_laser

```
* [jsk_tilt_laser] Support multisense sensors without 'multisense/' prefix
* Contributors: Ryohei Ueda
```
## jsk_tools

```
* [jsk_tools] check NO_ROS_PROMPT environmental variable when updating
  prompt in order not to change prompt by rossetmaster and rossetip
* [jsk_tools] Add rqt_reconfigure to run_depend
* [jsk_tools] Add new rule to replace handle to name
* [jsk_tools] Fix dependency of jsk_tools
* rename rossetrobot -> rossetmaster, keep rossetrobot for backword compatibility
* Contributors: Ryohei Ueda, Kentaro Wada
```
## jsk_topic_tools

```
* [jsk_topic_tools] Publish timestamp from snapshot as it publishes ~output
* [jsk_topic_tools] Add ~stop service to force to stop publishing messages
* Contributors: Ryohei Ueda
```
## julius
- No changes
## laser_filters_jsk_patch
- No changes
## libsiftfast
- No changes
## mini_maxwell

```
* [mini_maxwell] Add script to launch official script
* [mini_maxwell] Add script to download maxwell pro's script
* Contributors: Ryohei Ueda
```
## multi_map_server
- No changes
## nlopt
- No changes
## opt_camera

```
* [opt_camera] support pan control of panorama view, use enum for flip/small in reconfigure gui
* [opt_camera] use argument to pass camera_index
* Contributors: JSK Lab member, Kei Okada
```
## posedetection_msgs

```
* [posedetection_msgs] Generate binary in lib directory as other catkin
  packages do
* Contributors: Ryohei Ueda
```
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## sklearn
- No changes
## speech_recognition_msgs
- No changes
## virtual_force_publisher
- No changes
## voice_text
- No changes
