### PR TITLE
jsk_3rdparty: 2.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3169,6 +3169,38 @@ repositories:
       url: https://github.com/ros-gbp/joystick_drivers-release.git
       version: 1.10.1-0
     status: maintained
+  jsk_3rdparty:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
+      version: master
+    release:
+      packages:
+      - assimp_devel
+      - bayesian_belief_networks
+      - downward
+      - ff
+      - ffha
+      - jsk_3rdparty
+      - julius
+      - libsiftfast
+      - mini_maxwell
+      - nlopt
+      - opt_camera
+      - rospatlite
+      - rosping
+      - rostwitter
+      - sklearn
+      - voice_text
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/jsk_3rdparty-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
+      version: master
+    status: developed
   jsk_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.0.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## assimp_devel

```
* move from jsk_common to jsk_3rdparty
```
## bayesian_belief_networks

```
* move from jsk_common to jsk_3rdparty
```
## downward

```
* move from jsk_common to jsk_3rdparty
```
## ff

```
* move from jsk_common to jsk_3rdparty
* [ff/package.xml] add mk to build_depend
* 1.0.72
* Contributors: Ryohei Ueda
```
## ffha

```
* move from jsk_common to jsk_3rdparty
```
## jsk_3rdparty

```
* move from jsk_common to jsk_3rdparty
* add jsk_3rdparty meta package
* Contributors: Kei Okada
```
## julius

```
* move from jsk_common to jsk_3rdparty
```
## libsiftfast

```
* move from jsk_common to jsk_3rdparty
```
## mini_maxwell

```
* move from jsk_common to jsk_3rdparty
```
## nlopt

```
* move from jsk_common to jsk_3rdparty
```
## opt_camera

```
* move from jsk_common to jsk_3rdparty
```
## rospatlite

```
* move from jsk_common to jsk_3rdparty
```
## rosping

```
* move from jsk_common to jsk_3rdparty
```
## rostwitter

```
* move from jsk_common to jsk_3rdparty
* [tweet.py] fix to post more than 116 character on PostMedia
* Contributors: Kei Okada
```
## sklearn

```
* move from jsk_common to jsk_3rdparty
```
## voice_text

```
* move from jsk_common to jsk_3rdparty
```
