### PR TITLE
Revert "warehouse_ros: 0.8.8-1 in 'jade/distribution.yaml' [bloom]"

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3325,7 +3325,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/warehouse_ros-release.git
-      version: 0.8.8-1
+      version: 0.8.8-0
     status: maintained
   web_video_server:
     doc:


### PR DESCRIPTION
Reverts ros/rosdistro#8587

@vrabaud just pointed out this won't work -- if we merge this fast, maybe we can stop the farm from breaking the trusty build
