### PR TITLE
laser_proc: 0.1.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -342,19 +342,6 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: indigo-devel
     status: maintained
-  driver_common:
-    release:
-      packages:
-      - driver_base
-      - driver_common
-      - timestamp_tools
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/driver_common-release.git
-      version: 1.6.8-0
-    status: end-of-life
-    status_description: Will be released only as long as required for PR2 drivers
-      (hokuyo_node, wge100_driver)
   dynamic_reconfigure:
     doc:
       type: git
@@ -734,6 +721,13 @@ repositories:
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
       version: indigo-devel
+    status: maintained
+  laser_proc:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/laser_proc-release.git
+      version: 0.1.4-0
     status: maintained
   librms:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_proc` to `0.1.4-0`:
- upstream repository: git://github.com/ros-perception/laser_proc.git
- release repository: https://github.com/ros-gbp/laser_proc-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## laser_proc

```
* Install fix for Android.
* Contributors: Chad Rockey
```
