### PR TITLE
imu_tools: 1.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2932,7 +2932,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/imu_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.0.4-0`:
- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.3-0`
## imu_filter_madgwick

```
* update dynamic reconfigure param descriptions
* only advertise debug topics if they are used
* allow remapping of the whole imu namespace
  with this change, all topics can be remapped at once, like this:
  rosrun imu_filter_madgwick imu_filter_node imu:=my_imu
* Contributors: Martin Günther
```
## imu_tools
- No changes
## rviz_imu_plugin
- No changes
