### PR TITLE
twist_mux: 2.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3008,6 +3008,21 @@ repositories:
       url: https://github.com/RobotWebTools/tf2_web_republisher.git
       version: develop
     status: maintained
+  twist_mux:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/twist_mux-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux.git
+      version: jade-devel
+    status: maintained
   twist_mux_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux` to `2.0.0-0`:
- upstream repository: https://github.com/ros-teleop/twist_mux.git
- release repository: https://github.com/ros-gbp/twist_mux-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## twist_mux

```
* Add rosindex tags
  http://rosindex.github.io/contribute/metadata/#metadata-elements
* Add missed test dependencies on rospy, rostopic
* Add .gitignore for *.pyc in test
* Fix rostest dependency
* Contributors: Enrique Fernandez
```
