### PR TITLE
ros: 1.11.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6771,7 +6771,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.11.6-0
+      version: 1.11.7-0
     source:
       type: git
       url: https://github.com/ros/ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.11.7-0`:
- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.11.6-0`
## mk
- No changes
## rosbash

```
* add support for fish shell (#77 <https://github.com/ros/ros/pull/77>)
* enable roslaunch args completion in rosbash
```
## rosboost_cfg
- No changes
## rosbuild
- No changes
## rosclean
- No changes
## roscreate
- No changes
## roslang
- No changes
## roslib

```
* remove usage of CATKIN_TEST_RESULTS_DIR environment variable (#80 <https://github.com/ros/ros/pull/80>)
```
## rosmake
- No changes
## rosunit
- No changes
