### PR TITLE
nerian_sp1: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4793,7 +4793,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/nerian-vision/nerian_sp1-release.git
-      version: 1.0.0-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_sp1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_sp1` to `1.0.2-0`:
- upstream repository: https://github.com/nerian-vision/nerian_sp1.git
- release repository: https://github.com/nerian-vision/nerian_sp1-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.0-0`
