### PR TITLE
rtmros_hironx: 1.0.32-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8321,7 +8321,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.31-0
+      version: 1.0.32-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.32-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.31-0`
## hironx_calibration
- No changes
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* [feat] force compensation for old hrpsys version
* [Doc] Indigo update. hironx clarification for conf files.
* [sys] Remove manifest.xml from hironx_ros_bridge package.
* Contributors: Kei Okada, TORK Developer 534, Isaac I.Y. Saito
```
## rtmros_hironx

```
* [feat] force compensation for old hrpsys version
* [Doc] Indigo update. hironx clarification for conf files.
* [sys] Remove manifest.xml from hironx_ros_bridge package.
* Contributors: Kei Okada, TORK Developer 534, Isaac I.Y. Saito
```
