### PR TITLE
ecto: 0.6.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -539,7 +539,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ecto-release.git
-      version: 0.6.9-0
+      version: 0.6.10-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto` to `0.6.10-0`:
- upstream repository: https://github.com/plasmodic/ecto.git
- release repository: https://github.com/ros-gbp/ecto-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.9-0`
## ecto

```
* update test for future fix
* potentially fix compilation with Boost 1.58
  could be a fix for #275 <https://github.com/plasmodic/ecto/issues/275>
* Contributors: Vincent Rabaud
```
