### PR TITLE
mrpt_navigation: 0.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4367,7 +4367,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `0.1.5-0`:
- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.4-0`
## mrpt_bridge

```
* mrpt_bridge: BUGFIX in convert() for 360deg scans
* Cleaner build against mrpt 1.3.0
* Fix build against mrpt 1.3.0
* Contributors: Jose Luis Blanco
```
## mrpt_local_obstacles

```
* mrpt_local_obstacles: Fix wrong report of number of scan sources
* Fix build against mrpt 1.3.0
* Contributors: Jose Luis Blanco
```
## mrpt_localization

```
* fix to strange pf-localization bug
* Cleaner build against mrpt 1.3.0
* Fix build against mrpt 1.3.0
* Contributors: Jose Luis Blanco
```
## mrpt_map

```
* Fix build against mrpt 1.3.0
* Contributors: Jose Luis Blanco
```
## mrpt_msgs
- No changes
## mrpt_navigation
- No changes
## mrpt_rawlog

```
* Cleaner build against mrpt 1.3.0
* Fix build against mrpt 1.3.0
* Contributors: Jose Luis Blanco
```
## mrpt_reactivenav2d
- No changes
## mrpt_tutorials

```
* update on gazebo model for tutorial
* Contributors: Markus Bader
```
