### PR TITLE
nav_pcontroller: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4920,6 +4920,13 @@ repositories:
       url: https://github.com/paulbovbel/nav2_platform.git
       version: hydro-devel
     status: maintained
+  nav_pcontroller:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/code-iai-release/nav_pcontroller-release.git
+      version: 0.1.1-0
+    status: developed
   navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nav_pcontroller` to `0.1.1-0`:
- upstream repository: https://github.com/code-iai/nav_pcontroller.git
- release repository: https://github.com/code-iai-release/nav_pcontroller-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `null`
## nav_pcontroller

```
* Catkinization and getting rid of JLO (in order to release it)
  The JLO-version is tagged as "JLO-controlled".
* Added .gitignore
* Initial commit
* Contributors: Jan Winkler
```
