### PR TITLE
libccd: 2.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1061,6 +1061,13 @@ repositories:
       url: https://github.com/ros-gbp/laser_proc-release.git
       version: 0.1.4-0
     status: maintained
+  libccd:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/libccd-release.git
+      version: 2.0.0-0
+    status: maintained
   librms:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libccd` to `2.0.0-0`:
- upstream repository: https://github.com/danfis/libccd.git
- release repository: https://github.com/ros-gbp/libccd-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
