### PR TITLE
Revert "flask-ext-catkin: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1946,14 +1946,6 @@ repositories:
       url: https://github.com/introlab/find_object_2d-release.git
       version: 0.5.1-0
     status: maintained
-  flask-ext-catkin:
-    release:
-      packages:
-      - flask_ext_catkin
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/yujinrobot-release/flask-ext-catkin-release.git
-      version: 0.1.0-0
   flatbuffers:
     release:
       tags:


### PR DESCRIPTION
Reverts ros/rosdistro#8630 since the release repo does not contain any Debian related branches / tags.
