### PR TITLE
leap_motion: 0.0.8-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3692,7 +3692,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/leap_motion-release.git
-      version: 0.0.7-0
+      version: 0.0.8-1
     source:
       type: git
       url: https://github.com/ros-drivers/leap_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leap_motion` to `0.0.8-1`:
- upstream repository: https://github.com/ros-drivers/leap_motion
- release repository: https://github.com/ros-gbp/leap_motion-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.7-0`
## leap_motion

```
* (Feature) Take ROS msg publish frequency from commandline, set it to Parameter Server
* (Maintenance) Add unittest structure.
* Contributors: Isaac I.Y. Saito
```
