### PR TITLE
jsk_3rdparty: 2.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3176,7 +3176,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.0.1-0
+      version: 2.0.2-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.0.2-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2.0.1-0`
## assimp_devel

```
* [Makefile] use http instead of https
* Contributors: Kei Okada
```
## bayesian_belief_networks
- No changes
## collada_urdf_jsk_patch

```
* [/jsk_ros_patch/collada_urdf_jsk_patch/CMakeLists.txt] if ROS_DISTRO is jade, the we'll use robot_model for indigo. jade-devel branch for robot_model is not released yet
* Contributors: Kei Okada
```
## downward
- No changes
## ff

```
* [Makefile] use http instead of https
* Contributors: Kei Okada
```
## ffha
- No changes
## jsk_3rdparty
- No changes
## julius
- No changes
## laser_filters_jsk_patch
- No changes
## libsiftfast
- No changes
## mini_maxwell
- No changes
## nlopt
- No changes
## opt_camera
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## sklearn
- No changes
## voice_text
- No changes
