### PR TITLE
cob_driver: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1060,7 +1060,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.6.4-0`:
- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.3-0`
## cob_base_drive_chain

```
* install tags for libraries
* do not install headers in executable-only packages
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_camera_sensors

```
* boost revision
* explicit dependency to boost
* more cleanup
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_canopen_motor

```
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_driver

```
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_generic_can

```
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_head_axis

```
* rising no longer supported
* boost revision
* do not install headers in executable-only packages
* explicit dependency to boost
* more cleanup
* remove obsolete autogenerated mainpage.dox files
* catkin_package according to install tags
* remove trailing whitespaces
* add_dependencies EXPORTED_TARGETS
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm, ipa-nhg
```
## cob_light

```
* boost revision
* do not install headers in executable-only packages
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_mimic

```
* cleanup
* fixing dependencies
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_phidgets

```
* do not install headers in executable-only packages
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* add_dependencies EXPORTED_TARGETS
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_relayboard

```
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* add_dependencies EXPORTED_TARGETS
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_sick_lms1xx

```
* install tags for libraries
* boost revision
* do not install headers in executable-only packages
* explicit dependency to boost
* catkin_package according to install tags
* remove trailing whitespaces
* add_dependencies EXPORTED_TARGETS
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_sick_s300

```
* do not install headers in executable-only packages
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* catkin_package according to install tags
* remove trailing whitespaces
* add_dependencies EXPORTED_TARGETS
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_sound

```
* boost revision
* do not install headers in executable-only packages
* explicit dependency to boost
* alsa-oss dependency
* fixing dependencies
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* add_dependencies EXPORTED_TARGETS
* migrate to package format 2
* merge
* deleted name argument and added a comment
* update cob_sound
* sort dependencies
* critically review dependencies
* play sound
* Contributors: ipa-fxm, ipa-nhg
```
## cob_undercarriage_ctrl

```
* install tags for libraries
* do not install headers in executable-only packages
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* add_dependencies EXPORTED_TARGETS
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_utilities

```
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_voltage_control

```
* explicit dependency to boost
* remove trailing whitespaces
* add_dependencies EXPORTED_TARGETS
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
