### PR TITLE
ardrone_autonomy: 1.4.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -272,7 +272,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/AutonomyLab/ardrone_autonomy-release.git
-      version: 1.3.7-0
+      version: 1.4.0-0
     source:
       type: git
       url: https://github.com/AutonomyLab/ardrone_autonomy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ardrone_autonomy` to `1.4.0-0`:
- upstream repository: https://github.com/AutonomyLab/ardrone_autonomy.git
- release repository: https://github.com/AutonomyLab/ardrone_autonomy-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.3.7-0`
## ardrone_autonomy

```
* Added support for running multiple instances of the driver on a same machine
* Added support for publishing odometry data and transform
* Deprecated "Setting TF root" and "IMU Calibration"
* Use reception time for video streams
* Improved documentation. Documentation is now hosted on readthedocs
* Updated gps-waypoint branch and its documentation
* Build system improvements + roslint + code cleanups
* Contributors: Mani Monajjemi, v01d, kbogert
```
