### PR TITLE
household_objects_database_msgs: 0.1.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -831,6 +831,17 @@ repositories:
       url: https://github.com/ros-gbp/hokuyo_node-release.git
       version: 1.7.8-0
     status: maintained
+  household_objects_database_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-interactive-manipulation/household_objects_database_msgs.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/household_objects_database_msgs-release.git
+      version: 0.1.1-0
+    status: maintained
   humanoid_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `household_objects_database_msgs` to `0.1.1-0`:
- upstream repository: https://github.com/ros-interactive-manipulation/household_objects_database_msgs.git
- release repository: https://github.com/ros-gbp/household_objects_database_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
