### PR TITLE
pepper_robot: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5387,6 +5387,10 @@ repositories:
       version: master
     status: maintained
   pepper_robot:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_robot.git
+      version: master
     release:
       packages:
       - pepper_bringup
@@ -5396,7 +5400,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_robot-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_robot` to `0.1.2-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_robot.git
- release repository: https://github.com/ros-naoqi/pepper_robot-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.1-0`
## pepper_bringup
- No changes
## pepper_description
- No changes
## pepper_robot
- No changes
## pepper_sensors

```
* clean CMake file
* Contributors: Vincent Rabaud
```
