### PR TITLE
handle_detector: 1.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2461,7 +2461,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/atenpas/handle_detector-release.git
-      version: 1.1.0-6
+      version: 1.3.1-0
     source:
       type: git
       url: https://github.com/atenpas/handle_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `handle_detector` to `1.3.1-0`:
- upstream repository: https://github.com/atenpas/handle_detector
- release repository: https://github.com/atenpas/handle_detector-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.0-6`
## handle_detector

```
* removed pcl ros includes from importance sampling
* update CHANGELOG
* update CHANGELOG
* Contributors: atenpas
```
