### PR TITLE
ubiquity_motor: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9762,6 +9762,12 @@ repositories:
       url: https://github.com/orocos-toolchain/typelib.git
       version: toolchain-2.8
     status: maintained
+  ubiquity_motor:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
+      version: 0.2.0-0
   ublox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ubiquity_motor` to `0.2.0-0`:
- upstream repository: https://github.com/UbiquityRobotics/ubiquity_motor.git
- release repository: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
