### PR TITLE
iiwa: 2.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2809,7 +2809,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/stanfordroboticslab/iiwa-release.git
-      version: 2.0.0-2
+      version: 2.0.1-0
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iiwa` to `2.0.1-0`:
- upstream repository: https://bitbucket.org/khansari/iiwa.git
- release repository: https://github.com/stanfordroboticslab/iiwa-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2.0.0-2`
## iiwa

```
* renamed package to make consistent with ros standards
* Merged in virgaS/iiwa/sunrise1.5 (pull request #1)
  Fix for Sunrise.OS 1.5+ and comments
* Code to fix for Sunrise.OS 1.5+ and comments
* The basic control interface for the IIWA robot
```
