### PR TITLE
jsk_robot: 0.0.9-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3336,7 +3336,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_robot-release.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     status: developed
   jsk_roseus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `0.0.9-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.8-0`
## baxtereus
- No changes
## jsk_201504_miraikan
- No changes
## jsk_baxter_desktop
- No changes
## jsk_baxter_startup

```
* [jsk_robot] use common database jsk_robot_lifelog, with identify with collection name ROBOT_NAME
* remove old rosmake related files
* Contributors: Yuki Furuta, Kei Okada
```
## jsk_baxter_web
- No changes
## jsk_nao_startup
- No changes
## jsk_pepper_startup

```
* package.xml: add joy
* [jsk_pepper_startup] add test_code to check if pepper launch is valid
* Contributors: Hitoshi Kamada, Kei Okada
```
## jsk_pr2_calibration
- No changes
## jsk_pr2_startup

```
* [jsk_pr2_startup] add 73b2 sample launch file
* [jsk_pr2_startup/people_detection.launch] add people tracker
* [jsk_pr2_startup] add rosinstall for jsk pr2
* [jsk_robot] use common database jsk_robot_lifelog, with identify with collection name ROBOT_NAME
* [jsk_pr2_startup/pr2_bringup.launch] use daemon mode mongod for pr2
* change openni namespace to kinect_head
* [jsk_pr2_startup/pr2_gazebo.launch] add initial pose of pr2 in gazebo
* [jsk_pr2_startup] fix typo in pr2.launch
* Contributors: Yuki Furuta, Yuto Inagaki, Chi Wun Aau, Hitoshi Kamada
```
## jsk_robot_startup

```
* [jsk_robot_startup] Modify node name of gmapping and pointcloud_to_laserscan
* [jsk_robot_startup] Add respawn to gmapping
* [jsk_robot_startup] Add angle_max and angle_min arguments to determine horizontal scan range
* [jsk_robot_startup] Fix x, y and yaw of pointcloud_toscan_base to parent, roll and pitch to /odom
* [jsk_robot_startup] Fix roll and pitch angle of cosntant height frame same as /odom
* [jsk_robot_startup] Add gmapping to run_depend
* [jsk_robot_startup] Add scripts and launch files for gmapping
* [jsk_robot_startup] support daemon mode mongod; enable replication to jsk robot-database
* Contributors: Iori Kumagai, Yuki Furuta
```
## jsk_robot_utils
- No changes
## peppereus

```
* since ros-naoqi repository chages names (naoqi_sensors -. naoqi_sensors_py), we removed unstable pacagkes
* [peppereus] Do not run test if no meshes are found
* add sed command of correct spell
* test/test-peppereus.l: add test codes
* Contributors: Kei Okada, Ryohei Ueda, Akira Kako
```
## pr2_base_trajectory_action

```
* remove old rosmake related files
* Contributors: Kei Okada
```
## roseus_remote
- No changes
