### PR TITLE
vision_visp: 0.8.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9080,7 +9080,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.8.0-0
+      version: 0.8.1-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.8.1-0`:
- upstream repository: https://github.com/lagadic/vision_visp.git
- release repository: https://github.com/lagadic/vision_visp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.8.0-0`
## vision_visp

```
* indigo-0.8.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_auto_tracker

```
* Fix warning detected with bloom
* indigo-0.8.0
* Prepare changelogs
* Merge branch 'indigo-devel' into indigo
* Contributors: Fabien Spindler
```
## visp_bridge

```
* indigo-0.8.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_camera_calibration

```
* indigo-0.8.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_hand2eye_calibration

```
* indigo-0.8.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_tracker

```
* Improve data synchronization test based only on pose, klt points, and moving edges features
* Make ROS warn messages more explicit
* Make dynamic reconfigure working with ViSP 2.9.0.
  Ensure that the image is ready (test image size != 0) during dynamic reconfigure
  initialisation.
* Use VP_VERSION_INT
* Fix compat with ViSP 2.9.0. Fix ROS_INFO message. Code indentation.
* Improve ROS debug messages to be more generic.
  Remove parameters that should not be modified by the user in dynamic reconfigure files.
* Improve viewer node to handle dynamic reconfigure modifications.
  Modify tutorials so that they use the new functionnalities.
* Fix bug in visp_tracker_client to work without visp_tracker_viewer.
* Remove useless call to setKltOpencv and setMovingEdge (as it is done by default by
  the reconfigure server).
  Remove useless vpKltOpencv and vpMe variables.
* Modify dynamic reconfigure files to suppressed deprecated values.
  Adapt library to work with those modifications.
  Fix ROS debug message error.
* Reorganise ROS debug message to display trackers, edges and KLT parameters value.
* indigo-0.8.0
* Prepare changelogs
* Merge branch 'indigo-devel' into indigo
* Contributors: Aurelien Yol, Fabien Spindler
```
