### PR TITLE
vrpn: 0.7.33-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9803,7 +9803,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/vrpn-release.git
-      version: 0.7.33-2
+      version: 0.7.33-3
     source:
       type: git
       url: https://github.com/vrpn/vrpn.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn` to `0.7.33-3`:
- upstream repository: https://github.com/vrpn/vrpn.git
- release repository: https://github.com/clearpath-gbp/vrpn-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.33-2`
