### PR TITLE
robot_controllers: 0.3.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6577,6 +6577,25 @@ repositories:
       url: https://github.com/mikeferguson/robot_calibration.git
       version: indigo-devel
     status: developed
+  robot_controllers:
+    doc:
+      type: git
+      url: https://github.com/fetchrobotics/robot_controllers.git
+      version: indigo-devel
+    release:
+      packages:
+      - robot_controllers
+      - robot_controllers_interface
+      - robot_controllers_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
+      version: 0.3.4-0
+    source:
+      type: git
+      url: https://github.com/fetchrobotics/robot_controllers.git
+      version: indigo-devel
+    status: developed
   robot_localization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_controllers` to `0.3.4-0`:
- upstream repository: git@github.com:fetchrobotics/robot_controllers.git
- release repository: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## robot_controllers

```
* add ability to reset controllers
* add timeout to laser speed scaling
* maintain constant curvature when scaling base velocity
* remove DiffDriveBaseController::publish()
* Contributors: Michael Ferguson
```
## robot_controllers_interface

```
* add ability to reset controllers
* Contributors: Michael Ferguson
```
## robot_controllers_msgs
- No changes
