### PR TITLE
moveit_resources: 0.5.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1151,6 +1151,13 @@ repositories:
       url: https://github.com/ros-gbp/moveit_msgs-release.git
       version: 0.6.1-0
     status: developed
+  moveit_resources:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_resources-release.git
+      version: 0.5.0-0
+    status: maintained
   mrpt_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `0.5.0-0`:
- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros-gbp/moveit_resources-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## moveit_resources

```
* bump version for hydro
```
