### PR TITLE
flask-ext-catkin: 0.1.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1953,7 +1953,12 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/flask-ext-catkin-release.git
-      version: 0.1.0-0
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/asmodehn/flask-ext-catkin.git
+      version: 0.1.0
+    status: developed
   flatbuffers:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `flask-ext-catkin` to `0.1.0-1`:
- upstream repository: https://github.com/asmodehn/flask-ext-catkin.git
- release repository: https://github.com/yujinrobot-release/flask-ext-catkin-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.0-0`
