### PR TITLE
hokuyo_node: 1.7.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -606,6 +606,13 @@ repositories:
       url: https://github.com/ros/geometry_experimental.git
       version: indigo-devel
     status: maintained
+  hokuyo_node:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/hokuyo_node-release.git
+      version: 1.7.8-0
+    status: maintained
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hokuyo_node` to `1.7.8-0`:
- upstream repository: https://github.com/ros-drivers/hokuyo_node.git
- release repository: https://github.com/ros-gbp/hokuyo_node-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## hokuyo_node

```
* Merge pull request #8 <https://github.com/ros-drivers/hokuyo_node/issues/8> from trainman419/hydro-devel
  Use rosconsole to set logger levels. Fixes #7 <https://github.com/ros-drivers/hokuyo_node/issues/7>
* Use rosconsole to set logger levels. Fixes #7 <https://github.com/ros-drivers/hokuyo_node/issues/7>
* Added changelog
* Contributors: Chad Rockey, chadrockey, trainman419
```
