### PR TITLE
control_toolbox: 1.13.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -319,6 +319,21 @@ repositories:
       url: https://github.com/ros-controls/control_msgs.git
       version: indigo-devel
     status: maintained
+  control_toolbox:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/control_toolbox.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/control_toolbox-release.git
+      version: 1.13.1-0
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_toolbox.git
+      version: indigo-devel
+    status: maintained
   convex_decomposition:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `1.13.1-0`:
- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros-gbp/control_toolbox-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## control_toolbox

```
* Improvement in integral contribution implementation. Resolve #32 <https://github.com/ros-controls/control_toolbox/issues/32>.
* Contributors: Adolfo Rodriguez Tsouroukdissian, Carlos Rosales
```
