### PR TITLE
python_trep: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6259,7 +6259,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/MurpheyLab/trep-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     status: developed
   qt_gui_core:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `python_trep` to `1.0.1-0`:
- upstream repository: https://github.com/MurpheyLab/trep.git
- release repository: https://github.com/MurpheyLab/trep-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.0-0`
