### PR TITLE
image_transport_plugins: 1.9.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -730,6 +730,22 @@ repositories:
       url: https://github.com/ros-perception/image_pipeline.git
       version: indigo
     status: maintained
+  image_transport_plugins:
+    release:
+      packages:
+      - compressed_depth_image_transport
+      - compressed_image_transport
+      - image_transport_plugins
+      - theora_image_transport
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/image_transport_plugins-release.git
+      version: 1.9.2-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: indigo-devel
+    status: maintained
   interactive_marker_proxy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `1.9.2-0`:
- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros-gbp/image_transport_plugins-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## compressed_depth_image_transport

```
* use compression parameters for both depths
  fixes #12 <https://github.com/ros-perception/image_transport_plugins/issues/12>
* get code to compile with OpenCV3
* Contributors: Vincent Rabaud
```
## compressed_image_transport

```
* get code to compile with OpenCV3
* avoid yet another image copy
* avoid copying data if it can be shared
* Contributors: Vincent Rabaud
```
## image_transport_plugins
- No changes
## theora_image_transport

```
* get code to compile with OpenCV3
* Contributors: Vincent Rabaud
```
