### PR TITLE
barrett_hand_common: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -417,6 +417,16 @@ repositories:
       url: https://github.com/clearpathrobotics/axis_camera.git
       version: master
     status: maintained
+  barrett_hand_common:
+    release:
+      packages:
+      - barrett_hand_common
+      - barrett_hand_description
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotnikAutomation/barrett_hand_common-release.git
+      version: 0.1.0-0
+    status: maintained
   battery_monitor_rmp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `barrett_hand_common` to `0.1.0-0`:
- upstream repository: https://github.com/RobotnikAutomation/barrett_hand_common.git
- release repository: https://github.com/RobotnikAutomation/barrett_hand_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## barrett_hand_common

```
* Adding metapackage and setting CMakeLists and package.xml for release
* Contributors: RomanRobotnik
```
## barrett_hand_description

```
* Url fix
* Fixing catkin error
* Adding metapackage and setting CMakeLists and package.xml for release
* Add Barrett Hand description package
* Contributors: Elena Gambaro, RomanRobotnik
```
