### PR TITLE
agvs_sim: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -143,6 +143,19 @@ repositories:
       url: https://github.com/RobotnikAutomation/agvs_common-release.git
       version: 0.1.0-0
     status: maintained
+  agvs_sim:
+    release:
+      packages:
+      - agvs_control
+      - agvs_gazebo
+      - agvs_robot_control
+      - agvs_sim
+      - agvs_sim_bringup
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotnikAutomation/agvs_sim-release.git
+      version: 0.1.0-0
+    status: maintained
   android_apps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `agvs_sim` to `0.1.0-0`:
- upstream repository: https://github.com/RobotnikAutomation/agvs_sim.git
- release repository: https://github.com/RobotnikAutomation/agvs_sim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## agvs_control

```
* Adding the install macro to the CMakelists
* Wrong catkin package macro invocation
* Cleaning CMakelists and more
* First indigo version commit
* Contributors: Elena Gambaro, Isaac IY Saito, RomanRobotnik
```
## agvs_gazebo

```
* Adding the install macro to the CMakelists
* Cleaning CMakelists and more
* First indigo version commit
* Contributors: Elena Gambaro, RomanRobotnik
```
## agvs_robot_control

```
* Adding the install macro to the CMakelists
* Removing old msgs for AckermanDrive
* Cleaning CMakelists and more
* First indigo version commit
* Contributors: Elena Gambaro, RomanRobotnik
```
## agvs_sim

```
* Update package.xml
* Update package.xml
* Update CMakeLists.txt
* First indigo version commit
* Contributors: Elena Gambaro, ElenaFG
```
## agvs_sim_bringup

```
* Adding the install macro to the CMakelists
* Cleaning CMakelists and more
* First indigo version commit
* Contributors: Elena Gambaro, RomanRobotnik
```
