### PR TITLE
robot_calibration: 0.5.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6843,7 +6843,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/robot_calibration-release.git
-      version: 0.5.1-0
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/mikeferguson/robot_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.5.2-0`:
- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/fetchrobotics-gbp/robot_calibration-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.1-0`
## robot_calibration

```
* remove dependency on PCL
* cleanup naming of member variables
* fix centroid refinement, fixes #20 <https://github.com/mikeferguson/robot_calibration/issues/20>
* Contributors: Michael Ferguson
```
## robot_calibration_msgs
- No changes
