### PR TITLE
cob_navigation: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1186,7 +1186,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_navigation-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/ipa320/cob_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_navigation` to `0.6.3-0`:
- upstream repository: https://github.com/ipa320/cob_navigation.git
- release repository: https://github.com/ipa320/cob_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.2-0`
## cob_linear_nav

```
* remove trailing whitespace
* migration to package format v2, indentation fixes
* Contributors: ipa-mig
```
## cob_mapping_slam

```
* migration to package format v2, indentation fixes
* Contributors: ipa-mig
```
## cob_navigation

```
* migration to package format v2, indentation fixes
* Contributors: ipa-mig
```
## cob_navigation_config

```
* cob_navigation_config: remove robots not supported anymore
* remove trailing whitespace
* migration to package format v2, indentation fixes
* Contributors: ipa-mig
```
## cob_navigation_global

```
* remove trailing whitespace
* migration to package format v2, indentation fixes
* remove deprecated launchfiles
* Contributors: ipa-mig
```
## cob_navigation_local

```
* migration to package format v2, indentation fixes
* Contributors: ipa-mig
```
## cob_navigation_slam

```
* migration to package format v2, indentation fixes
* remove deprecated launchfiles
* Contributors: ipa-mig
```
## cob_scan_unifier

```
* remove trailing whitespace
* migration to package format v2, indentation fixes
* Merge remote-tracking branch 'origin-ipa320/hydro_dev' into indigo_dev
* reduced MAGIC NUMBER
* check range values
* round index
* Contributors: ipa-josh, ipa-mig
```
