### PR TITLE
libccd: 2.0.0-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1073,7 +1073,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/libccd-release.git
-      version: 2.0.0-0
+      version: 2.0.0-1
     status: maintained
   librms:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `libccd` to `2.0.0-1`:
- upstream repository: https://github.com/danfis/libccd.git
- release repository: https://github.com/ros-gbp/libccd-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.0.0-0`
