### PR TITLE
nodelet_core: 1.9.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5293,7 +5293,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.9.2-0
+      version: 1.9.3-0
     source:
       type: git
       url: https://github.com/ros/nodelet_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.3-0`:
- upstream repository: git://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.9.2-0`
## nodelet

```
* adding support for named nodelet loggers
* nodelet loader: display error messages from both load attempts on failure
* Contributors: Max Schwarz, Tully Foote
```
## nodelet_core

```
* Update bugtracker url
* Contributors: Esteve Fernandez
```
## nodelet_topic_tools
- No changes
