### PR TITLE
ethercat_grant: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1718,7 +1718,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/shadow-robot/ethercat_grant-release.git
-      version: 0.1.0-1
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/shadow-robot/ethercat_grant.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ethercat_grant` to `0.1.1-0`:
- upstream repository: https://github.com/shadow-robot/ethercat_grant.git
- release repository: https://github.com/shadow-robot/ethercat_grant-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.0-1`
## ethercat_grant

```
* Modify postinst script
```
