### PR TITLE
Adding ar_tools to documentation index for distro 

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -195,6 +195,12 @@ repositories:
       url: https://github.com/Sahloul/ar_sys.git
       version: indigo-devel
     status: developed
+  ar_tools:
+    source:
+      type: git
+      url: https://github.com/ar-tools/ar_tools
+      version: master
+    status: maintained
   ar_track_alvar:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -196,9 +196,13 @@ repositories:
       version: indigo-devel
     status: developed
   ar_tools:
+    doc:
+      type: git
+      url: https://github.com/ar-tools/ar_tools.git
+      version: master
     source:
       type: git
-      url: https://github.com/ar-tools/ar_tools
+      url: https://github.com/ar-tools/ar_tools.git
       version: master
     status: maintained
   ar_track_alvar:


### PR DESCRIPTION
I'd like my repo to be indexed and documented on ros.org please.
