### PR TITLE
cob_control: 0.6.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1021,13 +1021,14 @@ repositories:
       - cob_footprint_observer
       - cob_frame_tracker
       - cob_model_identifier
+      - cob_obstacle_distance
       - cob_omni_drive_controller
       - cob_trajectory_controller
       - cob_twist_controller
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.6.8-5
+      version: 0.6.9-0
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.6.9-0`:
- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.8-5`
## cob_base_velocity_smoother

```
* boost revision
* do not install headers in executable-only packages
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* explicit dependency to boost
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* update with ipa320
* review dependencies
* Contributors: ipa-fxm
```
## cob_cartesian_controller

```
* Corrections integrated from PR: [WIP] Finalizing/Testing of TwistController features (#51 <https://github.com/ipa-fxm/cob_control/issues/51>). Renaming from frame_to_collision to link_to_collision.
* boost revision
* more dependency fixes according to review comments
* Resolved merge conflicts.
* more fixes for migration afer merge
* merge with package_xml_2
* remove trailing whitespaces
* migrate to package format 2
* 

    * Removed unnecessary function.
    * Prepared configuration params.

* resolve possible endless-loop
* consider PR review comments
* review dependencies
* updates from ipa-fxm-mb
* updates from ipa320
* Implemented Python package to set dyn_reconfigure params. Made test_move_around_torus use of this class.
* missing add_dependencies
* sort dependencies
* review dependencies
* print result, use sci in test scripts
* Created test, Removed commends, Removed output.
* Fixed bugs in cartesian_controller: waitFor last available transform else extrapolation error; send always a new constructed StampedTransform instead of using an already existent one, else end-effector is decoupled from manipulator and other confusing things happen...; Added responsible node to tf error msg.
* fix cartesian_interface
* first draft for python interface
* re-work message structure use pose and frame_id, proper handling transformation to root_frame
* added publisher for path preview
* split and restructure ProfileGenerator
* simplify data_type conversion, cleanup
* re-work of ActionServer: more failure handling
* draft for example
* replace .prog files with according .py scripts, use rospy.sleep() instead of holdPosition action
* get rid of holdPosition, replaced by rospy.sleep()
* restructure and simplify cartesian_controller_utils, beautification
* Further tests and adaptations for test.
* Made cob_cartesian_controller work again: Added CartesianController::convertMoveLinRelToAbs method again (why removed?)
* Added generated const from .cfg; Styling
* Merge with code style fixes.
* code styling cob_cartesian_controller
* renamed variable
* restructured cartesian controller with action interface
* added action server
* fix install tags
* restructured functions
* added headers..
* restructured
* Contributors: ipa-fxm, ipa-fxm-cm, ipa-fxm-mb
```
## cob_collision_velocity_filter

```
* boost revision
* do not install headers in executable-only packages
* explicit dependency to boost
* explicit dependency to boost
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* review dependencies
* Contributors: ipa-fxm
```
## cob_control

```
* migrate to package format 2
* sort dependencies
* review dependencies
* add missing run_depends to meta-package
* Contributors: ipa-fxm
```
## cob_control_mode_adapter

```
* more dependency fixes according to review comments
* explicit dependency to boost
* more fixes for migration afer merge
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* review dependencies
* code styling cob_control_mode_adapter
* Contributors: ipa-fxm
```
## cob_footprint_observer

```
* boost revision
* do not install headers in executable-only packages
* explicit dependency to boost
* explicit dependency to boost
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* review dependencies
* Contributors: ipa-fxm
```
## cob_frame_tracker

