### PR TITLE
carl_moveit: 0.0.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -855,7 +855,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_moveit-release.git
-      version: 0.0.15-0
+      version: 0.0.16-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_moveit` to `0.0.16-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_moveit.git
- release repository: https://github.com/wpi-rail-release/carl_moveit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.15-0`
## carl_moveit

```
* Added store pose to the store action, instead of hardcoding it to CARL's storage platform
* re-enabled collision object generation from segmented objects
* Moved obtain object to carl_demos, as it probably won't be re-used anywhere
* adjusted wiping motion
* changed wiping motion
* changed wiping motion
* updated gripper orientation
* started wipe server
* Added wipe surface action
* Updated store action
* Debugging store action
* Debugging store action.
* Added a pickup action where an object name can be specified
* Detached picked up objects on store action execution
* store bug fix
* store bug fix
* Added store action for storing objects in a container on CARL's platform
* Update .travis.yml
* Contributors: David Kent, Russell Toris
```
