### PR TITLE
vision_opencv: 1.11.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3524,11 +3524,13 @@ repositories:
       packages:
       - cv_bridge
       - image_geometry
+      - opencv_apps
+      - opencv_tests
       - vision_opencv
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.11.7-0
+      version: 1.11.8-0
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.11.8-0`:
- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.7-0`
## cv_bridge

```
* Simplify some OpenCV3 distinction
* fix tests
* fix test under OpenCV3
* Remove Python for Android
* Contributors: Gary Servin, Vincent Rabaud
```
## image_geometry

```
* fixes #62 <https://github.com/ros-perception/vision_opencv/issues/62>, bug in Python rectifyPoint old opencv1 API
* Simplify some OpenCV3 distinction
* Contributors: Basheer Subei, Vincent Rabaud
```
## opencv_apps

```
* simplify the OpenCV3 compatibility
* fix image output of fback_flow
* fix error: ISO C++ forbids initialization of member for gcc 4.6
* add std_srvs
* add std_srvs
* fix error: ISO C++ forbids initialization of member for gcc 4.6
* get opencv_apps to compile with OpenCV3
* fix licenses for Kei
* add opencv_apps, proposed in #40 <https://github.com/ros-perception/vision_opencv/issues/40>
* Contributors: Kei Okada, Vincent Rabaud, Yuto Inagaki
```
## opencv_tests

```
* simplify dependencies
* Contributors: Vincent Rabaud
```
## vision_opencv
- No changes
