### PR TITLE
robot_localization: 1.2.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6539,7 +6539,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 1.2.0-1
+      version: 1.2.1-0
     source:
       type: git
       url: https://github.com/cra-ros-pkg/robot_localization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `1.2.1-0`:
- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.2.0-1`
