### PR TITLE
power_msgs: 0.1.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1814,6 +1814,17 @@ repositories:
       url: https://github.com/ros-drivers/pointgrey_camera_driver.git
       version: master
     status: maintained
+  power_msgs:
+    doc:
+      type: git
+      url: https://github.com/fetchrobotics/power_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/power_msgs-release.git
+      version: 0.1.3-0
+    status: developed
   pr2_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `power_msgs` to `0.1.3-0`:
- upstream repository: https://github.com/fetchrobotics/power_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/power_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## power_msgs

```
* add name to breaker state message (for multiple breakers in an array)
* Contributors: Michael Ferguson
```
