### PR TITLE
euslisp: 9.12.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -447,7 +447,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/euslisp-release.git
-      version: 9.12.0-0
+      version: 9.12.1-0
     status: developed
   filters:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `euslisp` to `9.12.1-0`:
- upstream repository: https://github.com/euslisp/EusLisp
- release repository: https://github.com/tork-a/euslisp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `9.12.0-0`
