### PR TITLE
graft: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2060,7 +2060,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/graft-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/ros-perception/graft.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graft` to `0.2.2-0`:
- upstream repository: https://github.com/ros-perception/graft.git
- release repository: https://github.com/ros-gbp/graft-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.1-0`
## graft

```
* fix compilation on 32-bit systems
* update maintainer email
* Contributors: Michael Ferguson
```
