### PR TITLE
iot_bridge: 0.8.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3052,6 +3052,17 @@ repositories:
       url: https://github.com/WPI-RAIL/interactive_world.git
       version: develop
     status: maintained
+  iot_bridge:
+    doc:
+      type: git
+      url: dsd
+      version: gf
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/corb555/iot_bridge-release.git
+      version: 0.8.2-0
+    status: developed
   ipa_canopen:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iot_bridge` to `0.8.2-0`:
- upstream repository: https://github.com/corb555/iot_bridge.git
- release repository: https://github.com/corb555/iot_bridge-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
