### PR TITLE
roslisp: 1.9.18-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7318,7 +7318,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/roslisp-release.git
-      version: 1.9.17-0
+      version: 1.9.18-0
+    source:
+      type: git
+      url: https://github.com/ros/roslisp.git
+      version: master
     status: maintained
   roslisp_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp` to `1.9.18-0`:
- upstream repository: git://github.com/ros/roslisp.git
- release repository: https://github.com/ros-gbp/roslisp-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.9.17-0`
