### PR TITLE
youbot_description: 0.8.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9650,6 +9650,12 @@ repositories:
       url: https://github.com/yujinrobot/yocs_msgs.git
       version: indigo
     status: developed
+  youbot_description:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/youbot-release/youbot_description-release.git
+      version: 0.8.1-0
   yujin_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `youbot_description` to `0.8.1-0`:
- upstream repository: https://github.com/youbot/youbot_description
- release repository: https://github.com/youbot-release/youbot_description-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
