### PR TITLE
Updating robot_localization hydro release

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6539,7 +6539,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 1.1.7-0
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/cra-ros-pkg/robot_localization.git


### PR DESCRIPTION
Prerelease failure is due to rosjava downstream packages. robot_localization built successfully and passed its tests in the prerelease.
