### PR TITLE
cmake_nodejs_hook: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -772,6 +772,21 @@ repositories:
       url: https://github.com/ros/cmake_modules.git
       version: 0.3-devel
     status: maintained
+  cmake_nodejs_hook:
+    doc:
+      type: git
+      url: https://github.com/jihoonl/cmake_nodejs_hook.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/jihoonl/cmake_nodejs_hook-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/jihoonl/cmake_nodejs_hook.git
+      version: master
+    status: developed
   cob_calibration_data:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_nodejs_hook` to `0.0.2-0`:
- upstream repository: https://github.com/jihoonl/cmake_nodejs_hook.git
- release repository: https://github.com/jihoonl/cmake_nodejs_hook-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## cmake_nodejs_hook

```
* rename the package
* Contributors: Jihoon Lee
```
