### PR TITLE
ros_ethernet_rmp: 0.0.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1180,6 +1180,21 @@ repositories:
       url: https://github.com/ros/ros_comm_msgs.git
       version: indigo-devel
     status: maintained
+  ros_ethernet_rmp:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/ros_ethernet_rmp.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wpi-rail-release/ros_ethernet_rmp-release.git
+      version: 0.0.8-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/ros_ethernet_rmp.git
+      version: develop
+    status: maintained
   ros_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ethernet_rmp` to `0.0.8-0`:
- upstream repository: https://github.com/WPI-RAIL/ros_ethernet_rmp.git
- release repository: https://github.com/wpi-rail-release/ros_ethernet_rmp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## ros_ethernet_rmp

```
* Changed args in launch file so that they can be overriden
* Contributors: David Kent
```
