### PR TITLE
rail_collada_models: 0.0.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1385,6 +1385,21 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: groovy-devel
     status: maintained
+  rail_collada_models:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_collada_models.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wpi-rail-release/rail_collada_models-release.git
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_collada_models.git
+      version: develop
+    status: maintained
   rail_manipulation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_collada_models` to `0.0.4-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_collada_models.git
- release repository: https://github.com/wpi-rail-release/rail_collada_models-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## rail_collada_models

```
* Merge pull request #12 from PeterMitrano/develop
  Fixed surfaces on kitchen table and coffee table
* flipped table surface. added chair surfaces
* Merge branch 'develop' of https://github.com/WPI-RAIL/rail_collada_models into develop
* moved table marker closer
* added sizes of surfaces
* marker too close for arm
* added surfaces with macro
* Contributors: Peter, Russell Toris
```
