### PR TITLE
battery_monitor_rmp: 0.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -93,6 +93,21 @@ repositories:
       url: https://github.com/WPI-RAIL/async_web_server_cpp.git
       version: develop
     status: maintained
+  battery_monitor_rmp:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/battery_monitor_rmp.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wpi-rail-release/battery_monitor_rmp-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/battery_monitor_rmp.git
+      version: develop
+    status: maintained
   bfl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `battery_monitor_rmp` to `0.0.2-0`:
- upstream repository: https://github.com/WPI-RAIL/battery_monitor_rmp.git
- release repository: https://github.com/wpi-rail-release/battery_monitor_rmp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## battery_monitor_rmp

```
* fixed node name in launch
* missing dep added for travis
* travis now pull messages from source
* removed unused build deps
* moved to rmp_msgs
* Contributors: Russell Toris
```
