### PR TITLE
graft: 0.2.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2317,7 +2317,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/graft-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/graft.git
+      version: hydro-devel
     status: developed
   graph_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `graft` to `0.2.2-0`:
- upstream repository: https://github.com/ros-perception/graft.git
- release repository: https://github.com/ros-gbp/graft-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.1-0`
## graft

```
* fix compilation on 32-bit systems
* update maintainer email
* Contributors: Michael Ferguson
```
