### PR TITLE
depthimage_to_laserscan: 1.0.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -319,6 +319,13 @@ repositories:
       url: https://github.com/RobotWebTools/depthcloud_encoder.git
       version: develop
     status: maintained
+  depthimage_to_laserscan:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/depthimage_to_laserscan-release.git
+      version: 1.0.7-0
+    status: maintained
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthimage_to_laserscan` to `1.0.7-0`:
- upstream repository: https://github.com/ros-perception/depthimage_to_laserscan.git
- release repository: https://github.com/ros-gbp/depthimage_to_laserscan-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## depthimage_to_laserscan

```
* Merge pull request #11 <https://github.com/ros-perception/depthimage_to_laserscan/issues/11> from ros-perception/hydro-devel
  Update indigo devel with angle fix
* Merge pull request #8 <https://github.com/ros-perception/depthimage_to_laserscan/issues/8> from vliedel/hydro-devel
  fixed angle_increment
* fixed angle_increment
* Merge pull request #7 <https://github.com/ros-perception/depthimage_to_laserscan/issues/7> from bulwahn/hydro-devel
  check for CATKIN_ENABLE_TESTING
* check for CATKIN_ENABLE_TESTING
* Added ARCHIVE DESTINATION
* Contributors: Chad Rockey, Lukas Bulwahn, vliedel
```
