### PR TITLE
cob_robots: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1078,7 +1078,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.6.3-0`:
- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.2-0`
## cob_bringup

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* last update
* install tags and scanners config
* small changes
* setup cob3-2
* fix run dependency
* added controllers
* adapt cob3-2
* added cob3-2
* fix launch xml syntax
* rename can_modul to can_device
* use component namespaces for light, mimic and say
* Merge remote-tracking branch 'origin-320/indigo_dev' into aggregated_robot_state_publisher_for_all_robots
* Merge branch 'indigo_dev' of github.com:ipa320/cob_robots into indigo_dev
* add sensorring to dashboard and robot.xml
* Merge pull request #5 <https://github.com/ipa320/cob_robots/issues/5> from ipa-fxm/aggregated_robot_state_publisher_for_all_robots
  aggregated robot_state_publisher for all robots, fixed machine tag in la...
* remove torso and sensorring (untill working properly
* aggregated robot_state_publisher for all robots, fixed machine tag in launch files
* adapt flexisoft config for updated driver with diagnostics
* Merge branch 'indigo_dev' of https://github.com/ipa-cob4-2/cob_robots into indigo_dev_cob4-2
* remap diagnostics for cob_head_axis
* add aggregating robot_state_publisher instead of one per component
* move script_server to t1 pc, add machine timeouts
* add 2dof torso to cob4-2 including all configuration files
* merge
* added cob4-4
* robot test
* remove side argument
* no default value in image_flip_nodelet launch file
* robot_state_publisher moved to base_controller launch file
* robot_state_publisher moved to base_controller
* fix namespace
* proper remap for joint_states
* add robot_state_publisher and joint_state relay
* updates from raw3-1 robot user
* some consistency renaming
* harmonize launch files and resolve node name conflicts
* merge conflict after cherry-picking image_flip updates
* rename yaml file
* remove duplicate robot_state_publisher - it is in controller
* remove deprecation warning again so that tests pass
* moved cob sound launch file
* use updated and adjusted driver and controller launch files for all available robots
* adjust to new namespaces
* remove controller aspects from driver launch file
* adjust old driver launch file to namespaces
* adjust cob_trajectory_controller launch file to namespaces
* unify xml order and beautify
* unify xml order and beautify
* beautify
* cleanup and add dependencies from cob_controller_configuration_gazebo
* remove unused files
* restructure robot_state_publisher
* fix syntax error
* tabs vs. spaces and cleanup
* restructure generic controller launch files
* restructure base_controller_plugin launch file
* tabs vs. spaces
* restructure laser_scan_filter
* adjust image_flip launch and config files
* beautify CMakeLists
* fix missing mode adapter
* add end-of-comment
* remove old non-functional launch files
* added deprecation warning for cob_trajectory_controller
* enable sound for cob4-2 and emergency monitor
* make cob3-6 work in indigo simulation using new namespace structure and fjt controllers only
* make cob3-6 work in indigo simulation using new namespace structure and fjt controllers only
* cob4-6 setup
* add dependency to topic_tools
* update cob4-2 config on real robot
* Adds the joint limits for the base
* Introduces the mode_adapter argument to optionally load the cob_mode_adapter
* resolve conflicts
* setup cob4-6
* setup cob46
* use relay instead of remap for joint_states topic
* setup cob3-9
* setup cob3-9
* set ROBOT variable
* addapted diagnostics new ns and create a separated image_flip launch file
* Contributors: Florian Weisshardt, ipa-cob3-2, ipa-cob3-9, ipa-cob4-2, ipa-cob4-4, ipa-cob4-6, ipa-fmw, ipa-fxm, ipa-nhg, thiagodefreitas
```
## cob_controller_configuration_gazebo

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* cob3-2 simulation test
* added cob3-2
* fix launch xml syntax
* aggregated robot_state_publisher for all robots, fixed machine tag in launch files
* use new Trigger from std_srvs
* add 2dof torso to cob4-2 including all configuration files
* added cob4-4
* remove side argument
* merge conflict after cherry-picking image_flip updates
* moved cob sound launch file
* added dependencies required for catkin_make test
* cleanup dependencies
* restructure robot_state_publisher
* use correct simulated driver services
* restructure generic controller launch files
* restructure base_controller_plugin launch file
* restructure laser_scan_filter
* restructure simulated tray_sensors
* adjust image_flip launch and config files
* beautify CMakeLists
* spawn correct controller
* remove obsolete gazebo_services_base
* updated gazebo_services
* add gripper for cob4-1
* update configs and launch file for cob4-6
* update configs and launch file for raw3-6
* update configs and launch file for raw3-5
* update configs and launch file for raw3-4
* update configs and launch file for raw3-3
* update configs and launch file for raw3-2
* update configs and launch file for raw3-1
* update configs and launch file for cob4-2
* update configs and launch file for cob4-1
* update configs and launch file for cob3-6
* update configs and launch file for cob3-6
* restructure, unify and cleanup component launch files
* update install tags
* remove old test scripts
* remove old controller_adapter
* remove obsolete yaml files
* testing new base control plugins with simulation
* test new base controller plugin
* more namespace adjustments for cob3-6 simulation
* make cob3-6 work in indigo simulation using new namespace structure and fjt controllers only
* more namespace adjustments for cob3-6 simulation
* make cob3-6 work in indigo simulation using new namespace structure and fjt controllers only
* Merge pull request #270 <https://github.com/ipa320/cob_robots/issues/270> from ipa-nhg/cob4_gripper
  cob4_gripper
* added robot_state_publisher
* missing joint_state relays
* merge
* Merge pull request #267 <https://github.com/ipa320/cob_robots/issues/267> from ipa-nhg/cob4-updates
  Cob4 updates
* cob4_gripper
* Merge remote-tracking branch 'nhg/cob4-updates' into indigo_dev
* setup cob4
* remove obsolete files
* resolve conflicts
* setup cob4-6
* setup cob46
* missing joint_state topic relay
* use c++ version of interactive marker
* faster shutdown of controller_spawner
* proper exception handling on shutdown
* addapted diagnostics new ns and create a separated image_flip launch file
* Contributors: Florian Weisshardt, ipa-cob4-4, ipa-cob4-6, ipa-fxm, ipa-nhg, thiagodefreitas
```
## cob_default_robot_config

```
* last update
* install tags and scanners config
* small changes
* setup cob3-2
* update
* added controllers
* added cob3-2
* adapt all light yaml files
* remove mimic yaml file
* use component namespaces for light, mimic and say
* use component namespaces for light, mimic and say
* add sensorring to dashboard and robot.xml
* remove torso and sensorring (untill working properly
* update joint configuration for grippers, add spread pose
* Merge branch 'indigo_dev' of https://github.com/ipa-cob4-2/cob_robots into indigo_dev_cob4-2
* add 2dof torso to cob4-2 including all configuration files
* added cob4-4
* Update upload_param_cob4-2.launch
* robot test
* add missing base_configurations
* add service_ns for light
* addedd missing default parameters and namespaces
* updates from raw3-1 robot user
* beautify CMakeLists
* add stop button for gripper
* add gripper for cob4-1
* added default_vel
* cob4-1 has no grippers
* fix action_name and service_ns
* adapt light settings for all robots
* more namespace adjustments for cob3-6 simulation
* more namespace adjustments for cob3-6 simulation
* more namespace adjustments for cob3-6 simulation
* more namespace adjustments for cob3-6 simulation
* renamed joints
* setup cob4-6
* setup cob46
* update cob3-9
* teached arm position
* setup cob3-9
* setup cob3-9
* setup cob3-9
* Contributors: ipa-cob3-2, ipa-cob3-9, ipa-cob4-2, ipa-cob4-4, ipa-cob4-6, ipa-fmw, ipa-fxm, ipa-nhg
```
## cob_hardware_config

```
* apply changes for cob3-2
* allow laser calibration
* remove unsupported calibration_rising
* last update
* install tags and scanners config
* cob3-2 simulation test
* small changes
* setup cob3-2
* update
* added controllers
* adapt cob3-2
* adapt cob3-2
* added cob3-2
* new parameter layout for cartesian controller
* updated rviz config for cob4
* use center links for light marker
* configure emergency_stop_monitor for all robots
* configuration for light maker frame
* cleanup diagnostics
* joint diagnostics aggregator for light
* diagnostics aggregator config for light
* remove torso and sensorring (untill working properly
* aggregated robot_state_publisher for all robots, fixed machine tag in launch files
* pwm update for gripper right due to wrong joint direction
* display jostick diagnostics correctly in IO group
* add flexisoft to diagnostics
* adapt flexisoft config for updated driver with diagnostics
* Merge branch 'indigo_dev' of https://github.com/ipa-cob4-2/cob_robots into indigo_dev_cob4-2
* add aggregating robot_state_publisher instead of one per component
* use diagnostics for emergency_stop_monitor
* remove sensorring from diagnostics
* increase buffer of base_velocity_smoother
* use new name for hwi_switch_gazebo_ros_control_plugin
* renaming in cob_common
* add 2dof torso to cob4-2 including all configuration files
* merge
* obey update time of 250us for synchronized PDOs
* updated sensorring config
* removed homing method paramterization
* removed default home offset -> force overwrite on init if needed
* use ring buffer for IP mode
* switched to new mapping
* set heartbeat to 100ms
* added conditional EMCY cob id entry 0x1014
* Update Schunk_0_63.dcf
  No homing for schunk
* Update sensorring_driver.yaml
  Adds homing method for the sensorring
* removed unnecessary file
* added cob4-4
* robot test
* adjust cob4_base joint_names
* jerky - jerk
* updates from raw3-1 robot user
* some consistency renaming
* adjust diagnostic namespaces
* merge conflict after cherry-picking image_flip updates
* split up head_sensorring component
* rename yaml file
* add parameters for cob_joint_trajectory_controller
* added placeholder files
* restructure simulated tray_sensors
* adjust image_flip launch and config files
* beautify CMakeLists
* added missing file
* catkin_lint
* unifying base_controller yamls
* add missing parameters to reduce output
* add gripper for cob4-1
* update configs and launch file for cob4-6
* update configs and launch file for raw3-6
* update configs and launch file for raw3-5
* update configs and launch file for raw3-4
* update configs and launch file for raw3-3
* update configs and launch file for raw3-2
* update configs and launch file for raw3-1
* update configs and launch file for cob4-2
* update configs and launch file for cob4-1
* update configs and launch file for cob3-6
* update configs and launch file for cob3-6
* adjust limits for base
* enable sound for cob4-2 and emergency monitor
* adapt light settings for all robots
* add led_components parameter to emergency_stop monitor
* testing new base control plugins with simulation
* test new base controller plugin
* more namespace adjustments for cob3-6 simulation
* make cob3-6 work in indigo simulation using new namespace structure and fjt controllers only
* more namespace adjustments for cob3-6 simulation
* make cob3-6 work in indigo simulation using new namespace structure and fjt controllers only
* add can0 config file
* cob4-6 setup
* Corrected suffixes
* update cob4-2 urdf model
* removed velocity_controller parameters
* update cob4-2 config on real robot
* cob4_gripper
* cob4_gripper
* Configures the Homing speed parameters for the base modules
* Adds the dcf_overlay to the configuration file.
  This provides the possibility to change the homing method directly on the YAML file.
* Fixes error on the HW mode for using the base on Velocity Mode
* Adds the joint limits for the base
* renamed joints
* resolve conflicts
* setup cob4-6
* setup cob46
* new schunk description structure
* updates for twist controller parameter
* new structure, lwa4p_extended_withour_base
* cleanup parameters
* updated schunk_lwa4d description
* update cob3-9
* merge with 320
* setup cob3-9
* fix cartesian controller parameters for arms
* setup cob3-9
* default damping parameters
* added default damping parameters
* spaces vs tabs
* addapted diagnostics new ns and create a separated image_flip launch file
* set interpolation perdiod to sync interval (10ms/100Hz)
* Contributors: Florian Weisshardt, Mathias Lüdtke, Thiago de Freitas Oliveira Araujo, ipa-cob3-2, ipa-cob3-9, ipa-cob4-2, ipa-cob4-4, ipa-cob4-6, ipa-fmw, ipa-fxm, ipa-fxm-fm, ipa-nhg, thiagodefreitas
```
## cob_robots
- No changes
