### PR TITLE
flask-ext-catkin: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1946,6 +1946,14 @@ repositories:
       url: https://github.com/introlab/find_object_2d-release.git
       version: 0.5.1-0
     status: maintained
+  flask-ext-catkin:
+    release:
+      packages:
+      - flask_ext_catkin
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/flask-ext-catkin-release.git
+      version: 0.1.0-0
   flatbuffers:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `flask-ext-catkin` to `0.1.0-0`:
- upstream repository: https://github.com/asmodehn/flask-ext-catkin.git
- release repository: https://github.com/yujinrobot-release/flask-ext-catkin-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
