### PR TITLE
talos_audio: 1.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9240,7 +9240,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/openrobotics-gbp/talos_audio-release.git
-      version: 1.0.3-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/openrobotics/talos_audio.git


### PR DESCRIPTION
Increasing version of package(s) in repository `talos_audio` to `1.0.5-0`:
- upstream repository: https://github.com/openrobotics/talos_audio.git
- release repository: https://github.com/openrobotics-gbp/talos_audio-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.3-0`
## talos_audio
- No changes
