### PR TITLE
Added acpi, libssh2, vrep, python-jinja2.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2,6 +2,8 @@ ace:
   arch: [ace]
   debian: [libace-dev]
   ubuntu: [libace-dev]
+acpi:
+  ubuntu: [acpi]
 alsa-oss:
   arch: [alsa-oss]
   debian: [alsa-oss]
@@ -2044,6 +2046,10 @@ libsqlite3-dev:
 libsrtp0-dev:
   fedora: [libsrtp-devel]
   ubuntu: [libsrtp0-dev]
+libssh2:
+  ubuntu: [libssh2-1]
+libssh2-dev:
+  ubuntu: [libssh2-1-dev]
 libssl-dev:
   arch: [openssl]
   debian: [libssl-dev]
@@ -3142,6 +3148,12 @@ vlc:
   debian: [vlc]
   fedora: [vlc]
   ubuntu: [vlc]
+vrep:
+  ubuntu:
+    trusty:
+      source:
+        uri: 'https://raw.githubusercontent.com/peci1/vrep_ros_bridge/rdmanifest/vrep.rdmanifest'
+
 wkhtmltopdf:
   arch: [wkhtmltopdf]
   debian: [wkhtmltopdf]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -527,6 +527,8 @@ python-impacket:
     trusty: [python-impacket]
     utopic: [python-impacket]
     vivid: [python-impacket]
+python-jinja2:
+  ubuntu: [python-jinja2]
 python-kitchen:
   arch: [python-kitchen]
   debian: [python-kitchen]

--- a/scripts/clean_rosdep_yaml.py
+++ b/scripts/clean_rosdep_yaml.py
@@ -3,6 +3,7 @@
 import yaml
 import argparse
 import re
+import io
 
 dont_bracket = ['uri', 'md5sum']
 
@@ -51,5 +52,5 @@ if __name__ == '__main__':
     for a in sorted(iny):
         buf += prn(iny[a], a, 0)
 
-    with open(args.outfile, 'w') as f:
+    with io.open(args.outfile, 'w', encoding='utf-8') as f:
         f.write(buf)


### PR DESCRIPTION
I also fixed the clean_rosdep_yaml.py to write out files in utf-8. That's because a distro named `schrödinger's` cannot be written out as ascii.

The source uri for `vrep` should change to https://github.com/lagadic/vrep_ros_bridge as soon as my PR gets merged there. I'll take care of that.
