### PR TITLE
spur: 0.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8960,7 +8960,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/spur-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/tork-a/spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `spur` to `0.2.4-0`:
- upstream repository: https://github.com/tork-a/spur.git
- release repository: https://github.com/tork-a/spur-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.3-0`
## spur
- No changes
## spur_2dnav

```
* add test for gmapping.launch
* Contributors: Tokyo Opensource Robotics Programmer 534o
```
## spur_bringup

```
* set use_base_odom to true as default
* Tailor to the actual robot hardware
* Contributors: Isaac IY Saito
```
## spur_controller

```
* set use_base_odom to true as default
* support use_base_odom args for base_contraller, on gazebo it is dsiabled by default and on realroobt, it is enabled
* add publish_odom parm to publish odom from base_controller
* Contributors: Isaac IY Saito
```
## spur_description

```
* if you want to put urg upside down, do not change visual, but change origin
* Fix the possible robot_state_publisher crash issue
* Add map plugin in RViz conf (resolves #47)
* Model updated with measurement.
* Contributors: Isaac IY Saito
```
## spur_gazebo

```
* support use_base_odom args for base_contraller, on gazebo it is dsiabled by default and on realroobt, it is enabled
* Contributors: Isaac IY Saito
```
