### PR TITLE
rail_ceiling: 0.0.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1864,6 +1864,21 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: groovy-devel
     status: maintained
+  rail_ceiling:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_ceiling.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wpi-rail-release/rail_ceiling-release.git
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_ceiling.git
+      version: develop
+    status: maintained
   rail_collada_models:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_ceiling` to `0.0.4-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_ceiling.git
- release repository: https://github.com/wpi-rail-release/rail_ceiling-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rail_ceiling

```
* adds missing dep
* Merge branch 'develop' of github.com:WPI-RAIL/rail_ceiling into develop
* Updated launch for calibration from carl
* Update .travis.yml
* Update .travis.yml
* Contributors: David Kent, Russell Toris
```
