### PR TITLE
teb_local_planner: 0.1.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9380,7 +9380,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
-      version: 0.1.9-0
+      version: 0.1.10-0
     source:
       type: git
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner` to `0.1.10-0`:
- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.9-0`
## teb_local_planner

```
* The optimizer copies the global plan as initialization now instead of using a simple straight line approximation.
* Some bugfixes and improvements
```
