### PR TITLE
schunk_modular_robotics: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8843,7 +8843,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/schunk_modular_robotics-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/ipa320/schunk_modular_robotics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_modular_robotics` to `0.6.4-0`:
- upstream repository: https://github.com/ipa320/schunk_modular_robotics.git
- release repository: https://github.com/ipa320/schunk_modular_robotics-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.3-0`
## schunk_description

```
* fix pg70
* migration to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* review dependencies
* Contributors: ipa-fxm
```
## schunk_libm5api

```
* boost revision
* migration to package format 2
* remove obsolete autogenerated mainpage.dox files
* sort dependencies
* review dependencies
* Contributors: ipa-fxm
```
## schunk_modular_robotics

```
* migration to package format 2
* remove trailing whitespaces
* review dependencies
* Contributors: ipa-fxm
```
## schunk_powercube_chain

```
* boost revision
* migration to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* sort dependencies
* review dependencies
* Contributors: ipa-fxm
```
## schunk_sdh

```
* boost revision
* migration to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* sort dependencies
* review dependencies
* Contributors: ipa-fxm
```
## schunk_sdhx

```
* migration to package format 2
* remove trailing whitespaces
* sort dependencies
* review dependencies
* Contributors: ipa-fxm
```
## schunk_simulated_tactile_sensors

```
* migration to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* sort dependencies
* review dependencies
* Contributors: ipa-fxm
```
