### PR TITLE
rocon_qt_gui: 0.7.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7384,7 +7384,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_qt_gui-release.git
-      version: 0.7.11-0
+      version: 0.7.12-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_qt_gui.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_qt_gui` to `0.7.12-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_qt_gui.git
- release repository: https://github.com/yujinrobot-release/rocon_qt_gui-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.11-0`
## concert_admin_app
- No changes
## concert_conductor_graph

```
* [concert_conductor_graph] bugfix set_color -> set_node_color, fixes #194 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/194>.
* Contributors: Daniel Stonier
```
## concert_qt_image_stream
- No changes
## concert_qt_make_a_map
- No changes
## concert_qt_map_annotation
- No changes
## concert_qt_service_info
- No changes
## concert_qt_teleop
- No changes
## rocon_gateway_graph
- No changes
## rocon_qt_app_manager
- No changes
## rocon_qt_gui
- No changes
## rocon_qt_library

```
* package dependency patch closes #199 <https://github.com/robotics-in-concert/rocon_qt_gui/issues/199>
* Contributors: Jihoon Lee
```
## rocon_qt_listener
- No changes
## rocon_qt_master_info
- No changes
## rocon_qt_teleop
- No changes
## rocon_remocon
- No changes
