### PR TITLE
gazebo_ros_pkgs: 2.4.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2243,7 +2243,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.4.8-0
+      version: 2.4.9-0
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.4.9-0`:
- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.4.8-0`
## gazebo_msgs
- No changes
## gazebo_plugins

```
* Adds range plugin for infrared and ultrasound sensors from PAL Robotics
* Import changes from jade-branch
* Add range world and launch file
* Add ifdefs to fix build with gazebo2
* Use Joint::SetParam for joint velocity motors
* Set GAZEBO_CXX_FLAGS to fix c++11 compilation errors
* Contributors: Bence Magyar, Jose Luis Rivero, Steven Peters
```
## gazebo_ros

```
* Import changes from jade-branch
* Add range world and launch file
* fix crash
* Set GAZEBO_CXX_FLAGS to fix c++11 compilation errors
* Contributors: Bence Magyar, Ian Chen, Jose Luis Rivero, Steven Peters
```
## gazebo_ros_control

```
* Import changes from jade-branch
* add missing dependencies
* Fix DefaultRobotHWSim puts robotNamespace twice
  DefaultRobotHWSim::initSim() member function uses both
  namespaced NodeHandle and robot_namespace string to create
  parameter names.
  For example,  if a robotNamespace is "rrbot",
  DefaultRobotHWSim tries to get parameters from following names:
  - /rrbot/rrbot/gazebo_ros_control/pid_gains/*
  - /rrbot/rrbot/joint_limits/*
  This commit change these names to:
  - /rrbot/gazebo_ros_control/pid_gains/*
  - /rrbot/joint_limits/*
* Add ifdefs to fix build with gazebo2
  It was broken by #315 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/315>.
  Fixes #321 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/321>.
* Use Joint::SetParam for joint velocity motors
  Before gazebo5, Joint::SetVelocity and SetMaxForce
  were used to set joint velocity motors.
  The API has changed in gazebo5, to use Joint::SetParam
  instead.
  The functionality is still available through the SetParam API.
* Set GAZEBO_CXX_FLAGS to fix c++11 compilation errors
* Contributors: Akiyoshi Ochiai, Jose Luis Rivero, Steven Peters, ipa-fxm
```
## gazebo_ros_pkgs
- No changes
