### PR TITLE
pmb2_simulation: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5961,6 +5961,16 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/pmb2_simulation.git
       version: indigo-devel
+    release:
+      packages:
+      - pmb2_controller_configuration_gazebo
+      - pmb2_gazebo
+      - pmb2_hardware_gazebo
+      - pmb2_simulation
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pal-gbp/pmb2_simulation-release.git
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_simulation` to `0.1.0-0`:
- upstream repository: https://github.com/pal-robotics/pmb2_simulation.git
- release repository: https://github.com/pal-gbp/pmb2_simulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## pmb2_controller_configuration_gazebo

```
* July sync
* Contributors: Bence Magyar
```
## pmb2_gazebo

```
* July sync
* Contributors: Bence Magyar
```
## pmb2_hardware_gazebo

```
* July sync
* Contributors: Bence Magyar
```
## pmb2_simulation

```
* July sync
* Contributors: Bence Magyar
```
