### PR TITLE
sicktoolbox: 1.0.103-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1680,6 +1680,12 @@ repositories:
       url: https://github.com/ros-gbp/shape_tools-release.git
       version: 0.2.1-0
     status: maintained
+  sicktoolbox:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/sicktoolbox-release.git
+      version: 1.0.103-0
   slam_gmapping:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `sicktoolbox` to `1.0.103-0`:
- upstream repository: https://github.com/ros-drivers/sicktoolbox.git
- release repository: https://github.com/ros-gbp/sicktoolbox-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
