### PR TITLE
object_recognition_reconstruction: 0.3.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4897,7 +4897,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_reconstruction-release.git
-      version: 0.3.3-0
+      version: 0.3.4-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/reconstruction.git
+      version: master
     status: maintained
   object_recognition_renderer:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_reconstruction` to `0.3.4-0`:
- upstream repository: https://github.com/wg-perception/reconstruction.git
- release repository: https://github.com/ros-gbp/object_recognition_reconstruction-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.3.3-0`
## object_recognition_reconstruction

```
* re-writing of #5 without sudo. Needs testing
* Add a missing parameter to the Laplacian Smooth filter (cotangentWeight)
* clean extensions
* Contributors: Jorge Santos Simón, Vincent Rabaud
```
