### PR TITLE
wu_ros_tools: 0.2.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3651,6 +3651,30 @@ repositories:
       url: https://github.com/RobotWebTools/web_video_server.git
       version: develop
     status: maintained
+  wu_ros_tools:
+    doc:
+      type: git
+      url: https://github.com/DLu/wu_ros_tools.git
+      version: hydro
+    release:
+      packages:
+      - catkinize_this
+      - easy_markers
+      - joy_listener
+      - kalman_filter
+      - manifest_cleaner
+      - rosbaglive
+      - roswiki_node
+      - wu_ros_tools
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wu-robotics/wu_ros_tools.git
+      version: 0.2.4-0
+    source:
+      type: git
+      url: https://github.com/DLu/wu_ros_tools.git
+      version: hydro
+    status: maintained
   xacro:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wu_ros_tools` to `0.2.4-0`:
- upstream repository: https://github.com/DLu/wu_ros_tools
- release repository: https://github.com/wu-robotics/wu_ros_tools.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
