### PR TITLE
ecto_ros: 0.4.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1798,7 +1798,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ecto_ros-release.git
-      version: 0.4.6-0
+      version: 0.4.7-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto_ros` to `0.4.7-0`:
- upstream repository: /home/vrabaud/workspace/recognition_kitchen/src/ecto_ros
- release repository: https://github.com/ros-gbp/ecto_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.4.6-0`
## ecto_ros

```
* remove code that was in cv_bridge
* [Image2Mat] lazy conversion depending on presence of input.
  This lets the consumer of the cv mat decide how he wants to handle
  the situation when there is nothing coming through rather than
  the current situation where it will crash if the input shared
  ptr is null, or throw an exception (about unknown encoding)
  and terminate if it is an empty image message.
* Contributors: Daniel Stonier, Vincent Rabaud
```
