### PR TITLE
manipulation_msgs: 0.2.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1116,6 +1116,13 @@ repositories:
       url: https://github.com/WPI-RAIL/m4atx_battery_monitor.git
       version: develop
     status: maintained
+  manipulation_msgs:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/manipulation_msgs-release.git
+      version: 0.2.0-0
+    status: maintained
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `manipulation_msgs` to `0.2.0-0`:
- upstream repository: https://github.com/ros-interactive-manipulation/manipulation_msgs.git
- release repository: https://github.com/ros-gbp/manipulation_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
