### PR TITLE
jsk_pr2eus: 0.1.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3001,7 +3001,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_pr2eus-release.git
-      version: 0.1.8-0
+      version: 0.1.9-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.1.9-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_pr2eus
- release repository: https://github.com/tork-a/jsk_pr2eus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.1.8-0`
## jsk_pr2eus
- No changes
## pr2eus

```
* [robot-interface.l] :min-time=0.0 in :angle-vector-sequence because smooth  angle-vector may have short duration for each angle-vector
* [jsk_pr2eus] FIx :angle-vector-sequence by passing ctype argument to :angle-vector-duration
* [pr2-interface.l] remove unused service call '/move_base_node/clear_unknown_space'
* [robot-interface.l] change default 5 to 1 as :scale in angle-vector
* [robot-intetface.l] check if :controller-type is valid in :angle-vector and :angle-vector-sequence
* [robot-interface.l] Support ctype in :angle-vector-duration
* [robot-interface.l] add :angle-vector-safe for prototype robot
* [robot-interface.l] Add euslisp implementation mannequin mode. (:eus-mannequin-mode)
* [robot-interface.l] modify robot-interface.l to support control_msgs::SingleJointPositionGoal
* Contributors: Kei Okada, Ryohei Ueda, Shunichi Nozawa, Yohei Kakiuchi, Yuki Furuta, Yuto Inagaki
```
