### PR TITLE
rail_pick_and_place: 1.1.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1909,6 +1909,28 @@ repositories:
       url: https://github.com/WPI-RAIL/rail_maps.git
       version: develop
     status: maintained
+  rail_pick_and_place:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_pick_and_place.git
+      version: master
+    release:
+      packages:
+      - graspdb
+      - rail_grasp_collection
+      - rail_pick_and_place
+      - rail_pick_and_place_msgs
+      - rail_pick_and_place_tools
+      - rail_recognition
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
+      version: 1.1.5-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_pick_and_place.git
+      version: develop
+    status: maintained
   rail_segmentation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_pick_and_place` to `1.1.5-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_pick_and_place.git
- release repository: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## graspdb
- No changes
## rail_grasp_collection
- No changes
## rail_pick_and_place
- No changes
## rail_pick_and_place_msgs
- No changes
## rail_pick_and_place_tools
- No changes
## rail_recognition

```
* Bugfix for running recognition on empty object lists
* Contributors: David Kent
```
