### PR TITLE
geometry_experimental: 0.5.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2068,6 +2068,7 @@ repositories:
       - geometry_experimental
       - tf2
       - tf2_bullet
+      - tf2_eigen
       - tf2_geometry_msgs
       - tf2_kdl
       - tf2_msgs
@@ -2078,7 +2079,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry_experimental-release.git
-      version: 0.5.9-0
+      version: 0.5.11-0
     source:
       type: git
       url: https://github.com/ros/geometry_experimental.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_experimental` to `0.5.11-0`:
- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry_experimental-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.5.9-0`
## geometry_experimental
- No changes
## tf2
- No changes
## tf2_bullet
- No changes
## tf2_eigen
- No changes
## tf2_geometry_msgs
- No changes
## tf2_kdl
- No changes
## tf2_msgs
- No changes
## tf2_py
- No changes
## tf2_ros

```
* do not short circuit waitForTransform timeout when running inside pytf. Fixes #102 <https://github.com/ros/geometry_experimental/issues/102>
  roscpp is not initialized inside pytf which means that ros::ok is not
  valid. This was causing the timer to abort immediately.
  This breaks support for pytf with respect to early breaking out of a loop re #26 <https://github.com/ros/geometry_experimental/issues/26>.
  This is conceptually broken in pytf, and is fixed in tf2_ros python implementation.
  If you want this behavior I recommend switching to the tf2 python bindings.
* inject timeout information into error string for canTransform with timeout
* Contributors: Tully Foote
```
## tf2_sensor_msgs
- No changes
## tf2_tools
- No changes
