### PR TITLE
rocon_tools: 0.1.21-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7197,7 +7197,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_tools-release.git
-      version: 0.1.19-0
+      version: 0.1.21-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_tools` to `0.1.21-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_tools.git
- release repository: https://github.com/yujinrobot-release/rocon_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.19-0`
## rocon_bubble_icons
- No changes
## rocon_console
- No changes
## rocon_ebnf
- No changes
## rocon_icons
- No changes
## rocon_interactions

```
* Revert "Enterprise mode for interactions (interaction with a required running rapp)"
* added optional silencer for rappwatcher
* [rocon_interactions] better exception handling.
* [rocon_interactions] deal with required action server detection, pep8 and cleanup.
* Merge pull request #89 <https://github.com/robotics-in-concert/rocon_tools/issues/89> from asmodehn/gocart
  Gocart
* added a callback to signal when the list of interactions might have changed
* now getting running rapp from status topic.
  Also replacing the original public_interface with the published one.
* cleanup and fixes on required rapp verification.
* adding required field for interaction
  adding rapp_watcher and extending rapp_handler.
* Contributors: AlexV, Daniel Stonier, Jihoon Lee
```
## rocon_launch
- No changes
## rocon_master_info
- No changes
## rocon_python_comms

```
* Revert "Enterprise mode for interactions (interaction with a required running rapp)"
* [rocon_interactions] better exception handling.
* Contributors: Daniel Stonier, Jihoon Lee
```
## rocon_python_redis
- No changes
## rocon_python_utils

```
* fix opencv dependency closes #96 <https://github.com/robotics-in-concert/rocon_tools/issues/96>
* image conveter works
* add image converter
* Contributors: Jihoon Lee
```
## rocon_python_wifi
- No changes
## rocon_semantic_version
- No changes
## rocon_tools
- No changes
## rocon_uri
- No changes
