### PR TITLE
jskeus: 1.0.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1069,7 +1069,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jskeus-release.git
-      version: 1.0.6-0
+      version: 1.0.8-0
     status: developed
   korg_nanokontrol:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.0.8-0`:
- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.6-0`
## jskeus

```
* [README.md] add documents of null-space-ik

    * downsized null-space-ik.png
    * added null-space-ik sample in README.md
    * added null-space-ik sample image
    * Update README.md

* [irtrobot] fix torque-vector for those who does not have two leg, ex) pepper
* [irteus/test/const.l] add code to check intern/shadow/defconst
* [irteus/irtrobot.l] fix :look-at problem (https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/72)

    * fix :look-at, check othre direction
    * add test code for :look-at
    * check if look-at try to across non-valid joint angle
    * set +-150 for neck-p range

* Contributors: Kazuhiro Sasabuchi, Kei Okada
```
