### PR TITLE
rocon_concert: 0.6.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7054,7 +7054,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_concert-release.git
-      version: 0.6.8-0
+      version: 0.6.9-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_concert.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_concert` to `0.6.9-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_concert
- release repository: https://github.com/yujinrobot-release/rocon_concert-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.8-0`
## concert_conductor

```
* add transition available to uninvited #302 <https://github.com/robotics-in-concert/rocon_concert/issues/302>
* callable error fix
* update transition table #302 <https://github.com/robotics-in-concert/rocon_concert/issues/302>
* comment out transition caused by wait for service timeout. closes #302 <https://github.com/robotics-in-concert/rocon_concert/issues/302>
* fixing the logic to use remote controller slot in concert_client #302 <https://github.com/robotics-in-concert/rocon_concert/issues/302>
* add state transition from busy to pending #302 <https://github.com/robotics-in-concert/rocon_concert/issues/302>
* correcting the transition table
* add not in network node
* increae gap between nodes
* remove dummy from label
* add conductor state transition dotgraph generator for easy introspection closes #301 <https://github.com/robotics-in-concert/rocon_concert/issues/301>
* add state transition graph
* configurable ros service timeout closes #300 <https://github.com/robotics-in-concert/rocon_concert/issues/300>
* Contributors: Jihoon Lee
```
## concert_master

```
* default webserver address is now webapp.robotconcert.org closes #295 <https://github.com/robotics-in-concert/rocon_concert/issues/295>
* expose disable cache arg closes #294 <https://github.com/robotics-in-concert/rocon_concert/issues/294>
* Contributors: Jihoon Lee
```
## concert_schedulers

```
* ros friendly name matching for releasing client closes #307 <https://github.com/robotics-in-concert/rocon_concert/issues/307>
* Contributors: Jihoon Lee
```
## concert_service_link_graph
- No changes
## concert_service_manager

```
* [concert_service_manager] bugfix concert when no services are provided, fixes #304 <https://github.com/robotics-in-concert/rocon_concert/issues/304>.
* Contributors: Daniel Stonier
```
## concert_service_utilities
- No changes
## concert_software_farmer
- No changes
## concert_utilities

```
* add not in network node
* increae gap between nodes
* remove dummy from label
* add conductor state transition dotgraph generator for easy introspection closes #301 <https://github.com/robotics-in-concert/rocon_concert/issues/301>
* Contributors: Jihoon Lee
```
## rocon_concert
- No changes
## rocon_tf_reconstructor

```
* it should be key instead of name #306 <https://github.com/robotics-in-concert/rocon_concert/issues/306>
* convert to ros friendly name for subscriber closes #306 <https://github.com/robotics-in-concert/rocon_concert/issues/306>
* Contributors: Jihoon Lee
```
