### PR TITLE
naoqi_libqicore: 2.3.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4656,6 +4656,13 @@ repositories:
       url: https://github.com/ros-naoqi/libqi-release.git
       version: 2.3.0-1
     status: maintained
+  naoqi_libqicore:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-naoqi/libqicore-release.git
+      version: 2.3.1-1
+    status: maintained
   nav2_platform:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqicore` to `2.3.1-1`:
- upstream repository: https://github.com/aldebaran/libqicore.git
- release repository: https://github.com/ros-naoqi/libqicore-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
