### PR TITLE
ueye_cam: 1.0.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9847,7 +9847,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/anqixu/ueye_cam-release.git
-      version: 1.0.10-0
+      version: 1.0.11-0
     source:
       type: git
       url: https://github.com/anqixu/ueye_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `1.0.11-0`:
- upstream repository: https://github.com/anqixu/ueye_cam.git
- release repository: https://github.com/anqixu/ueye_cam-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.10-0`
## ueye_cam

```
* updated barebones IDS drivers to 4.61
* removed barebones IDS drivers from debian packaging
* Added proper checking for C++11 features on compilers
* Performed minor code cleanup, updated old PLUGINLIB_DECLARE_CLASS to
  newer PLUGINLIB_EXPORT_CLASS
* Contributors: Anqi Xu, Aris Synodinos
```
