### PR TITLE
cob_common: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -850,7 +850,6 @@ repositories:
       version: indigo_release_candidate
     release:
       packages:
-      - brics_actuator
       - cob_common
       - cob_description
       - cob_msgs
@@ -859,7 +858,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.6.3-0`:
- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.2-0`
## cob_common

```
* remove brics_actuator
* Contributors: ipa-fxm
```
## cob_description

```
* missing dependency for urdf checks
* remove unsupported calibration_rising
* separate xacro macro for drive_wheel module used in all bases + significant simplification
* use extended collision model for torso
* add grasp link to sdhx and fix finger orientation
* fix type error
* renamed 'dof'  urdfs
* add temporary fix urdf argument for cob4_base joint_names
* recalculated head joint positions
* collada meshes for cob4_gripper
* add new parameter with default value
* allow cob3 components to be used with PositionJointInterface
* renamed joints
* Corrects the suffixes for the basis
* redefined meshes origin
* addapted urdf to the real gripper positions
* proper meshes for cob4_gripper
* Limits now come from the yaml files
* correct collision checking for cob4 components
* Openni needs that topic and link name are the same
* missed joint
* Contributors: Florian Weisshardt, ipa-cob3-9, ipa-cob4-2, ipa-cob4-6, ipa-fxm, ipa-nhg, thiagodefreitas
```
## cob_msgs
- No changes
## cob_srvs

```
* Merge branch 'indigo_dev' of github.com:ipa320/cob_common into remove_Trigger_srv
* readd SetInt service
* remove Trigger from cob_srvs
* cleanup cob_srvs
* beautify CMakeLists
* Contributors: ipa-fxm
```
## raw_description

```
* allow laser calibration
* remove unsupported calibration_rising
* separate xacro macro for drive_wheel module used in all bases + significant simplification
* use PositionJointInterface
* Contributors: ipa-fxm
```
