### PR TITLE
web_video_server: 0.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -614,21 +614,6 @@ repositories:
       url: https://github.com/WPI-RAIL/librms.git
       version: develop
     status: maintained
-  m4atx_battery_monitor:
-    doc:
-      type: git
-      url: https://github.com/WPI-RAIL/m4atx_battery_monitor.git
-      version: master
-    release:
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/wpi-rail-release/m4atx_battery_monitor-release.git
-      version: 0.0.2-0
-    source:
-      type: git
-      url: https://github.com/WPI-RAIL/m4atx_battery_monitor.git
-      version: develop
-    status: maintained
   mavlink:
     doc:
       type: git
@@ -993,21 +978,6 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: indigo-devel
     status: maintained
-  python_ethernet_rmp:
-    doc:
-      type: git
-      url: https://github.com/WPI-RAIL/python_ethernet_rmp.git
-      version: master
-    release:
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/wpi-rail-release/python_ethernet_rmp-release.git
-      version: 0.0.2-0
-    source:
-      type: git
-      url: https://github.com/WPI-RAIL/python_ethernet_rmp.git
-      version: develop
-    status: maintained
   rail_manipulation_msgs:
     doc:
       type: git
@@ -1021,21 +991,6 @@ repositories:
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_manipulation_msgs.git
-      version: develop
-    status: maintained
-  rail_maps:
-    doc:
-      type: git
-      url: https://github.com/WPI-RAIL/rail_maps.git
-      version: master
-    release:
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/wpi-rail-release/rail_maps-release.git
-      version: 0.2.5-0
-    source:
-      type: git
-      url: https://github.com/WPI-RAIL/rail_maps.git
       version: develop
     status: maintained
   robot_upstart:
@@ -1478,6 +1433,21 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
       version: 2.10.0-3
+    status: maintained
+  web_video_server:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/web_video_server.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/RobotWebTools-release/web_video_server-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/web_video_server.git
+      version: develop
     status: maintained
   xacro:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `web_video_server` to `0.0.2-0`:
- upstream repository: https://github.com/RobotWebTools/web_video_server.git
- release repository: https://github.com/RobotWebTools-release/web_video_server-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## web_video_server

```
* Merge pull request #10 from mitchellwills/develop
  Added option to specify server address
* Added option to specify server address
* Merge pull request #3 from mitchellwills/develop
  Remove old http_server implementation and replace it with async_web_server_cpp package
* Moved from using built in http server to new async_web_server_cpp package
* Did some cleanup of streamers
* Update package.xml
* Contributors: Mitchell Wills, Russell Toris
```
