### PR TITLE
ar_track_alvar_msgs: 0.5.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -222,7 +222,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ar_track_alvar_msgs-release.git
-      version: 0.5.0-0
+      version: 0.5.1-0
     source:
       type: git
       url: https://github.com/sniekum/ar_track_alvar_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar_msgs` to `0.5.1-0`:
- upstream repository: https://github.com/sniekum/ar_track_alvar_msgs.git
- release repository: https://github.com/ros-gbp/ar_track_alvar_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.5.0-0`
## ar_track_alvar_msgs

```
* Release into Jade ROS
* Contributors: Isaac IY Saito
```
