### PR TITLE
removing flask-ext-catkin.

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1974,19 +1974,6 @@ repositories:
       url: https://github.com/introlab/find_object_2d-release.git
       version: 0.5.1-0
     status: maintained
-  flask-ext-catkin:
-    release:
-      packages:
-      - flask_ext_catkin
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/yujinrobot-release/flask-ext-catkin-release.git
-      version: 0.1.0-2
-    source:
-      type: git
-      url: https://github.com/asmodehn/flask-ext-catkin.git
-      version: indigo-devel
-    status: developed
   flatbuffers:
     release:
       tags:


### PR DESCRIPTION
flask-ext-catkin is a collection of flask extensions for a main flask app that I am currently developing...
It cannot be build on debian because saucy doesnt have some of the dependencies as a package, and the distribution is obsolete now.
I ll make my main flask application a pure python, and i'll manage depedencies directly with pip, the python way.
So I'm removing that package as it is useless.
