### PR TITLE
rtmros_hironx: 1.0.35-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8519,7 +8519,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.34-0
+      version: 1.0.35-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.35-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.34-0`
## hironx_calibration
- No changes
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* [feat] show Hrpsys host controller version info
* [sys] Install missing older IDL (hrpsys_315_1_9.hrpsys) to increase compatibility with older version of hrpsys host
* [test] Generalization, add some robust tests (test_set_target_pose_relative_333 will be fail for old hrpsys https://github.com/start-jsk/rtmros_hironx/pull/334)
* Contributors: Kei Okada, Isaac IY Saito
```
## rtmros_hironx

```
* [feat] show Hrpsys host controller version info
* [sys] Install missing older IDL (hrpsys_315_1_9.hrpsys) to increase compatibility with older version of hrpsys host
* [test] Generalization, add some robust tests (test_set_target_pose_relative_333 will be fail for old hrpsys https://github.com/start-jsk/rtmros_hironx/pull/334)
* Contributors: Kei Okada, Isaac IY Saito
```
