### PR TITLE
youbot_simulation: 0.8.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10505,6 +10505,17 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/youbot-release/youbot_driver-release.git
       version: 1.1.0-0
+  youbot_simulation:
+    release:
+      packages:
+      - youbot_gazebo_control
+      - youbot_gazebo_robot
+      - youbot_gazebo_worlds
+      - youbot_simulation
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/youbot-release/youbot_simulation-release.git
+      version: 0.8.0-0
   yujin_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `youbot_simulation` to `0.8.0-0`:
- upstream repository: https://github.com/youbot/youbot_simulation
- release repository: https://github.com/youbot-release/youbot_simulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
