### PR TITLE
mavros: 0.11.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3957,7 +3957,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.11.1-0
+      version: 0.11.2-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.11.2-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.11.1-0`
## libmavconn

```
* libmavconn fix #269 <https://github.com/vooon/mavros/issues/269>: override default channel getter helpers
  Default inlined mavlink getter helpers cause issue, when each
  plugin has it's own sequence number.
* libmavconn #269 <https://github.com/vooon/mavros/issues/269>: add seq number to debug
* Contributors: Vladimir Ermakov
```
## mavros

```
* plugin: param fix #276 <https://github.com/vooon/mavros/issues/276>: add check before reset request downcounter.
  If on MR request FCU responses param with different param_index
  do not reset repeat counter to prevent endless loop.
* gcs bridge fix #277 <https://github.com/vooon/mavros/issues/277>: add link diagnostics
* plugin: setpoint_position #273 <https://github.com/vooon/mavros/issues/273>: add quirk for PX4.
* readme: fir glossary misprint
* readme: add notes about catkin tool
* Contributors: Vladimir Ermakov
```
## mavros_extras

```
* gcs bridge fix #277 <https://github.com/vooon/mavros/issues/277>: add link diagnostics
* Contributors: Vladimir Ermakov
```
