### PR TITLE
gazebo5: new rosdep keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -694,6 +694,9 @@ gazebo:
     raring: [gazebo]
     saucy: [gazebo2]
     trusty: [gazebo2]
+gazebo5:
+  arch: [gazebo]
+  ubuntu: [gazebo5]
 gcc-avr:
   arch: [avr-gcc]
   debian: [gcc-avr]
@@ -1265,6 +1268,9 @@ libftgl-dev:
     portage:
       packages: [media-libs/ftgl]
   ubuntu: [libftgl-dev]
+libgazebo5-dev:
+  arch: [gazebo]
+  ubuntu: [libgazebo5-dev]
 libgflags-dev:
   fedora: [gflags-devel]
   gentoo:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -107,6 +107,10 @@ gazebo:
   osx:
     homebrew:
       packages: [gazebo]
+gazebo5:
+  osx:
+    homebrew:
+      packages: [osrf/simulation/gazebo5]
 gccxml:
   osx:
     homebrew:
@@ -183,6 +187,10 @@ libftgl-dev:
   osx:
     homebrew:
       packages: [ftgl]
+libgazebo5-dev:
+  osx:
+    homebrew:
+      depends: [gazebo5]
 libglew-dev:
   osx:
     homebrew:


### PR DESCRIPTION
Includes arch, homebrew, and ubuntu.
The latest Fedora version is gazebo4 so that will have to wait.

Needed for gazebo_ros_pkgs jade release (https://github.com/ros-simulation/gazebo_ros_pkgs/issues/318).

@wjwwood 
