### PR TITLE
rosjava_messages: 0.1.341-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7328,7 +7328,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_messages-release.git
-      version: 0.1.329-0
+      version: 0.1.341-0
     source:
       type: git
       url: https://github.com/rosjava/rosjava_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_messages` to `0.1.341-0`:
- upstream repository: https://github.com/rosjava/rosjava_messages.git
- release repository: https://github.com/rosjava-release/rosjava_messages-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.329-0`
