### PR TITLE
bwi_common: 0.3.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -666,7 +666,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/bwi_common-release.git
-      version: 0.3.3-0
+      version: 0.3.4-0
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi_common` to `0.3.4-0`:
- upstream repository: https://github.com/utexas-bwi/bwi_common.git
- release repository: https://github.com/utexas-bwi-gbp/bwi_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.3-0`
## bwi_common
- No changes
## bwi_gazebo_entities
- No changes
## bwi_interruptable_action_server
- No changes
## bwi_kr_execution
- No changes
## bwi_logging

```
* added maintainers, and minor changes in package.xml files
* merged clingo version 4 updates
* Contributors: Jack O'Quin, Shiqi Zhang
```
## bwi_mapper
- No changes
## bwi_msgs
- No changes
## bwi_planning_common
- No changes
## bwi_rqt_plugins

```
* change segbot references to bwi_common (fixes #29 <https://github.com/utexas-bwi/bwi_common/issues/29>)
* Contributors: Jack O'Quin
```
## bwi_scavenger

```
* restore missing package versions
* added maintainers, and minor changes in package.xml files
* fixed yaml-cpp version problem
* Contributors: Jack O'Quin, Shiqi Zhang
```
## bwi_tasks
- No changes
## bwi_tools
- No changes
## stop_base
- No changes
## utexas_gdc
- No changes
