### PR TITLE
ros_emacs_utils: 0.4.7-1 in 'indigo/distribution.yaml'

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7181,7 +7181,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/code-iai-release/ros_emacs_utils-release.git
-      version: 0.4.6-0
+      version: 0.4.7-1
     source:
       type: git
       url: https://github.com/code-iai/ros_emacs_utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository ros_emacs_utils to 0.4.7-1:

upstream repository: https://github.com/code-iai/ros_emacs_utils.git
release repository: https://github.com/code-iai-release/ros_emacs_utils-release
distro file: indigo/distribution.yaml
bloom version: 0.5.20
previous version for package: 0.4.6-0
