### PR TITLE
rocon_devices: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6835,6 +6835,16 @@ repositories:
       type: git
       url: https://github.com/robotics-in-concert/rocon_devices.git
       version: indigo
+    release:
+      packages:
+      - rocon_devices
+      - rocon_hue
+      - rocon_python_hue
+      - rocon_rtsp_camera_relay
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/rocon_devices-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_devices.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_devices` to `0.0.1-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_devices.git
- release repository: https://github.com/yujinrobot-release/rocon_devices-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rocon_devices

```
* release preparation
* rename rtsp_camera_driver to rocon_rtsp_camera_relay closes #33 <https://github.com/robotics-in-concert/rocon_devices/issues/33>
* update package.xml to include all packages as run depend. closes #32 <https://github.com/robotics-in-concert/rocon_devices/issues/32>
* a rocon_devices metapackage for releasing.
* Contributors: DongWook Lee, Jihoon Lee, dwlee
```
## rocon_hue

```
* release preparation
* rtsp camera relay package ready
* update bulb checker
* fix magenta color
* fis color of violet
* update pre define color
* create rocon_hue rapp, delete remap rule, change hue value setting method
* delete default value of hue ip
* create look up table of predefined color
* fixed wrong commit
* modify hue bridge launch file
* restructure complete
* update nb bridge and change rocon hue logging rule
* updates
* add remap argument
* delete wrong file
* add exception
* update exceptrion
* add the exception about no response
* fixed CMAKE install list
* add the hue manager launch and script file
* move the hue manager from office_conccert in rocon_demo repository
* add No response exception from hue bridge
* always turn on when chage the hue color
* add the status of hue regarding bulb reachable
* fix comment of launch file
* add parameter about hue ip and launch file
* add the exception handling more than before
* delete log printing
* fix the parameter bug
* fixed #19 <https://github.com/robotics-in-concert/rocon_devices/issues/19>
* fixed #18 <https://github.com/robotics-in-concert/rocon_devices/issues/18>
* fixed #17 <https://github.com/robotics-in-concert/rocon_devices/issues/17>
* fix the wrong exception handling and show ip when bridge is diconnected
* exception handling to connect web url in phue
* fix the time out error and change the ping checking method
* now it provides log with rocon hue prefix
* fix the bug regarding of bridge connection error at first time
* fix the 3 times color change
* upgrade the order method
* change the sending rule about the valid bulb and fix the test code
* fix the changed name and add the sended property about reachable
* update message package name to coincide with fixes in rocon_msgs.
* fix install rule to resolve issue #9 <https://github.com/robotics-in-concert/rocon_devices/issues/9> and comment in #8 <https://github.com/robotics-in-concert/rocon_devices/issues/8>
* migrate msgs into rocon_msgs as independent package
* change the package name to rocon_hue
* Contributors: Daniel Stonier, DongWook Lee, Dongwook Lee, Jihoon Lee, dwlee
```
## rocon_python_hue

```
* release preparation
* update exception handler for  no result
* fix wron exception logging
* add execption
* restructure complete
* create rocon_device_tools
* Contributors: dwlee
```
## rocon_rtsp_camera_relay

```
* convert stdstring to std_msgs string closes #37 <https://github.com/robotics-in-concert/rocon_devices/issues/37>
* release preparation
* rtsp camera relay package ready
* rename rtsp_camera_driver to rocon_rtsp_camera_relay closes #33 <https://github.com/robotics-in-concert/rocon_devices/issues/33>
* Contributors: Jihoon Lee, dwlee
```
