### PR TITLE
geometric_shapes: 0.4.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -530,6 +530,21 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: indigo-devel
     status: maintained
+  geometric_shapes:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/geometric_shapes-release.git
+      version: 0.4.2-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: indigo-devel
+    status: maintained
   geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.4.2-0`:
- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## geometric_shapes

```
* PR #32 <https://github.com/ros-planning/geometric_shapes/issues/32>
  Merge shape_tools package into geometric shapes
* PR #33 <https://github.com/ros-planning/geometric_shapes/issues/33>
  Add run_depend on visualization_msgs
* PR #26 <https://github.com/ros-planning/geometric_shapes/issues/26>
  Prevent every mesh generation opening a new file handle.
* Contributors: Christian Dornhege, Dave Coleman, Jochen Sprickerhof, Michael Ferguson, Steven Peters
```
