### PR TITLE
teb_local_planner: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8751,7 +8751,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner` to `0.1.3-0`:
- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.2-0`
## teb_local_planner

```
* Fixed compilation issues on ubuntu saucy
```
