### PR TITLE
mavlink: 2015.8.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4050,7 +4050,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: 2015.7.7-0
+      version: 2015.8.8-0
     status: maintained
   mavros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2015.8.8-0`:
- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/mavlink/mavlink-gbp-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2015.7.7-0`
