### PR TITLE
rtmros_common: 1.2.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7787,7 +7787,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.2.10-0
+      version: 1.2.11-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.2.11-0`:
- upstream repository: https://github.com/start-jsk/rtmros_common.git
- release repository: https://github.com/tork-a/rtmros_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.2.10-0`
## hrpsys_ros_bridge

```
* [catkin.cmake] add depend to pr2_controllers_msgs in catpkin_package
* [cmake/compile_robot_model.cmake] fix dependency add_custom_depend need to DEPEND to other target
* [euslisp/rtm-ros-robot-interface.l] Add calculate-toe-heel-pos-offsets and set-foot-steps-with-param
* Contributors: Kei Okada, Shunichi Nozawa
```
## hrpsys_tools
- No changes
## openrtm_ros_bridge
- No changes
## openrtm_tools
- No changes
## rosnode_rtc
- No changes
## rtmbuild
- No changes
## rtmros_common
- No changes
