### PR TITLE
ros_controllers: 0.9.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6983,7 +6983,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.9.1-0
+      version: 0.9.2-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.9.2-0`:
- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.9.1-0`
## diff_drive_controller

```
* Allow the wheel separation and radius to be set from different sources
  i.e. one can be set from the URDF, the other from the parameter server.
  If wheel separation and wheel diameter is specified in the parameter server, don't look them up from urdf
* Contributors: Bence Magyar, Nils Berg
```
## effort_controllers

```
* Thread-safe and realtime-safe forward controllers.
* Contributors: Mathias Lüdtke
```
## force_torque_sensor_controller
- No changes
## forward_command_controller

```
* Thread-safe and realtime-safe forward controllers.
* Complain if list of joints is empty.
* Contributors: Mathias Lüdtke
```
## gripper_action_controller
- No changes
## imu_sensor_controller
- No changes
## joint_state_controller
- No changes
## joint_trajectory_controller
- No changes
## position_controllers

```
* Thread-safe and realtime-safe forward controllers.
* Contributors: Mathias Lüdtke
```
## ros_controllers
- No changes
## rqt_joint_trajectory_controller

```
* rqt_joint_traj_controller: Add missing runtime dep
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## velocity_controllers

```
* Thread-safe and realtime-safe forward controllers.
* Contributors: Mathias Lüdtke
```
