### PR TITLE
Adding python-enum34 as a rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -397,8 +397,7 @@ python-enum:
     saucy: [python-enum]
     trusty: [python-enum]
 python-enum34:
-  ubuntu:
-    trusty: [python-enum34]
+  ubuntu: [python-enum34]
 python-espeak:
   debian: [python-espeak]
   fedora: [python-espeak]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -396,6 +396,9 @@ python-enum:
     raring: [python-enum]
     saucy: [python-enum]
     trusty: [python-enum]
+python-enum34:
+  ubuntu:
+    trusty: [python-enum34]
 python-espeak:
   debian: [python-espeak]
   fedora: [python-espeak]


### PR DESCRIPTION
Only added to ubuntu trusty as I'm not aware of naming on other platforms.
