### PR TITLE
fetch_gazebo: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1869,6 +1869,21 @@ repositories:
       url: https://github.com/ros-gbp/fcl-release.git
       version: 0.3.2-0
     status: maintained
+  fetch_gazebo:
+    doc:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_gazebo.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/fetch_gazebo-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_gazebo.git
+      version: master
+    status: developed
   fetch_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_gazebo` to `0.3.0-0`:
- upstream repository: https://github.com/fetchrobotics/fetch_gazebo.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## fetch_gazebo

```
* init from preview repo
* Contributors: Michael Ferguson
```
