### PR TITLE
laser_geometry: 1.6.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1066,11 +1066,15 @@ repositories:
       version: 1.8.0-0
     status: maintained
   laser_geometry:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: indigo-devel
     release:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/laser_geometry-release.git
-      version: 1.6.3-0
+      version: 1.6.4-0
     source:
       type: git
       url: https://github.com/ros-perception/laser_geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `1.6.4-0`:
- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros-gbp/laser_geometry-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.6.3-0`
## laser_geometry

```
* Fix segfault when laserscan ranges[] is empty
* Contributors: Timm Linder, Vincent Rabaud
```
