### PR TITLE
jsk_recognition: 0.2.17-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3575,7 +3575,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.2.16-0
+      version: 0.2.17-0
     status: developed
   jsk_robot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.2.17-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.16-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros
- No changes
## jsk_perception
- No changes
## jsk_recognition
- No changes
## jsk_recognition_msgs

```
* [jsk_recognition_msgs/PolygonArray] Add lebels and likelihood for
  colorizing on rviz
* Contributors: Ryohei Ueda
```
## resized_image_transport
- No changes
