### PR TITLE
geometry: 1.11.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -539,7 +539,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/geometry-release.git
-      version: 1.11.6-0
+      version: 1.11.7-0
     source:
       type: git
       url: https://github.com/ros/geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry` to `1.11.7-0`:
- upstream repository: https://github.com/ros/geometry.git
- release repository: https://github.com/ros-gbp/geometry-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.11.6-0`
## eigen_conversions
- No changes
## geometry
- No changes
## kdl_conversions
- No changes
## tf

```
* add a unit test for pytf wait_for_transform
* removed msg serv installation from cmakelists
* generated autodoc
* Fixed Vector3 documentation
* display RPY in both radian and degree
* Fixed command line arguments
* using TimeStamp and FrameId in message filter
  this allows to use tf::MessageFilter with pcl::PointCloud<T>
  see #55 <https://github.com/ros/geometry/issues/55>
* Added and optional third argument to specify publishing frequency
* Contributors: Adnan Munawar, Brice Rebsamen, Jackie Kay, Tully Foote, Ying Lu
```
## tf_conversions

```
* Fixed Vector3 documentation
* Contributors: Jackie Kay
```
