### PR TITLE
h4r_thermapp_camera: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2311,7 +2311,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/Hacks4ROS-release/h4r_thermapp_camera.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/Hacks4ROS/h4r_thermapp_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `h4r_thermapp_camera` to `0.0.3-0`:
- upstream repository: https://github.com/Hacks4ROS/h4r_thermapp_camera.git
- release repository: https://github.com/Hacks4ROS-release/h4r_thermapp_camera.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.2-0`
## h4r_thermapp_camera

```
* add source code of ThermAppCam
* remove submodule
* Contributors: Christian Holl
```
