### PR TITLE
rosjava_build_tools: 0.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7544,11 +7544,15 @@ repositories:
       version: indigo
     status: maintained
   rosjava_build_tools:
+    doc:
+      type: git
+      url: https://github.com/rosjava/rosjava_build_tools.git
+      version: indigo
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_build_tools-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/rosjava/rosjava_build_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_build_tools` to `0.2.4-0`:
- upstream repository: https://github.com/rosjava/rosjava_build_tools.git
- release repository: https://github.com/rosjava-release/rosjava_build_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.3-0`
## rosjava_build_tools

```
* bugfix environment hooks for workspaces with spaces.
```
