### PR TITLE
octomap_ros: 0.4.0-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1255,6 +1255,21 @@ repositories:
       url: https://github.com/OctoMap/octomap_msgs.git
       version: indigo-devel
     status: maintained
+  octomap_ros:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_ros.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_ros-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_ros.git
+      version: indigo-devel
+    status: maintained
   opencv_candidate:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_ros` to `0.4.0-1`:
- upstream repository: https://github.com/OctoMap/octomap_ros.git
- release repository: https://github.com/ros-gbp/octomap_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## octomap_ros

```
* Dropped PCL support in favor of sensor_msgs::PointCloud2.
```
