### PR TITLE
segbot: 0.3.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8785,11 +8785,16 @@ repositories:
       - segbot_bringup
       - segbot_description
       - segbot_firmware
+      - segbot_gazebo
+      - segbot_gui
+      - segbot_logical_translator
+      - segbot_navigation
       - segbot_sensors
+      - segbot_simulation_apps
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/segbot-release.git
-      version: 0.3.2-0
+      version: 0.3.3-0
     source:
       type: git
       url: https://github.com/utexas-bwi/segbot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot` to `0.3.3-0`:
- upstream repository: https://github.com/utexas-bwi/segbot.git
- release repository: https://github.com/utexas-bwi-gbp/segbot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.2-0`
## segbot

```
* merge segbot_simulator packages into segbot (#46 <https://github.com/utexas-bwi/segbot/issues/46>)
* merge segbot_apps packages into segbot (#46 <https://github.com/utexas-bwi/segbot/issues/46>)
* Contributors: Jack O'Quin
```
## segbot_bringup

```
* segbot_bringup: launch stop controller with segway base (#41 <https://github.com/utexas-bwi/segbot/issues/41>)
* segbot_bringup: pass correct port to Arduino driver
* fixed launch command for arduino and diagnostics. closes #36 <https://github.com/utexas-bwi/segbot/issues/36>.
* segbot_bringup: convert to package format two (#35 <https://github.com/utexas-bwi/segbot/issues/35>)
* segbot_bringup: add diagnostics and arduino to segbot_v2 launch (#35 <https://github.com/utexas-bwi/segbot/issues/35>)
* segbot_bringup: minor launch file cleanup and formatting
* Contributors: Jack O'Quin, Piyush Khandelwal
```
## segbot_description

```
* fixed long standing issue of robot not rotating in place correctly using gazebo_ros_planar_move.
* Contributors: Piyush Khandelwal
```
## segbot_firmware
- No changes
## segbot_gazebo

```
* merge segbot_simulator packages into segbot (#46 <https://github.com/utexas-bwi/segbot/issues/46>)
* Contributors: Jack O'Quin
```
## segbot_gui

```
* merge segbot_apps packages into segbot (#46 <https://github.com/utexas-bwi/segbot/issues/46>)
* Contributors: Jack O'Quin
```
## segbot_logical_translator

```
* merge segbot_apps packages into segbot (#46 <https://github.com/utexas-bwi/segbot/issues/46>)
* Contributors: Jack O'Quin
```
## segbot_navigation

```
* merge segbot_apps packages into segbot (#46 <https://github.com/utexas-bwi/segbot/issues/46>)
* Contributors: Jack O'Quin
```
## segbot_sensors

```
* partial fix to #48 <https://github.com/utexas-bwi/segbot/issues/48>.
* segbot_sensors: lower bettery diagnostics smoothing parameter (#40 <https://github.com/utexas-bwi/segbot/issues/40>)
* segbot_sensors: set rospy.Publisher queue_size (fixes #38 <https://github.com/utexas-bwi/segbot/issues/38>)
* updated kinect launch file to work on both hydro and indigo.
* segbot_sensors: convert to package format two (#35 <https://github.com/utexas-bwi/segbot/issues/35>)
* segbot_sensors: add missing diagnostics dependencies (#35 <https://github.com/utexas-bwi/segbot/issues/35>)
  add launch check for diagnostics script
* segbot_sensors: separate basic arduino launch from test scaffolding (#35 <https://github.com/utexas-bwi/segbot/issues/35>)
* segbot_sensors: use narrower sonar field of view, experimentally measured
* Contributors: Jack O'Quin, Maxwell Svetlik, Piyush Khandelwal
```
## segbot_simulation_apps

```
* merge segbot_simulator packages into segbot (#46 <https://github.com/utexas-bwi/segbot/issues/46>)
* Contributors: Jack O'Quin
```
