### PR TITLE
hpcl_rtt: 0.0.4-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2682,6 +2682,21 @@ repositories:
       url: https://github.com/ros-gbp/household_objects_database_msgs-release.git
       version: 0.1.1-2
     status: maintained
+  hpcl_rtt:
+    doc:
+      type: git
+      url: https://github.com/sukha-cn/hpcl_rtt.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/sukha-cn/hpcl_rtt-release.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://github.com/sukha-cn/hpcl_rtt.git
+      version: master
+    status: developed
   hrpsys:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hpcl_rtt` to `0.0.4-1`:
- upstream repository: https://github.com/sukha-cn/hpcl_rtt.git
- release repository: https://github.com/sukha-cn/hpcl_rtt-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## hpcl_rtt

```
* change the prefix of package name from ros to hpcl
* change package.xml for release
* create project
* Contributors: sukha-cn
```
