### PR TITLE
nmea_msgs: 1.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -984,6 +984,11 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/nmea_msgs.git
       version: jade-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/nmea_msgs-release.git
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/nmea_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_msgs` to `1.0.0-0`:
- upstream repository: https://github.com/ros-drivers/nmea_msgs.git
- release repository: https://github.com/ros-drivers-gbp/nmea_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## nmea_msgs

```
* Release into Jade.
```
