### PR TITLE
rosbridge_suite: 0.7.13-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3104,7 +3104,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.7.12-0
+      version: 0.7.13-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.7.13-0`:
- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.12-0`
## rosapi

```
* Fix catkin_lint issues
* Contributors: Matt Vollrath
```
## rosbridge_library

```
* Nevermind o_O
* Add test_depend too (just in case)
* Add dependency on python bson
* Get parameter at encode time
* Add flag for using the bson encoding
* revert comment regarding unpublisher
* avoiding racing condition
* Add bson encoding to the server side
* Fix catkin_lint issues
* don't unregister topic from rosbridge. It creates md5 sum warning.. #138
* Contributors: David Lu, Jihoon Lee, Matt Vollrath, dwlee
```
## rosbridge_server

```
* Add bson encoding to the server side
* Add default strings for certfile and keyfile
  This allows downstream packages with roslaunch_add_file_check tests to pass.
* Fix whitespace in RosbridgeTcpHandler
* Modularize RosbridgeTcpSocket
* Modularize RosbridgeWebSocket
* add shutdown handling to rosbridge_tcp and make rosbridge_websocket more robust
* Removed space from empty line.
  Thanks @T045T
* Stop IOLoop on shutdown.
* Contributors: Benny, David Lu, Matt Vollrath, Nils Berg, Paul Bovbel
```
## rosbridge_suite
- No changes
