### PR TITLE
katana_driver: 1.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3435,7 +3435,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/uos-gbp/katana_driver-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/uos/katana_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `katana_driver` to `1.0.3-0`:
- upstream repository: https://github.com/uos/katana_driver.git
- release repository: https://github.com/uos-gbp/katana_driver-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.2-0`
## katana
- No changes
## katana_arm_gazebo

```
* remove dependencies to non-existing cmake targets
* find_package gazebo instead of using PkgConfig
* Contributors: Michael Görner
```
## katana_description

```
* fix cmake developer warning
* Contributors: Michael Görner
```
## katana_driver
- No changes
## katana_gazebo_plugins

```
* remove dependencies to non-existing cmake targets
* find_package gazebo instead of using PkgConfig
* Contributors: Michael Görner
```
## katana_moveit_ikfast_plugin
- No changes
## katana_msgs
- No changes
## katana_teleop

```
* remove dependencies to non-existing cmake targets
* Contributors: Michael Görner
```
## katana_tutorials

```
* remove dependencies to non-existing cmake targets
* Contributors: Michael Görner
```
## kni

```
* Removed external project handling scheme from CMakeLists.txt.
  The kni package's catkin definitions now do not rely on the original
  project's Makefiles anymore. It now directly handles the build process.
  This has the advantage that resulting targets are no "meta" targets
  anymore. This caused client applications to link against the absolute
  library path from build time, not using the library name + path pattern.
* Contributors: Leon Ziegler
```