```
* Corrections integrated from PR: [WIP] Finalizing/Testing of TwistController features (#51 <https://github.com/ipa-fxm/cob_control/issues/51>). Renaming from frame_to_collision to link_to_collision.
* 

    * Made some changes for test. - Decreased Duration time for markers. - Corrected pose update for self collision check frames. - Added new scripts.

* boost revision
* Some preparations for test: IMarker smaller, Alpha settings, More scripts. Default value for Frame Tracker params.
* 

    * Added functionality to hold twist in case of deviation of cart. distance gets to large.

* add actionlib
* explicit dependency to boost
* more fixes for migration afer merge
* remove trailing whitespaces
* migrate to package format 2
* review dependencies
* updates from ipa320
* cleanup
* sort dependencies
* review dependencies
* Fixed bugs in cartesian_controller: waitFor last available transform else extrapolation error; send always a new constructed StampedTransform instead of using an already existent one, else end-effector is decoupled from manipulator and other confusing things happen...; Added responsible node to tf error msg.
* code styling cob_frame_tracker
* Implemented proposals from discussion https://github.com/ipa320/cob_control/pull/38. Removed tabs. Corrected node handles.
* Removed tracking error publisher / subscriber and removed additional p gain for PD-Control (already done in FrameTracker with PID controller)
* bug fix
* 

    * Added a publisher for the tracking errors to send them to cob_twist_controller
    * Added a subscriber to collect the errors and put them to the solver.
    * Added a parameter to set the p gain. If 0.0 old behavior is active (default value).

* Contributors: ipa-fxm, ipa-fxm-cm, ipa-fxm-mb
```
## cob_model_identifier

```
* boost revision
* do not install headers in executable-only packages
* explicit dependency to boost
* more dependency fixes according to review comments
* explicit dependency to boost
* more fixes for migration afer merge
* remove trailing whitespaces
* migrate to package format 2
* cleanup
* sort dependencies
* update with ipa320
* review dependencies
* code styling cob_model_identifier
* beautify and code-review
* Contributors: ipa-fxm
```
## cob_obstacle_distance

