### PR TITLE
object_recognition_tod: 0.5.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4944,7 +4944,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_tod-release.git
-      version: 0.5.4-0
+      version: 0.5.5-0
     source:
       type: git
       url: https://github.com/wg-perception/tod.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_tod` to `0.5.5-0`:
- upstream repository: https://github.com/wg-perception/tod.git
- release repository: https://github.com/ros-gbp/object_recognition_tod-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.5.4-0`
## object_recognition_tod

```
* Fix seg fault while detecting objects
  In many cases, matches[i] contains less than 5 elements (varies seemingly random between 0 and 4)
  Long history available [here](https://github.com/plasmodic/ecto_opencv/commit/2f2fe7fb75d09337c1d594cee416bd948f337b30#commitcomment-10687068)
* Contributors: Jorge Santos Simón
```
