### PR TITLE
hakuto: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2223,7 +2223,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/hakuto-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/tork-a/hakuto.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hakuto` to `0.1.3-0`:
- upstream repository: https://github.com/tork-a/hakuto.git
- release repository: https://github.com/tork-a/hakuto-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.2-0`
## hakuto

```
* (Improve) Cosmetics; Robot spawned at more adventurous starting pose. Sun location to cast more realistic shadow.
* (Doc) No fragment aura around the earth to fix #40 <https://github.com/tork-a/hakuto/issues/40>
* Contributors: Isaac IY Saito
```
## tetris_description
- No changes
## tetris_gazebo

```
* (Improve) Cosmetics; Robot spawned at more adventurous starting pose. Sun location to cast more realistic shadow.
* Contributors: Isaac IY Saito
```
## tetris_launch

```
* (Doc) No fragment aura around the earth to fix #40 <https://github.com/tork-a/hakuto/issues/40>
* Contributors: Isaac IY Saito
```
