### PR TITLE
image_common: 1.11.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -980,7 +980,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/image_common-release.git
-      version: 1.11.5-0
+      version: 1.11.6-0
     source:
       type: git
       url: https://github.com/ros-perception/image_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `1.11.6-0`:
- upstream repository: https://github.com/ros-perception/image_common.git
- release repository: https://github.com/ros-gbp/image_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.5-0`
## camera_calibration_parsers

```
* [camera_calibration_parsers] Better error message when calib file can't be written
* add rosbash as a test dependency
* add a test dependency now that we have tests
* parse distortion of arbitraty length in INI
  This fixes #33 <https://github.com/ros-perception/image_common/issues/33>
* add a test to parse INI calibration files with 5 or 8 D param
* Add yaml-cpp case for building on Android
* Contributors: Gary Servin, Isaac IY Saito, Vincent Rabaud
```
## camera_info_manager

```
* simplify target_link_libraries
  That should fix #35 <https://github.com/ros-perception/image_common/issues/35>
* Contributors: Vincent Rabaud
```
## image_common
- No changes
## image_transport
- No changes
## polled_camera
- No changes
