### PR TITLE
Add python modules required for rospeex in rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -118,6 +118,19 @@ python-argparse:
       packages: []
     vivid:
       packages: []
+python-autobahn:
+  debian:
+    pip:
+      packages: [autobahn]
+  fedora:
+    pip:
+      packages: [autobahn]
+  osx:
+    pip:
+      packages: [autobahn]
+  ubuntu:
+    pip:
+      packages: [autobahn]
 python-avahi:
   arch: [avahi]
   debian: [python-avahi]


### PR DESCRIPTION
The modules are required for the next version of rospeex, which will be updated later.
