### PR TITLE
image_common: 1.11.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2651,7 +2651,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/image_common-release.git
-      version: 1.11.4-0
+      version: 1.11.5-0
     source:
       type: git
       url: https://github.com/ros-perception/image_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `1.11.5-0`:
- upstream repository: https://github.com/ros-perception/image_common.git
- release repository: https://github.com/ros-gbp/image_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.4-0`
## camera_calibration_parsers

```
* Fix catkin_make failure (due to yaml-cpp deps) for mac os
* Contributors: Yifei Zhang
```
## camera_info_manager
- No changes
## image_common
- No changes
## image_transport

```
* image_transport: fix CameraSubscriber shutdown (circular shared_ptr ref)
  CameraSubscriber uses a private boost::shared_ptr to share an impl object
  between copied instances. In CameraSubscriber::CameraSubscriber(), it
  handed this shared_ptr to boost::bind() and saved the created wall timer
  in the impl object, thus creating a circular reference. The impl object
  was therefore never freed.
  Fix that by passing a plain pointer to boost::bind().
* avoid a memory copy for the raw publisher
* add a way to publish an image with only the data pointer
* Make function inline to avoid duplicated names when linking statically
* add plugin examples for the tutorial
* update instructions for catkin
* remove uselessly linked library
  fixes #28 <https://github.com/ros-perception/image_common/issues/28>
* add a tutorial for image_transport
* Contributors: Gary Servin, Max Schwarz, Vincent Rabaud
```
## polled_camera
- No changes
