### PR TITLE
object_recognition_ros_visualization: 0.3.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4994,7 +4994,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_ros_visualization-release.git
-      version: 0.3.6-1
+      version: 0.3.7-0
     source:
       type: git
       url: https://github.com/wg-perception/object_recognition_ros_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_ros_visualization` to `0.3.7-0`:
- upstream repository: https://github.com/wg-perception/object_recognition_ros_visualization.git
- release repository: https://github.com/ros-gbp/object_recognition_ros_visualization-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.6-1`
## object_recognition_ros_visualization

```
* Merge pull request #4 <https://github.com/wg-perception/object_recognition_ros_visualization/issues/4> from v4hn/fix-empty-hull-segfault
  fix segfault when table with empty hull is received
* fix segfault when table with empty hull is received
* update conf file for docs
* Contributors: Vincent Rabaud, v4hn
```
