### PR TITLE
geometric_shapes: 0.3.9-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2194,7 +2194,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.3.6-0
+      version: 0.3.9-0
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.3.9-0`:
- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.6-0`
## geometric_shapes

```
* Prevent every mesh generation opening a new file handle.
* add functions for better display of convex meshes
* produce actual triangles for qhull mesh
* Fixed inverted scale for convex meshes inside check
* fix configure config.h.in when paths contain spaces (fix #9 <https://github.com/ros-planning/geometric_shapes/issues/9>)
* Contributors: Acorn, Christian Dornhege, Dave Hershberger, Dirk Thomas, Ioan A Sucan, Michael Ferguson
```
