### PR TITLE
nao_extras: 0.3.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1677,6 +1677,10 @@ repositories:
       version: master
     status: maintained
   nao_extras:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/nao_extras.git
+      version: master
     release:
       packages:
       - nao_extras
@@ -1685,7 +1689,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/nao_extras-release.git
-      version: 0.2.2-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_extras.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_extras` to `0.3.0-0`:
- upstream repository: https://github.com/ros-nao/nao_extras.git
- release repository: https://github.com/ros-gbp/nao_extras-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.2-0`
## nao_extras
- No changes
## nao_path_follower

```
* get code to use naoqi_bridge_msgs and not naoqi_msgs
* Contributors: Vincent Rabaud
```
## nao_teleop

```
* get code to use naoqi_bridge_msgs and not naoqi_msgs
* Contributors: Vincent Rabaud
```
