### PR TITLE
rqt_robot_plugins: 0.4.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7685,7 +7685,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins` to `0.4.1-0`:
- upstream repository: https://github.com/ros-visualization/rqt_robot_plugins.git
- release repository: https://github.com/ros-gbp/rqt_robot_plugins-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.4.0-0`
## rqt_moveit

```
* marking plugin as experimental for now
```
## rqt_nav_view
- No changes
## rqt_pose_view
- No changes
## rqt_robot_dashboard
- No changes
## rqt_robot_monitor

```
* fix installing missing bag_plugin xml (#288 <https://github.com/ros-visualization/rqt_common_plugins/issues/288>)
```
## rqt_robot_plugins
- No changes
## rqt_robot_steering
- No changes
## rqt_runtime_monitor
- No changes
## rqt_rviz
- No changes
## rqt_tf_tree
- No changes
