### PR TITLE
message_generation: 0.3.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -791,7 +791,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/message_generation-release.git
-      version: 0.2.10-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/ros/message_generation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_generation` to `0.3.0-0`:
- upstream repository: https://github.com/ros/message_generation.git
- release repository: https://github.com/ros-gbp/message_generation-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.10-0`
