### PR TITLE
cob_perception_common: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1057,7 +1057,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_perception_common-release.git
-      version: 0.6.5-0
+      version: 0.6.6-0
     source:
       type: git
       url: https://github.com/ipa320/cob_perception_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_perception_common` to `0.6.6-0`:
- upstream repository: https://github.com/ipa320/cob_perception_common.git
- release repository: https://github.com/ipa320/cob_perception_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.5-0`
## cob_cam3d_throttle
- No changes
## cob_image_flip
- No changes
## cob_object_detection_msgs
- No changes
## cob_object_detection_visualizer

```
* fix maintainer
* Contributors: Florian Weisshardt
```
## cob_perception_common
- No changes
## cob_perception_msgs
- No changes
## cob_vision_utils
- No changes
