### PR TITLE
rail_pick_and_place: 1.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6274,7 +6274,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
-      version: 1.1.3-0
+      version: 1.1.4-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_pick_and_place.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_pick_and_place` to `1.1.4-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_pick_and_place.git
- release repository: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.3-0`
## graspdb

```
* weighted average of colors
* reuse of grasp message
* Contributors: Russell Toris
* changelog updated
* removed metric pre-compute
* stores metrics
* added segmented images to the database
* Contributors: Russell Toris
```
## rail_grasp_collection

```
* changelog updated
* added segmented images to the database
* Contributors: Russell Toris
```
## rail_pick_and_place

```
* changelog updated
* Contributors: Russell Toris
```
## rail_pick_and_place_msgs

```
* reuse of grasp message
* Added remove object functionality for the recognized object list
* Contributors: David Kent, Russell Toris
* changelog updated
* removed metric pre-compute
* stores metrics
* added segmented images to the database
* Contributors: Russell Toris
```
## rail_pick_and_place_tools

```
* changelog updated
* Contributors: Russell Toris
```
## rail_recognition

```
* weighted average of colors
* added doxygen
* bug fixes in point cloud merging
* Added remove object functionality for the recognized object list
* Combined close together objects of the same type into single objects
* Contributors: David Kent, Russell Toris
* changelog updated
* uses PCL models for generation
* cleanup of new stuff
* Recognition first performs a color check
* Recognition tuning
* added avg functions for color
* removed metric pre-compute
* stores metrics
* Contributors: David Kent, Russell Toris
```
