### PR TITLE
rosauth: 0.1.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3059,7 +3059,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/wpi-rail-release/rosauth-release.git
-      version: 0.1.6-0
+      version: 0.1.7-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rosauth.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosauth` to `0.1.7-0`:
- upstream repository: https://github.com/WPI-RAIL/rosauth.git
- release repository: https://github.com/wpi-rail-release/rosauth-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.6-0`
## rosauth

```
* Merge pull request #8 from ckrooss/develop
  Added gencpp-dependency for test target
* Added gencpp-dependency for test target
* Contributors: Russell Toris, ckrooss
```
