### PR TITLE
ros_canopen: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7287,7 +7287,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git
-      version: indigo_dev
+      version: indigo-devel
     status: maintained
   ros_comm:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7283,7 +7283,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/ros_canopen-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/ipa320/ros_canopen.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7270,7 +7270,7 @@ repositories:
   ros_canopen:
     doc:
       type: git
-      url: https://github.com/ipa320/ros_canopen.git
+      url: https://github.com/ros-industrial/ros_canopen.git
       version: indigo_release_candidate
     release:
       packages:
@@ -7282,11 +7282,11 @@ repositories:
       - socketcan_interface
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ipa320/ros_canopen-release.git
+      url: https://github.com/ros-industrial-release/ros_canopen-release.git
       version: 0.6.3-0
     source:
       type: git
-      url: https://github.com/ipa320/ros_canopen.git
+      url: https://github.com/ros-industrial/ros_canopen.git
       version: indigo_dev
     status: maintained
   ros_comm:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.6.3-0`:
- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ipa320/ros_canopen-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.2-0`
## canopen_402

```
* improved PP mode
* do not quickstop in fault states
* do not diable selected mode on recover, just restart it
* initialize to No_Mode
* removed some empty lines
* implemented support for mode switching in a certain 402 state, defaults to Operation_Enable
* pass LayerStatus to switchMode
* remove enableMotor, introduced switchState
* added motor_layer settings
* fixed PP mode
* explicit find for class_loader
* fail-safe setting of op_mode to No_Mode
* Improved behaviour of concurrent commands
* added alternative Transitions 7 and 10 via Quickstop
* added alternative success condition to waitForNewState
* make motor init/recover interruptable
* changed maintainer
* removed SM-based 402 implementation
* added Motor402 plugin
* added new 402 implementation
* added MotorBase
* Added validity checks
* Removed overloaded functions and makes the handle functions protected
* Removes test executable
* Removes unnecessary configure_drive and clears the set Targets
* Some position fixes
* Removed timeout
  Reduced recover trials
* Removes some logs
* Homing integrated
* handleRead, handleWrite fixes
* Merge remote-tracking branch 'mdl/indigo_dev' into refactor_sm
  Conflicts:
  canopen_402/include/canopen_402/canopen_402.h
  canopen_402/src/canopen_402/canopen_402.cpp
  canopen_motor_node/src/control_node.cpp
* Moved supported_drive_modes to ModeSpecificEntries
* 

    * Init, Recover, Halt for SCHUNK
    * Removed sleeps from the state machine
    * Now works as reentrant states

* refactored Layer mechanisms
* Recover failure
* Merge remote-tracking branch 'mdl/indigo_dev' into refactor_sm
  Conflicts:
  canopen_402/include/canopen_402/canopen_402.h
  canopen_402/src/canopen_402/canopen_402.cpp
* Removing some unnecessary couts
* First version with Recover
  * Tested on SCHUNK LWA4D
* Initializing all modules at once
* Moving SCHUNK using the IP mode sub-state machine
* Schunk does not set operation mode via synchronized RPDO
* initialize homing_needed to false
* Working with the guard handling and some scoped_locks to prevent unwanted access
* Passing state_ to motor machine
* Fixes crash for unitialized boost pointer for target_vel_ and target_pos_
* Thread running
* Separates the hw with the SM test
  Advance on the Mode Switching Machine
* Organizing IPMode State Machine
* Adds mode switch and a pre-version of the turnOn sequence
* Event argument passed to the Motor state machine
* Adds the internal actions
* Control_word is set from motor state machine
* Motor abstraction on higher level machine
  Some pointers organization
* 

    * Begins with the Higher Level Machine
    * Separates the status and control from the 402 node

* Ip mode sub-machine
* Organizing the status and control machine
* do not read homing method if homing mode is not supported
* inti enter_mode_failure_ to false
* require message strings for error indicators, added missing strings, added ROS logging in sync loop
* Merge pull request #75 <https://github.com/ros-industrial/ros_canopen/issues/75> from mistoll/indigo_release_candidate
  Move ip_mode_sub_mode to configureModeSpecificEntries
* Fixed tabs/spaces
* bind IP sub mode only if IP is supported
* Move ip_mode_sub_mode to configureModeSpecificEntries
* Update state_machine.h
* Ongoing changes for the state machine
* 

    * Eliminates Internal State conflict
    * Treats exceptions inside the state machine

* Cleaning the 402.cpp file
* Test file
* Adds state machine definition
* Adds state machine simple test
* Some cleaning necessary to proceed
* Header files for isolating the 402 state machine
* Effort value
* Merge pull request #6 <https://github.com/ros-industrial/ros_canopen/issues/6> from ipa-mdl/indigo_dev
  Work-around for https://github.com/ipa320/ros_canopen/issues/62
* Merge branch 'indigo_dev' of https://github.com/ipa-mdl/ros_canopen into indigo_dev
* fixed unintialized members
* Mode Error priority
* Order issue
* Merge branch 'indigo_dev' of https://github.com/ipa-mdl/ros_canopen into indigo_dev
  Conflicts:
  canopen_motor_node/CMakeLists.txt
* Error status
* Merge branch 'indigo_dev' into merge
  Conflicts:
  canopen_chain_node/include/canopen_chain_node/chain_ros.h
  canopen_master/include/canopen_master/canopen.h
  canopen_master/include/canopen_master/layer.h
  canopen_master/src/node.cpp
  canopen_motor_node/CMakeLists.txt
  canopen_motor_node/src/control_node.cpp
* Contributors: Florian Weisshardt, Mathias Lüdtke, Michael Stoll, Thiago de Freitas Oliveira Araujo, thiagodefreitas
```
## canopen_chain_node

