### PR TITLE
maggie_drivers: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3983,7 +3983,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/UC3MSocialRobots/maggie_drivers-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/UC3MSocialRobots/maggie_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `maggie_drivers` to `0.0.2-0`:
- upstream repository: https://github.com/UC3MSocialRobots/maggie_drivers.git
- release repository: https://github.com/UC3MSocialRobots/maggie_drivers-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.1-0`
## maggie_drivers
- No changes
## maggie_ir_drivers

```
* testing 3rd party header catking install
* workaround config script
* Contributors: Raul Perula-Martinez, Raúl Pérula-Martínez
```
## maggie_labjack_drivers

```
* testing 3rd party header catking install
* updated bug in labjack
* commented unnecesary 3rd party
* Contributors: Raul Perula-Martinez, Raúl Pérula-Martínez
```
## maggie_motor_drivers

```
* updated format
* debug neck calibration: working version
* debug neck calibration
* debug neck calibration
* debug neck calibration
* debug neck calibration
* debug neck calibration
* debug neck calibration
* debug neck calibration
* Contributors: Marco Faroni, Raúl Pérula-Martínez
```
## maggie_rfid_drivers

```
* testing 3rd party header catking install
* Contributors: Raul Perula-Martinez
```
## maggie_serial_comm_drivers
- No changes
