### PR TITLE
metapackages: 1.1.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1117,6 +1117,22 @@ repositories:
       url: https://github.com/ros/message_runtime.git
       version: groovy-devel
     status: maintained
+  metapackages:
+    release:
+      packages:
+      - desktop
+      - desktop_full
+      - perception
+      - robot
+      - ros_base
+      - ros_core
+      - simulators
+      - viz
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/metapackages-release.git
+      version: 1.1.3-0
+    status: maintained
   microstrain_3dmgx2_imu:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `metapackages` to `1.1.3-0`:
- upstream repository: https://github.com/ros/metapackages.git
- release repository: https://github.com/ros-gbp/metapackages-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
