### PR TITLE
pocketsphinx: 0.4.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1771,6 +1771,17 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: indigo-devel
     status: maintained
+  pocketsphinx:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/pocketsphinx.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/pocketsphinx-release.git
+      version: 0.4.0-0
+    status: maintained
   pointgrey_camera_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pocketsphinx` to `0.4.0-0`:
- upstream repository: https://github.com/mikeferguson/pocketsphinx.git
- release repository: https://github.com/ros-gbp/pocketsphinx-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## pocketsphinx

```
* add ~source parameter, for setting things like 'alsasrc'
* add depend on python-gst
* Contributors: Michael Ferguson
```
