### PR TITLE
rtabmap, rtabmap_ros: 0.8.12-0 in 'jade/distribution.yaml'

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2585,6 +2585,36 @@ repositories:
       url: https://github.com/ros-visualization/rqt_robot_plugins.git
       version: hydro-devel
     status: developed
+  rtabmap:
+    doc:
+      type: git
+      url: https://github.com/introlab/rtabmap.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/introlab/rtabmap-release.git
+      version: 0.8.12-0
+    source:
+      type: git
+      url: https://github.com/introlab/rtabmap.git
+      version: jade-devel
+    status: maintained
+  rtabmap_ros:
+    doc:
+      type: git
+      url: https://github.com/introlab/rtabmap_ros.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/introlab/rtabmap_ros-release.git
+      version: 0.8.12-0
+    source:
+      type: git
+      url: https://github.com/introlab/rtabmap_ros.git
+      version: master
+    status: maintained
   rtctree:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repositories `rtabmap` and `rtabmap_ros` to `0.8.12-0`:
- upstream repository: https://github.com/introlab/rtabmap.git, https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap-release.git, https://github.com/introlab/rtabmap_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
