### PR TITLE
rostful_node: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7983,6 +7983,11 @@ repositories:
       version: indigo-devel
     status: maintained
   rostful_node:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/rostful-node-release.git
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/asmodehn/rostful-node.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rostful_node` to `0.0.3-0`:
- upstream repository: https://github.com/asmodehn/rostful-node.git
- release repository: https://github.com/asmodehn/rostful-node-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
