### PR TITLE
husky_simulator: 0.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2773,7 +2773,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_simulator-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/husky/husky_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_simulator` to `0.2.4-0`:
- upstream repository: https://github.com/husky/husky_simulator.git
- release repository: https://github.com/clearpath-gbp/husky_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.3-0`
## husky_gazebo

```
* Add pointcloud to laserscan config for simulated kinect
* Contributors: Paul Bovbel
```
## husky_simulator
- No changes
