### PR TITLE
jsk_visualization: 1.0.23-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3485,7 +3485,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.22-0
+      version: 1.0.23-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.23-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `1.0.22-0`
## jsk_interactive
- No changes
## jsk_interactive_marker

```
* [jsk_interactive_marker] Install include directory and library
* Contributors: Ryohei Ueda
```
## jsk_interactive_test
- No changes
## jsk_rqt_plugins
- No changes
## jsk_rviz_plugins

```
* [jsk_rviz_plugins/PoseArray] Clear pose array if checkbox is unchecked
* fix coords bug
* Contributors: Ryohei Ueda, Yu Ohara
```
## jsk_visualization
- No changes
