### PR TITLE
rail_pick_and_place: 1.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6184,7 +6184,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
-      version: 1.1.1-0
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_pick_and_place.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_pick_and_place` to `1.1.2-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_pick_and_place.git
- release repository: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.1.1-0`
## graspdb

```
* changed to upper case checking for names
* changed to lower case checking for names
* Contributors: Russell Toris
```
## rail_grasp_collection

```
* graph search used
* Contributors: Russell Toris
```
## rail_pick_and_place
- No changes
## rail_pick_and_place_msgs

```
* new metric trainier
* metric trainer addition
* Added metric data collection for decision tree training
* Contributors: David Kent, Russell Toris
```
## rail_pick_and_place_tools

```
* docs added for rail_pick_and_place_tools
* splash screen added
* new metric trainier
* graph search used
* Contributors: Russell Toris
```
## rail_recognition

```
* removed the swap check from recognition
* Merge branch 'develop' of github.com:WPI-RAIL/rail_pick_and_place into develop
* New decision tree for object models
* docs finished
* more docs
* new metric trainier
* Metric trainer filters point clouds first
* bug removed
* metric trainer addition
* Added metric data collection for decision tree training
* random selection added
* fixes segfaults in graph search
* graph search used
* Contributors: David Kent, Russell Toris
```
