### PR TITLE
Adds libgeos

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -751,6 +751,8 @@ gdal-bin:
   fedora: [gdal]
   gentoo: [sci-libs/gdal]
   ubuntu: [gdal-bin]
+geos:
+  ubuntu: [libgeos-dev]
 gforth:
   arch: [gforth]
   debian: [gforth]


### PR DESCRIPTION
GEOS (Geometry Engine - Open Source) is a geometry library that is available on Ubuntu as libgeos-dev.
