### PR TITLE
jsk_recognition: 0.2.10-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3267,7 +3267,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.2.9-0
+      version: 0.2.10-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.2.10-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.9-0`
## checkerboard_detector

```
* [checkerboard_detector/capture.launch] remove bags in launch
* Contributors: Yu Ohara
```
## imagesift
- No changes
## jsk_pcl_ros

```
* [jsk_pcl_ros] generalize namespace of launch value
* [jsk_pcl_ros] Add option to flip z axis direction
* [jsk_pcl_ros] Add geometry_msgs/PolygonStamped input for TorusFinder
* [jsk_pcl_ros] Use simple ros::Subscriber for ResizePointsPublisher
* [jsk_pcl_ros] remove bags in launch
* [jsk_pcl_ros] Supress debug message of AttentionClipper
* [jsk_pcl_ros] change tf fixed frame of config file
* [jsk_pcl_ros] Better caching to handle different frame_id well in attention_clipper
* [jsk_pcl_ros] Resolve tf only once in attention clipper
* [jsk_pcl_ros] Fix projection bug around ConvexPolygon::projectOnPlane
* [jsk_pcl_ros] Fix typo in EnvironmentPlaneModeling
* Contributors: Ryohei Ueda, Yu Ohara
```
## jsk_perception

```
* [jsk_perception] add Simple Fisheye to Panorama
* [jsk_perception] changed order of dynamic reconfigure
* [jsk_perception] default max value of histogram should be 256 to include 255 pixel
* [jsk_perception] print number of point when encoding sparse image
* [jsk_perception] Publish empty camera info from image_publisher.py
* [jsk_perception] Add sample for ColorHistogramLabelMatch
* [jsk_perception] Add documentation about ColorHistogramLabelMatch
* Contributors: Yuki Furuta, Kamada Hitoshi, Kentaro Wada, Ryohei Ueda, Yuto Inagaki
```
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## resized_image_transport
- No changes
