### PR TITLE
ecto_pcl: 0.4.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -401,6 +401,17 @@ repositories:
       url: https://github.com/plasmodic/ecto_openni.git
       version: master
     status: maintained
+  ecto_pcl:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/ecto_pcl-release.git
+      version: 0.4.2-0
+    source:
+      type: git
+      url: https://github.com/plasmodic/ecto_pcl.git
+      version: master
+    status: maintained
   ecto_ros:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto_pcl` to `0.4.2-0`:
- upstream repository: https://github.com/plasmodic/ecto_pcl.git
- release repository: https://github.com/ros-gbp/ecto_pcl-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## ecto_pcl

```
* Use the new header with PCL 1.7.0+
* Always find pcl_conversions
  Should be okay since it's a package dependency.
* Find pcl_conversions if building against PCL 1.7.0+
  It gets included depending on the PCL version in src/ros/pcl_bridge.cpp
* fix sample with newer API
* Contributors: Vincent Rabaud, pgorczak
```
