### PR TITLE
rtt_ros_integration: 2.8.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3232,6 +3232,49 @@ repositories:
       url: https://github.com/orocos-toolchain/rtt.git
       version: toolchain-2.8
     status: maintained
+  rtt_ros_integration:
+    doc:
+      type: git
+      url: https://github.com/orocos/rtt_ros_integration.git
+      version: jade-devel
+    release:
+      packages:
+      - rtt_actionlib
+      - rtt_actionlib_msgs
+      - rtt_common_msgs
+      - rtt_diagnostic_msgs
+      - rtt_dynamic_reconfigure
+      - rtt_geometry_msgs
+      - rtt_kdl_conversions
+      - rtt_nav_msgs
+      - rtt_ros
+      - rtt_ros_comm
+      - rtt_ros_integration
+      - rtt_ros_msgs
+      - rtt_rosclock
+      - rtt_roscomm
+      - rtt_rosdeployment
+      - rtt_rosgraph_msgs
+      - rtt_rosnode
+      - rtt_rospack
+      - rtt_rosparam
+      - rtt_sensor_msgs
+      - rtt_shape_msgs
+      - rtt_std_msgs
+      - rtt_std_srvs
+      - rtt_stereo_msgs
+      - rtt_tf
+      - rtt_trajectory_msgs
+      - rtt_visualization_msgs
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/orocos-gbp/rtt_ros_integration-release.git
+      version: 2.8.2-0
+    source:
+      type: git
+      url: https://github.com/orocos/rtt_ros_integration.git
+      version: jade-devel
+    status: maintained
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_ros_integration` to `2.8.2-0`:
- upstream repository: https://github.com/orocos/rtt_ros_integration.git
- release repository: https://github.com/orocos-gbp/rtt_ros_integration-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
