### PR TITLE
lms1xx: 0.1.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1329,6 +1329,21 @@ repositories:
       url: https://github.com/WPI-RAIL/librms.git
       version: develop
     status: maintained
+  lms1xx:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/lms1xx.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/clearpath-gbp/lms1xx-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/lms1xx.git
+      version: master
+    status: maintained
   lyap_control:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lms1xx` to `0.1.3-0`:
- upstream repository: https://github.com/clearpathrobotics/LMS1xx.git
- release repository: https://github.com/clearpath-gbp/lms1xx-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## lms1xx

```
* Added URDF with simulation plugin.
* Added script to set static IP of LMS1xx
* Fixed startup publishing issue
* Removed one second delay in login
* Contributors: Mike Purvis, Mustafa Safri, Tony Baltovski
```
