### PR TITLE
Adding evapi_ros to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1981,6 +1981,16 @@ repositories:
       url: https://github.com/tork-a/euslisp-release.git
       version: 9.15.0-0
     status: developed
+  evapi_ros:
+    doc:
+      type: git
+      url: https://github.com/inomuh/evapi_ros.git
+      version: eva50
+    source:
+      type: git
+      url: https://github.com/inomuh/evapi_ros.git
+      version: eva50
+    status: developed
   executive_smach:
     release:
       packages:


### PR DESCRIPTION
I'd like evapi_ros to be indexed and documented on ros.org.
