### PR TITLE
async_web_server_cpp: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -380,7 +380,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wpi-rail-release/async_web_server_cpp-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/async_web_server_cpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_web_server_cpp` to `0.0.3-0`:
- upstream repository: https://github.com/WPI-RAIL/async_web_server_cpp.git
- release repository: https://github.com/wpi-rail-release/async_web_server_cpp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.2-0`
## async_web_server_cpp

```
* Merge pull request #6 from mitchellwills/develop
  Added some tests
* Added filesystem tests
* Added some more tests (including websocket tests)
* Added some more http tests
* Added an echo test and enabled tests on travis
* Began working on some tests
* Fixed missing boost dep
* Merge pull request #5 from mitchellwills/develop
  Some more improvements
* Added filesystem request handler
  This serves both files from a given root and directory listings (if requested)
* Modified request handler signature so that it can reject requests (causing them to be pushed to the next handler in a handler group)
* Now load a file to be served each time it is requested
* Fix HTTP Server stop to allow it to be safe to call multiple times
* Merge pull request #4 from mitchellwills/develop
  A few small improvements
* Allow for a server to be created even if the system has no non-local IP
  See http://stackoverflow.com/questions/5971242/how-does-boost-asios-hostname-resolution-work-on-linux-is-it-possible-to-use-n
* Changed write resource to be a const shared ptr
* Contributors: Mitchell Wills, Russell Toris
```
