### PR TITLE
naoqi_driver: 0.5.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1935,7 +1935,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_driver-release.git
-      version: 0.5.3-0
+      version: 0.5.4-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_driver` to `0.5.4-0`:
- upstream repository: https://github.com/ros-naoqi/alrosbridge.git
- release repository: https://github.com/ros-naoqi/naoqi_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.3-0`
## naoqi_driver

```
* remove useless include
* add V Rabaud as a maintainer
* Contributors: Vincent Rabaud
```
