### PR TITLE
kobuki_led_controller: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3411,6 +3411,21 @@ repositories:
       url: https://github.com/yujinrobot/kobuki_desktop.git
       version: indigo
     status: developed
+  kobuki_led_controller:
+    doc:
+      type: git
+      url: https://github.com/jihoonl/kobuki_led_controller.git
+      version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/jihoonl/kobuki_led_controller-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/jihoonl/kobuki_led_controller.git
+      version: indigo
+    status: developed
   kobuki_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_led_controller` to `0.0.1-0`:
- upstream repository: https://github.com/jihoonl/kobuki_led_controller.git
- release repository: https://github.com/jihoonl/kobuki_led_controller-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## kobuki_led_controller

```
* kobuki led controller init
* Initial commit
* Contributors: Jihoon Lee
```
