### PR TITLE
graspit_ros: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2301,6 +2301,15 @@ repositories:
       url: https://github.com/mikeferguson/grasping_msgs-gbp.git
       version: 0.3.1-0
     status: developed
+  graspit_ros:
+    release:
+      packages:
+      - graspit
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/graspit_ros-release.git
+      version: 0.3.0-0
+    status: developed
   grid_map:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `graspit_ros` to `0.3.0-0`:
- upstream repository: https://github.com/roamlab/graspit-ros.git
- release repository: https://github.com/ros-gbp/graspit_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
