### PR TITLE
roslint: 0.10.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8092,7 +8092,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/roslint-release.git
-      version: 0.9.3-0
+      version: 0.10.0-0
     source:
       type: git
       url: https://github.com/ros/roslint.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslint` to `0.10.0-0`:
- upstream repository: https://github.com/ros/roslint.git
- release repository: https://github.com/ros-gbp/roslint-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.9.3-0`
## roslint

```
* Updated pep8 from 1.4.7a0 to 1.6.2
* Updated cpplint to the latest version (https://github.com/google/styleguide/tree/554223dc5432f9bd67951cde662f7a023c512dec)
* Fix for falsely reporting do-whiles as an error
* Fixes for access control in structs
* Contributors: Alex Henning, Mike Purvis
```
