### PR TITLE
octomap: 1.6.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1026,6 +1026,25 @@ repositories:
       url: https://github.com/wg-perception/tod.git
       version: master
     status: maintained
+  octomap:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap.git
+      version: v1.6.8
+    release:
+      packages:
+      - dynamic_edt_3d
+      - octomap
+      - octovis
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/octomap-release.git
+      version: 1.6.8-0
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap.git
+      version: devel
+    status: maintained
   opencv_candidate:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap` to `1.6.8-0`:
- upstream repository: https://github.com/OctoMap/octomap.git
- release repository: https://github.com/ros-gbp/octomap-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
