### PR TITLE
mavros: 0.14.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1502,7 +1502,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.14.1-0
+      version: 0.14.2-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.14.2-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.14.1-0`
## libmavconn
- No changes
## mavros
- No changes
## mavros_extras

```
* extras: fix catkin lint warnings
* Contributors: Vladimir Ermakov
```
## mavros_msgs
- No changes
## test_mavros

```
* test: fix depend on angles, fix catkin lint warnings
* Contributors: Vladimir Ermakov
```
