### PR TITLE
pepper_robot: 0.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1655,6 +1655,26 @@ repositories:
       url: https://github.com/ros-naoqi/pepper_meshes.git
       version: master
     status: maintained
+  pepper_robot:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_robot.git
+      version: master
+    release:
+      packages:
+      - pepper_bringup
+      - pepper_description
+      - pepper_robot
+      - pepper_sensors
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-naoqi/pepper_robot-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_robot.git
+      version: master
+    status: maintained
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_robot` to `0.1.2-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_robot.git
- release repository: https://github.com/ros-naoqi/pepper_robot-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## pepper_bringup
- No changes
## pepper_description
- No changes
## pepper_robot
- No changes
## pepper_sensors

```
* clean CMake file
* Contributors: Vincent Rabaud
```
