### PR TITLE
p2os: 2.0.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5364,16 +5364,23 @@ repositories:
       version: toolchain-2.7
     status: maintained
   p2os:
+    doc:
+      type: git
+      url: https://github.com/allenh1/p2os.git
+      version: master
     release:
       packages:
+      - p2os_doc
       - p2os_driver
       - p2os_launch
+      - p2os_msgs
       - p2os_teleop
       - p2os_urdf
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
-      version: 1.0.10-0
+      version: 2.0.0-0
+    status: developed
   pal_vision_segmentation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `2.0.0-0`:
- upstream repository: https://github.com/allenh1/p2os
- release repository: https://github.com/allenh1/p2os-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.10-0`
