### PR TITLE
pepper_meshes: 0.2.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1110,7 +1110,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_meshes-installer.git
-      version: 0.1.2-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_meshes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_meshes` to `0.2.0-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_meshes.git
- release repository: https://github.com/ros-naoqi/pepper_meshes-installer.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.2-0`
## pepper_meshes

```
* update to the latest version of the meshes
* Contributors: Vincent Rabaud
```
