### PR TITLE
xacro: 1.10.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3427,7 +3427,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.10.3-0
+      version: 1.10.4-0
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.10.4-0`:
- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.10.3-0`
## xacro

```
* removed test_DEPRECATED_should_replace_before_macroexpand()
  duplicates test_should_replace_before_macroexpand()
* fixed evaluation order of macro arguments and body
  Macro arguments need to be evaluated and assigned to properties before
  body is evaluated. Otherwise, the evaluated value will be converted to
  str, i.e. loosing original type.
* Contributors: Robert Haschke
```
