### PR TITLE
librms: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3785,7 +3785,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/wpi-rail-release/librms-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/librms.git


### PR DESCRIPTION
Increasing version of package(s) in repository `librms` to `0.0.3-0`:
- upstream repository: https://github.com/WPI-RAIL/librms.git
- release repository: https://github.com/wpi-rail-release/librms-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.2-0`
## librms

```
* Merge pull request #2 from jpgr87/develop
  Use find_library to detect libmysqlclient
* Use find_library to detect libmysqlclient
  Fedora packages libmysqlclient.so in the mysql subdirectory of the
  system library directory, which means that passing -lmysqlclient
  to the linker will result in a linking error.  This commit adds
  logic to search for libmysqlclient.so on the current library paths
  as well as the system-wide path /usr/lib/mysql.
  Signed-off-by: Rich Mattes <mailto:richmattes@gmail.com>
* Contributors: Rich Mattes, Russell Toris
```
