### PR TITLE
cram_3rdparty: 0.1.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -304,6 +304,38 @@ repositories:
       url: https://github.com/ros-controls/control_msgs.git
       version: indigo-devel
     status: maintained
+  cram_3rdparty:
+    doc:
+      type: git
+      url: https://github.com/cram-code/cram_3rdparty.git
+      version: master
+    release:
+      packages:
+      - alexandria
+      - babel
+      - cffi
+      - cl_store
+      - cl_utilities
+      - cram_3rdparty
+      - fiveam
+      - gsd
+      - gsll
+      - lisp_unit
+      - split_sequence
+      - synchronization_tools
+      - trivial_features
+      - trivial_garbage
+      - trivial_gray_streams
+      - yason
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/cram_3rdparty-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/cram-code/cram_3rdparty.git
+      version: master
+    status: maintained
   depthcloud_encoder:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cram_3rdparty` to `0.1.3-0`:
- upstream repository: https://github.com/cram-code/cram_3rdparty.git
- release repository: https://github.com/ros-gbp/cram_3rdparty-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
