### PR TITLE
nao_moveit_config: 0.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4556,7 +4556,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-naoqi/nao_moveit_config-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_moveit_config` to `0.0.5-0`:
- upstream repository: https://github.com/ros-nao/nao_moveit_config.git
- release repository: https://github.com/ros-naoqi/nao_moveit_config-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.4-0`
## nao_moveit_config

```
* install the .setup_assistant file for potential introspection
* remove the URDF and fix the README
* add a .setup_assistant
* Added foot and pelvis fake controllers
* Added foot and pelvis controllers
* Contributors: Arguedas Mikael, Konstantinos Chatzilygeroudis, Vincent Rabaud
```
