### PR TITLE
teleop_tools: 0.2.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3635,6 +3635,16 @@ repositories:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git
       version: indigo-devel
+    release:
+      packages:
+      - joy_teleop
+      - key_teleop
+      - teleop_tools
+      - teleop_tools_msgs
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/teleop_tools-release.git
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `0.2.0-0`:
- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros-gbp/teleop_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## joy_teleop

```
* Add example for incrementer
* Update package.xmls
* Add incrementer_server
* Contributors: Bence Magyar
```
## key_teleop

```
* Update package.xmls
* Contributors: Bence Magyar
```
## teleop_tools

```
* Update package.xmls
* Contributors: Bence Magyar
```
## teleop_tools_msgs

```
* Add teleop_tools_msgs
* Contributors: Bence Magyar
```
