### PR TITLE
rtt: 2.8.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3177,6 +3177,21 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/rtsprofile-release.git
       version: 2.0.0-0
+  rtt:
+    doc:
+      type: git
+      url: https://github.com/orocos-toolchain/rtt.git
+      version: toolchain-2.8
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/orocos-gbp/rtt-release.git
+      version: 2.8.1-0
+    source:
+      type: git
+      url: https://github.com/orocos-toolchain/rtt.git
+      version: toolchain-2.8
+    status: maintained
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt` to `2.8.1-0`:
- upstream repository: https://github.com/orocos-toolchain/rtt.git
- release repository: https://github.com/orocos-gbp/rtt-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
