### PR TITLE
rotors_simulator: 1.1.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7886,7 +7886,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-asl/rotors_simulator-release.git
-      version: 1.1.5-0
+      version: 1.1.6-0
     source:
       type: git
       url: https://github.com/ethz-asl/rotors_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rotors_simulator` to `1.1.6-0`:
- upstream repository: https://github.com/ethz-asl/rotors_simulator.git
- release repository: https://github.com/ethz-asl/rotors_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.1.5-0`
## rotors_comm
- No changes
## rotors_control
- No changes
## rotors_description
- No changes
## rotors_evaluation
- No changes
## rotors_gazebo
- No changes
## rotors_gazebo_plugins
- No changes
## rotors_joy_interface

```
* removed wrong install folder
```
## rotors_simulator
- No changes
