### PR TITLE
async_web_server_cpp: 0.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -78,6 +78,21 @@ repositories:
       url: https://github.com/vanadiumlabs/arbotix_ros.git
       version: indigo-devel
     status: maintained
+  async_web_server_cpp:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/async_web_server_cpp.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wpi-rail-release/async_web_server_cpp-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/async_web_server_cpp.git
+      version: develop
+    status: maintained
   bfl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_web_server_cpp` to `0.0.2-0`:
- upstream repository: https://github.com/WPI-RAIL/async_web_server_cpp.git
- release repository: https://github.com/wpi-rail-release/async_web_server_cpp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## async_web_server_cpp

```
* Merge pull request #3 from mitchellwills/develop
  Added support for specifying additional headers when creating static request handlers
* Added some comments to the HTTP reply methods
* Added support for specifying additional headers when creating static request handlers
* Contributors: Mitchell Wills, Russell Toris
```
