### PR TITLE
jsk_roseus: 1.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3193,7 +3193,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.3.0-0
+      version: 1.3.1-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.3.1-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.3.0-0`
## jsk_roseus
- No changes
## roseus

```
* [cmake/roseus.cmake] fix for package only with action
* [roseus/test/roseus.cmake] check package only action messages, (jsk_demo_common)
* Contributors: Kei Okada
```
## roseus_smach

```
* [roseus_smach/src/state-machine-actionlib.l] support spin action client group, see #274 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/274>
* [roseus_smach/src/state-machine-utils.l] modify make-state-machine
* [roseus_smach/src/state-machine-utils.l] add iterative execute state machine util
* Contributors: Yuki Furuta, Hitoshi Kamada, Kei Okada
```
## roseus_tutorials
- No changes
