### PR TITLE
teb_local_planner: 0.1.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2972,7 +2972,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2967,7 +2967,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git
-      version: jade-devel
+      version: master
     release:
       tags:
         release: release/jade/{package}/{version}
@@ -2976,7 +2976,7 @@ repositories:
     source:
       type: git
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git
-      version: jade-devel
+      version: master
     status: developed
   teleop_twist_keyboard:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner` to `0.1.5-0`:
- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.4-0`
## teb_local_planner

```
* Added possibility to dynamically change parameters of test_optim_node using dynamic reconfigure.
* Fixed a wrong default-min-max tuple in the dynamic reconfigure config.
* Useful config and launch files are now added to cmake install.
* Added install target for the test_optim_node executable.
```
