### PR TITLE
perception_pcl: 1.3.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2164,7 +2164,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/perception_pcl-release.git
-      version: 1.2.6-1
+      version: 1.3.0-0
     source:
       type: git
       url: https://github.com/ros-perception/perception_pcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.3.0-0`:
- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.2.6-1`
## pcl_ros

```
* cleanup broken library links
  All removed library names are included in ${PCL_LIBRARIES}.
  However, the plain library names broke catkin's overlay mechanism:
  Where ${PCL_LIBRARIES} could point to a local installation of the PCL,
  e.g. pcd_ros_segmentation might still link to the system-wide installed version
  of pcl_segmentation.
* Fixed test for jade-devel. Progress on #92 <https://github.com/ros-perception/perception_pcl/issues/92>
* commented out test_tf_message_filter_pcl
  Until ros/geometry#80 <https://github.com/ros/geometry/issues/80> has been merged the test will fail.
* fixed indentation and author
* Adds a test for tf message filters with pcl pointclouds
* specialized HasHeader, TimeStamp, FrameId
  - HasHeader now returns false
  - TimeStamp and FrameId specialed for pcl::PointCloud<T> for any point type T
  These changes allow to use pcl::PointCloud with tf::MessageFilter
* Sync pcl_nodelets.xml from hydro to indigo
  Fixes to pass catkin lint -W1
* Fixes #87 <https://github.com/ros-perception/perception_pcl/issues/87> for Indigo
* Fixes #85 <https://github.com/ros-perception/perception_pcl/issues/85> for Indigo
* Fixes #77 <https://github.com/ros-perception/perception_pcl/issues/77> and #80 <https://github.com/ros-perception/perception_pcl/issues/80> for indigo
* Added option to save pointclouds in binary and binary compressed format
* Contributors: Brice Rebsamen, Lucid One, Mitchell Wills, v4hn
```
## perception_pcl

```
* Remove pointcloud_to_laserscan package
* Contributors: Paul Bovbel
```
