### PR TITLE
mvsim: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4505,7 +4505,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/ual-arm-ros-pkg/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.1.2-0`:
- upstream repository: https://github.com/ual-arm-ros-pkg/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.1-0`
## mvsim

```
* Cleaner build against mrpt 1.3.0
* Fix build against mrpt 1.3.0
* Contributors: Jose Luis Blanco
```
