### PR TITLE
Adding firos to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1974,6 +1974,16 @@ repositories:
       url: https://github.com/introlab/find_object_2d-release.git
       version: 0.5.1-0
     status: maintained
+  firos:
+    doc:
+      type: git
+      url: https://github.com/Ikergune/firos.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/Ikergune/firos.git
+      version: master
+    status: maintained
   flatbuffers:
     release:
       tags:


### PR DESCRIPTION
I'd like firos to be indexed and documented on ros.org.
