### PR TITLE
imu_tools: 1.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2908,7 +2908,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/imu_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.0.5-0`:
- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.4-0`
## imu_filter_madgwick

```
* Add "~use_magnetic_field_msg" param.
  This allows the user to subscribe to the /imu/mag topic as a
  sensor_msgs/MagneticField rather than a geometry_msgs/Vector3Stamped.
  The default for now is false, which preserves the legacy behaviour via a
  separate subscriber which converts Vector3Stamped to MagneticField and
  republishes.
* Contributors: Mike Purvis, Martin Günther
```
## imu_tools
- No changes
## rviz_imu_plugin
- No changes
