### PR TITLE
geometry_experimental: 0.5.12-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -879,7 +879,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/geometry_experimental-release.git
-      version: 0.5.11-0
+      version: 0.5.12-0
     source:
       type: git
       url: https://github.com/ros/geometry_experimental.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_experimental` to `0.5.12-0`:
- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry_experimental-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.11-0`
## geometry_experimental
- No changes
## tf2

```
* add utilities to get yaw, pitch, roll and identity transform
* provide more conversions between types
  The previous conversion always assumed that it was converting a
  non-message type to a non-message type. Now, one, both or none
  can be a message or a non-message.
* Contributors: Vincent Rabaud
```
## tf2_bullet
- No changes
## tf2_eigen
- No changes
## tf2_geometry_msgs

```
* Merge pull request #112 <https://github.com/ros/geometry_experimental/issues/112> from vrabaud/getYaw
  Get yaw
* add toMsg and fromMsg for QuaternionStamped
* Contributors: Tully Foote, Vincent Rabaud
```
## tf2_kdl

```
* Add kdl::Frame to TransformStamped conversion
* Contributors: Paul Bovbel
```
## tf2_msgs
- No changes
## tf2_py
- No changes
## tf2_ros

```
* remove annoying gcc warning
  This is because the roslog macro cannot have two arguments that are
  formatting strings: we need to concatenate them first.
* break canTransform loop only for non-tiny negative time deltas
  (At least) with Python 2 ros.Time.now() is not necessarily monotonic
  and one can experience negative time deltas (usually well below 1s)
  on real hardware under full load. This check was originally introduced
  to allow for backjumps with rosbag replays, and only there it makes sense.
  So we'll add a small duration threshold to ignore backjumps due to
  non-monotonic clocks.
* Contributors: Vincent Rabaud, v4hn
```
## tf2_sensor_msgs
- No changes
## tf2_tools
- No changes
