### PR TITLE
catkin: 0.6.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -740,7 +740,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.6.11-0
+      version: 0.6.13-0
     source:
       type: git
       url: https://github.com/ros/catkin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.6.13-0`:
- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.6.11-0`
## catkin

```
* allow setting CATKIN_GLOBAL_LIBEXEC_DESTINATION to libexec (#713 <https://github.com/ros/catkin/pull/713>)
```
