### PR TITLE
grasping_msgs: 0.3.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -794,6 +794,18 @@ repositories:
       url: https://github.com/ros-gbp/graft-release.git
       version: 0.2.2-0
     status: developed
+  grasping_msgs:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/grasping_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/mikeferguson/grasping_msgs-gbp.git
+      version: 0.3.1-0
+    status: maintained
+    status_description: ']'
   hokuyo_node:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `grasping_msgs` to `0.3.1-0`:
- upstream repository: git@github.com:mikeferguson/grasping_msgs.git
- release repository: https://github.com/mikeferguson/grasping_msgs-gbp.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## grasping_msgs

```
* update email
* update description in package.xml
* Contributors: Michael Ferguson
```
