### PR TITLE
image_pipeline: 1.12.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2547,7 +2547,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/image_pipeline-release.git
-      version: 1.12.12-0
+      version: 1.12.13-0
     source:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `1.12.13-0`:
- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros-gbp/image_pipeline-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.12.12-0`
## camera_calibration

```
* replace Queue by deque of fixed size for simplicity
  That is a potential fix for #112 <https://github.com/ros-perception/image_pipeline/issues/112>
* Contributors: Vincent Rabaud
```
## depth_image_proc

```
* Add radial point cloud processors
* Contributors: Hunter Laux
```
## image_pipeline
- No changes
## image_proc

```
* fix dependencies
* Contributors: Vincent Rabaud
```
## image_rotate
- No changes
## image_view
- No changes
## stereo_image_proc

```
* get code to compile with OpenCV3
* modify pointcloud data format of stereo_image_proc using point_cloud2_iterator
* Contributors: Hiroaki Yaguchi, Vincent Rabaud
```
