### PR TITLE
driver_common: 1.6.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -342,6 +342,19 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: indigo-devel
     status: maintained
+  driver_common:
+    release:
+      packages:
+      - driver_base
+      - driver_common
+      - timestamp_tools
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/driver_common-release.git
+      version: 1.6.8-0
+    status: end-of-life
+    status_description: Will be released only as long as required for PR2 drivers
+      (hokuyo_node, wge100_driver)
   dynamic_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `driver_common` to `1.6.8-0`:
- upstream repository: https://github.com/ros-drivers/driver_common.git
- release repository: https://github.com/ros-gbp/driver_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## driver_base
- No changes
## driver_common
- No changes
## timestamp_tools
- No changes
