### PR TITLE
rospilot_deps: 0.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1982,7 +1982,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/rospilot/rospilot_deps-release.git
-      version: 0.0.7-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/rospilot/rospilot_deps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot_deps` to `0.1.0-0`:
- upstream repository: https://github.com/rospilot/rospilot_deps.git
- release repository: https://github.com/rospilot/rospilot_deps-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.7-0`
## rospilot_deps

```
* Switch to new constant names for libavconv
* Contributors: Christopher Berner
```
