### PR TITLE
slam_gmapping: 1.3.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3392,6 +3392,10 @@ repositories:
       version: 2.5.3-0
     status: maintained
   slam_gmapping:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/slam_gmapping.git
+      version: hydro-devel
     release:
       packages:
       - gmapping
@@ -3399,7 +3403,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/slam_gmapping-release.git
-      version: 1.3.7-0
+      version: 1.3.8-0
     source:
       type: git
       url: https://github.com/ros-perception/slam_gmapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_gmapping` to `1.3.8-0`:
- upstream repository: https://github.com/ros-perception/slam_gmapping
- release repository: https://github.com/ros-gbp/slam_gmapping-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.3.7-0`
## gmapping

```
* fix a test that would take too long sometimes
* better verbosity
* add a test for upside down lasers
* add a test for symmetry
* make sure the laser sent to gmapping is always centered
* do not display warning message if scan is processed at some point
* Contributors: Vincent Rabaud
```
## slam_gmapping
- No changes
