### PR TITLE
maggie_drivers: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3930,6 +3930,18 @@ repositories:
       type: git
       url: https://github.com/UC3MSocialRobots/maggie_drivers.git
       version: hydro-devel
+    release:
+      packages:
+      - maggie_drivers
+      - maggie_ir_drivers
+      - maggie_labjack_drivers
+      - maggie_motor_drivers
+      - maggie_rfid_drivers
+      - maggie_serial_comm_drivers
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/UC3MSocialRobots/maggie_drivers-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/UC3MSocialRobots/maggie_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `maggie_drivers` to `0.0.1-0`:
- upstream repository: https://github.com/UC3MSocialRobots/maggie_drivers.git
- release repository: https://github.com/UC3MSocialRobots/maggie_drivers-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## maggie_drivers

```
Initial release.
```
## maggie_ir_drivers

```
Initial release.
```
## maggie_labjack_drivers

```
Initial release.
```
## maggie_motor_drivers

```
Initial release.
```
## maggie_rfid_drivers

```
Initial release.
```
## maggie_serial_comm_drivers

```
Initial release.
```
