### PR TITLE
rospilot: 1.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3192,7 +3192,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/rospilot/rospilot-release.git
-      version: 0.2.5-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/rospilot/rospilot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot` to `1.0.0-0`:
- upstream repository: https://github.com/rospilot/rospilot.git
- release repository: https://github.com/rospilot/rospilot-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.5-0`
## rospilot

```
* Switch to H264 codec for streaming and recording
* Fix a variety of minor bugs
* Contributors: Christopher Berner
```
