### PR TITLE
image_common: 1.11.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2940,7 +2940,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/image_common-release.git
-      version: 1.11.6-0
+      version: 1.11.7-0
     source:
       type: git
       url: https://github.com/ros-perception/image_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `1.11.7-0`:
- upstream repository: https://github.com/ros-perception/image_common.git
- release repository: https://github.com/ros-gbp/image_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.6-0`
## camera_calibration_parsers

```
* fix #39 <https://github.com/ros-perception/image_common/issues/39>
* make sure test does not fail
* Contributors: Vincent Rabaud
```
## camera_info_manager
- No changes
## image_common
- No changes
## image_transport
- No changes
## polled_camera
- No changes
