### PR TITLE
rocon_tutorials: 0.6.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6792,7 +6792,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_tutorials-release.git
-      version: 0.6.6-0
+      version: 0.6.7-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_tutorials` to `0.6.7-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_tutorials.git
- release repository: https://github.com/yujinrobot-release/rocon_tutorials-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.6-0`
## chatter_concert
- No changes
## gazebo_concert
- No changes
## rocon_app_manager_tutorials

```
* add web interaction tutorial closes #63 <https://github.com/robotics-in-concert/rocon_tutorials/issues/63>
* update interactions. add interactions dir in cmake rule closes #62 <https://github.com/robotics-in-concert/rocon_tutorials/issues/62>
* Contributors: Jihoon Lee
```
## rocon_gateway_tutorials
- No changes
## rocon_tutorials
- No changes
## turtle_concert
- No changes
