### PR TITLE
shadow_robot: 1.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7987,11 +7987,11 @@ repositories:
       - sr_description
       - sr_example
       - sr_gazebo_plugins
+      - sr_grasp
       - sr_hand
       - sr_hardware_interface
       - sr_mechanism_controllers
       - sr_mechanism_model
-      - sr_moveit_config
       - sr_movements
       - sr_robot_msgs
       - sr_self_test
@@ -8001,7 +8001,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/shadow-robot/sr-ros-interface-release.git
-      version: 1.3.2-0
+      version: 1.4.0-0
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ros-interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `shadow_robot` to `1.4.0-0`:
- upstream repository: https://github.com/shadow-robot/sr-ros-interface.git
- release repository: https://github.com/shadow-robot/sr-ros-interface-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.3.2-0`
## shadow_robot
- No changes
## sr_description

```
* removing cartesian control - not implemented in ros-control + changing to the new traj controller
* Inertia now exact values, with inertia tensor at COM (gazebo and ode support the small values now)
  Removed explicit viscous damping from sr_gazebo_plugin,
  enabled springDamper in each joint (implicit viscous damping)
  changed simulation parameters for stability
  and retuned the controllers, explicitely define friction_deadband for simulated controllers (default is for real hand and is too high)
* Added mechanicalReduction to get valid URDF, still warnings about doubled joints or collision that are allowed actually
* Fixed color problems in biotac and forearm_lite
* adding the missing is_lite=0 param
* Rough weight guess for forearm
* Remove wrist mount collider
* Fix forearm collision.
* Fix forearm color in gazebo
* Fix scale
* Rotate the forearm
* Bring in the new forearm part.
* Start on xacro.
* Added a wrist mount collision box (motor and muscle hand)
  Added more precision to the palm collision shape (still using boxes)
* Add model for bimanual motor hand robot
* Changed inertia and force limits for biotac fingertip
* Upgraded kinect definition to use plugins, reactivated simulated kinect.
* Add the missing mesh for the finger biotac adapter.
* sr_description upgrade from groovy to hydro + update from hydro to indigo
  new collision model port from hydro to indigo
  fixed biotac finger missing the prefix parameter and middle transmission parameters
  fixed thumb vibrations (tuning and collision model)
  updated middle transmission to new J0Transmission syntax
```
## sr_example
- No changes
## sr_gazebo_plugins

```
* Inertia now exact values, with inertia tensor at COM (gazebo and ode support the small values now)
  Removed explicit viscous damping from sr_gazebo_plugin,
  enabled springDamper in each joint (implicit viscous damping)
  changed simulation parameters for stability
  and retuned the controllers, explicitely define friction_deadband for simulated controllers (default is for real hand and is too high)
* Added shutdown-timeout=1.0 in controller spawner to improve shutdown time
  Added a boolean to stop spinner in gazebo controller manager plugin to improve shutdown
* using prefix on joints didn't work with gazebo controllers. This is now working
```
## sr_grasp

```
* First release
```
## sr_hand

```
* starting trajectory controllers only for the arm when running arm + hand as it is more standard. Can't have both running with ros_control
* removing cartesian control - not implemented in ros-control + changing to the new traj controller
* Added shutdown-timeout=1.0 in controller spawner to improve shutdown time
  Added a boolean to stop spinner in gazebo controller manager plugin to improve shutdown
* Better ethercat compatibility
* Add arguments to allow launching a particular robot model on gazebo.
* Moved gnuplot as a run dependency since sr_self_test is also running outside the gtest
  Fixed missing image_path
* mod debug mode of launch file
  added args for launching gazebo
  renamed joint variable in python because it shadowed import
* deleting deprecated rviz config
* adding the standard ros topics to our old hand interface - useulf for the virtual hand
```
## sr_hardware_interface
- No changes
## sr_mechanism_controllers

```
* Adapt calibration controller
* Fix joint limit reading
* using prefix on joints didn't work with gazebo controllers. This is now working
* removed the divide by 2 for the velocity commands
```
## sr_mechanism_model

```
* fix for joint names of bimanual systems
```
## sr_movements
- No changes
## sr_robot_msgs

```
* Add a GraspArray message.
* Add PlanGrasp action.
* Port the Contact message and Grasp action from GSC
```
## sr_self_test

```
* Modified behaviour in case there is no HOME to fallback to /tmp only
* Moved gnuplot as a run dependency since sr_self_test is also running outside the gtest
  Fixed missing image_path
* ported the multiuser fix for sr_self_test to indigo
```
## sr_standalone
- No changes
## sr_tactile_sensors
- No changes
## sr_utilities

```
* initialize commands to current state
```
