### PR TITLE
perception_pcl: 1.2.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5676,7 +5676,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/perception_pcl-release.git
-      version: 1.2.6-0
+      version: 1.2.7-0
     source:
       type: git
       url: https://github.com/ros-perception/perception_pcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.2.7-0`:
- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.2.6-0`
## pcl_ros

```
* Sync pcl_nodelets.xml from hydro to indigo
  Fixes to pass catkin lint -W1
* Fixes #87 <https://github.com/ros-perception/perception_pcl/issues/87> for Indigo
* Fixes #85 <https://github.com/ros-perception/perception_pcl/issues/85> for Indigo
* Fixes #77 <https://github.com/ros-perception/perception_pcl/issues/77> and #80 <https://github.com/ros-perception/perception_pcl/issues/80> for indigo
* Added option to save pointclouds in binary and binary compressed format
* Contributors: Lucid One, Mitchell Wills
```
## perception_pcl
- No changes
## pointcloud_to_laserscan

```
* Cleanup pointcloud_to_laserscan launch files
* Contributors: Paul Bovbel
```
