### PR TITLE
iiwa: 2.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2824,7 +2824,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/stanfordroboticslab/iiwa-release.git
-      version: 2.0.3-0
+      version: 2.0.4-0
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iiwa` to `2.0.4-0`:
- upstream repository: https://bitbucket.org/khansari/iiwa.git
- release repository: https://github.com/stanfordroboticslab/iiwa-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2.0.3-0`
