### PR TITLE
dynpick_driver: 0.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1533,7 +1533,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/dynpick_driver-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/tork-a/dynpick_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynpick_driver` to `0.0.5-0`:
- upstream repository: https://github.com/tork-a/dynpick_driver.git
- release repository: https://github.com/tork-a/dynpick_driver-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.4-0`
## dynpick_driver

```
* (Feature) Do while to read enough data (fix for #1 <https://github.com/tork-a/dynpick_driver/issues/1>)
* (Doc) Add to readme new launch usage.
* Contributors: Kei Okada, Isaac I.Y. Saito
```
