### PR TITLE
spur: 0.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8878,7 +8878,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/spur-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/tork-a/spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `spur` to `0.2.3-0`:
- upstream repository: https://github.com/tork-a/spur.git
- release repository: https://github.com/tork-a/spur-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.2-0`
## spur

```
* [feat] Add simulation capability of dynamixel's joint_state_publisher (temporary addition until https://github.com/arebgun/dynamixel_motor/pull/27 and https://github.com/arebgun/dynamixel_motor/pull/28 get merged)
* [sys] add test
* [sys] Fix files wrong location
* [sys] workaround for travis test (pass visualize_laser as arg. Only hydro can be tested on travis)
* [sys] Fix CMake build rule issue40 <https://github.com/tork-a/spur/pull/40>
* [sys] urg_node only runs with simulation
* Contributors: TORK 534o
```
## spur_2dnav

```
* [sys] Fix CMake build rule issue40 <https://github.com/tork-a/spur/pull/40>
* Contributors: Isaac IY Saito
```
## spur_bringup

```
* [feat] Add simulation capability of dynamixel's joint_state_publisher (temporary addition until https://github.com/arebgun/dynamixel_motor/pull/27 and https://github.com/arebgun/dynamixel_motor/pull/28 get merged)
* [sys] Fix files wrong location
* [sys] Fix CMake build rule issue40 <https://github.com/tork-a/spur/pull/40>
* [sys] urg_node only runs with simulation
* [sys] add test
* Contributors: Isaac IY Saito, Tokyo Opensource Robotics Programmer 534o
```
## spur_controller

```
* [feat] Add simulation capability of dynamixel's joint_state_publisher (temporary addition until https://github.com/arebgun/dynamixel_motor/pull/27 and https://github.com/arebgun/dynamixel_motor/pull/28 get merged)
* [sys] Fix files wrong location
* [sys] workaround for travis test (pass visualize_laser as arg. Only hydro can be tested on travis)
* Contributors: Isaac IY Saito, TORK 534o
```
## spur_description
- No changes
## spur_gazebo

```
* [sys] add test
* Contributors: TORK 534o
```
