### PR TITLE
rtmros_nextage: 0.6.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7865,7 +7865,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.6.2-1
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.6.3-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.2-1`
## nextage_description
- No changes
## nextage_moveit_config

```
* [feat] Add botharms' MoveIt! group.
* Contributors: Isaac IY Saito
```
## nextage_ros_bridge
- No changes
## rtmros_nextage

```
* [feat] Add botharms' MoveIt! group.
* Contributors: Isaac IY Saito
```
