### PR TITLE
rail_segmentation: 0.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6211,7 +6211,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_segmentation.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_segmentation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_segmentation` to `0.1.5-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_segmentation.git
- release repository: https://github.com/wpi-rail-release/rail_segmentation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.4-0`
## rail_segmentation

```
* Added center point calculation for segmented objects
* Contributors: David Kent
```
