### PR TITLE
jsk_robot: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3089,7 +3089,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_robot-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `0.0.6-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.5-0`
## baxtereus

```
* [baxter-interface.l] we found that input data must be larget then 3, and add dummy last element works very nice!
* Contributors: Yuto Inagaki
```
## jsk_baxter_desktop
- No changes
## jsk_baxter_startup
- No changes
## jsk_baxter_web
- No changes
## jsk_nao_startup
- No changes
## jsk_pepper_startup
- No changes
## jsk_pr2_calibration
- No changes
## jsk_pr2_startup
- No changes
## jsk_robot_startup
- No changes
## peppereus

```
* pepper-init added
* Contributors: kochigami
```
## pr2_base_trajectory_action
- No changes
