### PR TITLE
jsk_robot: 0.0.10-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3582,7 +3582,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_robot-release.git
-      version: 0.0.9-0
+      version: 0.0.10-1
     status: developed
   jsk_roseus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `0.0.10-1`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.9-0`
## baxtereus
- No changes
## jsk_201504_miraikan
- No changes
## jsk_baxter_desktop
- No changes
## jsk_baxter_startup

```
* Revert "[jsk_robot] unified database"
* Contributors: Yuki Furuta
```
## jsk_baxter_web
- No changes
## jsk_nao_startup

```
* jsk_nao_startup/CMakeLists.txt : remove naoqi_driver from find_package
* Contributors: Kei Okada
```
## jsk_pepper_startup
- No changes
## jsk_pr2_calibration
- No changes
## jsk_pr2_startup

```
* [jsk_pr2_startup] logging images/pointclouds/tf/jointstates/people
* [jsk_pr2_startup] enable logging pr2_gripper_action
* [jsk_pr2_startup] add pr2 heightmap sample launch
* [jsk_pr2_startup/package.xml] add missing deps for pr2
* [jsk_pr2_startup/pr2_gazebo.launch] use relay/republish instead of rgbd_launch for creating rectified images
* [jsk_pr2_startup/package.xml] add social_navigation_layers to run_depends
* [jsk_robot_startup] use param "robot/name"
  [jsk_pr2_startup] use daemon mongod
* Revert "[jsk_robot] unified database"
* [jsk_pr2_startup/jsk_pr2.rosinstall] add temporal missing package mongodb_store
* Contributors: Yuki Furuta, Yuto Inagaki
```
## jsk_robot_startup

```
* [jsk_robot_startup] fix camera namespace openni -> kinect_head
* [jsk_robot_startup] Add odometry accuracy parameters for gmapping
* [jsk_robot_startup] Add scripts to reset slam and heightmap according to /odom_init_trigger
  topic
* [jsk_robot_startup] Add gmapping.rviz for gmapping.launch
* [jsk_robot_startup] Add delta/particle/minimum_score parameters for gmapping
* [jsk_robot_startup] use param "robot/name"
  [jsk_pr2_startup] use daemon mongod
* [jsk_robot_startup] Add rate param to modify tf publish rate and set 10.0 as defalut
* add run depend for mapping
* [jsk_robot_startup] Enable inf value in pointcloud_to_laserscan to prevent robot from obtaining wrong obstacles
* Contributors: Yuki Furuta, Ryohei Ueda, Yu Ohara, Iori Kumagai
```
## jsk_robot_utils
- No changes
## peppereus

```
* do not add naoqi_driver in find_package
* pepper-interface.l: use naoqi_bridge_msgs, but if not found use naoqi_msgs
* CMakeLists.txt, package.xml: add nao_interaction_msgs
* add depends to naoqi_driver
* roseus/CMakeLists.txt: add rostest, roseus to find_pakcage
* Contributors: Kei Okada
```
## pr2_base_trajectory_action
- No changes
## roseus_remote
- No changes
