### PR TITLE
agvs_common: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -132,6 +132,17 @@ repositories:
       url: https://github.com/atenpas/agile_grasp.git
       version: master
     status: maintained
+  agvs_common:
+    release:
+      packages:
+      - agvs_common
+      - agvs_description
+      - agvs_pad
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotnikAutomation/agvs_common-release.git
+      version: 0.1.0-0
+    status: maintained
   android_apps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `agvs_common` to `0.1.0-0`:
- upstream repository: https://github.com/RobotnikAutomation/agvs_common.git
- release repository: https://github.com/RobotnikAutomation/agvs_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## agvs_common

```
* Update package.xml
* Update CMakeLists.txt
* Update package.xml
* First indigo version commit
* Contributors: Elena Gambaro, ElenaFG
```
## agvs_description

```
* Adding gitignore file and configuring dependencies
* First indigo version commit
* Contributors: Elena Gambaro, RomanRobotnik
```
## agvs_pad

```
* Adding gitignore file and configuring dependencies
* First indigo version commit
* Contributors: Elena Gambaro, RomanRobotnik
```
