### PR TITLE
rocon_multimaster: 0.7.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7126,7 +7126,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_multimaster-release.git
-      version: 0.7.8-0
+      version: 0.7.9-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_multimaster.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_multimaster` to `0.7.9-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_multimaster.git
- release repository: https://github.com/yujinrobot-release/rocon_multimaster-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.8-0`
## rocon_gateway

```
* add rosgraph dependency
* import rosgraph to handle MasterError
* skipps if node is not availalble
* update
* xmlrpc uri is also recorded now
* add xmlrpc in node
* refactoring
* refactoring flipp updates
* refactoring ros service callback functions closes #307 <https://github.com/robotics-in-concert/rocon_multimaster/issues/307>
* add more prints to investigate insecure pickle closes #302 <https://github.com/robotics-in-concert/rocon_multimaster/issues/302>
* increase hubconnection socket timeout to resolve frequent hub disengagement closes #301 <https://github.com/robotics-in-concert/rocon_multimaster/issues/301>
* [rocon_gateway] some new convenience args.
* Contributors: Daniel Stonier, Jihoon Lee, dwlee
```
## rocon_gateway_tests
- No changes
## rocon_gateway_utils
- No changes
## rocon_hub
- No changes
## rocon_hub_client

```
* uses rospy wall time sleep instead of python sleep #308 <https://github.com/robotics-in-concert/rocon_multimaster/issues/308>
* adding a 5s retry in case we couldnt read the rocon:hub:name from redis yet.
* update timeouts #302 <https://github.com/robotics-in-concert/rocon_multimaster/issues/302>
* increate socket timeout to ping frequency
* setting default timeout in ping hub
* increase hubconnection socket timeout to resolve frequent hub disengagement closes #301 <https://github.com/robotics-in-concert/rocon_multimaster/issues/301>
* Contributors: AlexV, Jihoon Lee, dwlee
```
## rocon_multimaster
- No changes
## rocon_test
- No changes
## rocon_unreliable_experiments
- No changes
