### PR TITLE
jsk_robot: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3084,14 +3084,12 @@ repositories:
       - jsk_pr2_calibration
       - jsk_pr2_startup
       - jsk_robot_startup
-      - pepper_bringup
-      - pepper_description
       - peppereus
       - pr2_base_trajectory_action
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_robot-release.git
-      version: 0.0.4-1
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `0.0.5-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `0.0.4-1`
## baxtereus

```
* [baxter-interface.l] fix typo
* [baxter-interface.l] overwrite :angle-vector-seuqnce for tm = :fast
* [baxter-interface.l] notify this warning is ok
* [baxtereus] add head action client for baxter
* Contributors: Yuto Inagaki
```
## jsk_baxter_desktop
- No changes
## jsk_baxter_startup

```
* [jsk_baxter_startup/baxter.launch] head_trajectory_action is available after v1.1.0
* [jsk_baxter_sensors] add kinecct2 use_machine parameter
* [jsk_baxter_startup] update to add position diff paramter for tweet
* [jsk_baxter_startup] update rviz config
* [jsk_baxter_startup] add head trajectory server for baxter.launch
* [jsk_baxter_startup] modify to prevent baxter.launch fail
* [jsk_baxter_startup] add more dependencies to jsk_baxter_startup
* [jsk_baxter_startup] shift to use kinect2 from kinect
* [jsk_baxter_startup] remove checkerboard yaml rosparam
* [jsk_baxter_startup] add use_color and keep_organized option to baxter self_filter.launch
* [jsk_baxter_startup] add self_filter launch and config to jsk_baxter
* Contributors: Kei Okada, Yuto Inagaki
```
## jsk_baxter_web
- No changes
## jsk_nao_startup
- No changes
## jsk_pepper_startup

```
* modify msg name and launch file name
* Contributors: Jiang Jun
```
## jsk_pr2_calibration
- No changes
## jsk_pr2_startup

```
* [jsk_pr2_startup] Add rossetpr1012 and rossetpr1040 automatically by env-hooks
* add deps jsk_interactive_marker for jsk_pr2_startup
* add pr2 deps package for build test
* use only catkin; add deps for running pr2.launch
* add dwa_local_planner to build/run dependencies
* add move_base_msgs, roseus to build dependencies
* update readme for launching mongodb by multi users
* [jsk_pr2_startup] Remove collider related roslaunch
* launch mongodb when robot starts
* add action_result_db to record action result/goal and joint_states
* add tilt_scan_interpolated topic
* add openni_cloud_self_filter to launch as default and publish color pointclouds
* tested objectdetection for all camera on PR2
* tested on PR2
* fix option of db_client launch
* add debug message to objectdetection_db.py
* [jsk_pr2_robot] Use jsk_network_tools' euslisp code to
  compress/decompress joint angles
* migrate pr2 move_base, objectdetection db from postgre to mongodb
* Contributors: Ryohei Ueda, Yuki Furuta, Yuto Inagaki
```
## jsk_robot_startup

```
* [jsk_baxter_startup] update to add position diff paramter for tweet
* [jsk_baxter_startup] modify to prevent baxter.launch fail
* [jsk_robot_startup/package.xml: add diagnostic_msgs, pr2_mechanism_controllers, sensor_msgs to build dependencies
* [sk_robot_startup/CMakeLists.txt] update to set permission for installed script files
* [jsk_robot_startup] modfiy CMakeLists.txt to install jsk_robot_startup correctly
* [jsk_robot_startup/lifelog/active_user.l] repair tweet lifelog
* [jsk_robot_startup/lifelog/mongodb.launch] fix typo of option in launch
* [jsk_robot_startup/lifelog/mongodb.launch: add mongodb launch; mongod kill watcher
* Contributors: Yuki Furuta, Yuto Inagaki
```
## peppereus

```
* change nao_msgs to naoqi_msgs
* Contributors: Jiang Jun
```
## pr2_base_trajectory_action
- No changes
