### PR TITLE
naoqi_dashboard: 0.1.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1915,6 +1915,17 @@ repositories:
       url: https://github.com/ros-naoqi/naoqi_bridge_msgs.git
       version: master
     status: maintained
+  naoqi_dashboard:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-naoqi/naoqi_dashboard-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_dashboard.git
+      version: master
+    status: maintained
   naoqi_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_dashboard` to `0.1.3-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_dashboard.git
- release repository: https://github.com/ros-naoqi/naoqi_dashboard-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## naoqi_dashboard

```
* resolve ns deb
* add conflicts with the previous naming conventions
* fix bad import
* fix default namespace
* update posture execution
* hardcode /diagnostic_agg topic
* actions for rest,wakeup,life
* clean the statuses of the buttons according to the new aggregator
* rename the package to naoqi_dashboard
* move files around
* update to the latest diagnostics
* rename info to be more NAOqi robot agnostic
* update the frame to handle the new diagnostics
* get the code to depend on naoqi_bridge_msgs
* offer a uniquified and sorted list of robots
* Contributors: Karsten Knese, Vincent Rabaud
```
