### PR TITLE
p2os: 2.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5863,7 +5863,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
-      version: 1.0.11-3
+      version: 2.0.2-0
     source:
       type: git
       url: https://github.com/allenh1/p2os.git


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `2.0.2-0`:
- upstream repository: https://github.com/allenh1/p2os
- release repository: https://github.com/allenh1/p2os-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.11-3`
## p2os_doc
- No changes
## p2os_driver

```
* Fixed a small issue (but a big problem) in the source.
* Contributors: Hunter Allen
```
## p2os_launch
- No changes
## p2os_msgs
- No changes
## p2os_teleop
- No changes
## p2os_urdf
- No changes
