### PR TITLE
rocon_app_platform: 0.7.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6624,7 +6624,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_app_platform-release.git
-      version: 0.7.8-0
+      version: 0.7.9-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_app_platform` to `0.7.9-0`:
- upstream repository: http://github.com/robotics-in-concert/rocon_app_platform
- release repository: https://github.com/yujinrobot-release/rocon_app_platform-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.8-0`
## rocon_app_manager

```
* remove legacy paird.concert closes #282 <https://github.com/robotics-in-concert/rocon_app_platform/issues/282>
* Contributors: Jihoon Lee
```
## rocon_app_platform

```
* add rocon_app_utilities in meta pkg closes #284 <https://github.com/robotics-in-concert/rocon_app_platform/issues/284>
* Contributors: Jihoon Lee
```
## rocon_app_utilities
- No changes
## rocon_apps

```
* update waypoint_nav rapp
* Contributors: Jihoon Lee
```
