### PR TITLE
jsk_common: 1.0.68-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3044,7 +3044,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.67-0
+      version: 1.0.68-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.68-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.67-0`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## downward
- No changes
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_data

```
* [jsk_data] env value ARIES_USER will be default username to login aries
* [jsk_data] Add usage of KEYWORD for make large-list / small-list
* [jsk_data] Add KEYWORD to large-list/small-list target in Makefile
* Contributors: Kentaro Wada
```
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_network_tools

```
* [jsk_network_tools] Use 1500*8 bits as default packet_size for MTU:=1500
  environment in silverhammer_highspeed communication
* Contributors: Ryohei Ueda
```
## jsk_tilt_laser
- No changes
## jsk_tools
- No changes
## jsk_topic_tools

```
* [jsk_topic_tools] Add log_utils.h to print with __PRETY_FUNCTION__
* Contributors: Ryohei Ueda
```
## julius
- No changes
## libsiftfast
- No changes
## mini_maxwell
- No changes
## multi_map_server
- No changes
## nlopt
- No changes
## opt_camera
- No changes
## posedetection_msgs
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## sklearn
- No changes
## speech_recognition_msgs
- No changes
## virtual_force_publisher
- No changes
## voice_text
- No changes
