### PR TITLE
roslisp: 1.9.18-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1759,7 +1759,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/roslisp-release.git
-      version: 1.9.17-0
+      version: 1.9.18-0
     source:
       type: git
       url: https://github.com/ros/roslisp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp` to `1.9.18-0`:
- upstream repository: git://github.com/ros/roslisp.git
- release repository: https://github.com/ros-gbp/roslisp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.9.17-0`
