### PR TITLE
turtlebot: 2.3.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8606,7 +8606,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot-release.git
-      version: 2.3.10-0
+      version: 2.3.11-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot` to `2.3.11-0`:
- upstream repository: https://github.com/turtlebot/turtlebot.git
- release repository: https://github.com/turtlebot-release/turtlebot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2.3.10-0`
## turtlebot
- No changes
## turtlebot_bringup

```
* interaction fix closes #208 <https://github.com/turtlebot/turtlebot/issues/208>
* Contributors: Jihoon Lee
```
## turtlebot_capabilities
- No changes
## turtlebot_description
- No changes
## turtlebot_teleop
- No changes
