### PR TITLE
xacro: 1.10.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1338,7 +1338,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.10.0-0
+      version: 1.10.1-0
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.10.1-0`:
- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.10.0-0`
## xacro

```
* improved error handling and more descriptive error messages
* correctly raise a XacroException on invalid, i.e. non-boolean, <xacro:if> expressions.
  (removed left-over debugging code, added test case)
* raise an exception on undefined, but used macros
  Using the syntax <xacro:macroname/> should raise an exception if
  macroname is not defined. Added appropriate code and a test case.
* fixed bookkeeping in lazy evaluation
  switch Table.unevaluated from list to set to avoid multiple key entries
* fix formatting of changelog
* Contributors: Robert Haschke
```
