### PR TITLE
ros: 1.12.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1175,7 +1175,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.12.0-0
+      version: 1.12.1-0
     source:
       type: git
       url: https://github.com/ros/ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.12.1-0`:
- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.12.0-0`
## mk
- No changes
## rosbash

```
* add support for fish shell (#77 <https://github.com/ros/ros/pull/77>)
* enable roslaunch args completion in rosbash
```
## rosboost_cfg
- No changes
## rosbuild
- No changes
## rosclean
- No changes
## roscreate
- No changes
## roslang
- No changes
## roslib

```
* remove usage of CATKIN_TEST_RESULTS_DIR environment variable (#80 <https://github.com/ros/ros/pull/80>)
```
## rosmake
- No changes
## rosunit
- No changes
