### PR TITLE
realtime_tools: 1.9.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1705,6 +1705,21 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  realtime_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/realtime_tools-release.git
+      version: 1.9.1-0
+    source:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: indigo-devel
+    status: maintained
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `1.9.1-0`:
- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros-gbp/realtime_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## realtime_tools

```
* RealtimeBox: Fix member doc
* Contributors: Adolfo Rodriguez Tsouroukdissian, Dave Coleman
```
