### PR TITLE
Add walrus and responses python packages to rosdep db

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1360,6 +1360,10 @@ python-requests:
     vivid_python3: [python3-requests]
     wily: [python-requests]
     wily_python3: [python3-requests]
+python-responses-pip:
+  ubuntu:
+    pip:
+      packages: [responses]
 python-rosdep:
   debian: [python-rosdep]
   fedora: [python-rosdep]
@@ -1891,6 +1895,10 @@ python-vtk:
     trusty: [python-vtk]
     utopic: [python-vtk]
     vivid: [python-vtk]
+python-walrus-pip:
+  ubuntu:
+    pip:
+      packages: [walrus]
 python-websocket:
   ubuntu:
     precise:


### PR DESCRIPTION
Walrus is a redis toolkit for Python.

Responses is a utility library for mocking out the Python requests library.
