### PR TITLE
concert_software_farm: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1160,7 +1160,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/concert_software_farm-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/concert_software_farm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `concert_software_farm` to `0.0.3-0`:
- upstream repository: https://github.com/robotics-in-concert/concert_software_farm.git
- release repository: https://github.com/yujinrobot-release/concert_software_farm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.2-0`
## concert_software_common

```
* re name parameter field
* update parameter format
* add web video server
* Contributors: Jihoon Lee
```
## concert_software_farm

```
* fix maintainer name
* Contributors: Jihoon Lee
```
