### PR TITLE
Added 'tinyxml2' rosdep key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3189,6 +3189,11 @@ tinyxml:
   opensuse: [tinyxml-devel]
   rhel: [tinyxml-devel]
   ubuntu: [libtinyxml-dev]
+tinyxml2:
+  arch: [tinyxml2]
+  debian: [libtinyxml2-dev]
+  fedora: [tinyxml2-devel]
+  ubuntu: [libtinyxml2-dev]
 tix:
   arch: [tix]
   debian: [tix]


### PR DESCRIPTION
This pull request adds a rosdep key for `tinyxml2`.
