### PR TITLE
spur: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8465,7 +8465,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/spur-release.git
-      version: 0.1.3-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/tork-a/spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `spur` to `0.2.0-0`:
- upstream repository: https://github.com/tork-a/spur.git
- release repository: https://github.com/tork-a/spur-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.3-0`
## spur

```
* (Fix) Complete adjusting model to real robot
* (Fix) Specific dependency
* (Feature) Allow configuring idle time for Twist command.
* (Doc) Copyright to the project owner. Update package description.
* Contributors: Isaac IY Saito
```
## spur_controller

```
* (Fix) Adjust spur controller to the real robot config
* (Fix) Specific dependency
* (Feature) Allow configuring idle time for Twist command.
* (Doc) Copyright to the project owner. Update package description.
* (Doc) PEP8
* Contributors: Isaac IY Saito
```
## spur_description

```
* (Fix) Complete adjusting model to real robot
* (Fix) Specific dependency
* (Doc) Copyright to the project owner. Update package description.
* Contributors: Isaac IY Saito
```
## spur_gazebo

```
* (Feature) Allow configuring idle time for Twist command.
* (Doc) Copyright to the project owner. Update package description.
* Contributors: Isaac IY Saito
```
