### PR TITLE
object_recognition_reconstruction: 0.3.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -926,6 +926,17 @@ repositories:
       url: https://github.com/wg-perception/object_recognition_msgs.git
       version: master
     status: maintained
+  object_recognition_reconstruction:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_reconstruction-release.git
+      version: 0.3.4-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/reconstruction.git
+      version: master
+    status: maintained
   object_recognition_renderer:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_reconstruction` to `0.3.4-0`:
- upstream repository: https://github.com/wg-perception/reconstruction.git
- release repository: https://github.com/ros-gbp/object_recognition_reconstruction-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## object_recognition_reconstruction

```
* re-writing of #5 without sudo. Needs testing
* Add a missing parameter to the Laplacian Smooth filter (cotangentWeight)
* clean extensions
* Contributors: Jorge Santos Simón, Vincent Rabaud
```
