### PR TITLE
ar_track_alvar 0.5.1-0 in 'indigo/distribution.yaml'. Release repo change. Metapkg removed.

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -201,13 +201,10 @@ repositories:
       url: https://github.com/sniekum/ar_track_alvar.git
       version: indigo-devel
     release:
-      packages:
-      - ar_track_alvar
-      - ar_track_alvar_meta
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/jihoonl/ar_track_alvar-release.git
-      version: 0.5.0-0
+      url: https://github.com/ros-gbp/ar_track_alvar-release.git
+      version: 0.5.1-0
     source:
       type: git
       url: https://github.com/sniekum/ar_track_alvar.git


### PR DESCRIPTION
Addresses https://github.com/sniekum/ar_track_alvar/issues/48
Related to https://github.com/sniekum/ar_track_alvar/pull/50
