### PR TITLE
cob_calibration_data: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -956,7 +956,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_calibration_data-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/ipa320/cob_calibration_data.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_calibration_data` to `0.6.4-0`:
- upstream repository: https://github.com/ipa320/cob_calibration_data.git
- release repository: https://github.com/ipa320/cob_calibration_data-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.3-0`
## cob_calibration_data

```
* remove obsolete autogenerated mainpage.dox files
* add explicit exec_depend to xacro
* remove trailing whitespaces
* migrate to package format 2
* cleanup
* Contributors: Felix Messmer, Florian Weisshardt, Nadia Hammoudeh García, ipa-fxm
```
