### PR TITLE
urdf_tutorial: 0.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9049,11 +9049,19 @@ repositories:
       url: https://github.com/uos/uos_tools.git
       version: indigo
   urdf_tutorial:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_tutorial.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/urdf_tutorial-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
+    source:
+      type: git
+      url: https://github.com/ros/urdf_tutorial.git
+      version: master
     status: maintained
   urdfdom_py:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tutorial` to `0.2.4-0`:
- upstream repository: https://github.com/ros/urdf_tutorial.git
- release repository: https://github.com/ros-gbp/urdf_tutorial-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.3-0`
## urdf_tutorial

```
* Maintainer list changes
* Add .rviz as an arg
* fix gazebo.launch for indigo, update to new package name
* Add run depends
* Contributors: David V. Lu, Ioan A Sucan, Isaac IY Saito, Kei Okada
```
