### PR TITLE
carl_moveit: 0.0.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -659,7 +659,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_moveit-release.git
-      version: 0.0.10-0
+      version: 0.0.11-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_moveit` to `0.0.11-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_moveit.git
- release repository: https://github.com/wpi-rail-release/carl_moveit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.10-0`
## carl_moveit

```
* Removed some unnecessary output
* Clear octomap after the jaco arm homes using the kinova api
* Enabled clear_octomap service
* Contributors: David Kent
```
