### PR TITLE
Remove rospilot_deps

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3198,17 +3198,6 @@ repositories:
       url: https://github.com/rospilot/rospilot.git
       version: master
     status: developed
-  rospilot_deps:
-    release:
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/rospilot/rospilot_deps-release.git
-      version: 0.1.2-0
-    source:
-      type: git
-      url: https://github.com/rospilot/rospilot_deps.git
-      version: master
-    status: developed
   rosserial:
     doc:
       type: git


### PR DESCRIPTION
rospilot no longer depends on rospilot_deps, so it's not needed now
