### PR TITLE
nerian_sp1: 1.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2002,7 +2002,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/nerian-vision/nerian_sp1-release.git
-      version: 1.0.2-1
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_sp1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_sp1` to `1.1.0-0`:
- upstream repository: https://github.com/nerian-vision/nerian_sp1.git
- release repository: https://github.com/nerian-vision/nerian_sp1-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.2-1`
## nerian_sp1

```
* Cleaned-up example launch file
* Minor bugfixes
* Updated SP1 software package
* Publishing of camera information
* Optional disparity window
* Performance optimization
* Removed enable parameters
* Fixed ROS coordinate system
* Contributors: Konstantin Schauwecker
```
