### PR TITLE
web_video_server: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10282,7 +10282,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/web_video_server-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/RobotWebTools/web_video_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `web_video_server` to `0.0.4-0`:
- upstream repository: https://github.com/RobotWebTools/web_video_server.git
- release repository: https://github.com/RobotWebTools-release/web_video_server-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.3-0`
## web_video_server

```
* Merge pull request #16 from mitchellwills/compressed
  Adds support for streaming ROS compressed image topics without the need to reencode them
* Switch to checkout async_web_server_cpp from source
* Upgrade for change in signature of async_web_server_cpp request handler
* Added ros compressed video streamer type
  This directly passes the ros compressed frame data to the http socket without reencoding it
* Switched from passing image transport to passing node handle to streamer constructors
* Added default transport parameter for regular image streamers
* Contributors: Mitchell Wills, Russell Toris
```
