### PR TITLE
ros_comm: 1.11.11-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1212,7 +1212,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.10-0
+      version: 1.11.11-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.11-0`:
- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.11.10-0`
## message_filters

```
* implement message filter cache in Python (#599 <https://github.com/ros/ros_comm/pull/599>)
```
## ros_comm
- No changes
## rosbag

```
* add support for pausing when specified topics are about to be published (#569 <https://github.com/ros/ros_comm/pull/569>)
```
## rosbag_storage

```
* support large bagfiles (>2GB) on 32-bit systems (#464 <https://github.com/ros/ros_comm/issues/464>)
```
## rosconsole

```
* add DELAYED_THROTTLE versions of log macros (#571 <https://github.com/ros/ros_comm/issues/571>)
```
## roscpp

```
* fix memory leak in transport constructor (#570 <https://github.com/ros/ros_comm/pull/570>)
* fix computation of stddev in statistics (#556 <https://github.com/ros/ros_comm/pull/556>)
* fix empty connection header topic (#543 <https://github.com/ros/ros_comm/issues/543>)
* alternative API to get parameter values (#592 <https://github.com/ros/ros_comm/pull/592>)
* add getCached() for float parameters (#584 <https://github.com/ros/ros_comm/pull/584>)
```
## rosgraph
- No changes
## roslaunch
- No changes
## roslz4

```
* fix import of compiled library with Python 3.x (#563 <https://github.com/ros/ros_comm/pull/563>)
```
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy

```
* add rosconsole command line tool to change logger levels (#576 <https://github.com/ros/ros_comm/pull/576>)
* add accessor for remaining time of the Rate class (#588 <https://github.com/ros/ros_comm/pull/588>)
* fix high latency when using asynchronous publishing (#547 <https://github.com/ros/ros_comm/issues/547>)
* fix error handling when publishing on Empty topic (#566 <https://github.com/ros/ros_comm/pull/566>)
```
## rosservice
- No changes
## rostest

```
* add DEPENDENCIES option to CMake function add_rostest (#546 <https://github.com/ros/ros_comm/issues/546>)
```
## rostopic
- No changes
## roswtf

```
* support IPv6 addresses containing percentage symbols (#585 <https://github.com/ros/ros_comm/issues/585>)
```
## topic_tools
- No changes
## xmlrpcpp
- No changes
