### PR TITLE
wireless: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9915,11 +9915,12 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/wireless-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/wireless.git
       version: master
+    status: maintained
   world_canvas:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless` to `0.0.4-0`:
- upstream repository: https://github.com/clearpathrobotics/wireless.git
- release repository: https://github.com/clearpath-gbp/wireless-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.3-0`
## wireless_msgs
- No changes
## wireless_watcher

```
* Add install rule for launch dir
* Contributors: Paul Bovbel
```
