### PR TITLE
roslisp: 1.9.19-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3184,7 +3184,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/roslisp-release.git
-      version: 1.9.18-0
+      version: 1.9.19-0
     source:
       type: git
       url: https://github.com/ros/roslisp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp` to `1.9.19-0`:
- upstream repository: git://github.com/ros/roslisp.git
- release repository: https://github.com/ros-gbp/roslisp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.9.18-0`
## roslisp

```
* Merge pull request #25 <https://github.com/ros/roslisp/issues/25> from airballking/symbol-codes
  roslisp-msg-protocol: looking up symbols from constants
* Followed Gaya's suggestion of throwing an error if no symbol-code with the requested code can be found in (code-symbol ...).
* Merge pull request #26 <https://github.com/ros/roslisp/issues/26> from gaya-/deprecated-quit
  Replaced deprecated SB-EXT:QUIT with SB-EXT:EXIT
* Merge pull request #19 <https://github.com/ros/roslisp/issues/19> from gaya-/master
  Fixed the outdated executables generation pipeline
* Replaced deprecated SB-EXT:QUIT with SB-EXT:EXIT
* Contributors: Dirk Thomas, Gayane Kazhoyan, Georg Bartels
```
