### PR TITLE
iot_bridge: 0.8.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1031,6 +1031,17 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: indigo-devel
     status: maintained
+  iot_bridge:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/corb555/iot_bridge-release.git
+      version: 0.8.2-0
+    source:
+      type: git
+      url: https://github.com/corb555/iot_bridge.git
+      version: master
+    status: developed
   ivcon:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iot_bridge` to `0.8.2-0`:
- upstream repository: https://github.com/corb555/iot_bridge.git
- release repository: https://github.com/corb555/iot_bridge-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
