### PR TITLE
ros_ethercat: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7535,7 +7535,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/shadow-robot/ros_ethercat-release.git
-      version: 0.2.0-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/shadow-robot/ros_ethercat.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ethercat` to `0.3.0-0`:
- upstream repository: https://github.com/shadow-robot/ros_ethercat.git
- release repository: https://github.com/shadow-robot/ros_ethercat-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.0-0`
## ros_ethercat_model

```
* checking type as an element as well as attribute, for new transmission style
* ignore transmissions with no type instead of crashing
```
