### PR TITLE
rail_pick_and_place: 1.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6094,7 +6094,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
-      version: 1.1.0-0
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_pick_and_place.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_pick_and_place` to `1.1.1-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_pick_and_place.git
- release repository: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.1.0-0`
## graspdb
- No changes
## rail_grasp_collection
- No changes
## rail_pick_and_place
- No changes
## rail_pick_and_place_msgs
- No changes
## rail_pick_and_place_tools

```
* refactor of RViz GUIs
* cleanup of grasp collection panel
* Contributors: Russell Toris
```
## rail_recognition
- No changes
