### PR TITLE
media_export: 0.2.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -715,6 +715,21 @@ repositories:
       url: https://github.com/mavlink/mavros.git
       version: master
     status: developed
+  media_export:
+    doc:
+      type: git
+      url: https://github.com/ros/media_export.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/media_export-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros/media_export.git
+      version: indigo-devel
+    status: maintained
   message_generation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `media_export` to `0.2.0-0`:
- upstream repository: https://github.com/ros/media_export.git
- release repository: https://github.com/ros-gbp/media_export-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## media_export

```
* set myself (william) as maintainer
* Contributors: William Woodall
```
