### PR TITLE
rospilot_deps: 0.0.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1977,6 +1977,17 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: indigo-devel
     status: maintained
+  rospilot_deps:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/rospilot/rospilot_deps-release.git
+      version: 0.0.7-0
+    source:
+      type: git
+      url: https://github.com/rospilot/rospilot_deps.git
+      version: master
+    status: developed
   rosserial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot_deps` to `0.0.7-0`:
- upstream repository: https://github.com/rospilot/rospilot_deps.git
- release repository: https://github.com/rospilot/rospilot_deps-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rospilot_deps

```
* Add Exynos MFC library
* Contributors: Christopher Berner
```
