### PR TITLE
jsk_robot: 0.0.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3354,13 +3354,14 @@ repositories:
       - jsk_pr2_calibration
       - jsk_pr2_startup
       - jsk_robot_startup
+      - jsk_robot_utils
       - peppereus
       - pr2_base_trajectory_action
       - roseus_remote
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_robot-release.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `0.0.8-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.7-0`
## baxtereus

```
* [package.xml] add roseus pr2eus to baxtereus/package.xml, (https://github.com/start-jsk/2014-semi/issues/816)
```
## jsk_201504_miraikan

```
* delete unnecessary words
* change english demo
* add english demo (need modifying)
* Contributors: Kanae Kochigami
```
## jsk_baxter_desktop
- No changes
## jsk_baxter_startup
- No changes
## jsk_baxter_web
- No changes
## jsk_nao_startup
- No changes
## jsk_pepper_startup

```
* use front/camera until https://github.com/ros-naoqi/pepper_robot/pull/1/files is merged
* Contributors: Kanae Kochigami
```
## jsk_pr2_calibration
- No changes
## jsk_pr2_startup

```
* [jsk_pr2_startup] add option map_frame to change eng2/eng8
* [jsk_pr2_startup/pr2_gazebo.launch] include rgbd_launch to rectify kinect rgb image
* [jsk_pr2_startup] add pr2_gazebo.launch
* [jsk_pr2_startup] use env ROBOT for including machine tags
* [jsk_pr2_startup/jsk_pr2_sensors/kinect_head.launch] add deprecated relay for openni_c2 rgb, depth, depth_registered topics
* [jsk_pr2_startup] use kinect_head(_c2) instead of openni(_c2) following pr2 default naming
* [jsk_pr2_startup/jsk_pr2_move_base] fix topic name /base_scan_filtered -> base_scan
* [jsk_pr2_startup/jsk_pr2_move_base] split name space along with modules; use hydro-based costmap params
* [jsk_pr2_startup/jsk_pr2_move_base] enable clear params option to move_base_node; increase nice value
* [jsk_pr2_start_up] set ROBOT=pr2 in rossetpr10XX
* Contributors: Kentaro Wada, Yuki Furuta
```
## jsk_robot_startup
- No changes
## jsk_robot_utils

```
* [jsk_robot_utils] Add jsk_robot_utils package and move script to compress/decompress joint angles from jsk_network_tools to jsk_robot_utils
* Contributors: Ryohei Ueda
```
## peppereus

```
* modify send-stiffness-controller method for pepper
* modify ros::advertise to be consistent with ros::publish
* modify speak method
* [package.xml] add nao_interaction_msgs to depends
* 0.0.7
* Contributors: Kanae Kochigami, Kei Okada, Jiang Jun
```
## pr2_base_trajectory_action
- No changes
## roseus_remote
- No changes
