### PR TITLE
p2os: 1.0.11-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5368,6 +5368,10 @@ repositories:
       url: https://github.com/Oriense/orsens_ros.git
       version: master
   p2os:
+    doc:
+      type: git
+      url: https://raw.githubusercontent.com/allenh1/p2os/master/p2os_doc/p2os_driver/html/index.html
+      version: master
     release:
       packages:
       - p2os_doc
@@ -5379,7 +5383,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
-      version: 1.0.11-0
+      version: 1.0.11-1
     status: developed
   pcan_topics:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `1.0.11-1`:
- upstream repository: https://github.com/allenh1/p2os
- release repository: https://github.com/allenh1/p2os-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.11-0`
## p2os_doc

```
* Added documentation package. Currently just the p2os_driver. Also removed a line in p2os_launch cmake list.
* Contributors: Hunter Allen
```
## p2os_driver
- No changes
## p2os_launch
- No changes
## p2os_msgs

```
* Fixed dependency issues and cleaned up package.xml and CMakeLists.txt for p2os_driver and p2os_msgs
* Separated p2os_driver and p2os_msgs
* Contributors: Aris Synodinos
```
## p2os_teleop
- No changes
## p2os_urdf
- No changes
