### PR TITLE
robot_state_publisher: 1.10.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1830,13 +1830,13 @@ repositories:
       version: indigo-devel
     release:
       tags:
-        release: release/jade/{package}/{version}		
-      url: https://github.com/ros-gbp/rviz-release.git		
-      version: 1.11.7-0		
-    source:		
-      type: git		
-      url: https://github.com/ros-visualization/rviz.git		
-      version: indigo-devel		
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/rviz-release.git
+      version: 1.11.7-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rviz.git
+      version: indigo-devel
     status: maintained
   sbpl:
     release:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1481,6 +1481,21 @@ repositories:
       url: https://github.com/WPI-RAIL/robot_pose_publisher.git
       version: develop
     status: maintained
+  robot_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/robot_state_publisher.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/robot_state_publisher-release.git
+      version: 1.10.4-0
+    source:
+      type: git
+      url: https://github.com/ros/robot_state_publisher.git
+      version: jade-devel
+    status: maintained
   robot_upstart:
     doc:
       type: git
@@ -1808,21 +1823,6 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/rtsprofile-release.git
       version: 2.0.0-0
-  rviz:
-    doc:
-      type: git
-      url: https://github.com/ros-visualization/rviz.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.11.7-0
-    source:
-      type: git
-      url: https://github.com/ros-visualization/rviz.git
-      version: indigo-devel
-    status: maintained
   sbpl:
     release:
       tags:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1823,6 +1823,21 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/rtsprofile-release.git
       version: 2.0.0-0
+  rviz:		
+    doc:		
+      type: git		
+      url: https://github.com/ros-visualization/rviz.git		
+      version: indigo-devel		
+    release:		
+      tags:		
+        release: release/jade/{package}/{version}		
+      url: https://github.com/ros-gbp/rviz-release.git		
+      version: 1.11.7-0		
+    source:		
+      type: git		
+      url: https://github.com/ros-visualization/rviz.git		
+      version: indigo-devel		
+    status: maintained
   sbpl:
     release:
       tags:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1823,13 +1823,13 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/rtsprofile-release.git
       version: 2.0.0-0
-  rviz:		
-    doc:		
-      type: git		
-      url: https://github.com/ros-visualization/rviz.git		
-      version: indigo-devel		
-    release:		
-      tags:		
+  rviz:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rviz.git
+      version: indigo-devel
+    release:
+      tags:
         release: release/jade/{package}/{version}		
       url: https://github.com/ros-gbp/rviz-release.git		
       version: 1.11.7-0		


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `1.10.4-0`:
- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros-gbp/robot_state_publisher-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## robot_state_publisher

```
* Merge pull request #21 <https://github.com/ros/robot_state_publisher/issues/21> from rcodddow/patch-1
* Fix for joint transforms not being published anymore after a clock reset (e.g. when playing a bagfile and looping)
* Contributors: Ioan A Sucan, Robert Codd-Downey, Timm Linder
```
