### PR TITLE
grizzly: 0.3.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -843,6 +843,27 @@ repositories:
       version: 0.3.1-0
     status: maintained
     status_description: ']'
+  grizzly:
+    doc:
+      type: git
+      url: https://github.com/g/grizzly.git
+      version: indigo-devel
+    release:
+      packages:
+      - grizzly_description
+      - grizzly_motion
+      - grizzly_msgs
+      - grizzly_navigation
+      - grizzly_teleop
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/clearpath-gbp/grizzly-release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/g/grizzly.git
+      version: indigo-devel
+    status: maintained
   hokuyo_node:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly` to `0.3.1-0`:
- upstream repository: https://github.com/g/grizzly.git
- release repository: https://github.com/clearpath-gbp/grizzly-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## grizzly_description

```
* Find includes in URDF relative to package locations.
* Remove unneeded joint_state_publisher dependency.
* fix imu topic in simulator
* In navigation pkg, rename config and launch files to localization
* set imu frame ID as imu_link
* Contributors: Mike Purvis, Shokoofeh Pourmehr
```
## grizzly_motion

```
* Fix grizzly_motion/tests bugs
* Contributors: Shokoofeh Pourmehr
```
## grizzly_msgs
- No changes
## grizzly_navigation

```
* fix imu topic
* change imu topic to imu/data_combined
* In navigation pkg, rename config and launch files to localization
* Contributors: Shokoofeh Pourmehr
```
## grizzly_teleop

```
* Add modified sixpair to grizzly_teleop.
  This version supports the Navigation controller, and a wrapper
  is included which allows it to be run easily from ROS while
  wrapped in sudo.
* Add queue_size to rospy.Publisher.
* Contributors: Mike Purvis
```
