### PR TITLE
rtmros_common: 1.2.9-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7653,7 +7653,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.2.8-0
+      version: 1.2.9-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.2.9-0`:
- upstream repository: https://github.com/start-jsk/rtmros_common.git
- release repository: https://github.com/tork-a/rtmros_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.2.8-0`
## hrpsys_ros_bridge

```
* [package.xml] remove pr2_controllers, add pr2_controller_msgs, pr2_msgs, control_msgs package.xml
* [collision_state] fix to work collision state

    * [collision_state.py] fix minor bug of collision_state.py CORBA.OBJECT_NOT_EXIST -> omniORB.CORBA.OBJECT_NOT_EXIST
    * [collision_state.py] check isActive() to avoid raise error during servo on phase

* [hrpsys_tools/hrpsys.launch] support DEBUG_HRPSYS argument to run
  rtcd with gdb
* [hrpsys_ros_bridge/cmake/compile_robot_model.cmake]

    * Add dependency from the files generated by  export_collada to compile_robots in order to prevent parallel execution  of export_collada
    * Check current if scope has parent scope when set  variable in PARENT_SCOPE in compile_robot_model.cmake to supress warning messages
    * Fix serious typo: daefile -> _daefile in compile_robot_model.cmake
    * fix warning in if/endif macro
    * compile_robtos should be list of all generated lisp file, not targets

* [euslisp/rtm-ros-robotics-interface.l]

    * Add impedance controller mode getter method
    * Return Euslisp coordinates from :get-foot-step-param
    * Add methods to get Euslisp style parameters from IDL enum type
    * Add comments for st methods
    * Add methods to tune st parameter
    * Add functions to calculate eefm st parameters
    * Fix order of ee setting
    * Pass arguments for joint-properties to ProjectGenerator

* [hrpsys_ros_bridge/catkin.cmake] we do not have rtmlaunch/rtmtest under hrpsys_ros_bridge
* move rtmlaunch/rtmtest from hrpsys_ros_bridge to openrtm_tools, add envhook for catkin users
* Contributors: JAXON, Kei Okada, Ryohei Ueda, Shunichi Nozawa
```
## hrpsys_tools

```
* [hrpsys_tools/hrpsys.launch] support DEBUG_HRPSYS argument to run rtcd with gdb
* Contributors: Kei Okada
```
## openrtm_ros_bridge

```
* [openrtm_ros_bridge/samples/myservice_example.launch] use MyService{Provider,Consumer}Comp of  openrtm_tools
* Contributors: Kei Okada
```
## openrtm_tools

```
* [openrtm_tools/scripts/rtshell-setup.sh] modify rtmlaunch alias
* [openrtm_tools/rtmlaunch.py] disable execute bit and remove __main__, we have script/rtmluanch.py for this purpose
* [src/openrtm_tools/rtmlaunch.py] forget to import signal
* [openrtm_tools/scripts/rtmluanch.py] forget to import sys
* [openrtm_tools] create openrtm example program under openrtm_examles to use rosrun command in test code
* move rtmlaunch/rtmtest from hrpsys_ros_bridge to openrtm_tools, add envhook for catkin users
* Contributors: Kei Okada, Kunio Kojima
```
## rosnode_rtc
- No changes
## rtmbuild
- No changes
## rtmros_common
- No changes
