### PR TITLE
graft: 0.2.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -783,6 +783,17 @@ repositories:
       url: https://github.com/ros/geometry_tutorials.git
       version: indigo-devel
     status: maintained
+  graft:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/graft.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/graft-release.git
+      version: 0.2.2-0
+    status: developed
   hokuyo_node:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `graft` to `0.2.2-0`:
- upstream repository: https://github.com/ros-perception/graft.git
- release repository: https://github.com/ros-gbp/graft-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## graft

```
* fix compilation on 32-bit systems
* update maintainer email
* Contributors: Michael Ferguson
```