```
* review dependencies
* authors in package xml
* Merge branch 'test_of_feature_with_adapt_frame_tracker' of github.com:ipa-fxm-mb/cob_control into test_of_feature
* Corrections integrated from PR: [WIP] Finalizing/Testing of TwistController features (#51 <https://github.com/ipa-fxm/cob_control/issues/51>). Renaming from frame_to_collision to link_to_collision.
* 

    * Made some changes for test. - Decreased Duration time for markers. - Corrected pose update for self collision check frames. - Added new scripts.

* boost revision
* Some preparations for test: IMarker smaller, Alpha settings, More scripts. Default value for Frame Tracker params.
* 

    * CA: Increased exp. decay from 0.1 to 0.2 - Added comments. - Moved constraints set and management to base class. - Added time delta to test script.

* 

    * Removed parameter mu. - Added obstacle id for identification of collision pair in ObstacleDistance.msg. - Added Frametracking to DataCollector. - Restructured obstacle distance data collecting. - In debug trajectory marker added explicit usage of frame_tracker/tracking_frame.

* merge
* more dependency fixes according to review comments
* explicit dependency to boost
* Fixed bug when obstacles move away from robot. Clear distances list when new distances arrive (also in case nothing is available for current link) to avoid no movement.
* Due to restructuring of self-collision YYAMLs also restructured computation of the file and the ignoreSelfCollisionPart method.
* 

    * Renaming obstacle_marker_server for interactive obstacle
    * Now publishing all obstacle distances instead of the minimal distance only. Defined a MIN_DISTANCE for selection of data to publish (e.g. > than 0.5 m doesn't make sense for CA).
    * Selection of the minimal distance in debug node.
    * Callback data mediator processes all obstacles for a frame of interest id now.
    * Restructured methods in constraint classes.
    * In CA constraint now processing all collision pairs for one link in a CollisionAvoidance instance.
    * Removed unnecessary output.

* Resolved merge conflicts.
* more fixes for migration afer merge
* merge with package_xml_2
* remove trailing whitespaces
* migrate to package format 2
* 

    * Avoided drawing of self-collision frames -> can be done via rviz.
    * Increased CA activation threshold to 0.25 m

* 

    * For BVH introduced a shared_ptr member -> so a collision object can be created without copying the whole BVH. This saves computation time (5% for 3 SCA and 1 torus)
    * Decreased rate for cob_obstacle_distance because the movement does not change that often.
    * According to the rate adapted the moving average for distance in constraint_ca_impl

* Merge branch 'indigo_dev' of github.com:ipa320/cob_control into test_of_feature
* Fixed message generation issue
* review dependencies
* updates from ipa-fxm-mb
* updates from ipa320
* cleanup
* missing add_dependencies
* sort dependencies
* Fixed bugs in cartesian_controller: waitFor last available transform else extrapolation error; send always a new constructed StampedTransform instead of using an already existent one, else end-effector is decoupled from manipulator and other confusing things happen...; Added responsible node to tf error msg.
* Merged with ipa-fxm/test_of_feature branch.
* 

    * Corrected JLA constraint. - Added weighting of GPM prio dependent. - Added buffer region for CA constraint to become active.

* 

    * Removed PredictDistance Service (not necessary anymore; found a lightweight computational algorithm).
    * Made KDL::ChainFkSolverVel_recursive in CA constraint available for prediction.
    * Replace constraints update method prediction variable with JntArrayVel.
    * Refactored ObstacleDistance.msg: Reduced number of members, renamings, added frame_of_interest for registration and made use of header->frame_id for arm_base_link.
    * Renamed service for registration.
    * Improved input twist damping in case of a constraint is in CRITICAL state.

* added publisher for path preview
* allow target_frame to be configured via private param, beautifying
* added interactive_obstacle test node, less sleep time on marker publisher
* Further tests and adaptations for test.
* Reduced granularity of a fcl::shape representation. Replaced arm_1_collision with mild.dae.
* Fixed integer size. There might never be 2^64 joints. But maybe more than 255 that's why 2^16 had been chosen.
* finalize example.launch
* move distance_vector marker publisher to separate node
* Reduced granularity of a fcl::shape representation. Replaced arm_1_collision with mild.dae.
* fix sleep rates
* add topic name to ROS_WARN output
* add example launch file
* generalize scripts, minor changes
* Corrected CMakeLists.txt. Replaced ASSIMP_LIBRARIES with assimp.
* Added consideration of origin from URDF tags. Removed shape_type and so Registration.srv and replaced by SetString service. Removed comments.
* Considering visual tag as fallback now. Removed duplicate map and struct.
* Considered further proposals from https://github.com/ipa-fxm/cob_control/pull/7.
* Considered proposals from https://github.com/ipa-fxm/cob_control/pull/7
* Added a YAML file to have the parameters as example. This folder can be deleted after integration into cob_robots package.
* Added self-collision checking. Corrected fcl bug(?): In case of simple geometric shapes the nearest_points differ from BVH models. Therefore converted simple shapes into BVH models to have the same behaviour in all cases.
* Made usage of common methods. Added defines for conversion of array access.
* Transform is done in a separate thread now. Added subscriber to CollisionObject messages to create obstacle in other nodes (e.g. Python test nodes). Added corresponding methods to process CollisionObject mesh data.
* Integrated comments of https://github.com/ipa-fxm/cob_control/pull/7. Replaced static link2collision map with URDF parser. Added class for URDF parser and create marker shapes.
* Added functions to represent a registered robot link as a mesh instead of simple shapes. Added a mapping between robot link name and mesh resource name.
* Added JLA inequality constraint to be used within the dynamic task strategy. Added checking and resetting of dynamic_reconfigure params. Corrected formatting of LSV damping.
* Separated constraints from solvers and vice versa. Added new parameters. Prettified GUI.
* Added assimp library for generic mesh file parsing. Added a parser base to specify common interfaces and methods.
* Added roslib to resolve package:// uris. Renamed typedefs. Specialized template implementation for fcl::BVHModel<fcl::RSS> > to use meshes like simple shapes. Added example code for a arm_1_collision.stl mesh.
* Made CA possible with active base. Bug fixing of solvers in case of base active. Corrected JLA constraints.
* re-arrange Parameter structs
* Added new method for dynamic tasks readjustment. Implemented prediction of distance now for vectors.
* resolve conflicts after merging ipa-fxm-mb/task_stack_prio_feature
* beautify and code-review
* Added chain recursive fk vel calculator. Corrected calculation of translational Jacobian for CA. Introduced further msg types to achieve that. Extended solvers: CA as first prio task, CA as GPM, CA as GPM with disappearing main tasks.
* Corrected dist calclation for GPM CA
* Corrected CMakeLists.txt and package.xml. Resolved dependencies.
* Added stack of tasks and further developments on GPM CA.
* Further developments.
* Implemented proposals from discussion https://github.com/ipa320/cob_control/pull/38. Removed tabs. Corrected node handles.
* Made corrections proposed in https://github.com/ipa320/cob_control/pull/38#
* 

    * Made cob_obstacle_distance independent from testdata/robot_description.xml file.
  Only in case of the parameter /robot_description could not be read the xml file is used (e.g. for testing purposes).
  - For that added roslib as dependency.
* 

    * Added doxygen comments
    * Corrected the messages produced by catkin_lint
    * Created a static method to return SolverFactory

* 

    * Made obstacle tracking independent from arm_right.
    * Refactored signatures of solve methods: Instead of using dynamic vector now a 6d vector is used because twists are of dim 6d.
    * Removed unnecessary comments.
    * Introduced eigen_conversions to have simple converters instead of filling matrices and vectors manually -> Reduces typing and copying errors!

* 

    * Renamed some variables according to ROS C++ style guide
    * Moved advanced chain fk solver from cob_twist_controller to cob_obstacle_distance.
    * Replaced complicated transformation of base_link to arm_base_link with simpler and direct one.
    * Removed unnecessary services and replaced with message publisher and subscriber (for distance calculation).
    * Added example launch file for cob_obstacle_distance.
    * Corrected handling of objects of interest. Now in both packages frames are used (instead of joint names) -> made it similar to KDL and tf handlings.
    * Removed commented code.
    * Removed pointer where objects could be used directly (constraint params generation)
    * callback data mediator keeps old distance values until new ones were received. An iterator is used to go through the container.

* 

    * Created a obstacle distance publisher in cob_obstacle_distance package and a subscriber in cob_twist_controller package.
    * Created registration service in cob_obstacle_distance
    * Creation of multiple CA constraints dependent on formerly registered joint regions.

* Renaming
* Contributors: Andriy Petlovanyy, ipa-fxm, ipa-fxm-mb
```
## cob_omni_drive_controller

