### PR TITLE
husky: 0.2.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2718,7 +2718,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.2.5-0
+      version: 0.2.6-0
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.2.6-0`:
- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.5-0`
## husky_control

```
* Added angular_scale_turbo to teleop.config.
* Move interactive marker launch from teleop into control launch file
* Added fix for ur5 arm in gazebo
* Contributors: Paul Bovbel, Devon Ash, Tony Baltovski
```
## husky_description

```
* Adjust Kinect angle so it doesn't hit top plate
* Contributors: Paul Bovbel
```
## husky_msgs
- No changes
## husky_navigation
- No changes
## husky_ur5_moveit_config

```
* Commented out roslaunch check
* Fix unstable tests
* Contributors: TheDash
```
