### PR TITLE
dynamic_reconfigure: 1.5.39-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -35,7 +35,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.11.4-0
+      version: 1.11.3-0
     source:
       type: git
       url: https://github.com/ros/actionlib.git
@@ -351,7 +351,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.5.38-1
+      version: 1.5.39-0
     source:
       type: git
       url: https://github.com/ros/dynamic_reconfigure.git
@@ -791,7 +791,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/message_generation-release.git
-      version: 0.3.0-0
+      version: 0.2.10-0
     source:
       type: git
       url: https://github.com/ros/message_generation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.5.39-0`:
- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.5.38-1`
## dynamic_reconfigure

```
* Better error message, to fix #32 <https://github.com/ros/dynamic_reconfigure/issues/32>
* Make Python callback code consistent with the C++ API
* Commented unused parameters to avoid compile warnings
* Contributors: Esteve Fernandez, Morgan Quigley
```
