### PR TITLE
rtmros_common: 1.2.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8143,7 +8143,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.2.13-0
+      version: 1.2.14-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.2.14-0`:
- upstream repository: https://github.com/start-jsk/rtmros_common.git
- release repository: https://github.com/tork-a/rtmros_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.2.13-0`
## hrpsys_ros_bridge

```
* [hrpsys_ros_bridge] Add splash screen to hrpsys dashboard
* Enable to set step time for each foot steps and update documentation
* Add emergency walking stop and update documentations
* [hrpsys_ros_bridge] set position of imu_floor zero
* Add method to get remaining foot steps and displaying method
* [cmake_compile_robot_model.cmake] get_filename_component DIRECTORY is only available > cmake 2.8.12
* Publish cop position in end link frame
* Publish COP for each end effectors. COPInfo is provided by Stabilizer.
* Add --use-robot-hrpsys-config argument to compile robot old (added to compile robot in 54e64bf3c4131fc907c6b7c0a34d728f82948e76)
* Contributors: Kei Okada, Ryohei Ueda, Shunichi Nozawa
```
## hrpsys_tools

```
* Add EmergencyStopper setting to hrpsys.launch
* Contributors: Shunichi Nozawa
```
## openrtm_ros_bridge
- No changes
## openrtm_tools
- No changes
## rosnode_rtc
- No changes
## rtmbuild

```
* [rtmbuild/scripts/idl2srv.py] print when service is called and returned
* Contributors: Kei Okada
```
## rtmros_common
- No changes
