### PR TITLE
naoqi_rosbridge: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4855,7 +4855,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_rosbridge-release.git
-      version: 0.0.7-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/ros-naoqi/alrosbridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_rosbridge` to `0.1.0-0`:
- upstream repository: https://github.com/ros-naoqi/alrosbridge.git
- release repository: https://github.com/ros-naoqi/naoqi_rosbridge-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.7-0`
## naoqi_rosbridge

```
* devel-space compatibility
* move application files to app folder
* Add methods to remove bags presents on folder
* Add an helper function to check size taken by bags
* Add an helper function to check presents bags on folder
* rename urdf
* add romeo.urdf
* update and rename files to be consistent with *description
* update doc for rosrun
* updated roscore option in doc
* remove test folder
* Contributors: Karsten Knese, Marine CHAMOUX, Vincent Rabaud
```
