### PR TITLE
applanix_driver: 0.0.9-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -175,7 +175,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/applanix_driver-release.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/applanix_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `applanix_driver` to `0.0.9-0`:
- upstream repository: git@github.com:clearpathrobotics/applanix_driver.git
- release repository: https://github.com/clearpath-gbp/applanix_driver-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.8-0`
## applanix_bridge

```
* Added a parameter for setting the origin in publisher.py. If not set, and zero_start is set then the first GPS fix is used. Otherwise, default is UTM.
* Contributors: Kareem Shehata
```
## applanix_driver
- No changes
## applanix_msgs
- No changes
