### PR TITLE
cob_simulation: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1099,7 +1099,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_simulation-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/ipa320/cob_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.6.3-0`:
- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.2-0`
## cob_bringup_sim

```
* beautify CMakeLists
* Contributors: ipa-fxm
```
## cob_gazebo

```
* beautify CMakeLists
* Contributors: ipa-fxm
```
## cob_gazebo_objects

```
* beautify CMakeLists
* Contributors: ipa-fxm
```
## cob_gazebo_worlds

```
* beautify CMakeLists
* catkin_lint
* fix joint_states for world
* velocity controller for door
* catkin_lint'ing
* Contributors: Florian Weisshardt, ipa-fxm
```
## cob_simulation
- No changes
