### PR TITLE
robot_web_tools: 0.0.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1221,6 +1221,21 @@ repositories:
       url: https://github.com/clearpathrobotics/robot_upstart.git
       version: jade-devel
     status: maintained
+  robot_web_tools:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/robot_web_tools.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/RobotWebTools-release/robot_web_tools-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/robot_web_tools.git
+      version: develop
+    status: maintained
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_web_tools` to `0.0.3-0`:
- upstream repository: https://github.com/RobotWebTools/robot_web_tools.git
- release repository: https://github.com/RobotWebTools-release/robot_web_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## robot_web_tools

```
* changes to new video server dep
* Contributors: Russell Toris
```
