### PR TITLE
Rosdep for python-pygraph

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1063,6 +1063,8 @@ python-pygithub3:
   ubuntu:
     pip:
       packages: [pygithub3]
+python-pygraph:
+  ubuntu: python-pygraph
 python-pygraphviz:
   debian: [python-pygraphviz]
   fedora: [graphviz-python]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1064,7 +1064,7 @@ python-pygithub3:
     pip:
       packages: [pygithub3]
 python-pygraph:
-  ubuntu: python-pygraph
+  ubuntu: [python-pygraph]
 python-pygraphviz:
   debian: [python-pygraphviz]
   fedora: [graphviz-python]


### PR DESCRIPTION
Should be available across multiple ubuntu distros that we care about:
- http://packages.ubuntu.com/search?keywords=python-pygraph
