### PR TITLE
rosserial: 0.7.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2987,7 +2987,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rosserial-release.git
-      version: 0.7.0-0
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/ros-drivers/rosserial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial` to `0.7.1-0`:
- upstream repository: https://github.com/ros-drivers/rosserial.git
- release repository: https://github.com/ros-gbp/rosserial-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.0-0`
## rosserial
- No changes
## rosserial_arduino
- No changes
## rosserial_client

```
* Provide option to pass through CMake arguments in the CMAKE_COMMAND
  invocation. The use-case is primarily specifying additional paths to
  modules, for separately-packaged libraries.
* Contributors: Mike Purvis
```
## rosserial_embeddedlinux
- No changes
## rosserial_msgs
- No changes
## rosserial_python
- No changes
## rosserial_server
- No changes
## rosserial_windows
- No changes
## rosserial_xbee
- No changes
