### PR TITLE
fixed merge conflict for evapi_ros

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1982,6 +1982,10 @@ repositories:
       version: 9.15.0-0
     status: developed
   evapi_ros:
+    doc:
+      type: git
+      url: https://github.com/inomuh/evapi_ros.git
+      version: eva50
     release:
       packages:
       - evarobot_bumper
@@ -1999,6 +2003,10 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/inomuh/evapi_ros.git
       version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/inomuh/evapi_ros.git
+      version: eva50
     status: developed
   executive_smach:
     release:


### PR DESCRIPTION
I'd like evapi_ros to be indexed and documented on ros.org. I added doc and source part to #9245
