### PR TITLE
naoqi_rosbridge: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4693,7 +4693,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/vrabaud/naoqi_robridge-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     status: maintained
   nav2_platform:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_rosbridge` to `0.0.3-0`:
- upstream repository: https://github.com/vrabaud/alrosbridge.git
- release repository: https://github.com/vrabaud/naoqi_robridge-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.2-0`
