### PR TITLE
find_object_2d: 0.5.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -587,6 +587,17 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/filters-release.git
       version: 1.7.4-2
+  find_object_2d:
+    doc:
+      type: svn
+      url: https://find-object.googlecode.com/svn/trunk/ros-pkg/find_object_2d
+      version: HEAD
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/introlab/find_object_2d-release.git
+      version: 0.5.1-0
+    status: maintained
   gazebo_ros_pkgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `find_object_2d` to `0.5.1-0`:
- upstream repository: https://find-object.googlecode.com/svn/files/ros/find_object_2d-0.5.1.tar.gz
- release repository: https://github.com/introlab/find_object_2d-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
