### PR TITLE
naoqi_driver: 0.5.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5123,7 +5123,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_driver-release.git
-      version: 0.5.4-0
+      version: 0.5.5-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_driver` to `0.5.5-0`:
- upstream repository: https://github.com/ros-naoqi/alrosbridge.git
- release repository: https://github.com/ros-naoqi/naoqi_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.4-0`
## naoqi_driver

```
* fix correct loading of urdf
* Contributors: Karsten Knese
```
