### PR TITLE
cram_3rdparty: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1267,6 +1267,38 @@ repositories:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/cpp_introspection.git
       version: master
+  cram_3rdparty:
+    doc:
+      type: git
+      url: https://github.com/cram-code/cram_3rdparty.git
+      version: master
+    release:
+      packages:
+      - alexandria
+      - babel
+      - cffi
+      - cl_store
+      - cl_utilities
+      - cram_3rdparty
+      - fiveam
+      - gsd
+      - gsll
+      - lisp_unit
+      - split_sequence
+      - synchronization_tools
+      - trivial_features
+      - trivial_garbage
+      - trivial_gray_streams
+      - yason
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/cram_3rdparty-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/cram-code/cram_3rdparty.git
+      version: master
+    status: maintained
   crazyflie:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cram_3rdparty` to `0.1.3-0`:
- upstream repository: https://github.com/cram-code/cram_3rdparty.git
- release repository: https://github.com/ros-gbp/cram_3rdparty-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
