### PR TITLE
tiago_moveit_config: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9495,6 +9495,11 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/tiago_moveit_config.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pal-gbp/tiago_moveit_config-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_moveit_config` to `0.0.1-0`:
- upstream repository: https://github.com/pal-robotics/tiago_moveit_config.git
- release repository: https://github.com/pal-gbp/tiago_moveit_config-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## tiago_moveit_config

```
* Tiago first release
* Contributors: Bence Magyar
```
