### PR TITLE
jsk_roseus: 1.3.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3397,7 +3397,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.3.5-0
+      version: 1.3.6-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.3.6-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.3.5-0`
## jsk_roseus
- No changes
## roseus

```
* [CMakeLists.txt] add catkin_INCLUDE_DIRS, this fixes #317
* [roseus] Add NO_GENERATE_EUSDOC environmental variable to disable
  generation of eusdoc
* Contributors: Kei Okada, Ryohei Ueda
```
## roseus_smach
- No changes
## roseus_tutorials
- No changes
