### PR TITLE
descartes: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1394,6 +1394,7 @@ repositories:
       version: hydro-devel
     release:
       packages:
+      - descartes
       - descartes_core
       - descartes_moveit
       - descartes_planner
@@ -1401,7 +1402,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-industrial-release/descartes-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/ros-industrial-consortium/descartes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `descartes` to `0.0.2-0`:
- upstream repository: https://github.com/ros-industrial-consortium/descartes.git
- release repository: https://github.com/ros-industrial-release/descartes-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.1-0`
## descartes

```
* adds descartes metapackage
* Contributors: Jonathan Meyer, Ratnesh Madaan, Shaun Edwards, ratnesh
```
## descartes_core

```
* Created two new base class methods for trajectory points: clone and copy that preserve the prior semantics while making sure that the underlying data type is copied correctly
* Added install to CMakeLists.txt
* Removed the use of boost atomic and replaced with mutex in order to support old versions of boost library
* Added documentation
* Contributors: Jonathan Meyer, Shaun Edwards
```
## descartes_moveit

```
* Added install to CMakeLists.txt
* Contributors: Shaun Edwards
```
## descartes_planner

```
* Added install to CMakeLists.txt
* Removed non-ascii symbol from metapackage tag and fixed merge issues caused by my oversight
* Merge pull request #96 <https://github.com/ros-industrial-consortium/descartes/issues/96> from Jmeyer1292/issue#77 <https://github.com/Jmeyer1292/issue/issues/77>`__uuid_replacement Issue`#77 <https://github.com/ros-industrial-consortium/descartes/issues/77> uuid replacement
* Contributors: Jonathan Meyer, Shaun Edwards
```
## descartes_trajectory

```
* Created two new base class methods for trajectory points: clone and copy that preserve the prior semantics while making sure that the underlying data type is copied correctly
* Added install to CMakeLists.txt
* Merge pull request #85 <https://github.com/ros-industrial-consortium/descartes/issues/85> from `ros-industrial-consortium/issue_#84 <https://github.com/ros-industrial-consortium/issue_/issues/84>`__incorrect_cartesian_discretization
  Incorrect cartesian point discretization
* uses const references in all range-based for loops that used auto type deduction
* added computeCartesionPoses method which is invoked by any method that needs to discretize the cartesian pose such getCartesianPoses and getJointPoses
* Added line on main page to document axial symmetric pt
* Added documentation
* finds the closest pose in joint space when ik for the closest cartesian pose fails
* Contributors: Jonathan Meyer, Shaun Edwards, jrgnicho
```
