### PR TITLE
sr_ronex: 0.10.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8256,7 +8256,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/shadow-robot/sr-ronex-release.git
-      version: 0.9.15-0
+      version: 0.10.0-0
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ronex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_ronex` to `0.10.0-0`:
- upstream repository: https://github.com/shadow-robot/sr-ronex.git
- release repository: https://github.com/shadow-robot/sr-ronex-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.9.15-0`
## sr_ronex
- No changes
## sr_ronex_controllers

```
* Adapt SPI controller and configuration to changes in the protocol
* Fix SPI dynamic config.
* adding SPI modes
```
## sr_ronex_drivers

```
* Adapt SPI controller and configuration to changes in the protocol
* Add filter to discard invalid status frames.
* Fix SPI dynamic config.
* adding SPI modes
```
## sr_ronex_examples

```
* Fix bug in example
```
## sr_ronex_external_protocol

```
* Change Ronex_Protocol_0x02000002_SPI_00.h
* Add esi xml files.
```
## sr_ronex_hardware_interface
- No changes
## sr_ronex_launch

```
* mod debug mode of launch file
```
## sr_ronex_msgs
- No changes
## sr_ronex_test
- No changes
## sr_ronex_transmissions

```
* Fix command to pwm. abs value
* Add a mapping type, and modify the ronex transmission to solve some newly discovered bugs.
```
## sr_ronex_utilities
- No changes
