### PR TITLE
wpi_jaco: 0.0.20-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9344,7 +9344,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/wpi_jaco-release.git
-      version: 0.0.19-0
+      version: 0.0.20-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/wpi_jaco.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wpi_jaco` to `0.0.20-0`:
- upstream repository: https://github.com/RIVeR-Lab/wpi_jaco.git
- release repository: https://github.com/wpi-rail-release/wpi_jaco-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.19-0`
## jaco_description

```
* removed .urdf file
* urdf file
* urdf file
* Contributors: Mathijs de Langen
```
## jaco_interaction
- No changes
## jaco_moveit_config

```
* file not used
* Revert "file not used"
  This reverts commit 51053ff0f7325aef8ee1345cefbe790f48ba003b.
* file not used
* Revert "removed jaco_description just for testing"
  This reverts commit 92dd7c0762ee89bbd69c68fec269f4711db5e58a.
  Conflicts:
  jaco_moveit_config/package.xml
* removed jaco_description just for testing
* Contributors: Mathijs de Langen
```
## jaco_sdk

```
* Revert "Updated Kinova libraries"
  This reverts commit 34891e5e0ea0b547004840b03da2fdac95f2a16a.
* Contributors: Mathijs de Langen
```
## jaco_teleop
- No changes
## mico_description

```
* URDF is not needed on GIT (xacro is used)
* jaco = mico
* xacro updated to be in line with the urdf
* mico model xacro model update
* Mico description update
* Added first part of the fingers
* commented out the fingers
* moveitmodel
* Second positions fix
* Fixed the positions of the joints
* Mico descriptions
* mico description adaptions
* Stuff with models for the Mico
* Contributors: Mathijs de Langen
```
## mico_moveit_config

```
* rviz configuration
* just look at all points
* Contributors: Mathijs de Langen
```
## wpi_jaco
- No changes
## wpi_jaco_msgs
- No changes
## wpi_jaco_wrapper

```
* typo
* Server starts immediately and we check if the arm is initialized in the callback function
* Revert "file not used"
  This reverts commit 51053ff0f7325aef8ee1345cefbe790f48ba003b.
* file not used
* Forgotten { during merge
* Merge branch 'develop' of https://github.com/RobotRose/wpi_jaco into develop
  Conflicts:
  wpi_jaco_wrapper/include/wpi_jaco_wrapper/jaco_arm_trajectory_node.h
  wpi_jaco_wrapper/launch/arm.launch
  wpi_jaco_wrapper/src/jaco_arm_trajectory_node.cpp
* default to mico_arm for us :P
* moveitmodel
* Making the jaco_arm_trajectory node work for MoveIt! with the Mico
* Made some remapping for the arm.launch (so the topics are in order)
* Finger speed added as constant (3000 is ~half of the Mico speeds)
* debug ON
* Changed joint_state publisher to what MoveIt! understands (change back in future)
* movements somewhat slower
* Finger speed added as constant (3000 is ~half of the Mico speeds)
* Merge remote-tracking branch 'upstream/master' into develop
* debug ON
* Changed joint_state publisher to what MoveIt! understands (change back in future)
* movements somewhat slower
* Contributors: Mathijs de Langen
```
