### PR TITLE
ros_tutorials: 0.6.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2482,7 +2482,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ros_tutorials-release.git
-      version: 0.5.3-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/ros/ros_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `0.6.0-0`:
- upstream repository: git@github.com:ros/ros_tutorials.git
- release repository: https://github.com/ros-gbp/ros_tutorials-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.3-0`
## ros_tutorials
- No changes
## roscpp_tutorials
- No changes
## rospy_tutorials
- No changes
## turtlesim

```
* add jade turtle (#22 <https://github.com/ros/ros_tutorials/pull/22>)
```
