### PR TITLE
nao_viz: 0.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1243,6 +1243,19 @@ repositories:
       url: https://github.com/ros-naoqi/nao_robot.git
       version: master
     status: maintained
+  nao_viz:
+    release:
+      packages:
+      - nao_dashboard
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/nao_viz-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/nao_viz.git
+      version: master
+    status: maintained
   naoqi_bridge:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_viz` to `0.1.2-0`:
- upstream repository: https://github.com/ros-nao/nao_viz.git
- release repository: https://github.com/ros-gbp/nao_viz-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## nao_dashboard

```
* switch to using naoqi_msgs and not nao_msgs
* Contributors: Vincent Rabaud
```
