### PR TITLE
mav_comm: 3.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1457,6 +1457,24 @@ repositories:
       url: https://github.com/ros-gbp/manipulation_msgs-release.git
       version: 0.2.0-0
     status: maintained
+  mav_comm:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/mav_comm.git
+      version: master
+    release:
+      packages:
+      - mav_comm
+      - mav_msgs
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ethz-asl/mav_comm-release.git
+      version: 3.0.0-0
+    source:
+      type: git
+      url: https://github.com/ethz-asl/mav_comm.git
+      version: master
+    status: developed
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mav_comm` to `3.0.0-0`:
- upstream repository: https://github.com/ethz-asl/mav_comm.git
- release repository: https://github.com/ethz-asl/mav_comm-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## mav_comm

```
* Changed API for mav_msgs, see mav_msgs changelog for details.
```
## mav_msgs

```
* Dropped "Command" from the names of all messages.
* Converted CommandPositionYawTrajectory message to MultiDOFJointTrajectory (with an additional option to use a geometry_msgs/PoseStamped instead) as the two ways to send trajectory/waypoint commands.
* Added conversions between the Eigen and ROS message types.
* Switched to using full orientation instead of just yaw where appropriate.
* Documented reference frame in the Eigen messages where possible.
* Contributors: Helen Oleynikova, Markus Achtelik
```
