### PR TITLE
jskeus: 1.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3181,7 +3181,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jskeus-release.git
-      version: 1.0.4-1
+      version: 1.0.5-0
   katana_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.0.5-0`:
- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.4-1`
## jskeus

```
* ARM suppoort

    * [Makefile.LinuxARM] add -fPIC for arm
    * [Makefile] fix to work with armv7l

* [irtrobot.l/irtdyna.l] support :ik-thre and :ik-rthre keyword for :calc-walk-pattern-from-footstep-list
* [irtgraph.l] Add :debug keyword to :pop-from-open-list for consistency in API
* [irtrobot.l] Update calculation of sole polygon (do not use end-coords)
* Contributors: Kei Okada, Ryohei Ueda, Shunichi Nozawa
```
