### PR TITLE
rail_segmentation: 0.1.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1210,7 +1210,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_segmentation.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_segmentation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_segmentation` to `0.1.6-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_segmentation.git
- release repository: https://github.com/wpi-rail-release/rail_segmentation.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.5-0`
## rail_segmentation

```
* cleared flag added
* Contributors: Russell Toris
```
