### PR TITLE
cob_navigation: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1024,7 +1024,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_navigation-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ipa320/cob_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_navigation` to `0.6.2-0`:
- upstream repository: https://github.com/ipa320/cob_navigation.git
- release repository: https://github.com/ipa320/cob_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.1-0`
## cob_linear_nav
- No changes
## cob_mapping_slam
- No changes
## cob_navigation
- No changes
## cob_navigation_config
- No changes
## cob_navigation_global
- No changes
## cob_navigation_local
- No changes
## cob_navigation_slam
- No changes
## cob_scan_unifier

```
* cob_scan_unifier: get rid of exported but uninstalled include path
* cob_scan_unifier: fix include folder stuff
* Contributors: ipa-mig
```
