### PR TITLE
naoqi_bridge: 0.5.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1873,7 +1873,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_bridge-release.git
-      version: 0.5.1-0
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge` to `0.5.2-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_bridge.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.1-0`
## naoqi_apps
- No changes
## naoqi_bridge
- No changes
## naoqi_driver_py

```
* really remove the .xml for diagnostics
* Contributors: Vincent Rabaud
```
## naoqi_pose
- No changes
## naoqi_sensors_py

```
* naoqi_sensors_py no longer contains nodelt plugins
* OCTOMAP: Use binaryMsg for compliance with other octree types.
* SONAR: Fix Sonar FOV.
* Contributors: Kei Okada, lsouchet
```
## naoqi_tools
- No changes
