### PR TITLE
mav_comm: 2.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3830,6 +3830,19 @@ repositories:
       url: https://github.com/ros-planning/map_store.git
       version: hydro-devel
     status: maintained
+  mav_comm:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/mav_comm.git
+      version: master
+    release:
+      packages:
+      - mav_comm
+      - mav_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ethz-asl/mav_comm-release.git
+      version: 2.0.0-0
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mav_comm` to `2.0.0-0`:
- upstream repository: https://github.com/ethz-asl/mav_comm.git
- release repository: https://github.com/ethz-asl/mav_comm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
