### PR TITLE
schunk_modular_robotics: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8883,7 +8883,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/schunk_modular_robotics-release.git
-      version: 0.6.5-0
+      version: 0.6.6-0
     source:
       type: git
       url: https://github.com/ipa320/schunk_modular_robotics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_modular_robotics` to `0.6.6-0`:
- upstream repository: https://github.com/ipa320/schunk_modular_robotics.git
- release repository: https://github.com/ipa320/schunk_modular_robotics-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.5-0`
## schunk_description
- No changes
## schunk_libm5api

```
* fix include
* Contributors: ipa-fxm
```
## schunk_modular_robotics
- No changes
## schunk_powercube_chain
- No changes
## schunk_sdh
- No changes
## schunk_sdhx
- No changes
## schunk_simulated_tactile_sensors
- No changes
