### PR TITLE
talos_audio: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8925,6 +8925,21 @@ repositories:
       url: https://github.com/clearpath-gbp/libswiftnav-release.git
       version: 0.13.0-3
     status: maintained
+  talos_audio:
+    doc:
+      type: git
+      url: https://github.com/openrobotics/talos_audio.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/openrobotics-gbp/talos_audio-release.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/openrobotics/talos_audio.git
+      version: indigo-devel
+    status: developed
   teb_local_planner:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `talos_audio` to `1.0.3-0`:
- upstream repository: https://github.com/openrobotics/talos_audio.git
- release repository: https://github.com/openrobotics-gbp/talos_audio-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
