### PR TITLE
Adding riskrrt to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7133,6 +7133,16 @@ repositories:
       url: https://github.com/robotican/ric.git
       version: indigo-devel
     status: maintained
+  riskrrt:
+  	doc:
+      type: git
+      url: https://github.com/spalanza/riskrrt.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/spalanza/riskrrt.git
+      version: indigo-devel
+    status: maintained
   rmp_msgs:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7134,7 +7134,7 @@ repositories:
       version: indigo-devel
     status: maintained
   riskrrt:
-  	doc:
+    doc:
       type: git
       url: https://github.com/spalanza/riskrrt.git
       version: indigo-devel


### PR DESCRIPTION
I'd like riskrrt to be indexed and documented on ros.org
