### PR TITLE
slam_gmapping: 1.3.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8794,7 +8794,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/slam_gmapping-release.git
-      version: 1.3.5-0
+      version: 1.3.7-0
     source:
       type: git
       url: https://github.com/ros-perception/slam_gmapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_gmapping` to `1.3.7-0`:
- upstream repository: https://github.com/ros-perception/slam_gmapping
- release repository: https://github.com/ros-gbp/slam_gmapping-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.3.5-0`
## gmapping

```
* get replay to behave like live processing
* Contributors: Vincent Rabaud
```
## slam_gmapping
- No changes
