### PR TITLE
kobuki: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3377,7 +3377,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki-release.git
-      version: 0.6.5-0
+      version: 0.6.6-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki` to `0.6.6-0`:
- upstream repository: https://github.com/yujinrobot/kobuki.git
- release repository: https://github.com/yujinrobot-release/kobuki-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.5-0`
## kobuki
- No changes
## kobuki_auto_docking
- No changes
## kobuki_bumper2pc
- No changes
## kobuki_capabilities
- No changes
## kobuki_controller_tutorial
- No changes
## kobuki_description
- No changes
## kobuki_keyop

```
* Installed both C/C++ headers.
* Installed missing include directory.
* Contributors: James Goppert
```
## kobuki_node

```
* install image directory closes #357 <https://github.com/yujinrobot/kobuki/issues/357>
* Contributors: Jihoon Lee
```
## kobuki_random_walker
- No changes
## kobuki_rapps
- No changes
## kobuki_safety_controller
- No changes
## kobuki_testsuite

```
* add comment for new variable #353 <https://github.com/yujinrobot/kobuki/issues/353>
* checks scan_angle variable. correct msg import #353 <https://github.com/yujinrobot/kobuki/issues/353>
* Contributors: Jihoon Lee
```
