### PR TITLE
rtt: 2.8.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7867,7 +7867,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/orocos-gbp/rtt-release.git
-      version: 2.8.0-1
+      version: 2.8.0-2
     source:
       type: git
       url: https://github.com/orocos-toolchain/rtt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt` to `2.8.0-2`:
- upstream repository: https://github.com/orocos-toolchain/rtt.git
- release repository: https://github.com/orocos-gbp/rtt-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.8.0-1`
