### PR TITLE
Adding source and doc tags for packages agvs_common, agvs_sim, barret…

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -133,6 +133,10 @@ repositories:
       version: master
     status: maintained
   agvs_common:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/agvs_common.git
+      version: indigo-devel
     release:
       packages:
       - agvs_common
@@ -142,8 +146,16 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/agvs_common-release.git
       version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/agvs_common.git
+      version: indigo-devel
     status: maintained
   agvs_sim:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/agvs_sim.git
+      version: indigo-devel
     release:
       packages:
       - agvs_control
@@ -155,6 +167,10 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/agvs_sim-release.git
       version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/agvs_sim.git
+      version: indigo-devel
     status: maintained
   android_apps:
     doc:
@@ -418,6 +434,10 @@ repositories:
       version: master
     status: maintained
   barrett_hand:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/barrett_hand.git
+      version: indigo-devel
     release:
       packages:
       - barrett_hand
@@ -427,8 +447,16 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/barrett_hand-release.git
       version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/barrett_hand.git
+      version: indigo-devel
     status: maintained
   barrett_hand_common:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/barrett_hand_common.git
+      version: indigo-devel
     release:
       packages:
       - barrett_hand_common
@@ -437,8 +465,16 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/barrett_hand_common-release.git
       version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/barrett_hand_common.git
+      version: indigo-devel
     status: maintained
   barrett_hand_sim:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/barrett_hand_sim.git
+      version: indigo-devel
     release:
       packages:
       - barrett_hand_control
@@ -448,6 +484,11 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/barrett_hand_sim-release.git
       version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/barrett_hand_sim.git
+      version: indigo-devel
+    status: maintained
   battery_monitor_rmp:
     doc:
       type: git


### PR DESCRIPTION
I'd like to index the 'source' and 'doc' tags of the packages agvs_common, agvs_sim, barrett_hand, barrett_hand_common, barrett_hand_sim
