### PR TITLE
jsk_recognition: 0.2.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3151,7 +3151,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.2.11-0
+      version: 0.2.12-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.2.12-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.2.11-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros

```
* [jsk_pcl_ros] fix attention clipper non nan part
* [jsk_pcl_ros] Add getRadius method to Cylinder
* [jsk_pcl_ros] Remove nan indices from AttentionClipper
* [jsk_pcl_ros] add prefixes params to publish each indices in AttentionClipper
* [jsk_pcl_ros] Set pcl verbosity level to ERROR in multi_plane_extraction
* [jsk_pcl_ros] Relay organized point cloud to "points" topic in stereo_reconstruction.launch
* [jsk_pcl_ros] Ignore tf timestamp in TfTransformPointCloud if ~use_latest_tf is set
* [jsk_pcl_ros] Add stereo_reconstruction.launch to reconstruct stereo
  pointcloud from color images and depth image
* [jsk_pcl_ros] Relay compressed images too in multi_resolution_organized_pointcloud.launch
* [jsk_pcl_ros/mask_image_to_depth_considered_mask_image.cpp] add pcl::removeNaNFromPointCloud
* [jsk_pcl_ros] Resize images in addition to pointcloud
* change input image_points topic to /image_points_color
* [jsk_pcl_ros]change icp result when none reference
* [jsk_pcl_ros] remove nan point before icp kdtree search
* chnage ros-param
* change from linear to non-linear
* modify extract_only_directed_region_of_close_mask_image.launch
* add apply mask image publisher in mask_image_to_depth_considered_mask_image.cpp
* change default parameter of extract num
* rename to NODELET info and short fix
* [jsk_pcl_ros] modify extract_only_directed_region_of_close_mask_image.launch
* [jsk_pcl_ros] resize_points_publisher_nodelet resize rate feedback
* [jsk_pcl_ros] mask_image_to_depth_considered_mask_image_nodelet resize rate feedback
* change default parameter
* rosparam to dynamic-reconfigure
* check if current point is in directed region
* change ROS_ERROR message
* [jsk_pcl_ros] remove duplicate declaration of dependencies
* enable selection of config direction method
* ROS_INFO to ROS_ERROR
* modify README and add image
* [jsk_pcl_ros] add in_the_order_of_depth config
* [jsk_pcl_ros] Add fisheye sphere pub
* Changes to the syntax
* Changes to syntax
* Changes and modification of syntax
* Changes as to the files
* [jsk_pcl_ros] Use rectangle mode for image_view2 in extract_only_directed_region_of_close_mask_image.launch
* add extract_only_directed_region_of_close_mask_image.launch
* [jsk_pcl_ros] extract only directed region of mask image
* changed config name and README
* add dynamic reconfigure config
* [jsk_pcl_ros] Add parameter to skip publishing assembled cloud
* mask image to mask image which is at close range
* Added a launch file for rtabmap mapping with multisense.
* [jsk_pcl_ros] remove unneeded ROS_INFO line
* Contributors: HRP2, Kamada Hitoshi, Kentaro Wada, Ryohei Ueda, Yohei Kakiuchi, Yoshimaru Tanaka, Yu Ohara, Yuto Inagaki, aginika, iKrishneel
```
## jsk_perception

```
* Revert "[jsk_perception/point_pose_extractor] Use OpenCV's matcher class to estimate mathcing"
* [jsk_perception/point_pose_extractor] Use OpenCV's matcher class to
  estimate mathcing
* [jsk_perception/point_pose_extractor] Add license header
* [jsk_perception] Untabify point_pose_extractor.cpp
* [jsk_perception/point_pose_extractor] Publish PoseStamped from
  point_pose_extractor result
* add ROS_INFO
* [jsk_perception] check if pcam.intrinsicMatrix is valid
* [jsk_perception] Download drill trained data in compiling time
* Removed opencv non-free header directive
  Corrected the nodelet name in CMakeLists.txt
* Corrected the nodelet name in CMakeLists.txt
* Removed opencv non-free header directive
* Nodelet for Edge, Contour Thinning and Nodelet for Sliding window object detector
* [jsk_perception] add Fisheye Rotate parameter
* add upside down option to cfg
* add Fisheye Ray Publisher
* [jsk_perception] Add ProjectImagePoint nodelet to project image local
  coordinates into 3-D point
* [jsk_perception] Update README for fisheye
* [jsk_perception] update Fisheye To Panoarama
* [jsk_perception] Modify typo
* [jsk_perception] Add MaskImageGenerator
* add scale command to shrink the output and make faster
* add cfg
* [jsk_perception] Add fisheye rectify
* [jsk_perception] Add attributeError message to image_publisher.py
* [jsk_perception] Fix README.md about erode/dilate nodelets
* Merge pull request #834 from wkentaro/update-readme-for-pr-811
  [jsk_perception] Update README for histogram max_value of SingleChannelHistogram
* [jsk_perception] Update README for histogram max_value of SingleChannelHistogram
* [jsk_perception] Update README for iterations param of Dilate/ErodeMaskImage
* [jsk_perception] Add iteration param to DilateMaskImage & ErodeMaskImage
* Contributors: Kamada Hitoshi, Kentaro Wada, Ryohei Ueda, Yuto Inagaki, iKrishneel
```
## jsk_recognition
- No changes
## jsk_recognition_msgs

```
* JSK Recognition Msg for handling Array of 2D Rects
* Contributors: iKrishneel
```
## resized_image_transport

```
* [resized_image_transport] Fix dynamic_reconfigure name in LogPolar
* [resized_image_transport] Pass private nodehandle to dynamic_reconfigure to set handle the name of dynamic_reconfigrue in nodelet correctly
* [resized_image_transport] change from linear to non-linear
* rename to NODELET info and short fix
* [resized_image_transport] image_resizer_nodelet resize rate feedback
* Contributors: Kamada Hitoshi, Ryohei Ueda
```
