### PR TITLE
talos_description: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8940,6 +8940,17 @@ repositories:
       url: https://github.com/openrobotics/talos_audio.git
       version: indigo-devel
     status: developed
+  talos_description:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/openrobotics-gbp/talos_description-release.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/openrobotics/talos_description.git
+      version: indigo-devel
+    status: developed
   teb_local_planner:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `talos_description` to `1.0.3-0`:
- upstream repository: https://github.com/openrobotics/talos_description.git
- release repository: https://github.com/openrobotics-gbp/talos_description-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
