### PR TITLE
pr2_navigation: 0.1.27-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6188,7 +6188,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_navigation-release.git
-      version: 0.1.26-0
+      version: 0.1.27-0
     source:
       type: git
       url: https://github.com/pr2/pr2_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_navigation` to `0.1.27-0`:
- upstream repository: https://github.com/PR2/pr2_navigation.git
- release repository: https://github.com/pr2-gbp/pr2_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.26-0`
## laser_tilt_controller_filter
- No changes
## pr2_move_base
- No changes
## pr2_navigation
- No changes
## pr2_navigation_config
- No changes
## pr2_navigation_global

```
* Merge pull request #16 <https://github.com/pr2/pr2_navigation/issues/16> from k-okada/remove_build_depend
  we do not need any package during build process
* we do not need any package during build process
* Contributors: Devon Ash, Kei Okada
```
## pr2_navigation_local

```
* Merge pull request #16 <https://github.com/pr2/pr2_navigation/issues/16> from k-okada/remove_build_depend
  we do not need any package during build process
* we do not need any package during build process
* Contributors: Devon Ash, Kei Okada
```
## pr2_navigation_perception
- No changes
## pr2_navigation_self_filter

```
* Support collada dae mesh file as well as stl files
* Install self_filter binary to the package_bin directory
* Contributors: Ryohei Ueda, aginika
```
## pr2_navigation_slam

```
* Merge pull request #16 <https://github.com/pr2/pr2_navigation/issues/16> from k-okada/remove_build_depend
  we do not need any package during build process
* we do not need any package during build process
* Contributors: Devon Ash, Kei Okada
```
## pr2_navigation_teleop
- No changes
## semantic_point_annotator
- No changes
