### PR TITLE
p2os: 2.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1625,6 +1625,24 @@ repositories:
       url: https://github.com/orocos/orocos_kinematics_dynamics.git
       version: master
     status: maintained
+  p2os:
+    doc:
+      type: git
+      url: https://github.com/allenh1/p2os.git
+      version: master
+    release:
+      packages:
+      - p2os_doc
+      - p2os_driver
+      - p2os_launch
+      - p2os_msgs
+      - p2os_teleop
+      - p2os_urdf
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/allenh1/p2os-release.git
+      version: 2.0.0-0
+    status: developed
   pcl_conversions:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `2.0.0-0`:
- upstream repository: https://github.com/allenh1/p2os
- release repository: https://github.com/allenh1/p2os-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
