### PR TITLE
pepper_robot: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5350,6 +5350,22 @@ repositories:
       url: https://github.com/ros-naoqi/pepper_meshes.git
       version: master
     status: maintained
+  pepper_robot:
+    release:
+      packages:
+      - pepper_bringup
+      - pepper_description
+      - pepper_robot
+      - pepper_sensors
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-naoqi/pepper_robot-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_robot.git
+      version: master
+    status: maintained
   pepperl_fuchs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_robot` to `0.1.1-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_robot.git
- release repository: https://github.com/ros-naoqi/pepper_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## pepper_bringup

```
* update dependency
* initial commit of URDF and basic scripts
* Contributors: Vincent Rabaud
```
## pepper_description

```
* update dependencies
* initial commit of URDF and basic scripts
* Contributors: Vincent Rabaud
```
## pepper_robot

```
* initial commit of URDF and basic scripts
* Contributors: Vincent Rabaud
```
## pepper_sensors

```
* update dependencies
* initial commit of URDF and basic scripts
* Contributors: Vincent Rabaud
```
