### PR TITLE
rosdep: define python-catkin-tools for Fedora

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -192,6 +192,7 @@ python-catkin-pkg:
     utopic: [python-catkin-pkg]
     vivid: [python-catkin-pkg]
 python-catkin-tools:
+  fedora: [python-catkin_tools]
   osx:
     pip:
       packages: [catkin_tools]


### PR DESCRIPTION
see: utexas-bwi/bwi#19
