### PR TITLE
microstrain_3dmgx2_imu: 1.5.12-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -854,6 +854,13 @@ repositories:
       url: https://github.com/ros/message_runtime.git
       version: groovy-devel
     status: maintained
+  microstrain_3dmgx2_imu:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/microstrain_3dmgx2_imu-release.git
+      version: 1.5.12-0
+    status: maintained
   mrpt_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_3dmgx2_imu` to `1.5.12-0`:
- upstream repository: https://github.com/ros-drivers/microstrain_3dmgx2_imu.git
- release repository: https://github.com/ros-gbp/microstrain_3dmgx2_imu-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## microstrain_3dmgx2_imu

```
* Added dependency on log4cxx.
* Contributors: Chad Rockey
```
