### PR TITLE
rocon_concert: 0.6.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6461,7 +6461,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_concert-release.git
-      version: 0.6.6-0
+      version: 0.6.7-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_concert.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_concert` to `0.6.7-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_concert
- release repository: https://github.com/yujinrobot-release/rocon_concert-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.6.6-0`
## concert_conductor

```
* add sleep for spining closes #278 <https://github.com/robotics-in-concert/rocon_concert/issues/278>
* Contributors: Jihoon Lee
```
## concert_master
- No changes
## concert_schedulers
- No changes
## concert_service_link_graph
- No changes
## concert_service_manager

```
* updates
* update doc for concert_service manager
* Contributors: Jihoon Lee
```
## concert_service_utilities
- No changes
## concert_software_farmer

```
* lock at allocation and release
* parameter works #279 <https://github.com/robotics-in-concert/rocon_concert/issues/279>
* expose exception for client #279 <https://github.com/robotics-in-concert/rocon_concert/issues/279>
* fixes for parameter support #279 <https://github.com/robotics-in-concert/rocon_concert/issues/279>
* support software parameter closes #279 <https://github.com/robotics-in-concert/rocon_concert/issues/279>
* updates
* updates
* farmer doc working
* in the middle of documentation
* ready
* doc init
* Contributors: Jihoon Lee, dwlee
```
## concert_utilities
- No changes
## rocon_concert
- No changes
## rocon_tf_reconstructor
- No changes
