### PR TITLE
adding python-babel

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -131,8 +131,13 @@ python-avahi:
     utopic: [python-avahi]
     vivid: [python-avahi]
 python-babel:
-  ubuntu: [python-babel]
   fedora: [python-babel]
+  ubuntu:
+    precise: [python-babel]
+    trusty: [python-babel]
+    utopic: [python-babel]
+    vivid: [python-babel]
+    wily: [python-babel]
 python-beautifulsoup:
   arch: [python2-beautifulsoup3]
   debian: [python-beautifulsoup]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -130,6 +130,9 @@ python-avahi:
     trusty: [python-avahi]
     utopic: [python-avahi]
     vivid: [python-avahi]
+python-babel:
+  ubuntu: [python-babel]
+  fedora: [python-babel]
 python-beautifulsoup:
   arch: [python2-beautifulsoup3]
   debian: [python-beautifulsoup]


### PR DESCRIPTION
warning : this package doesn't exist for saucy, and therefore builds depending on it will break for saucy...
ref : https://launchpad.net/ubuntu/+source/python-babel
Should I put a warning somewhere, or somehow specify it differently ? Or maybe not add it here at all ?
