### PR TITLE
ecto_image_pipeline: 0.5.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1640,7 +1640,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ecto_image_pipeline-release.git
-      version: 0.5.5-0
+      version: 0.5.6-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto_image_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto_image_pipeline` to `0.5.6-0`:
- upstream repository: https://github.com/plasmodic/ecto_image_pipeline.git
- release repository: https://github.com/ros-gbp/ecto_image_pipeline-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.5.5-0`
## ecto_image_pipeline

```
* fixing the depth rescale and its calibration matrix
* Contributors: nlyubova
```
