### PR TITLE
carl_safety: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -725,7 +725,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_safety-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_safety.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_safety` to `0.0.7-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_safety.git
- release repository: https://github.com/wpi-rail-release/carl_safety-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.6-0`
## carl_safety

```
* Merge branch 'develop' of https://github.com/WPI-RAIL/carl_safety into develop
* Added time check to arm not contained feedback to prevent multiple repeated feedback messages
* Contributors: David Kent
```
