### PR TITLE
roboteq: 0.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2424,6 +2424,25 @@ repositories:
       url: https://github.com/RobotWebTools/robot_web_tools.git
       version: develop
     status: maintained
+  roboteq:
+    doc:
+      type: git
+      url: https://github.com/g/roboteq.git
+      version: master
+    release:
+      packages:
+      - roboteq_diagnostics
+      - roboteq_driver
+      - roboteq_msgs
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/clearpath-gbp/roboteq-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/g/roboteq.git
+      version: master
+    status: maintained
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roboteq` to `0.1.2-0`:
- upstream repository: https://github.com/g/roboteq.git
- release repository: https://github.com/clearpath-gbp/roboteq-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## roboteq_diagnostics

```
* Add queue_size, fixes #4 <https://github.com/g/roboteq//issues/4>
* Contributors: Mike Purvis
```
## roboteq_driver
- No changes
## roboteq_msgs
- No changes
