### PR TITLE
epos_hardware: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1805,7 +1805,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RIVeR-Lab-release/epos_hardware-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/epos_hardware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `epos_hardware` to `0.0.3-0`:
- upstream repository: https://github.com/RIVeR-Lab/epos_hardware.git
- release repository: https://github.com/RIVeR-Lab-release/epos_hardware-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.2-0`
## epos_hardware

```
* Fixed quickstop diagnostics status
* Added diagnostics information from statusword
* Added ability to set fault recovery option
* Added nominal current and max current to diagnostics
* Added diagnostics warning if nominal current is exceeded
* Added diagnostics for motor output
* Added torque constant parameter
* Added support for velocity halt command
* Show error message if not all faults were cleared
* Don't write value if command is nan
* Limit profile velocity to specified limit
* Cast parameters to integers because sometimes it causes the configuration to fail
* Contributors: Mitchell Wills
```
## epos_library
- No changes
