### PR TITLE
agvs_sim: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -154,7 +154,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/agvs_sim-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     status: maintained
   android_apps:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `agvs_sim` to `0.1.1-0`:
- upstream repository: https://github.com/RobotnikAutomation/agvs_sim.git
- release repository: https://github.com/RobotnikAutomation/agvs_sim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.0-0`
## agvs_control

```
* Adding changelogs for the release
* Adding the install macro to the CMakelists
* Wrong catkin package macro invocation
* Cleaning CMakelists and more
* First indigo version commit
* Contributors: Elena Gambaro, Isaac IY Saito, RomanRobotnik
```
## agvs_gazebo

```
* agvs_gazebo: adding run dependency on agvs_pad and agvs_robot_control
* Adding changelogs for the release
* Adding the install macro to the CMakelists
* Cleaning CMakelists and more
* First indigo version commit
* Contributors: Elena Gambaro, RomanRobotnik
```
## agvs_robot_control

```
* agvs_robot_control: Adding build and run dependencies
* Adding changelogs for the release
* Adding the install macro to the CMakelists
* Removing old msgs for AckermanDrive
* Cleaning CMakelists and more
* First indigo version commit
* Contributors: Elena Gambaro, RomanRobotnik
```
## agvs_sim

```
* Fixing error name on dependency
* Adding changelogs for the release
* Update package.xml
* Update package.xml
* Update CMakeLists.txt
* First indigo version commit
* Contributors: Elena Gambaro, ElenaFG, RomanRobotnik
```
## agvs_sim_bringup

```
* Adding changelogs for the release
* Adding the install macro to the CMakelists
* Cleaning CMakelists and more
* First indigo version commit
* Contributors: Elena Gambaro, RomanRobotnik
```
