### PR TITLE
ros_ethercat: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6857,7 +6857,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/shadow-robot/ros_ethercat-release.git
-      version: 0.1.8-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/shadow-robot/ros_ethercat.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ethercat` to `0.2.0-0`:
- upstream repository: https://github.com/shadow-robot/ros_ethercat.git
- release repository: https://github.com/shadow-robot/ros_ethercat-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.8-0`
## ros_ethercat
- No changes
## ros_ethercat_eml

```
* Delete unnecessary class EtherCAT_SlaveDb that was causing sigsegv
* Make the start address non-static (each ethercat port will have its own separate logical address space)
* bug fixes in initialization
```
## ros_ethercat_hardware

```
* Delete motor halted message
* Make the start address non-static (each ethercat port will have its own separate logical address space)
* Add run dependency, otherwise catkin complains.
* Enable rpath for ros_ethercat_hardware. We add a build dep on ros_ethercat_model to have the new cmake function available.
* bug fixes in initialization
```
## ros_ethercat_loop

```
* Check if a port has been defined before starting EtherCAT
* Check if an ethercat port has been defined
* Enable rpath in ros_ethercat_loop.
```
## ros_ethercat_model

```
* Added shutdown-timeout=1.0 to improve controller shutdown time
* Check if a port has been defined before starting EtherCAT
* Check if an ethercat port has been defined
* Fix wait for calibration problem
* Add cmake function to enable rpath
* bug fixes in initialization
* added and registered JointCommandInterfaces
* added install directives
```
