### PR TITLE
ueye_cam: 1.0.10-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -9022,7 +9022,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/anqixu/ueye_cam-release.git
-      version: 1.0.9-0
+      version: 1.0.10-0
     source:
       type: git
       url: https://github.com/anqixu/ueye_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `1.0.10-0`:
- upstream repository: https://github.com/anqixu/ueye_cam.git
- release repository: https://github.com/anqixu/ueye_cam-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.9-0`
## ueye_cam

```
* fixed setting synchronization bugs during camera initialization
* added support for (packed) BGR8 color mode
* failing to set non-essential parameters will no longer prematurily terminate nodelet
* updated printouts to be more verbose and consistent
* fix for reported ARM arch on Fedora
* Contributors: Anqi Xu, Scott K Logan
```
