### PR TITLE
pcl_conversions: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5579,7 +5579,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/pcl_conversions-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/ros-perception/pcl_conversions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_conversions` to `0.2.1-0`:
- upstream repository: https://github.com/ros-perception/pcl_conversions.git
- release repository: https://github.com/ros-gbp/pcl_conversions-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.0-0`
## pcl_conversions

```
* Added a test for rounding errors in stamp conversion
  for some values the test fails.
* add pcl::PointCloud to Image msg converter for extracting the rgb component of a cloud
* Contributors: Brice Rebsamen, Lucid One, Michael Ferguson, Paul Bovbel
```
