### PR TITLE
robot_model: 1.11.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6446,7 +6446,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.11.6-0
+      version: 1.11.7-0
     source:
       type: git
       url: https://github.com/ros/robot_model.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.11.7-0`:
- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.11.6-0`
## collada_parser
- No changes
## collada_urdf

```
* Fixed #89 <https://github.com/ros/robot_model/issues/89>
  Accomplished by loading libpcrecpp before collada-dom.
* Contributors: Kei Okada, William Woodall
```
## joint_state_publisher

```
* Added a randomize button for the joints.
* Contributors: Aaron Blasdel
```
## kdl_parser
- No changes
## robot_model
- No changes
## urdf

```
* Removed the exporting of Boost and pcre as they are not used in the headers, and added TinyXML because it is.
* Fixed a bug with pcrecpp on Ubuntu > 13.04.
* Contributors: Kei Okada, William Woodall
```
## urdf_parser_plugin
- No changes
