### PR TITLE
moveit_python: 0.2.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4316,7 +4316,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mikeferguson/moveit_python-release.git
-      version: 0.2.13-0
+      version: 0.2.14-0
     source:
       type: git
       url: https://github.com/mikeferguson/moveit_python.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_python` to `0.2.14-0`:
- upstream repository: https://github.com/mikeferguson/moveit_python.git
- release repository: https://github.com/mikeferguson/moveit_python-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.13-0`
## moveit_python

```
* add no-wait behavior for move, pick, and place
* updates for compliance with PEP8
* Contributors: Aaron Blasdel, Michael Ferguson
```
