### PR TITLE
naoqi_dashboard: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5108,7 +5108,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_dashboard-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_dashboard.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_dashboard` to `0.1.4-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_dashboard.git
- release repository: https://github.com/ros-naoqi/naoqi_dashboard-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.3-0`
## naoqi_dashboard

```
* remove find_package components
* Contributors: Karsten Knese
```
