### PR TITLE
install libtool-bin for U and V

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2131,8 +2131,17 @@ libtool:
   opensuse: [libtool, libltdl3]
   rhel: [libtool, libtool-ltdl-devel]
   ubuntu:
-    apt:
-      packages: [libtool, libltdl-dev]
+    lucid: [libtool, libltdl-dev]
+    maverick: [libtool, libltdl-dev]
+    natty: [libtool, libltdl-dev]
+    oneiric: [libtool, libltdl-dev]
+    precise: [libtool, libltdl-dev]
+    quantal: [libtool, libltdl-dev]
+    raring: [libtool, libltdl-dev]
+    saucy: [libtool, libltdl-dev]
+    trusty: [libtool, libltdl-dev]
+    utopic: [libtool, libltdl-dev, libtool-bin]
+    vivid: [libtool, libltdl-dev, libtool-bin]
 libturbojpeg:
   fedora: [turbojpeg-devel]
   ubuntu: [libturbojpeg]


### PR DESCRIPTION
until T, libtool is installed from libtool package 
http://packages.ubuntu.com/trusty/amd64/libtool/filelist

but from U, it seems it is moved from libtool to libtool-bin
http://packages.ubuntu.com/vivid/amd64/libtool/filelist
http://packages.ubuntu.com/vivid/amd64/libtool-bin/filelist

I choose to add libtool-bin to libtool so that users do not have to change their package.xml, specially changing between T and V may trouble on Jade
