### PR TITLE
ar_track_alvar: 0.5.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -56,6 +56,21 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  ar_track_alvar:
+    doc:
+      type: git
+      url: https://github.com/sniekum/ar_track_alvar.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/ar_track_alvar-release.git
+      version: 0.5.1-0
+    source:
+      type: git
+      url: https://github.com/sniekum/ar_track_alvar.git
+      version: indigo-devel
+    status: maintained
   ar_track_alvar_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar` to `0.5.1-0`:
- upstream repository: https://github.com/sniekum/ar_track_alvar
- release repository: https://github.com/ros-gbp/ar_track_alvar-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## ar_track_alvar

```
* Remove meta pkg; ar_track_alvar is 'unary stack' so no need for the meta pkg.
* Contributors: Scott Niekum, Isaac IY Saito
```
