### PR TITLE
jackal_navigation_cpr: 0.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3374,6 +3374,12 @@ repositories:
       url: https://github.com/jackal/jackal_desktop.git
       version: indigo-devel
     status: developed
+  jackal_navigation_cpr:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:clearpathrobotics/jackal_navigation_cpr-gbp
+      version: 0.0.1-1
   jackal_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_navigation_cpr` to `0.0.1-1`:
- upstream repository: git@bitbucket.org:clearpathrobotics/jackal_navigation_cpr
- release repository: git@bitbucket.org:clearpathrobotics/jackal_navigation_cpr-gbp
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## jackal_navigation_cpr

```
* After months of one step forwards, one step back, we are releasing. Nothing much of consequence happened in between which needs to be recorded here.
* Contributors: Alex Bencz, Andrew Blakey, Enrique Fernandez, Guillaume Autran, James Servos, Jonathan Jekir, Paul Bovbel, Peiyi Chen, Ryan Gariepy, Shahab Kaynama
```
