### PR TITLE
pepper_robot: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5364,6 +5364,10 @@ repositories:
       version: master
     status: maintained
   pepper_robot:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_robot.git
+      version: master
     release:
       packages:
       - pepper_bringup
@@ -5373,7 +5377,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_robot-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_robot` to `0.1.2-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_robot.git
- release repository: https://github.com/ros-naoqi/pepper_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.1-0`
## pepper_bringup
- No changes
## pepper_description
- No changes
## pepper_robot
- No changes
## pepper_sensors

```
* clean CMake file
* Contributors: Vincent Rabaud
```
