### PR TITLE
agile_grasp: 0.7.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -121,7 +121,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/atenpas/agile_grasp-release.git
-      version: 0.6.2-1
+      version: 0.7.2-0
     source:
       type: git
       url: https://github.com/atenpas/agile_grasp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `agile_grasp` to `0.7.2-0`:
- upstream repository: https://github.com/atenpas/agile_grasp.git
- release repository: https://github.com/atenpas/agile_grasp-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.2-1`
## agile_grasp

```
* added author to package.xml
* 0.7.1
* update CHANGELOG.rst
* added dependency for visualization msgs
* Contributors: Andreas, atp
* 0.7.1
* update CHANGELOG.rst
* added dependency for visualization msgs
* Contributors: Andreas, atp
```
