### PR TITLE
depthcloud_encoder: 0.0.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -244,6 +244,21 @@ repositories:
       url: https://github.com/ros-controls/control_msgs.git
       version: indigo-devel
     status: maintained
+  depthcloud_encoder:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/depthcloud_encoder.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/RobotWebTools-release/depthcloud_encoder-release.git
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/depthcloud_encoder.git
+      version: develop
+    status: maintained
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthcloud_encoder` to `0.0.4-0`:
- upstream repository: https://github.com/RobotWebTools/depthcloud_encoder.git
- release repository: https://github.com/RobotWebTools-release/depthcloud_encoder-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## depthcloud_encoder

```
* source cleanup
* basic cleanup
* depricated launch package removed
* Contributors: Russell Toris
```
