### PR TITLE
power_msgs: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5991,7 +5991,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/power_msgs-release.git
-      version: 0.1.3-0
+      version: 0.2.0-0
     status: developed
   pr2_apps:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `power_msgs` to `0.2.0-0`:
- upstream repository: https://github.com/fetchrobotics/power_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/power_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.3-0`
## power_msgs

```
* add message for battery state
* Contributors: Michael Ferguson
```
