### PR TITLE
descartes: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1392,10 +1392,21 @@ repositories:
       type: git
       url: https://github.com/ros-industrial-consortium/descartes.git
       version: hydro-devel
+    release:
+      packages:
+      - descartes_core
+      - descartes_moveit
+      - descartes_planner
+      - descartes_trajectory
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-industrial-release/descartes-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/ros-industrial-consortium/descartes.git
       version: hydro-devel
+    status: developed
   designator_integration:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `descartes` to `0.0.1-0`:
- upstream repository: https://github.com/ros-industrial-consortium/descartes.git
- release repository: https://github.com/ros-industrial-release/descartes-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## descartes_core

```
* Alpha Release
* Contributors: Jonathan Meyer, Purser Sturgeon II, Shaun Edwards, gavanderhoorn, jrgnicho, ros, ros-devel
```
## descartes_moveit

```
* Alpha Release
* Contributors: Jonathan Meyer, Shaun Edwards, gavanderhoorn, jrgnicho, ros-devel
```
## descartes_planner

```
* Alpha Release
* Contributors: Jonathan Meyer, Shaun Edwards, gavanderhoorn, jrgnicho, ratnesh, ros-devel
```
## descartes_trajectory

```
* Alpha Release
* Contributors: Jonathan Meyer, Shaun Edwards, gavanderhoorn, jrgnicho, ros-devel
```
