### PR TITLE
pepper_meshes: 0.1.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -989,6 +989,17 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: indigo-devel
     status: maintained
+  pepper_meshes:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-naoqi/pepper_meshes-installer.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_meshes.git
+      version: master
+    status: maintained
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_meshes` to `0.1.1-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_meshes.git
- release repository: https://github.com/ros-naoqi/pepper_meshes-installer.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## pepper_meshes

```
* update MD5
* first commit of the installer
* Contributors: Vincent Rabaud
```
