### PR TITLE
pointgrey_camera_driver: 0.12.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1156,6 +1156,26 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: indigo-devel
     status: maintained
+  pointgrey_camera_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/pointgrey_camera_driver.git
+      version: master
+    release:
+      packages:
+      - image_exposure_msgs
+      - pointgrey_camera_driver
+      - statistics_msgs
+      - wfov_camera_msgs
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
+      version: 0.12.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/pointgrey_camera_driver.git
+      version: master
+    status: maintained
   python_ethernet_rmp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointgrey_camera_driver` to `0.12.0-0`:
- upstream repository: https://github.com/ros-drivers/pointgrey_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## image_exposure_msgs
- No changes
## pointgrey_camera_driver

```
* Remove dependency on driver_base.
  Define SensorLevels constants directly in the relevant places, rather
  than using the external message for this.
* Improve list_cameras by outputing more information about it
  The previous list_cameras only output 1 serial number which is
  not very informative. The improved one will print serial, model,
  vendor, sensor, resolution, color and firmware version.
* Add auto white balance and fix not able to write white balance
  Fix the problem of not being able to set white balance using Property.
  When trying to set white balance on my FL3-U3-13E4C-C, both this ros
  driver and flycap software cannot set the white balance naturally.
  After playing around with the flycap software, I found that I have
  to set the highest bit of register 80C (which is white balance) to 1
  to enable this feature. So I modified the original SetWhiteBalance to
  use WriteRegister directly. And add support for auto white balance.
* Framerate improvements.
* Support downloading the SDK for ARM.
* Downgrade flycaptyre SDK to 2.6.3.4, see:
  https://github.com/ros-drivers/pointgrey_camera_driver/issues/28
* Contributors: Chao Qu, Julius Gelšvartas, Konrad Banachowicz, L0g1x, Mike Purvis
```
## statistics_msgs
- No changes
## wfov_camera_msgs
- No changes
