### PR TITLE
kobuki_core: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3397,7 +3397,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki_core-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core` to `0.6.1-0`:
- upstream repository: https://github.com/yujinrobot/kobuki_core.git
- release repository: https://github.com/yujinrobot-release/kobuki_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.0-0`
## kobuki_core
- No changes
## kobuki_dock_drive
- No changes
## kobuki_driver
- No changes
## kobuki_ftdi

```
* remove kobuki_ros kobuki_nodelet libaries export in catkin_package closes #16 <https://github.com/yujinrobot/kobuki_core/issues/16>
* Contributors: Jihoon Lee
```
