### PR TITLE
robot_calibration: 0.5.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2666,6 +2666,24 @@ repositories:
       url: https://github.com/WPI-RAIL/rmp_msgs.git
       version: develop
     status: maintained
+  robot_calibration:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/robot_calibration.git
+      version: indigo-devel
+    release:
+      packages:
+      - robot_calibration
+      - robot_calibration_msgs
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/robot_calibration-release.git
+      version: 0.5.2-0
+    source:
+      type: git
+      url: https://github.com/mikeferguson/robot_calibration.git
+      version: indigo-devel
+    status: developed
   robot_controllers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.5.2-0`:
- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/fetchrobotics-gbp/robot_calibration-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## robot_calibration

```
* remove dependency on PCL
* cleanup naming of member variables
* fix centroid refinement, fixes #20 <https://github.com/mikeferguson/robot_calibration/issues/20>
* Contributors: Michael Ferguson
```
## robot_calibration_msgs
- No changes
