### PR TITLE
laser_assembler: 1.7.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -853,6 +853,21 @@ repositories:
       url: https://github.com/ros-drivers/korg_nanokontrol.git
       version: master
     status: maintained
+  laser_assembler:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_assembler.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/laser_assembler-release.git
+      version: 1.7.3-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_assembler.git
+      version: hydro-devel
+    status: maintained
   laser_filters:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_assembler` to `1.7.3-0`:
- upstream repository: https://github.com/ros-perception/laser_assembler.git
- release repository: https://github.com/ros-gbp/laser_assembler-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## laser_assembler

```
* get the test as a proper rostest and clean CMake
  that fixes #7 <https://github.com/ros-perception/laser_assembler/issues/7>
* Merge pull request #4 <https://github.com/ros-perception/laser_assembler/issues/4> from bulwahn/hydro-devel
  make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* Contributors: Lukas Bulwahn, Vincent Rabaud
```
