### PR TITLE
nao_extras: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4883,7 +4883,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/nao_extras-release.git
-      version: 0.2.2-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_extras.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_extras` to `0.3.0-0`:
- upstream repository: https://github.com/ros-nao/nao_extras.git
- release repository: https://github.com/ros-gbp/nao_extras-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.2-0`
## nao_extras
- No changes
## nao_path_follower

```
* get code to use naoqi_bridge_msgs and not naoqi_msgs
* Contributors: Vincent Rabaud
```
## nao_teleop

```
* get code to use naoqi_bridge_msgs and not naoqi_msgs
* Contributors: Vincent Rabaud
```
