### PR TITLE
rtmros_gazebo: 0.1.9-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7830,7 +7830,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_gazebo-release.git
-      version: 0.1.8-0
+      version: 0.1.9-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_gazebo` to `0.1.9-0`:
- upstream repository: https://github.com/start-jsk/rtmros_gazebo.git
- release repository: https://github.com/tork-a/rtmros_gazebo-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.1.8-0`
## eusgazebo

```
* [eusgazebo] Add roseus to dependency
* Contributors: Ryohei Ueda
```
## hrpsys_gazebo_general

```
* Replace shared_dynamic_cast to dynamic_pointer_cast because shared_dynamic_cast is deprecated from boost 1.53
* [hrpsys_gazebo_general] Use find_package macro to look up collada_jsk_patch package
* [hrpsys_gazebo_general] Fix typo
* [hrpsys_gazebo_general] Fix path for catkin build
* add use_joint_effort for using effort on velocity feedback mode
* Contributors: Ryohei Ueda, YoheiKakiuchi, Iori Kumagai
```
## hrpsys_gazebo_msgs
- No changes
## staro_moveit_config
- No changes
