### PR TITLE
flatbuffers: 1.1.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1896,7 +1896,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/flatbuffers-release.git
-      version: 1.1.0-0
+      version: 1.1.0-1
     status: maintained
   flir_ptu:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `flatbuffers` to `1.1.0-1`:
- upstream repository: https://github.com/stonier/flatbuffers
- release repository: https://github.com/yujinrobot-release/flatbuffers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.0-0`
