### PR TITLE
Wave of Fedora deps

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4,6 +4,7 @@ ace:
   gentoo: [dev-libs/ace]
   ubuntu: [libace-dev]
 acpi:
+  fedora: [acpi]
   gentoo: [sys-power/acpi]
   ubuntu: [acpi]
 alsa-oss:
@@ -521,6 +522,7 @@ disper:
   gentoo: [x11-apps/disper]
   ubuntu: [disper]
 dnsmasq:
+  fedora: [dnsmasq]
   gentoo: [net-dns/dnsmasq]
   ubuntu: [dnsmasq]
 doxygen:
@@ -539,6 +541,7 @@ dpkg:
   gentoo: [app-arch/dpkg]
   ubuntu: [dpkg]
 dvipng:
+  fedora: [texlive-dvipng-bin]
   gentoo: [app-text/dvipng]
   ubuntu: [dvipng]
 eclipse:
@@ -590,6 +593,7 @@ emacs:
   gentoo: [virtual/emacs]
   ubuntu: [emacs]
 enet:
+  fedora: [enet-devel]
   ubuntu: [libenet-dev]
 epydoc:
   arch: [epydoc]
@@ -757,6 +761,7 @@ gdal-bin:
   gentoo: [sci-libs/gdal]
   ubuntu: [gdal-bin]
 geos:
+  fedora: [geos-devel]
   ubuntu: [libgeos-dev]
 gforth:
   arch: [gforth]
@@ -1050,6 +1055,7 @@ kakasi:
 kgraphviewer:
   arch: [kgraphviewer]
   debian: [kgraphviewer]
+  fedora: [kgraphviewer]
   gentoo:
     portage:
       packages: [media-gfx/kgraphviewer]
@@ -1296,6 +1302,7 @@ libfltk-dev:
     utopic: [libfltk1.3-dev]
     vivid: [libfltk1.3-dev]
 libfontconfig1-dev:
+  fedora: [fontconfig-devel]
   ubuntu: [libfontconfig1-dev]
 libfreenect-dev:
   arch: [libfreenect]
@@ -1303,6 +1310,7 @@ libfreenect-dev:
   fedora: [libfreenect-devel]
   ubuntu: [libfreenect-dev]
 libfreetype6:
+  fedora: [freetype-devel]
   ubuntu: [libfreetype6]
 libftdi-dev:
   arch: [libftdi]
@@ -1470,6 +1478,7 @@ libhal-dev:
     apt:
       packages: [libhal-dev]
 libicu-dev:
+  fedora: [libicu-devel]
   ubuntu: [libicu-dev]
 libirrlicht-dev:
   arch: [irrlicht]
@@ -1544,6 +1553,7 @@ libjsoncpp-dev:
       packages: [dev-libs/jsoncpp]
   ubuntu: [libjsoncpp-dev]
 libkdtree++-dev:
+  fedora: [libkdtree++-devel]
   ubuntu: [libkdtree++-dev]
 liblapack-dev:
   arch: [lapack]
@@ -1578,6 +1588,7 @@ libmarble-dev:
       packages: [kde-base/marble]
   ubuntu: [libmarble-dev]
 libmicrohttpd:
+  fedora: [libmicrohttpd-devel]
   ubuntu: [libmicrohttpd-dev]
 libmodbus-dev:
   fedora: [libmodbus-devel]
@@ -1646,6 +1657,7 @@ libnl-dev:
       packages: [dev-libs/libnl]
   ubuntu: [libnl-dev]
 libnss3-dev:
+  fedora: [nss-devel]
   ubuntu: [libnss3-dev]
 libogg:
   arch: [libogg]
@@ -1882,6 +1894,7 @@ libpulse-dev:
   fedora: [pulseaudio-libs-devel]
   ubuntu: [libpulse-dev]
 libqcustomplot-dev:
+  fedroa: [qcustomplot-devel]
   ubuntu: [libqcustomplot-dev]
 libqd-dev:
   debian: [libqd-dev]
@@ -2093,6 +2106,7 @@ libsimage-dev:
       packages: [media-libs/simage]
   ubuntu: [libsimage-dev]
 libsndfile1-dev:
+  fedora: [libsndfile-devel]
   ubuntu: [libsndfile1-dev]
 libsoqt4-dev:
   arch: [soqt]
@@ -2122,8 +2136,10 @@ libsrtp0-dev:
   fedora: [libsrtp-devel]
   ubuntu: [libsrtp0-dev]
 libssh2:
+  fedora: [libssh2]
   ubuntu: [libssh2-1]
 libssh2-dev:
+  fedora: [libssh2-devel]
   ubuntu: [libssh2-1-dev]
 libssl-dev:
   arch: [openssl]
@@ -2283,6 +2299,7 @@ liburdfdom-headers-dev:
     vivid: [liburdfdom-headers-dev]
 liburdfdom-tools:
   debian: [liburdfdom-tools]
+  fedora: [urdfdom]
   ubuntu: [liburdfdom-tools]
 libusb:
   arch: [libusb-compat]
@@ -2744,6 +2761,7 @@ osm2pgsql:
   fedora: [osm2pgsql]
   ubuntu: [osm2pgsql]
 osmium:
+  fedora: [libosmium-devel]
   ubuntu: [libosmium-dev]
 pcre:
   arch: [pcre]
@@ -2782,6 +2800,7 @@ postgresql:
   fedora: [postgresql-server, postgresql-contrib]
   ubuntu: [postgresql, postgresql-contrib]
 postgresql-9.x-postgis:
+  fedora: [postgis]
   ubuntu:
     precise: [postgresql-9.1-postgis, postgresql-contrib-9.1, postgresql-server-dev-9.1]
     raring: [postgresql-9.1-postgis, postgresql-contrib-9.1, postgresql-server-dev-9.1]
