### PR TITLE
linux_peripheral_interfaces: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4043,7 +4043,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/linux_peripheral_interfaces-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/ros-drivers/linux_peripheral_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `linux_peripheral_interfaces` to `0.1.3-0`:
- upstream repository: https://github.com/ros-drivers/linux_peripheral_interfaces.git
- release repository: https://github.com/ros-gbp/linux_peripheral_interfaces-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.2-0`
## laptop_battery_monitor
- No changes
## libsensors_monitor

```
* Made labels match format in laptop_battery_monitor
  Removed degree symbols from temps
* Now use the sensor label for diangostics name
* in libsensors monitor now put unit in the value instead of in the key
* Added a package description
* switch to using utf-8 for degree symbol for libsensors_monitor
* Contributors: Mitchell Wills
```
## linux_peripheral_interfaces
- No changes
