### PR TITLE
jsk_robot: 0.0.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3345,6 +3345,7 @@ repositories:
     release:
       packages:
       - baxtereus
+      - jsk_201504_miraikan
       - jsk_baxter_desktop
       - jsk_baxter_startup
       - jsk_baxter_web
@@ -3355,10 +3356,11 @@ repositories:
       - jsk_robot_startup
       - peppereus
       - pr2_base_trajectory_action
+      - roseus_remote
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_robot-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `0.0.7-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.6-0`
## baxtereus

```
* [baxtereus/test/test-baxter.l] add test code for baxter-interface
* [baxtereus] overwrite ros-state-callback in baxter-interface.l for suppress torso warning
* [baxter.l] expand joint limit to refrect precice robot model
* [baxter-interface.l] fix wrong joint name in head_controller head-neck-y -> head_pan
* [baxter-util.l] set default avoid-collision-distance from 200 to 5 for baxter
* [test/test-baxter.l] add ik test, see https://github.com/start-jsk/2014-semi/pull/411
* [test/test-baxgter.test] extend time-limit to 500
* [baxter-interface.l] :angle-vector-sequence use default if nil ctype was passed
* [baxtereus] add arm option for baxter-init
* [baxtereus] fix baxter-interface :init args passing
* [baxtereus] overwrite baxter max joint velocity
* [test/test-baxter.{l,test}] add test code for baxter model (:self-collision-check)
* [baxter-util.l] use :collision-check-paris to get collision link pair, instaed of combination
* [baxter-util.l] (length args) always retruns non nil, so it never goes to self-collision-check with pairs
* [baxter-interface.l, baxter-util.l] move baxter-robot-safe class definition to baxter-util.l
* [baxtereus] add baxter's custom self check collision
* [baxtereus] add Baxter Safe Interface
* [baxter-util.l] comment out test code
* [CMakeLists.txt] describe which branch is used to generate collada
* [CMakeLists.txt] use SOURCE_PREFIX instead of SOURCE_DIR
* [baxter.l] 1) rotate is wrong, we need , for python list, 2) the order of limb is head,larm,rarm
* [baxtereus/baxter-util.l] add util program for baxter
* Contributors: Kei Okada, Kentaro Wada, Yuto Inagaki
```
## jsk_201504_miraikan

```
* add japanese demo
* [package.xml] add depends to jsk_pepper_startup and peppereus
* [jsk_201504_miraikan] add demo program performed at miraikan on 20150413
* Contributors: Kanae Kochigami, Kei Okada
```
## jsk_baxter_desktop

```
* [jsk_baxter_desktop] add ROS_DISTRO param to desktop shortcuts
* Contributors: Kentaro Wada
```
## jsk_baxter_startup

```
* [jsk_baxter_startup]add mongodb_launch option
* [jsk_baxter_startup] remove face_recognition from baxter.launch
* [jsk_baxter_startup] remove clear_params from joint actionservers in baxter.launch
* [jsk_baxter_robot] add rossetbaxter env-hooks
* Contributors: Yuto Inagaki
```
## jsk_baxter_web
- No changes
## jsk_nao_startup

```
* change name of nao_speech.launch to speech.launch
* Contributors: Kanae Kochigami
```
## jsk_pepper_startup

```
* [package.xml] add depends to nao_apps
* [jsk_pepper_startup] add joy-client.l
* Contributors: Kanae Kochigami, Kei Okada
```
## jsk_pr2_calibration
- No changes
## jsk_pr2_startup

```
* solve not updating problem after recharge
* speak the percentage of the battery with min charge
* [jsk_pr2_startup] warn more detail batrery information
* Contributors: Yuki Furuta, Chi Wun Au
```
## jsk_robot_startup
- No changes
## peppereus

```
* add speak method
* [pepper-interface.l] add error-vector method, this requires https://github.com/ros-naoqi/naoqi_bridge/pull/37
* [peppereus] Compilation does not fail even though pepper_urdf is not
  installed because the package is not yet released
* [peppereus/CMakeLists.txt] run pepper.l only when pepper_meahes found
* [CMakeLists.txt, pepper.yaml] generate pepper model from pepper_description
* [package.xml] add more depends
* [.gitignore] ignore dae file too
* [peppereus/pepper-interface.l] add :play-audio-file and :set-master-volume
* Contributors: Kanae Kochigami, Kei Okada, Ryohei Ueda
```
## pr2_base_trajectory_action
- No changes
## roseus_remote

```
* [roseus_remote] Remove null characters from the strings from server and
  return result from $ macro.
  You can use $ like:
  (setq awesome-code-result ($ (awesome-code)))
* [roseus_remote] Add LAUNCH_PREFIX argument to roseus_eusserver.launch and
  roseus_eusclient.launch to use ports which require super user permission
* [remote_roseus] Add client in euslisp implementation
* [roseus_remote] use ros::spin instead of ros::spin-once loop
* [roseus_remote] add server powered by roseus
* [jsk_robot] add roseus remote server/client for silverhummer
* Contributors: Yuki Furuta, Ryohei Ueda
```
