### PR TITLE
queue_manager: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6310,6 +6310,21 @@ repositories:
       url: https://github.com/stonier/qt_ros.git
       version: hydro
     status: maintained
+  queue_manager:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/queue_manager.git
+      version: master
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/wpi-rail-release/queue_manager-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/queue_manager.git
+      version: develop
+    status: maintained
   rFSM:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `queue_manager` to `0.0.1-0`:
- upstream repository: https://github.com/WPI-RAIL/queue_manager.git
- release repository: https://github.com/wpi-rail-release/queue_manager-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## queue_manager

```
* cleanup so it will compile
* Merge pull request #1 from PeterMitrano/develop
  moved to queue_manager
* updated to matched repo name, and added info in the readme
* moved to queue_manager
* Initial commit
* Contributors: Russell Toris, peter mitrano, petermitrano
```
