### PR TITLE
geneus: 2.2.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2105,7 +2105,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/geneus-release.git
-      version: 2.1.2-0
+      version: 2.2.0-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/geneus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geneus` to `2.2.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/geneus
- release repository: https://github.com/tork-a/geneus-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2.1.2-0`
## geneus

```
* [generate.py] load roseus-add-msgs for srv too
* [geneus_main.py] add timestamp message to manifest.l
* [geneus_main.py] message loding problem https://github.com/start-jsk/2014-semi/issues/196, https://github.com/jsk-ros-pkg/jsk_roseus/issues/257

    * [geneus_main.py] gen msg/srv does not need get_pkg_map
    * [geneus_main.py] fix comment and messages
    * [geneus_main.py] use topological_order instaed of rearrange_depends
    * [geneus_main.py] use catkin as a substitute for rospkg
    * [geneus_main.py] see only run_depend in package.xml
    * [geneus_main.py] Resolve package dependencies with attention to the order

* [geneus] treat uint8[] as string like rospy https://github.com/jsk-ros-pkg/geneus/issues/14
  * [generate.py] fixed version of #15 <https://github.com/jsk-ros-pkg/geneus/issues/15> which did not pass test at  https://github.com/jsk-ros-pkg/jsk_roseus/pull/276
* [geneus_main.py] fix pakcage_dpeneds, to solve https://github.com/start-jsk/2014-semi/issues/196 issue
* [.travis.yml] use latest version of travis test
* [.travis.yml] use latest catkin for --no-jobserver option
* [.travis.yml] Add after failure
* [.gitignore] initial commit
* Contributors: Yuki Furuta Kei Okada, Kentaro Wada
```
