### PR TITLE
bwi_common: 0.3.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -666,7 +666,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/bwi_common-release.git
-      version: 0.3.4-0
+      version: 0.3.5-0
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi_common` to `0.3.5-0`:
- upstream repository: https://github.com/utexas-bwi/bwi_common.git
- release repository: https://github.com/utexas-bwi-gbp/bwi_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.4-0`
## bwi_common
- No changes
## bwi_gazebo_entities
- No changes
## bwi_interruptable_action_server
- No changes
## bwi_kr_execution

```
* bwi_kr_execution: fix catkin lint warning (#31 <https://github.com/utexas-bwi/bwi_common/issues/31>)
* Contributors: Jack O'Quin
```
## bwi_logging

```
* bwi_logging: fix catkin lint problems (#31 <https://github.com/utexas-bwi/bwi_common/issues/31>)
* Contributors: Jack O'Quin
```
## bwi_mapper
- No changes
## bwi_msgs

```
* bwi_msgs: fix catkin lint problems (#31 <https://github.com/utexas-bwi/bwi_common/issues/31>)
* Contributors: Jack O'Quin
```
## bwi_planning_common
- No changes
## bwi_rqt_plugins

```
* bwi_rqt_plugins: fix catkin lint problems (#31 <https://github.com/utexas-bwi/bwi_common/issues/31>)
* Contributors: Jack O'Quin
```
## bwi_scavenger

```
* bwi_scavenger: fix catkin lint and build problems (#31 <https://github.com/utexas-bwi/bwi_common/issues/31>)
* Contributors: Jack O'Quin
```
## bwi_tasks

```
* bwi_tasks: fix catkin lint problems (#31 <https://github.com/utexas-bwi/bwi_common/issues/31>)
* Contributors: Jack O'Quin
```
## bwi_tools

```
* bwi_tools: fix catkin lint problems (#31 <https://github.com/utexas-bwi/bwi_common/issues/31>)
* Contributors: Jack O'Quin
```
## stop_base

```
* stop_base: eliminate catkin lint errors (#31 <https://github.com/utexas-bwi/bwi_common/issues/31>)
* Contributors: Jack O'Quin
```
## utexas_gdc
- No changes
