### PR TITLE
applanix_driver: 0.0.10-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -190,7 +190,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/applanix_driver-release.git
-      version: 0.0.9-0
+      version: 0.0.10-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/applanix_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `applanix_driver` to `0.0.10-0`:
- upstream repository: git@github.com:clearpathrobotics/applanix_driver.git
- release repository: https://github.com/clearpath-gbp/applanix_driver-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.9-0`
## applanix_bridge

```
* Applanix driver will now set the /gps_origin parameter if not set at startup with the origin used for fixes
* Contributors: Kareem Shehata
```
## applanix_driver
- No changes
## applanix_msgs
- No changes
