### PR TITLE
nmea_navsat_driver: 0.4.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4784,7 +4784,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/nmea_navsat_driver-release.git
-      version: 0.4.1-0
+      version: 0.4.2-0
     source:
       type: git
       url: https://github.com/ros-drivers/nmea_navsat_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_navsat_driver` to `0.4.2-0`:
- upstream repository: https://github.com/ros-drivers/nmea_navsat_driver.git
- release repository: https://github.com/ros-drivers-gbp/nmea_navsat_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.4.1-0`
## nmea_navsat_driver

```
* Fix remaining parse problem with NovAtel receivers (empty field specified for num_satellite).
```
