### PR TITLE
rail_user_queue_manager: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6298,6 +6298,21 @@ repositories:
       url: https://github.com/WPI-RAIL/rail_segmentation.git
       version: develop
     status: maintained
+  rail_user_queue_manager:
+    doc:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_user_queue_manager.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wpi-rail-release/rail_user_queue_manager-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/WPI-RAIL/rail_user_queue_manager.git
+      version: develop
+    status: maintained
   random_numbers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_user_queue_manager` to `0.0.1-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_user_queue_manager.git
- release repository: https://github.com/wpi-rail-release/rail_user_queue_manager-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rail_user_queue_manager

```
* Update rail_user_queue_manager.cpp
* updated readme with new name
* renamed to make it sound less generic
* 0.0.1
* changelog updated
* cleanup so it will compile
* Merge pull request #1 from PeterMitrano/develop
  moved to queue_manager
* updated to matched repo name, and added info in the readme
* moved to queue_manager
* Initial commit
* Contributors: Russell Toris, peter mitrano, petermitrano
```
