### PR TITLE
p2os: 2.0.0-1 in 'groovy/distribution.yaml' [bloom]

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3101,14 +3101,21 @@ repositories:
       url: https://github.com/allenh1/p2os.git
     release:
       packages:
+      - p2os_doc
       - p2os_driver
       - p2os_launch
+      - p2os_msgs
       - p2os_teleop
       - p2os_urdf
       tags:
         release: release/groovy/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
-      version: 1.0.9-0
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/allenh1/p2os.git
+      version: master
+    status: developed
   pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `2.0.0-1`:
- upstream repository: https://github.com/allenh1/p2os
- release repository: https://github.com/allenh1/p2os-release.git
- distro file: `groovy/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.9-0`
