### PR TITLE
naoqi_rosbridge: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4739,7 +4739,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_rosbridge-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/ros-naoqi/alrosbridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_rosbridge` to `0.0.6-0`:
- upstream repository: https://github.com/ros-naoqi/alrosbridge.git
- release repository: https://github.com/ros-naoqi/naoqi_rosbridge-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.5-0`
## naoqi_rosbridge

```
* add install rule for the module file
* Contributors: Vincent Rabaud
```
