### PR TITLE
rtmros_hironx: 1.0.33-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8416,7 +8416,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.32-0
+      version: 1.0.33-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.33-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.32-0`
## hironx_calibration
- No changes
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* [fix] Fix unusual Hironx robot host name in launch file.
* [fix] Cleaner tf frame (BODY_LINK to WAIST)
* [sys] More robust unit test
* Contributors: Ryosuke, Shunichi Nozawa, Isaac IY Saito
```
## rtmros_hironx

```
* [fix] Fix unusual Hironx robot host name in launch file.
* [fix] Cleaner tf frame (BODY_LINK to WAIST)
* [sys] More robust unit test
* Contributors: Ryosuke, Shunichi Nozawa, Isaac IY Saito
```
