### PR TITLE
handle_detector: 1.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2249,6 +2249,21 @@ repositories:
       url: https://github.com/tork-a/hakuto.git
       version: master
     status: developed
+  handle_detector:
+    doc:
+      type: git
+      url: https://github.com/atenpas/handle_detector.git
+      version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/atenpas/handle_detector-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/atenpas/handle_detector.git
+      version: indigo
+    status: maintained
   hector_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `handle_detector` to `1.1.0-0`:
- upstream repository: https://github.com/atenpas/handle_detector
- release repository: https://github.com/atenpas/handle_detector-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## handle_detector

```
* updated readme
* updated CMakeLists and package.xml
* cleaned up folders; added documentation
* added importance sampling (reduces number of samples)
* Contributors: atenpas
```
