### PR TITLE
catkin: 0.6.12-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -206,7 +206,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.6.11-0
+      version: 0.6.12-0
     source:
       type: git
       url: https://github.com/ros/catkin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.6.12-0`:
- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.6.11-0`
## catkin

```
* remove CATKIN_TEST_RESULTS_DIR environment variable (#728 <https://github.com/ros/catkin/issues/728>)
* catkin_test_results will output skipped xml files only when --all is being passed (#733 <https://github.com/ros/catkin/pull/733>)
* extract catkin_add_executable_with_gtest() from catkin_add_gtest() (#726 <https://github.com/ros/catkin/issues/726>)
* separate download function from tests (#633 <https://github.com/ros/catkin/issues/633>)
* only install environment hooks for catkin_make(_isolated) completion in the catkin package (#732 <https://github.com/ros/catkin/issues/732>)
* avoid warning with CMake 3.1 and newer (#731 <https://github.com/ros/catkin/issues/731>)
* quote command in "Reproduce this error" instructions (#730 <https://github.com/ros/catkin/issues/730>)
* fix Python error when working with non-ascii characters in catkin workspace path (#724 <https://github.com/ros/catkin/issues/724>)
* use $TMPDIR for temporary _setup_util.py file if set (#710 <https://github.com/ros/catkin/issues/710>)
* fix regex for library config types (#723 <https://github.com/ros/catkin/issues/723>)
* fix potential race condition in download_checkmd5.py (#715 <https://github.com/ros/catkin/issues/715>)
* output package whitelist / blacklist if set (#714 <https://github.com/ros/catkin/issues/714>)
* add --verbose option to catkin_test_results to show the content of result files (#705 <https://github.com/ros/catkin/issues/705>)
* source in reset zsh emulation mode  (#686 <https://github.com/ros/catkin/issues/686>)
* improve help text for --only-pkg-with-deps (#706 <https://github.com/ros/catkin/issues/706>)
```
