### PR TITLE
rtctree: 3.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1539,6 +1539,12 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: indigo-devel
     status: maintained
+  rtctree:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/rtctree-release.git
+      version: 3.0.1-0
   rtsprofile:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtctree` to `3.0.1-0`:
- upstream repository: https://github.com/gbiggs/rtctree.git
- release repository: https://github.com/tork-a/rtctree-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
