### PR TITLE
image_pipeline: 1.12.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2904,7 +2904,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/image_pipeline-release.git
-      version: 1.12.13-0
+      version: 1.12.14-0
     source:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `1.12.14-0`:
- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros-gbp/image_pipeline-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.12.13-0`
## camera_calibration

```
* remove camera_hammer and install Python nodes properly
  camera_hammer was just a test for camera info, nothing to do with
  calibration. Plus the test was basic.
* Correct three errors that prevented the node to work properly.
* Contributors: Filippo Basso, Vincent Rabaud
```
## depth_image_proc
- No changes
## image_pipeline
- No changes
## image_proc
- No changes
## image_rotate
- No changes
## image_view

```
* reduce the differences between OpenCV2 and 3
* do not build GUIs on Android
  This fixes #137 <https://github.com/ros-perception/image_pipeline/issues/137>
* Contributors: Vincent Rabaud
```
## stereo_image_proc

```
* add StereoSGBM and it can be chosen from dynamic_reconfigure
* Contributors: Ryohei Ueda
```
