### PR TITLE
jsk_visualization: 1.0.21-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3424,7 +3424,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.20-0
+      version: 1.0.21-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.21-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.20-0`
## jsk_interactive
- No changes
## jsk_interactive_marker

```
* [jsk_interactive_marker] Add menu to select rleg or lleg as the first step
* [jsk_interactive_marker] Add menu to set heuristic
* [jsk_interactive_marker] Add ~always_planning parameter to footstep_marker
* [jsk_interactive_marker] Fix for terrain task
* [jsk_interactive_marker] Add topic interface to footstep_marker
* [jsk_interactive_marker] Decide footstep margin from robot name
* [jsk_interactive_marker] enable to change mesh marker control size
* [jsk_interactive_marker] add changing focus marker name line
* Contributors: Ryohei Ueda, Yu Ohara
```
## jsk_interactive_test
- No changes
## jsk_rqt_plugins

```
* [jsk_rqt_plugins] Add sign for configuration button in the README image of rqt_service_button
* [jsk_rqt_plugins] catch import error and use roslib in rqt_yn_btn
* [jsk_rqt_plugins] Add README for rqt_service_button
* [jsk_rqt_plugins] Add rqt_yn_btn
* [jsk_rqt_plugins] generate button groups
* Contributors: Kentaro Wada, Masaki Murooka
```
## jsk_rviz_plugins

```
* [jsk_rviz_plugins/PolygonArrayDisplay] Cleanup codes to be within 80 columns
* [jsk_rviz_plugins/BoundingBoxArray] Immediately apply change of attributes
* [jsk_rviz_plugins/BoundingBoxArray] Refactor codes by splitting processMessages into several functions
* [jsk_rviz_plugins/BoundingBoxArray] Use symmetrical radius for coordinates arrow
* [jsk_rviz_plugins/BoundingBoxArray] Fix coding style around if/else/for
* [jsk_rviz_plugins/BoundingBoxArray] Check if the size of box is nan
* [jsk_rviz_plugins/BoundingBoxArray] Fix indent to be within 80 columns
* Contributors: Ryohei Ueda
```
## jsk_visualization
- No changes
