### PR TITLE
carl_demos: 0.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -825,7 +825,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/carl_demos-release.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/carl_demos.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_demos` to `0.0.8-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_demos.git
- release repository: https://github.com/wpi-rail-release/carl_demos-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.7-0`
## carl_demos

```
* update
* Merge branch 'develop' of github.com:WPI-RAIL/carl_demos into develop
* Added fruit basket task
* Update .travis.yml
* Update .travis.yml
* Update .travis.yml
* Update .travis.yml
* Update .travis.yml
* Update .travis.yml
* Moved obtain object action into demos
* Updated surface link name
* Used Kinova home to get out of a bad position
* updated sequential tasks demo for packing a schoolbag
* debugging sequential task executer
* Merge branch 'develop' of github.com:WPI-RAIL/carl_demos into develop
* Added a sequential task executor for preprogrammed demo tasks.
* Contributors: David Kent
```
