### PR TITLE
object_recognition_linemod: 0.3.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5252,7 +5252,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_linemod-release.git
-      version: 0.3.6-0
+      version: 0.3.7-0
     source:
       type: git
       url: https://github.com/wg-perception/linemod.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_linemod` to `0.3.7-0`:
- upstream repository: https://github.com/wg-perception/linemod.git
- release repository: https://github.com/ros-gbp/object_recognition_linemod-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.6-0`
## object_recognition_linemod

```
* small changes in training: object distance and mesh path
* Contributors: Vincent Rabaud, nlyubova
```
