### PR TITLE
Added pip install of python websocket for older ubuntu distros and support for python3

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1815,7 +1815,31 @@ python-vtk:
     utopic: [python-vtk]
     vivid: [python-vtk]
 python-websocket:
-  ubuntu: [python-websocket]
+  ubuntu:
+    precise:
+      pip:
+        packages: [websocket-client]
+    quantal:
+      pip:
+        packages: [websocket-client]
+    raring:
+      pip:
+        packages: [websocket-client]
+    saucy:
+      pip:
+        packages: [websocket-client]
+    trusty: [python-websocket]
+    trusty_python3:
+      pip:
+        packages: [websocket-client]
+    utopic: [python-websocket]
+    utopic_python3:
+      pip:
+        packages: [websocket-client]
+    vivid: [python-websocket]
+    vivid_python3: [python3-websocket]
+    wily: [python-websocket]
+    wily_python3: [python3-websocket]
 python-werkzeug:
   ubuntu: [python-werkzeug]
 python-ws4py-pip:


### PR DESCRIPTION
Does what I did for trusty_python3 and utopic_python3 correctly use python3 pip or do I need to do something special? The python3-websocket ubuntu package is only released in vivid and wily.
