### PR TITLE
vrpn_client_ros: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9817,7 +9817,7 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: git@github.com:clearpath-gbp/vrpn_client_ros-release.git
+      url: https://github.com/clearpath-gbp/vrpn_client_ros-release.git
       version: 0.0.1-0
     source:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9812,8 +9812,8 @@ repositories:
   vrpn_client_ros:
     doc:
       type: git
-      url: git
-      version: https://github.com/clearpathrobotics/vrpn_client_ros.git
+      url: https://github.com/clearpathrobotics/vrpn_client_ros.git
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9809,6 +9809,21 @@ repositories:
       url: https://github.com/vrpn/vrpn.git
       version: master
     status: maintained
+  vrpn_client_ros:
+    doc:
+      type: git
+      url: git
+      version: https://github.com/clearpathrobotics/vrpn_client_ros.git
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@github.com:clearpath-gbp/vrpn_client_ros-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/vrpn_client_ros.git
+      version: indigo-devel
+    status: maintained
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn_client_ros` to `0.0.1-0`:
- upstream repository: git@github.com:clearpathrobotics/vrpn_client_ros.git
- release repository: git@github.com:clearpath-gbp/vrpn_client_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## vrpn_client_ros

```
* Rename to vrpn_client_ros
* Simplify tracker update logic; add blacklist for VRPN Control
* Break out separate nodes for client and tracker, and clean up build
* Initial prototype
* Contributors: Paul Bovbel
```
