### PR TITLE
mavros: 0.13.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1445,10 +1445,11 @@ repositories:
       - libmavconn
       - mavros
       - mavros_extras
+      - test_mavros
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.12.0-0
+      version: 0.13.0-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.13.0-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.12.0-0`
## libmavconn

```
* libmavconn: simpify exception code.
* Contributors: Vladimir Ermakov
```
## mavros

```
* plugin: setpoint_attitude #352 <https://github.com/mavlink/mavros/issues/352>: use new helper.
* plugin: sys: Fix cppcheck and YouCompleteMe warnings
* plugin: ftp: Fix cppcheck errors.
* lib #352 <https://github.com/mavlink/mavros/issues/352>: Add helper function UAS::quaternion_to_mavlink()
* Fixed bug in send_attitude_target()
  The transformed quaternion wasn't being passed to set_attitude_target(), resulting in an incorrect attitude setpoint. I've now fixed this issue.
* scripts: fix mavwp
* test: add test cases for new sensor orientation functions
* remove tf1 dep
* lib #319 <https://github.com/mavlink/mavros/issues/319>: Remove TF types from UAS
* plugin: param: new message type: ParamValue
* msgs: Move MAV_CMD values to separate msg
* plugin: command: fix build
* fix whitespaces in python scripts
* Merge pull request #312 <https://github.com/mavlink/mavros/issues/312> from mhkabir/cam_imu_sync
  Camera IMU synchronisation support added
* Added launch file for PX4 posix sitl to launch gcs_bridge node for bridging posix and gazebo
* scripts: mavftp: little speed up by aligning access to payload length
* launch: Add optional log_output arg
* Merge branch 'orientation_enum_name'
  * orientation_enum_name:
  distance_sensor #342 <https://github.com/mavlink/mavros/issues/342>: correct orientation parameter handling.
  lib #342 <https://github.com/mavlink/mavros/issues/342>: try to convert numeric value too
  px4_config: adapt to distance_sensor params to new features
  distance_sensor: restructure orientation matching and verification
  lib #342 <https://github.com/mavlink/mavros/issues/342>: Added sensor orientation string repr.
* lib #342 <https://github.com/mavlink/mavros/issues/342>: try to convert numeric value too
* px4_config: adapt to distance_sensor params to new features
* lib #342 <https://github.com/mavlink/mavros/issues/342>: Added sensor orientation string repr.
* launch: update local_position conf
* test: Add test for UAS::sensor_orientation_matching()
* Update cmake Eigen3 finding rules.
  Migration described at:
  http://wiki.ros.org/jade/Migration#Eigen_CMake_Module_in_cmake_modules
* lib #319 <https://github.com/mavlink/mavros/issues/319>, #341 <https://github.com/mavlink/mavros/issues/341>: preparation for str->MAV_SENSOR_ORIENTATION func
* lib #319 <https://github.com/mavlink/mavros/issues/319>: Return quaternion from UAS::sensor_matching()
* lib: Remove unneded NodeHandle
* launch fix #340 <https://github.com/mavlink/mavros/issues/340>: update default component id of PX4.
* plugin: sys_status: Add fallback to adressed version request.
* Can not remove tf package before #319 <https://github.com/mavlink/mavros/issues/319> is done.
  tf::Vector3 and other tf1-bullet still in use.
* plugin: sys_status: Use broadcast for version request.
* fix #71 <https://github.com/mavlink/mavros/issues/71>: replace depend tf to tf2_ros.
* plugin: Use UAS::syncronized_header() for reduce LOC.
* lib #319 <https://github.com/mavlink/mavros/issues/319>: use similar names for covariances as eigen vector
* lib #319 <https://github.com/mavlink/mavros/issues/319>: transform_frame() for Covariance3x3
* lib #319 <https://github.com/mavlink/mavros/issues/319>: remove unused bullet based transform_frame()
* extras: vision_pose #71 <https://github.com/mavlink/mavros/issues/71>: Use TF2 listener.
  Also #319 <https://github.com/mavlink/mavros/issues/319>.
* plugin #71 <https://github.com/mavlink/mavros/issues/71>: Implement TF2 listener. Change param names.
  Breaks extras.
* uas #71 <https://github.com/mavlink/mavros/issues/71>: Use single TF2 objects for broadcasting and subscription.
* launch: Update configs.
* lib: Add UAS::quaternion_to_rpy()
* plugin: safety_area #319 <https://github.com/mavlink/mavros/issues/319>: Change transform_frame()
* plugin: local_position #71 <https://github.com/mavlink/mavros/issues/71> #319 <https://github.com/mavlink/mavros/issues/319>: port to TF2 and Eigen
* lib: Add UAS::synchonized_header()
* plugin: command: Add command broadcasting support.
* Perform the autopilot version request as broadcast
* lib: Update PX4 mode list
* plugin: global_position #325 <https://github.com/mavlink/mavros/issues/325>: port tf broadcaster to tf2
  Also #71 <https://github.com/mavlink/mavros/issues/71>.
* plugin: global_position #325 <https://github.com/mavlink/mavros/issues/325>: reenable UTM calc
* plugin: gps #325 <https://github.com/mavlink/mavros/issues/325>: remove gps plugin.
* plugin: global_position #325 <https://github.com/mavlink/mavros/issues/325>: merge gps_raw_int handler
* plugin: setpoint_accel #319 <https://github.com/mavlink/mavros/issues/319>: use eigen frame transform.
  I don't think that PX4 support any other frame than LOCAL_NED.
  So i removed comment.
  Also style fix in setpoint_velocity.
