### PR TITLE
rqt_common_plugins: 0.3.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7678,7 +7678,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.3.10-0
+      version: 0.3.11-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `0.3.11-0`:
- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/ros-gbp/rqt_common_plugins-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.10-0`
## rqt_action
- No changes
## rqt_bag

```
* fix viewer plugin relocation issue (#306 <https://github.com/ros-visualization/rqt_common_plugins/issues/306>)
```
## rqt_bag_plugins

```
* add missing dependency on rqt_plot (#316 <https://github.com/ros-visualization/rqt_common_plugins/pull/316>)
* work around Pillow segfault if PyQt5 is installed (#289 <https://github.com/ros-visualization/rqt_common_plugins/pull/289>, #290 <https://github.com/ros-visualization/rqt_common_plugins/pull/290>)
```
## rqt_common_plugins
- No changes
## rqt_console
- No changes
## rqt_dep

```
* install rqt_dep globally (#286 <https://github.com/ros-visualization/rqt_common_plugins/pull/286>)
```
## rqt_graph

```
* fix duplicate rendering of statistics information (#283 <https://github.com/ros-visualization/rqt_common_plugins/issues/283>)
```
## rqt_image_view

```
* fix image shrinking problem (#291 <https://github.com/ros-visualization/rqt_common_plugins/issues/291>)
```
## rqt_launch
- No changes
## rqt_logger_level
- No changes
## rqt_msg

```
* fix right click view (#317 <https://github.com/ros-visualization/rqt_common_plugins/issues/317>)
```
## rqt_plot

```
* save and restore axes settings (#234 <https://github.com/ros-visualization/rqt_common_plugins/issues/234>)
* remove warning when backend is not found (#301 <https://github.com/ros-visualization/rqt_common_plugins/issues/301>)
* fix version clash for matplot backend when PyQt5 is installed (#299 <https://github.com/ros-visualization/rqt_common_plugins/pull/200>)
```
## rqt_publisher
- No changes
## rqt_py_common
- No changes
## rqt_py_console
- No changes
## rqt_reconfigure

```
* restore support for parameter groups (#162 <https://github.com/ros-visualization/rqt_common_plugins/issues/162>)
* fix background colors for dark themes (#293 <https://github.com/ros-visualization/rqt_common_plugins/issues/293>)
```
## rqt_service_caller
- No changes
## rqt_shell
- No changes
## rqt_srv
- No changes
## rqt_top

```
* fix information when nodes are restarted, remove dead nodes from memory (#294 <https://github.com/ros-visualization/rqt_common_plugins/issues/294>)
* fix rqt_top script (#303 <https://github.com/ros-visualization/rqt_common_plugins/issues/303>)
```
## rqt_topic
- No changes
## rqt_web
- No changes
