### PR TITLE
rail_segmentation: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6105,7 +6105,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_segmentation.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_segmentation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_segmentation` to `0.1.2-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_segmentation.git
- release repository: https://github.com/wpi-rail-release/rail_segmentation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.1-0`
## rail_segmentation

```
* cmake cleanup
* header cleanup
* header cleanup
* header cleanup
* checks for incoming point cloud first
* new lines added
* new lines added
* more const ptrs
* moved to ptr based storage
* const ptrs
* Contributors: Russell Toris
```
