### PR TITLE
xacro: 1.9.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9269,7 +9269,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.9.3-0
+      version: 1.9.4-0
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.9.4-0`:
- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.9.3-0`
## xacro

```
* Using xacro for launch files with <arg> tags would cause the <args> tags to get
  eaten. Removed "arg" and only look for "xacro:arg".
* Add test for eating launch parameter arguments
* updated pr2 gold standard to include all comments
* allow to ignore comments in nodes_match()
* fixed handling of non-element nodes in <include>, <if>, <macro>
* fixed writexml: text nodes were not printed when other siblings exist
* improved xml matching, add some new unit tests
* travis-ci: fixup running of tests
* fix pathnames used in test case
* Include CATKIN_ENV params at build time.
* use output filename flag instead of shell redirection
* create output file only if parsing is successful
* Contributors: Mike O'Driscoll, Morgan Quigley, Robert Haschke, William Woodall
```
