### PR TITLE
removing cmake_node_hook

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -772,21 +772,6 @@ repositories:
       url: https://github.com/ros/cmake_modules.git
       version: 0.3-devel
     status: maintained
-  cmake_node_hook:
-    doc:
-      type: git
-      url: https://github.com/jihoonl/cmake_node_hook.git
-      version: master
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/jihoonl/cmake_node_hook-release.git
-      version: 0.0.1-0
-    source:
-      type: git
-      url: https://github.com/jihoonl/cmake_node_hook.git
-      version: master
-    status: developed
   cob_calibration_data:
     doc:
       type: git


### PR DESCRIPTION
`cmake_node_hook` name seems vague. I will rename the package as `cmake_nodejs_hook` and re-register
