### PR TITLE
Add pcre-dev key for OS X

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -450,6 +450,10 @@ pcre:
   osx:
     homebrew:
       packages: [pcre++]
+pcre-dev:
+  osx:
+    homebrew:
+      packages: [pcre++]
 pkg-config:
   osx:
     homebrew:


### PR DESCRIPTION
Added a mapping for Mac OS X for the pcre-dev key that robot_model package (1.11.7 on) now uses.

I added (rather than changed) because the build and run dependencies use different rosdep keys.  The homebrew/pcre++ package appears to satisfy both (pcre++ depends on pcre).  I'm thinking that because this is an additional key, it should not affect previous releases.

I didn't see any other dependencies on pcre based on this:
$ find . -name 'package.xml' -exec grep -Hni '_depend>pcre' {} \;
./src/robot_model/collada_urdf/package.xml:28:  <build_depend>pcre-dev</build_depend>
./src/robot_model/collada_urdf/package.xml:42:  <run_depend>pcre</run_depend>
./src/robot_model/urdf/package.xml:26:  <build_depend>pcre-dev</build_depend>
./src/robot_model/urdf/package.xml:36:  <run_depend>pcre</run_depend>
