### PR TITLE
web_video_server: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9361,7 +9361,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/web_video_server-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/RobotWebTools/web_video_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `web_video_server` to `0.0.3-0`:
- upstream repository: https://github.com/RobotWebTools/web_video_server.git
- release repository: https://github.com/RobotWebTools-release/web_video_server-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.2-0`
## web_video_server

```
* added verbose flag
* Contributors: Russell Toris
```
