### PR TITLE
flatbuffers: 1.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1891,6 +1891,13 @@ repositories:
       url: https://github.com/introlab/find_object_2d-release.git
       version: 0.5.1-0
     status: maintained
+  flatbuffers:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/flatbuffers-release.git
+      version: 1.1.0-0
+    status: maintained
   flir_ptu:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `flatbuffers` to `1.1.0-0`:
- upstream repository: https://github.com/stonier/flatbuffers
- release repository: https://github.com/yujinrobot-release/flatbuffers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
