### PR TITLE
gazebo_ros_pkgs: 2.5.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -741,7 +741,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.5.0-0
+      version: 2.5.1-0
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.5.1-0`:
- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.5.0-0`
## gazebo_msgs
- No changes
## gazebo_plugins

```
* Port of Pal Robotics range sensor plugin to Jade
* Added a comment about the need of libgazebo5-dev in runtime
* Added gazebo version check
* Added missing files
* Added elevator plugin
* Use c++11
* run_depend on libgazebo5-dev (#323 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/323>)
  Declare the dependency.
  It can be fixed later if we don't want it.
* Contributors: Jose Luis Rivero, Nate Koenig, Steven Peters
* Port of Pal Robotics range sensor plugin to Jade
* Added a comment about the need of libgazebo5-dev in runtime
* Added gazebo version check
* Added missing files
* Added elevator plugin
* Use c++11
* run_depend on libgazebo5-dev
* Contributors: Jose Luis Rivero, Nate Koenig, Steven Peters
```
## gazebo_ros

```
* Port of Pal Robotics range sensor plugin to Jade
* Added a comment about the need of libgazebo5-dev in runtime
* Added missing files
* Added elevator plugin
* Use c++11
* run_depend on libgazebo5-dev (#323 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/323>)
  Declare the dependency.
  It can be fixed later if we don't want it.
* Contributors: Jose Luis Rivero, Nate Koenig, Steven Peters
* Port of Pal Robotics range sensor plugin to Jade
* Added a comment about the need of libgazebo5-dev in runtime
* Added missing files
* Added elevator plugin
* Use c++11
* run_depend on libgazebo5-dev
* Contributors: Jose Luis Rivero, Nate Koenig, Steven Peters
```
## gazebo_ros_pkgs
- No changes