```
* boost revision
* explicit dependency to boost
* more dependency fixes according to review comments
* explicit dependency to boost
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* review dependencies
* Contributors: ipa-fxm
```
## cob_trajectory_controller

```
* boost revision
* do not install headers in executable-only packages
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* more dependency fixes according to review comments
* remove trailing whitespaces
* migrate to package format 2
* cleanup
* sort dependencies
* review dependencies
* Contributors: ipa-fxm
```
## cob_twist_controller

```
* authors in package xml
* Corrections integrated from PR: [WIP] Finalizing/Testing of TwistController features (#51 <https://github.com/ipa-fxm/cob_control/issues/51>). Renaming from frame_to_collision to link_to_collision.
* 

    * Fixed bug in constraint implementation: sign was "-" but must be "+".
    * Moved scripts.

* 

    * Added more text to package.xml
    * Moved scripts to subfolder test.

* Added new script for raw3-1.
* In config file avoided setting of 0 tolerance (DIV/0!). Removed additional output.
* 

    * Made some changes for test. - Decreased Duration time for markers. - Corrected pose update for self collision check frames. - Added new scripts.

* Added comment to activation buffer.
* boost revision
* Merge branch 'test_of_feature' into test_of_feature_with_adapt_frame_tracker
* Overwritten numerical_filtering with false.
* Some preparations for test: IMarker smaller, Alpha settings, More scripts. Default value for Frame Tracker params.
* 

    * Added parameters for activation buffer and critical threshold of CA and JLA constraints.
    * Removed method getActivationThreshold because parameter can be used directly.
    * Packed thresholds into struct.
    * Commented some outputs.

* 

    * CA: Increased exp. decay from 0.1 to 0.2 - Added comments. - Moved constraints set and management to base class. - Added time delta to test script.

* 

    * Removed parameter mu. - Added obstacle id for identification of collision pair in ObstacleDistance.msg. - Added Frametracking to DataCollector. - Restructured obstacle distance data collecting. - In debug trajectory marker added explicit usage of frame_tracker/tracking_frame.

* merge
* explicit dependency to boost
* Fixed bug when obstacles move away from robot. Clear distances list when new distances arrive (also in case nothing is available for current link) to avoid no movement.
* 

    * Renaming obstacle_marker_server for interactive obstacle
    * Now publishing all obstacle distances instead of the minimal distance only. Defined a MIN_DISTANCE for selection of data to publish (e.g. > than 0.5 m doesn't make sense for CA).
    * Selection of the minimal distance in debug node.
    * Callback data mediator processes all obstacles for a frame of interest id now.
    * Restructured methods in constraint classes.
    * In CA constraint now processing all collision pairs for one link in a CollisionAvoidance instance.
    * Removed unnecessary output.

* Resolved merge conflicts.
* more fixes for migration afer merge
* merge with package_xml_2
* remove trailing whitespaces
* migrate to package format 2
* 

    * Removed unnecessary commented code.

* 

    * Added handling of no exception: Save files.

* 

    * Avoided drawing of self-collision frames -> can be done via rviz.
    * Increased CA activation threshold to 0.25 m

* Deleted unnecessary files.
* 

    * Renamed dynamics_tasks_readjust_solver -> stack_of_tasks_solver. Therefore adapted corresponding cfg and data_types.
    * Created Python package for data collection.

* fix HardwareInterfacePosition
* consider PR review comments
* 

    * Removed experiment solvers for task stacks. Now the dynamic_tasks_readjust_solver works better than them.
    * adapted MakeLists and config and data_types.

* 

    * For BVH introduced a shared_ptr member -> so a collision object can be created without copying the whole BVH. This saves computation time (5% for 3 SCA and 1 torus)
    * Decreased rate for cob_obstacle_distance because the movement does not change that often.
    * According to the rate adapted the moving average for distance in constraint_ca_impl

* updates from ipa-fxm-mb
* Implemented Python package to set dyn_reconfigure params. Made test_move_around_torus use of this class.
* cleanup
* sort dependencies
* Created test, Removed commends, Removed output.
* Fixed bugs in cartesian_controller: waitFor last available transform else extrapolation error; send always a new constructed StampedTransform instead of using an already existent one, else end-effector is decoupled from manipulator and other confusing things happen...; Added responsible node to tf error msg.
* Merged with ipa-fxm/test_of_feature branch.
* Separated JLA and CA constraints from constraint_impl.h
* 

    * Corrected JLA constraint. - Added weighting of GPM prio dependent. - Added buffer region for CA constraint to become active.

* Made movinge average generic for other data types. Using moving average for CA constraint.
* simplify simpson
* 

    * Removed PredictDistance Service (not necessary anymore; found a lightweight computational algorithm).
    * Made KDL::ChainFkSolverVel_recursive in CA constraint available for prediction.
    * Replace constraints update method prediction variable with JntArrayVel.
    * Refactored ObstacleDistance.msg: Reduced number of members, renamings, added frame_of_interest for registration and made use of header->frame_id for arm_base_link.
    * Renamed service for registration.
    * Improved input twist damping in case of a constraint is in CRITICAL state.

* check for frame existence
* allow target_frame to be configured via private param, beautifying
* Further tests and adaptations for test.
* Added generated const from .cfg; Styling
* re-implementation of trajectory_publisher in c++
* Added Python package to collect data and write collected data into a file.
* Fixed parameter initialization.
* fix parameter initialization + add max_vel_base to cfg
* add topic name to ROS_WARN output
* add doxygen documentation
* add example launch file
* publish joint_states in separate thread
* adding JointStateInterface
* add base_marker to publisher
* generalize scripts, minor changes
* Corrected default values in cfg.
* Corrected CMakeLists.txt. Replaced ASSIMP_LIBRARIES with assimp.
* Added consideration of origin from URDF tags. Removed shape_type and so Registration.srv and replaced by SetString service. Removed comments.
* Considering visual tag as fallback now. Removed duplicate map and struct.
* Considered further proposals from https://github.com/ipa-fxm/cob_control/pull/7.
* Considered proposals from https://github.com/ipa-fxm/cob_control/pull/7
* Integrated comments of https://github.com/ipa-fxm/cob_control/pull/7. Replaced static link2collision map with URDF parser. Added class for URDF parser and create marker shapes.
* Added functions to represent a registered robot link as a mesh instead of simple shapes. Added a mapping between robot link name and mesh resource name.
* Integration. To avoid controller jump into critical region again introduced in cart vel damping.
* Fixed DIV/0 error in distance cost function calculation.
* Reassignment of corrected values to twist_controller_params_ instance.
* Added JLA inequality constraint to be used within the dynamic task strategy. Added checking and resetting of dynamic_reconfigure params. Corrected formatting of LSV damping.
* Moved TaskStackController to parameters list. Added new damping factor for constraints (to avoid algo. singularities). Added new inverse for testing.
* Separated constraints from solvers and vice versa. Added new parameters. Prettified GUI.
* Added a Simple Python node to publish a line strip to see the real trajectory and the desired one.
* Made CA possible with active base. Bug fixing of solvers in case of base active. Corrected JLA constraints.
* more style unification
* parameter initialization
* enforceLimits now in inv_diff_kin_solver
* enum for KinematicExtension and styling for constants
* consider remarks from CodeReview: mainly styling and beautify
* hardware_interface_type renaming
* re-arrange Parameter structs
* Merge branch 'task_stack_prio_feature' of github.com:ipa-fxm-mb/cob_control into multi_feature_merge
* Added new method for dynamic tasks readjustment. Implemented prediction of distance now for vectors.
* resolve conflicts after merging ipa-fxm-mb/task_stack_prio_feature
* KinematicExtensionBaseActive works
* WIP: further cleanup and introduction of abstract helper class
* WIP: kinematic_extension replaces base_active
* Refactored task stack solvers. Fixed creation of solver instances. Removed unnecessary test code.
* beautify and code-review
* remove auto generatable doc
* merge with ipa320
* generic interface types
* Added chain recursive fk vel calculator. Corrected calculation of translational Jacobian for CA. Introduced further msg types to achieve that. Extended solvers: CA as first prio task, CA as GPM, CA as GPM with disappearing main tasks.
* Added task stack controller.
* Corrected dist calclation for GPM CA
* Added stack of tasks and Macijewski task prio CA.
* Added stack of tasks and further developments on GPM CA.
* Further developments.
* Implemented proposals from discussion https://github.com/ipa320/cob_control/pull/38. Removed tabs. Corrected node handles.
* Merge with IPA320 Indigo Dev.
* removed bug
* merged
* Added moving average filter and simpson integration formula
* New octave script to check whether split of vector v into separate tasks works.
* Removed rad variable.
* Fixed issue in WLN_JLA: Removed conversion to radian.
* Made code more CppStyleGuide ROS compliant.
* Made corrections proposed in https://github.com/ipa320/cob_control/pull/38#
* 

    * Renaming: AugmentedSolver -> InverseDifferentialKinematicsSolver
    * Merged cob_twist_controller_data_types and augmented_solver_data_types -> cob_twist_controller_data_types
    * Renamings: According to ROS C++ Style Guide.

* 

    * Added doxygen comments
    * Corrected the messages produced by catkin_lint
    * Created a static method to return SolverFactory

* 

    * Made obstacle tracking independent from arm_right.
    * Refactored signatures of solve methods: Instead of using dynamic vector now a 6d vector is used because twists are of dim 6d.
    * Removed unnecessary comments.
    * Introduced eigen_conversions to have simple converters instead of filling matrices and vectors manually -> Reduces typing and copying errors!

* 

    * Renamed some variables according to ROS C++ style guide
    * Moved advanced chain fk solver from cob_twist_controller to cob_obstacle_distance.
    * Replaced complicated transformation of base_link to arm_base_link with simpler and direct one.
    * Removed unnecessary services and replaced with message publisher and subscriber (for distance calculation).
    * Added example launch file for cob_obstacle_distance.
    * Corrected handling of objects of interest. Now in both packages frames are used (instead of joint names) -> made it similar to KDL and tf handlings.
    * Removed commented code.
    * Removed pointer where objects could be used directly (constraint params generation)
    * callback data mediator keeps old distance values until new ones were received. An iterator is used to go through the container.

* Added missing modules
* 

    * Created a obstacle distance publisher in cob_obstacle_distance package and a subscriber in cob_twist_controller package.
    * Created registration service in cob_obstacle_distance
    * Creation of multiple CA constraints dependent on formerly registered joint regions.

* test
* Renaming
* Added collision avoidance feature. Solve with GPM. Made usage of cob_collision_object_publisher via ROS service.
* Added possibility to calculate self motion magnitude dependent from joint velocity limits.
* Removed tracking error publisher / subscriber and removed additional p gain for PD-Control (already done in FrameTracker with PID controller)
* Solved merge conflicts
* WIP:
  - Added new solver feature: GradientProjectionMethod.
  - Added cost function for: JLA, JLA_MID, CA
  - Added kappa parameter to set GPM scaling.
  - Added builder to support build of multiple constraints.
* Added new implementation for KDL::ChainFkSolverPos_recursive. Provides storage of joint positions.
* Beautify.
  Corresponding to PR https://github.com/ipa-fxm-mb/cob_control/pull/1.
* renamed parameters and functions
* Generischer Ansatz
* Low Isotropic Damping
* 

    * Added constraints for JLA and JLA mid.
    * Added calculation for step size.

* 

    * Prepared the implementation of a builder to create a set of constraints.
    * Decoupled constraints generation from solver class GPM (now they could be used for other methods as well).
    * Removed asParams from constraints. Only necessary for constraintParams.

* 

    * Added a possibility to implement constraint functions.
    * Added a registration mechanism to the solver (registration in a priorized set).
    * Added a parameter to select it

* 

    * Renamed pseudoinverse_calculation -> inverse_jacobian_calculation

* 

    * Decoupled pseudoinverse calculation from constraint_solvers. That allows new implementations for pseudoinverse calculations. Additionally it allows to calculate pseudoinverses of further Jacobians (e.g. for constraints)
    * Removed unnecessary _base.cpp files and removed them from CMakeLists.txt.

* 

    * Refactored parametrization of damping -> damping method is now given to solver for extensions (like numerical filtering)
    * Considered damping method NONE in case of no damping for solving IK.

* 

    * Added a publisher for the tracking errors to send them to cob_twist_controller
    * Added a subscriber to collect the errors and put them to the solver.
    * Added a parameter to set the p gain. If 0.0 old behavior is active (default value).

* Contributors: ipa-fxm, ipa-fxm-cm, ipa-fxm-mb
* add missing include
* Contributors: ipa-fxm
* missing dependency
* Contributors: ipa-fxm
```
