### PR TITLE
p2os: 2.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2250,7 +2250,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
-      version: 2.0.1-0
+      version: 2.0.2-0
     source:
       type: git
       url: https://github.com/allenh1/p2os.git


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `2.0.2-0`:
- upstream repository: https://github.com/allenh1/p2os
- release repository: https://github.com/allenh1/p2os-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.0.1-0`
## p2os_doc
- No changes
## p2os_driver

```
* Fixed a small issue (but a big problem) in the source.
* Contributors: Hunter Allen
```
## p2os_launch
- No changes
## p2os_msgs
- No changes
## p2os_teleop
- No changes
## p2os_urdf
- No changes
