### PR TITLE
rqt_common_plugins: 0.3.12-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3136,7 +3136,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.3.11-0
+      version: 0.3.12-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `0.3.12-0`:
- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/ros-gbp/rqt_common_plugins-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.11-0`
## rqt_action
- No changes
## rqt_bag

```
* Added step-by-step playback capability
* Contributors: Aaron Blasdel, sambrose
```
## rqt_bag_plugins
- No changes
## rqt_common_plugins
- No changes
## rqt_console
- No changes
## rqt_dep
- No changes
## rqt_graph
- No changes
## rqt_image_view

```
* Added button to save current image to file
* Contributors: Dirk Thomas
```
## rqt_launch
- No changes
## rqt_logger_level
- No changes
## rqt_msg
- No changes
## rqt_plot
- No changes
## rqt_publisher
- No changes
## rqt_py_common
- No changes
## rqt_py_console
- No changes
## rqt_reconfigure

```
* Added refresh button to re-scan reconfigure server list
* Now retains functioning nodes when refreshing
* Contributors: Kei Okada, Scott K Logan
```
## rqt_service_caller
- No changes
## rqt_shell
- No changes
## rqt_srv
- No changes
## rqt_top
- No changes
## rqt_topic

```
* Save/Restore of headers added
* Contributors: Aaron Blasdel
```
## rqt_web
- No changes
