### PR TITLE
jsk_model_tools: 0.1.9-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3204,7 +3204,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.1.8-0
+      version: 0.1.9-0
     source:
       type: git
       url: https://github.com/tork-a/jsk_model_tools-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.1.9-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.1.8-0`
## eus_assimp
- No changes
## euscollada

```
* [euscollada] Update urdf_patch.py to handle joint without xyz and rpy tag and to output patched urdf to standard output
* [euscollada] Support multiple links in remove_sensor_from_urdf.py
* [euscollada] Remove pyc file added by mistake
* [euscollada] (remove_sensor_from_urdf.py) Add script to remove link from urdf
* [esucollada] update parseColladaBase.py and add_sensor_to_collada.py for handling urdf file
* Contributors: Ryohei Ueda, Yohei Kakiuchi
```
## jsk_model_tools
- No changes
