### PR TITLE
pr2_navigation: 0.1.26-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5965,7 +5965,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/TheDash/pr2_navigation-release.git
-      version: 0.1.23-0
+      version: 0.1.26-0
     source:
       type: git
       url: https://github.com/pr2/pr2_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_navigation` to `0.1.26-0`:
- upstream repository: https://github.com/PR2/pr2_navigation.git
- release repository: https://github.com/TheDash/pr2_navigation-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.23-0`
## laser_tilt_controller_filter
- No changes
## pr2_move_base
- No changes
## pr2_navigation

```
* Merge branch 'hydro-devel' of https://github.com/PR2/pr2_navigation into hydro-devel
* Updated maintanership
* Contributors: TheDash
```
## pr2_navigation_config
- No changes
## pr2_navigation_global
- No changes
## pr2_navigation_local
- No changes
## pr2_navigation_perception

```
* Updated maintanership
* Contributors: TheDash
```
## pr2_navigation_self_filter

```
* Updated maintanership
* Contributors: TheDash
```
## pr2_navigation_slam
- No changes
## pr2_navigation_teleop
- No changes
## semantic_point_annotator
- No changes
