### PR TITLE
fetch_gazebo: 0.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1890,10 +1890,13 @@ repositories:
       url: https://github.com/fetchrobotics/fetch_gazebo.git
       version: master
     release:
+      packages:
+      - fetch_gazebo
+      - fetch_gazebo_demo
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_gazebo-release.git
-      version: 0.3.2-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_gazebo` to `0.4.0-0`:
- upstream repository: https://github.com/fetchrobotics/fetch_gazebo.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.2-0`
## fetch_gazebo

```
* split demos into separate package
* Contributors: Michael Ferguson
```
## fetch_gazebo_demo

```
* split demos into separate package
* Contributors: Michael Ferguson
```
