### PR TITLE
ntpd_driver: 1.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -861,7 +861,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/vooon/ntpd_driver-release.git
-      version: 1.0.2-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/vooon/ntpd_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ntpd_driver` to `1.1.0-0`:
- upstream repository: https://github.com/vooon/ntpd_driver.git
- release repository: https://github.com/vooon/ntpd_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.2-0`
## ntpd_driver

```
* Update package.xml for REP 140
* Change topic param name to ~/time_ref_topic
* Merge pull request #1 <https://github.com/vooon/ntpd_driver/issues/1> from oceansystemslab/master
  Updated Driver
* Updated README with new node input parameter
* fixed indentation according to ROS guidelines and added input parameter for time reference topic
* Removed transport hints to allow the driver to work with the nmea_serial_driver Python publisher and added ROS style indentation.
* Updated .gitignore with C++ version on GitHub
* Contributors: Valerio De Carolis, Vladimir Ermakov
```
