### PR TITLE
cob_control: 0.6.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -877,8 +877,6 @@ repositories:
       - cob_control_mode_adapter
       - cob_footprint_observer
       - cob_frame_tracker
-      - cob_hardware_interface
-      - cob_lookat_controller
       - cob_model_identifier
       - cob_omni_drive_controller
       - cob_path_broadcaster
@@ -887,7 +885,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.6.6-0
+      version: 0.6.7-0
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.6.7-0`:
- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.6-0`
## cob_base_velocity_smoother
- No changes
## cob_collision_velocity_filter

```
* beautify CMakeLists
* Contributors: ipa-fxm
```
## cob_control

```
* update meta-package
* Contributors: ipa-fxm
```
## cob_control_mode_adapter

```
* beautify CMakeLists
* reduce output
* check which controllers are available
* Contributors: ipa-fxm
```
## cob_footprint_observer

```
* beautify CMakeLists
* Contributors: ipa-fxm
```
## cob_frame_tracker

```
* restructure namespaces for parameters of cartesian controllers
* complete revision of frame_tracker structure and action server
* cleanup/replace cob_srvs
* beautify CMakeLists
* cleanup dependencies
* use individual pid parameters to reduce output
* remove obsolet files
* proper expert interaction mode
* delete obsolete files
* merged running
* frame_tracker after merge
* merge with fxm - not working
* remove obsolete files
* last update
* attach menu to marker, beautify
* MOVE_ROTATE_3D for interactive markers
* update before creating new branch
* gitignore
* gitignore
* update working frame_tracker
* correct cmake
* update after merge
* merge with fm-cm-ce
* cleaning up
* more efficient c++ version of interactive_frame_target
* diff twist calc
* update frame_tracker
* frame_tracker_new
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_control into fm_cm_merged_new
* new rqt_features
* test
* cleaned up again
* Cleaned up
* Contributors: Christian Ehrmann, ipa-fxm, ipa-fxm-cm
```
## cob_model_identifier

```
* restructure namespaces for parameters of cartesian controllers
* cleanup/replace cob_srvs
* beautify CMakeLists
* remove obsolete files
* remove obsolete config
* new features
* Added README
* cleaned up
* last commit before pull
* cleaning up cob_model_identifier
* neutral file path
* input script for model_identifier
* close file
* fixed console bug
* input_generator as python script
* new features
* merge with fmx-cm
* add tracking_action
* test
* Contributors: Christian Ehrmann, ipa-fxm, ipa-fxm-cm
```
## cob_omni_drive_controller

```
* migrated to std_srvs/Trigger
* improved realtime behavoíour, no updates can get lost anymore
* added dependency on cob_srvs, fixed c&p bug
* do not reset odometry on restarts
* fixed reset service: compiles again and thread/RT-safe
* added service to reset odometry to zero
* rename topic as agreed
* update examples
* support for wheel struct
* Handle XmlRpcValue parsing error, special case for double
* fix for logic bug
* init to neutral position works now
* so not reset target on reset(), should be done externally if needed
* fixed copy&paste bugs
* added controller type in examples
* try_read is now read_with_default
* validity checks  for wheel_radius
* introduced read_optional, fixed URDF parsing
* steer_name and drive_name are now read from steer and drive paramater (as in examples)
* logic bug
* publish_rate was used as duration, added validity check
* advertise odom topic
* UndercarriageCtrl::reset got lost during split-up
* refactored WheelController to improve locking behaviour, implement timeout and limit checks
* reset Target to zero on reset()
* expose UndercarriageCtrl::limitValue with limit validity check
* updated examples
* splitted UndercarriageCtrlGeom into UndercarriageGeomBase, UndercarriageGeom and UndercarriageCtrl
* enforced lower camel case methods
* removed parseIniFiles
* added example yamls
* implemented parseWheelParams with URDF look-up
* limit steer and drive rate if specified
* added WheelParams::dSteerDriveCoupling, WheelData::dFactorVel is now filled automatically
* removed debugging output
* adaptet constructor of WheelData to set the neutralPos of a wheel
* Merge branch 'omni_wheel' of https://github.com/olgen2013/cob_control into omni_wheel
* fix assignment bug
* online/robot modifications
* fixed assignment bug and added console out put for online-testing
* improved INI parsing
* migrated to shared implementation of GeomController
* verbose exception handling
* library path was wrong
* Contributors: Florian Weisshardt, Joshua Hampp, Mathias Lüdtke, ipa-fxm, mig-jg
```
## cob_path_broadcaster

```
* restructure namespaces for parameters of cartesian controllers
* beautify CMakeLists
* remove obsolete files
* testing
* missing files
* new prog files
* new features
* new files
* new movement files
* clean up cob_path_broadcaster
* new features
* cleaned up
* update merged2
* feature reachable_goal
* fixed a bug in circular interpolation
* test
* Modified for the new structure
* Contributors: Christian Ehrmann, ipa-fxm, ipa-fxm-cm, ipa-fxm-fm
```
## cob_trajectory_controller

