### PR TITLE
nerian_sp1: 1.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1990,6 +1990,21 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: jade-devel
     status: maintained
+  nerian_sp1:
+    doc:
+      type: git
+      url: https://github.com/nerian-vision/nerian_sp1.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/nerian-vision/nerian_sp1-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/nerian-vision/nerian_sp1.git
+      version: master
+    status: developed
   nmea_comms:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_sp1` to `1.0.0-0`:
- upstream repository: https://github.com/nerian-vision/nerian_sp1.git
- release repository: https://github.com/nerian-vision/nerian_sp1-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
