### PR TITLE
husky: 0.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2433,7 +2433,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.2.3-0`:
- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.2-0`
## husky_control
- No changes
## husky_description

```
* Integrate husky_customization workflow
* Disable all accessories by default
* Contributors: Paul Bovbel
```
## husky_msgs
- No changes
## husky_navigation

```
* Increase inflation radius
* Contributors: Paul Bovbel
```
## husky_ur5_moveit_config

```
* Added collisions so the robot can plan
* Contributors: TheDash
* Added collisions so the robot can plan
* Contributors: TheDash
```
