### PR TITLE
frontier_exploration: 0.2.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1853,7 +1853,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/paulbovbel/frontier_exploration-release.git
-      version: 0.2.3-0
+      version: 0.2.5-0
     source:
       type: git
       url: https://github.com/paulbovbel/frontier_exploration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `frontier_exploration` to `0.2.5-0`:
- upstream repository: https://github.com/paulbovbel/frontier_exploration.git
- release repository: https://github.com/paulbovbel/frontier_exploration-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.3-0`
## frontier_exploration

```
* Remove lazy initialization
* Contributors: Paul Bovbel
```
