### PR TITLE
rocon_concert: 0.6.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6645,7 +6645,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_concert-release.git
-      version: 0.6.7-0
+      version: 0.6.8-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_concert.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_concert` to `0.6.8-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_concert
- release repository: https://github.com/yujinrobot-release/rocon_concert-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.7-0`
## concert_conductor
- No changes
## concert_master

```
* add concert_software_farmer is missing dependency clsoses #289 <https://github.com/robotics-in-concert/rocon_concert/issues/289>
* Contributors: Jihoon Lee
```
## concert_schedulers
- No changes
## concert_service_link_graph
- No changes
## concert_service_manager

```
* improve log closes #292 <https://github.com/robotics-in-concert/rocon_concert/issues/292>
* Contributors: Jihoon Lee
```
## concert_service_utilities
- No changes
## concert_software_farmer

```
* delete timeout exception and fix wrong timeout time
* change variable name and adjusting release timeout
* update releasing process when it is shutdown
* delete dependency
* fix lock
* add dependency
* fix return value in deallocate software
* Contributors: dwlee
```
## concert_utilities
- No changes
## rocon_concert

```
* add concert_software_farmer is missing dependency clsoses #289 <https://github.com/robotics-in-concert/rocon_concert/issues/289>
* Contributors: Jihoon Lee
```
## rocon_tf_reconstructor
- No changes
