### PR TITLE
nao_robot: 0.5.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1226,6 +1226,23 @@ repositories:
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
       version: master
     status: maintained
+  nao_robot:
+    release:
+      packages:
+      - nao_apps
+      - nao_bringup
+      - nao_description
+      - nao_pose
+      - nao_robot
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-naoqi/nao_robot-release.git
+      version: 0.5.7-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/nao_robot.git
+      version: master
+    status: maintained
   naoqi_bridge:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_robot` to `0.5.7-0`:
- upstream repository: https://github.com/ros-naoqi/nao_robot.git
- release repository: https://github.com/ros-naoqi/nao_robot-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## nao_apps

```
* properly install Python scripts
  This fixes #19 <https://github.com/ros-naoqi/nao_robot/issues/19>
* no need for custom file
* enable goto initial pose to start walking
* Contributors: Karsten Knese, Vincent Rabaud
```
## nao_bringup

```
* remove legacy sonar node
* set nao walker by default
* Contributors: Karsten Knese
```
## nao_description

```
* update full .urdf file using xacro
* fixed ankle drift
* Contributors: Mikael Arguedas, Vincent Rabaud
```
## nao_pose

```
* properly install Python scripts
  This fixes #19 <https://github.com/ros-naoqi/nao_robot/issues/19>
* Contributors: Vincent Rabaud
```
## nao_robot
- No changes
