### PR TITLE
cob_common: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1000,7 +1000,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.6.4-0`:
- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.3-0`
## cob_common

```
* migrate to package format 2
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_description

```
* remove obsolete autogenerated mainpage.dox files
* add explicit exec_depend to xacro
* fix catkin_minimum_required version
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_msgs

```
* remove trailing whitespaces
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_srvs

```
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* Contributors: ipa-fxm
```
## raw_description

```
* fix typo in collision mesh file name
* add explicit exec_depend to xacro
* fix catkin_minimum_required version
* remove trailing whitespaces
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
