### PR TITLE
aruco_ros: 0.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -131,7 +131,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/bmagyar/aruco_ros-release.git
-      version: 0.0.1-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/pal-robotics/aruco_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_ros` to `0.1.0-0`:
- upstream repository: https://github.com/pal-robotics/aruco_ros.git
- release repository: https://github.com/bmagyar/aruco_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.1-0`
## aruco

```
* Depend on libopencv-dev directly
* Replace opencv2 dependency with cv_bridge
* Update changelogs and maintainer email
* Add aruco marker generator and opencv dependency
* Remove duplicated images
* Remove old launch files
* Contributors: Bence Magyar
```
## aruco_msgs

```
* Update changelogs and maintainer email
* Contributors: Bence Magyar
```
## aruco_ros

```
* Update changelogs and maintainer email
* Frame parameters only checked when using camera info
* Add marker list publisher
* Remove unused broadcaster
* Only do 3d when there is camera info
* Use waitForMessage for camerainfo
* Remove nonsense assert
* Reorganize and allow no camera_info
* Fix crash when distortion vector is 0 long (usb_cam)
* Contributors: Bence Magyar
```
