### PR TITLE
jsk_roseus: 1.3.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -940,7 +940,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.3.3-0
+      version: 1.3.4-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.3.4-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.3.3-0`
## jsk_roseus
- No changes
## roseus

```
* [roseus.cpp] add get-host, get-nodes, get-port, get-uri, get-topics, from http://docs.ros.org/indigo/api/roscpp/html/master_8h.html
* [euslisp/roseus-utils.l] support bodyset object
* [euslisp/roseus-utils.l] support random color
* [euslisp/roseus-utils.l] support object with :glvertices
* [jsk_roseus] Parallelize generate-all-msg-srv
* Contributors: Kei Okada, Ryohei Ueda
```
