### PR TITLE
moveit_planners: 0.6.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1568,6 +1568,24 @@ repositories:
       url: https://github.com/ros-gbp/moveit_msgs-release.git
       version: 0.6.1-0
     status: developed
+  moveit_planners:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_planners.git
+      version: indigo-devel
+    release:
+      packages:
+      - moveit_planners
+      - moveit_planners_ompl
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_planners-release.git
+      version: 0.6.7-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_planners.git
+      version: indigo-devel
+    status: maintained
   moveit_plugins:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_planners` to `0.6.7-0`:
- upstream repository: https://github.com/ros-planning/moveit_planners.git
- release repository: https://github.com/ros-gbp/moveit_planners-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## moveit_planners
- No changes
## moveit_planners_ompl

```
* Changed OMPL SimpleSetup member variable to shared pointer, passed MotionPlanningRequest to child function
* Simplified number of solve() entry points in moveit_planners_ompl
* Fixed uninitialized ptc_ pointer causing a crash.
* renamed newGoal to new_goal for keeping with formatting
* setting GroupStateValidityCallbackFn member for constraint_sampler member and implementing callbacks for state validity checking
* added functions to check validit of state, and also to act as callback for constraint sampler
* Added copy function from MoveIt! robot_state joint values to ompl state
* fix for demo constraints database linking error
* Namespaced less useful debug output to allow to be easily silenced using ros console
* Contributors: Dave Coleman, Dave Hershberger, Sachin Chitta, arjungm
```
