### PR TITLE
rocon_app_platform: 0.7.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6622,7 +6622,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_app_platform-release.git
-      version: 0.7.10-0
+      version: 0.7.11-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_app_platform` to `0.7.11-0`:
- upstream repository: http://github.com/robotics-in-concert/rocon_app_platform
- release repository: https://github.com/yujinrobot-release/rocon_app_platform-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.10-0`
## rocon_app_manager

```
* add webserver_address arg closes #285 <https://github.com/robotics-in-concert/rocon_app_platform/issues/285>
* disable_zeroconf does not start zeroconf node #273 <https://github.com/robotics-in-concert/rocon_app_platform/issues/273>
* Contributors: Jihoon Lee
```
## rocon_app_platform
- No changes
## rocon_app_utilities
- No changes
## rocon_apps
- No changes
