### PR TITLE
fetch_ros: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1946,7 +1946,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
-      version: 0.5.14-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.6.0-0`:
- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.14-0`
## fetch_calibration

```
* update capture for new multi_sensor branch of calibration
* Contributors: Michael Ferguson
```
## fetch_depth_layer
- No changes
## fetch_description
- No changes
## fetch_moveit_config
- No changes
## fetch_navigation
- No changes
## fetch_teleop

```
* install tuck_arm.py
* add a keepout zone for extra margin around base
* add ability to run tuck arm script without joystick
* Contributors: Michael Ferguson
```
