### PR TITLE
nao_robot: 0.5.10-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1733,12 +1733,11 @@ repositories:
       - nao_apps
       - nao_bringup
       - nao_description
-      - nao_pose
       - nao_robot
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/nao_robot-release.git
-      version: 0.5.9-0
+      version: 0.5.10-1
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_robot` to `0.5.10-1`:
- upstream repository: https://github.com/ros-naoqi/nao_robot.git
- release repository: https://github.com/ros-naoqi/nao_robot-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.9-0`
## nao_apps
- No changes
## nao_bringup
- No changes
## nao_description
- No changes
## nao_robot

```
* remove nao_pose
* Contributors: Karsten Knese
```
