### PR TITLE
cob_navigation: 0.5.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -980,11 +980,11 @@ repositories:
       - cob_navigation_global
       - cob_navigation_local
       - cob_navigation_slam
-      - cob_unified_scan_publisher
+      - cob_scan_unifier
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/ipa320/cob_navigation-release.git
-      version: 0.5.1-2
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/ipa320/cob_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_navigation` to `0.5.3-0`:
- upstream repository: https://github.com/ipa320/cob_navigation.git
- release repository: https://github.com/ipa320/cob_navigation-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.1-2`
## cob_linear_nav
- No changes
## cob_mapping_slam

```
* Merge tag '0.5.2' into hydro_release_candidate
* Contributors: ipa-mig
```
## cob_navigation

```
* Merge tag '0.5.2' into hydro_release_candidate
* Contributors: ipa-mig
```
## cob_navigation_config
- No changes
## cob_navigation_global

```
* Merge tag '0.5.2' into hydro_release_candidate
* Contributors: ipa-mig
```
## cob_navigation_local
- No changes
## cob_navigation_slam
- No changes
## cob_scan_unifier

```
* reduced MAGIC NUMBER
* check range values
* round index
* Contributors: ipa-josh
```
