### PR TITLE
vrpn: 0.7.33-5 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3392,6 +3392,21 @@ repositories:
       url: https://github.com/ros-visualization/visualization_tutorials.git
       version: indigo-devel
     status: maintained
+  vrpn:
+    doc:
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/clearpath-gbp/vrpn-release.git
+      version: 0.7.33-5
+    source:
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: master
+    status: maintained
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn` to `0.7.33-5`:
- upstream repository: https://github.com/vrpn/vrpn.git
- release repository: https://github.com/clearpath-gbp/vrpn-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
