### PR TITLE
descartes: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1417,7 +1417,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-industrial-release/descartes-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/ros-industrial-consortium/descartes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `descartes` to `0.0.3-0`:
- upstream repository: https://github.com/ros-industrial-consortium/descartes.git
- release repository: https://github.com/ros-industrial-release/descartes-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.2-0`
## descartes

```
* No changes
```
## descartes_core

```
* No changes
```
## descartes_moveit

```
* Calls the isValid(...) method in order to verify the joint solution
* Robot state now passed by reference to seed generator to remove requirement to use smart pointer. Added getter function for robot state object so you can get it even if you use the initialize method
* State adapter now automatically creates random seeds that can be mutated by calling helper functions in the seed namespace
Contributors: Jonathan Meyer, jrgnicho
```
## descartes_planner

```
* No changes
```
## descartes_trajectory

```
* Initializes the wobj_pt tolerance frame member with a fully defined nominal pose
* Contributors: Shaun Edwards, jrgnicho
```
