### PR TITLE
force_torque_tools: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2182,7 +2182,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/force_torque_tools-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/kth-ros-pkg/force_torque_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `force_torque_tools` to `1.0.2-0`:
- upstream repository: https://github.com/kth-ros-pkg/force_torque_tools.git
- release repository: https://github.com/tork-a/force_torque_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.1-0`
## force_torque_sensor_calib

```
* Add missing install rules
* Contributors: Isaac IY Saito
```
## force_torque_tools

```
* [fix] Add missing install rules
* [sys] Redundant maintainer names
* Contributors: Isaac IY Saito
```
## gravity_compensation

```
* [fix] Add missing install rules
* [sys] Redundant maintainer names
* Contributors: Isaac IY Saito
```
