### PR TITLE
carl_moveit: 0.0.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -695,7 +695,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_moveit-release.git
-      version: 0.0.12-0
+      version: 0.0.13-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_moveit` to `0.0.13-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_moveit.git
- release repository: https://github.com/wpi-rail-release/carl_moveit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.12-0`
## carl_moveit

```
* changelog reverted
* Merge branch 'develop' of github.com:WPI-RAIL/carl_moveit into develop
* changelog updated
* Added threshold for attaching scene objects to the robot end-effector
* Debug statement cleanup
* Approach angle fix
* Connected pickup action with scene object attaching
* Added fingers as allowable touch links for scene object attachment
* Merge branch 'develop' of github.com:WPI-RAIL/carl_moveit into develop
* Support for scene collision objects from segmented/recognized object data
* Contributors: David Kent, Russell Toris
```
