### PR TITLE
rocon_multimaster: 0.7.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7126,7 +7126,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_multimaster-release.git
-      version: 0.7.8-0
+      version: 0.7.10-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_multimaster.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_multimaster` to `0.7.10-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_multimaster.git
- release repository: https://github.com/yujinrobot-release/rocon_multimaster-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.8-0`
## rocon_gateway
- No changes
## rocon_gateway_tests
- No changes
## rocon_gateway_utils
- No changes
## rocon_hub
- No changes
## rocon_hub_client

```
* [rocon_hub_client] bugfix boolean check of paired ping_hub return value.
  This fixes #312 <https://github.com/robotics-in-concert/rocon_multimaster/issues/312>.
* Contributors: Daniel Stonier
```
## rocon_multimaster
- No changes
## rocon_test
- No changes
## rocon_unreliable_experiments
- No changes
