### PR TITLE
jsk_roseus: 1.3.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3202,7 +3202,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.3.4-0
+      version: 1.3.5-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.3.5-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.3.4-0`
## jsk_roseus
- No changes
## roseus

```
* [roseus.cpp] remove error message in get-topic-subscriber
* [roseus.cpp] add more documentations
* [cmake/roseus.cmake] update generate_eusdoc for installed functionsnn this requires https://github.com/euslisp/EusLisp/pull/112
* [cmake/roseus.cmake] do not raise error when geneus doc failed
* [euslisp/{eustf.l, roseus-utils.l, roseus.l}] add more documenations
* [roseus.cpp] is fix error message, You must call ros::init() -> (ros::roseus "name")
* [roseus/CMakeLists.txt] add compiler option for C to suppress looking-up undefined symbol when linking using Clang compiler
* [roseus/eustf.cpp] undef duplicated macros defined in standard library and in euslisp
* [roseus.cpp] remove error message meanless in get-topic-publisher
* Contributors: Yuki Furuta, Kei Okada, Yuto Inagaki
```
## roseus_smach
- No changes
## roseus_tutorials
- No changes
