### PR TITLE
random_numbers: 0.3.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1270,6 +1270,21 @@ repositories:
       url: https://github.com/WPI-RAIL/rail_segmentation.git
       version: develop
     status: maintained
+  random_numbers:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/random_numbers-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: master
+    status: maintained
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `random_numbers` to `0.3.0-0`:
- upstream repository: https://github.com/ros-planning/random_numbers
- release repository: https://github.com/ros-gbp/random_numbers-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## random_numbers

```
* Update README.md with Documentation
* Allow the randomly generated seed to be saved so that experiments / benc...
* Initialize static int to 0
* Save the first_seed even when passed in manually.
* Allow the randomly generated seed to be saved so that experiments / benchmarks can be recreated in the future
* Added ability to specify random number generator seed for stochastic behavior
* Added travis build status indicator in README.md
* Contributors: Dave Coleman, Dave Hershberger, Ioan A Sucan
```
