### PR TITLE
rocon_msgs: 0.7.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6802,6 +6802,7 @@ repositories:
       packages:
       - concert_msgs
       - concert_service_msgs
+      - concert_workflow_engine_msgs
       - gateway_msgs
       - rocon_app_manager_msgs
       - rocon_device_msgs
@@ -6814,7 +6815,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-      version: 0.7.10-0
+      version: 0.7.11-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs` to `0.7.11-0`:
- upstream repository: http://github.com/robotics-in-concert/rocon_msgs.git
- release repository: https://github.com/yujinrobot-release/rocon_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.10-0`
## concert_msgs
- No changes
## concert_service_msgs
- No changes
## concert_workflow_engine_msgs

```
* add ready status
* re define workflow status message included pre-defined status
* change status type and add pre define about status
* delete unused variable
* delete unused file
* update concert workflow engine message
* Contributors: dwlee
```
## gateway_msgs
- No changes
## rocon_app_manager_msgs

```
* [rocon_app_manager_msgs] published interface types.
* Contributors: Daniel Stonier
```
## rocon_device_msgs
- No changes
## rocon_interaction_msgs
- No changes
## rocon_msgs
- No changes
## rocon_service_pair_msgs
- No changes
## rocon_std_msgs

```
* connections.
* Contributors: Daniel Stonier
```
## rocon_tutorial_msgs
- No changes
## scheduler_msgs
- No changes
