### PR TITLE
tf2_web_republisher: 0.3.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1247,6 +1247,21 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  tf2_web_republisher:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/tf2_web_republisher.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/RobotWebTools-release/tf2_web_republisher-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/tf2_web_republisher.git
+      version: develop
+    status: maintained
   ueye:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_web_republisher` to `0.3.0-0`:
- upstream repository: https://github.com/RobotWebTools/tf2_web_republisher.git
- release repository: https://github.com/RobotWebTools-release/tf2_web_republisher-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## tf2_web_republisher

```
* Merge pull request #16 from T045T/tf2_republisher_service
  Tf2 republisher service
* add back action server functionality
* modularize code that can be used by both the action and service implementation
* remove test folder
* change terminology to reflect the fact that this is now a service, rather than an Action server
  also remove some high-frequency debug output
* change TFArray member name from data to transforms
* change tf2_web_republisher to use a service and dynamically advertised topics instead of an action call
  TODO: testing
* consistent 2 space indentation
* Contributors: Nils Berg, Russell Toris
```
