### PR TITLE
unique_identifier: 1.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8897,7 +8897,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-geographic-info/unique_identifier-release.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/ros-geographic-info/unique_identifier.git


### PR DESCRIPTION
Increasing version of package(s) in repository `unique_identifier` to `1.0.5-0`:
- upstream repository: https://github.com/ros-geographic-info/unique_identifier.git
- release repository: https://github.com/ros-geographic-info/unique_identifier-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.4-0`
## unique_id
- No changes
## unique_identifier
- No changes
## uuid_msgs
- No changes
