### PR TITLE
Revert "abb: 1.1.7-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10,31 +10,6 @@ release_platforms:
   - saucy
   - trusty
 repositories:
-  abb:
-    doc:
-      type: git
-      url: https://github.com/ros-industrial/abb.git
-      version: indigo
-    release:
-      packages:
-      - abb
-      - abb_driver
-      - abb_irb2400_moveit_config
-      - abb_irb2400_moveit_plugins
-      - abb_irb2400_support
-      - abb_irb5400_support
-      - abb_irb6600_support
-      - abb_irb6640_moveit_config
-      - abb_moveit_plugins
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-industrial-release/abb-release.git
-      version: 1.1.7-0
-    source:
-      type: git
-      url: https://github.com/ros-industrial/abb.git
-      version: indigo
-    status: developed
   acado:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#7747

The release repos is missing all the indigo tags. It's causing repeated failures of the sourcedeb jobs. 

```
tfoote@yeti:/tmp/abb-release$ git tag | grep debian | grep hydro | wc -l
174
tfoote@yeti:/tmp/abb-release$ git tag | grep debian | grep indigo | wc -l
0
```
