### PR TITLE
rtabmap/rtabmap_ros: 0.10.4 in '[indigo,jade]/distribution.yaml'

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8422,31 +8422,31 @@ repositories:
     doc:
       type: git
       url: https://github.com/introlab/rtabmap.git
-      version: master
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.8.12-0
+      version: 0.10.4-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
-      version: master
+      version: indigo-devel
     status: maintained
   rtabmap_ros:
     doc:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git
-      version: master
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.8.12-0
+      version: 0.10.4-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git
-      version: master
+      version: indigo-devel
     status: maintained
   rtctree:
     release:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3310,7 +3310,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.9.0-0
+      version: 0.10.4-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -3320,16 +3320,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git
-      version: master
+      version: jade-devel
     release:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.9.0-0
+      version: 0.10.4-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git
-      version: master
+      version: jade-devel
     status: maintained
   rtctree:
     release:


### PR DESCRIPTION
- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
