### PR TITLE
naoqi_dashboard: 0.1.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1920,7 +1920,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_dashboard-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_dashboard.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_dashboard` to `0.1.4-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_dashboard.git
- release repository: https://github.com/ros-naoqi/naoqi_dashboard-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.3-0`
## naoqi_dashboard

```
* remove find_package components
* Contributors: Karsten Knese
```
