### PR TITLE
rail_pick_and_place: 1.1.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2682,7 +2682,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
-      version: 1.1.7-0
+      version: 1.1.8-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rail_pick_and_place.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_pick_and_place` to `1.1.8-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_pick_and_place.git
- release repository: https://github.com/wpi-rail-release/rail_pick_and_place-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.7-0`
## graspdb
- No changes
## rail_grasp_collection
- No changes
## rail_pick_and_place
- No changes
## rail_pick_and_place_msgs
- No changes
## rail_pick_and_place_tools
- No changes
## rail_recognition

```
* Merge branch 'develop' of github.com:WPI-RAIL/rail_pick_and_place into develop
* 2D image recognition added
* Contributors: David Kent
```
