### PR TITLE
rtshell: 3.0.1-2 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1816,7 +1816,8 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/rtshell-release.git
-      version: 3.0.1-0
+      version: 3.0.1-2
+    status: developed
   rtsprofile:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell` to `3.0.1-2`:
- upstream repository: https://github.com/gbiggs/rtshell.git
- release repository: https://github.com/tork-a/rtshell-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `3.0.1-0`
