### PR TITLE
frontier_exploration: 0.2.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2017,7 +2017,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/paulbovbel/frontier_exploration-release.git
-      version: 0.2.2-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/paulbovbel/frontier_exploration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `frontier_exploration` to `0.2.4-0`:
- upstream repository: https://github.com/paulbovbel/frontier_exploration.git
- release repository: https://github.com/paulbovbel/frontier_exploration-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.2-0`
## frontier_exploration

```
* Fix compiler optimization issue where perimeter is always 0
* Allow empty polygon goals for unbounded exploration
* Contributors: Paul Bovbel
```
