### PR TITLE
filters: 1.7.4-2 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -449,6 +449,12 @@ repositories:
       url: https://github.com/tork-a/euslisp-release.git
       version: 9.11.1-0
     status: developed
+  filters:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/filters-release.git
+      version: 1.7.4-2
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `1.7.4-2`:
- upstream repository: https://github.com/ros/filters.git
- release repository: https://github.com/ros-gbp/filters-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
