### PR TITLE
cob_manipulation: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1162,7 +1162,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_manipulation-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/ipa320/cob_manipulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_manipulation` to `0.6.3-0`:
- upstream repository: https://github.com/ipa320/cob_manipulation.git
- release repository: https://github.com/ipa320/cob_manipulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.2-0`
## cob_grasp_generation
- No changes
## cob_kinematics

```
* fix dependencies
* Contributors: ipa-fxm
```
## cob_lookat_action
- No changes
## cob_manipulation
- No changes
## cob_moveit_config
- No changes
## cob_moveit_interface
- No changes
## cob_pick_place_action
- No changes
## cob_tactiletools
- No changes
## cob_tray_monitor
- No changes
