### PR TITLE
vision_visp: 0.8.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -9172,7 +9172,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.8.0-0
+      version: 0.8.1-1
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.8.1-1`:
- upstream repository: https://github.com/lagadic/vision_visp.git
- release repository: https://github.com/lagadic/vision_visp-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.8.0-0`
## vision_visp

```
* hydro-0.8.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_auto_tracker

```
* hydro-0.8.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_bridge

```
* hydro-0.8.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_camera_calibration

```
* hydro-0.8.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_hand2eye_calibration

```
* hydro-0.8.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_tracker

```
* Merge branch 'master' into hydro-devel
* Improve data synchronization test based only on pose, klt points, and
  moving edges features
* Make ROS warn messages more explicit
* Make dynamic reconfigure working with ViSP 2.9.0.
  Ensure that the image is ready (test image size != 0) during dynamic
  reconfigure initialisation.
* Use VP_VERSION_INT
* Fix compat with ViSP 2.9.0. Fix ROS_INFO message. Code indentation.
* Improve ROS debug messages to be more generic.
  Remove parameters that should not be modified by the user in dynamic reconfigure files.
* Improve viewer node to handle dynamic reconfigure modifications.
  Modify tutorials so that they use the new functionnalities.
* Fix bug in visp_tracker_client to work without visp_tracker_viewer.
* hydro-0.8.0
* Prepare changelogs
* Contributors: Aurelien Yol, Fabien Spindler
```
