### PR TITLE
play_motion: 0.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5962,6 +5962,14 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/play_motion.git
       version: indigo-devel
+    release:
+      packages:
+      - play_motion
+      - play_motion_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pal-gbp/play_motion-release2.git
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion` to `0.4.1-0`:
- upstream repository: https://github.com/pal-robotics/play_motion.git
- release repository: https://github.com/pal-gbp/play_motion-release2.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## play_motion

```
* Migrate to format2
* remove module file
* Add missing configuration for depender projects
* Refactor argument names to convention
* Add function alternatives where NodeHandle defaults to one of play_motion
* log error when core is 0
* Add default values and units to sample config.
* Add new optional config parameter.
  Add new parameter to configure the minimum approach time to use when
  skip_planning = true.
  If we time-parameterize trajectories using MoveIt's built-in methods, we'd
  be able to get rid of this additional parameter, but in the meantime, it
  addresses an important issue.
* Contributors: Adolfo Rodriguez Tsouroukdissian, Bence Magyar, Daniel Pinyol, Víctor López
```
## play_motion_msgs

```
* Migrate to format2
* Contributors: Bence Magyar
```
