### PR TITLE
evapi_ros: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1981,6 +1981,25 @@ repositories:
       url: https://github.com/tork-a/euslisp-release.git
       version: 9.15.0-0
     status: developed
+  evapi_ros:
+    release:
+      packages:
+      - evarobot_bumper
+      - evarobot_controller
+      - evarobot_driver
+      - evarobot_eio
+      - evarobot_infrared
+      - evarobot_minimu9
+      - evarobot_odometry
+      - evarobot_orientation
+      - evarobot_sonar
+      - evarobot_start
+      - im_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/inomuh/evapi_ros.git
+      version: 0.1.2-0
+    status: developed
   executive_smach:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `evapi_ros` to `0.1.2-0`:
- upstream repository: https://github.com/inomuh/evapi_ros
- release repository: https://github.com/inomuh/evapi_ros.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## im_msgs

```
* add im_msgs
* Contributors: Mehmet Akcakoca
```
