### PR TITLE
rosdep: rename Arch's python2-catkin_pkg.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -182,7 +182,7 @@ python-cairo:
     utopic: [python-cairo]
     vivid: [python-cairo]
 python-catkin-pkg:
-  arch: [python2-catkin_pkg]
+  arch: [python2-catkin-pkg]
   debian: [python-catkin-pkg]
   fedora: [python-catkin_pkg]
   gentoo: [dev-python/catkin_pkg]


### PR DESCRIPTION
The package name was fixed when added to AUR4.
