### PR TITLE
object_recognition_ros_visualization: 0.3.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1492,6 +1492,17 @@ repositories:
       url: https://github.com/wg-perception/ork_renderer.git
       version: master
     status: maintained
+  object_recognition_ros_visualization:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_ros_visualization-release.git
+      version: 0.3.6-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/object_recognition_ros_visualization.git
+      version: master
+    status: maintained
   object_recognition_tod:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_ros_visualization` to `0.3.6-0`:
- upstream repository: https://github.com/wg-perception/object_recognition_ros_visualization.git
- release repository: https://github.com/ros-gbp/object_recognition_ros_visualization-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## object_recognition_ros_visualization

```
* Merge pull request #3 <https://github.com/wg-perception/object_recognition_ros_visualization/issues/3> from v4hn/colorful-tables
  Add color property to table display
* Add color property to table display
  Now tables can have different colors.
  This is helpful if you get tables from different sources...
* Merge pull request #2 <https://github.com/wg-perception/object_recognition_ros_visualization/issues/2> from v4hn/moc-boost-1.57
  Fix build with qt4's moc & boost 1.57
* Fix build with qt4's moc & boost 1.57
  This is a common workaround to make sure moc doesn't see
  preprocessorvariables it doesn't like in boost...
* Contributors: Michael Görner, Vincent Rabaud
```
