### PR TITLE
fetch_tools: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2074,6 +2074,13 @@ repositories:
       url: https://github.com/fetchrobotics/fetch_ros.git
       version: indigo-devel
     status: developed
+  fetch_tools:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
+      version: 0.1.1-0
+    status: developed
   filters:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_tools` to `0.1.1-0`:
- upstream repository: https://github.com/fetchrobotics/fetch_tools.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
