### PR TITLE
update openssl/ca-certificates

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -394,6 +394,8 @@ bzip2:
   rhel: [bzip2-devel]
   ubuntu: [libbz2-dev]
 ca-certificates:
+  debian: [ca-certificates]
+  fedora: [ca-certificates]
   ubuntu: [ca-certificates]
 catkin_pkg:
   gentoo:
@@ -2735,6 +2737,8 @@ openssh-server:
   fedora: [openssh-server]
   ubuntu: [openssh-server]
 openssl:
+  debian: [openssh]
+  fedora: [openssh]
   ubuntu: [openssh]
 osm2pgsql:
   fedora: [osm2pgsql]


### PR DESCRIPTION
add fedra/debian for openssl and ca-certificates (https://github.com/ros/rosdistro/pull/8864)
