### PR TITLE
agile_grasp: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -107,7 +107,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/atenpas/agile_grasp-release.git
-      version: 0.6.1-3
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/atenpas/agile_grasp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `agile_grasp` to `0.6.2-0`:
- upstream repository: https://github.com/atenpas/agile_grasp.git
- release repository: https://github.com/atenpas/agile_grasp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.6.1-3`
## agile_grasp

```
* fix some dependencies
* Contributors: atp
```
