### PR TITLE
nao_interaction: 0.1.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1282,6 +1282,27 @@ repositories:
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
       version: master
     status: maintained
+  nao_interaction:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_interaction.git
+      version: master
+    release:
+      packages:
+      - nao_audio
+      - nao_interaction
+      - nao_interaction_launchers
+      - nao_interaction_msgs
+      - nao_vision
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/nao_interaction-release.git
+      version: 0.1.5-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_interaction.git
+      version: master
+    status: maintained
   nao_meshes:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_interaction` to `0.1.5-0`:
- upstream repository: https://github.com/ros-naoqi/nao_interaction.git
- release repository: https://github.com/ros-gbp/nao_interaction-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## nao_audio

```
* change value to boolean
* Contributors: kochigami
```
## nao_interaction
- No changes
## nao_interaction_launchers
- No changes
## nao_interaction_msgs

```
* add learn face service
* Contributors: tarukosu
```
## nao_vision

```
* add self. to global variables
* add learn face service
* Contributors: Kei Okada, tarukosu
```
