### PR TITLE
smart_battery_msgs: 0.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3210,6 +3210,21 @@ repositories:
       url: https://github.com/ros-perception/slam_gmapping.git
       version: hydro-devel
     status: developed
+  smart_battery_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/smart_battery_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/smart_battery_msgs-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/smart_battery_msgs.git
+      version: master
+    status: maintained
   spatial_temporal_learning:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `smart_battery_msgs` to `0.1.0-0`:
- upstream repository: https://github.com/ros-drivers/smart_battery_msgs.git
- release repository: https://github.com/ros-gbp/smart_battery_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## smart_battery_msgs

```
* initial commit
* Contributors: Jihoon Lee
```