```
* added motor_layer settings
* remove boost::posix_time::milliseconds from SyncProperties
* removed support for silence_us since bus timing cannot be guaranteed
* implemented plugin-based Master allocators, defaults to LocalMaster
* set initialized to false explicitly if init failed
* include for std_msgs::String was missing
* Merge remote-tracking branch 'origin/std_trigger' into new_402
  Conflicts:
  canopen_chain_node/CMakeLists.txt
  canopen_chain_node/include/canopen_chain_node/chain_ros.h
* halt explicitly on shutdown
* stop heartbeat after stack was shutdown
* migrated to Timer instead of ros::Timer to send heartbeat even after ros was shutdown
* run loop even if ros is shutdown
* improved chain shutdown behaviour
* fix for g++: proper message generation
* Merge branch 'publisher' into muparser
  Conflicts:
  canopen_motor_node/src/control_node.cpp
* added generic object publishers
* migrated to std_srvs/Trigger
* use atomic flag instead of thread pointer for synchronization
* do not run diagnostics if chain was not initalized, output warning instead
* Changes Layer Status to Warning during the service calls
* refactored Layer mechanisms
* heartbeat works now
* check XmlRpcValue types in dcf_overlay
* removed IPCLayer sync listener, loopback is disabled per default
* added simple heartbeat timer
* added sync silence feature
* parse sync properties only if sync_ms is valid
* require message strings for error indicators, added missing strings, added ROS logging in sync loop
* skip "eds_pkg" if not provided
* clear layer before plugin loader is deleted
* implemented node list as struct
* 'modules' was renamed to 'nodes'
* removed chain name
* added driver_plugin parameter for pluginlib look-up
* implemented threading in CANLayer
* removed bitrate, added loopback to DriverInterface::init
* allow dcf_overlay in defaults as well
* recursive merge of MergedXmlRpcStruct
* added dcf_overlay parameter
* Merge branch 'auto_scale' into indigo_dev
  Conflicts:
  canopen_chain_node/include/canopen_chain_node/chain_ros.h
* Merge remote-tracking branch 'ipa320/indigo_dev' into indigo_dev
  Conflicts:
  canopen_chain_node/include/canopen_chain_node/chain_ros.h
  canopen_motor_node/src/control_node.cpp
* catch exceptions during master creation
* removed MasterType form template
* added master_type parameter
* Merge branch 'indigo_dev' into merge
  Conflicts:
  canopen_chain_node/include/canopen_chain_node/chain_ros.h
  canopen_master/include/canopen_master/canopen.h
  canopen_master/include/canopen_master/layer.h
  canopen_master/src/node.cpp
  canopen_motor_node/CMakeLists.txt
  canopen_motor_node/src/control_node.cpp
* added MergedXmlRpcStruct as replacement for read_xmlrpc_or_praram
* Contributors: Mathias Lüdtke, thiagodefreitas
```
## canopen_master

