### PR TITLE
metapackages: 1.2.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1242,7 +1242,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/metapackages-release.git
-      version: 1.1.3-0
+      version: 1.2.0-0
     status: maintained
   microstrain_3dmgx2_imu:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `metapackages` to `1.2.0-0`:
- upstream repository: https://github.com/ros/metapackages.git
- release repository: https://github.com/ros-gbp/metapackages-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.3-0`
