### PR TITLE
opencv3: 2.9.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1355,6 +1355,13 @@ repositories:
       url: https://github.com/OctoMap/octomap_ros.git
       version: indigo-devel
     status: maintained
+  opencv3:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/vrabaud/opencv3-release.git
+      version: 2.9.5-0
+    status: maintained
   opencv_candidate:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `opencv3` to `2.9.5-0`:
- upstream repository: /home/vrabaud/software/opencv
- release repository: https://github.com/vrabaud/opencv3-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
