### PR TITLE
fetch_gazebo: 0.5.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1896,7 +1896,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_gazebo-release.git
-      version: 0.4.4-0
+      version: 0.5.0-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_gazebo` to `0.5.0-0`:
- upstream repository: https://github.com/fetchrobotics/fetch_gazebo.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.4.4-0`
## fetch_gazebo

```
* apply filter to velocity
* implement servo loop
  * position wraps velocity controller
  * velocity limits are now loaded for continuous joints
  * retuned all but base motors
* Contributors: Michael Ferguson
```
## fetch_gazebo_demo

```
* force gripper fully open for demo
* Contributors: Michael Ferguson
```
