### PR TITLE
mavros: 0.14.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4381,11 +4381,12 @@ repositories:
       - libmavconn
       - mavros
       - mavros_extras
+      - mavros_msgs
       - test_mavros
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.13.1-0
+      version: 0.14.0-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.14.0-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.13.1-0`
## libmavconn
- No changes
## mavros

```
* python: call of mavros.set_namespace() is required.
* scripts: mavftp fix #357 <https://github.com/mavlink/mavros/issues/357>: add verify command
* scripts: mavftp #357 <https://github.com/mavlink/mavros/issues/357>: progressbar on download operation
* scripts: mavftp #357 <https://github.com/mavlink/mavros/issues/357>: progress bar for upload operation.
* scripts: mavftp: New command cd.
  All path arguments now may handle relative paths.
* readme: fix frame tansform section
* mavros: readme: update info on frame conversions
* mavros: readme: update contribution steps
* node: Replace deprecated copy functions.
  Also allow mavlink to & from topics to be namespaced.
* extras: scripts: use API from mavros module
* scripts: fix for new message location
* python: update mavros lib to new message location
* package: remove not exist dependency
* plugin: waypoint: Fix message include
* plugin: vfr_hud: Fix message include
* plugin: rc_io: Fix message include
* plugin: param: Fix message include
* plugin: ftp: Fix message include
* plugin: sys_status: Fix message include
* plugin: command: Fix message include
* plugin: 3dr_radio: Fix message include
* plugin: actuator_control: Fix message include.
* msgs: update copyright year
* msgs: deprecate mavros::Mavlink and copy utils.
* msgs: change description, make catkin lint happy
* msgs #354 <https://github.com/mavlink/mavros/issues/354>: move all messages to mavros_msgs package.
* Minor typo fix.
* node: increase diag timer to 2 Hz
* node: move diagnostic to AsyncSpinner threads.
* Contributors: TSC21, Tony Baltovski, Vladimir Ermakov
```
## mavros_extras

```
* extras: gcs node: replace deprecated copy function
* extras: scripts: use API from mavros module
* package: remove not exist dependency
* extras: vibration: Fix message include
* extras: px4flow: Fix message include
* extras: cam_imu_sync: Fix message include
* extras: update package description
* msgs: deprecate mavros::Mavlink and copy utils.
* msgs #354 <https://github.com/mavlink/mavros/issues/354>: move all messages to mavros_msgs package.
* opencv 3.0/2.4 header compatibility
* fix orientation empty error
* Contributors: Vladimir Ermakov, andre-nguyen, v01d
```
## mavros_msgs

```
* msgs: Add mixer group constants ActuatorControl
* msgs: Add notes to message headers.
* msgs: sort msgs in alphabetical order
* msgs: use std::move for mavlink->ros convert
* msgs: add note about convert function
* msgs: change description, make catkin lint happy
* msgs: move convert functions to msgs package.
* msgs: fix message generator and runtime depent tags
* msgs: remove never used Mavlink.fromlcm field.
* msgs: add package name for all non basic types
* msgs: fix msgs build
* msgs #354 <https://github.com/mavlink/mavros/issues/354>: move all messages to mavros_msgs package.
* Contributors: Vladimir Ermakov
```
## test_mavros

```
* test fix #368 <https://github.com/mavlink/mavros/issues/368>: use mavros.setpoint module in demo
* test: #368 <https://github.com/mavlink/mavros/issues/368>: initial import of setpoint_demo.py
* test: Fix library name.
* test_mavros: pid_controller: declare PID variables as local
* test_mavros: move headers to include/test_mavros and setup for install
* test_mavros: removed pid_controller as lib; instantiate object so to use on offboard test
* test_mavros: CMakeLists: small ident correction
* test_mavros: pid_controller: include <array> so to make Travis happy
* test_mavros: added PID controller utility for velocity control on tests
* test_mavros: changed test_type to test_setup; namespace also
* Contributors: TSC21, Vladimir Ermakov
```
