### PR TITLE
octomap_msgs: 0.3.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1045,6 +1045,21 @@ repositories:
       url: https://github.com/OctoMap/octomap.git
       version: devel
     status: maintained
+  octomap_msgs:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_msgs.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_msgs-release.git
+      version: 0.3.2-0
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_msgs.git
+      version: indigo-devel
+    status: maintained
   opencv_candidate:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_msgs` to `0.3.2-0`:
- upstream repository: https://github.com/OctoMap/octomap_msgs.git
- release repository: https://github.com/ros-gbp/octomap_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## octomap_msgs

```
* Fixing issue octomap_rviz_plugins/#10: Allow deserializing an empty octree
* Contributors: Armin Hornung
```
