### PR TITLE
mongodb_store: 0.1.16-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1531,6 +1531,21 @@ repositories:
       url: https://github.com/ros-gbp/mongo_cxx_driver-release.git
       version: 1.0.2-1
     status: maintained
+  mongodb_store:
+    release:
+      packages:
+      - mongodb_log
+      - mongodb_store
+      - mongodb_store_msgs
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/strands-project-releases/mongodb_store.git
+      version: 0.1.16-0
+    source:
+      type: git
+      url: https://github.com/strands-project/mongodb_store.git
+      version: hydro-devel
+    status: developed
   moveit_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.16-0`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## mongodb_log

```
* add option to treat topic name arguments as regular expression
* add option to specify collection name
* Contributors: Furushchev
```
## mongodb_store

```
* use False as default value of param 'mongodb_use_daemon'
* add option to use already launched mongod
* Fix exception catch.
* Silence wait_for_service.
  This adds some more helpful output if the messages store services can't be found, but produces no output if they are found within 5 seconds.
* Contributors: Chris Burbridge, Yuki Furuta
```
## mongodb_store_msgs
- No changes
