### PR TITLE
heatmap: 0.2.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -976,7 +976,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/eybee/heatmap-release.git
-      version: 0.2.3-1
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/eybee/heatmap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heatmap` to `0.2.4-0`:
- upstream repository: https://github.com/eybee/heatmap.git
- release repository: https://github.com/eybee/heatmap-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.3-1`
## heatmap

```
* fixed linking error
* Contributors: Adrian Bauer
```
