### PR TITLE
openslam_gmapping: 0.1.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2092,7 +2092,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/openslam_gmapping-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ros-perception/openslam_gmapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openslam_gmapping` to `0.1.1-0`:
- upstream repository: https://github.com/ros-perception/openslam_gmapping
- release repository: https://github.com/ros-gbp/openslam_gmapping-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.0-0`
## openslam_gmapping

```
* fix cppcheck warnings
* License from BSD to CC
* Contributors: Isaac IY Saito, Vincent Rabaud
```
