### PR TITLE
euslisp: 9.12.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1760,7 +1760,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/euslisp-release.git
-      version: 9.11.1-0
+      version: 9.12.0-0
     status: developed
   executive_smach:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `euslisp` to `9.12.0-0`:
- upstream repository: https://github.com/euslisp/EusLisp
- release repository: https://github.com/tork-a/euslisp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `9.11.1-0`
