### PR TITLE
agile_grasp: 0.6.2-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -112,6 +112,21 @@ repositories:
       url: https://github.com/ros/actionlib.git
       version: hydro-devel
     status: maintained
+  agile_grasp:
+    doc:
+      type: git
+      url: https://github.com/atenpas/agile_grasp.git
+      version: hydro
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/atenpas/agile_grasp-release.git
+      version: 0.6.2-1
+    source:
+      type: git
+      url: https://github.com/atenpas/agile_grasp.git
+      version: hydro
+    status: maintained
   agvs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `agile_grasp` to `0.6.2-1`:
- upstream repository: https://github.com/atenpas/agile_grasp.git
- release repository: https://github.com/atenpas/agile_grasp-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## agile_grasp

```
* fix some dependencies
* Contributors: atp
```
