### PR TITLE
rqt_robot_plugins: 0.4.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2199,6 +2199,32 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: groovy-devel
     status: maintained
+  rqt_robot_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_plugins.git
+      version: hydro-devel
+    release:
+      packages:
+      - rqt_moveit
+      - rqt_nav_view
+      - rqt_pose_view
+      - rqt_robot_dashboard
+      - rqt_robot_monitor
+      - rqt_robot_plugins
+      - rqt_robot_steering
+      - rqt_runtime_monitor
+      - rqt_rviz
+      - rqt_tf_tree
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
+      version: 0.4.1-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_plugins.git
+      version: hydro-devel
+    status: developed
   rtctree:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins` to `0.4.1-0`:
- upstream repository: https://github.com/ros-visualization/rqt_robot_plugins.git
- release repository: https://github.com/ros-gbp/rqt_robot_plugins-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rqt_moveit

```
* marking plugin as experimental for now
```
## rqt_nav_view
- No changes
## rqt_pose_view
- No changes
## rqt_robot_dashboard
- No changes
## rqt_robot_monitor

```
* fix installing missing bag_plugin xml (#288 <https://github.com/ros-visualization/rqt_common_plugins/issues/288>)
```
## rqt_robot_plugins
- No changes
## rqt_robot_steering
- No changes
## rqt_runtime_monitor
- No changes
## rqt_rviz
- No changes
## rqt_tf_tree
- No changes
