### PR TITLE
jsk_common: 1.0.70-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3185,7 +3185,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.69-0
+      version: 1.0.70-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.70-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.69-0`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## collada_urdf_jsk_patch
- No changes
## downward
- No changes
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_data

```
* [jsk_data] add option in hrp2_play with multisense
* Contributors: Yu Ohara
```
## jsk_footstep_msgs

```
* [jsk_footstep_msgs] Add swing_height field to Footstep.msg
* Contributors: Ryohei Ueda
```
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_network_tools

```
* [jsk_network_tools] Fix bytes/bits conversions
* Contributors: Ryohei Ueda
```
## jsk_tilt_laser

```
* [jsk_tilt_laser] More detailed laser pointcloud for precise perception
* Contributors: Ryohei Ueda
```
## jsk_tools
- No changes
## jsk_topic_tools

```
* [jsk_topic_tools/Passthrough] Add ~request service like Snapshot
* Contributors: Ryohei Ueda
```
## julius
- No changes
## laser_filters_jsk_patch
- No changes
## libsiftfast
- No changes
## mini_maxwell
- No changes
## multi_map_server
- No changes
## nlopt
- No changes
## opt_camera
- No changes
## posedetection_msgs
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## sklearn
- No changes
## speech_recognition_msgs
- No changes
## virtual_force_publisher
- No changes
## voice_text
- No changes
