### PR TITLE
nmea_msgs: 1.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -679,21 +679,6 @@ repositories:
       url: https://github.com/RobotWebTools/interactive_marker_proxy.git
       version: develop
     status: maintained
-  interactive_marker_twist_server:
-    doc:
-      type: git
-      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
-      version: 1.0.0-0
-    source:
-      type: git
-      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
-      version: indigo-devel
-    status: maintained
   interactive_markers:
     doc:
       type: git
@@ -984,6 +969,11 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/nmea_msgs.git
       version: jade-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/nmea_msgs-release.git
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/nmea_msgs.git
@@ -1302,21 +1292,6 @@ repositories:
       type: git
       url: https://github.com/WPI-RAIL/python_ethernet_rmp.git
       version: develop
-    status: maintained
-  python_qt_binding:
-    doc:
-      type: git
-      url: https://github.com/ros-visualization/python_qt_binding.git
-      version: groovy-devel
-    release:
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/python_qt_binding-release.git
-      version: 0.2.15-0
-    source:
-      type: git
-      url: https://github.com/ros-visualization/python_qt_binding.git
-      version: groovy-devel
     status: maintained
   rail_manipulation_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_msgs` to `1.0.0-0`:
- upstream repository: https://github.com/ros-drivers/nmea_msgs.git
- release repository: https://github.com/ros-drivers-gbp/nmea_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## nmea_msgs

```
* Release into Jade.
```
