### PR TITLE
laser_assembler: 1.7.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3624,7 +3624,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/laser_assembler-release.git
-      version: 1.7.2-0
+      version: 1.7.3-0
     source:
       type: git
       url: https://github.com/ros-perception/laser_assembler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_assembler` to `1.7.3-0`:
- upstream repository: https://github.com/ros-perception/laser_assembler.git
- release repository: https://github.com/ros-gbp/laser_assembler-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.7.2-0`
## laser_assembler

```
* get the test as a proper rostest and clean CMake
  that fixes #7 <https://github.com/ros-perception/laser_assembler/issues/7>
* Merge pull request #4 <https://github.com/ros-perception/laser_assembler/issues/4> from bulwahn/hydro-devel
  make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* Contributors: Lukas Bulwahn, Vincent Rabaud
```
