### PR TITLE
jsk_roseus: 1.3.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -721,7 +721,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.2.7-0
+      version: 1.3.0-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.3.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.2.7-0`
## jsk_roseus
- No changes
## roseus

```
* add generate_eusdoc

    * [roseus/cmake/roseus.cmake] depends on install_roseus for doc generation
    * [roseus/CMakeLists.txt] generate eus-docs
    * [roseus/cmake/roseus.cmake] add generate_eusdoc macro

* CMakeLists.txt

    * [roseus/CMakeLists.txt] use add_custom_target to copy roseus to   bin

* roseus.cmake

    * [cmake/roseus/roseus.cmake] fix for msg in workspace using {$msg}_SOURCE_PREFIX
    * do not raise error for old catkin

* convert unit8[] as string https://github.com/jsk-ros-pkg/geneus/issues/14

    * [test/test_geneus] add test for fixed length data
    * [test-genmsg.sh] compile with -j1 and -l1, unset MAKEFLAGS  https://github.com/catkin/catkin_tools/pull/85
    * [roseus] fix test for treating uint8[] as string

* [roseus] add test-anonymous for #179 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/179>
* Contributors: Yuki Furuta, Kei Okada
```
