### PR TITLE
ecto: 0.6.9-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1707,7 +1707,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/ecto-release.git
-      version: 0.6.8-0
+      version: 0.6.9-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto` to `0.6.9-0`:
- upstream repository: /home/vrabaud/workspace/recognition_kitchen/src/ecto
- release repository: https://github.com/ros-gbp/ecto-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.8-0`
## ecto

```
* re-add some Python tests
* add missing PySide dependency
* Contributors: Vincent Rabaud
```
