### PR TITLE
rail_pick_and_place: 1.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6199,7 +6199,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
-      version: 1.1.2-0
+      version: 1.1.3-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_pick_and_place.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_pick_and_place` to `1.1.3-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_pick_and_place.git
- release repository: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.1.2-0`
## graspdb

```
* removed metric pre-compute
* stores metrics
* added segmented images to the database
* Contributors: Russell Toris
```
## rail_grasp_collection

```
* added segmented images to the database
* Contributors: Russell Toris
```
## rail_pick_and_place
- No changes
## rail_pick_and_place_msgs

```
* removed metric pre-compute
* stores metrics
* added segmented images to the database
* Contributors: Russell Toris
```
## rail_pick_and_place_tools
- No changes
## rail_recognition

```
* uses PCL models for generation
* cleanup of new stuff
* Recognition first performs a color check
* Recognition tuning
* added avg functions for color
* removed metric pre-compute
* stores metrics
* Contributors: David Kent, Russell Toris
```
