### PR TITLE
interactive_marker_proxy: 0.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -600,6 +600,21 @@ repositories:
       url: https://github.com/ros-perception/image_pipeline.git
       version: indigo
     status: maintained
+  interactive_marker_proxy:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/interactive_marker_proxy.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/RobotWebTools-release/interactive_marker_proxy-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/interactive_marker_proxy.git
+      version: develop
+    status: maintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_marker_proxy` to `0.1.2-0`:
- upstream repository: https://github.com/RobotWebTools/interactive_marker_proxy.git
- release repository: https://github.com/RobotWebTools-release/interactive_marker_proxy-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## interactive_marker_proxy

```
* cleanup
* Contributors: Russell Toris
```
