### PR TITLE
spur: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8469,7 +8469,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/spur-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/tork-a/spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `spur` to `0.2.1-0`:
- upstream repository: https://github.com/tork-a/spur.git
- release repository: https://github.com/tork-a/spur-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.0-0`
## spur

```
* (Fix) Add more dependency
* Contributors: Isaac IY Saito
```
## spur_controller

```
* (Fix) Add more dependency
* Contributors: Isaac IY Saito
```
## spur_description
- No changes
## spur_gazebo

```
* (Fix) Add more dependency
* Contributors: Isaac IY Saito
```
