### PR TITLE
rqt_pr2_dashboard: 0.2.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7671,7 +7671,11 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
-      version: 0.2.6-0
+      version: 0.2.7-0
+    source:
+      type: git
+      url: https://github.com/pr2/rqt_pr2_dashboard.git
+      version: hydro-devel
     status: maintained
   rqt_robot_plugins:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_pr2_dashboard` to `0.2.7-0`:
- upstream repository: https://github.com/ros-visualization/rqt_pr2_dashboard.git
- release repository: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.6-0`
## rqt_pr2_dashboard

```
* Merge pull request #17 <https://github.com/pr2/rqt_pr2_dashboard/issues/17> from jstnhuang/hydro-devel
  Hydro migration: pr2_etherCAT -> pr2_ethercat
* Hydro migration: pr2_etherCAT -> pr2_ethercat
* Contributors: Devon Ash, Justin Huang
```
