### PR TITLE
python_ethernet_rmp: 0.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -933,6 +933,21 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: indigo-devel
     status: maintained
+  python_ethernet_rmp:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/python_ethernet_rmp.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wpi-rail-release/python_ethernet_rmp-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/python_ethernet_rmp.git
+      version: develop
+    status: maintained
   robot_upstart:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_ethernet_rmp` to `0.0.2-0`:
- upstream repository: https://github.com/WPI-RAIL/python_ethernet_rmp.git
- release repository: https://github.com/wpi-rail-release/python_ethernet_rmp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## python_ethernet_rmp

```
* Merge pull request #6 <https://github.com/WPI-RAIL/python_ethernet_rmp/issues/6> from cmdunkers/develop
  fixed the default_bitmap issue
* Fixed the default_config bitmap to 1 instead of the default since default does not work with carl
* Merge pull request #2 <https://github.com/WPI-RAIL/python_ethernet_rmp/issues/2> from WPI-RAIL/develop
  Update CMakeLists.txt
* Merge pull request #1 <https://github.com/WPI-RAIL/python_ethernet_rmp/issues/1> from WPI-RAIL/master
  Cleanup and release of 0.0.1
* Update CMakeLists.txt
* Merge pull request #5 <https://github.com/WPI-RAIL/python_ethernet_rmp/issues/5> from WPI-RAIL/develop
  0.0.1
* Contributors: Chris Dunkers, Russell Toris, cmdunkers
```
