### PR TITLE
ecto_opencv: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1698,7 +1698,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ecto_opencv-release.git
-      version: 0.5.6-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto_opencv` to `0.6.0-0`:
- upstream repository: https://github.com/plasmodic/ecto_opencv.git
- release repository: https://github.com/ros-gbp/ecto_opencv-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.6-0`
## ecto_opencv

```
* add proper rosunit dependency
* convert Python tests to proper nose tests
* use cv_backports to pull in opencv2.4.9 imshows with zoom and parallel thread support.
* Contributors: Daniel Stonier, Vincent Rabaud
```
