### PR TITLE
Declare the gazebo5 rosdep keys for fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -725,6 +725,7 @@ gazebo:
     trusty: [gazebo2]
 gazebo5:
   arch: [gazebo]
+  fedora: [gazebo]
   gentoo: [sci-electronics/gazebo]
   ubuntu: [gazebo5]
 gcc-avr:
@@ -1322,6 +1323,7 @@ libftgl-dev:
   ubuntu: [libftgl-dev]
 libgazebo5-dev:
   arch: [gazebo]
+  fedora: [gazebo-devel]
   gentoo: [sci-electronics/gazebo]
   ubuntu: [libgazebo5-dev]
 libgflags-dev:


### PR DESCRIPTION
I found a problem when releasing gazebo_ros_pkgs with missing fedora rosdep keys:

```
Failed to resolve gazebo5 on fedora:21 with: Error running generator: Failed to resolve rosdep key 'gazebo5', aborting.
gazebo5 is depended on by these packages: ['gazebo_plugins', 'gazebo_ros']
<== Failed
Could not resolve rosdep key 'gazebo5' for distro '22':
No definition of [gazebo5] for OS [fedora]
    rosdep key : gazebo5
    OS name    : fedora
    OS version : 22
    Data: arch:
- gazebo
gentoo:
- sci-electronics/gazebo
ubuntu:
- gazebo5

Failed to resolve gazebo5 on fedora:22 with: Error running generator: Failed to resolve rosdep key 'gazebo5', aborting.
gazebo5 is depended on by these packages: ['gazebo_plugins', 'gazebo_ros']
<== Failed
Could not resolve rosdep key 'libgazebo5-dev' for distro '21':
No definition of [libgazebo5-dev] for OS [fedora]
    rosdep key : libgazebo5-dev
    OS name    : fedora

    OS version : 21
    Data: arch:
- gazebo
gentoo:
- sci-electronics/gazebo
ubuntu:
- libgazebo5-dev

Failed to resolve libgazebo5-dev on fedora:21 with: Error running generator: Failed to resolve rosdep key 'libgazebo5-dev', aborting.
libgazebo5-dev is depended on by these packages: ['gazebo_plugins', 'gazebo_ros']
<== Failed
Could not resolve rosdep key 'libgazebo5-dev' for distro '22':
No definition of [libgazebo5-dev] for OS [fedora]
    rosdep key : libgazebo5-dev
    OS name    : fedora
    OS version : 22
    Data: arch:
```

This pull request should fix the problem.
