### PR TITLE
camera_info_manager_py: 0.2.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -197,6 +197,21 @@ repositories:
       url: https://github.com/ros-perception/calibration.git
       version: hydro
     status: maintained
+  camera_info_manager_py:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/camera_info_manager_py.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/camera_info_manager_py-release.git
+      version: 0.2.3-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/camera_info_manager_py.git
+      version: master
+    status: maintained
   carl_estop:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_info_manager_py` to `0.2.3-0`:
- upstream repository: https://github.com/ros-perception/camera_info_manager_py.git
- release repository: https://github.com/ros-gbp/camera_info_manager_py-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## camera_info_manager_py
- No changes
