### PR TITLE
rosauth: 0.1.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1050,6 +1050,21 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: indigo-devel
     status: maintained
+  rosauth:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rosauth.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wpi-rail-release/rosauth-release.git
+      version: 0.1.6-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rosauth.git
+      version: develop
+    status: maintained
   rosbag_migration_rule:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosauth` to `0.1.6-0`:
- upstream repository: https://github.com/WPI-RAIL/rosauth.git
- release repository: https://github.com/wpi-rail-release/rosauth-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## rosauth

```
* Merge pull request #5 from cottsay/hydro-devel
  missing libssl-dev during build
* Added libssl-dev to build_depend
* Contributors: Russell Toris, Scott K Logan
```
