### PR TITLE
naoqi_rosbridge: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4674,6 +4674,12 @@ repositories:
       url: https://github.com/ros-naoqi/libqicore-release.git
       version: 2.3.1-2
     status: maintained
+  naoqi_rosbridge:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/vrabaud/naoqi_robridge-release.git
+      version: 0.0.1-0
   nav2_platform:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_rosbridge` to `0.0.1-0`:
- upstream repository: https://github.com/vrabaud/alrosbridge.git
- release repository: https://github.com/vrabaud/naoqi_robridge-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
