### PR TITLE
adding orsens_ros to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5218,12 +5218,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/Oriense/orsens_ros.git
-      version: 1.0-beta
+      version: master
     source:
       type: git
       url: https://github.com/Oriense/orsens_ros.git
-      version: 1.0-beta
-    status: developed
+      version: master
   p2os:
     release:
       packages:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5214,6 +5214,16 @@ repositories:
       url: https://github.com/orocos-toolchain/orogen.git
       version: toolchain-2.8
     status: maintained
+  orsens_ros:
+    doc:
+      type: git
+      url: https://github.com/Oriense/orsens_ros.git
+      version: 1.0-beta
+    source:
+      type: git
+      url: https://github.com/Oriense/orsens_ros.git
+      version: 1.0-beta
+    status: developed
   p2os:
     release:
       packages:


### PR DESCRIPTION
i'd like orsens_ros to be indexed and documented on ros.org.
wiki page - http://wiki.ros.org/orsens_ros
