### PR TITLE
rail_user_queue_manager: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6307,7 +6307,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_user_queue_manager-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_user_queue_manager.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_user_queue_manager` to `0.0.2-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_user_queue_manager.git
- release repository: https://github.com/wpi-rail-release/rail_user_queue_manager-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.1-0`
## rail_user_queue_manager

```
* Update rail_user_queue_manager.cpp
* Initialized private node handle
* Contributors: David Kent, Russell Toris
```
