### PR TITLE
rail_manipulation_msgs: 0.0.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6312,7 +6312,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_manipulation_msgs-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_manipulation_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_manipulation_msgs` to `0.0.7-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_manipulation_msgs.git
- release repository: https://github.com/wpi-rail-release/rail_manipulation_msgs-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.6-0`
## rail_manipulation_msgs

```
* Merge branch 'develop' of github.com:WPI-RAIL/rail_manipulation_msgs into develop
* Included success rate data with grasps
* Contributors: David Kent
```
