### PR TITLE
spur: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8426,7 +8426,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/spur-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/tork-a/spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `spur` to `0.1.1-0`:
- upstream repository: https://github.com/tork-a/spur.git
- release repository: https://github.com/tork-a/spur-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.0-0`
## spur

```
* Enable Odometry RViz plugin.
* (Feature) Add a launch for joy, kb teleop
* Contributors: Isaac IY Saito
```
## spur_controller

```
* (Feature) Add a launch for joy, kb teleop
* Contributors: Isaac IY Saito
```
## spur_description

```
* Enable Odometry RViz plugin.
* Contributors: Isaac IY Saito
```
## spur_gazebo
- No changes
