### PR TITLE
hrpsys: 315.7.0-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2684,7 +2684,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/hrpsys-release.git
-      version: 315.6.0-0
+      version: 315.7.0-2
     source:
       type: git
       url: https://github.com/start-jsk/hrpsys.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys` to `315.7.0-2`:
- upstream repository: https://github.com/fkanehiro/hrpsys-base.git
- release repository: https://github.com/tork-a/hrpsys-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `315.6.0-0`
## hrpsys
- No changes
