### PR TITLE
Add ceres-solver rosdep key for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1111,6 +1111,7 @@ libcegui-mk2-dev:
       packages: [dev-games/cegui]
   ubuntu: [libcegui-mk2-dev]
 libceres-dev:
+  fedora: [ceres-solver-devel]
   gentoo:
     portage:
       packages: [sci-libs/ceres-solver]


### PR DESCRIPTION
Adding a Fedora ceres-solver key for ceres-solver-devel, which was
recently introduced to Fedora:
https://bugzilla.redhat.com/show_bug.cgi?id=1183193

Signed-off-by: Rich Mattes richmattes@gmail.com
