### PR TITLE
rqt: 0.2.14-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2107,6 +2107,26 @@ repositories:
       url: https://github.com/ros-drivers/rosserial.git
       version: jade-devel
     status: maintained
+  rqt:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: groovy-devel
+    release:
+      packages:
+      - rqt
+      - rqt_gui
+      - rqt_gui_cpp
+      - rqt_gui_py
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/rqt-release.git
+      version: 0.2.14-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: groovy-devel
+    status: maintained
   rtctree:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `0.2.14-0`:
- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros-gbp/rqt-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rqt_gui
- No changes
## rqt_gui_cpp

```
* add ros spinner thread for cpp plugins (#95 <https://github.com/ros-visualization/rqt/issues/95>)
```
## rqt_gui_py
- No changes
