### PR TITLE
fetch_driver_msgs: 0.5.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1878,7 +1878,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_driver_msgs-release.git
-      version: 0.5.0-0
+      version: 0.5.1-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_driver_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_driver_msgs` to `0.5.1-0`:
- upstream repository: https://github.com/fetchrobotics/fetch_driver_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_driver_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.0-0`
## fetch_driver_msgs

```
* Add balancing_mode to charger message. Change mode to charging_mode.
* Contributors: Derek King, Michael Ferguson
```
