### PR TITLE
python_qt_binding: 0.2.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6139,7 +6139,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/python_qt_binding-release.git
-      version: 0.2.14-0
+      version: 0.2.15-0
     source:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `0.2.15-0`:
- upstream repository: git://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros-gbp/python_qt_binding-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.14-0`
## python_qt_binding

```
* support PyQt4.11 and higher when built with configure-ng.py (#13 <https://github.com/ros-visualization/python_qt_binding/issues/13>)
* __builtin__ became builtins in Python 3 (#16 <https://github.com/ros-visualization/python_qt_binding/issues/16>)
```
