### PR TITLE
agile_grasp: 0.6.1-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -98,6 +98,21 @@ repositories:
       url: https://github.com/ros/actionlib.git
       version: indigo-devel
     status: maintained
+  agile_grasp:
+    doc:
+      type: git
+      url: https://github.com/atenpas/agile_grasp.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/atenpas/agile_grasp-release.git
+      version: 0.6.1-3
+    source:
+      type: git
+      url: https://github.com/atenpas/agile_grasp.git
+      version: master
+    status: maintained
   android_apps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `agile_grasp` to `0.6.1-3`:
- upstream repository: https://github.com/atenpas/agile_grasp.git
- release repository: https://github.com/atenpas/agile_grasp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## agile_grasp

```
* initial commit
* Contributors: atp
```
