### PR TITLE
Adding osmium to the rosdep db.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2734,6 +2734,8 @@ openssl:
 osm2pgsql:
   fedora: [osm2pgsql]
   ubuntu: [osm2pgsql]
+osmium:
+  ubuntu: [libosmium-dev]
 pcre:
   arch: [pcre]
   debian: [libpcre3-dev]


### PR DESCRIPTION
osmium is a C++ toolkit for working with OpenStreetMaps data.
It is available as a Ubuntu apt package as libosmium-dev.
