### PR TITLE
Add python modules required for rospeex in rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -118,6 +118,42 @@ python-argparse:
       packages: []
     vivid:
       packages: []
+python-autobahn:
+  debian: [python-autobahn]
+  fedora:
+    pip:
+      packages: [autobahn]
+  osx:
+    pip:
+      packages: [autobahn]
+  ubuntu:
+    lucid:
+      pip:
+        packages: [autobahn]
+    maverick:
+      pip:
+        packages: [autobahn]
+    natty:
+      pip:
+        packages: [autobahn]
+    oneiric:
+      pip:
+        packages: [autobahn]
+    precise:
+      pip:
+        packages: [autobahn]
+    quantal:
+      pip:
+        packages: [autobahn]
+    raring:
+      pip:
+        packages: [autobahn]
+    saucy:
+      pip:
+        packages: [autobahn]
+    trusty: [python-autobahn]
+    utopic: [python-autobahn]
+    vivid: [python-autobahn]
 python-avahi:
   arch: [avahi]
   debian: [python-avahi]


### PR DESCRIPTION
The modules are required for the next version of rospeex, which will be updated later.
