### PR TITLE
rtabmap and rtabmap_ros: 0.8.12-0 in Hydro and Indigo

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7727,7 +7727,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.8.3-0
+      version: 0.8.12-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -7742,7 +7742,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.8.3-0
+      version: 0.8.12-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7767,7 +7767,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.8.3-1
+      version: 0.8.12-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -7782,7 +7782,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.8.3-0
+      version: 0.8.12-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of packages `rtabmap` and `rtabmap_ros` to `0.8.12-0`.
