### PR TITLE
schunk_modular_robotics: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8373,7 +8373,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/schunk_modular_robotics-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/ipa320/schunk_modular_robotics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_modular_robotics` to `0.6.3-0`:
- upstream repository: https://github.com/ipa320/schunk_modular_robotics.git
- release repository: https://github.com/ipa320/schunk_modular_robotics-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.2-0`
## schunk_description

```
* remove unsupported calibration_rising
* proper rounding of joint_limits for lwa4d
* proper rounding of joint_limits for lwa4p
* round down joint limits for lwa4p_extended
* Update lwa4p_extended.urdf.xacro
  Velocity and Positions limits updated according to firmware settings
* reduce joint limits for moveit
* default inertia
* fix transmission for mimic joint
* allow cob3 components to be used with PositionJointInterface
* empty lines
* Fixes import error
* Safety_offset
* safety_offset
* Merge branch 'patch-1' of github.com:thiagodefreitas/schunk_modular_robotics into patch-2
  Conflicts:
  schunk_description/urdf/lwa4p_extended/lwa4p_extended_without_base.urdf.xacro
* Fixes the limits for the lwa4d
* Merge branch 'indigo_dev' of https://github.com/ipa320/schunk_modular_robotics into patch-2
  Conflicts:
  schunk_description/urdf/lwa4p_extended/lwa4p_extended.urdf.xacro
* new urdf structure
* Merge branch 'patch-1' of github.com:thiagodefreitas/schunk_modular_robotics into indigo_dev
  Conflicts:
  schunk_description/urdf/lwa4d/lwa4d.urdf.xacro
* new without_base descriptions
* updated schunk_lwa4d description
* Update pg70.urdf.xacro
* lwad description without base
* Update lwa4p_extended.urdf.xacro
  Proposing this as according to the tests on the Schunk LWA4D, the limits should be reduced from the HW limit in a range of 0.01 radians
* Update lwa4d.urdf.xacro
  According to HW limits
* Contributors: Nadia Hammoudeh García, Thiago de Freitas Oliveira Araujo, ipa-cob3-9, ipa-cob4-2, ipa-fxm, ipa-nhg, thiagodefreitas
```
## schunk_libm5api
- No changes
## schunk_modular_robotics
- No changes
## schunk_powercube_chain

```
* fix topic names
* replace brics_actuator
* missing dependency
* use new Trigger from std_srvs
* cleanup/replace cob_srvs
* adapt schunk_powercube_chain to new namespaces
* beautify CMakeLists
* Contributors: ipa-fxm
```
## schunk_sdh

```
* fix topic names
* replace brics_actuator
* use new Trigger from std_srvs
* cleanup/replace cob_srvs
* adapt schunk_sdh to new namespaces
* beautify CMakeLists
* beautify CMakeLists
* Contributors: ipa-fxm
```
## schunk_sdhx

```
* missing import
* Merge branch 'indigo_dev' of github.com:ipa320/schunk_modular_robotics into replace_Trigger
* hmi fixes for sdhx driver, needs revision
* use new Trigger from std_srvs
* Merge pull request #5 <https://github.com/ipa320/schunk_modular_robotics/issues/5> from thiagodefreitas/indigo_dev
  Trying to fix move delay
* Trying to fix move delay
* Merge pull request #4 <https://github.com/ipa320/schunk_modular_robotics/issues/4> from thiagodefreitas/indigo_dev
  sending continous position
* Merge branch 'indigo_dev' of https://github.com/thiagodefreitas/schunk_modular_robotics into indigo_dev
* Command agin
* Merge pull request #3 <https://github.com/ipa320/schunk_modular_robotics/issues/3> from thiagodefreitas/indigo_dev
  updates for new firmware
* merge
* Update sdhx_node.py
* fix namespaces
* rospy.Timer
* 

    * Removed sleep after moving the finger
    * Spawns another thread for updating the joint_states

* beautify CMakeLists
* Contributors: Thiago de Freitas Oliveira Araujo, ipa-cob4-2, ipa-fxm, thiagodefreitas
```
## schunk_simulated_tactile_sensors

```
* beautify CMakeLists
* Contributors: ipa-fxm
```
