### PR TITLE
ecto_image_pipeline: 0.5.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1698,7 +1698,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ecto_image_pipeline-release.git
-      version: 0.5.4-0
+      version: 0.5.5-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto_image_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto_image_pipeline` to `0.5.5-0`:
- upstream repository: https://github.com/plasmodic/ecto_image_pipeline.git
- release repository: https://github.com/ros-gbp/ecto_image_pipeline-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.5.4-0`
## ecto_image_pipeline

```
* Fixed issue with the format of images (now it is CV_32F)
* clean extensions
* do not depend on ecto_opencv for building
* convert a test to a proper gtest
* Contributors: Vincent Rabaud, nlyubova
```
