### PR TITLE
moveit_plugins: 0.5.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1568,6 +1568,25 @@ repositories:
       url: https://github.com/ros-gbp/moveit_msgs-release.git
       version: 0.6.1-0
     status: developed
+  moveit_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_plugins.git
+      version: indigo-devel
+    release:
+      packages:
+      - moveit_fake_controller_manager
+      - moveit_plugins
+      - moveit_simple_controller_manager
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_plugins-release.git
+      version: 0.5.6-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_plugins.git
+      version: indigo-devel
+    status: maintained
   moveit_python:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_plugins` to `0.5.6-0`:
- upstream repository: https://github.com/ros-planning/moveit_plugins.git
- release repository: https://github.com/ros-gbp/moveit_plugins-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## moveit_fake_controller_manager
- No changes
## moveit_plugins
- No changes
## moveit_simple_controller_manager

```
* Allow simple controller manager to ignore virtual joints without failing
* Contributors: Dave Coleman
```
