### PR TITLE
Ubuntu support for *r-base*, *r-base-dev* and *texlive-full* added.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2776,6 +2776,10 @@ qtmobility-dev:
   debian: [qtmobility-dev]
   fedora: [qt-mobility-devel]
   ubuntu: [qtmobility-dev]
+r-base:
+  ubuntu: [r-base]
+r-base-dev:
+  ubuntu: [r-base-dev]
 readline-dev:
   arch: [readline]
   debian: [libreadline-dev]
@@ -3072,6 +3076,8 @@ texlive-fonts-recommended:
   fedora: [texlive-times, texlive-helvetic]
   macports: [texlive-fonts-recommended]
   ubuntu: [texlive-fonts-recommended]
+texlive-full:
+  ubuntu: [texlive-full]
 texlive-latex-base:
   arch: [texlive-core]
   debian: [texlive-latex-base]


### PR DESCRIPTION
I extended Ubuntu ROS dependencies with `R` and full `texlive` distribution support.
