### PR TITLE
naoqi_bridge_msgs: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4786,7 +4786,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_bridge_msgs-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_bridge_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge_msgs` to `0.0.2-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_bridge_msgs.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.1-0`
## naoqi_bridge_msgs

```
* add confidence
* Merge pull request #1 <https://github.com/ros-naoqi/naoqi_bridge_msgs/issues/1> from lsouchet/master
  Add Event, PoseWithConfidence and Status msgs.
* Add Event, PoseWithConfidence and Status msgs.
* Contributors: Karsten Knese, karsten1987, lsouchet
```
