### PR TITLE
mongo_cxx_driver: 1.0.2-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1289,6 +1289,13 @@ repositories:
       url: https://github.com/ros-gbp/microstrain_3dmgx2_imu-release.git
       version: 1.5.12-0
     status: maintained
+  mongo_cxx_driver:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/mongo_cxx_driver-release.git
+      version: 1.0.2-1
+    status: maintained
   moveit_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongo_cxx_driver` to `1.0.2-1`:
- upstream repository: https://github.com/mongodb/mongo-cxx-driver.git
- release repository: https://github.com/ros-gbp/mongo_cxx_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
