### PR TITLE
graspit_ros: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2497,7 +2497,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/graspit_ros-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     status: developed
   grid_map:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `graspit_ros` to `0.3.1-0`:
- upstream repository: https://github.com/roamlab/graspit-ros.git
- release repository: https://github.com/ros-gbp/graspit_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.0-0`
