### PR TITLE
rocon_devices: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6926,7 +6926,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_devices-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_devices.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_devices` to `0.0.4-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_devices.git
- release repository: https://github.com/yujinrobot-release/rocon_devices-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.3-0`
## rocon_devices
- No changes
## rocon_hue
- No changes
## rocon_python_hue
- No changes
## rocon_rtsp_camera_relay

```
* Merge branch 'indigo' into rename_rapp_launcher
* rename rapp launcher closes #40 <https://github.com/robotics-in-concert/rocon_devices/issues/40>
* Contributors: Jihoon Lee
```
