### PR TITLE
fetch_driver_msgs: 0.5.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1869,6 +1869,21 @@ repositories:
       url: https://github.com/ros-gbp/fcl-release.git
       version: 0.3.2-0
     status: maintained
+  fetch_driver_msgs:
+    doc:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_driver_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/fetch_driver_msgs-release.git
+      version: 0.5.0-0
+    source:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_driver_msgs.git
+      version: master
+    status: developed
   fetch_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_driver_msgs` to `0.5.0-0`:
- upstream repository: https://github.com/fetchrobotics/fetch_driver_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_driver_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## fetch_driver_msgs

```
* move messages into their own package
* Contributors: Michael Ferguson
```
