### PR TITLE
Adding dlut_smartrob to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1479,6 +1479,15 @@ repositories:
       type: git
       url: https://github.com/uos/diffdrive_gazebo_plugin.git
       version: indigo
+  dlut_smartrob:
+    doc:
+      type: git
+      url: https://github.com/ZhuangYanDLUT/dlut_smartrob.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/ZhuangYanDLUT/dlut_smartrob.git
+      version: indigo-devel
   driver_common:
     doc:
       type: git


### PR DESCRIPTION
Switch our SmartROB robot packages to indigo:
Adding viso2 used with multisense S7, we use MaxClique in outliers rejection step, and use Ceres Solver to solve the least square problem. Our code developed from viso2_ros and libviso2.
Adding a pointcloud alignment package dlut_hash_icp, example:
![screenshot-1433209443](https://cloud.githubusercontent.com/assets/3293366/8155808/88395dc6-137a-11e5-8b45-c4a43bd23c32.png)
![screenshot-1429598743](https://cloud.githubusercontent.com/assets/3293366/8155816/9f0eb5fa-137a-11e5-98e0-907cb15a815c.png)
