### PR TITLE
rosserial: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7995,7 +7995,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rosserial-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/ros-drivers/rosserial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial` to `0.6.4-0`:
- upstream repository: https://github.com/ros-drivers/rosserial.git
- release repository: https://github.com/ros-gbp/rosserial-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.3-0`
## rosserial
- No changes
## rosserial_arduino
- No changes
## rosserial_client

```
* Provide option to pass through CMake arguments.
* Make make_library.py error more verbose.
* createQuaternionFromYaw made static, fixes "multiple definition" error
* Fix initializer for fixed-length arrays.
* Generate constructors for messages.
* Switch to stdint integers; this allows the client to run on 64-bit systems.
* Contributors: Mickaël, Mike Purvis, chuck-h
```
## rosserial_embeddedlinux

```
* Use native 64-bit double on embeddedlinux.
* Contributors: Mike Purvis
```
## rosserial_msgs
- No changes
## rosserial_python

```
* Add default queue_size of 10 for rosserial_python publisher, fixes warning.
* Contributors: Basheer Subei, David Lavoie-Boutin
```
## rosserial_server

```
* Bugfix for checksum, fixes messages > 255 chars in length.
* Contributors: Chad Attermann, Mike Purvis
```
## rosserial_windows
- No changes
## rosserial_xbee
- No changes
