### PR TITLE
rospeex: 2.12.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7437,6 +7437,20 @@ repositories:
       type: git
       url: https://bitbucket.org/rospeex/rospeex.git
       version: indigo
+    release:
+      packages:
+      - rospeex
+      - rospeex_audiomonitor
+      - rospeex_core
+      - rospeex_if
+      - rospeex_launch
+      - rospeex_msgs
+      - rospeex_samples
+      - rospeex_webaudiomonitor
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://bitbucket.org/rospeex/rospeex-release.git
+      version: 2.12.6-0
     source:
       type: git
       url: https://bitbucket.org/rospeex/rospeex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospeex` to `2.12.6-0`:
- upstream repository: https://bitbucket.org/rospeex/rospeex.git
- release repository: https://bitbucket.org/rospeex/rospeex-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rospeex
- No changes
## rospeex_audiomonitor
- No changes
## rospeex_core

```
* Add libav to rospeex_core/package.xml
* modify audio converter process.
```
## rospeex_if
- No changes
## rospeex_launch
- No changes
## rospeex_msgs
- No changes
## rospeex_samples
- No changes
## rospeex_webaudiomonitor
- No changes
