### PR TITLE
geometry_experimental: 0.5.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2068,6 +2068,7 @@ repositories:
       - geometry_experimental
       - tf2
       - tf2_bullet
+      - tf2_eigen
       - tf2_geometry_msgs
       - tf2_kdl
       - tf2_msgs
@@ -2078,7 +2079,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry_experimental-release.git
-      version: 0.5.9-0
+      version: 0.5.10-0
     source:
       type: git
       url: https://github.com/ros/geometry_experimental.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_experimental` to `0.5.10-0`:
- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry_experimental-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.5.9-0`
## geometry_experimental
- No changes
## tf2

```
* move lct_cache into function local memoryfor #92 <https://github.com/ros/geometry_experimental/issues/92>
* Clean up range checking. Re: #92 <https://github.com/ros/geometry_experimental/issues/92>
* Fixed chainToVector
* release lock before possibly invoking user callbacks. Fixes #91 <https://github.com/ros/geometry_experimental/issues/91>
* Contributors: Jackie Kay, Tully Foote
```
## tf2_bullet
- No changes
## tf2_eigen

```
* fixing CMakeLists.txt from #97 <https://github.com/ros/geometry_experimental/issues/97>
* create tf2_eigen.
* Contributors: Tully Foote, koji
```
## tf2_geometry_msgs
- No changes
## tf2_kdl
- No changes
## tf2_msgs
- No changes
## tf2_py
- No changes
## tf2_ros

```
* switch to use a shared lock with upgrade instead of only a unique lock. For #91 <https://github.com/ros/geometry_experimental/issues/91>
* Update message_filter.h
* filters: fix unsupported old messages with frame_id starting with '/'
* Enabled tf2 documentation
* make sure the messages get processed before testing the effects. Fixes #88 <https://github.com/ros/geometry_experimental/issues/88>
* allowing to use message filters with PCL types
* Contributors: Brice Rebsamen, Jackie Kay, Tully Foote, Vincent Rabaud, jmtatsch
```
## tf2_sensor_msgs
- No changes
## tf2_tools
- No changes
