### PR TITLE
jsk_recognition: 0.2.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3019,7 +3019,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.2.7-0
+      version: 0.2.9-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.2.9-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.2.7-0`
## checkerboard_detector

```
* 0.2.8
* Update Changelog
* Contributors: Ryohei Ueda
```
## imagesift

```
* 0.2.8
* Update Changelog
* Contributors: Ryohei Ueda
```
## jsk_pcl_ros

```
* 0.2.8
* Update Changelog
* [jsk_pcl_ros] Publish point indices which do not belong to any polygons
  in EnvironmentPlaneModeling
* [jsk_pcl_ros] Erode grid maps as c-space padding in EnvironmentPlaneModeling
* [jsk_pcl_ros] Latch output topic of EnvironmentPlaneModeling
* [jsk_pcl_ros] Check orientation of plane in GridPlane::fromROSMsg
* Contributors: Ryohei Ueda
```
## jsk_perception

```
* 0.2.8
* Update Changelog
* Contributors: Ryohei Ueda
```
## jsk_recognition

```
* 0.2.8
* Update Changelog
* Contributors: Ryohei Ueda
```
## jsk_recognition_msgs

```
* 0.2.8
* Update Changelog
* Contributors: Ryohei Ueda
```
## resized_image_transport

```
* 0.2.8
* Update Changelog
* Contributors: Ryohei Ueda
```
