### PR TITLE
heatmap: 0.2.3-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -976,7 +976,12 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/eybee/heatmap-release.git
-      version: 0.2.2-0
+      version: 0.2.3-1
+    source:
+      type: git
+      url: https://github.com/eybee/heatmap.git
+      version: jade-devel
+    status: maintained
   hokuyo_node:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `heatmap` to `0.2.3-1`:
- upstream repository: https://github.com/eybee/heatmap.git
- release repository: https://github.com/eybee/heatmap-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.2-0`
## heatmap

```
* fixed dependecy error
* fixed include path issue
* Contributors: Adrian Bauer
```
