### PR TITLE
rfsm: 1.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2626,6 +2626,21 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: indigo-devel
     status: maintained
+  rfsm:
+    doc:
+      type: git
+      url: https://github.com/orocos/rFSM.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/orocos-gbp/rfsm-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/orocos/rFSM.git
+      version: master
+    status: maintained
   rmp_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rfsm` to `1.0.0-0`:
- upstream repository: https://github.com/orocos/rFSM.git
- release repository: https://github.com/orocos-gbp/rfsm-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
