### PR TITLE
rail_pick_and_place: 1.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6090,7 +6090,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
-      version: 1.0.4-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_pick_and_place.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_pick_and_place` to `1.1.0-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_pick_and_place.git
- release repository: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.4-0`
## graspdb

```
* general cleanup
* header cleanup
* major refactor of model generation
* mutable accessors added
* added TF2 data types
* Contributors: Russell Toris
```
## rail_grasp_collection

```
* new launch files
* header cleanup
* moved to ptr based storage
* begin refactor of metrics
* Contributors: Russell Toris
```
## rail_pick_and_place
- No changes
## rail_pick_and_place_msgs

```
* grasp model retriever added
* general cleanup
* major refactor of model generation
* Contributors: Russell Toris
```
## rail_pick_and_place_tools

```
* new launch files
* grasp model retriever added
* travis fix
* travis fix
* Merge branch 'develop' of github.com:WPI-RAIL/rail_pick_and_place into develop
* major refactor of model generation
* Buttons should now correctly handle the case of an unconnected action client - server pair
* Added confirmation dialog for model removal
* Contributors: David Kent, Russell Toris
```
## rail_recognition

```
* new launch files
* grasp model retriever added
* general cleanup
* refactor of model generator
* major refactor of model generation
* adds vector for search
* more refactoring
* begin refactor of metrics
* Contributors: Russell Toris
```
