### PR TITLE
rosauth: 0.1.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7120,7 +7120,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/wpi-rail-release/rosauth-release.git
-      version: 0.1.6-0
+      version: 0.1.7-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rosauth.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosauth` to `0.1.7-0`:
- upstream repository: https://github.com/WPI-RAIL/rosauth.git
- release repository: https://github.com/wpi-rail-release/rosauth-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.6-0`
## rosauth

```
* Merge pull request #8 from ckrooss/develop
  Added gencpp-dependency for test target
* Added gencpp-dependency for test target
* Contributors: Russell Toris, ckrooss
```
