### PR TITLE
p2os: 1.0.11-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5744,7 +5744,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
-      version: 1.0.11-2
+      version: 1.0.11-3
+    source:
+      type: git
+      url: https://github.com/allenh1/p2os.git
+      version: master
     status: developed
   pcan_topics:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `1.0.11-3`:
- upstream repository: https://github.com/allenh1/p2os
- release repository: https://github.com/allenh1/p2os-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.11-2`
## p2os_doc

```
* Added documentation package. Currently just the p2os_driver. Also removed a line in p2os_launch cmake list.
* Contributors: Hunter Allen
```
## p2os_driver
- No changes
## p2os_launch
- No changes
## p2os_msgs

```
* Fixed dependency issues and cleaned up package.xml and CMakeLists.txt for p2os_driver and p2os_msgs
* Separated p2os_driver and p2os_msgs
* Contributors: Aris Synodinos
```
## p2os_teleop
- No changes
## p2os_urdf
- No changes
