### PR TITLE
vrpn: 0.7.33-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9794,6 +9794,21 @@ repositories:
       type: git
       url: https://github.com/lagadic/vrep_ros_bridge.git
       version: master
+  vrpn:
+    doc:
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: v07.33
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/vrpn-release.git
+      version: 0.7.33-2
+    source:
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: v07.33
+    status: maintained
   warehouse_ros:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9798,7 +9798,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/vrpn/vrpn.git
-      version: v07.33
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -9807,7 +9807,7 @@ repositories:
     source:
       type: git
       url: https://github.com/vrpn/vrpn.git
-      version: v07.33
+      version: master
     status: maintained
   warehouse_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn` to `0.7.33-2`:
- upstream repository: https://github.com/vrpn/vrpn.git
- release repository: https://github.com/clearpath-gbp/vrpn-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
