### PR TITLE
jsk_common: 1.0.67-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3185,7 +3185,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.66-0
+      version: 1.0.67-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.67-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.66-0`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## collada_urdf_jsk_patch
- No changes
## downward

```
* [downward] use xzf to extract .tar.gz, instaed of xvzf to reduce log length
* Contributors: Kei Okada
```
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha
- No changes
## image_view2

```
* [image_view2] add Fisheye Grid Line option
* [jsk_perception] add dynamic reconf for image_view2
* [image_view2] add grid option
* Contributors: Yuto Inagaki
```
## jsk_common
- No changes
## jsk_data

```
* [jsk_data/rosbag_always.py] Remove old active file too
* [jsk_data] enable to select use_depth_image_proc or use_stereo_image_proc
* [jsk_data] add save_multisense parameter in hrp2_record.launch
* [jsk_data] add save_multisense parameter in common_record.launch
* [jsk_data] Save bags under ~/.ros directory
* Contributors: Kamada Hitoshi, Ryohei Ueda
```
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_network_tools

```
* [angle-vector-compress.l] 360-mode input of 0 will return 0
* [angle-vector-compress.l] add debug code (but commented out for now)
* [jsk_network_tools] Use ~robot parameter and it's initialized to ROBOT
  environment variable
* [jsk_network_tools/test/launch_joint_state_compressor.xml] set ROBOT environment for test (and this should be removed), see https://github.com/jsk-ros-pkg/jsk_common/commit/39089ecfc793ac655d45552545ddc13c1fe87b09#commitcomment-10899961
* load environment variable for setting robot in joint-state-compressor.l
* [jsk_network_tools] add test for angle-vector/JointStates compress
* [jsk_network_tools] Including pr2_description/upload_pr2.launch in order
  to set /robot_description
* [jsk_network_tools] Support jaxon in compressing/decompressing angle-vector
* Contributors: Yuki Furuta, Kei Okada, MasakiMurooka, Ryohei Ueda
```
## jsk_tilt_laser

```
* [jsk_tilt_laser] Use resized and compressed images to reconstruct
  multisense pointcloud
* [jsk_tilt_laser] Do not use spindle_half model in order to decrease risk of
  dropping of tilt laser scans
* [jsk_tilt_laser] Add arguments for resized images in multisense.launch
* [jsk_tilt_laser] Increase queue size of point_xyz and point_xyzrgb in multisense_remote.launch
* [jsk_tilt_laser] Downsample pointcloud in default
* [jsk_tilt_laser] Fix indent and typo
* [jsk_network_tools] Load laser_pipeline.launch from multisense_remote.launch
* [jsk_tilt_laser] Fix indent
* [jsk_tilt_laser] Use compressed rgb image to colorize pointcloud and
  separate laser pipeline into multisense_laser_pipeline.launch
* [jsk_tilt_laser] Relay multisense_local/left/camera_info to
  multisense/left/camera_info in remote machine
* Merge remote-tracking branch 'refs/remotes/origin/master' into multisense-local
  Conflicts:
  jsk_tilt_laser/launch/multisense.launch
* [jsk_tilt_laser] Add local argument to multisense.launch and add multisense_remote.launch
  to separatly run multisense driver
* [jsk_tilt_laser] Add options to run multisense local mode
* Contributors: Ryohei Ueda
```
## jsk_tools

```
* [jsk_tools] return error status when unable ``rossetip``
* Merge remote-tracking branch 'refs/remotes/origin/master' into add-level
  Conflicts:
  jsk_tools/bin/ros_console.py
* [jsk_tools] Add -l option to specify level in ros_console.py
* [jsk_tools] does not support sh but only bash and zsh
* [jsk_tools] store correctly default rosmaster by rossetdefault in bash
  issue: https://github.com/jsk-ros-pkg/jsk_common/issues/899
* [force_to_rename_changelog_user.py] keep order of Contributors
* [force_to_rename_changelog_user.py] add manabu -> Manabu Saito
* Merge pull request #892 <https://github.com/jsk-ros-pkg/jsk_common/issues/892> from garaemon/add-slash-prefix
  [jsk_tools] Add / prefix to node names in ros_console.py
* [jsk_tools] Add / prefix to node names in ros_console.py
* [jsk_tools] Print more detailed timestamp in ros_console.py
* [jsk_tools] temporary change to avoid error caused by bug in ros/catkin repo
* [jsk_tools] Script to check /etc/hosts sanity
* [jsk_tools] See CATKIN_SHELL to find shell
* [jsk_tools] now you can install pygithub3 by rosdep install
* [jsk_tools] save rosdefault file under ROS_HOME
* [env-hooks/99.jsk_tools.bash] fix typo and wrong -q option for cd
* [jsk_tools] Merge 99.jsk_tools.[bash|zsh] to 99.jsk_tools.sh
* [jsk_tools] Update README for PR #868 <https://github.com/jsk-ros-pkg/jsk_common/issues/868>
* [jsk_tools] Add rossetdefault, rosdefault to bashrc.ros
* [jsk_tools] Add rossetdefault, rosdefault to zshrc.ros
* [jsk_tools] Add Documentation for rossetip,rossetlocal,rossetmaster
* [jsk_tools] Remove no need comment
* [jsk_tools] Display ROS_IP in rossetmaster for zsh
* [jsk_tool] Add script to add git commit aliases like commit-ueda
* [jsk_tools] Remove -a option from zshrc.ros
* Contributors: Kei Okada, Kentaro Wada, Ryohei Ueda, iori
```
## jsk_topic_tools

```
* [jsk_topic_tools] Do not subscribe input if no need in Passthrough nodelet
* [jsk_topic_tools] Remove non-used TransportHint from relay_nodelet
* Contributors: Ryohei Ueda
```
## julius
- No changes
## laser_filters_jsk_patch
- No changes
## libsiftfast
- No changes
## mini_maxwell
- No changes
## multi_map_server
- No changes
## nlopt
- No changes
## opt_camera
- No changes
## posedetection_msgs

```
* [posedetection_msgs] Add feature0d_to_image node
* Contributors: Kentaro Wada
```
## rospatlite
- No changes
## rosping
- No changes
## rostwitter

```
* [scripts/tweet.py] fix for error handling
* Contributors: Kanae Kochigami
```
## sklearn
- No changes
## speech_recognition_msgs
- No changes
## virtual_force_publisher
- No changes
## voice_text
- No changes
