### PR TITLE
cob_substitute: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1259,10 +1259,11 @@ repositories:
       - frida_driver
       - prace_common
       - prace_gripper_driver
+      - rplidar_ros
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_substitute-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ipa320/cob_substitute.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_substitute` to `0.6.2-0`:
- upstream repository: https://github.com/ipa320/cob_substitute.git
- release repository: https://github.com/ipa320/cob_substitute-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.1-0`
## cob_lbr

```
* migration to package format 2
* remove obsolete autogenerated mainpage.dox files
* cleanup
* Contributors: ipa-fxm
```
## cob_safety_controller

```
* migration to package format 2
* remove trailing whitespaces
* cleanup
* Contributors: ipa-fxm
```
## cob_substitute

```
* migration to package format 2
* new substitue package rplidar_ros
* Contributors: ipa-fxm
```
## frida_driver

```
* migration to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* cleanup
* Contributors: ipa-fxm
```
## prace_common

```
* migration to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* cleanup
* Contributors: ipa-fxm
```
## prace_gripper_driver

```
* migration to package format 2
* remove obsolete autogenerated mainpage.dox files
* cleanup
* Contributors: ipa-fxm
```
## rplidar_ros

```
* migration to package format 2
* remove trailing whitespaces
* new substitue package rplidar_ros
* Contributors: ipa-fxm
```
