### PR TITLE
fetch_msgs: 0.5.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1903,11 +1903,12 @@ repositories:
       version: master
     release:
       packages:
+      - fetch_auto_dock_msgs
       - fetch_driver_msgs
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_msgs-release.git
-      version: 0.5.1-0
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_msgs` to `0.5.2-0`:
- upstream repository: https://github.com/fetchrobotics/fetch_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.1-0`
## fetch_auto_dock_msgs

```
* release fetch_auto_dock_msgs package
* Contributors: Michael Ferguson
```
## fetch_driver_msgs

```
* update license to BSD
* move fetch_driver_msgs into package folder
* Contributors: Michael Ferguson
```
