### PR TITLE
Adding followme to documentation index for distro distribution.yaml

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2005,6 +2005,20 @@ repositories:
       url: https://github.com/ros-drivers/flir_ptu.git
       version: master
     status: developed
+  followme:
+    doc:
+      type: git
+      url: https://github.com/kendemu/followme.git
+      version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/kendemu/followme.git
+      version: 0.0.1
+    source:
+      type: git
+      url: https://github.com/kendemu/followme.git
+      version: indigo
   force_torque_tools:
     doc:
       type: git


### PR DESCRIPTION
I'd like followme to be index and documented on ros.org.
