### PR TITLE
rail_segmentation: 0.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1053,6 +1053,21 @@ repositories:
       url: https://github.com/WPI-RAIL/rail_maps.git
       version: develop
     status: maintained
+  rail_segmentation:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_segmentation.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wpi-rail-release/rail_segmentation.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_segmentation.git
+      version: develop
+    status: maintained
   rmp_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_segmentation` to `0.1.2-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_segmentation.git
- release repository: https://github.com/wpi-rail-release/rail_segmentation.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## rail_segmentation

```
* cmake cleanup
* header cleanup
* header cleanup
* header cleanup
* checks for incoming point cloud first
* new lines added
* new lines added
* more const ptrs
* moved to ptr based storage
* const ptrs
* Contributors: Russell Toris
```
