### PR TITLE
naoqi_bridge: 0.5.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1898,7 +1898,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_bridge-release.git
-      version: 0.5.2-0
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge` to `0.5.3-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_bridge.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.2-0`
## naoqi_apps
- No changes
## naoqi_bridge
- No changes
## naoqi_driver_py

```
* remove useless dependencies
* Contributors: Vincent Rabaud
```
## naoqi_pose

```
* add services for life
* Contributors: Karsten Knese
```
## naoqi_sensors_py

```
* remove useless dependencies
* Contributors: Vincent Rabaud
```
## naoqi_tools

```
* add add_dummy_collision function for gazebo simulation
* Contributors: Mikael Arguedas
```
