### PR TITLE
carl_navigation: 0.0.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -710,7 +710,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_navigation-release.git
-      version: 0.0.10-0
+      version: 0.0.11-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_navigation` to `0.0.11-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_navigation.git
- release repository: https://github.com/wpi-rail-release/carl_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.10-0`
## carl_navigation

```
* pretty world rviz
* pretty world rviz
* Contributors: Russell Toris
```
