### PR TITLE
Adding reinforcment_learning to documentation index for indigo

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3582,11 +3582,6 @@ repositories:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/reflexxes_type2-release.git
       version: 1.2.4-0
-  reinforcement_learning:
-    doc:
-      type: git
-      url: https://github.com/toddhester/rl-texplore-ros-pkg.git
-      version: master
   remote_lab:
     doc:
       type: svn

--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -3582,6 +3582,11 @@ repositories:
         release: release/groovy/{package}/{version}
       url: https://github.com/ros-gbp/reflexxes_type2-release.git
       version: 1.2.4-0
+  reinforcement_learning:
+    doc:
+      type: git
+      url: https://github.com/toddhester/rl-texplore-ros-pkg.git
+      version: master
   remote_lab:
     doc:
       type: svn

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6622,6 +6622,11 @@ repositories:
       type: git
       url: https://github.com/jizhang-cmu/receive_xsens.git
       version: indigo
+  reinforcement_learning:
+    doc:
+      type: git
+      url: https://github.com/toddhester/rl-texplore-ros-pkg.git
+      version: master
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
I would like to have my package documented by ROS.
