### PR TITLE
rtt_geometry: 2.8.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3247,6 +3247,25 @@ repositories:
       url: https://github.com/orocos-toolchain/rtt.git
       version: toolchain-2.8
     status: maintained
+  rtt_geometry:
+    doc:
+      type: git
+      url: https://github.com/orocos/rtt_geometry.git
+      version: jade-devel
+    release:
+      packages:
+      - eigen_typekit
+      - kdl_typekit
+      - rtt_geometry
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/orocos-gbp/rtt_geometry-release.git
+      version: 2.8.1-0
+    source:
+      type: git
+      url: https://github.com/orocos/rtt_geometry.git
+      version: jade-devel
+    status: maintained
   rtt_ros_integration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_geometry` to `2.8.1-0`:
- upstream repository: https://github.com/orocos/rtt_geometry.git
- release repository: https://github.com/orocos-gbp/rtt_geometry-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rtt_geometry

```
* Merge pull request #14 <https://github.com/orocos/rtt_geometry/issues/14> from orocos/fix/extern_template_explicit_instantiation
  kdl_typekit: fix extern declare, explicit instantiate mechanism
* Merge pull request #13 <https://github.com/orocos/rtt_geometry/issues/13> from orocos/introduce_index_operator_for_vector_wrench_twist
  kdl_typekit: added index operators for Vector, Wrench and Twist
* Merge remote-tracking branch 'origin/indigo-devel' into introduce_index_operator_for_vector_wrench_twist
* kdl_typekit: fix extern declare, explicit instantiate mechanism
  We forgot the explicit instantiation, also added the channelelement type
* kdl_typekit: Incomplete but working unittest for kdl typekit scripting
  Use indigo from now on.
* kdl_typekit: added index operators for Vector, Wrench and Twist
* replace lua based corba typekit test with c++ based gtest
* Install typekit header additionally as Types.hpp to be consistent with orogen generated typekits
* eigen_typekit: unified maintainer name in package.xml across orocos-toolchain and related packages
```
