### PR TITLE
agvs_common: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -141,7 +141,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/agvs_common-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     status: maintained
   agvs_sim:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `agvs_common` to `0.1.1-0`:
- upstream repository: https://github.com/RobotnikAutomation/agvs_common.git
- release repository: https://github.com/RobotnikAutomation/agvs_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.0-0`
## agvs_common

```
* agvs_common: Adding options for metapackages
* Fixing repositories in package.xml files
* Corrected dependency name
* Corrected dependency name
* Preparing repo for release
* Update package.xml
* Update CMakeLists.txt
* Update package.xml
* First indigo version commit
* Contributors: Elena Gambaro, ElenaFG, RomanRobotnik
```
## agvs_description

```
* Fixing repositories in package.xml files
* agvs_description: modifying model colors
* Preparing repo for release
* Adding gitignore file and configuring dependencies
* First indigo version commit
* Contributors: Elena Gambaro, RomanRobotnik
```
## agvs_pad

```
* Fixing repositories in package.xml files
* Removing dependency on agvs_robot_control
* Preparing repo for release
* Adding gitignore file and configuring dependencies
* First indigo version commit
* Contributors: Elena Gambaro, RomanRobotnik
```
