### PR TITLE
evapc_ros: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1983,6 +1983,29 @@ repositories:
       url: https://github.com/tork-a/euslisp-release.git
       version: 9.15.0-0
     status: developed
+  evapc_ros:
+    doc:
+      type: git
+      url: https://github.com/inomuh/evapc_ros.git
+      version: eva50
+    release:
+      packages:
+      - evapc_ros
+      - evarobot_description
+      - evarobot_navigation
+      - evarobot_pose_ekf
+      - evarobot_slam
+      - evarobot_state_publisher
+      - impc_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/inomuh/evapc_ros-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/inomuh/evapc_ros.git
+      version: eva50
+    status: developed
   evapi_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `evapc_ros` to `0.0.3-0`:
- upstream repository: https://github.com/inomuh/evapc_ros
- release repository: https://github.com/inomuh/evapc_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## impc_msgs
- No changes
