### PR TITLE
resource_retriever: 1.11.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6322,11 +6322,20 @@ repositories:
       url: https://github.com/jizhang-cmu/receive_xsens.git
       version: indigo
   resource_retriever:
+    doc:
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/resource_retriever-release.git
-      version: 1.11.0-2
+      version: 1.11.6-0
+    source:
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: indigo-devel
+    status: maintained
   rfsm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `1.11.6-0`:
- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros-gbp/resource_retriever-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.11.0-2`
## resource_retriever
- No changes
