### PR TITLE
open_karto: 1.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5159,7 +5159,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/open_karto-release.git
-      version: 1.1.0-0
+      version: 1.1.1-0
     status: maintained
   open_street_map:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `open_karto` to `1.1.1-0`:
- upstream repository: https://github.com/ros-perception/open_karto.git
- release repository: https://github.com/ros-gbp/open_karto-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.0-0`
## open_karto

```
* Makes FindValidPoints robust to the first point in the scan being a NaN
* Bump minimum cmake version requirement
* Fix cppcheck warnings
* Fix newlines (dos2unix) & superfluous whitespace
* Protect functions that throw away const-ness (check dirty flag) with mutex
* Don't modify scan during loop closure check - work on a copy of it
* removed useless return to avoid cppcheck error
* Add Mapper::SetUseScanMatching
* Remove html entities from log output
* Fix NANs cause raytracing to take forever
* Contributors: Daniel Pinyol, Michael Ferguson, Paul Mathieu, Siegfried-A. Gevatter Pujals, liz-murphy
```
