### PR TITLE
rqt_ez_publisher: 0.3.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2385,6 +2385,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_common_plugins.git
       version: groovy-devel
     status: developed
+  rqt_ez_publisher:
+    doc:
+      type: git
+      url: https://github.com/OTL/rqt_ez_publisher.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/OTL/rqt_ez_publisher-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/OTL/rqt_ez_publisher.git
+      version: jade-devel
+    status: developed
   rqt_robot_plugins:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_ez_publisher` to `0.3.0-0`:
- upstream repository: https://github.com/OTL/rqt_ez_publisher.git
- release repository: https://github.com/OTL/rqt_ez_publisher-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rqt_ez_publisher

```
* Add save/load button in config dialog
* Support yaml setting file
* Support action in devel environment
* update some log messages
```
