### PR TITLE
log4cpp: 2.8.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4134,7 +4134,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/orocos-gbp/log4cpp-release.git
-      version: 2.8.0-0
+      version: 2.8.1-0
     source:
       type: git
       url: https://github.com/orocos-toolchain/log4cpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `log4cpp` to `2.8.1-0`:
- upstream repository: https://github.com/orocos-toolchain/log4cpp.git
- release repository: https://github.com/orocos-gbp/log4cpp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.8.0-0`
