### PR TITLE
jsk_recognition: 0.2.11-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3268,7 +3268,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.2.10-0
+      version: 0.2.11-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.2.11-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.10-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros

```
* [jsk_pcl_ros] Add argument to specify manager name to multi_resolution_pointcloud.launch
* [jsk_pcl_ros] Add several methods and add voxel grid filter to estimate torus
* [jsk_pcl_ros] Keep exact timestamp in AddPointIndices
* Contributors: Ryohei Ueda
```
## jsk_perception

```
* add encoded points rate
* Contributors: Kamada Hitoshi
```
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## resized_image_transport
- No changes
