### PR TITLE
carl_bot: 0.0.32-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -650,7 +650,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_bot-release.git
-      version: 0.0.31-0
+      version: 0.0.32-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_bot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_bot` to `0.0.32-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_bot.git
- release repository: https://github.com/wpi-rail-release/carl_bot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.31-0`
## carl_bot
- No changes
## carl_bringup

```
* missed )
* Passed arg to arm.launch
* Merge branch 'develop' of github.com:WPI-RAIL/carl_bot into develop
* Added a parameter for carl interactive manipulation to create object markers from segmented objects instead of recognized objects
* Contributors: David Kent
```
## carl_description
- No changes
## carl_dynamixel
- No changes
## carl_interactive_manipulation

```
* Merge branch 'develop' of github.com:WPI-RAIL/carl_bot into develop
* Added a parameter for carl interactive manipulation to create object markers from segmented objects instead of recognized objects
* Contributors: David Kent
```
## carl_phidgets
- No changes
## carl_teleop
- No changes
## carl_tools
- No changes
