### PR TITLE
jsk_model_tools: 0.1.12-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3229,7 +3229,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.1.11-0
+      version: 0.1.12-0
     source:
       type: git
       url: https://github.com/tork-a/jsk_model_tools-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.1.12-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.11-0`
## eus_assimp

```
* [jsk_model_tools] remove old rosmake files
* Contributors: Kei Okada
```
## euscollada

```
* [src/collada2eus.cpp] on newer yaml, doc["angle-vector"]["reset-pose"] did not raise error
* [jsk_model_tools] remove old rosmake files
* [collada2eus.cpp] do not exit when polylistElementCound or polygoneElementCount is 0
* [euscollada/src/collada2eus.cpp] super ugry hack untilyaml-cpp 0.5.2
* [collada2eus] set verbose=true when --verbose
* [euscollada] Removed unnecessary fprintf in collada2eus.cpp
* [euscollada] Add size check to end-coords translation/rotation because undefiend limb end-coords transformation/rotation breaks matching of parentheses in yaml-cpp 0.5.
* Contributors: Kei Okada, Iori Kumagai
```
## jsk_model_tools
- No changes
