### PR TITLE
hakuto: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2208,7 +2208,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/hakuto-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/tork-a/hakuto.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hakuto` to `0.1.1-0`:
- upstream repository: https://github.com/tork-a/hakuto.git
- release repository: https://github.com/tork-a/hakuto-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.0-0`
## hakuto

```
* (Feature) More friction for better uphill climbing.
* (Doc) Elaborate instruction.
* Contributors: Isaac IY Saito
```
## tetris_description
- No changes
## tetris_gazebo

```
* More friction for better uphill climbing.
* Contributors: Isaac IY Saito
```
## tetris_launch

```
* (Doc) Elaborate instruction.
* Contributors: Isaac IY Saito
```
