### PR TITLE
rmp_msgs: 0.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -933,6 +933,21 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: indigo-devel
     status: maintained
+  rmp_msgs:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rmp_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wpi-rail-release/rmp_msgs-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rmp_msgs.git
+      version: develop
+    status: maintained
   robot_upstart:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmp_msgs` to `0.0.1-0`:
- upstream repository: https://github.com/WPI-RAIL/rmp_msgs.git
- release repository: https://github.com/wpi-rail-release/rmp_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## rmp_msgs

```
* removed whitespace
* cleanup of repo
* Merge pull request #1 from cmdunkers/master
  added messages
* added messages
* Initial commit
* Contributors: Chris Dunkers, Russell Toris
```
