### PR TITLE
ros_comm: 1.11.12-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1781,7 +1781,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.11-0
+      version: 1.11.12-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.12-0`:
- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.11-0`
## message_filters
- No changes
## ros_comm
- No changes
## rosbag
- No changes
## rosbag_storage
- No changes
## rosconsole
- No changes
## roscpp
- No changes
## rosgraph
- No changes
## roslaunch
- No changes
## roslz4
- No changes
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy
- No changes
## rosservice

```
* fix command parsing for rosservice and rostopic to not accept arbitrary substrings of 'list' (#609 <https://github.com/ros/ros_comm/issues/609>)
```
## rostest

```
* fix location of rostest result files (#82 <https://github.com/ros/ros/pull/82>)
```
## rostopic

```
* fix command parsing for rosservice and rostopic to not accept arbitrary substrings of 'list' (#609 <https://github.com/ros/ros_comm/issues/609>)
```
## roswtf
- No changes
## topic_tools
- No changes
## xmlrpcpp
- No changes
