### PR TITLE
jskeus: 1.0.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3366,7 +3366,8 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jskeus-release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
+    status: developed
   katana_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.0.6-0`:
- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.5-0`
## jskeus

```
* fix minor bugs

    * [irteus/PQP/Makefile.LinuxARM] add -fPIC for arm
    * [Makefile] add .PHONE: doc
    * [irtrobot.l] Fix initial refzmp pos.

* Contributors: Kei Okada, Shunichi Nozawa
```
