### PR TITLE
lms1xx: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4119,7 +4119,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/lms1xx-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/lms1xx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lms1xx` to `0.1.3-0`:
- upstream repository: https://github.com/clearpathrobotics/LMS1xx.git
- release repository: https://github.com/clearpath-gbp/lms1xx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.2-0`
## lms1xx

```
* Added URDF with simulation plugin.
* Added script to set static IP of LMS1xx
* Fixed startup publishing issue
* Removed one second delay in login
* Contributors: Mike Purvis, Mustafa Safri, Tony Baltovski
```
