### PR TITLE
cob_substitute: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1120,7 +1120,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_substitute-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/ipa320/cob_substitute.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_substitute` to `0.6.1-0`:
- upstream repository: https://github.com/ipa320/cob_substitute.git
- release repository: https://github.com/ipa320/cob_substitute-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.0-0`
## cob_lbr

```
* beautify CMakeLists
* Contributors: ipa-fxm
```
## cob_safety_controller

```
* beautify CMakeLists
* Contributors: ipa-fxm
```
## cob_substitute

```
* Merge pull request #24 <https://github.com/ipa320/cob_substitute/issues/24> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #23 <https://github.com/ipa320/cob_substitute/issues/23> from ipa-nhg/indigo_dev
  missed run_depends
* missed run_depends
* Merge pull request #22 <https://github.com/ipa320/cob_substitute/issues/22> from ipa320/hydro_dev
  fiy typo
* Update package.xml
* Contributors: Florian Weisshardt, ipa-nhg
```
## frida_driver

```
* beautify CMakeLists
* Contributors: ipa-fxm
```
## prace_common

```
* beautify CMakeLists
* Contributors: ipa-fxm
```
## prace_gripper_driver

```
* add missing argument "sim"
  This fixes the roslaunch file check for raw3-3
* beautify CMakeLists
* Contributors: Frederik Hegger, ipa-fxm
```
