### PR TITLE
naoqi_driver: 0.5.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5112,7 +5112,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_driver-release.git
-      version: 0.5.1-0
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_driver` to `0.5.2-0`:
- upstream repository: https://github.com/ros-naoqi/alrosbridge.git
- release repository: https://github.com/ros-naoqi/naoqi_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.1-0`
## naoqi_driver

```
* build and run dependency v004 for bridge msgs
* fill robot config data
* implement robot config service call
* change to latest robotinfo msg
* add sessionptr to service
* fill the service to get the robot info
* Merge pull request #38 <https://github.com/ros-naoqi/naoqi_driver/issues/38> from antegallya/patch-1
  Fix repo url in install.rst
* Fix repo url in install.rst
* Merge pull request #37 <https://github.com/ros-naoqi/naoqi_driver/issues/37> from antegallya/patch-1
  Fix a code-block in install.rst
* Fix a code-block in install.rst
* rename service topic to ros standard
* add license declaration
* add support for ros services
* update doc
* enhance error message in camera converter
* naoqi_driver_node is an executable not a library
* Contributors: Karsten Knese, Pierre Hauweele, Vincent Rabaud
```
