### PR TITLE
rtmros_common: 1.2.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7762,7 +7762,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.2.9-0
+      version: 1.2.10-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.2.10-0`:
- upstream repository: https://github.com/start-jsk/rtmros_common.git
- release repository: https://github.com/tork-a/rtmros_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.2.9-0`
## hrpsys_ros_bridge

```
* add rewrited version of compile_robot_model.cmake

    * [compile_robot_model.cmake] generate controller_config even if yaml is not found
    * [compile_robot_model.cmake] use add_custom_target/command for eusif and launch, set PROJECT_PKG_NAME
    * [compile_robot_model.cmake] rewrite everything from scratch

* euslisp

    * [rtm-ros-robot-interface.l] Add method to align footsteps    with roll or pitch angle
    * [datalogger-log-parser.l] change max-line count method
    * [rtm-ros-robot-interface.l] Add sync-controller method, which preserve limb-controller angle before remove-joint-group is called.
    * [rtm-ros-robot-interface.l] Enable to set gravitational acceleration for calculating st parameter

* [HrpsysSeqStateROSBridgeImpl.{cpp,h}] display more debug info for diagnostics
* [cmake/compile_robot_model.cmake] Revert "compile_robot contains output files, not targets"
* [hrpsys_ros_bridge/package.xml] Limits dependent pkg version to avoid critical error in downstream (tork-a/rtmros_nextage/#160)
* Contributors: Eisoku Kuroiwa, Isaac IY Saito, Kei Okada, Shunichi Nozawa, Iori Kumagai
```
## hrpsys_tools
- No changes
## openrtm_ros_bridge
- No changes
## openrtm_tools
- No changes
## rosnode_rtc
- No changes
## rtmbuild
- No changes
## rtmros_common
- No changes
