### PR TITLE
add gmock for more platforms

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -776,8 +776,12 @@ gnuplot:
   ubuntu: [gnuplot]
 google-mock:
   arch: [gmock]
-  fedora: [gmock]
+  debian: [google-mock]
+  fedora: [gmock-devel]
+  freebsd: [googlemock]
   gentoo: [dev-cpp/gmock]
+  opensuse: [gmock-devel]
+  rhel: [gmock-devel]
   ubuntu: [google-mock]
 gperftools:
   fedora: [gperftools, gperftools-devel]


### PR DESCRIPTION
I have added the keys for other platforms only based on "googling" the package names. If anyone using these platforms can confirm / correct that would be great.
