### PR TITLE
nao_extras: 0.3.1-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1774,8 +1774,8 @@ repositories:
       - nao_teleop
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/nao_extras-release.git
-      version: 0.3.0-0
+      url: https://github.com/ros-naoqi/nao_extras-release.git
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_extras.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_extras` to `0.3.1-1`:
- upstream repository: https://github.com/ros-nao/nao_extras.git
- release repository: https://github.com/ros-naoqi/nao_extras-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.0-0`
## nao_extras
- No changes
## nao_path_follower
- No changes
## nao_teleop

```
* publish only when move not zero
* Contributors: Karsten Knese
```
