### PR TITLE
dynamixel_motor: 0.4.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -474,6 +474,27 @@ repositories:
       url: https://github.com/ros/dynamic_reconfigure.git
       version: master
     status: maintained
+  dynamixel_motor:
+    doc:
+      type: git
+      url: https://github.com/arebgun/dynamixel_motor.git
+      version: master
+    release:
+      packages:
+      - dynamixel_controllers
+      - dynamixel_driver
+      - dynamixel_motor
+      - dynamixel_msgs
+      - dynamixel_tutorials
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/arebgun/dynamixel_motor-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/arebgun/dynamixel_motor.git
+      version: master
+    status: maintained
   ecto:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_motor` to `0.4.0-0`:
- upstream repository: https://github.com/arebgun/dynamixel_motor.git
- release repository: https://github.com/arebgun/dynamixel_motor-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## dynamixel_controllers

```
* stack is now catkin compatible
```
## dynamixel_driver

```
* stack is now catkin compatible
```
## dynamixel_motor

```
* stack is now catkin compatible
```
## dynamixel_msgs

```
* stack is now catkin compatible
```
## dynamixel_tutorials

```
* stack is now catkin compatible
```
