### PR TITLE
fcl: 0.3.2-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -586,7 +586,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/fcl-release.git
-      version: 0.3.2-0
+      version: 0.3.2-1
     status: maintained
   filters:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `fcl` to `0.3.2-1`:
- upstream repository: https://github.com/flexible-collision-library/fcl.git
- release repository: https://github.com/ros-gbp/fcl-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.2-0`
