### PR TITLE
naoqi_libqi: 2.1.3-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4649,6 +4649,15 @@ repositories:
       url: https://github.com/ros-naoqi/naoqi_bridge.git
       version: master
     status: developed
+  naoqi_libqi:
+    release:
+      packages:
+      - maoqi_libqi
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-naoqi/libqi-release.git
+      version: 2.1.3-2
+    status: maintained
   nav2_platform:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqi` to `2.1.3-2`:
- upstream repository: https://github.com/aldebaran/libqi.git
- release repository: https://github.com/ros-naoqi/libqi-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
