### PR TITLE
robotnik_msgs: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7063,6 +7063,21 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/robotiq.git
       version: indigo-devel
+  robotnik_msgs:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotnikAutomation/robotnik_msgs-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_msgs.git
+      version: master
+    status: maintained
   rocon:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotnik_msgs` to `0.2.0-0`:
- upstream repository: https://github.com/RobotnikAutomation/robotnik_msgs.git
- release repository: https://github.com/RobotnikAutomation/robotnik_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## robotnik_msgs

```
* Adding new field for the Axis.msg
* Adding msg State.msg
* Merge branch 'master' of https://github.com/RobotnikAutomation/robotnik_msgs
* Adding new msg State
```
