### PR TITLE
robot_model: 1.11.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1371,6 +1371,29 @@ repositories:
       url: https://github.com/WPI-RAIL/rmp_msgs.git
       version: develop
     status: maintained
+  robot_model:
+    doc:
+      type: git
+      url: https://github.com/ros/robot_model.git
+      version: indigo-devel
+    release:
+      packages:
+      - collada_parser
+      - collada_urdf
+      - joint_state_publisher
+      - kdl_parser
+      - robot_model
+      - urdf
+      - urdf_parser_plugin
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/robot_model-release.git
+      version: 1.11.7-0
+    source:
+      type: git
+      url: https://github.com/ros/robot_model.git
+      version: indigo-devel
+    status: maintained
   robot_pose_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.11.7-0`:
- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## collada_parser
- No changes
## collada_urdf

```
* Fixed #89 <https://github.com/ros/robot_model/issues/89>
  Accomplished by loading libpcrecpp before collada-dom.
* Contributors: Kei Okada, William Woodall
```
## joint_state_publisher

```
* Added a randomize button for the joints.
* Contributors: Aaron Blasdel
```
## kdl_parser
- No changes
## robot_model
- No changes
## urdf

```
* Removed the exporting of Boost and pcre as they are not used in the headers, and added TinyXML because it is.
* Fixed a bug with pcrecpp on Ubuntu > 13.04.
* Contributors: Kei Okada, William Woodall
```
## urdf_parser_plugin
- No changes
