### PR TITLE
rail_manipulation_msgs: 0.0.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -933,6 +933,21 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: indigo-devel
     status: maintained
+  rail_manipulation_msgs:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_manipulation_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wpi-rail-release/rail_manipulation_msgs-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_manipulation_msgs.git
+      version: develop
+    status: maintained
   robot_upstart:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_manipulation_msgs` to `0.0.3-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_manipulation_msgs.git
- release repository: https://github.com/wpi-rail-release/rail_manipulation_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## rail_manipulation_msgs

```
* orientation added
* removed old recognize actions
* Contributors: Russell Toris
```
