### PR TITLE
Adding reinforcment_learning to documentation index for groovy

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3582,6 +3582,11 @@ repositories:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/reflexxes_type2-release.git
       version: 1.2.4-0
+  reinforcement_learning:
+    doc:
+      type: git
+      url: https://github.com/toddhester/rl-texplore-ros-pkg.git
+      version: master
   remote_lab:
     doc:
       type: svn


### PR DESCRIPTION
I'd like my repo reinforcement_learning to be indexed and documented on ros.org. It was previously a long time ago, but I never updated to the new doc process.
