### PR TITLE
designator_integration: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1425,10 +1425,14 @@ repositories:
     status: developed
   designator_integration:
     release:
+      packages:
+      - designator_integration
+      - designator_integration_cpp
+      - designator_integration_lisp
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/code-iai-release/designator_integration-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     status: developed
   diagnostics:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `designator_integration` to `0.0.2-0`:
- upstream repository: https://github.com/code-iai/designator_integration.git
- release repository: https://github.com/code-iai-release/designator_integration-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.0.1-0`
## designator_integration

```
* package.xml updates
* Added metapackage designator_integration to prepare release.
* Renamed package designator_integration into designator_integration_cpp.
* fixed indentation
* Moved code of designator-integration into sub-folder of same name.
* Contributors: Georg Bartels, Jan Winkler, Sanic
```
## designator_integration_cpp

```
* package.xml updates
* Added support for human desigs in cpp.
* Added default value parameters for string and double values
* Renamed package designator_integration into designator_integration_cpp.
* Contributors: Georg Bartels, Jan Winkler
```
## designator_integration_lisp

```
* package.xml updates
* Supported for new designator type: Human.
* Removed symlink to asd-file in designator_integration_lisp because this breaks during bloom releases.
* Moved in designator-integration-lisp.
* Contributors: Georg Bartels, Jan Winkler
```
