### PR TITLE
abb: 1.1.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10,6 +10,30 @@ release_platforms:
   - saucy
   - trusty
 repositories:
+  abb:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/abb.git
+      version: indigo
+    release:
+      packages:
+      - abb
+      - abb_driver
+      - abb_irb2400_moveit_config
+      - abb_irb2400_moveit_plugins
+      - abb_irb2400_support
+      - abb_irb5400_support
+      - abb_irb6600_support
+      - abb_irb6640_moveit_config
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-industrial-release/abb-release.git
+      version: 1.1.9-0
+    source:
+      type: git
+      url: https://github.com/ros-industrial/abb.git
+      version: indigo
+    status: developed
   acado:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `abb` to `1.1.9-0`:
- upstream repository: https://github.com/ros-industrial/abb.git
- release repository: https://github.com/ros-industrial-release/abb-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## abb

```
* Remove dependencies from package.xml for removed deprecated packages
* Removed deprecated package abb_moveit_plugins
* Contributors: Levi Armstrong
```
## abb_driver

```
* No changes
```
## abb_irb2400_moveit_config

```
* No changes
```
## abb_irb2400_moveit_plugins

```
* No changes
```
## abb_irb2400_support

```
* No changes
```
## abb_irb5400_support

```
* No changes
```
## abb_irb6600_support

```
* No changes
```
## abb_irb6640_moveit_config

```
* No changes
```
