### PR TITLE
rosh_core: 1.0.9-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7154,7 +7154,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/OSUrobotics/rosh_core-release.git
-      version: 1.0.8-0
+      version: 1.0.9-0
     source:
       type: git
       url: https://github.com/OSUrobotics/rosh_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_core` to `1.0.9-0`:
- upstream repository: https://github.com/OSUrobotics/rosh_core.git
- release repository: https://github.com/OSUrobotics/rosh_core-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.8-0`
## rosh

```
* pass remapping args onto the Node object
* add argument so nodes can be explicitly named
* Contributors: Dan Lazewatsky
```
## rosh_core
- No changes
## roshlaunch
- No changes
