### PR TITLE
agile_grasp: 0.7.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -107,7 +107,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/atenpas/agile_grasp-release.git
-      version: 0.6.2-0
+      version: 0.7.0-0
     source:
       type: git
       url: https://github.com/atenpas/agile_grasp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `agile_grasp` to `0.7.0-0`:
- upstream repository: https://github.com/atenpas/agile_grasp.git
- release repository: https://github.com/atenpas/agile_grasp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.2-0`
## agile_grasp

```
* update CMakeLists
* added rviz visualization
* fixed instructions -> (6)
* added instructions
* fixed launch files
* Contributors: atp
* added rviz visualization
* fixed instructions -> (6)
* added instructions
* fixed launch files
* Contributors: atp
```
