### PR TITLE
concert_services: 0.1.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1225,6 +1225,7 @@ repositories:
       packages:
       - concert_service_admin
       - concert_service_gazebo
+      - concert_service_image_stream
       - concert_service_indoor_2d_map_prep
       - concert_service_teleop
       - concert_service_turtlesim
@@ -1233,7 +1234,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/concert_services-release.git
-      version: 0.1.11-0
+      version: 0.1.12-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/concert_services.git


### PR DESCRIPTION
Increasing version of package(s) in repository `concert_services` to `0.1.12-0`:
- upstream repository: https://github.com/robotics-in-concert/concert_services.git
- release repository: https://github.com/yujinrobot-release/concert_services-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.11-0`
## concert_service_admin
- No changes
## concert_service_gazebo

```
* gazebo is now headless. viewer is now interactions closes #32 <https://github.com/robotics-in-concert/concert_services/issues/32>
* Contributors: Jihoon Lee
```
## concert_service_image_stream

```
* add imagestrea service in meta pkg
* image stream service
* update launcher and intreactions
* create image stream service
* Contributors: Jihoon Lee
* image stream service
* update launcher and intreactions
* create image stream service
* Contributors: Jihoon Lee
```
## concert_service_indoor_2d_map_prep

```
* use rocon_apps/make_a_map closes #48 <https://github.com/robotics-in-concert/concert_services/issues/48>
* Contributors: Jihoon Lee
```
## concert_service_teleop
- No changes
## concert_service_turtlesim
- No changes
## concert_service_waypoint_navigation

```
* Merge branch 'indigo' of https://github.com/robotics-in-concert/concert_services into indigo
* add navigator client
* updates
* add rviz
* updates
* update interactions
* updates
* add publish world and parameters
* add interactions and parameters
* add waypoint nav service
* Contributors: Jihoon Lee
```
## concert_services

```
* add imagestrea service in meta pkg
* Contributors: Jihoon Lee
```
