### PR TITLE
rqt_common_plugins/rqt_robot_plugins: update source/docs branches to …

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7676,7 +7676,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
-      version: groovy-devel
+      version: master
     release:
       packages:
       - rqt_action
@@ -7708,7 +7708,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
-      version: groovy-devel
+      version: master
     status: developed
   rqt_ez_publisher:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8232,7 +8232,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
-      version: groovy-devel
+      version: master
     release:
       packages:
       - rqt_action
@@ -8264,7 +8264,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
-      version: groovy-devel
+      version: master
     status: developed
   rqt_ez_publisher:
     doc:
@@ -8300,7 +8300,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git
-      version: hydro-devel
+      version: master
     release:
       packages:
       - rqt_moveit
@@ -8320,7 +8320,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git
-      version: hydro-devel
+      version: master
     status: developed
   rtabmap:
     doc:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3108,7 +3108,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
-      version: groovy-devel
+      version: master
     release:
       packages:
       - rqt_action
@@ -3140,7 +3140,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
-      version: groovy-devel
+      version: master
     status: developed
   rqt_ez_publisher:
     doc:
@@ -3161,7 +3161,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git
-      version: hydro-devel
+      version: master
     release:
       packages:
       - rqt_moveit
@@ -3181,7 +3181,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git
-      version: hydro-devel
+      version: master
     status: developed
   rtabmap:
     doc:


### PR DESCRIPTION
…new master branch

Note: rqt_robot_plugins was NOT released into hydro on purpose so I left the old branch for that one.
