### PR TITLE
libpointmatcher: 1.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3755,7 +3755,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-asl/libpointmatcher-release.git
-      version: 1.2.2-0
+      version: 1.2.3-0
     source:
       type: git
       url: https://github.com/ethz-asl/libpointmatcher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libpointmatcher` to `1.2.3-0`:
- upstream repository: https://github.com/ethz-asl/libpointmatcher.git
- release repository: https://github.com/ethz-asl/libpointmatcher-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.2.2-0`
## libpointmatcher

```
* Support including other versions of YAML in compilation units that also include the YAML version packed with libpointmatcher (PR #80)
* Changed immutability concept for SupportLabel to support MSVC 2012 (#78)
* Fixed build system related bugs (#79, #70, ..).
* updated build_map example, added better error message, added better information prints
* cleaned CMakeList and added missing dependencies for external projetcs
* avoid possibility of building dynamic library on MacOS
* updated Mac build instructions
* Tim3xx laser support on Simple Noise filter (#64)
* Modified default covariance return in PointToPlaneWithCovErrorMinimizer (#59)
* update usage text and retab
* Removed compilation warnings
* add unit test for ICPSequence
* added application of reference data points filters for ICPSequence objects (#56)
* Merge branch 'master' of github.com:ethz-asl/libpointmatcher
* fix problem with libnabo linking (#54)
* Adapted the code to handle 2D point clouds and decided to split the initial/icp/complete transformation matrices in 3 different files. It should be easier to post process the transformations.
* Changed matrix for matrices as output suffix
* Changed the ICP example (pmicp) to accept initial translation/rotation input and allow to output the transformation matrices
* CutBelowLevelDataPointsFilter (PR #48)
* split unit tests (PR #47)
* Delete roadmap.txt
* change year to 2014
* correct bug in DataPoints operator==
* add a method to remove features or descriptors
* add empty function for removing features and descriptors
* add functions to DataPoints avoiding error on rows and cols
* fill missing documentation
* resolve warning from unsigned to int in IO.cpp
* add extra empty line in utest
* add extra unit tests and resolve remaining bugs
* Refactored how to load PLY files
* Allow 2D descriptors (##45)
* Allow saving 2D descriptors coming from a 2Dmap, that are converted to 3D when writing to the file but needed after if we want to load the map as 2D.
* Contributors: Francis Colas, Francisco J Perez Grau, François Pomerleau, HannesSommer, Philipp Kruesi, Renaud Dube, Simon Lynen, chipironcin, pomerlef, smichaud, v01d
```
