### PR TITLE
wireless: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9824,6 +9824,23 @@ repositories:
       url: https://github.com/pr2/willow_maps.git
       version: hydro-devel
     status: maintained
+  wireless:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/wireless.git
+      version: master
+    release:
+      packages:
+      - wireless_msgs
+      - wireless_watcher
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/wireless-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/wireless.git
+      version: master
   world_canvas:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless` to `0.0.3-0`:
- upstream repository: https://github.com/clearpathrobotics/wireless.git
- release repository: https://github.com/clearpath-gbp/wireless-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## wireless_msgs

```
* Added ESSID and BSSID fields, use floats for bitrate
* Contributors: Alex Bencz
```
## wireless_watcher

```
* Added ESSID and BSSID fields, use floats for bitrate
* Contributors: Alex Bencz
```
