### PR TITLE
jskeus: 1.0.9-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3409,11 +3409,15 @@ repositories:
       version: master
     status: developed
   jskeus:
+    doc:
+      type: git
+      url: https://github.com/tork-a/jskeus-release.git
+      version: release/jade/jskeus
     release:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jskeus-release.git
-      version: 1.0.8-0
+      version: 1.0.9-0
     status: developed
   katana_driver:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.0.9-0`:
- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.8-0`
## jskeus

```
* irtpointcloud.l: impliment :append methods on pointcloud
* irtgl.l:

    * fix transparent method on glvertices
    * add :mirror-axis method to glvertices

* irtmodel.l:

    * Set (/ stop 10) as min-loop default value not to change ik behavior
    * Update documentations for :inverse-kinematics-loop and add  documentations for min-loop argument
  Remove unncessary loop checking and add min-loop argument  discussed in https://github.com/euslisp/jskeus/issues/107
* Contributors: Kei Okada, Shunichi Nozawa, Yohei Kakiuchi
```
