### PR TITLE
object_recognition_linemod: 0.3.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -894,7 +894,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_linemod-release.git
-      version: 0.3.3-0
+      version: 0.3.4-0
     source:
       type: git
       url: https://github.com/wg-perception/linemod.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_linemod` to `0.3.4-0`:
- upstream repository: https://github.com/wg-perception/linemod.git
- release repository: https://github.com/ros-gbp/object_recognition_linemod-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.3.3-0`
## object_recognition_linemod

```
* remove the sample folder: a lot of old non-working code
  This also fixes #11 <https://github.com/wg-perception/linemod/issues/11>
* fix #13 <https://github.com/wg-perception/linemod/issues/13> fully
* Merge pull request #13 <https://github.com/wg-perception/linemod/issues/13> from nlyubova/master
  Fixed issue with openNI2 while handing both 32F and 8U depth formats
* Fixed issue with openNI2 while handing both 32F and 8U depth formats
* Contributors: Vincent Rabaud, nlyubova
```
