### PR TITLE
qt_ros: 0.2.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6665,7 +6665,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/qt_ros-release.git
-      version: 0.2.7-1
+      version: 0.2.8-0
     source:
       type: git
       url: https://github.com/stonier/qt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_ros` to `0.2.8-0`:
- upstream repository: https://github.com/stonier/qt_ros.git
- release repository: https://github.com/yujinrobot-release/qt_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.7-1`
## qt_create

```
* bugfix catkin package depend tags
```
