### PR TITLE
robot_pose_publisher: 0.2.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -933,6 +933,21 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: indigo-devel
     status: maintained
+  robot_pose_publisher:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/robot_pose_publisher.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wpi-rail-release/robot_pose_publisher-release.git
+      version: 0.2.3-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/robot_pose_publisher.git
+      version: develop
+    status: maintained
   robot_upstart:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_pose_publisher` to `0.2.3-0`:
- upstream repository: https://github.com/WPI-RAIL/robot_pose_publisher.git
- release repository: https://github.com/wpi-rail-release/robot_pose_publisher-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## robot_pose_publisher

```
* cleanup for release
* travis fix
* travis test
* gitignore cleanup
* Dry branch cleanup
* Contributors: Russell Toris
```
