### PR TITLE
spur: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8859,13 +8859,15 @@ repositories:
     release:
       packages:
       - spur
+      - spur_2dnav
+      - spur_bringup
       - spur_controller
       - spur_description
       - spur_gazebo
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/spur-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/tork-a/spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `spur` to `0.2.2-0`:
- upstream repository: https://github.com/tork-a/spur.git
- release repository: https://github.com/tork-a/spur-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.1-0`
## spur

```
* [Feat] Enable Hokuyo
* [Sys] Adjust to bringup pkg. Add 2dnav pkg up to gmapping feature
* [Sys] Port general stuff to spur_bringup package
* Contributors: Isaac IY Saito
```
## spur_2dnav

```
* Adjust to bringup pkg. Add 2dnav pkg up to gmapping feature.
* Contributors: Isaac IY Saito
* Initial commit of a package. Added up to gmapping feature.
* Contributors: Isaac IY Saito
```
## spur_bringup

```
* Adjust to bringup pkg. Add 2dnav pkg up to gmapping feature.
* Add bringup package. Move non-controller files into it. Integrate URG.
* Contributors: Isaac IY Saito
* Initial commit of a package.
* Contributors: Isaac IY Saito
```
## spur_controller

```
* [Sys] Port general stuff to spur_bringup package
* Contributors: Isaac IY Saito
```
## spur_description

```
* [Feat] Enable Hokuyo
* Contributors: Isaac IY Saito
```
## spur_gazebo

```
* [Feat] Selectable laser visualization via roslaunch argument
* [Sys] Adjust to bringup pkg. Add 2dnav pkg up to gmapping feature
* Contributors: Isaac IY Saito
```
