### PR TITLE
downgrading OpenCV3 on Indigo until Saucy compilation is fixed

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5169,7 +5169,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/opencv3-release.git
-      version: 2.9.5-0
+      version: 2.9.4-0
     status: maintained
   opencv_candidate:
     release:


### PR DESCRIPTION
follow-up on http://code.opencv.org/issues/3986
