### PR TITLE
jskeus: 1.0.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -721,7 +721,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jskeus-release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     status: developed
   korg_nanokontrol:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.0.6-0`:
- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.5-0`
## jskeus

```
* fix minor bugs

    * [irteus/PQP/Makefile.LinuxARM] add -fPIC for arm
    * [Makefile] add .PHONE: doc
    * [irtrobot.l] Fix initial refzmp pos.

* Contributors: Kei Okada, Shunichi Nozawa
```
