### PR TITLE
ocl: 2.8.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2072,6 +2072,21 @@ repositories:
       url: https://github.com/wg-perception/transparent_objects.git
       version: master
     status: maintained
+  ocl:
+    doc:
+      type: git
+      url: https://github.com/orocos-toolchain/ocl.git
+      version: toolchain-2.8
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/orocos-gbp/ocl-release.git
+      version: 2.8.1-0
+    source:
+      type: git
+      url: https://github.com/orocos-toolchain/ocl.git
+      version: toolchain-2.8
+    status: maintained
   octomap:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ocl` to `2.8.1-0`:
- upstream repository: https://github.com/orocos-toolchain/ocl.git
- release repository: https://github.com/orocos-gbp/ocl-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
