### PR TITLE
filters: 1.7.4-3 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -664,15 +664,20 @@ repositories:
       version: 0.3.2-1
     status: maintained
   filters:
+    doc:
+      type: git
+      url: https://github.com/ros/filters.git
+      version: hydro-devel
     release:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/filters-release.git
-      version: 1.7.4-2
+      version: 1.7.4-3
     source:
       type: git
       url: https://github.com/ros/filters.git
       version: hydro-devel
+    status: maintained
   find_object_2d:
     doc:
       type: svn


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `1.7.4-3`:
- upstream repository: https://github.com/ros/filters.git
- release repository: https://github.com/ros-gbp/filters-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.7.4-2`
