### PR TITLE
m4atx_battery_monitor: 0.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -614,6 +614,21 @@ repositories:
       url: https://github.com/WPI-RAIL/librms.git
       version: develop
     status: maintained
+  m4atx_battery_monitor:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/m4atx_battery_monitor.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wpi-rail-release/m4atx_battery_monitor-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/m4atx_battery_monitor.git
+      version: develop
+    status: maintained
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `m4atx_battery_monitor` to `0.0.2-0`:
- upstream repository: https://github.com/WPI-RAIL/m4atx_battery_monitor.git
- release repository: https://github.com/wpi-rail-release/m4atx_battery_monitor-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## m4atx_battery_monitor

```
* moved .sh to .bash
* permissions script added to install
* Contributors: Russell Toris
* usb dev added
* comments
* moved script
* Merge branch 'cmdunkers-develop' into develop
* merege
* Added a script to make sure the device can be read from
  script applies appropriate permissions
* revert to 0.0.0'
* Added a startup script
* Contributors: Chris Dunkers, Russell Toris
```
