### PR TITLE
laser_filters: 1.8.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -738,6 +738,13 @@ repositories:
       url: https://github.com/ros-drivers/korg_nanokontrol.git
       version: master
     status: maintained
+  laser_filters:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/laser_filters-release.git
+      version: 1.8.0-0
+    status: maintained
   laser_geometry:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `1.8.0-0`:
- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros-gbp/laser_filters-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## laser_filters
- No changes
