### PR TITLE
web_video_server: 0.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1529,6 +1529,21 @@ repositories:
       url: https://github.com/lagadic/visp-release.git
       version: 2.10.0-3
     status: maintained
+  web_video_server:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/web_video_server.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/RobotWebTools-release/web_video_server-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/web_video_server.git
+      version: develop
+    status: maintained
   xacro:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `web_video_server` to `0.0.2-0`:
- upstream repository: https://github.com/RobotWebTools/web_video_server.git
- release repository: https://github.com/RobotWebTools-release/web_video_server-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## web_video_server

```
* Merge pull request #10 from mitchellwills/develop
  Added option to specify server address
* Added option to specify server address
* Merge pull request #3 from mitchellwills/develop
  Remove old http_server implementation and replace it with async_web_server_cpp package
* Moved from using built in http server to new async_web_server_cpp package
* Did some cleanup of streamers
* Update package.xml
* Contributors: Mitchell Wills, Russell Toris
```
