### PR TITLE
carl_bot: 0.0.30-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -650,7 +650,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_bot-release.git
-      version: 0.0.29-0
+      version: 0.0.30-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_bot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_bot` to `0.0.30-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_bot.git
- release repository: https://github.com/wpi-rail-release/carl_bot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.29-0`
## carl_bot
- No changes
## carl_bringup

```
* Added parking spots and interactive marker pickup option to the bringup launch file
* Contributors: David Kent
```
## carl_description
- No changes
## carl_dynamixel
- No changes
## carl_interactive_manipulation

```
* Limited move while retracted feedback to publish at most every 5 seconds
* Contributors: David Kent
```
## carl_phidgets
- No changes
## carl_teleop
- No changes
## carl_tools
- No changes
