### PR TITLE
multimaster_fkie: 0.4.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4447,7 +4447,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.4.1-0`:
- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.4.0-0`
## default_cfg_fkie

```
* multimaster_fkie: fixed double log output
* Contributors: Alexander Tiderko
```
## master_discovery_fkie

```
* Deprecate is_ignored_topic. Move new parameters to the end of the parameter list
* Make configuration more granular
  allows filtering of specific subscribers or publishers
* multimaster_fkie: fixed double log output
* multimaster_fkie: added network problem detection on remote hosts
* multimaster_fkie: fixed error in launch files included in this package
* Contributors: Alexander Tiderko, Julian Cerruti
```
## master_sync_fkie

```
* Deprecate is_ignored_topic. Move new parameters to the end of the parameter list
* Make configuration more granular
  allows filtering of specific subscribers or publishers
* multimaster_fkie: fixed double log output
* multimaster_fkie: fixed error in launch files included in this package
* Contributors: Alexander Tiderko, Julian Cerruti
```
## multimaster_fkie
- No changes
## multimaster_msgs_fkie
- No changes
## node_manager_fkie

```
* node_manager_fkie: fixed error while parsing list of lists in parameter dialog
* node_manager_fkie: added scrollarea for dynamic_reconfigure widget
* fixed the usage of new parameter in node_manager
* node_manager_fkie: fixed binary selection while 'add node'
* multimaster_fkie: fixed double log output
* node_manager_fkie: fix to enable the master list if a master_discavery was started
* node_manager_fkie: fixed recursive search
* multimaster_fkie: added network problem detection on remote hosts
* node_manager_fkie: older paramiko versions does not support get_pty parameter in exce_command
* node_manager_fkie: fixed stdout error while transfer files to remote host
* node_manager_fkie: ignore errors caused on after the echo dialog was closed
* node_manager_fkie: changed the color of illegal ros node names
* Contributors: Alexander Tiderko
```
