### PR TITLE
jsk_visualization: 1.0.20-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3221,10 +3221,11 @@ repositories:
       - jsk_interactive_test
       - jsk_rqt_plugins
       - jsk_rviz_plugins
+      - jsk_visualization
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.19-0
+      version: 1.0.20-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.20-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.19-0`
## jsk_interactive
- No changes
## jsk_interactive_marker

```
* update furutaructive system. add load-ros-manifest. fix hand model path
* [jsk_interactive_marker/urdf_control_marker] Transform pose respected to fixed_frame_id
  when urdf_control_marker is moved by topic interface
* [jsk_interactive_marker] Supress messages while loading urdf mesh
* [jsk_interactive_marker] Add look ground menu to footstep_marker
* [jsk_interactive_marker] Fix timestamp handling in transformable object when ~strict_tf:=false
* Contributors: Masaki Murooka, Ryohei Ueda
```
## jsk_interactive_test
- No changes
## jsk_rqt_plugins

```
* [jsk_rqt_plugins/iamge_view2_wrapper] Use thread to update image topic
  list isntead of QTimer not to hung up rqt_gui
* use button general class for push button and radio button. enable to set parameter name to set layout
* add radio button plugin
* display label and icon in button
* [jsk_rqt_plugins] Add python-urlgrabber dependency
* Contributors: Masaki Murooka, Ryohei Ueda
```
## jsk_rviz_plugins

```
* [jsk_rviz_plugins] add rotate speed to pictogram
* [jsk_rviz_plugins] add String PopupMode for Pictogram
* [jsk_rviz_plugins] Make arrow nodes invisible as default in PolygonArrayDisplay not to show normal if no needed
* [jsk_rviz_plugins] Check size of BoundingBox
* Contributors: Ryohei Ueda, Yuto Inagaki
```
## jsk_visualization

```
* [jsk_visualization] Add jsk_visualization meta package
* Contributors: Ryohei Ueda
```
