### PR TITLE
Updated rosdep rules for the libaria package

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1033,25 +1033,13 @@ libaria:
       source:
         md5sum: 589c387995beb951edd9c77f33cb2286
         uri: 'https://raw.github.com/amor-ros-pkg/rosaria/master/libaria.rdmanifest'
-    saucy:
-      apt:
-        packages: [libaria-dev]
-    trusty:
-      apt:
-        packages: [libaria-dev]
-    utopic:
-      apt:
-        packages: [libaria-dev]
-    vivid:
-      apt:
-        packages: [libaria-dev]
+    saucy: [libaria-dev]
+    trusty: [libaria-dev]
+    utopic: [libaria-dev]
+    vivid: [libaria-dev]
   debian:
-    jessie:
-      apt:
-        packages: [libaria-dev]
-    sid:
-      apd:
-        packages: [libaria-dev]
+    jessie: [libaria-dev]
+    sid: [libaria-dev]
 libasound2-dev:
   arch: [alsa-lib]
   fedora: [alsa-lib]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1028,6 +1028,13 @@ libargtable2-dev:
       packages: [dev-libs/argtable]
   ubuntu: [libargtable2-dev]
 libaria:
+  debian:
+    jessie: [libaria-dev]
+    sid: [libaria-dev]
+    wheezy:
+      source:
+        md5sum: 589c387995beb951edd9c77f33cb2286
+        uri: 'https://raw.github.com/amor-ros-pkg/rosaria/master/libaria.rdmanifest'
   ubuntu:
     precise:
       source:
@@ -1037,9 +1044,6 @@ libaria:
     trusty: [libaria-dev]
     utopic: [libaria-dev]
     vivid: [libaria-dev]
-  debian:
-    jessie: [libaria-dev]
-    sid: [libaria-dev]
 libasound2-dev:
   arch: [alsa-lib]
   fedora: [alsa-lib]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1029,9 +1029,29 @@ libargtable2-dev:
   ubuntu: [libargtable2-dev]
 libaria:
   ubuntu:
-    source:
-      md5sum: 589c387995beb951edd9c77f33cb2286
-      uri: 'https://raw.github.com/amor-ros-pkg/rosaria/master/libaria.rdmanifest'
+    precise:
+      source:
+        md5sum: 589c387995beb951edd9c77f33cb2286
+        uri: 'https://raw.github.com/amor-ros-pkg/rosaria/master/libaria.rdmanifest'
+    saucy:
+      apt:
+        packages: [libaria-dev]
+    trusty:
+      apt:
+        packages: [libaria-dev]
+    utopic:
+      apt:
+        packages: [libaria-dev]
+    vivid:
+      apt:
+        packages: [libaria-dev]
+  debian:
+    jessie:
+      apt:
+        packages: [libaria-dev]
+    sid:
+      apd:
+        packages: [libaria-dev]
 libasound2-dev:
   arch: [alsa-lib]
   fedora: [alsa-lib]


### PR DESCRIPTION
Updated rosdep rules to use the binary libaria-dev package, where available.
