### PR TITLE
resource_retriever: 1.11.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1191,6 +1191,21 @@ repositories:
       url: https://github.com/WPI-RAIL/rail_segmentation.git
       version: develop
     status: maintained
+  resource_retriever:
+    doc:
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/resource_retriever-release.git
+      version: 1.11.6-0
+    source:
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: indigo-devel
+    status: maintained
   rmp_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `1.11.6-0`:
- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros-gbp/resource_retriever-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## resource_retriever
- No changes
