### PR TITLE
lyap_control: 0.0.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1169,6 +1169,21 @@ repositories:
       url: https://github.com/WPI-RAIL/librms.git
       version: develop
     status: maintained
+  lyap_control:
+    doc:
+      type: git
+      url: https://bitbucket.org/AndyZe/lyap_control.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/AndyZelenak/lyap_control-release.git
+      version: 0.0.8-0
+    source:
+      type: git
+      url: https://bitbucket.org/AndyZe/lyap_control.git
+      version: master
+    status: maintained
   m4atx_battery_monitor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lyap_control` to `0.0.8-0`:
- upstream repository: https://bitbucket.org/AndyZe/lyap_control.git
- release repository: https://github.com/AndyZelenak/lyap_control-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## lyap_control
- No changes
