### PR TITLE
head_action: 0.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2491,6 +2491,11 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/head_action.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pal-gbp/head_action-release.git
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/head_action.git


### PR DESCRIPTION
Increasing version of package(s) in repository `head_action` to `0.0.1-1`:
- upstream repository: https://github.com/pal-robotics/head_action.git
- release repository: https://github.com/pal-gbp/head_action-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## head_action

```
* Add head_action
* Contributors: Bence Magyar, Sammy Pfeiffer
```
