### PR TITLE
pmb2_robot: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5941,6 +5941,16 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/pmb2_robot.git
       version: indigo-devel
+    release:
+      packages:
+      - pmb2_bringup
+      - pmb2_controller_configuration
+      - pmb2_description
+      - pmb2_robot
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pal-gbp/pmb2_robot-release.git
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_robot` to `0.1.0-0`:
- upstream repository: https://github.com/pal-robotics/pmb2_robot
- release repository: https://github.com/pal-gbp/pmb2_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## pmb2_bringup

```
* July sync
* Contributors: Bence Magyar
```
## pmb2_controller_configuration

```
* July sync
* Contributors: Bence Magyar
```
## pmb2_description

```
* July sync
* Contributors: Bence Magyar
```
## pmb2_robot

```
* July sync
* Contributors: Bence Magyar
```
