### PR TITLE
naoqi_bridge: 0.4.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1226,6 +1226,24 @@ repositories:
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
       version: master
     status: maintained
+  naoqi_bridge:
+    release:
+      packages:
+      - naoqi_apps
+      - naoqi_bridge
+      - naoqi_driver
+      - naoqi_msgs
+      - naoqi_sensors
+      - naoqi_tools
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-naoqi/naoqi_bridge-release.git
+      version: 0.4.7-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_bridge.git
+      version: master
+    status: maintained
   navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge` to `0.4.7-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_bridge.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## naoqi_apps
- No changes
## naoqi_bridge
- No changes
## naoqi_driver

```
* MOVETO: transform moveTo commands in /base_footprint frame.
* Contributors: lsouchet
```
## naoqi_msgs
- No changes
## naoqi_sensors

```
* install octomap_python
* Contributors: Vincent Rabaud
```
## naoqi_tools
- No changes
