### PR TITLE
teleop_twist_joy: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9081,7 +9081,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-teleop/teleop_twist_joy-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_twist_joy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `0.1.1-0`:
- upstream repository: https://github.com/ros-teleop/teleop_twist_joy.git
- release repository: https://github.com/ros-teleop/teleop_twist_joy-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.0-0`
## teleop_twist_joy

```
* Add rostests.
* Added maps to allow multi-dof velocity publishing.
* Added Xbox 360 controller example.
* Contributors: Mike Purvis, Tony Baltovski
```
