### PR TITLE
depthcloud_encoder: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1551,7 +1551,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/depthcloud_encoder-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/RobotWebTools/depthcloud_encoder.git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthcloud_encoder` to `0.0.5-0`:
- upstream repository: https://github.com/RobotWebTools/depthcloud_encoder.git
- release repository: https://github.com/RobotWebTools-release/depthcloud_encoder-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.4-0`
## depthcloud_encoder

```
* Merge pull request #5 from psoetens/develop-closecloud
  Develop closecloud encoding
* depthcloud: allow user to force use of depthmap or cloud source in case multiple options are available
  Without this, we would always subscribe to the cloud topic, even if it
  was not set in the launch file, but it was set in the rosparam server.
  Signed-off-by: Peter Soetens <mailto:peter@intermodalics.eu>
* package: add dependencies to pcl_conversions and tf_conversions.
  Signed-off-by: Peter Soetens <mailto:peter@thesourceworks.com>
* update package.xml to add pcl dependencies.
  Signed-off-by: Peter Soetens <mailto:peter@thesourceworks.com>
* Multiply resolution by 6 by taking closer images and more efficient use of color channels.
  This patch also needs a change on the Depthcloud.js side.
  We could encode these mapping settings on a separate topic
  for Depthcloud.js to pickup again.
  Signed-off-by: Peter Soetens <mailto:peter@thesourceworks.com>
* encoder: support encoding of PCL point clouds
  This does add a dependency to TF and PCL but makes the
  encoder much more flexible in what it can encode.
  Signed-off-by: Peter Soetens <mailto:peter@thesourceworks.com>
* Changed to explicit casting
* Contributors: Akin Sisbot, Peter Soetens, Russell Toris
```
