### PR TITLE
naoqi_bridge: 0.5.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5011,7 +5011,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_bridge-release.git
-      version: 0.5.0-0
+      version: 0.5.1-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge` to `0.5.1-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_bridge.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.0-0`
## naoqi_apps

```
* generate changelog
* generate changelog
* cleanup meta package.xml
* Contributors: Karsten Knese
* generate changelog
* cleanup meta package.xml
* Contributors: Karsten Knese
* cleanup meta package.xml
* Contributors: Karsten Knese
```
## naoqi_bridge

```
* generate changelog
* generate changelog
* cleanup meta package.xml
* Contributors: Karsten Knese
* generate changelog
* cleanup meta package.xml
* Contributors: Karsten Knese
* cleanup meta package.xml
* Contributors: Karsten Knese
```
## naoqi_driver_py

```
* generate changelog
* generate changelog
* Contributors: Karsten Knese
* generate changelog
* Contributors: Karsten Knese
```
## naoqi_pose

```
* generate changelog
* generate changelog
* rename naoqi_msgs to naoqi_bridge_msgs
* Contributors: Karsten Knese
* generate changelog
* rename naoqi_msgs to naoqi_bridge_msgs
* Contributors: Karsten Knese
* rename naoqi_msgs to naoqi_bridge_msgs
* Contributors: Karsten Knese
```
## naoqi_sensors_py

```
* generate changelog
* generate changelog
* Contributors: Karsten Knese
* generate changelog
* Contributors: Karsten Knese
```
## naoqi_tools

```
* generate changelog
* generate changelog
* Contributors: Karsten Knese
* generate changelog
* Contributors: Karsten Knese
```
