### PR TITLE
mongodb_store: 0.1.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4511,7 +4511,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.1.12-1
+      version: 0.1.16-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.16-0`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.12-1`
## mongodb_log

```
* add option to treat topic name arguments as regular expression
* add option to specify collection name
* Contributors: Furushchev
```
## mongodb_store

```
* use False as default value of param 'mongodb_use_daemon'
* add option to use already launched mongod
* Fix exception catch.
* Silence wait_for_service.
  This adds some more helpful output if the messages store services can't be found, but produces no output if they are found within 5 seconds.
* Contributors: Chris Burbridge, Yuki Furuta
```
## mongodb_store_msgs
- No changes
