### PR TITLE
acado: 1.2.1-4 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -43,7 +43,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/acado-release.git
-      version: 1.2.1-3
+      version: 1.2.1-4
     source:
       type: git
       url: https://github.com/clearpath-gbp/acado-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `acado` to `1.2.1-4`:
- upstream repository: https://github.com/clearpathrobotics/acado.git
- release repository: https://github.com/clearpath-gbp/acado-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.2.1-3`
