### PR TITLE
cob_control: 0.6.8-5 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -885,7 +885,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.6.8-4
+      version: 0.6.8-5
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.6.8-5`:
- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.8-4`
## cob_base_velocity_smoother
- No changes
## cob_cartesian_controller

```
* merge with release candidate
* package renaming: cob_path_broadcaster -> cob_cartesian_controller
* Contributors: ipa-fxm
```
## cob_collision_velocity_filter
- No changes
## cob_control

```
* merge with release candidate
* package renaming: cob_path_broadcaster -> cob_cartesian_controller
* Contributors: ipa-fxm
```
## cob_control_mode_adapter
- No changes
## cob_footprint_observer
- No changes
## cob_frame_tracker
- No changes
## cob_model_identifier
- No changes
## cob_omni_drive_controller
- No changes
## cob_trajectory_controller
- No changes
## cob_twist_controller
- No changes
