### PR TITLE
mavros: 0.11.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3822,7 +3822,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.11.0-0
+      version: 0.11.1-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.11.1-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.11.0-0`
## libmavconn
- No changes
## mavros

```
* scripts #262 <https://github.com/vooon/mavros/issues/262>: update mavwp
* scripts #262 <https://github.com/vooon/mavros/issues/262>: mavsetp, new module mavros.setpoint
* mavftpfuse #129 <https://github.com/vooon/mavros/issues/129>: cache file attrs
* mavparam #262 <https://github.com/vooon/mavros/issues/262>: use get_topic()
* mavsys #262 <https://github.com/vooon/mavros/issues/262>: use get_topic()
* mavcmd #262 <https://github.com/vooon/mavros/issues/262>: use get_topic()
* mavftp #263 <https://github.com/vooon/mavros/issues/263>, #262 <https://github.com/vooon/mavros/issues/262>: use crc32 checksums
* python #262 <https://github.com/vooon/mavros/issues/262>: add get_topic()
* Update local_position.cpp
  removed irritating comment
* readme: add short glossary
* plugin: setpoint_attitude: remove unneded ns
* Contributors: Marcel Stuettgen, Vladimir Ermakov
```
## mavros_extras

```
* mavftpfuse #129 <https://github.com/vooon/mavros/issues/129>: done!
  Fix #129 <https://github.com/vooon/mavros/issues/129>.
* mavftpfuse #129 <https://github.com/vooon/mavros/issues/129>: cache file attrs
* mavftpfuse #129 <https://github.com/vooon/mavros/issues/129>: initial import
* Contributors: Vladimir Ermakov
```