```
* added Settings class
* added SimpleMaster
* remove boost::posix_time::milliseconds from SyncProperties
* removed support for silence_us since bus timing cannot be guaranteed
* properly handle cases where def_val == init_val
* implemented plugin-based Master allocators, defaults to LocalMaster
* moved master/synclayer base classes to canopen.h
* added support for non-continuous PDO ranges
* added has() check to object dictionary interface
* improved ObjectStorage entry interface
* verbose out_of_range exception
* improved timer: duration cast, autostart flag
* reset sync waiter number after timeout
* verbose timeout exception
* little fix im EMCY diagnostics
* string instead of mulit-char constant
* Merge branch 'hwi_switch' into muparser
* added std::string converters to ObjectDict::Key
* do not warn on profile-only errors
* added get_abs_time without parameter
* link against boost_atomic for platforms with lock-based implementation
* reset sent Reset and Reset_Com, c&p bug
* stop heartbeat after node shutdown
* protect reads of LayerState
* protect layers in VectorHelper
* protect buffer data
* set error only if generic error bit is set, otherwise just warn about it
* Fixes https://github.com/ipa320/ros_canopen/issues/81
* Update emcy.cpp
* removed debug outputs
* refactored Layer mechanisms
* simplified init
* simplified EMCY handling
* improved hearbeat handling
* do not stop master on slave timeout
* improved pending handling in complex layers
* added set_cached for object entries
* removed IPCLayer sync listener, loopback is disabled per default
* Merge branch 'dummy_interface' into indigo_dev
  Conflicts:
  canopen_master/src/objdict.cpp
* added sync silence feature
* Merge remote-tracking branch 'origin/fix32bit' into indigo_dev
* require message strings for error indicators, added missing strings, added ROS logging in sync loop
* fix ambiguous buffer access with 32bit compilers
* pad octet strings if necessary
* reset pending to layers.begin()
* enforce RPDO (device-side) transmimssion type to 1 if <=240
* introduced LayerVector to unify pending support
* introduced read_integer to enfoce hex parsing, closes #74 <https://github.com/ros-industrial/ros_canopen/issues/74>
* clear layer before plugin loader is deleted
* Merge branch 'indigo_dev' of https://github.com/ipa320/ros_canopen into indigo_dev
* Merge pull request #70 <https://github.com/ros-industrial/ros_canopen/issues/70> from ipa-mdl/pluginlib
  added plugin feature to socketcan_interface
* exception-aware get functions
* removed RPDO sync timeout in favour of LayerStatus
* added message string helper
* EDS files are case-insensitive, so switching to iptree
* handle errors entries that are not in the dictionary
* sub entry number must be hex coded
* do not send initilized-only PDO data
* init entries if init value was given and default value was not
* implemented threading in CANLayer
* removed bitrate, added loopback to DriverInterface::init
* removed SimpleLayer, migrated to Layer
* Layer::pending and Layer::halt are now virtual pure as well
* schunk version of reset
* Merge branch 'elmo_console' of https://github.com/ipa-mdl/ros_canopen into dcf_overlay
* remove debug prints
* resize buffer if needed in expedited SDO upload
* fix SDO segment download
* only access EMCY errors if available
* added ObjectStorage:Entry::valid()
* added ObjectDict overlay feature
* Fixes the bus controller problems for the Elmo chain
* Work-around for Elmo SDO bug(?)
* improved PDO buffer initialization, buffer if filled per SDO if needed
* pass permission object
* disable threading interrupts while waiting for SDO response
* Merge branch 'indigo_dev' into merge
  Conflicts:
  canopen_chain_node/include/canopen_chain_node/chain_ros.h
  canopen_master/include/canopen_master/canopen.h
  canopen_master/include/canopen_master/layer.h
  canopen_master/src/node.cpp
  canopen_motor_node/CMakeLists.txt
  canopen_motor_node/src/control_node.cpp
* Contributors: Mathias Lüdtke, Thiago de Freitas Oliveira Araujo, ipa-cob4-2, ipa-fmw, thiagodefreitas
```
## canopen_motor_node

