### PR TITLE
terarangerone-ros: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8863,6 +8863,19 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  terarangerone-ros:
+    release:
+      packages:
+      - terarangerone
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/Terabee/terarangerone-ros-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/Terabee/terarangerone-ros.git
+      version: master
+    status: maintained
   tf2_web_republisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `terarangerone-ros` to `0.1.1-0`:
- upstream repository: https://github.com/Terabee/terarangerone-ros.git
- release repository: https://github.com/Terabee/terarangerone-ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## terarangerone

```
* Updated readme to make it more clear
* Improved the parser, now every time we receive T character we reset the input_buffer
* Tweacked the console output
* Renamed port_name->portname variable to reflect ros parameter
* Updated the format to comply with the ros style guide
* The serial loop has a sleep in it to reduce cpu load
* Contributors: Flavio Fontana, Luis Rodrigues
```
