### PR TITLE
rospilot: 0.2.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2065,7 +2065,11 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/rospilot/rospilot-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/rospilot/rospilot.git
+      version: master
     status: developed
   rospilot_deps:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot` to `0.2.1-0`:
- upstream repository: https://github.com/rospilot/rospilot.git
- release repository: https://github.com/rospilot/rospilot-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.0-0`
## rospilot

```
* Switch to libnl 3.0
* Update to new libavconv constants
* Improve error handling in setup script
* Contributors: Christopher Berner
```
