### PR TITLE
handle_detector: 1.1.0-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2314,7 +2314,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/atenpas/handle_detector-release.git
-      version: 1.1.0-2
+      version: 1.1.0-3
     source:
       type: git
       url: https://github.com/atenpas/handle_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `handle_detector` to `1.1.0-3`:
- upstream repository: https://github.com/atenpas/handle_detector
- release repository: https://github.com/atenpas/handle_detector-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.0-2`
## handle_detector

```
* updated readme
* updated CMakeLists and package.xml
* cleaned up folders; added documentation
* added importance sampling (reduces number of samples)
* Contributors: atenpas
```
