### PR TITLE
rtmros_hironx: 1.0.31-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7968,7 +7968,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.30-0
+      version: 1.0.31-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.31-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.30-0`
## hironx_calibration
- No changes
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* (Improvement) [hironx_client.py] need to support newer version of idl (https://github.com/fkanehiro/hrpsys-base/pull/580)
* Contributors: Kei Okada
```
## rtmros_hironx

```
* (Improvement) [hironx_client.py] need to support newer version of idl (https://github.com/fkanehiro/hrpsys-base/pull/580)
* Contributors: Kei Okada
```
