### PR TITLE
rviz: 1.10.20-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7994,7 +7994,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.10.19-0
+      version: 1.10.20-0
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.10.20-0`:
- upstream repository: git@github.com:ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.10.19-0`
## rviz

```
* Force and Torque can now be scaled separately in the Wrench display: #862 <https://github.com/ros-visualization/rviz/issues/862>
* Fixed a bug in the Wrench display: #883 <https://github.com/ros-visualization/rviz/issues/883>
* Improved error checking when loading ascii stl files.
* Suppressing some new CMake warnings by setting cmake policies.
* Re-enable most all of the tests.
* Check if position and orientation of links of robots contain NaNs when updating pose of robot links.
* Contributors: Carlos Agüero, Gustavo N Goretkin, Jonathan Bohren, Kei Okada, Ryohei Ueda, William Woodall, louise
```
