### PR TITLE
pepper_robot: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5744,7 +5744,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_robot-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_robot` to `0.1.3-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_robot.git
- release repository: https://github.com/ros-naoqi/pepper_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.2-0`
## pepper_bringup
- No changes
## pepper_description

```
* generate a new .urdf file from the .xacro files
* update to the latest alrobotmodelutils
* Contributors: Vincent Rabaud
```
## pepper_robot
- No changes
## pepper_sensors
- No changes
