### PR TITLE
dynamic_reconfigure: 1.5.39-2 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -351,7 +351,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.5.38-1
+      version: 1.5.39-2
     source:
       type: git
       url: https://github.com/ros/dynamic_reconfigure.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.5.39-2`:
- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.5.38-1`
## dynamic_reconfigure

```
* Better error message, to fix #32 <https://github.com/ros/dynamic_reconfigure/issues/32>
* Make Python callback code consistent with the C++ API
* Commented unused parameters to avoid compile warnings
* Contributors: Esteve Fernandez, Morgan Quigley
```
