### PR TITLE
Adding haf_grasping repo to documentation index for distro indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2495,6 +2495,21 @@ repositories:
       url: https://github.com/Hacks4ROS/h4r_x52_joyext.git
       version: develop
     status: maintained
+  haf_grasping:
+    doc:
+      type: git
+      url: https://github.com/davidfischinger/haf_grasping.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/davidfischinger/haf_grasping/tree/v0.5-beta
+      version: 0.5.0-0
+    source:
+      type: git
+      url: https://github.com/davidfischinger/haf_grasping.git
+      version: master
+    status: maintained
   hakuto:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2500,11 +2500,6 @@ repositories:
       type: git
       url: https://github.com/davidfischinger/haf_grasping.git
       version: master
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/davidfischinger/haf_grasping/tree/v0.5-beta
-      version: 0.5.0-0
     source:
       type: git
       url: https://github.com/davidfischinger/haf_grasping.git


### PR DESCRIPTION
I'd like my repo haf_grasping to be indexed and documented on ros.org
