### PR TITLE
joystick_drivers: 1.10.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -999,6 +999,23 @@ repositories:
       url: https://github.com/ros/ivcon.git
       version: indigo-devel
     status: maintained
+  joystick_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: indigo-devel
+    release:
+      packages:
+      - joy
+      - joystick_drivers
+      - ps3joy
+      - spacenav_node
+      - wiimote
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/joystick_drivers-release.git
+      version: 1.10.1-0
+    status: maintained
   jsk_roseus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `1.10.1-0`:
- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros-gbp/joystick_drivers-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## joy

```
* Remove stray architechture_independent flags
* Contributors: Jonathan Bohren, Scott K Logan
```
## joystick_drivers
- No changes
## ps3joy

```
* Remove stray architechture_independent flags
* Contributors: Jonathan Bohren, Scott K Logan
```
## spacenav_node

```
* Add full_scale parameter and apply to offset
* Remove stray architechture_independent flags
* Contributors: Gaël Ecorchard, Jonathan Bohren, Scott K Logan
```
## wiimote
- No changes
