### PR TITLE
ros_control: 0.9.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6955,7 +6955,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.9.2-0
+      version: 0.9.3-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.9.3-0`:
- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.9.2-0`
## controller_interface
- No changes
## controller_manager

```
* controller_manager: Add missing rostest dep
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## controller_manager_msgs
- No changes
## controller_manager_tests
- No changes
## hardware_interface
- No changes
## joint_limits_interface
- No changes
## ros_control
- No changes
## rqt_controller_manager
- No changes
## transmission_interface
- No changes
