### PR TITLE
object_recognition_ros: 0.3.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1492,6 +1492,17 @@ repositories:
       url: https://github.com/wg-perception/ork_renderer.git
       version: master
     status: maintained
+  object_recognition_ros:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_ros-release.git
+      version: 0.3.5-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/object_recognition_ros.git
+      version: master
+    status: maintained
   object_recognition_tod:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_ros` to `0.3.5-0`:
- upstream repository: https://github.com/wg-perception/object_recognition_ros.git
- release repository: https://github.com/ros-gbp/object_recognition_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## object_recognition_ros

```
* remove useless dependency on tf
* Merge pull request #17 <https://github.com/wg-perception/object_recognition_ros/issues/17> from v4hn/boost-scoped-ptr
  add missing include of scoped_ptr
* add missing include of scoped_ptr
  This becomes necessary with boost 1.57
* export the proper library
* Contributors: Michael Görner, Vincent Rabaud
```
