### PR TITLE
sr_config: 1.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8244,7 +8244,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/shadow-robot/sr-config-release.git
-      version: 1.3.4-0
+      version: 1.4.0-0
     source:
       type: git
       url: https://github.com/shadow-robot/sr-config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_config` to `1.4.0-0`:
- upstream repository: https://github.com/shadow-robot/sr-config.git
- release repository: https://github.com/shadow-robot/sr-config-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.3.4-0`
## sr_config
- No changes
## sr_cyberglove_config
- No changes
## sr_ethercat_hand_config

```
* Fix J0 names for effort controllers
* Fix diagnostics prefix
* Add bimanual diagnostic analyzer
* Add pwm_control argument
* Adapt config files to bimanual single loop
* adding tactile controller config for easier customer customisation
```
