### PR TITLE
multi_level_map: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4798,7 +4798,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/multi_level_map-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/utexas-bwi/multi_level_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multi_level_map` to `0.1.2-0`:
- upstream repository: https://github.com/utexas-bwi/multi_level_map.git
- release repository: https://github.com/utexas-bwi-gbp/multi_level_map-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.1-0`
## multi_level_map
- No changes
## multi_level_map_msgs
- No changes
## multi_level_map_server

```
* set queue_size for rospy Publishers (#7 <https://github.com/utexas-bwi/multi_level_map/issues/7>)
* Contributors: Jack O'Quin
```
## multi_level_map_utils

```
* set queue_size for rospy Publishers (#7 <https://github.com/utexas-bwi/multi_level_map/issues/7>)
* added a parameter for setting the default level. closes #6 <https://github.com/utexas-bwi/multi_level_map/issues/6>.
* level_selector now waits for change_level service to be available before using it. closes #5 <https://github.com/utexas-bwi/multi_level_map/issues/5>
* Contributors: Jack O'Quin, Piyush Khandelwal
```
