### PR TITLE
husky_desktop: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2451,7 +2451,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_desktop-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/husky/husky_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_desktop` to `0.2.2-0`:
- upstream repository: https://github.com/husky/husky_desktop.git
- release repository: https://github.com/clearpath-gbp/husky_desktop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.1-0`
## husky_desktop
- No changes
## husky_viz

```
* Toggle viz settings
* Integrate husky_customization workflow
* Contributors: Paul Bovbel
```
