### PR TITLE
audio_common: 0.2.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -123,6 +123,27 @@ repositories:
       url: https://github.com/WPI-RAIL/async_web_server_cpp.git
       version: develop
     status: maintained
+  audio_common:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/audio_common.git
+      version: hydro-devel
+    release:
+      packages:
+      - audio_capture
+      - audio_common
+      - audio_common_msgs
+      - audio_play
+      - sound_play
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/audio_common-release.git
+      version: 0.2.7-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/audio_common.git
+      version: hydro-devel
+    status: maintained
   battery_monitor_rmp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.2.7-0`:
- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
