### PR TITLE
jsk_3rdparty: 2.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1042,6 +1042,37 @@ repositories:
       url: https://github.com/ros-gbp/joystick_drivers-release.git
       version: 1.10.1-0
     status: maintained
+  jsk_3rdparty:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
+      version: master
+    release:
+      packages:
+      - assimp_devel
+      - bayesian_belief_networks
+      - downward
+      - ff
+      - ffha
+      - jsk_3rdparty
+      - julius
+      - libsiftfast
+      - mini_maxwell
+      - nlopt
+      - opt_camera
+      - rospatlite
+      - rosping
+      - rostwitter
+      - voice_text
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/jsk_3rdparty-release.git
+      version: 2.0.1-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
+      version: master
+    status: developed
   jsk_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.0.1-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## downward
- No changes
## ff
- No changes
## ffha
- No changes
## jsk_3rdparty

```
* jsk_patch is not releasesd on indigo
* Contributors: Kei Okada
```
## julius
- No changes
## libsiftfast
- No changes
## mini_maxwell
- No changes
## nlopt
- No changes
## opt_camera
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## voice_text
- No changes
