### PR TITLE
barrett_hand_sim: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -427,6 +427,16 @@ repositories:
       url: https://github.com/RobotnikAutomation/barrett_hand_common-release.git
       version: 0.1.0-0
     status: maintained
+  barrett_hand_sim:
+    release:
+      packages:
+      - barrett_hand_control
+      - barrett_hand_gazebo
+      - barrett_hand_sim
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotnikAutomation/barrett_hand_sim-release.git
+      version: 0.1.0-0
   battery_monitor_rmp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `barrett_hand_sim` to `0.1.0-0`:
- upstream repository: https://github.com/RobotnikAutomation/barrett_hand_sim.git
- release repository: https://github.com/RobotnikAutomation/barrett_hand_sim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## barrett_hand_control

```
* Add Barrett Hand gazebo and Barrett Hand control packages
* Contributors: Elena Gambaro
```
## barrett_hand_gazebo

```
* Add Barrett Hand gazebo and Barrett Hand control packages
* Contributors: Elena Gambaro
```
## barrett_hand_sim

```
* Adding metapackage folder
* Contributors: RomanRobotnik
```
