### PR TITLE
cob_robots: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1219,7 +1219,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.6.4-0`:
- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.3-0`
## cob_bringup

```
* renamed parameter
* making 'sim_enabled' a launch argument
* migrate to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* Torso->can0
* sort dependencies
* revies dependencies
* renamed launch-argument to use_rplidar in raw3-3.xml
* fix indentation in raw3-3.xml
* merge
* include torso in bringup
* Separate launch file for cob_obstacle_distance.
* updates for cartesian_controller yaml
* torso setup
* moved base components of cob3-9 to correct machine tag
* cob_bringup: removed run-dependency of rplidar_ros and trigger start of rplidar-driver via launch-argument as suggested
* unify cob3-X config and launch
* use controller_manager spawn
* cob_bringup: added run_dependency for rplidar_ros
* added rplidar sensor to raw3-3 urdf and bringup
* Contributors: Florian Mirus, ipa-cob4-2, ipa-fxm, ipa-fxm-mb, ipa-nhg
```
## cob_controller_configuration_gazebo

```
* making 'sim_enabled' a launch argument
* migrate to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* sort dependencies
* revies dependencies
* unify cob3-X config and launch
* Contributors: ipa-fxm
```
## cob_default_robot_config

```
* migrate to package format 2
* remove obsolete autogenerated mainpage.dox files
* sort dependencies
* revies dependencies
* merge
* update arm configurations
* unify cob3-X config and launch
* Contributors: ipa-cob4-2, ipa-fxm
```
## cob_hardware_config

```
* add marker_frame parameter to all light yamls
* merge with 320
* making 'sim_enabled' a launch argument
* fixes for cob3-9
* migrate to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* sort dependencies
* revies dependencies
* fix leading space
* updates for cartesian_controller yaml
* torso setup
* torso setup
* unify cob3-X config and launch
* even better layout
* cartesian_controller yaml updates
* added rplidar sensor to raw3-3 urdf and bringup
* Contributors: Florian Mirus, ipa-cob4-2, ipa-fxm
```
## cob_robots

```
* migrate to package format 2
* remove trailing whitespaces
* revies dependencies
* Contributors: ipa-fxm
```
