### PR TITLE
ntpd_driver: 1.1.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1926,7 +1926,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/vooon/ntpd_driver-release.git
-      version: 1.1.0-0
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/vooon/ntpd_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ntpd_driver` to `1.1.1-0`:
- upstream repository: https://github.com/vooon/ntpd_driver.git
- release repository: https://github.com/vooon/ntpd_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.0-0`
## ntpd_driver

```
* Syncronize shm write with gpsd/ntpshmwrite.c
* Add fixup_date parameter.
  Now driver can setup system date.
* Contributors: Vladimir Ermakov
```
