### PR TITLE
libqi: 2.1.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3761,6 +3761,13 @@ repositories:
       url: https://github.com/ethz-asl/libpointmatcher.git
       version: master
     status: developed
+  libqi:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-naoqi/libqi-release.git
+      version: 2.1.3-1
+    status: maintained
   librms:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libqi` to `2.1.3-1`:
- upstream repository: https://github.com/aldebaran/libqi.git
- release repository: https://github.com/ros-naoqi/libqi-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
