### PR TITLE
openrtm_aist_python: 1.1.0-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1043,6 +1043,12 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/openrtm_aist-release.git
       version: 1.1.0-0
+  openrtm_aist_python:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/openrtm_aist_python-release.git
+      version: 1.1.0-1
   openslam_gmapping:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist_python` to `1.1.0-1`:
- upstream repository: http://svn.openrtm.org/OpenRTM-aist-Python/tags/RELEASE_1_1_0_RC1/OpenRTM-aist-Python/
- release repository: https://github.com/tork-a/openrtm_aist_python-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
