### PR TITLE
openslam_gmapping: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5558,7 +5558,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/openslam_gmapping-release.git
-      version: 0.1.0-2
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/openslam_gmapping.git
+      version: master
     status: maintained
   optris_drivers:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `openslam_gmapping` to `0.1.1-0`:
- upstream repository: https://github.com/ros-perception/openslam_gmapping
- release repository: https://github.com/ros-gbp/openslam_gmapping-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.0-2`
## openslam_gmapping

```
* fix cppcheck warnings
* License from BSD to CC
* Contributors: Isaac IY Saito, Vincent Rabaud
```
