### PR TITLE
slam_karto: 0.7.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8892,7 +8892,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/slam_karto-release.git
-      version: 0.7.1-0
+      version: 0.7.2-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/slam_karto.git
+      version: indigo-devel
     status: maintained
   smart_battery_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_karto` to `0.7.2-0`:
- upstream repository: https://github.com/ros-perception/slam_karto.git
- release repository: https://github.com/ros-gbp/slam_karto-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.1-0`
## slam_karto

```
* Added in parameter server settings for Mapper within slam_karto
* Contributors: Luc Bettaieb, Michael Ferguson
```
