### PR TITLE
spatial_temporal_learning: 0.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2693,7 +2693,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/wpi-rail-release/spatial_temporal_learning-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/spatial_temporal_learning.git


### PR DESCRIPTION
Increasing version of package(s) in repository `spatial_temporal_learning` to `0.0.2-0`:
- upstream repository: https://github.com/WPI-RAIL/spatial_temporal_learning.git
- release repository: https://github.com/wpi-rail-release/spatial_temporal_learning-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.1-0`
## spatial_temporal_learning
- No changes
## world_item_observer

```
* fixes bug in linking and adds new surfaces to RAIL world
* Contributors: Russell Toris
```
## world_item_search
- No changes
## worldlib

```
* fixes bug in linking and adds new surfaces to RAIL world
* Contributors: Russell Toris
```
