### PR TITLE
control_toolbox: 1.13.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1241,7 +1241,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/control_toolbox-release.git
-      version: 1.13.0-0
+      version: 1.13.1-0
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `1.13.1-0`:
- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros-gbp/control_toolbox-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.13.0-0`
## control_toolbox

```
* Improvement in integral contribution implementation. Resolve #32 <https://github.com/ros-controls/control_toolbox/issues/32>.
* Contributors: Adolfo Rodriguez Tsouroukdissian, Carlos Rosales
```
