### PR TITLE
cob_driver: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -919,7 +919,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.6.3-0`:
- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.2-0`
## cob_base_drive_chain

```
* add_dependencies to generate_messages_cpp
* use new Trigger from std_srvs
* changed hardcoded namespace
* changed wrong ROS output
* Contributors: Thorsten Kannacher, ipa-fxm
```
## cob_camera_sensors
- No changes
## cob_canopen_motor
- No changes
## cob_driver

```
* Merge pull request #199 <https://github.com/ipa320/cob_driver/issues/199> from ipa-nhg/indigo_dev
  added cob_mimic package
* added cob_mimic package
* Contributors: Florian Weisshardt, ipa-nhg
```
## cob_generic_can
- No changes
## cob_head_axis

```
* fix topic names
* use new Trigger from std_srvs
* cleanup cob_srvs
* adapt cob_head_axis to new namespaces
* Contributors: ipa-fxm, ipa-nhg
```
## cob_light

```
* use component namespaces for light, mimic and say
* make visualization marker frame configurable
* publish contiuous diagnostics
* small fixes
* Merge branch 'feature/newCircleMode' into feature/newSweepMode
  Conflicts:
  cob_light/common/src/modeFactory.cpp
* added color array msg
* modified message description
* added new sweep color mode
* Merge pull request #190 <https://github.com/ipa320/cob_driver/issues/190> from ipa-bnm/bug/infinit-send-error
  bugfix infinit-send-error
* Merge branch 'bug/infinit-send-error' into indigo_dev
* fix stageprofi init
* check for acknowledge message from controller
* recover serial connection and driver if there was an error during sending
* Contributors: Benjamin Maidel, Florian Weisshardt, ipa-fmw
```
## cob_mimic

```
* use component namespaces for light, mimic and say
* catkin_lint'ing
* Contributors: Florian Weisshardt, ipa-fmw
```
## cob_phidgets

```
* catkin_lint'ing
* Contributors: Florian Weisshardt
```
## cob_relayboard
- No changes
## cob_sick_lms1xx
- No changes
## cob_sick_s300

```
* cob_sick_s300: fix check for standby and only check for correct value
* cob_sick_s300: handle scanner in standby; publish std_msgs::Bool indicating status
* do not use private NodeHandle
* Contributors: ipa-fxm, ipa-mig
```
## cob_sound

```
* merge with ipa320
* adapt test script for sound
* use component namespaces for light, mimic and say
* add visualization marker to sound
* use Timer for diagnostics
* add hardware_id to sound
* reduce diagnostics frequency to 1Hz
* use new Trigger from std_srvs
* move cob_sound launch file to cob_bringup
* Contributors: ipa-fmw, ipa-fxm
```
## cob_undercarriage_ctrl

```
* now checking for NaN-values in Twist message
* Contributors: Thorsten Kannacher
```
## cob_utilities
- No changes
## cob_voltage_control
- No changes
