### PR TITLE
object_recognition_linemod: 0.3.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4871,7 +4871,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_linemod-release.git
-      version: 0.3.4-0
+      version: 0.3.5-0
     source:
       type: git
       url: https://github.com/wg-perception/linemod.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_linemod` to `0.3.5-0`:
- upstream repository: https://github.com/wg-perception/linemod.git
- release repository: https://github.com/ros-gbp/object_recognition_linemod-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.3.4-0`
## object_recognition_linemod

```
* fixed the depth conversion to 32F, updated possible mesh names for both training and detection
* Contributors: nlyubova
```
