### PR TITLE
spatial_temporal_learning: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8416,6 +8416,26 @@ repositories:
       url: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
       version: 0.3.2-0
     status: maintained
+  spatial_temporal_learning:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/spatial_temporal_learning.git
+      version: master
+    release:
+      packages:
+      - spatial_temporal_learning
+      - world_item_observer
+      - world_item_search
+      - worldlib
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/spatial_temporal_learning-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/spatial_temporal_learning.git
+      version: develop
+    status: developed
   spur:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `spatial_temporal_learning` to `0.0.1-0`:
- upstream repository: https://github.com/WPI-RAIL/spatial_temporal_learning.git
- release repository: https://github.com/wpi-rail-release/spatial_temporal_learning-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## spatial_temporal_learning

```
* basics of worldlib started
* metapackage started
* Contributors: Russell Toris
```
## world_item_observer

```
* added observer
* yaml fix
* marks items as removed
* added surface checks
* Contributors: Russell Toris
```
## world_item_search

```
* new default db
* initial testing of geolife data complete
* experiment started
* geolife parsing support with download script
* added geolife parsing
* added persistence model
* abstract node started
* Contributors: Russell Toris
```
## worldlib

```
* added observer
* yaml fix
* added surface checks
* initial testing of geolife data complete
* added geolife parsing
* probability of item still being on a surface added
* added persistence model
* mutable accesors
* abstract node started
* nodes started
* started parser for interactive world
* random value from gaussian used as removal estimate
* created Client --> SqlClient classes
* basics of worldlib started
* Contributors: Russell Toris
```
