### PR TITLE
freenect_stack: 0.3.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2002,7 +2002,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-drivers-gbp/freenect_stack-release.git
-      version: 0.3.2-1
+      version: 0.3.3-0
     source:
       type: git
       url: https://github.com/ros-drivers/freenect_stack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `freenect_stack` to `0.3.3-0`:
- upstream repository: https://github.com/ros-drivers/freenect_stack.git
- release repository: https://github.com/ros-drivers-gbp/freenect_stack-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.3.2-1`
## freenect_camera

```
* Including log4cxx in CMakefile file. Compilation on OS X fails without this.
* Contributors: Nick Hawes
```
## freenect_launch

```
* added tf_prefix version to Hydro for forward Indigo compatibility. closes #18 <https://github.com/ros-drivers/freenect_stack/issues/18>.
* Contributors: Piyush Khandelwal
```
## freenect_stack
- No changes
