### PR TITLE
cob_command_tools: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -979,7 +979,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.3-0`:
- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.2-0`
## cob_command_gui

```
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_command_tools

```
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_dashboard

```
* remove trailing whitespaces
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_interactive_teleop

```
* boost revision
* do not install headers in executable-only packages
* explicit dependency for boost
* remove obsolete autogenerated mainpage.dox files
* remove FILES_MATCHING
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_monitoring

```
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_script_server

```
* do not install headers in executable-only packages
* more cleanup
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* remove trailing whitespaces
* migrate to package format 2
* Merge pull request #105 <https://github.com/ipa-fxm/cob_command_tools/issues/105> from ipa-nhg/play_sound
  minor changes
* minor changes
* Merge pull request #103 <https://github.com/ipa-fxm/cob_command_tools/issues/103> from ipa-nhg/play_sound
  play sound
* log error
* cob_sound
* sort dependencies
* critically review dependencies
* play sound
* Contributors: Florian Weisshardt, ipa-fxm, ipa-nhg
```
## cob_teleop

```
* boost revision
* do not install headers in executable-only packages
* explicit dependency for boost
* more cleanup
* remove obsolete autogenerated mainpage.dox files
* remove FILES_MATCHING
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* Contributors: ipa-fxm
```
