### PR TITLE
Rosdep for libgv-python

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -17,6 +17,8 @@ ipython:
     trusty: [ipython]
     trusty_python3: [ipython3]
     utopic: [ipython]
+libgv-python
+  ubuntu: [libgv-python]
 paramiko:
   arch: [python2-paramiko]
   debian: [python-paramiko]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -17,7 +17,7 @@ ipython:
     trusty: [ipython]
     trusty_python3: [ipython3]
     utopic: [ipython]
-libgv-python
+libgv-python:
   ubuntu: [libgv-python]
 paramiko:
   arch: [python2-paramiko]


### PR DESCRIPTION
Should be available across ubuntu distros that we care about:
- http://packages.ubuntu.com/search?keywords=libgv-python
