### PR TITLE
add libx52pro and -dev (Saitek X52 Pro MFD functions) for rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2326,6 +2326,12 @@ libx264-dev:
   debian: [libx264-dev]
   fedora: [x264-devel]
   ubuntu: [libx264-dev]
+libx52pro:
+  debian: [libx52pro0]
+  ubuntu: [libx52pro0]
+libx52pro-dev:
+  debian: [libx52pro-dev]
+  ubuntu: [libx52pro-dev]
 libxaw:
   arch: [libxaw]
   debian: [libxaw7-dev]


### PR DESCRIPTION
Hi for my package I want to use libx52pro and -dev package, I know it is on Debian and Ubuntu, tried it on my system it does resolve the correct package names

I checked for Debian, the names should be the same there, I added them as well, but I do not have a Debian system here, so I just tested it with the os key.

For all other systems I do not know, I tried to find but they seem to only exist for Ubuntu and Debian.

Regards,

Christian
