### PR TITLE
spur: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8430,7 +8430,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/spur-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/tork-a/spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `spur` to `0.1.2-0`:
- upstream repository: https://github.com/tork-a/spur.git
- release repository: https://github.com/tork-a/spur-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.1-0`
## spur

```
* (Fix) Correct sides of wheels (replacing L and R).
* (Feat.) Separate launches to allow dynamixel to start by itself.
* (Maintenance) More correct dependency.
* Contributors: Isaac IY Saito
```
## spur_controller

```
* (Fix) Correct sides of wheels (replacing L and R).
* (Feat.) Separate launches to allow dynamixel to start by itself.
* Contributors: Isaac IY Saito
```
## spur_description
- No changes
## spur_gazebo

```
* More correct dependency.
* Contributors: Isaac IY Saito
```
