### PR TITLE
simple_grasping: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8322,7 +8322,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/simple_grasping-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/mikeferguson/simple_grasping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_grasping` to `0.2.2-0`:
- upstream repository: https://github.com/mikeferguson/simple_grasping.git
- release repository: https://github.com/fetchrobotics-gbp/simple_grasping-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.1-0`
## simple_grasping

```
* parameterize gripper opening tolerance
* Contributors: Michael Ferguson
```
