### PR TITLE
rotors_simulator: 2.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8296,7 +8296,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-asl/rotors_simulator-release.git
-      version: 2.0.0-0
+      version: 2.0.1-0
     source:
       type: git
       url: https://github.com/ethz-asl/rotors_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rotors_simulator` to `2.0.1-0`:
- upstream repository: https://github.com/ethz-asl/rotors_simulator.git
- release repository: https://github.com/ethz-asl/rotors_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.0.0-0`
## rotors_comm
- No changes
## rotors_control
- No changes
## rotors_description

```
* fixed the bag plugin and the evaluation
* Contributors: Fadri Furrer
```
## rotors_evaluation

```
* fixed the bag plugin and the evaluation
* Contributors: Fadri Furrer
```
## rotors_gazebo

```
* fixed the bag plugin and the evaluation
* Contributors: Fadri Furrer
```
## rotors_gazebo_plugins

```
* fixed the bag plugin and the evaluation
* Contributors: Fadri Furrer
```
## rotors_joy_interface
- No changes
## rotors_simulator
- No changes
