### PR TITLE
object_recognition_transparent_objects: 0.4.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1514,6 +1514,17 @@ repositories:
       url: https://github.com/wg-perception/tod.git
       version: master
     status: maintained
+  object_recognition_transparent_objects:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_transparent_objects-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/transparent_objects.git
+      version: master
+    status: maintained
   octomap:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_transparent_objects` to `0.4.0-0`:
- upstream repository: https://github.com/wg-perception/transparent_objects.git
- release repository: https://github.com/ros-gbp/object_recognition_transparent_objects-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## object_recognition_transparent_objects

```
* Fix check regarding whether the file is opened
* drop Fuerte support
* Contributors: Jordi Pages, Vincent Rabaud
```
