### PR TITLE
ocl: 2.8.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5017,7 +5017,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/orocos-gbp/ocl-release.git
-      version: 2.8.0-0
+      version: 2.8.0-1
     source:
       type: git
       url: https://github.com/orocos-toolchain/ocl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ocl` to `2.8.0-1`:
- upstream repository: https://github.com/orocos-toolchain/ocl.git
- release repository: https://github.com/orocos-gbp/ocl-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.8.0-0`
