### PR TITLE
jsk_common: 1.0.71-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3185,7 +3185,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.70-0
+      version: 1.0.71-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `1.0.71-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.70-0`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## collada_urdf_jsk_patch
- No changes
## downward
- No changes
## dynamic_tf_publisher
- No changes
## ff
- No changes
## ffha
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_data

```
* [jsk_data] common_record.launch: Mkdir for saving rosbag file
* [jsk_data] Add image to all_image regex to common_record.launch
* Contributors: Kentaro Wada
```
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## jsk_network_tools

```
* [jsk_network_tools] use multiprocess on silverhammer receiver
* [jsk_network_tools/silverhammer_lowspeed_receiver] Force to disable timeout
* [jsk_network_tools] add wireshark plugin for silverhammer udp protocol
* Contributors: Yuki Furuta, Ryohei Ueda
```
## jsk_tilt_laser

```
* [jsk_tilt_laser] Update threshold to remove laser noise of multisense
* [jsk_tilt_laser] Increase minimum intensity to use on multisense
* [jsk_tilt_laser/multisense_laser_pipeline.launch] Add xyz filter before
  downsample pointcloud in order to avoid overflow of indices
* Contributors: Ryohei Ueda
```
## jsk_tools

```
* [jsk_tools] Do not run rossetip_addr with device names because it takes
  a lot of time to resolve non-existing host
* [jsk_tools] Allow localhost in check_host_sanity.py
* [jsk_tools/git_commit_aliases] Add 'GitHub' for more easy-to-understand message
* Contributors: Ryohei Ueda
```
## jsk_topic_tools

```
* [jsk_topic_tools] Add ~always_subscribe parameter to ConnectionBasedNodelet
  and DiagnosticNodelet to always subscribe input topics
* Contributors: Ryohei Ueda
```
## julius
- No changes
## laser_filters_jsk_patch
- No changes
## libsiftfast
- No changes
## mini_maxwell
- No changes
## multi_map_server
- No changes
## nlopt
- No changes
## opt_camera
- No changes
## posedetection_msgs
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## sklearn
- No changes
## speech_recognition_msgs
- No changes
## virtual_force_publisher
- No changes
## voice_text
- No changes
