### PR TITLE
naoqi_driver: 0.5.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1899,7 +1899,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_driver-release.git
-      version: 0.5.0-0
+      version: 0.5.1-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_driver` to `0.5.1-0`:
- upstream repository: https://github.com/ros-naoqi/alrosbridge.git
- release repository: https://github.com/ros-naoqi/naoqi_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.0-0`
## naoqi_driver

```
* rename dump_enabled to log_enabled
* introduce prefix to naoqi driver c'tor
* switch to boost program options
* do not set the log level if it has not changed
* get a more generic way of setting the log level
* publish to diagnostics as it should be
* respect the ROS log level
* cleanup main
* update rviz configuration
* extend teleop for set_angles
* exclude driver helper to cpp for one-call only
* cleanup battery diagnostics
* remove max velocity
* Merge pull request #30 <https://github.com/ros-naoqi/naoqi_driver/issues/30> from laurent-george/patch-1
  fix git repo url
* fix git repo url
  it's a _ not a -
* change doc for renaming to naoqi driver
* renamed files for naoqi_driver
* update doc to correct renaming
* update doc to correct renaming
* add stiffness and fix battery status
* Contributors: George Laurent, Karsten Knese, Vincent Rabaud
* remove legacy code
* fix typo in package.xml
* rename package to naoqi_driver
* remove alrosbridge prefix and cleanup
* fix typo in cmakelist
* Fixes for c++11
* remove naoqi_msgs includes
* fix for correct header include of msgs
* remove deprecation warning
* Contributors: Guillaume JACOB, Karsten Knese, Vincent Rabaud
```
