### PR TITLE
sr_ronex: 0.11.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9032,7 +9032,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/shadow-robot/sr-ronex-release.git
-      version: 0.10.0-0
+      version: 0.11.0-0
     source:
       type: git
       url: https://github.com/shadow-robot/sr-ronex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_ronex` to `0.11.0-0`:
- upstream repository: https://github.com/shadow-robot/sr-ronex.git
- release repository: https://github.com/shadow-robot/sr-ronex-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.10.0-0`
## sr_ronex_drivers

```
* fixing broken ronex driver test
* adding test coverage to the other available packages
```
## sr_ronex_launch

```
* added ethercat_grant for non sudo access
* added launch file to load passthrough controllers
* propagating the robot description to the ronex no controllers launch file (makes it easier to use in a robot launch file)
```
## sr_ronex_test

```
* added more tests
* added test coverage to the other available packages
* sending packet and checking response per spi channel.
```
## sr_ronex_utilities

```
* added tests
```
