### PR TITLE
rtsprofile: 2.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1533,6 +1533,12 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: indigo-devel
     status: maintained
+  rtsprofile:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/rtsprofile-release.git
+      version: 2.0.0-0
   sbpl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtsprofile` to `2.0.0-0`:
- upstream repository: https://github.com/gbiggs/rtsprofile.git
- release repository: https://github.com/tork-a/rtsprofile-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
