### PR TITLE
aau_multi_robot: 0.1.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10,6 +10,25 @@ release_platforms:
   - saucy
   - trusty
 repositories:
+  aau_multi_robot:
+    doc:
+      type: git
+      url: https://github.com/aau-ros/aau_multi_robot.git
+      version: indigo
+    release:
+      packages:
+      - adhoc_communication
+      - explorer
+      - map_merger
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/aau-ros/aau_multi_robot-release.git
+      version: 0.1.8-0
+    source:
+      type: git
+      url: https://github.com/aau-ros/aau_multi_robot.git
+      version: indigo
+    status: developed
   abb:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aau_multi_robot` to `0.1.8-0`:
- upstream repository: https://github.com/aau-ros/aau_multi_robot.git
- release repository: https://github.com/aau-ros/aau_multi_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
