### PR TITLE
log4cpp: 2.8.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1344,6 +1344,21 @@ repositories:
       url: https://github.com/clearpathrobotics/lms1xx.git
       version: master
     status: maintained
+  log4cpp:
+    doc:
+      type: git
+      url: https://github.com/orocos-toolchain/log4cpp.git
+      version: toolchain-2.8
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/orocos-gbp/log4cpp-release.git
+      version: 2.8.1-0
+    source:
+      type: git
+      url: https://github.com/orocos-toolchain/log4cpp.git
+      version: toolchain-2.8
+    status: maintained
   lyap_control:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `log4cpp` to `2.8.1-0`:
- upstream repository: https://github.com/orocos-toolchain/log4cpp.git
- release repository: https://github.com/orocos-gbp/log4cpp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
