### PR TITLE
turtlebot_concert: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8849,7 +8849,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_concert-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot_concert.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_concert` to `0.0.2-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_concert.git
- release repository: https://github.com/turtlebot-release/turtlebot_concert-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.1-0`
## turtlebot_concert

```
* typo in cmake
* Contributors: Jihoon Lee
```
