### PR TITLE
barrett_hand: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -417,6 +417,17 @@ repositories:
       url: https://github.com/clearpathrobotics/axis_camera.git
       version: master
     status: maintained
+  barrett_hand:
+    release:
+      packages:
+      - barrett_hand
+      - bhand_controller
+      - rqt_bhand
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotnikAutomation/barrett_hand-release.git
+      version: 0.1.1-0
+    status: maintained
   barrett_hand_common:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `barrett_hand` to `0.1.1-0`:
- upstream repository: https://github.com/RobotnikAutomation/barrett_hand.git
- release repository: https://github.com/RobotnikAutomation/barrett_hand-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## barrett_hand

```
* barrett_hand: removing dependency on bhand_description
* Preparing changelog
* Adding changelog files
* Updating package.xml files
* Updating packages.xml config files
* Adding initial structure
* Contributors: RobotnikRoman, RomanRobotnik
```
## bhand_controller

```
* bhand_controller: renaming README
* Preparing changelog
* Modifying .gitignore, CMakelist to install the packages, removing .pyc files
* Modifying .gitignore, CMakelist to install the packages, removing .pyc files
* Indigo supported packages
* Adding changelog files
* Adding changelog files
* Updating package.xml files
* Updating packages.xml config files
* Adding initial structure
* Contributors: Elena Gambaro, RobotnikRoman, RomanRobotnik
```
## rqt_bhand

```
* rqt_bhand: Adding new rosrun dependency
* Preparing changelog
* Adding queue_size to publisher
* Modifying .gitignore, CMakelist to install the packages, removing .pyc files
* Modifying .gitignore, CMakelist to install the packages, removing .pyc files
* Indigo supported packages
* Adding changelog files
* Updating package.xml files
* Updating packages.xml config files
* Adding initial structure
* Contributors: Elena Gambaro, RobotnikRoman, RomanRobotnik
```
