### PR TITLE
turtlebot_msgs: 2.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5072,7 +5072,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 0.2.4-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git
@@ -8628,7 +8628,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_msgs-release.git
-      version: 2.2.0-0
+      version: 2.2.1-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_msgs` to `2.2.1-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_msgs.git
- release repository: https://github.com/turtlebot-release/turtlebot_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2.2.0-0`
## turtlebot_msgs

```
* remove laptop charge status message #2 <https://github.com/turtlebot/turtlebot_msgs/issues/2>
* LaptopChargeStatus moved here from turtlebot stack.
* Contributors: Daniel Stonier, Jihoon Lee
```
