### PR TITLE
carl_moveit: 0.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -698,7 +698,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_moveit-release.git
-      version: 0.0.11-0
+      version: 0.0.12-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_moveit` to `0.0.12-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_moveit.git
- release repository: https://github.com/wpi-rail-release/carl_moveit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.11-0`
## carl_moveit

```
* Scene object adjustment
* bug fix
* moveit planning scene collision object test
* Contributors: David Kent
```
