### PR TITLE
rosserial: 0.7.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1700,6 +1700,31 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: indigo-devel
     status: maintained
+  rosserial:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/rosserial.git
+      version: jade-devel
+    release:
+      packages:
+      - rosserial
+      - rosserial_arduino
+      - rosserial_client
+      - rosserial_embeddedlinux
+      - rosserial_msgs
+      - rosserial_python
+      - rosserial_server
+      - rosserial_windows
+      - rosserial_xbee
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/rosserial-release.git
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/rosserial.git
+      version: jade-devel
+    status: maintained
   rtctree:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial` to `0.7.0-0`:
- upstream repository: https://github.com/ros-drivers/rosserial.git
- release repository: https://github.com/ros-gbp/rosserial-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## rosserial
- No changes
## rosserial_arduino
- No changes
## rosserial_client

```
* Initial release for Jade.
* Make message generating error message more verbose.
* Fix initializer for fixed-length arrays.
* Generate constructors for messages.
* Switch to stdint integers. This allows the client to run on 64-bit systems.
* Contributors: Mickaël, Mike Purvis, Mitchell Wills, chuck-h
```
## rosserial_embeddedlinux

```
* Use native 64-bit double on embeddedlinux.
* Include time.h header for linux in embedded_linux_hardware.h.
* Support OS X time in the embeddedlinux port.
* Contributors: Mike Purvis
```
## rosserial_msgs
- No changes
## rosserial_python

```
* Adds default queue_size of 10 for rosserial_python publisher.
* Fixed queue size warning with diagnostics publisher.
* We don't need roslib.load_manifest any more under catkin.
* Contributors: Basheer Subei, David Lavoie-Boutin, Mike Purvis, eisoku9618
```
## rosserial_server

```
* Fill out description field in package.xml.
* Bugfix for checksum.
  Publishing topics fails when messages are over 256 bytes in length due to checksum() function or'ing high and low byte instead of adding them.
* rosserial_server: Properly receive messages > 255 bytes.
* Contributors: Chad Attermann, Mike Purvis
```
## rosserial_windows
- No changes
## rosserial_xbee
- No changes
