### PR TITLE
usb_cam: 0.3.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1303,6 +1303,21 @@ repositories:
       url: https://github.com/ros-gbp/urdfdom_py-release.git
       version: 0.3.0-1
     status: maintained
+  usb_cam:
+    doc:
+      type: git
+      url: https://github.com/bosch-ros-pkg/usb_cam.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/bosch-ros-pkg-release/usb_cam-release.git
+      version: 0.3.2-0
+    source:
+      type: git
+      url: https://github.com/bosch-ros-pkg/usb_cam.git
+      version: develop
+    status: maintained
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam` to `0.3.2-0`:
- upstream repository: https://github.com/bosch-ros-pkg/usb_cam.git
- release repository: https://github.com/bosch-ros-pkg-release/usb_cam-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## usb_cam

```
* Merge pull request #34 from eliasm/develop
  fixed check whether calibration file exists
* fixed check whether calibration file exists
* Contributors: Elias Mueggler, Russell Toris
```
