### PR TITLE
fetch_ros: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1970,7 +1970,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.6.1-0`:
- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.0-0`
## fetch_calibration

```
* delete old parameters before reloading
* use dated temp files to avoid permissions issues, fixes #9 <https://github.com/fetchrobotics/fetch_ros/issues/9>
* specify camera/chain names
* add checkboard based calibration config
* Contributors: Michael Ferguson
```
## fetch_depth_layer
- No changes
## fetch_description

```
* specify a license
* Contributors: Michael Ferguson
```
## fetch_moveit_config

```
* add (optional) octomap configuration
* Contributors: Michael Ferguson
```
## fetch_navigation
- No changes
## fetch_teleop

```
* make pan/tilt acceleration parameterized
* update head tilt joint limits in teleop
* Contributors: Michael Ferguson
```
