### PR TITLE
Fixed typo in #8858

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2772,9 +2772,9 @@ protobuf:
     precise: [libprotobuf7]
     raring: [libprotobuf7]
     saucy: [libprotobuf7]
-    trusty: [libprotbuf8]
-    utopic: [libprotbuf8]
-    vivid: [libprotbuf9]
+    trusty: [libprotobuf8]
+    utopic: [libprotobuf8]
+    vivid: [libprotobuf9]
 protobuf-dev:
   arch: [protobuf]
   debian: [libprotobuf-dev, protobuf-compiler, libprotoc-dev]


### PR DESCRIPTION
This fixes a typo in #8858 that I discovered after switching back to the default `sources.list.d` files. Sorry - I forgot to push this second commit to my fork.
