### PR TITLE
rocon_devices: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7229,7 +7229,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_devices-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_devices.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_devices` to `0.0.7-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_devices.git
- release repository: https://github.com/yujinrobot-release/rocon_devices-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.6-0`
## rocon_devices
- No changes
## rocon_hue
- No changes
## rocon_iot_bridge
- No changes
## rocon_ninjablock_bridge
- No changes
## rocon_python_hue
- No changes
## rocon_rtsp_camera_relay
- No changes
## rocon_smartthings_bridge

```
* fix Cmake
* Contributors: Jihoon Lee
```
