### PR TITLE
nao_extras: 0.2.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1411,6 +1411,21 @@ repositories:
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
       version: master
     status: maintained
+  nao_extras:
+    release:
+      packages:
+      - nao_extras
+      - nao_path_follower
+      - nao_teleop
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/nao_extras-release.git
+      version: 0.2.2-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/nao_extras.git
+      version: master
+    status: maintained
   nao_interaction:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_extras` to `0.2.2-0`:
- upstream repository: https://github.com/ros-nao/nao_extras.git
- release repository: https://github.com/ros-gbp/nao_extras-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## nao_extras

```
* comply to the new naoqi organization
* Contributors: Vincent Rabaud
```
## nao_path_follower

```
* comply to the new naoqi organization
* Contributors: Vincent Rabaud
```
## nao_teleop

```
* comply to the new naoqi organization
* Contributors: Vincent Rabaud
```
