### PR TITLE
rtmros_hironx: 1.0.36-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7846,7 +7846,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.0.35-0
+      version: 1.0.36-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.0.36-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.35-0`
## hironx_calibration
- No changes
## hironx_moveit_config

```
* [feat] Add dual-arm moveit group
* [feat] Add init pose to moveit_config
* [test] Add unit test cases for dual-arm group
* Contributors: Isaac IY Saito
```
## hironx_ros_bridge

```
* [feat] Add dual-arm moveit group
* Contributors: Isaac IY Saito
```
## rtmros_hironx

```
* [feat] Add dual-arm moveit group
* [feat] Add init pose to moveit_config
* [test] Add unit test cases for dual-arm group
* Contributors: Isaac IY Saito
```
