### PR TITLE
Adding epuck_driver to documentation index for hydro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1836,6 +1836,12 @@ repositories:
       url: https://github.com/tkucner/epos_driver-released.git
       version: upstream
     status: developed
+  epuck_driver:
+    source:
+      type: git
+      url: https://github.com/gctronic/epuck_driver
+      version: master
+    status: developed
   erratic_robot:
     doc:
       type: git


### PR DESCRIPTION
I'd like epuck_driver to be indexed and documented in ros.org.
