### PR TITLE
sr_common_drivers: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8421,7 +8421,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/UC3MSocialRobots/sr_common_drivers-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/UC3MSocialRobots/sr_common_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_common_drivers` to `0.0.3-0`:
- upstream repository: https://github.com/UC3MSocialRobots/sr_common_drivers.git
- release repository: https://github.com/UC3MSocialRobots/sr_common_drivers-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.2-0`
## sr_common_drivers

```
Updated with ROS headers structure.
```
## sr_communications

```
Updated with ROS headers structure.
```
