### PR TITLE
app_manager: 1.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -171,7 +171,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/app_manager-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/pr2/app_manager.git


### PR DESCRIPTION
Increasing version of package(s) in repository `app_manager` to `1.0.3-0`:
- upstream repository: https://github.com/pr2/app_manager.git
- release repository: https://github.com/ros-gbp/app_manager-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.2-0`
## app_manager
- No changes
