### PR TITLE
agile_grasp: 0.7.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -107,7 +107,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/atenpas/agile_grasp-release.git
-      version: 0.7.0-0
+      version: 0.7.2-0
     source:
       type: git
       url: https://github.com/atenpas/agile_grasp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `agile_grasp` to `0.7.2-0`:
- upstream repository: https://github.com/atenpas/agile_grasp.git
- release repository: https://github.com/atenpas/agile_grasp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.0-0`
## agile_grasp

```
* added author to package.xml
* 0.7.1
* update CHANGELOG.rst
* added dependency for visualization msgs
* Contributors: Andreas, atp
* 0.7.1
* update CHANGELOG.rst
* added dependency for visualization msgs
* Contributors: Andreas, atp
```
