### PR TITLE
test-release: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9356,6 +9356,23 @@ repositories:
       url: https://github.com/Terabee/terarangerone-ros.git
       version: master
     status: maintained
+  test-release:
+    doc:
+      type: git
+      url: https://github.com/tom8382/test-release.git
+      version: master
+    release:
+      packages:
+      - beginner_tutorials
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tom8382/test-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/tom8382/test.git
+      version: master
+    status: developed
   tf2_web_republisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `test-release` to `0.0.2-0`:
- upstream repository: https://github.com/tom8382/test.git
- release repository: https://github.com/tom8382/test-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
