### PR TITLE
acado: 1.2.1-7 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -66,7 +66,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/clearpath-gbp/acado-release.git
-      version: 1.2.1-6
+      version: 1.2.1-7
     source:
       type: git
       url: https://github.com/clearpath-gbp/acado-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `acado` to `1.2.1-7`:
- upstream repository: https://github.com/clearpathrobotics/acado.git
- release repository: https://github.com/clearpath-gbp/acado-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.2.1-6`
