### PR TITLE
naoqi_libqicore: 2.3.1-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4661,7 +4661,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/libqicore-release.git
-      version: 2.3.1-1
+      version: 2.3.1-2
     status: maintained
   nav2_platform:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqicore` to `2.3.1-2`:
- upstream repository: https://github.com/aldebaran/libqicore.git
- release repository: https://github.com/ros-naoqi/libqicore-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.3.1-1`
