### PR TITLE
interactive_marker_twist_server: 1.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -679,6 +679,21 @@ repositories:
       url: https://github.com/RobotWebTools/interactive_marker_proxy.git
       version: develop
     status: maintained
+  interactive_marker_twist_server:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
+      version: indigo-devel
+    status: maintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_marker_twist_server` to `1.0.0-0`:
- upstream repository: https://github.com/ros-visualization/interactive_marker_twist_server
- release repository: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## interactive_marker_twist_server

```
* Add roslaunch file check, roslint
* Make cmd_vel topic relative; fixes #3 <https://github.com/ros-visualization/interactive_marker_twist_server/issues/3>.
* Max speed control, fixes #1 <https://github.com/ros-visualization/interactive_marker_twist_server/issues/1>
* Update copyright.
* Contributors: Mike Purvis
```
