### PR TITLE
Revert "rospilot: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7500,7 +7500,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rospilot/rospilot-release.git
-      version: 0.2.0-0
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/rospilot/rospilot.git


### PR DESCRIPTION
Reverts ros/rosdistro#8154

0.2.0 doesn't build on saucy, due to dependency version mismatch. Will continue development in jade instead
