### PR TITLE
abb: 1.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10,6 +10,31 @@ release_platforms:
   - saucy
   - trusty
 repositories:
+  abb:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/abb.git
+      version: indigo
+    release:
+      packages:
+      - abb
+      - abb_driver
+      - abb_irb2400_moveit_config
+      - abb_irb2400_moveit_plugins
+      - abb_irb2400_support
+      - abb_irb5400_support
+      - abb_irb6600_support
+      - abb_irb6640_moveit_config
+      - abb_moveit_plugins
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-industrial-release/abb-release.git
+      version: 1.1.7-0
+    source:
+      type: git
+      url: https://github.com/ros-industrial/abb.git
+      version: indigo
+    status: developed
   acado:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `abb` to `1.1.7-0`:
- upstream repository: https://github.com/ros-industrial/abb.git
- release repository: https://github.com/ros-industrial-release/abb-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## abb

```
* Merged hydro branch
  - Updated CHANGELOG.rst and package.xml files
* Removed deprecated packages
  - abb_common
  - irb_2400_moveit_config
  - irb_6640_moveit_config
* Contributors: Levi Armstrong
```
## abb_driver

```
* Merged hydro branch
  - Updated CHANGELOG.rst and package.xml files
* Contributors: Levi Armstrong
```
## abb_irb2400_moveit_config

```
* Merged hydro branch
  - Updated CHANGELOG.rst and package.xml files
* Fix incorrect maintainer email in manifests. Fix #65 <https://github.com/Levi-Armstrong/abb/issues/65>.
* Contributors: Levi Armstrong, Shaun Edwards, gavanderhoorn
```
## abb_irb2400_moveit_plugins

```
* Merged hydro branch
  - Updated CHANGELOG.rst and package.xml files
* Fix incorrect maintainer email in manifests. Fix #65 <https://github.com/Levi-Armstrong/abb/issues/65>.
* Contributors: Levi Armstrong, Martin Günther, Scott K Logan, Shaun Edwards, gavanderhoorn
```
## abb_irb2400_support

```
* Merged hydro branch
  - Updated CHANGELOG.rst and package.xml files
* Fix incorrect maintainer email in manifests. Fix #65 <https://github.com/Levi-Armstrong/abb/issues/65>.
* Fix #32 <https://github.com/Levi-Armstrong/abb/issues/32>: corrects tool0 to match robot controller
* Fix for issue #49 <https://github.com/Levi-Armstrong/abb/issues/49>: add 'base' link (transform to World)
  This should not affect existing kinematic plugins or MoveIt configurations:
  - the link is not part of the main kinematic chain
  - the transform is implemented as a fixed joint
* Contributors: Levi Armstrong, Shaun Edwards, gavanderhoorn
```
## abb_irb5400_support

```
* Merged hydro branch
  - Updated CHANGELOG.rst and package.xml files
* Fix #48 <https://github.com/Levi-Armstrong/abb/issues/48>: added default true for J23_coupled for 5400
* Fix incorrect maintainer email in manifests. Fix #65 <https://github.com/Levi-Armstrong/abb/issues/65>.
* Fix #32 <https://github.com/Levi-Armstrong/abb/issues/32>: corrects tool0 to match robot controller
* Fix for issue #49 <https://github.com/Levi-Armstrong/abb/issues/49>: add 'base' link (transform to World)
  This should not affect existing kinematic plugins or MoveIt configurations:
  - the link is not part of the main kinematic chain
  - the transform is implemented as a fixed joint
* Contributors: Levi Armstrong, Shaun Edwards, dpsolomon, gavanderhoorn
```
## abb_irb6600_support

```
* Merged hydro branch
  - Updated CHANGELOG.rst and package.xml files
* Fix incorrect maintainer email in manifests. Fix #65 <https://github.com/Levi-Armstrong/abb/issues/65>.
* Fix #32 <https://github.com/Levi-Armstrong/abb/issues/32>: corrects tool0 to match robot controller
* Fix for issue #49 <https://github.com/Levi-Armstrong/abb/issues/49>: add 'base' link (transform to World)
  This should not affect existing kinematic plugins or MoveIt configurations:
  - the link is not part of the main kinematic chain
  - the transform is implemented as a fixed joint
* Contributors: Levi Armstrong, Shaun Edwards, gavanderhoorn
```
## abb_irb6640_moveit_config

```
* Merged hydro branch
  - Updated CHANGELOG.rst and package.xml files
* Fix incorrect maintainer email in manifests. Fix #65 <https://github.com/Levi-Armstrong/abb/issues/65>.
* Contributors: Levi Armstrong, Shaun Edwards, gavanderhoorn
```
## abb_moveit_plugins

```
* Merged hydro branch
  - Updated CHANGELOG.rst and package.xml files
* Contributors: Levi Armstrong
```
