### PR TITLE
husky: 0.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2448,7 +2448,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.2.4-0`:
- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.3-0`
## husky_control
- No changes
## husky_description

```
* Add argument to enable/disable top plate
* Fix sensor arch name
* Fix conflict with underlay
  When using -z check, underlayed instances of husky_gazebo would override overlays.
* Update top plate model
* Contributors: Paul Bovbel
```
## husky_msgs
- No changes
## husky_navigation
- No changes
## husky_ur5_moveit_config
- No changes
