### PR TITLE
jsk_3rdparty: 2.0.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1192,7 +1192,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.0.3-0
+      version: 2.0.4-0
     status: developed
   jsk_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.0.4-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.0.3-0`
## assimp_devel

```
* add ca-certificates for https download
* Contributors: Kei Okada
```
## bayesian_belief_networks
- No changes
## collada_urdf_jsk_patch

```
* collada_urdf_jsk_patch/Makefile: use catkin build to compile robot_model
* Contributors: Kei Okada
```
## downward
- No changes
## ff

```
* add ca-certificates for https download
* Contributors: Kei Okada
```
## ffha
- No changes
## jsk_3rdparty
- No changes
## julius
- No changes
## libcmt
- No changes
## libsiftfast
- No changes
## mini_maxwell
- No changes
## nlopt
- No changes
## opt_camera
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## voice_text
- No changes
