### PR TITLE
convex_decomposition: 0.1.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -319,6 +319,21 @@ repositories:
       url: https://github.com/ros-controls/control_msgs.git
       version: indigo-devel
     status: maintained
+  convex_decomposition:
+    doc:
+      type: git
+      url: https://github.com/ros/convex_decomposition.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/convex_decomposition-release.git
+      version: 0.1.10-0
+    source:
+      type: git
+      url: https://github.com/ros/convex_decomposition.git
+      version: indigo-devel
+    status: maintained
   cram_3rdparty:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `convex_decomposition` to `0.1.10-0`:
- upstream repository: https://github.com/ros/convex_decomposition.git
- release repository: https://github.com/ros-gbp/convex_decomposition-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## convex_decomposition

```
* Added tag 0.1.9 for changeset c7c2984fc16f
* Contributors: Dirk Thomas
```
