### PR TITLE
urg_node: 0.1.9-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1897,6 +1897,13 @@ repositories:
       url: https://github.com/ros-gbp/urg_c-release.git
       version: 1.0.404-0
     status: maintained
+  urg_node:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/urg_node-release.git
+      version: 0.1.9-0
+    status: maintained
   usb_cam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node` to `0.1.9-0`:
- upstream repository: https://github.com/ros-drivers/urg_node.git
- release repository: https://github.com/ros-gbp/urg_node-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## urg_node

```
* Merge pull request #7 <https://github.com/ros-drivers/urg_node/issues/7> from mikeferguson/indigo-devel
  add a script to set the IP address of an URG laser
* Updated diagnostics to support configurable parameters.
* add a script to set the IP address of an URG laser
* Contributors: Chad Rockey, Michael Ferguson
```
