### PR TITLE
cob_control: 0.6.8-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -872,6 +872,7 @@ repositories:
     release:
       packages:
       - cob_base_velocity_smoother
+      - cob_cartesian_controller
       - cob_collision_velocity_filter
       - cob_control
       - cob_control_mode_adapter
@@ -879,13 +880,12 @@ repositories:
       - cob_frame_tracker
       - cob_model_identifier
       - cob_omni_drive_controller
-      - cob_path_broadcaster
       - cob_trajectory_controller
       - cob_twist_controller
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.6.7-0
+      version: 0.6.8-1
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.6.8-1`:
- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.7-0`
## cob_base_velocity_smoother
- No changes
## cob_cartesian_controller

```
* merge with release candidate
* package renaming: cob_path_broadcaster -> cob_cartesian_controller
* Contributors: ipa-fxm
```
## cob_collision_velocity_filter
- No changes
## cob_control

```
* merge with release candidate
* package renaming: cob_path_broadcaster -> cob_cartesian_controller
* Contributors: ipa-fxm
```
## cob_control_mode_adapter
- No changes
## cob_footprint_observer
- No changes
## cob_frame_tracker
- No changes
## cob_model_identifier
- No changes
## cob_omni_drive_controller
- No changes
## cob_trajectory_controller
- No changes
## cob_twist_controller
- No changes
