### PR TITLE
naoqi_bridge_msgs: 0.0.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1909,7 +1909,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_bridge_msgs-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_bridge_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge_msgs` to `0.0.4-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_bridge_msgs.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.3-0`
## naoqi_bridge_msgs

```
* Merge pull request #2 <https://github.com/ros-naoqi/naoqi_bridge_msgs/issues/2> from vrabaud/master
  add a message concerning the robot information
* add a service to get robot info
* add a message concerning the robot information
* update package.xml with description and author
* Contributors: Karsten Knese, Vincent Rabaud
```
