### PR TITLE
Adding report_card to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -810,7 +810,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_bot-release.git
-      version: 0.0.32-0
+      version: 0.0.33-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_bot.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6978,6 +6978,16 @@ repositories:
       type: git
       url: https://github.com/toddhester/rl-texplore-ros-pkg.git
       version: master
+  report_card:
+    doc:
+      type: git
+      url: https://github.com/So-Cool/report_card.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/So-Cool/report_card.git
+      version: master
+    status: maintained
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
I'd like report_card to be indexed and documented on ros.org.
