### PR TITLE
jsk_pr2eus: 0.1.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3001,7 +3001,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_pr2eus-release.git
-      version: 0.1.9-0
+      version: 0.1.10-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.1.10-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_pr2eus
- release repository: https://github.com/tork-a/jsk_pr2eus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.1.9-0`
## jsk_pr2eus
- No changes
## pr2eus

```
* [robot-interface.l, pr2-interface.l] support :fast in :angle-vector-sequence
* Contributors: Yuto Inagaki
```
