### PR TITLE
navigation: 1.12.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4813,7 +4813,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.12.3-0
+      version: 1.12.4-0
     source:
       type: git
       url: https://github.com/ros-planning/navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.12.4-0`:
- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.12.3-0`
## amcl

```
* add the set_map service to amcl
* Contributors: Michael Ferguson, Stephan Wirth
```
## base_local_planner

```
* fix stuck_left/right calculation
* Contributors: Michael Ferguson
```
## carrot_planner
- No changes
## clear_costmap_recovery
- No changes
## costmap_2d

```
* Look for robot_radius when footprint is not set. #206 <https://github.com/mikeferguson/navigation/issues/206>
* Add a first_map_only parameter so we keep reusing the first received static map
* Contributors: Jihoon Lee, Patrick Chin
```
## dwa_local_planner
- No changes
## fake_localization
- No changes
## global_planner

```
* Fix for #337 <https://github.com/mikeferguson/navigation/issues/337>
* Contributors: David V. Lu!!
```
## map_server
- No changes
## move_base
- No changes
## move_base_msgs
- No changes
## move_slow_and_clear
- No changes
## nav_core
- No changes
## navfn

```
* Fix for #337 <https://github.com/mikeferguson/navigation/issues/337>
* Contributors: David V. Lu!!
```
## navigation
- No changes
## robot_pose_ekf
- No changes
## rotate_recovery
- No changes
## voxel_grid
- No changes
