### PR TITLE
ros: 1.12.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1744,7 +1744,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.12.1-0
+      version: 1.12.2-0
     source:
       type: git
       url: https://github.com/ros/ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.12.2-0`:
- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.12.1-0`
## mk
- No changes
## rosbash
- No changes
## rosboost_cfg
- No changes
## rosbuild
- No changes
## rosclean
- No changes
## roscreate
- No changes
## roslang
- No changes
## roslib
- No changes
## rosmake
- No changes
## rosunit

```
* allow custom environment when determining test results location (#82 <https://github.com/ros/ros/pull/82>)
```
