### PR TITLE
twist_mux_msgs: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8738,7 +8738,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/twist_mux_msgs-release.git
-      version: 0.0.1-1
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/ros-teleop/twist_mux_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux_msgs` to `0.0.2-0`:
- upstream repository: https://github.com/ros-teleop/twist_mux_msgs.git
- release repository: https://github.com/ros-gbp/twist_mux_msgs-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.1-1`
## twist_mux_msgs

```
* Remove not needed include_directories
* Contributors: Enrique Fernandez
```
