### PR TITLE
nao_meshes: 0.1.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1226,6 +1226,17 @@ repositories:
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
       version: master
     status: maintained
+  nao_meshes:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-naoqi/nao_meshes-release.git
+      version: 0.1.8-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/nao_meshes.git
+      version: master
+    status: maintained
   nao_robot:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_meshes` to `0.1.8-0`:
- upstream repository: https://github.com/ros-nao/nao_meshes.git
- release repository: https://github.com/ros-naoqi/nao_meshes-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## nao_meshes

```
* update md5 for 0.6.7 installers
* Update README
* Contributors: Mikael ARGUEDAS, Vincent Rabaud
```
