### PR TITLE
qt_gui_core: 0.2.28-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6364,7 +6364,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.2.27-0
+      version: 0.2.28-0
     source:
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.2.28-0`:
- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.27-0`
## qt_dotgraph

```
* skip subgraphs without a bounding box (ros-visualization/rqt_common_plugins#321 <https://github.com/ros-visualization/rqt_common_plugins/issues/321>)
```
## qt_gui
- No changes
## qt_gui_app
- No changes
## qt_gui_cpp
- No changes
## qt_gui_py_common
- No changes