@@ -2824,6 +2843,7 @@ ps-engine:
   fedora: [openni-primesense]
   ubuntu: [ps-engine]
 pstoedit:
+  fedora: [pstoedit]
   ubuntu: [pstoedit]
 pyqt4-dev-tools:
   arch: [python2-pyqt4]
@@ -2834,10 +2854,12 @@ pyqt4-dev-tools:
       packages: [dev-python/PyQt4]
   ubuntu: [pyqt4-dev-tools]
 python-cairo:
+  fedora: [pycairo]
   gentoo:
     portage:
       packages: [dev-python/pycairo]
 python-nose:
+  fedora: [python-nose]
   gentoo:
     portage:
       packages: [dev-python/nose]
@@ -2846,16 +2868,20 @@ python-opencv:
   gentoo: [media-libs/opencv]
   ubuntu: [python-opencv]
 python-pydot:
+  fedora: [pydot]
   gentoo:
     portage:
       packages: [media-gfx/pydot]
 python-pygraphviz:
+  fedora: [python-pygraphviz]
   gentoo:
     portage:
       packages: [dev-python/pygraphviz]
 python-sphinx:
+  fedora: [python-sphinx]
   gentoo: [dev-python/sphinx]
 python-vtk:
+  fedora: [vtk-phython]
   gentoo: [dev-python/pyvtk]
 qhull-bin:
   arch: [qhull]
@@ -2886,8 +2912,10 @@ qtmobility-dev:
   fedora: [qt-mobility-devel]
   ubuntu: [qtmobility-dev]
 r-base:
+  fedora: [R]
   ubuntu: [r-base]
 r-base-dev:
+  fedora: [R-devel]
   ubuntu: [r-base-dev]
 readline-dev:
   arch: [readline]
@@ -3039,6 +3067,7 @@ sqlite3:
   fedora: [sqlite]
   ubuntu: [sqlite3]
 sshpass:
+  fedora: [sshpass]
   ubuntu: [sshpass]
 subversion:
   arch: [subversion]
@@ -3134,6 +3163,7 @@ swi-prolog-xpce:
     quantal: [swi-prolog]
     raring: [swi-prolog]
 swig:
+  fedora: [swig]
   ubuntu: [swig]
 swig-wx:
   gentoo: [dev-lang/swig]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -79,12 +79,14 @@ python:
     utopic: [python-dev]
     vivid: [python-dev]
 python-alembic:
+  fedora: [python-alembic]
   ubuntu:
     trusty: [alembic]
     utopic: [python-alembic]
     vivid: [python-alembic]
     wily: [python-alembic]
 python-argcomplete:
+  fedora: [python-argcomplete]
   ubuntu: [python-argcomplete]
 python-argparse:
   arch: [python2]
@@ -237,6 +239,7 @@ python-cairo:
     utopic: [python-cairo]
     vivid: [python-cairo]
 python-catkin-lint:
+  fedora: [python-catkin_lint]
   ubuntu: [python-catkin-lint]
 python-catkin-pkg:
   arch: [python2-catkin-pkg]
@@ -398,6 +401,7 @@ python-deap-pip:
   ubuntu:
     pip: [deap]
 python-debian:
+  fedora: [python-debian]
   ubuntu:
     trusty: [python-debian]
     trusty_python3: [python3-debian]
@@ -430,6 +434,7 @@ python-docutils:
     vivid: [python-docutils]
     vivid_python3: [python3-docutils]
 python-docx:
+  fedora: [python-docx]
   ubuntu:
     pip: [python-docx]
 python-empy:
@@ -460,6 +465,7 @@ python-enum:
     saucy: [python-enum]
     trusty: [python-enum]
 python-enum34:
+  fedora: [python-enum34]
   ubuntu: [python-enum34]
 python-espeak:
   debian: [python-espeak]
@@ -638,14 +644,17 @@ python-impacket:
     utopic: [python-impacket]
     vivid: [python-impacket]
 python-itsdangerous:
+  fedora: [python-itsdangerous]
   ubuntu: [python-itsdangerous]
 python-jinja2:
+  fedora: [python-jinja2]
   ubuntu: [python-jinja2]
 python-jsonref-pip:
   ubuntu:
     pip:
       packages: [jsonref]
 python-kdtree:
+  fedora: [libkdtree++-python]
   ubuntu:
     pip:
       packages: [kdtree]
@@ -914,6 +923,7 @@ python-opengl:
     vivid: [python-opengl]
 python-pandas:
   debian: [python-pandas]
+  fedora: [python-pandas]
   ubuntu:
     lucid: [python-pandas]
     maverick: [python-pandas]
@@ -946,6 +956,7 @@ python-paramiko:
     utopic: [python-paramiko]
     vivid: [python-paramiko]
 python-passlib:
+  fedora: [python-passlib]
   ubuntu: [python-passlib]
 python-pcapy:
   debian: [python-pcapy]
@@ -997,6 +1008,7 @@ python-pexpect:
     trusty: [python-pexpect]
     trusty_python3: [python3-pexpect]
 python-progressbar:
+  fedora: [python-progressbar]
   osx:
     pip:
       packages: [progressbar]
@@ -1977,6 +1989,7 @@ python-websocket:
     wily: [python-websocket]
     wily_python3: [python3-websocket]
 python-werkzeug:
+  fedora: [python-werkzeug]
   ubuntu: [python-werkzeug]
 python-ws4py-pip:
   ubuntu:


### PR DESCRIPTION
No new `rosdep` keys, only values for Fedora.

All of these packages are present on both of the current versions of Fedora, `21` and `22`.

Thanks,

--scott