```
* fix topic names
* replace brics_actuator
* use new Trigger from std_srvs
* cleanup/replace cob_srvs
* fix getParam, fix ActionServer auto_start
* adapt cob_trajecory_controller to new namespaces
* remove obsolete files
* Contributors: ipa-fxm
```
## cob_twist_controller

```
* reduce output in limiters
* restructure namespaces for parameters of cartesian controllers
* 

    * Instead of creating png create eps.

* 

    * Added new damping method None
    * Added enum value to select damping None
    * Removed pure pointer usage and added boost::shared_ptr usage (which provides pointer management / ensure deletion of objects)
    * Removed unused includes
    * Renamings

* 

    * Removed unnecessary ROS_INFO_STREAMs
    * Removed temporary variables for test code

* 

    * Added debug code
    * Removed truncation
    * Removed unused members

* 

    * Grouped limiters in one .h and one .cpp
    * Grouped damping_methods in one .h and one .cpp
    * Removed separate factories. Made SolverFactory generic by introducing template parameters.
    * Made usage of boost::shared_ptr instead of own pointer handling.
    * Adapted CMakeLists.txt according to changes.
    * Split parameter enforce_limits into enforce_pos_limits and enforce_vel_limits

* 

    * To enforce limits for joint positions and velocities created new classes.
    * Additionally added parameter for keeping direction or not when enforcing limits.
    * Therefore removed normalize_velocities and enforce_limits from cob_twist_controller. Instead the new limiter_container is used.
    * Added new struct to provide cob_twist_controller params.
    * Removed debug code.

* 

    * Take care: W^(1/2) * q_dot = weighted_pinv_J * x_dot -> One must consider the weighting!!!
    * Added script to check pseudo-inverse calculation.

* 

    * Take care: W^(1/2) * q_dot = weighted_pinv_J * x_dot -> One must consider the weighting!!!
    * Added an octave script to verify the statement above.

* 

    * Removed unnecessary file

* 

    * Added doxygen comments
    * Activated graphviz for doc generation
    * Added const to method signatures to avoid undesired JntArray-Data change.

* 

    * moved enfore_limits from augmented_solver to cob_twist_controller
    * Added a base case WeightedLeastNorm to constraint solvers
  Instantiated it acts like an unconstraint solver.
  - Renamed JointLimitAvoidanceSolver to WLN_JointLimitAvoidanceSolver
  - WLN_JointLimitAvoidanceSolver inherits from WeightedLeastNormSolver and implements calculate_weighting
* 

    * moved enfore_limits from augmented_solver to cob_twist_controller
    * Added a base case WeightedLeastNorm to constraint solvers
  Instantiated it acts like an unconstraint solver.
  - Renamed JointLimitAvoidanceSolver to WLN_JointLimitAvoidanceSolver
  - WLN_JointLimitAvoidanceSolver inherits from WeightedLeastNormSolver and implements calculate_weighting only. -> Solving is done by the WLN Solver.
* Added validation outputs.
  Added comments for doxygen generation.
  Did some renaming.
* Made restructured changes active.
  Corrected some implementation.
  Activated both old and new implementation for comparison and testing purposes.
* Made usages of ConstraintSolverFactoryBuilder:
  - Creates DampingMethod
  - Creates ConstraintSolver
  - Executes calculation of joint velocities.
* Split up augmented_solver.cpp into different constraint solvers: JLA constraints and unconstraint.
* 

    * Restructured augmented_solver.
    * Renamed class augmented_solver to AugmentedSolver.
    * Created damping_methods as classes to ease creation of dampings (and new ones).

* add comments
* cleanup
* beautify CMakeLists
* using correct base topic names
* fix debug node
* remove obsolete code for parameter initialization, enforce_limits behaviour
* revision, simplification and cleanup
* remove obsolete files
* twist controller analyser
* last update
* update working frame_tracker
* base compensation test
* temporary adjust base topics
* reduce output
* twist series test script
* use component specific joint_states topic
* no output
* merge
* cleaning up
* new publisher and transformation names
* merge with cm
* added commentary, tolerance as dynamic reconfigure, modified enforce_limits
* Debug functions
* merge with cm
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_control into fm_cm_merged_new
* last commit before merging
* new rqt_features
* delete all test packages
* delete all test packages
* fixed errors from merging
* merged from ipa-fxm-cm
* beautify, added commentary, limit enforcing and dynamic reconfigure for JLA
* new debug twist
* add tracking_action
* test
* new features
* test
* Merge branch 'merge_fm_cm' of github.com:ipa-fxm-fm/cob_control into cm_dev
* changes
* Corrected errors from merging
* First merge attempt
* Joint Limit Avoidance added and cleaned up
* Added publisher for the pose
* Modified for the new structure
* cleaned up again
* Cleaned up
* New features
* a commit a day keeps the doctor away
* Contributors: Christian Ehrmann, ipa-fxm, ipa-fxm-cm, ipa-fxm-fm, ipa-fxm-mb
```
