### PR TITLE
warehouse_ros: 0.8.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3060,6 +3060,17 @@ repositories:
       url: https://github.com/ros-visualization/visualization_tutorials.git
       version: indigo-devel
     status: maintained
+  warehouse_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/warehouse_ros-release.git
+      version: 0.8.8-0
+    status: maintained
   web_video_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `0.8.8-0`:
- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/ros-gbp/warehouse_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## warehouse_ros

```
* Merge pull request #13 <https://github.com/ros-planning/warehouse_ros/issues/13> from corot/master
  Issue #11 <https://github.com/ros-planning/warehouse_ros/issues/11>: Add a Python library
* Merge pull request #15 <https://github.com/ros-planning/warehouse_ros/issues/15> from v4hn/shared-static-mongodb
  only export MongoDB dependency for shared mongodb-library
* only export MongoDB dependency for shared mongodb-library
  libmongoclient.a uses quite a number of other libs and the exact
  requirements can't be read from a cmake/pc file.
  Therefore it makes more sense to keep the dependency hidden from ROS
  when we use the static lib. libwarehouse_ros then provides all required functions.
  ... This is a bit like creating a libmongoclient.so, but the whole problem
  exists because debian/ubuntu don't provide this one, right?
  The shared library can - and has to - be exported as a dependency to ROS.
* Missing part of https://github.com/corot/world_canvas/issues/10:
  requires both mongodb and mongodb-dev
* Merge branch 'master' of https://github.com/corot/warehouse_ros.git
* Add kwargs also to insert so we can solves issues as
  https://github.com/corot/world_canvas/issues/13
* Add kwargs to ensure_index so we can solves issues as
  https://github.com/corot/world_canvas/issues/13
* Add python-pymongo dependency
* Issue https://github.com/corot/world_canvas/issues/11: rospy queue_size
  warnings
* Issue #11 <https://github.com/ros-planning/warehouse_ros/issues/11>: Add a Python library
* Contributors: Ioan A Sucan, corot, v4hn
```
