### PR TITLE
laser_proc: 0.1.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -749,6 +749,13 @@ repositories:
       url: https://github.com/ros-perception/laser_geometry.git
       version: indigo-devel
     status: maintained
+  laser_proc:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/laser_proc-release.git
+      version: 0.1.4-0
+    status: maintained
   librms:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_proc` to `0.1.4-0`:
- upstream repository: git://github.com/ros-perception/laser_proc.git
- release repository: https://github.com/ros-gbp/laser_proc-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## laser_proc

```
* Install fix for Android.
* Contributors: Chad Rockey
```
