### PR TITLE
joystick_drivers: 1.10.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3034,7 +3034,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/joystick_drivers-release.git
-      version: 1.10.0-0
+      version: 1.10.1-0
     status: maintained
   jsk_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `1.10.1-0`:
- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros-gbp/joystick_drivers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.10.0-0`
## joy

```
* Remove stray architechture_independent flags
* Contributors: Jonathan Bohren, Scott K Logan
```
## joystick_drivers
- No changes
## ps3joy

```
* Remove stray architechture_independent flags
* Contributors: Jonathan Bohren, Scott K Logan
```
## spacenav_node

```
* Add full_scale parameter and apply to offset
* Remove stray architechture_independent flags
* Contributors: Gaël Ecorchard, Jonathan Bohren, Scott K Logan
```
## wiimote
- No changes
