### PR TITLE
mavlink: 2015.4.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3807,7 +3807,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: 2015.3.11-0
+      version: 2015.4.4-0
     status: maintained
   mavros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2015.4.4-0`:
- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/mavlink/mavlink-gbp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2015.3.11-0`
