### PR TITLE
jsk_common: 2.0.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3155,42 +3155,20 @@ repositories:
       version: master
     release:
       packages:
-      - assimp_devel
-      - bayesian_belief_networks
-      - collada_urdf_jsk_patch
-      - downward
       - dynamic_tf_publisher
-      - ff
-      - ffha
       - image_view2
       - jsk_common
       - jsk_data
-      - jsk_footstep_msgs
-      - jsk_gui_msgs
-      - jsk_hark_msgs
       - jsk_network_tools
       - jsk_tilt_laser
       - jsk_tools
       - jsk_topic_tools
-      - julius
-      - laser_filters_jsk_patch
-      - libsiftfast
-      - mini_maxwell
       - multi_map_server
-      - nlopt
-      - opt_camera
-      - posedetection_msgs
-      - rospatlite
-      - rosping
-      - rostwitter
-      - sklearn
-      - speech_recognition_msgs
       - virtual_force_publisher
-      - voice_text
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 1.0.71-0
+      version: 2.0.0-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.0.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.71-0`
## dynamic_tf_publisher
- No changes
## image_view2
- No changes
## jsk_common

```
* split jsk_common into jsk_common_msgs and jsk_3rdparty https://github.com/jsk-ros-pkg/jsk_common/issues/919
* Contributors: Kei Okada
```
## jsk_data

```
* Fix default ROBOT name
* Contributors: Kohei Kimura
```
## jsk_network_tools
- No changes
## jsk_tilt_laser

```
* [jsk_tilt_laser] Do not use laser_assembler in order to reduce CPU load
* Contributors: Ryohei Ueda
```
## jsk_tools

```
* [jsk_tools] Record image_rect of axis camera
* [jsk_tools] Add calibration data
* [jsk_tools] Add launch to record axis camera
* Contributors: Kentaro Wada
```
## jsk_topic_tools
- No changes
## multi_map_server
- No changes
## virtual_force_publisher

```
* pseudo jacobian has different for m>n and n<m
* format jacobian/effort/force output
* Contributors: Kei Okada
```
