### PR TITLE
katana_driver: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3258,7 +3258,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uos-gbp/katana_driver-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/uos/katana_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `katana_driver` to `1.0.2-0`:
- upstream repository: https://github.com/uos/katana_driver.git
- release repository: https://github.com/uos-gbp/katana_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.1-0`
## katana
- No changes
## katana_arm_gazebo

```
* gazebo urdfs: remove self_collide tags
  Due to fixed joint reduction, there is only one link in the resulting
  SDF anyway, so there is nothing to collide with. Apart from that, this
  never made any sense for static models anyway.
* self_collide false for tall table
  The links of the table are statically connected.
  There's no need for collision checking here.
  gazebo5 raises a warning because the self_collide statements
  were inconsistent (not all specified) before.
* Contributors: Martin Günther, Michael Görner
```
## katana_description

```
* comment initial_joint_position in katana-gazebo urdf
  There is still no way to specify these, but gazebo5 fails
  to load the urdf because it doesn't know the tags.
* katana_description: ivcon + convex are only build dependencies
* Contributors: Martin Günther, Michael Görner
```
## katana_driver
- No changes
## katana_gazebo_plugins
- No changes
## katana_moveit_ikfast_plugin
- No changes
## katana_msgs
- No changes
## katana_teleop
- No changes
## katana_tutorials
- No changes
## kni

```
* Even more KNI dependencies
* Contributors: Jochen Sprickerhof
```
