### PR TITLE
bwi_common: 0.3.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -666,7 +666,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/bwi_common-release.git
-      version: 0.3.5-0
+      version: 0.3.6-0
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi_common` to `0.3.6-0`:
- upstream repository: https://github.com/utexas-bwi/bwi_common.git
- release repository: https://github.com/utexas-bwi-gbp/bwi_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.5-0`
## bwi_common
- No changes
## bwi_gazebo_entities
- No changes
## bwi_interruptable_action_server
- No changes
## bwi_kr_execution

```
* bwi_kr_execution: remove segbot_gui references (#30 <https://github.com/utexas-bwi/bwi_common/issues/30>)
* Contributors: Jack O'Quin
```
## bwi_logging
- No changes
## bwi_mapper
- No changes
## bwi_msgs

```
* add SemanticParser.srv to bwi_msgs (#30 <https://github.com/utexas-bwi/bwi_common/issues/30>)
* Contributors: Jack O'Quin
```
## bwi_planning_common
- No changes
## bwi_rqt_plugins

```
* bwi_rqt_plugins: remove broken CMake install (#34 <https://github.com/utexas-bwi/bwi_common/issues/34>)
* Contributors: Jack O'Quin
```
## bwi_scavenger

```
* bwi_scavenger: remove segbot_gui and bwi_rlg references (#30 <https://github.com/utexas-bwi/bwi_common/issues/30>)
* bwi_scavenger: work-around for yaml-cpp problem on Saucy (#35 <https://github.com/utexas-bwi/bwi_common/issues/35>)
* Contributors: Jack O'Quin
```
## bwi_tasks
- No changes
## bwi_tools
- No changes
## stop_base
- No changes
## utexas_gdc
- No changes
