### PR TITLE
laser_filters: 1.8.0-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1266,11 +1266,19 @@ repositories:
       version: hydro-devel
     status: maintained
   laser_filters:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_filters.git
+      version: jade-devel
     release:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/laser_filters-release.git
-      version: 1.8.0-0
+      version: 1.8.0-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_filters.git
+      version: jade-devel
     status: maintained
   laser_geometry:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `1.8.0-1`:
- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros-gbp/laser_filters-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.8.0-0`
## laser_filters
- No changes
