### PR TITLE
jsk_common_msgs: 2.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3195,6 +3195,28 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_common.git
       version: master
     status: developed
+  jsk_common_msgs:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
+      version: master
+    release:
+      packages:
+      - jsk_common_msgs
+      - jsk_footstep_msgs
+      - jsk_gui_msgs
+      - jsk_hark_msgs
+      - posedetection_msgs
+      - speech_recognition_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/jsk_common_msgs-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
+      version: master
+    status: developed
   jsk_control:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common_msgs` to `2.0.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common_msgs
- release repository: https://github.com/tork-a/jsk_common_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## jsk_common_msgs

```
* move from jsk_common to jsk_common_msgs
* add jsk_common_msgs meta package
* Contributors: Kei Okada
```
## jsk_footstep_msgs

```
* move from jsk_common to jsk_common_msgs
* [jsk_footstep_msgs] Add APPROVED and REJECTED constant to Footstep.msg
* [jsk_footstep_msgs] Add cost field to Footstep
* Contributors: Ryohei Ueda
```
## jsk_gui_msgs

```
* move from jsk_common to jsk_common_msgs
```
## jsk_hark_msgs

```
* move from jsk_common to jsk_common_msgs
```
## posedetection_msgs

```
* move from jsk_common to jsk_common_msgs
* [posedetection_msgs/package.xml] add message_filters to depends
* Contributors: Kei Okada
```
## speech_recognition_msgs

```
* move from jsk_common to jsk_common_msgs
```
