### PR TITLE
rosdep for python-bluez and python-cwiid on vivid

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -160,6 +160,7 @@ python-bluez:
     raring: [python-bluez]
     saucy: [python-bluez]
     trusty: [python-bluez]
+    utopic: [python-bluez]
     vivid: [python-bluez]
 python-cairo:
   debian: [python-cairo]
@@ -305,6 +306,7 @@ python-cwiid:
     raring: [python-cwiid]
     saucy: [python-cwiid]
     trusty: [python-cwiid]
+    utopic: [python-cwiid]
     vivid: [python-cwiid]
 python-dateutil:
   fedora: [python-dateutil]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -160,6 +160,7 @@ python-bluez:
     raring: [python-bluez]
     saucy: [python-bluez]
     trusty: [python-bluez]
+    vivid: [python-bluez]
 python-cairo:
   debian: [python-cairo]
   fedora: [pycairo]
@@ -304,6 +305,7 @@ python-cwiid:
     raring: [python-cwiid]
     saucy: [python-cwiid]
     trusty: [python-cwiid]
+    vivid: [python-cwiid]
 python-dateutil:
   fedora: [python-dateutil]
   ubuntu:


### PR DESCRIPTION
Added rosdep entries for python-bluez and python-cwiid on ubuntu vivid.
