### PR TITLE
adding ros_rtt to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7516,6 +7516,21 @@ repositories:
       url: https://github.com/ros/ros_realtime.git
       version: hydro-devel
     status: maintained
+  ros_rtt:
+    doc:
+      type: git
+      url: https://github.com/sukha-cn/ros_rtt.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/sukha-cn/ros_rtt/releases
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/sukha-cn/ros_rtt.git
+      version: master
+    status: maintained
   ros_statistics_msgs:
     doc:
       type: git


### PR DESCRIPTION
I did some work about real-time communication in ros. The package supports real-time communication within node at the moment. And it will support communication between nodes in the future. I'd like this repository to be indexed and documented on ros.org.
