### PR TITLE
rtmros_hironx: 1.0.30-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7759,7 +7759,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.29-0
+      version: 1.0.30-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.30-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.29-0`
## hironx_calibration
- No changes
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* [hironx_client.py] fix due to API changes https://github.com/fkanehiro/hrpsys-base/pull/555/files
* [test/test-hirionx-ros-bridge-send-pose.launch] remove some of test sequence to pass travis
* [test/test-hirionx-ros-bridge-send-test.launch] remove some of test sequence to pass travis
* (robot) Add OSS log files on QNX fetch script.
* Contributors: Isaac IY Saito, Kei Okada
```
## rtmros_hironx
- No changes
