### PR TITLE
bwi: 0.3.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -626,7 +626,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/bwi-release.git
-      version: 0.3.1-1
+      version: 0.3.3-0
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi` to `0.3.3-0`:
- upstream repository: https://github.com/utexas-bwi/bwi.git
- release repository: https://github.com/utexas-bwi-gbp/bwi-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.1-1`
## bwi_desktop

```
* delete metapackage dependencies on deprecated repositories (utexas-bwi/segbot#46 <https://github.com/utexas-bwi/segbot/issues/46>)
* Contributors: Jack O'Quin
```
## bwi_desktop_full
- No changes
## bwi_launch
- No changes
