### PR TITLE
urg_c: 1.0.404-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1869,6 +1869,13 @@ repositories:
       url: https://github.com/ros-gbp/urdfdom_py-release.git
       version: 0.3.0-1
     status: maintained
+  urg_c:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/urg_c-release.git
+      version: 1.0.404-0
+    status: maintained
   usb_cam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_c` to `1.0.404-0`:
- upstream repository: git://github.com/ros-drivers/urg_c.git
- release repository: https://github.com/ros-gbp/urg_c-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## urg_c

```
* Merge pull request #2 <https://github.com/ros-drivers/urg_c/issues/2> from dawonn/master
  Issue #1 <https://github.com/ros-drivers/urg_c/issues/1> - missing libmath link
* Ubuntu 14.04 Fix - missing libmath link
* Fix build for Android.
* Contributors: Chad Rockey, dawonn
```
