### PR TITLE
jsk_common: 2.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3202,7 +3202,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.0.1-0
+      version: 2.0.2-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.0.2-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2.0.1-0`
## dynamic_tf_publisher
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_data
- No changes
## jsk_network_tools

```
* [jsk_topic_tools] Check ROS original message size in silverhammer_lowspeed_check_size
* [jsk_network_tools] Remove euslisp code from jsk_network_tools to
  resolve distorted dependency
* [jsk_network_tools] Publish under hostname prefix in network_status.py
* Contributors: Ryohei Ueda
```
## jsk_tilt_laser
- No changes
## jsk_tools

```
* [jsk_tools] Remove monitor_roscore.py
* [jsk_tools] Add monitoring script to check roscore CLOSE_WAIT num
* [jsk_tools] Check msg type is same as published one
* [jsk_tools] import sanity_lib in __init__.py
* [jsk_tools] Add network stats to local_pc_monitor.launch
* Contributors: Kentaro Wada, Ryohei Ueda
```
## jsk_topic_tools

```
* [jsk_topic_tools] add install config directory
* [jsk_topic_tools] Add number of subscribers to diagnostic information
* [jsk_topic_tools/Relay] Add more readable diagnostic including last time it receives input topic
* [jsk_topic_tools/Relay] Add diagnostic information
* [jsk_topic_tools] Update default diagnostic message to be more useful
* Contributors: Yuki Furuta, Ryohei Ueda
```
## multi_map_server
- No changes
## virtual_force_publisher
- No changes
