### PR TITLE
Adding evapc_ros to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1983,6 +1983,28 @@ repositories:
       url: https://github.com/tork-a/euslisp-release.git
       version: 9.15.0-0
     status: developed
+  evapc_ros:
+    doc:
+      type: git
+      url: https://github.com/inomuh/evapc_ros.git
+      version: eva50
+    release:
+      packages:
+      - evapc_ros
+      - evarobot_description
+      - evarobot_navigation
+      - evarobot_pose_ekf
+      - evarobot_slam
+      - evarobot_state_publisher
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/inomuh/evapc_ros-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/inomuh/evapc_ros.git
+      version: eva50
+    status: developed
   evapi_ros:
     doc:
       type: git


### PR DESCRIPTION
I'd like evapc_ros to be indexed and documented and ros.org.
