### PR TITLE
rtmros_nextage: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7855,7 +7855,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.6.0-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.6.2-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.0-0`
## nextage_description

```
* Correct changelogs to apply the important announcement.
* Contributors: Isaac IY Saito
```
## nextage_moveit_config
- No changes
## nextage_ros_bridge

```
* (Feature) Add hands_ueye.launch for bringing up hand's ueye camera nodes.
* (Fix) [test_handlight.py] fix to pass the test, handlight (writeDigitalOutput always returns True in simulation https://github.com/fkanehiro/hrpsys-base/blob/master/python/hrpsys_config.py#L1284)
* Contributors: Kei Okada, Ryosuke Tajima
```
## rtmros_nextage

```
* (Doc) Correct changelogs to apply the important announcement.
* (Feature) Add hands_ueye.launch for bringing up hand's ueye camera nodes.
* (Fix) [test_handlight.py] fix to pass the test, handlight (writeDigitalOutput always returns True in simulation https://github.com/fkanehiro/hrpsys-base/blob/master/python/hrpsys_config.py#L1284)
* Contributors: Kei Okada, Ryosuke Tajima, Isaac IY Saito
```
