### PR TITLE
naoqi_rosbridge: 0.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1763,7 +1763,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_rosbridge-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/ros-naoqi/alrosbridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_rosbridge` to `0.1.2-0`:
- upstream repository: https://github.com/ros-naoqi/alrosbridge.git
- release repository: https://github.com/ros-naoqi/naoqi_rosbridge-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.1-0`
## naoqi_rosbridge

```
* update start doc for v1.2
* lower default values for camera
* add bottom camera
* create launch file for running rosbridge
* remove ros args from cmdline
* nao basefootprint
* remove ros args
* main:  support 2nd argument as network interface
* ros_env.hpp write error message when network interface is not found
* include install instructions for ROS
* Contributors: Karsten Knese, Kei Okada, Vincent Rabaud
```
