### PR TITLE
p2os: 2.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2169,7 +2169,11 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
-      version: 2.0.0-0
+      version: 2.0.1-0
+    source:
+      type: git
+      url: https://github.com/allenh1/p2os.git
+      version: master
     status: developed
   pcl_conversions:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `2.0.1-0`:
- upstream repository: https://github.com/allenh1/p2os
- release repository: https://github.com/allenh1/p2os-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.0.0-0`
## p2os_doc

```
* Forgot to update my email on p2os_doc's package.xml file. Oops. It's better now.
* Contributors: Hunter Allen
```
## p2os_driver

```
* Doing some cleanup of the code.
* Additional code updates for p3dx-sh-lms1xx parameters.
* Added robot parameters for the P3DX models that ship with LMS1xx lasers.
* Contributors: Damjan Miklic, Hunter Allen
```
## p2os_launch

```
* Doing some cleanup of the code.
* Contributors: Hunter Allen
```
## p2os_msgs
- No changes
## p2os_teleop
- No changes
## p2os_urdf

```
* Forgot a line.
* Working on Pioneer-3dx Gazebo.
* Contributors: Hunter Allen
```
