### PR TITLE
p2os: 1.0.10-0 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3108,7 +3108,8 @@ repositories:
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
-      version: 1.0.9-0
+      version: 1.0.10-0
+    status: developed
   pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `1.0.10-0`:
- upstream repository: https://github.com/allenh1/p2os
- release repository: https://github.com/allenh1/p2os-release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.9-0`
## p2os_driver
- No changes
## p2os_launch
- No changes
## p2os_teleop

```
* Added issue tracker to package.xml for telop
* Contributors: Hunter Allen
```
## p2os_urdf

```
* Added meshes directory to CMake install dir.
* Removed unneccessary files
* Contributors: Hunter Allen
```
