### PR TITLE
pepper_robot: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5946,11 +5946,11 @@ repositories:
       - pepper_bringup
       - pepper_description
       - pepper_robot
-      - pepper_sensors
+      - pepper_sensors_py
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_robot-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_robot` to `0.1.4-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_robot.git
- release repository: https://github.com/ros-naoqi/pepper_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.3-0`
## pepper_bringup

```
* update maintainer email
* rename naoqi_driver
* pepper_sensor to pepper_sensor_py
* transfer to naoqi_py
* Contributors: Karsten Knese
```
## pepper_description

```
* use proper macro names
* Contributors: Vincent Rabaud
```
## pepper_robot

```
* update maintainer email
* Contributors: Karsten Knese
```
## pepper_sensors_py

```
* update maintainer email
* pepper_sensor to pepper_sensor_py
* Contributors: Karsten Knese
```
