### PR TITLE
geometry_tutorials: 0.2.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -660,6 +660,25 @@ repositories:
       url: https://github.com/ros/geometry_experimental.git
       version: indigo-devel
     status: maintained
+  geometry_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry_tutorials.git
+      version: indigo-devel
+    release:
+      packages:
+      - geometry_tutorials
+      - turtle_tf
+      - turtle_tf2
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/geometry_tutorials-release.git
+      version: 0.2.2-0
+    source:
+      type: git
+      url: https://github.com/ros/geometry_tutorials.git
+      version: indigo-devel
+    status: maintained
   hokuyo_node:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_tutorials` to `0.2.2-0`:
- upstream repository: https://github.com/ros/geometry_tutorials
- release repository: https://github.com/ros-gbp/geometry_tutorials-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## geometry_tutorials
- No changes
## turtle_tf

```
* remove old roslib invocations
* Contributors: Tully Foote
```
## turtle_tf2

```
* homogenizing install rules and script locations with older versions
* remove old roslib invocations
* Contributors: Tully Foote
```
