### PR TITLE
add pygraphviz config for osx

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1009,6 +1009,9 @@ python-pygraphviz:
     trusty: [python-pygraphviz]
     utopic: [python-pygraphviz]
     vivid: [python-pygraphviz]
+  osx:
+    pip:
+      packages: [pygraphviz]
 python-pylint:
   debian: [pylint]
   fedora: [pylint]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -997,6 +997,9 @@ python-pygithub3:
 python-pygraphviz:
   debian: [python-pygraphviz]
   fedora: [graphviz-python]
+  osx:
+    pip:
+      packages: [pygraphviz]
   ubuntu:
     lucid: [python-pygraphviz]
     maverick: [python-pygraphviz]
@@ -1009,9 +1012,6 @@ python-pygraphviz:
     trusty: [python-pygraphviz]
     utopic: [python-pygraphviz]
     vivid: [python-pygraphviz]
-  osx:
-    pip:
-      packages: [pygraphviz]
 python-pylint:
   debian: [pylint]
   fedora: [pylint]


### PR DESCRIPTION
bug when install ros indigo desktop version on OS X 10.10.3
`rosdep install --from-paths src --ignore-src --rosdistro indigo -y` 
keep reporting error:

```
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
qt_dotgraph: No definition of [python-pygraphviz] for OS [osx]
```
