### PR TITLE
vrpn_client_ros: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9910,7 +9910,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/vrpn_client_ros-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/vrpn_client_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn_client_ros` to `0.0.2-0`:
- upstream repository: git@github.com:clearpathrobotics/vrpn_client_ros.git
- release repository: https://github.com/clearpath-gbp/vrpn_client_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.1-0`
## vrpn_client_ros

```
* Fix tf header timestamps
* Update sample.launch
* Contributors: Paul Bovbel
```
