### PR TITLE
shadow_robot_ethercat: 1.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7987,11 +7987,11 @@ repositories:
       - sr_description
       - sr_example
       - sr_gazebo_plugins
-      - sr_grasp
       - sr_hand
       - sr_hardware_interface
       - sr_mechanism_controllers
       - sr_mechanism_model
+      - sr_moveit_config
       - sr_movements
       - sr_robot_msgs
       - sr_self_test
@@ -8001,7 +8001,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/shadow-robot/sr-ros-interface-release.git
-      version: 1.4.0-0
+      version: 1.3.2-0
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ros-interface.git
@@ -8024,7 +8024,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/shadow-robot/sr-ros-interface-ethercat-release.git
-      version: 1.3.3-0
+      version: 1.4.0-0
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ros-interface-ethercat.git
@@ -8229,7 +8229,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/shadow-robot/sr-config-release.git
-      version: 1.4.0-0
+      version: 1.3.4-0
     source:
       type: git
       url: https://github.com/shadow-robot/sr-config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `shadow_robot_ethercat` to `1.4.0-0`:
- upstream repository: https://github.com/shadow-robot/sr-ros-interface-ethercat.git
- release repository: https://github.com/shadow-robot/sr-ros-interface-ethercat-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.3.3-0`
## shadow_robot_ethercat
- No changes
## sr_edc_controller_configuration
- No changes
## sr_edc_ethercat_drivers

```
* Fixed loop counter for tactile publisher throttling to be at 100Hz
* Fix serial to string conversion
* Set node handle from ouside the robot_lib. Prefix the diagnostics.
* Add ns_prefix and joint_prefix to hand devices.
```
## sr_edc_launch

```
* Rename ros_grant
* Add launchfile for a bimanual system in a single process
* replace pr2-grant with ros_grant
* UBI0.cpp, sr_motor_robot_lib.cpp and sr_muscle_robot_lib now match upstream
  Removed sr_bringup as calibration file is now in ros_ethercat
* now using calibrate.py in sr_mechanism_controllers
```
## sr_edc_muscle_tools

```
* Removed unuseful files
```
## sr_external_dependencies
- No changes
## sr_robot_lib

```
* Skip reset gains for arm controllers
* Skip reset_gains if the controller is a trajectory controller
* Fix diagnostics prefix
* Add muscle hand joint prefix
* Fix ns for controller resetting
* Use joint_prefix in order to get the right actuator from the hardware_interface.
* Set node handle for the tactile classes. Prefix the diagnostics.
* Set node handle from ouside the robot_lib. Prefix the diagnostics.
* Add ns_prefix and joint_prefix to hand devices.
* UBI0.cpp, sr_motor_robot_lib.cpp and sr_muscle_robot_lib now match upstream
  Removed sr_bringup as calibration file is now in ros_ethercat
* Increased UBI0 timeout to 10 seconds
* Now mid prox data are still extracted in UBI0 update, but do not require that the from_sensor_data_type is correct (as it is in fact incorrect when there is no distal tactile sensor connected)
* Added a 5s timeout to the tactile initialization. In case no tactiles are detected, we assume that we have UBI0 tactiles. This is a temporary solution that allow us to extract the middle, proximal and palm sensors even if no tactiles are plugged in
```
