### PR TITLE
jsk_robot: 0.0.11-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3337,7 +3337,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_robot-release.git
-      version: 0.0.10-1
+      version: 0.0.11-0
     status: developed
   jsk_roseus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `0.0.11-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.10-1`
## baxtereus

```
* [baxtereus/test/test-baxter.l] :debug-view :no-messages output too many messages for travis
* [baxtereus/CMakeLists.txt] forget installing baxter-util.l
* [baxtereus/CMakeLists.txt] install test directory
* Contributors: Kei Okada
```
## jsk_201504_miraikan
- No changes
## jsk_baxter_desktop
- No changes
## jsk_baxter_startup
- No changes
## jsk_baxter_web
- No changes
## jsk_nao_startup
- No changes
## jsk_pepper_startup

```
* set robot/type, robot/name
* Contributors: Kei Okada
```
## jsk_pr2_calibration
- No changes
## jsk_pr2_startup
- No changes
## jsk_robot_startup

```
* [jsk_robot_startup] Add visualization node for viso odom_combined
* [jsk_robot_startup] Add viso.launch for visual odometry
* Contributors: Iori Kumagai
```
## jsk_robot_utils
- No changes
## peppereus
- No changes
## pr2_base_trajectory_action
- No changes
## roseus_remote
- No changes
