### PR TITLE
sr_common_drivers: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8339,6 +8339,14 @@ repositories:
       type: git
       url: https://github.com/UC3MSocialRobots/sr_common_drivers.git
       version: hydro-devel
+    release:
+      packages:
+      - sr_common_drivers
+      - sr_communications
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/UC3MSocialRobots/sr_common_drivers-release.git
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/UC3MSocialRobots/sr_common_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_common_drivers` to `0.0.2-0`:
- upstream repository: https://github.com/UC3MSocialRobots/sr_common_drivers.git
- release repository: https://github.com/UC3MSocialRobots/sr_common_drivers-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## sr_common_drivers

```
Updated with ROS name convention.
```
## sr_communications

```
Updated with ROS name convention.
```
