### PR TITLE
Indexing ohm_tsd_slam ROS repository for documentation

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5539,6 +5539,11 @@ repositories:
       url: https://github.com/OctoMap/octomap_rviz_plugins.git
       version: indigo-devel
     status: maintained
+  ohm_tsd_slam:
+    doc:
+      type: git
+      url: https://github.com/autonohm/ohm_tsd_slam.git
+      version: indigo-devel
   ompl:
     release:
       tags:


### PR DESCRIPTION
I'd like to add the SLAM of the RoboCup Rescue Team Autonohm to the documentation. I hope everything is formated well.

Best regards, Markus
