### PR TITLE
sicktoolbox_wrapper: 2.5.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1727,6 +1727,13 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/sicktoolbox-release.git
       version: 1.0.103-0
+  sicktoolbox_wrapper:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/sicktoolbox_wrapper-release.git
+      version: 2.5.3-0
+    status: maintained
   slam_gmapping:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `sicktoolbox_wrapper` to `2.5.3-0`:
- upstream repository: https://github.com/ros-drivers/sicktoolbox_wrapper.git
- release repository: https://github.com/ros-gbp/sicktoolbox_wrapper-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
