### PR TITLE
rtmros_hironx: 1.0.29-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7575,7 +7575,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.28-0
+      version: 1.0.29-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.29-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.28-0`
## hironx_calibration

```
* Minor pkg description correction.
* Contributors: Isaac IY Saito
```
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* Feature
* Fix
* UnitTest
* Contributors: Kei Okada, Isaac IY Saito
```
## rtmros_hironx

```
* Feature
* Fix
* UnitTest
* Doc
* Contributors: Kei Okada, Isaac IY Saito
```
