### PR TITLE
naoqi_rosbridge: 0.0.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1499,6 +1499,17 @@ repositories:
       url: https://github.com/ros-naoqi/libqicore-release.git
       version: 2.3.1-1
     status: maintained
+  naoqi_rosbridge:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-naoqi/naoqi_rosbridge-release.git
+      version: 0.0.5-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/alrosbridge.git
+      version: master
+    status: maintained
   navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_rosbridge` to `0.0.5-0`:
- upstream repository: https://github.com/ros-naoqi/alrosbridge.git
- release repository: https://github.com/ros-naoqi/naoqi_rosbridge-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## naoqi_rosbridge

```
* clean seperation between catkin and qibuild
* adjust sdk prefixes with cmake_prefix
* fix devel problems and rename lib
* set sdk prefix to devel space
* add a file to register a NAOqi module
* Contributors: Karsten Knese, Vincent Rabaud
```
