### PR TITLE
pr2_common: 1.11.9-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1557,6 +1557,27 @@ repositories:
       url: https://github.com/ros-drivers/pointgrey_camera_driver.git
       version: master
     status: maintained
+  pr2_common:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_common.git
+      version: indigo-devel
+    release:
+      packages:
+      - pr2_common
+      - pr2_dashboard_aggregator
+      - pr2_description
+      - pr2_machine
+      - pr2_msgs
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_common-release.git
+      version: 1.11.9-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_common.git
+      version: indigo-devel
+    status: maintained
   python_ethernet_rmp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common` to `1.11.9-0`:
- upstream repository: https://github.com/pr2/pr2_common.git
- release repository: https://github.com/pr2-gbp/pr2_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## pr2_common
- No changes
## pr2_dashboard_aggregator
- No changes
## pr2_description

```
* Updated maintainership
* Contributors: TheDash
```
## pr2_machine
- No changes
## pr2_msgs
- No changes
