### PR TITLE
carl_estop: 0.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -167,6 +167,21 @@ repositories:
       url: https://github.com/ros-perception/calibration.git
       version: hydro
     status: maintained
+  carl_estop:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/carl_estop.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wpi-rail-release/carl_estop-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/carl_estop.git
+      version: develop
+    status: maintained
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_estop` to `0.0.2-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_estop.git
- release repository: https://github.com/wpi-rail-release/carl_estop-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## carl_estop

```
* moved to new messages
* updated travis
* Contributors: Russell Toris
```
