### PR TITLE
opencv3: 2.9.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5169,7 +5169,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/vrabaud/opencv3-release.git
-      version: 2.9.4-1
+      version: 2.9.5-0
     status: maintained
   opencv_candidate:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `opencv3` to `2.9.5-0`:
- upstream repository: /home/vrabaud/software/opencv
- release repository: https://github.com/vrabaud/opencv3-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.9.4-1`
