### PR TITLE
remove sources tag from jsk_hogehoge packages

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3177,10 +3177,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
       version: 2.0.2-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
-      version: master
     status: developed
   jsk_common:
     doc:
@@ -3203,10 +3199,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
       version: 2.0.3-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_common.git
-      version: master
     status: developed
   jsk_common_msgs:
     doc:
@@ -3225,10 +3217,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_common_msgs-release.git
       version: 2.0.0-1
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
-      version: master
     status: developed
   jsk_control:
     doc:
@@ -3250,10 +3238,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_control-release.git
       version: 0.1.6-1
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_control.git
-      version: master
     status: developed
   jsk_model_tools:
     doc:
@@ -3269,10 +3253,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
       version: 0.1.12-0
-    source:
-      type: git
-      url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: master
     status: developed
   jsk_planning:
     doc:
@@ -3290,10 +3270,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_planning-release.git
       version: 0.1.4-1
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_planning.git
-      version: master
     status: developed
   jsk_pr2eus:
     doc:
@@ -3309,10 +3285,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_pr2eus-release.git
       version: 0.1.11-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
-      version: master
     status: developed
   jsk_recognition:
     doc:
@@ -3332,10 +3304,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
       version: 0.2.13-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_recognition.git
-      version: master
     status: maintained
   jsk_robot:
     doc:
@@ -3362,10 +3330,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_robot-release.git
       version: 0.0.8-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_robot.git
-      version: master
     status: developed
   jsk_roseus:
     doc:
@@ -3382,10 +3346,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
       version: 1.3.6-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_roseus.git
-      version: master
     status: developed
   jsk_visualization:
     doc:
@@ -3404,10 +3364,6 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
       version: 1.0.23-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_visualization.git
-      version: master
     status: developed
   jskeus:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3310,10 +3310,6 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
       version: 2.0.2-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
-      version: master
     status: developed
   jsk_common:
     doc:
@@ -3336,10 +3332,6 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
       version: 2.0.3-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_common.git
-      version: master
     status: developed
   jsk_common_msgs:
     doc:
@@ -3358,10 +3350,6 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common_msgs-release.git
       version: 2.0.0-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
-      version: master
     status: developed
   jsk_control:
     doc:
@@ -3383,10 +3371,6 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_control-release.git
       version: 0.1.6-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_control.git
-      version: master
     status: developed
   jsk_model_tools:
     doc:
@@ -3402,10 +3386,6 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
       version: 0.1.12-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_model_tools.git
-      version: master
     status: developed
   jsk_planning:
     doc:
@@ -3423,10 +3403,6 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_planning-release.git
       version: 0.1.4-1
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_planning.git
-      version: master
     status: developed
   jsk_pr2eus:
     doc:
@@ -3442,10 +3418,6 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_pr2eus-release.git
       version: 0.1.11-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
-      version: master
     status: developed
   jsk_recognition:
     doc:
@@ -3465,10 +3437,6 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
       version: 0.2.13-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_recognition.git
-      version: master
     status: developed
   jsk_robot:
     doc:
@@ -3495,10 +3463,6 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_robot-release.git
       version: 0.0.8-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_robot.git
-      version: master
     status: developed
   jsk_roseus:
     doc:
@@ -3515,10 +3479,6 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
       version: 1.3.6-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_roseus.git
-      version: master
     status: maintained
   jsk_smart_apps:
     doc:
@@ -3542,10 +3502,6 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
       version: 1.0.23-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_visualization.git
-      version: master
     status: developed
   jskeus:
     doc:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1164,10 +1164,6 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
       version: 2.0.2-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
-      version: master
     status: developed
   jsk_common:
     doc:
@@ -1190,10 +1186,6 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
       version: 2.0.2-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_common.git
-      version: master
     status: developed
   jsk_common_msgs:
     doc:
@@ -1212,10 +1204,6 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_common_msgs-release.git
       version: 2.0.0-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
-      version: master
     status: developed
   jsk_roseus:
     doc:
@@ -1230,10 +1218,6 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
       version: 1.3.6-0
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/jsk_roseus.git
-      version: master
     status: developed
   jskeus:
     doc:


### PR DESCRIPTION
We realized that our frequent commits to the repository consumes many job resources to your jenkins.ors.org resources, I'm not sure but if removing sources tags stops executing ros-\$ROS_DISTRO-devel-jsk- jobs and that reduces cunsuming ros.org resources, I'm very happy about that.
