### PR TITLE
fetch_ros: 0.5.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1877,13 +1877,15 @@ repositories:
     release:
       packages:
       - fetch_calibration
+      - fetch_depth_layer
       - fetch_description
       - fetch_moveit_config
+      - fetch_navigation
       - fetch_teleop
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
-      version: 0.5.4-1
+      version: 0.5.5-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.5.5-0`:
- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.4-1`
## fetch_calibration
- No changes
## fetch_depth_layer

```
* release fetch_depth_layer
* Contributors: Michael Ferguson
```
## fetch_description
- No changes
## fetch_moveit_config
- No changes
## fetch_navigation

```
* import navigation
* Contributors: Michael Ferguson
```
## fetch_teleop
- No changes
