### PR TITLE
geneus: 2.2.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2114,7 +2114,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/geneus-release.git
-      version: 2.2.2-0
+      version: 2.2.3-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/geneus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geneus` to `2.2.3-0`:
- upstream repository: https://github.com/jsk-ros-pkg/geneus
- release repository: https://github.com/tork-a/geneus-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.2.2-0`
## geneus

```
* [src/geneus/geneus_main.py] Call get_pkg_map if pkg_map is None
* Contributors: Kentaro Wada
```
