### PR TITLE
python_qt_binding: 0.2.15-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1288,6 +1288,21 @@ repositories:
       url: https://github.com/WPI-RAIL/python_ethernet_rmp.git
       version: develop
     status: maintained
+  python_qt_binding:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: groovy-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/python_qt_binding-release.git
+      version: 0.2.15-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: groovy-devel
+    status: maintained
   rail_manipulation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `0.2.15-0`:
- upstream repository: git://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros-gbp/python_qt_binding-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## python_qt_binding

```
* support PyQt4.11 and higher when built with configure-ng.py (#13 <https://github.com/ros-visualization/python_qt_binding/issues/13>)
* __builtin__ became builtins in Python 3 (#16 <https://github.com/ros-visualization/python_qt_binding/issues/16>)
```
