### PR TITLE
cob_extern: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -958,7 +958,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_extern-release.git
-      version: 0.6.0-1
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/ipa320/cob_extern.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_extern` to `0.6.1-0`:
- upstream repository: https://github.com/ipa320/cob_extern.git
- release repository: https://github.com/ipa320/cob_extern-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.0-1`
## cob_extern
- No changes
## libntcan
- No changes
## libpcan
- No changes
## libphidgets

```
* update libphidgets URL
  This fixes #45 <https://github.com/ipa320/cob_extern/issues/45>.
* Contributors: Martin Günther
```
