### PR TITLE
geneus: 2.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2109,7 +2109,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/geneus-release.git
-      version: 2.2.0-0
+      version: 2.2.1-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/geneus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geneus` to `2.2.1-0`:
- upstream repository: https://github.com/jsk-ros-pkg/geneus
- release repository: https://github.com/tork-a/geneus-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2.2.0-0`
## geneus

```
* [geneus_main.py] fix when pkg_map does not have geneus
* [geneus_main.py] Fix unexpected function resposes caused by python gabage collection algorightm
* [geneus_main.py] fix typo for warning
* [geneus_main.py] Yellow color for warnings
* Contributors: Kei Okada, Kentaro Wada
```
