### PR TITLE
cob_command_tools: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -837,7 +837,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.1-2
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.2-0`:
- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.1-2`
## cob_command_gui

```
* cleanup CMakeLists
* remove anoying command_gui notification popups
* Contributors: ipa-fmw, ipa-fxm
```
## cob_command_tools
- No changes
## cob_dashboard

```
* minor fix
* remove obsolete pr2_etherCAT subscriber
* cleanup CMakeLists
* remove duplicate dependency cob_msgs
* Revert "add missing dependency"
* add missing dependency
* Contributors: Florian Weisshardt, ipa-cob3-2, ipa-fxm, ipa-nhg
```
## cob_interactive_teleop

```
* cleanup CMakeLists
* Contributors: ipa-fxm
```
## cob_monitoring

```
* fix emergency_stop_monitor (tested on cob4-2: OK)
* enhance emergency_stop_monitor with diagnostics_based and motion_based
* emergency stop monitor includes diagnostics and em stop
* reworked emergency_stop_monitor (sets leds based on diagnostics), still needs to be updated to be robot independent (hardcoded components)
* cleanup CMakeLists
* have speach output for emergency switch to OK
* make colors for error, warning and ok configurable
* fix light for simple_script_server, adapt emergency_stop_monitor for cob4 by supporting mulitple light components
* added install tags
* Contributors: Florian Weisshardt, ipa-cob4-2, ipa-fmw, ipa-fxm, ipa-nhg
```
## cob_script_server

```
* merge with ipa320
* Merge pull request #18 <https://github.com/ipa320/cob_command_tools/issues/18> from ipa-cob4-2/indigo_dev
  updates from cob4-2
* use actions for light, sound and mimic. Using new namespaces with component_name
* use wait_for_message instead of joint_state_listener
* use new Trigger from std_srvs
* fix indention
* fix wrong service handle
* Merge branch 'indigo_dev' of https://github.com/ipa-fmw/cob_command_tools into indigo_dev
* fix blocking of move_base_rel and add mimic support
* fix wrong variable name
* fixed bug: light service is expecting 4 instead of 3 parameters [r,g,b,a]
* cleanup CMakeLists
* fix light for simple_script_server, adapt emergency_stop_monitor for cob4 by supporting mulitple light components
* use transparency parameter, tiomeout for service and tabs vs spaces
* using light service instead of topic and adapted for multiple components
* added topic_name parameter set_light
* Contributors: Benjamin Maidel, Florian Weisshardt, ipa-cob3-9, ipa-cob4-2, ipa-fmw, ipa-fxm, ipa-nhg
```
## cob_teleop

```
* replace brics_actuator
* use new Trigger from std_srvs
* Update README-PS3.md
* Update README-PS3.md
* Update README-PS3.md
* Update README-PS3.md
* catkin_lint
* use correct default namespace
* Instruction for PS3 Joystick with Bluetooth
* changed hardcoded namespace
* improved ROS_DEBUG output
* improved ROS output
* improved homing/recover srv-calls: now checking success of pltf-init/recovering instead of just checking srv call response
* Contributors: Nadia Hammoudeh García, Thorsten Kannacher, fmw-ms, ipa-fxm
```
