### PR TITLE
fetch_ros: 0.5.4-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1869,6 +1869,26 @@ repositories:
       url: https://github.com/ros-gbp/fcl-release.git
       version: 0.3.2-0
     status: maintained
+  fetch_ros:
+    doc:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_ros.git
+      version: indigo-devel
+    release:
+      packages:
+      - fetch_calibration
+      - fetch_description
+      - fetch_moveit_config
+      - fetch_teleop
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
+      version: 0.5.4-1
+    source:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_ros.git
+      version: indigo-devel
+    status: developed
   filters:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.5.4-1`:
- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## fetch_calibration

```
* repository cleanup
```
## fetch_description

```
* repository cleanup
```
## fetch_moveit_config

```
* repository cleanup
```
## fetch_teleop

```
* repository cleanup
```
