### PR TITLE
rocon_tools: 0.1.18-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6770,7 +6770,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_tools-release.git
-      version: 0.1.17-0
+      version: 0.1.18-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_tools` to `0.1.18-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_tools.git
- release repository: https://github.com/yujinrobot-release/rocon_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.17-0`
## rocon_bubble_icons
- No changes
## rocon_console
- No changes
## rocon_ebnf
- No changes
## rocon_icons
- No changes
## rocon_interactions

```
* get_interctions accept empty rocon_uri as wild card closes #85 <https://github.com/robotics-in-concert/rocon_tools/issues/85>
* Contributors: Jihoon Lee
```
## rocon_launch
- No changes
## rocon_master_info
- No changes
## rocon_python_comms
- No changes
## rocon_python_redis
- No changes
## rocon_python_utils
- No changes
## rocon_python_wifi

```
* Don't fail on wifi-if check for different systems
  In wifi part of detection of network interfaces: Check if /proc/net/wireless exists before trying to read it, instead of failing on OS's / systems that don't have wifi and/or don't use that file.
* Contributors: Rob Linsalata
```
## rocon_semantic_version
- No changes
## rocon_tools
- No changes
## rocon_uri
- No changes
