### PR TITLE
abb: 1.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -28,7 +28,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/abb-release.git
-      version: 1.1.9-0
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/ros-industrial/abb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `abb` to `1.2.0-0`:
- upstream repository: https://github.com/ros-industrial/abb.git
- release repository: https://github.com/ros-industrial-release/abb-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.9-0`
## abb

```
* Remove deprecated package abb_moveit_plugins
* Contributors: Levi Armstrong
```
## abb_driver

```
* No changes
```
## abb_irb2400_moveit_config

```
* No changes
```
## abb_irb2400_moveit_plugins

```
* Regenerated the ikfast moveit plugin for the irb2400 using an
  older version of moveit-ikfast plugin. Fixes issue where the
  ik solutions and the URDF were off by 90 degrees.
* Contributors: Jonathan Meyer
```
## abb_irb2400_support

```
* No changes
```
## abb_irb5400_support

```
* No changes
```
## abb_irb6600_support

```
* No changes
```
## abb_irb6640_moveit_config

```
* No changes
```
