### PR TITLE
pepper_meshes: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5346,7 +5346,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_meshes-installer.git
-      version: 0.1.1-1
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_meshes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_meshes` to `0.1.2-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_meshes.git
- release repository: https://github.com/ros-naoqi/pepper_meshes-installer.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.1-1`
## pepper_meshes

```
* fix typo
* Contributors: Vincent Rabaud
```
