### PR TITLE
pr2_gripper_sensor: 1.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6060,7 +6060,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_gripper_sensor-release.git
-      version: 1.0.5-0
+      version: 1.0.9-0
     source:
       type: git
       url: https://github.com/PR2/pr2_gripper_sensor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_gripper_sensor` to `1.0.9-0`:
- upstream repository: https://github.com/PR2/pr2_gripper_sensor.git
- release repository: https://github.com/pr2-gbp/pr2_gripper_sensor-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.5-0`
## pr2_gripper_sensor
- No changes
## pr2_gripper_sensor_action
- No changes
## pr2_gripper_sensor_controller
- No changes
## pr2_gripper_sensor_msgs
- No changes
