### PR TITLE
Adding bta_ros to documentation index for jade

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -170,6 +170,11 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: master
     status: maintained
+  bta_ros:
+    doc:
+      type: git
+      url: https://github.com/voxel-dot-at/bta_ros.git
+      version: master
   calibration:
     doc:
       type: git


### PR DESCRIPTION
I would like to index and add documentation for package bta_ros in jade.
