### PR TITLE
fetch_msgs: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2068,7 +2068,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_msgs-release.git
-      version: 0.5.2-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_msgs` to `0.6.0-0`:
- upstream repository: https://github.com/fetchrobotics/fetch_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.2-0`
## fetch_auto_dock_msgs

```
* add a dock_id field to dock action
* add url to package.xmls
* Contributors: Michael Ferguson
```
## fetch_driver_msgs

```
* add new message for GripperState
* add url to package.xmls
* Contributors: Michael Ferguson
```
