### PR TITLE
rwt_config_generator: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8753,6 +8753,21 @@ repositories:
       url: https://github.com/davetcoleman/rviz_visual_tools.git
       version: indigo-devel
     status: developed
+  rwt_config_generator:
+    doc:
+      type: git
+      url: https://github.com/DLu/rwt_config_generator.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wu-robotics/rwt_config_generator-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/DLu/rwt_config_generator.git
+      version: master
+    status: maintained
   rwt_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rwt_config_generator` to `0.0.1-0`:
- upstream repository: https://github.com/DLu/rwt_config_generator.git
- release repository: https://github.com/wu-robotics/rwt_config_generator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
