### PR TITLE
terarangerduo-ros: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8685,6 +8685,15 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  terarangerduo-ros:
+    release:
+      packages:
+      - terarangerduo
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/Terabee/terarangerduo-ros-release.git
+      version: 0.1.1-0
+    status: maintained
   terarangerone-ros:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `terarangerduo-ros` to `0.1.1-0`:
- upstream repository: https://github.com/Terabee/terarangerduo-ros.git
- release repository: https://github.com/Terabee/terarangerduo-ros-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## terarangerduo

```
* Initial commit
* Contributors: Flavio Fontana, Luís Rodrigues, Ehsan Asadi
```
