### PR TITLE
naoqi_bridge: 0.5.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1754,17 +1754,22 @@ repositories:
       version: master
     status: maintained
   naoqi_bridge:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_bridge.git
+      version: master
     release:
       packages:
       - naoqi_apps
       - naoqi_bridge
-      - naoqi_msgs
-      - naoqi_sensors
+      - naoqi_driver_py
+      - naoqi_pose
+      - naoqi_sensors_py
       - naoqi_tools
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_bridge-release.git
-      version: 0.4.7-0
+      version: 0.5.0-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge` to `0.5.0-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_bridge.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.4.7-0`
## naoqi_apps
- No changes
## naoqi_bridge

```
* rename naoqi_rosbridge to naoqi_driver
* add naoqi_rosbridge dep
* delete legacy msg package
* Contributors: Karsten Knese
```
## naoqi_driver_py

```
* update package.xml description
* remove wrongly set conflict tag
* Merge branch 'naoqi_py'
* delete legacy msg package
* rename packages
* remove cpp library builds
* remove cpp code
* rename packages to *_py
* Contributors: Karsten Knese
```
## naoqi_pose

```
* delete legacy msg package
* Contributors: Karsten Knese
```
## naoqi_sensors_py

```
* renaming packag to _py
* change package dependencies to *_py
* delete legacy msg package
* rename packages
* remove cpp version
* remove camera nodelet
* rename packages to *_py
* Contributors: Karsten Knese
```
## naoqi_tools

```
* make sure we add the cap for Romeo
* fix bad macro names
* Contributors: Vincent Rabaud
```
