### PR TITLE
librms: 0.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -569,6 +569,21 @@ repositories:
       url: https://github.com/ros-perception/laser_geometry.git
       version: indigo-devel
     status: maintained
+  librms:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/librms.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wpi-rail-release/librms-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/librms.git
+      version: develop
+    status: maintained
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `librms` to `0.0.2-0`:
- upstream repository: https://github.com/WPI-RAIL/librms.git
- release repository: https://github.com/wpi-rail-release/librms-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## librms

```
* fix for header installs
* Contributors: Russell Toris
```
