### PR TITLE
ros_control: 0.9.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6955,7 +6955,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.9.1-0
+      version: 0.9.2-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.9.2-0`:
- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.9.1-0`
## controller_interface
- No changes
## controller_manager

```
* Add HW interface switch feature
* Contributors: Mathias Lüdtke
```
## controller_manager_msgs
- No changes
## controller_manager_tests
- No changes
## hardware_interface

```
* Add HW interface switch feature
* Contributors: Mathias Lüdtke
```
## joint_limits_interface

```
* Reset functionality for stateful position joint limit handles
* Contributors: Mathias Lüdtke
```
## ros_control
- No changes
## rqt_controller_manager
- No changes
## transmission_interface
- No changes
