### PR TITLE
visualization_osg: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10205,6 +10205,18 @@ repositories:
       type: git
       url: https://github.com/lagadic/visp_ros.git
       version: master
+  visualization_osg:
+    release:
+      packages:
+      - osg_interactive_markers
+      - osg_markers
+      - osg_utils
+      - visualization_osg
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/uji-ros-pkg/visualization_osg-release.git
+      version: 1.0.1-0
+    status: maintained
   visualization_rwt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_osg` to `1.0.1-0`:
- upstream repository: https://github.com/uji-ros-pkg/visualization_osg.git
- release repository: https://github.com/uji-ros-pkg/visualization_osg-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## osg_interactive_markers

```
* catkin_make_isolated compatibility
* catkinizing package
* osg_interactive_markers: fixed bug that published world tranform feedback instead of local transform
* IM: Fixed bug that removed all the scene when deleting IM
* IM: delete markers scenegraph in destructors
* IM: Fixes for fuerte
* IM: fixed wall_dt and ros_dt in demo
* IM: fix for getting fixed_frame from frameManager
* osg_interactive_markers changed example name
* Contributors: mailto:marioprats@gmail.com, perezsolerj
```
## osg_markers

```
* catkin_make_isolated compatibility
* catkinizing package
* IM: Fixes for fuerte
* IM: removed logs
* IM: Partial bug fix for showing text markers, although not screen-aligned for now
* osg_interactive_markers changed example name
* Contributors: mailto:marioprats@gmail.com, perezsolerj
```
## osg_utils

```
* catkin_make_isolated compatibility
* catkinizing package
* IM: fixes for hydro
* IM: Fixes for fuerte
* osg_interactive_markers changed example name
* Contributors: mailto:marioprats@gmail.com, perezsolerj
```
## visualization_osg

```
* catkinizing package
* Contributors: perezsolerj
```
