### PR TITLE
rotors_simulator: 1.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7743,7 +7743,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-asl/rotors_simulator-release.git
-      version: 1.1.1-0
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/ethz-asl/rotors_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rotors_simulator` to `1.1.2-0`:
- upstream repository: https://github.com/ethz-asl/rotors_simulator.git
- release repository: https://github.com/ethz-asl/rotors_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.1.1-0`
## rotors_comm
- No changes
## rotors_control

```
* added nav_msgs dependency and fixed rotors_evaluation's setup.py
```
## rotors_description

```
* added max depth cam range as param
* pointCloudCutoffMax tag added for depth cam
```
## rotors_evaluation

```
* added nav_msgs dependency and fixed rotors_evaluation's setup.py
* rotors_evaluation: added rospy dependency
```
## rotors_gazebo
- No changes
## rotors_gazebo_plugins
- No changes
## rotors_joy_interface
- No changes
## rotors_simulator
- No changes
