### PR TITLE
rail_maps: 0.2.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -993,6 +993,21 @@ repositories:
       url: https://github.com/WPI-RAIL/rail_manipulation_msgs.git
       version: develop
     status: maintained
+  rail_maps:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_maps.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wpi-rail-release/rail_maps-release.git
+      version: 0.2.5-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_maps.git
+      version: develop
+    status: maintained
   robot_upstart:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_maps` to `0.2.5-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_maps.git
- release repository: https://github.com/wpi-rail-release/rail_maps-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## rail_maps

```
* Rail lab with no furniture, for navigation that handles the furniture dynamically
* Contributors: David Kent
```
