### PR TITLE
ethercat_grant: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1711,10 +1711,20 @@ repositories:
       version: indigo-devel
     status: maintained
   ethercat_grant:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/ethercat_grant.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/shadow-robot/ethercat_grant-release.git
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/shadow-robot/ethercat_grant.git
       version: indigo-devel
+    status: developed
   euslisp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ethercat_grant` to `0.1.0-0`:
- upstream repository: https://github.com/shadow-robot/ethercat_grant.git
- release repository: https://github.com/shadow-robot/ethercat_grant-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## ethercat_grant

```
* Add postinstallation script
* Change package name
```
