### PR TITLE
nao_moveit_config: 0.0.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1763,6 +1763,21 @@ repositories:
       url: https://github.com/ros-naoqi/nao_meshes.git
       version: master
     status: maintained
+  nao_moveit_config:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/nao_moveit_config.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-naoqi/nao_moveit_config-release.git
+      version: 0.0.5-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/nao_moveit_config.git
+      version: master
+    status: maintained
   nao_robot:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_moveit_config` to `0.0.5-0`:
- upstream repository: https://github.com/ros-nao/nao_moveit_config.git
- release repository: https://github.com/ros-naoqi/nao_moveit_config-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## nao_moveit_config

```
* install the .setup_assistant file for potential introspection
* remove the URDF and fix the README
* add a .setup_assistant
* Added foot and pelvis fake controllers
* Added foot and pelvis controllers
* Contributors: Arguedas Mikael, Konstantinos Chatzilygeroudis, Vincent Rabaud
```
