### PR TITLE
rtmros_hironx: 1.0.30-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7677,7 +7677,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.29-0
+      version: 1.0.30-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.30-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.29-0`
## hironx_calibration
- No changes
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* [hironx_client.py] fix due to API changes https://github.com/fkanehiro/hrpsys-base/pull/555/files
* [test/test-hirionx-ros-bridge-send-pose.launch] remove some of test sequence to pass travis
* [test/test-hirionx-ros-bridge-send-test.launch] remove some of test sequence to pass travis
* (robot) Add OSS log files on QNX fetch script.
* Contributors: Isaac IY Saito, Kei Okada
```
## rtmros_hironx
- No changes
