### PR TITLE
ar_track_alvar_msgs: 0.5.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -56,6 +56,21 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  ar_track_alvar_msgs:
+    doc:
+      type: git
+      url: https://github.com/sniekum/ar_track_alvar_msgs.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/ar_track_alvar_msgs-release.git
+      version: 0.5.1-0
+    source:
+      type: git
+      url: https://github.com/sniekum/ar_track_alvar_msgs.git
+      version: indigo-devel
+    status: maintained
   arbotix_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar_msgs` to `0.5.1-0`:
- upstream repository: https://github.com/sniekum/ar_track_alvar_msgs.git
- release repository: https://github.com/ros-gbp/ar_track_alvar_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## ar_track_alvar_msgs

```
* Release into Jade ROS
* Contributors: Isaac IY Saito
```
