### PR TITLE
rocon_app_platform: 0.7.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6761,7 +6761,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_app_platform-release.git
-      version: 0.7.11-0
+      version: 0.7.12-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_app_platform` to `0.7.12-0`:
- upstream repository: http://github.com/robotics-in-concert/rocon_app_platform
- release repository: https://github.com/yujinrobot-release/rocon_app_platform-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.11-0`
## rocon_app_manager

```
* adding parameter to delay service creation (now only once) if gateway uuid is needed.
  changed standalone namespace to be robot_name (parameter) to match namespace with concert but without uuid
  added delay in spin
* fix typo regarding constant definition in utils
* [rocon_app_manager] status now publishes the runtime interfaces and parameters.
* Contributors: AlexV, Daniel Stonier, dwlee
```
## rocon_app_platform
- No changes
## rocon_app_utilities
- No changes
## rocon_apps

```
* add make a map rapp closes #290 <https://github.com/robotics-in-concert/rocon_app_platform/issues/290>
* add goal and path
* Contributors: Jihoon Lee
```
