### PR TITLE
ecto_opencv: 0.6.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -561,7 +561,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ecto_opencv-release.git
-      version: 0.5.6-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto_opencv` to `0.6.0-0`:
- upstream repository: https://github.com/plasmodic/ecto_opencv.git
- release repository: https://github.com/ros-gbp/ecto_opencv-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.6-0`
## ecto_opencv

```
* add proper rosunit dependency
* convert Python tests to proper nose tests
* use cv_backports to pull in opencv2.4.9 imshows with zoom and parallel thread support.
* Contributors: Daniel Stonier, Vincent Rabaud
```
