### PR TITLE
Update repo name for simple_grasping

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8089,7 +8089,7 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/fetchrobotics-gbp/simple_grasping-gbp.git
+      url: https://github.com/fetchrobotics-gbp/simple_grasping-release.git
       version: 0.2.0-0
     source:
       type: git


### PR DESCRIPTION
I changed the name to better match standard convention
