### PR TITLE
rotors_simulator: 2.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8296,7 +8296,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-asl/rotors_simulator-release.git
-      version: 1.1.6-0
+      version: 2.0.0-0
     source:
       type: git
       url: https://github.com/ethz-asl/rotors_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rotors_simulator` to `2.0.0-0`:
- upstream repository: https://github.com/ethz-asl/rotors_simulator.git
- release repository: https://github.com/ethz-asl/rotors_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.6-0`
## rotors_comm
- No changes
## rotors_control

```
* Converted to new mav_comm messages, including new MultiDOFJointTrajectory and PoseStamped as waypoints.
* Added subscriber for MultiDOFJointTrajectory messages and extended waypoint_publisher_file to test it. resolves #243 <https://github.com/ethz-asl/rotors_simulator/issues/243>
* Contributors: Helen Oleynikova, Markus Achtelik
```
## rotors_description

```
* fixed base_link issue with gazebo 2.2
* added a mesh for the vi_camera and fixed the mesh for the vi_sensor
* added possibility to add own meshes of propellers
* updated gazebo links to also contain the namespace
* Contributors: Fadri Furrer, Helen Oleynikova, Michael Burri
```
## rotors_evaluation
- No changes
## rotors_gazebo

```
* Change to use the new datatypes defined in mav_comm.
* Update hummingbird.yaml
  The original 0.68 did not involve the mass of rotors (0.009 each). Now change to 0.68 + 0.009*4
* Added subscriber for MultiDOFJointTrajectory messages and extended waypoint_publisher_file to test it. resolves #243 <https://github.com/ethz-asl/rotors_simulator/issues/243>
* Contributors: Haoyao Chen, Helen Oleynikova, Markus Achtelik
```
## rotors_gazebo_plugins

```
* Changed to new mav_comm messages.
* Changed default topics to be those from mav_msgs/default.h.
* Contributors: Haoyao Chen, Helen Oleynikova, Michael Burri
```
## rotors_joy_interface

```
* Propagate mav_comm changes.
* Contributors: Helen Oleynikova
```
## rotors_simulator
- No changes
