### PR TITLE
Adding turtlebot_2dnav to documentation index for hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8557,6 +8557,21 @@ repositories:
       url: https://github.com/turtlebot/turtlebot.git
       version: hydro
     status: developed
+  turtlebot_2dnav:
+    doc:
+      type: git
+      url: https://github.com/pexison/turtlebot_2dnav.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/pexison/turtlebot_2dnav.git
+      version: 1.0.0
+    source:
+      type: git
+      url: https://github.com/pexison/turtlebot_2dnav.git
+      version: hydro-devel
+    status: maintained
   turtlebot_android:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8563,6 +8563,8 @@ repositories:
       url: https://github.com/pexison/turtlebot_2dnav.git
       version: hydro-devel
     release:
+      packages:
+      - turtlebot_2dnav
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/pexison/turtlebot_2dnav.git


### PR DESCRIPTION
I'd like turtlebot_2dnav to be indexed and documented on ros.or
