### PR TITLE
rail_segmentation: 0.1.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6323,6 +6323,21 @@ repositories:
       url: https://github.com/WPI-RAIL/rail_maps.git
       version: develop
     status: maintained
+  rail_segmentation:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_segmentation.git
+      version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/wpi-rail-release/rail_segmentation.git
+      version: 0.1.4-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_segmentation.git
+      version: develop
+    status: maintained
   random_numbers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_segmentation` to `0.1.4-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_segmentation.git
- release repository: https://github.com/wpi-rail-release/rail_segmentation.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## rail_segmentation

```
* quick travis fix
* old parser format
* Update .travis.yml
* Contributors: Russell Toris
```
