### PR TITLE
robot_calibration: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6274,7 +6274,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/robot_calibration-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/mikeferguson/robot_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.2.1-0`:
- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/fetchrobotics-gbp/robot_calibration-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.0-0`
## robot_calibration

```
* fix uninitialized variable
* test files should not use .launch extension
* fix error_block_test, closes #11 <https://github.com/mikeferguson/robot_calibration/issues/11>
* fix issue with capture stalling
* Contributors: Michael Ferguson
```
## robot_calibration_msgs
- No changes
