### PR TITLE
nao_robot: 0.5.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4560,7 +4560,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-naoqi/nao_robot-release.git
-      version: 0.5.6-0
+      version: 0.5.7-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_robot.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4576,7 +4576,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/nao_robot-release.git
-      version: 0.5.6-0
+      version: 0.5.7-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_robot.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4415,7 +4415,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_robot` to `0.5.7-0`:
- upstream repository: https://github.com/ros-naoqi/nao_robot.git
- release repository: https://github.com/ros-naoqi/nao_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.5.6-0`
## nao_apps

```
* properly install Python scripts
  This fixes #19 <https://github.com/ros-naoqi/nao_robot/issues/19>
* no need for custom file
* enable goto initial pose to start walking
* Contributors: Karsten Knese, Vincent Rabaud
```
## nao_bringup

```
* remove legacy sonar node
* set nao walker by default
* Contributors: Karsten Knese
```
## nao_description

```
* update full .urdf file using xacro
* fixed ankle drift
* Contributors: Mikael Arguedas, Vincent Rabaud
```
## nao_pose

```
* properly install Python scripts
  This fixes #19 <https://github.com/ros-naoqi/nao_robot/issues/19>
* Contributors: Vincent Rabaud
```
## nao_robot
- No changes