* plugin: setpoint_velocity #319 <https://github.com/mavlink/mavros/issues/319>: use eigen based frame transform.
* plugin: setpoint_position #273 <https://github.com/mavlink/mavros/issues/273>: remove PX4 quirk, it is fixed.
* plugin: ftp: Update command enum.
* plugin: imu_pub fix #320 <https://github.com/mavlink/mavros/issues/320>: move constants outside class, else runtime linkage error.
* plugin: imu_pub #320 <https://github.com/mavlink/mavros/issues/320>: first attempt
* eigen #319 <https://github.com/mavlink/mavros/issues/319>: handy wrappers.
* eigen #319 <https://github.com/mavlink/mavros/issues/319>: add euler-quat function.
  Also #321 <https://github.com/mavlink/mavros/issues/321>.
* test #321 <https://github.com/mavlink/mavros/issues/321>: remove duplicated test cases, separate by library.
  Add test for checking compatibility of tf::quaternionFromRPY() and Eigen
  based math.
* test #321 <https://github.com/mavlink/mavros/issues/321>: testing eigen-based transforms.
  We should check what convention used by tf::Matrix to be sure that
  our method is compatible.
* mavros #319 <https://github.com/mavlink/mavros/issues/319>: Add Eigen dependency and cmake rule.
* test: test for UAS::transform_frame_attitude_rpy() (ERRORs!)
* test: test for UAS::transform_frame_xyz()
* test: Initial import test_frame_conv
* cam_imu_sync : fix running
* imu_cam_sync : fix formatting
* command handling in mavcmd for camera trigger
* Camera IMU synchronisation support added
* Contributors: Anurag Makineni, Lorenz Meier, Mohammed Kabir, TSC21, Vladimir Ermakov, devbharat
```
## mavros_extras

```
* extras: mocap fix #352 <https://github.com/mavlink/mavros/issues/352>: use new helper for quaternion.
* Merge pull request #312 <https://github.com/mavlink/mavros/issues/312> from mhkabir/cam_imu_sync
  Camera IMU synchronisation support added
* distance_sensor #342 <https://github.com/mavlink/mavros/issues/342>: correct orientation parameter handling.
* distance_sensor: restructure orientation matching and verification
* lib #319 <https://github.com/mavlink/mavros/issues/319>: Return quaternion from UAS::sensor_matching()
* launch fix #340 <https://github.com/mavlink/mavros/issues/340>: update default component id of PX4.
* extras: distance_sensor #71 <https://github.com/mavlink/mavros/issues/71>: Purt to TF2.
* plugin: Use UAS::syncronized_header() for reduce LOC.
* extras: vision_pose #71 <https://github.com/mavlink/mavros/issues/71>: Use TF2 listener.
  Also #319 <https://github.com/mavlink/mavros/issues/319>.
* launch: Update configs.
* extras: viz #336 <https://github.com/mavlink/mavros/issues/336>: convert plugin to node.
* extras: vision_speed #319 <https://github.com/mavlink/mavros/issues/319>: use eigen based transform
* extras: vibration: Use UAS::synchronized_header()
* extras: px4flow #319 <https://github.com/mavlink/mavros/issues/319>: change transform_frame()
* extras: mocap #319 <https://github.com/mavlink/mavros/issues/319>: use eigen based transform
* Camera IMU synchronisation support added
* Contributors: Mohammed Kabir, TSC21, Vladimir Ermakov
```
## test_mavros

```
* Update iris_empty_world_offboard_ctl.launch
* test: fix prerelease building
* test: move launch
* sitl_tests: turn pos_setpoint code more elegant
* sitl_tests: minor code tweak; use angles.h package
* sitl_tests: offboard_control: included array lib; init threshold in constructor
* sitl_tests: added normal distribution position error threshold generator
* sitl_tests: add eigen dependency to CMakeLists and package.xml
* sitl_tests: "eigenize" offboard_control code; generalize offb control launch file
* sitl_tests: added px4 and rotors_simulator packages to package.xml dependencies
* sitl_tests: define sitl_tests group; change tgt_component to 1
* sitl_tests: offboard_mode: minor code refining
* sitl_tests: code cleaning
* sitl_tests: uncrustify code
* sitl_tests: offboard_control: velocity: added eight and ellipse-shaped paths
* sitl_tests: offboard_control: velocity: added circle-shaped path
* sitl_tests: added offboard velocity control - square shaped path for now
* sitl_tests: offboard_control: added ellipse-shaped path
* sitl_tests: offboard_control: added circle-shaped path
* sitl_tests: generalize offboard posctl so it can handle vel/accel control; added support to "eight" sphaped path
* sitl_tests: added base node
* sitl_test: added integrated launch file for OFFB POSCTL square shape
* sitl_tests: turn sitl_test_node as generic node to both APM and PX4
* sitl_tests: test structure definition; first working test routine
* test: import launch for imu testing
* test: apm sitl and imu test reproduction steps
* test: Add test_marvros package stub
* Contributors: TSC21, Vladimir Ermakov, wangsen1312
```
