### PR TITLE
Fixes to compile ros indigo on Gentoo.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -84,7 +84,7 @@ assimp:
   fedora: [assimp]
   gentoo:
     portage:
-      packages: [media-libs/assimp]
+      packages: [media-gfx/assimp]
   macports: [assimp]
   opensuse: [libassimp3]
   rhel: [assimp-devel]
@@ -131,7 +131,7 @@ assimp-dev:
   fedora: [assimp-devel]
   gentoo:
     portage:
-      packages: [media-libs/assimp]
+      packages: [media-gfx/assimp]
   opensuse: [libassimp3]
   rhel: [assimp-devel]
   ubuntu:
@@ -430,7 +430,7 @@ collada-dom:
   fedora: [collada-dom-devel]
   gentoo:
     portage:
-      packages: [media-libs/collada-dom]
+      packages: [dev-libs/collada-dom]
   macports: [collada-dom]
   ubuntu: [collada-dom-dev]
 comedi:
@@ -692,6 +692,7 @@ gazebo:
     raring: [gazebo]
     saucy: [gazebo2]
     trusty: [gazebo2]
+  gentoo: [sci-electronics/gazebo]
 gcc-avr:
   arch: [avr-gcc]
   debian: [gcc-avr]
@@ -1119,6 +1120,9 @@ libconsole-bridge-dev:
     trusty: [libconsole-bridge-dev]
     utopic: [libconsole-bridge-dev]
     vivid: [libconsole-bridge-dev]
+  gentoo:
+    portage:
+      packages: [dev-libs/console-bridge]
 libdbus-dev:
   arch: [dbus-core]
   debian: [libdbus-1-dev]
@@ -2163,6 +2167,7 @@ liburdfdom-dev:
     trusty: [liburdfdom-dev]
     utopic: [liburdfdom-dev]
     vivid: [liburdfdom-dev]
+  gentoo: [media-libs/urdfdom]
 liburdfdom-headers-dev:
   arch: [urdfdom-headers]
   debian: [liburdfdom-headers-dev]
@@ -2172,6 +2177,7 @@ liburdfdom-headers-dev:
     trusty: [liburdfdom-headers-dev]
     utopic: [liburdfdom-headers-dev]
     vivid: [liburdfdom-headers-dev]
+  gentoo: [media-libs/urdfdom_headers]
 libusb:
   arch: [libusb-compat]
   debian: [libusb-0.1-4]
@@ -2260,6 +2266,10 @@ libvtk-java:
     trusty: [libvtk-java]
     utopic: [libvtk-java]
     vivid: [libvtk-java]
+  gentoo:
+    portage:
+      packages: [sci-libs/vtk]
+      use: [java]
 libvtk-qt:
   arch: [vtk]
   debian: [libvtk5-qt4-dev]
@@ -2624,7 +2634,7 @@ pkg-config:
   debian: [pkg-config]
   fedora: [pkgconfig]
   freebsd: [pkg-config]
-  gentoo: [dev-util/pkgconfig]
+  gentoo: [virtual/pkgconfig]
   macports: [pkgconfig]
   opensuse: [pkg-config]
   rhel: [pkgconfig]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -168,6 +168,10 @@ python-cairo:
     saucy: [python-cairo]
     trusty: [python-cairo]
     utopic: [python-cairo]
+  gentoo:
+    portage:
+      packages: [x11-libs/cairo]
+      use: [python]
 python-catkin-pkg:
   arch: [python2-catkin_pkg]
   debian: [python-catkin-pkg]
@@ -1690,6 +1694,10 @@ python-vtk:
     trusty: [python-vtk]
     utopic: [python-vtk]
     vivid: [python-vtk]
+  gentoo:
+    portage:
+      packages: [sci-libs/vtk]
+      use: [python]
 python-wstool:
   fedora: [python-wstool]
   macports: [py27-wstool]


### PR DESCRIPTION
Requires overlays ros and Gentoo-ROS-overlay (https://github.com/steup/Gentoo-ROS-Overlay)
