### PR TITLE
ecl_core: 0.61.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1638,6 +1638,7 @@ repositories:
       - ecl_devices
       - ecl_eigen
       - ecl_exceptions
+      - ecl_filesystem
       - ecl_formatters
       - ecl_geometry
       - ecl_ipc
@@ -1654,7 +1655,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_core-release.git
-      version: 0.61.0-0
+      version: 0.61.1-0
     source:
       type: git
       url: https://github.com/stonier/ecl_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_core` to `0.61.1-0`:
- upstream repository: https://github.com/stonier/ecl_core.git
- release repository: https://github.com/yujinrobot-release/ecl_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.61.0-0`
## ecl_core_apps

```
* quaternion2yaw utility
```
## ecl_devices

```
* catch the error code as a hint for when fcntl calls fail on serial devices
* additional baud rate enums for serial devices covering a wider range
* deprecated a couple of serial device baud rates that are no longer valid
```
## ecl_geometry

```
* linear segments and shortest path to these
```
## ecl_threads

```
* don't detach an ecl thread that hasn't been started
```
## ecl_time

```
* negative support for timestamps
```
