### PR TITLE
ivcon: 0.1.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -828,6 +828,21 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: indigo-devel
     status: maintained
+  ivcon:
+    doc:
+      type: git
+      url: https://github.com/ros/ivcon.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/ivcon-release.git
+      version: 0.1.5-0
+    source:
+      type: git
+      url: https://github.com/ros/ivcon.git
+      version: indigo-devel
+    status: maintained
   jsk_roseus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ivcon` to `0.1.5-0`:
- upstream repository: https://github.com/ros/ivcon.git
- release repository: https://github.com/ros-gbp/ivcon-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## ivcon

```
* Indigo devel
* Added tag 0.1.4 for changeset 4f7be6010df7
* Contributors: Ioan Sucan, dash
```
