### PR TITLE
rotors_simulator: 1.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7581,6 +7581,30 @@ repositories:
       url: https://github.com/tork-a/roswww.git
       version: develop
     status: developed
+  rotors_simulator:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/rotors_simulator.git
+      version: master
+    release:
+      packages:
+      - rotors_comm
+      - rotors_control
+      - rotors_description
+      - rotors_evaluation
+      - rotors_gazebo
+      - rotors_gazebo_plugins
+      - rotors_joy_interface
+      - rotors_simulator
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ethz-asl/rotors_simulator-release.git
+      version: 1.1.1-0
+    source:
+      type: git
+      url: https://github.com/ethz-asl/rotors_simulator.git
+      version: master
+    status: developed
   rqt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rotors_simulator` to `1.1.1-0`:
- upstream repository: https://github.com/ethz-asl/rotors_simulator.git
- release repository: https://github.com/ethz-asl/rotors_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## rotors_comm
- No changes
## rotors_control
- No changes
## rotors_description
- No changes
## rotors_evaluation
- No changes
## rotors_gazebo
- No changes
## rotors_gazebo_plugins

```
* switched from opencv to cv_bridge
```
## rotors_joy_interface
- No changes
## rotors_simulator
- No changes
