### PR TITLE
pepper_robot: 0.1.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2291,7 +2291,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_robot-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_robot` to `0.1.5-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_robot.git
- release repository: https://github.com/ros-naoqi/pepper_robot-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.4-0`
## pepper_bringup

```
* 0.1.4
* generate changelog
* update maintainer email
* rename naoqi_driver
* pepper_sensor to pepper_sensor_py
* transfer to naoqi_py
* Contributors: Karsten Knese
```
## pepper_description

```
* 0.1.4
* generate changelog
* use proper macro names
* Contributors: Karsten Knese, Vincent Rabaud
```
## pepper_robot

```
* 0.1.4
* generate changelog
* update maintainer email
* Contributors: Karsten Knese
```
## pepper_sensors_py

```
* 0.1.4
* generate changelog
* update maintainer email
* pepper_sensor to pepper_sensor_py
* Contributors: Karsten Knese
```
