### PR TITLE
cob_extern: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1097,7 +1097,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_extern-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ipa320/cob_extern.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_extern` to `0.6.2-0`:
- upstream repository: https://github.com/ipa320/cob_extern.git
- release repository: https://github.com/ipa320/cob_extern-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.1-0`
## cob_extern

```
* migrate to package format v2
* Contributors: ipa-mig
```
## libntcan

```
* catkin_linting and make all build_depends depends only
* remove mainpage.dox
* fix trailing whitespace
* don't use CATKIN_GLOBAL_* in CMakeLists
* Install Tag and catkin_package adaptations
* migrate to package format v2
* Contributors: ipa-mig
```
## libpcan

```
* catkin_linting and make all build_depends depends only
* revert trailing whitespace in autogenerated headers
* fix dependencies and find_package calls
* remove mainpage.dox
* fix trailing whitespace
* libpcan: don't use CATKIN_GLOBAL_* in CMakeLists and fix includes such that headers can be installed only once
* Install Tag and catkin_package adaptations
* migrate to package format v2
* Contributors: ipa-mig
```
## libphidgets

```
* catkin_linting and make all build_depends depends only
* revert trailing whitespace in autogenerated headers
* fix dependencies and find_package calls
* remove mainpage.dox
* fix trailing whitespace
* don't use CATKIN_GLOBAL_* in CMakeLists
* Install Tag and catkin_package adaptations
* migrate to package format v2
* Contributors: ipa-mig
```
