### PR TITLE
turtlebot_2dnav: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8572,6 +8572,13 @@ repositories:
       url: https://github.com/turtlebot/turtlebot.git
       version: hydro
     status: developed
+  turtlebot_2dnav:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/pexison/turtlebot_2dnav-release.git
+      version: 1.0.1-0
+    status: maintained
   turtlebot_android:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_2dnav` to `1.0.1-0`:
- upstream repository: https://github.com/pexison/turtlebot_2dnav.git
- release repository: https://github.com/pexison/turtlebot_2dnav-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
