### PR TITLE
geographic_info: 0.4.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -597,6 +597,25 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: indigo-devel
     status: maintained
+  geographic_info:
+    doc:
+      type: git
+      url: https://github.com/ros-geographic-info/geographic_info.git
+      version: master
+    release:
+      packages:
+      - geodesy
+      - geographic_info
+      - geographic_msgs
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-geographic-info/geographic_info-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/ros-geographic-info/geographic_info.git
+      version: master
+    status: maintained
   geometric_shapes:
     doc:
       type: git
@@ -885,21 +904,6 @@ repositories:
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
       version: indigo-devel
-    status: maintained
-  laser_pipeline:
-    doc:
-      type: git
-      url: https://github.com/ros-perception/laser_pipeline.git
-      version: hydro-devel
-    release:
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/laser_pipeline-release.git
-      version: 1.6.1-0
-    source:
-      type: git
-      url: https://github.com/ros-perception/laser_pipeline.git
-      version: hydro-devel
     status: maintained
   laser_proc:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `geographic_info` to `0.4.0-0`:
- upstream repository: https://github.com/ros-geographic-info/geographic_info.git
- release repository: https://github.com/ros-geographic-info/geographic_info-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## geodesy
- No changes
## geographic_info
- No changes
## geographic_msgs
- No changes
