### PR TITLE
pr2_apps: 0.5.20-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5672,7 +5672,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_apps-release.git
-      version: 0.5.18-0
+      version: 0.5.20-1
     source:
       type: git
       url: https://github.com/pr2/pr2_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_apps` to `0.5.20-1`:
- upstream repository: https://github.com/PR2/pr2_apps.git
- release repository: https://github.com/TheDash/pr2_apps-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.18-0`
## pr2_app_manager
- No changes
## pr2_apps
- No changes
## pr2_mannequin_mode
- No changes
## pr2_position_scripts
- No changes
## pr2_teleop
- No changes
## pr2_teleop_general
- No changes
## pr2_tuckarm
- No changes
