### PR TITLE
vrpn: 0.7.33-6 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3480,7 +3480,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/clearpath-gbp/vrpn-release.git
-      version: 0.7.33-5
+      version: 0.7.33-6
     source:
       type: git
       url: https://github.com/vrpn/vrpn.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn` to `0.7.33-6`:
- upstream repository: https://github.com/vrpn/vrpn.git
- release repository: https://github.com/clearpath-gbp/vrpn-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.33-5`
