### PR TITLE
Updating dynamic_bandwidth_manager (old name was rosdbm) in documentation index

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1180,6 +1180,11 @@ repositories:
     status: end-of-life
     status_description: Will be released only as long as required for PR2 drivers
       (hokuyo_node, wge100_driver)
+  dynamic_bandwidth_manager:
+    doc:
+      type: git
+      url: https://github.com/ricardoej/dynamic_bandwidth_manager.git
+      version: master
   dynamic_reconfigure:
     doc:
       type: git
@@ -5450,11 +5455,6 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: hydro-devel
     status: maintained
-  rosdbm:
-    doc:
-      type: git
-      url: https://github.com/ricardoej/rosdbm.git
-      version: master
   rosdoc_lite:
     doc:
       type: git


### PR DESCRIPTION
Updating dynamic_bandwidth_manager (old name was rosdbm) in documentation index for distro Hydro to follow the ROS naming conventions.
