### PR TITLE
cob_simulation: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1240,7 +1240,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_simulation-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/ipa320/cob_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.6.4-0`:
- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.3-0`
## cob_bringup_sim

```
* migration to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* sort dependencies
* review dependencies
* Contributors: ipa-fxm
```
## cob_gazebo

```
* migration to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* sort dependencies
* review dependencies
* Contributors: ipa-fxm
```
## cob_gazebo_objects

```
* migration to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* review dependencies
* Contributors: ipa-fxm
```
## cob_gazebo_worlds

```
* cleanup
* migration to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* sort dependencies
* review dependencies
* removed unnecessary imports
* added buttons controllers
* use default inertias
* use default inertias
* fix ipa-apartment elevator
* fix ipa-apartment elevetor controllers
* use controller_manager spawn
* Contributors: ipa-fxm, ipa-nhg
```
## cob_simulation

```
* migration to package format 2
* remove trailing whitespaces
* review dependencies
* Contributors: ipa-fxm
```
