### PR TITLE
rocon_qt_gui: 0.7.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7141,6 +7141,7 @@ repositories:
       packages:
       - concert_admin_app
       - concert_conductor_graph
+      - concert_qt_image_stream
       - concert_qt_make_a_map
       - concert_qt_map_annotation
       - concert_qt_service_info
@@ -7156,7 +7157,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_qt_gui-release.git
-      version: 0.7.10-0
+      version: 0.7.11-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_qt_gui.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_qt_gui` to `0.7.11-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_qt_gui.git
- release repository: https://github.com/yujinrobot-release/rocon_qt_gui-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.10-0`
## concert_admin_app
- No changes
## concert_conductor_graph
- No changes
## concert_qt_image_stream

```
* image stream gui works
* add concert image stream qt
* Contributors: Jihoon Lee
* image stream gui works
* add concert image stream qt
* Contributors: Jihoon Lee
```
## concert_qt_make_a_map
- No changes
## concert_qt_map_annotation
- No changes
## concert_qt_service_info
- No changes
## concert_qt_teleop
- No changes
## rocon_gateway_graph
- No changes
## rocon_qt_app_manager
- No changes
## rocon_qt_gui
- No changes
## rocon_qt_library

```
* resolve conflict between threading lock and qmessage box closes #196 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/196>
* Contributors: Jihoon Lee
```
## rocon_qt_listener
- No changes
## rocon_qt_master_info
- No changes
## rocon_qt_teleop
- No changes
## rocon_remocon

```
* [rocon_remocon] bypass role chooser if only one role.
* add firefox closes #190 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/190>
* Contributors: Daniel Stonier, Jihoon Lee
```
