### PR TITLE
jsk_roseus: 1.3.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3198,7 +3198,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.3.3-0
+      version: 1.3.4-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.3.4-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.3.3-0`
## jsk_roseus
- No changes
## roseus

```
* [roseus.cpp] add get-host, get-nodes, get-port, get-uri, get-topics, from http://docs.ros.org/indigo/api/roscpp/html/master_8h.html
* [euslisp/roseus-utils.l] support bodyset object
* [euslisp/roseus-utils.l] support random color
* [euslisp/roseus-utils.l] support object with :glvertices
* [jsk_roseus] Parallelize generate-all-msg-srv
* Contributors: Kei Okada, Ryohei Ueda
```
## roseus_smach

```
* [roseus_smach] add test for parallel state machine
* [roseus_smach] add parallel state machine sample test to CMakeLists
* [roseus_smach] add sample test to CMakeLists
* [roseus_smach] split sample test in order to inspect failure detail
* [roseus_smach] change order of roseus in find_package
* [roseus_smach] move smach-exec function from sample to utils
* [roseus_smach] fix wrong file/module name
* Merge pull request #294 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/294> from furushchev/fix-multiple-return-value-in-parallel-state
  [roseus_smach] fix transition fail when parallel state
* [roseus_smach] miscellaneous fixes
* [roseus_smach] add test launch
* Merge branch 'master' of https://github.com/jsk-ros-pkg/jsk_roseus into async-join-state
  Conflicts:
  .travis
* [roseus_smach] add feature async join
* [roseus_smach] fix transition fail when parallel state
* [roseus_smach] add async join state to  state-machine
* [roseus_smach] fix tmp -> next
* [roseus_smach] modify state-machine :execute-impl
* Contributors: Yuki Furuta, Kamada Hitoshi, Kei Okada
```
## roseus_tutorials
- No changes
