### PR TITLE
urg_c: 1.0.404-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -342,19 +342,6 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: indigo-devel
     status: maintained
-  driver_common:
-    release:
-      packages:
-      - driver_base
-      - driver_common
-      - timestamp_tools
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/driver_common-release.git
-      version: 1.6.8-0
-    status: end-of-life
-    status_description: Will be released only as long as required for PR2 drivers
-      (hokuyo_node, wge100_driver)
   dynamic_reconfigure:
     doc:
       type: git
@@ -1855,6 +1842,13 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/urdfdom_py-release.git
       version: 0.3.0-1
+    status: maintained
+  urg_c:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/urg_c-release.git
+      version: 1.0.404-0
     status: maintained
   usb_cam:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_c` to `1.0.404-0`:
- upstream repository: git://github.com/ros-drivers/urg_c.git
- release repository: https://github.com/ros-gbp/urg_c-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## urg_c

```
* Merge pull request #2 <https://github.com/ros-drivers/urg_c/issues/2> from dawonn/master
  Issue #1 <https://github.com/ros-drivers/urg_c/issues/1> - missing libmath link
* Ubuntu 14.04 Fix - missing libmath link
* Fix build for Android.
* Contributors: Chad Rockey, dawonn
```
