### PR TITLE
Fixed 'protobuf' versions on Ubuntu >= trusty

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2768,7 +2768,13 @@ protobuf:
   debian: [libprotobuf7]
   fedora: [protobuf]
   macports: [protobuf-cpp]
-  ubuntu: [libprotobuf7]
+  ubuntu:
+    precise: [libprotobuf7]
+    raring: [libprotobuf7]
+    saucy: [libprotobuf7]
+    trusty: [libprotbuf8]
+    utopic: [libprotbuf8]
+    vivid: [libprotbuf9]
 protobuf-dev:
   arch: [protobuf]
   debian: [libprotobuf-dev, protobuf-compiler, libprotoc-dev]


### PR DESCRIPTION
This pull request fixes an incorrect rosdep key on `protobuf` in recent versions of Ubuntu.
