### PR TITLE
rail_manipulation_msgs: 0.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6278,6 +6278,21 @@ repositories:
       url: https://github.com/orocos/rFSM.git
       version: master
     status: developed
+  rail_manipulation_msgs:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_manipulation_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/wpi-rail-release/rail_manipulation_msgs-release.git
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_manipulation_msgs.git
+      version: develop
+    status: maintained
   rail_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_manipulation_msgs` to `0.0.4-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_manipulation_msgs.git
- release repository: https://github.com/wpi-rail-release/rail_manipulation_msgs-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## rail_manipulation_msgs

```
* bounding box info added
* Contributors: Russell Toris
```
