### PR TITLE
mongodb_store: 0.1.17-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1597,7 +1597,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.1.16-0
+      version: 0.1.17-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.17-0`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.16-0`
## mongodb_log

```
* Added std namespace usage to tf logger.
* Contributors: Nick Haes
```
## mongodb_store

```
* Added dependency on jade package for legacy mongodb c++ driver. Updated the CMake file to search this location too.
* Fix: remove auto-generated databases in /tmp after a test has been completed that may e.g. fill up the harddisk of a Jenkins server
* Contributors: Moritz Tenorth, Nick Haes
```
## mongodb_store_msgs
- No changes
