### PR TITLE
aruco_ros: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -348,10 +348,20 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/aruco_ros.git
       version: indigo-devel
+    release:
+      packages:
+      - aruco
+      - aruco_msgs
+      - aruco_ros
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/bmagyar/aruco_ros-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/pal-robotics/aruco_ros.git
       version: indigo-devel
+    status: developed
   asctec_mav_framework:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_ros` to `0.0.1-0`:
- upstream repository: https://github.com/pal-robotics/aruco_ros.git
- release repository: https://github.com/bmagyar/aruco_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## aruco

```
* Initial release
* Contributors: Bence Magyar
```
## aruco_msgs

```
* Reorganize aruco_ros into 3 packages
* Contributors: Bence Magyar
```
## aruco_ros

```
* More accurate ROS timestamps (callback triggering time)
  This commit ensures that:
  - all published msgs in a callback have the same timestamp
  - the time is as close as possible to the frame grabbing time (as fast as the marker detection may be, the delay might affect TF interpolation in an unacceptable way for applications like visual servoing)
* Install marker_publisher executable
  This target was missing in the installation rule
* Finished some renaming
* changes to finish branch merge
* aruco_ros: Fixing superfluous (and broken) linker arg to -laruco
* Reorganize aruco_ros into 3 packages
* Contributors: Bence Magyar, Jordi Pages, Josh Langsfeld, ObiWan, Steve Vozar
```
