### PR TITLE
wpi_jaco: 0.0.24-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10427,7 +10427,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/wpi_jaco-release.git
-      version: 0.0.23-0
+      version: 0.0.24-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/wpi_jaco.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wpi_jaco` to `0.0.24-0`:
- upstream repository: https://github.com/RIVeR-Lab/wpi_jaco.git
- release repository: https://github.com/wpi-rail-release/wpi_jaco-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.23-0`
## jaco_description

```
* reverted changelog
* changelog updated
* Contributors: Russell Toris
```
## jaco_interaction

```
* reverted changelog
* changelog updated
* Contributors: Russell Toris
```
## jaco_moveit_config

```
* reverted changelog
* changelog updated
* Contributors: Russell Toris
```
## jaco_sdk

```
* reverted changelog
* changelog updated
* Contributors: Russell Toris
```
## jaco_teleop

```
* reverted changelog
* changelog updated
* Contributors: Russell Toris
```
## mico_description

```
* reverted changelog
* changelog updated
* Contributors: Russell Toris
```
## mico_moveit_config

```
* reverted changelog
* changelog updated
* Contributors: Russell Toris
```
## wpi_jaco

```
* reverted changelog
* changelog updated
* Updated metapackage run dependencies
* Contributors: David Kent, Russell Toris
```
## wpi_jaco_msgs

```
* reverted changelog
* changelog updated
* Contributors: Russell Toris
```
## wpi_jaco_wrapper

```
* reverted changelog
* changelog updated
* Added parameter to make homing the arm on initialization optional
* Added a fingers_controller_radian action server to better integrate with MoveIt! using joint_state information for gripper close/open actions
* Contributors: David Kent, Russell Toris
```
