### PR TITLE
jsk_model_tools: 0.1.11-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3204,7 +3204,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.1.10-0
+      version: 0.1.11-0
     source:
       type: git
       url: https://github.com/tork-a/jsk_model_tools-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.1.11-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.10-0`
## eus_assimp
- No changes
## euscollada

```
* [euscollada] Suppress output of debug information from collada2eus
  and add --verbose option to print the debug information
* Contributors: Ryohei Ueda
```
## jsk_model_tools
- No changes
