### PR TITLE
rtshell: 3.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1545,6 +1545,12 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/rtctree-release.git
       version: 3.0.1-0
+  rtshell:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/rtshell-release.git
+      version: 3.0.1-0
   rtsprofile:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell` to `3.0.1-0`:
- upstream repository: https://github.com/gbiggs/rtshell.git
- release repository: https://github.com/tork-a/rtshell-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