```
* added motor prefix to allocator entry
* only register limit interfaces with actual limits
* added motor_layer settings
* Migrated to ClassAllocator helper
* do not run controller manager on shutdown
* migrated to motor plug-in
* working compile-time check
* reset commands without controllers to current value
* got rid of getModeMask
* added check for old unit factors
* added closing braces in default conversion strings
* forgot var_func assignment in constructor
* ensured UnitConverter access to factory is valid during lifetime
* add unit conversion based on muparser
* dependency on muparser
* Refer to ipa320/ros_control overlay
* migrated to new hwi switch interface
* atomic joint handle pointer
* test if mode is support, add No_Mode
* enabled limit enforcing again
* removed debug output
* Fixes https://github.com/ipa320/ros_canopen/issues/81
* Enforce limits and current_state necessary for writing
* Merge remote-tracking branch 'mdl/indigo_dev' into refactor_sm
  Conflicts:
  canopen_402/include/canopen_402/canopen_402.h
  canopen_402/src/canopen_402/canopen_402.cpp
  canopen_motor_node/src/control_node.cpp
* refactored Layer mechanisms
* Fixes crash for unitialized boost pointer for target_vel_ and target_pos_
* MotorChain is now a template
* early check if joint is listed in URDF
* introduced 'joint' parameter (defaults to 'name')
* 'modules' was renamed to 'nodes'
* Merge branch 'indigo_dev' of https://github.com/ipa320/ros_canopen into indigo_dev
* Merge pull request #70 <https://github.com/ros-industrial/ros_canopen/issues/70> from ipa-mdl/pluginlib
  added plugin feature to socketcan_interface
* compile-time check for ros_control notifyHardwareInterface supportcompü
* added driver_plugin parameter for pluginlib look-up
* implemented threading in CANLayer
* removed SimpleLayer, migrated to Layer
* Layer::pending and Layer::halt are now virtual pure as well
* 

    * Eliminates Internal State conflict
    * Treats exceptions inside the state machine

* keep loop running
* proper locking for hardware interface switch (might fix #61 <https://github.com/ros-industrial/ros_canopen/issues/61>)
* Merge branch 'auto_scale' into indigo_dev
  Conflicts:
  canopen_chain_node/include/canopen_chain_node/chain_ros.h
* Merge remote-tracking branch 'ipa320/indigo_dev' into indigo_dev
  Conflicts:
  canopen_chain_node/include/canopen_chain_node/chain_ros.h
  canopen_motor_node/src/control_node.cpp
* removed MasterType form template
* Merge branch 'indigo_dev' into merge
  Conflicts:
  canopen_chain_node/include/canopen_chain_node/chain_ros.h
  canopen_master/include/canopen_master/canopen.h
  canopen_master/include/canopen_master/layer.h
  canopen_master/src/node.cpp
  canopen_motor_node/CMakeLists.txt
  canopen_motor_node/src/control_node.cpp
* added unit factor parameter parsing
* Scale factor acquired from yaml file
* Contributors: Mathias Lüdtke, thiagodefreitas
```
## ros_canopen
- No changes
## socketcan_interface

```
* dependencies revised
* reordering fix for #87 <https://github.com/ros-industrial/ros_canopen/issues/87>
* intialize structs
* tostring fixed for headers
* removed empty test
* added DummyInterface with first test
* added message string helper
* added missing include
* install socketcan_interface_plugin.xml
* migrated to class_loader for non-ROS parts
* moved ThreadedInterface to dedicated header
* removed bitrate, added loopback to DriverInterface::init
* added socketcan plugin
* CommInterstate and StateInterface are now bases of DriverInterface.
  Therefore DispatchedInterface was moved into AsioBase.
* remove debug prints
* shutdown asio driver in destructor
* proper mask shifts
* Contributors: Mathias Lüdtke
```
