### PR TITLE
jsk_roseus: 1.3.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3347,12 +3347,13 @@ repositories:
       packages:
       - jsk_roseus
       - roseus
+      - roseus_mongo
       - roseus_smach
       - roseus_tutorials
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.3.6-0
+      version: 1.3.7-0
     status: developed
   jsk_visualization:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.3.7-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.3.6-0`
## jsk_roseus

```
* adding build_depends to package.xml was wrong.
```

  WARNING: Metapackage "jsk_roseus" should not have other dependencies besides a buildtool_depend on catkin and run_depends.

```
* [package.xml] add build depend to roseus to avoid race condition on creating .catkin file
* Contributors: Kei Okada
```
## roseus

```
* geneus stuff

    * [cmake/get_all_depends.py] hydro releaes still uses 2.2.2, so we need to update pkg_map
    * [cmake/roseus.cmake] display eus-related package version
    * [cmake/roseus.cmake] call find_package  to get ${_pkg}_PREFIX
    * [cmake/roseus.cmake] fix for get_all_depends in installed space
    * [cmake/roseus.cmake] Set CMAKE_PREFIX_PATH to run generate all deps
    * [cmake/roseus.cmake] Add condition for roseus_SOURCE_PREFIX when building roseus
    * [cmake/roseus.cmake] Add macro(_package_depends_impl) in roseus.cmake
    * [cmake/get_all_depends.py] Add cmake/get_all_depends.py to get all implicit depends

* marker conversion
  * [euslisp/roseus-utils.l] fix eusobj->marker-msg 's check body type
  * [euslisp/roseus-utils.l] remove debug code (marker-msg->shape)
* test codes
  * [test/test-roseus.l] add test for irtpointcloud
  * [test/test-roseus.l] add test code for marker message <-> eus object conversion function in euslisp/roseus-utils.l
  * [test/test-genmsg.sh, test/test-genmsg.catkin.test] check after remove messages in devel/share/roseus/ros
  * [test/test-genmsg.sh] add test to check if messages in roseus is generated
  * [roseus/test/test-rosues.l] make-random-pointcloud is only available on jskeus 1.0.9
* build system
* [roseus/CMakeLists.txt] somehow regex in if statemet must be double quated?
* [roseus/cmake/roseus.cmake] Unset DISPLAY environmental variable when generating eusdoc to avoid init-xwindow error
* [roseus] Add .gitignore
* Contributors: Kei Okada, Kentaro Wada, Ryohei Ueda, Yohei Kakiuchi, Yuto Inagaki
```
## roseus_mongo

```
* [roseus_mongo/euslisp/json/json-decode.l] use keyword for key as default
* [roseus_mongo] support immediate replicatation function
* [roseus_mongo] avoid reserved function name delete -> delete-by-id
* [roseus_mongo] use "mongodb/database" and "robot/name" as default db/collection name
* [roseus_mongo] bugfix: support convert  to calendar-date object
* [roseus_mongo] add mongodb client for roseus
* Contributors: Yuki Furuta
```
## roseus_smach

```
* [README.md] describe how to run smach viewer
* [sample/state-machine-ros-sample.l, sample/state-machine-sample.l] add shbang
* [roseus_smach/CMakeLists.txt] disable test/test_parallel_state_machine_sample.launch for now
* [package.xml] add actionlib_tutorials depends to roseus_smach
* Contributors: Kei Okada
```
## roseus_tutorials
- No changes
