### PR TITLE
terarangerone-ros: 0.1.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8692,7 +8692,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/Terabee/terarangerone-ros-release.git
-      version: 0.1.0-0
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/Terabee/terarangerone-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `terarangerone-ros` to `0.1.1-1`:
- upstream repository: https://github.com/Terabee/terarangerone-ros.git
- release repository: https://github.com/Terabee/terarangerone-ros-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.0-0`
## terarangerone

```
* Updated readme to make it more clear
* Improved the parser, now every time we receive T character we reset the input_buffer
* Tweacked the console output
* Renamed port_name->portname variable to reflect ros parameter
* Updated the format to comply with the ros style guide
* The serial loop has a sleep in it to reduce cpu load
* Contributors: Flavio Fontana, Luis Rodrigues
```
