### PR TITLE
Adding dlut_laser and dlut_vision to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1479,6 +1479,15 @@ repositories:
       type: git
       url: https://github.com/uos/diffdrive_gazebo_plugin.git
       version: indigo
+  dlut_laser:
+    doc:
+      type: git
+      url: https://github.com/ZhuangYanDLUT/dlut_laser.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/ZhuangYanDLUT/dlut_laser.git
+      version: indigo-devel
   dlut_smartrob:
     doc:
       type: git
@@ -1487,6 +1496,15 @@ repositories:
     source:
       type: git
       url: https://github.com/ZhuangYanDLUT/dlut_smartrob.git
+      version: indigo-devel
+  dlut_vision:
+    doc:
+      type: git
+      url: https://github.com/ZhuangYanDLUT/dlut_vision.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/ZhuangYanDLUT/dlut_vision.git
       version: indigo-devel
   driver_common:
     doc:


### PR DESCRIPTION
Adding dlut_laser and dlut_vision to documentation index for distro.
dlut_laser contains some laser tools,  such as dlut_hash_icp.
dlut_vision contains dlut_viso2 which was developed from viso2_ros and libviso2, and other packages.
