### PR TITLE
people: 1.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6051,7 +6051,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/OSUrobotics/people-release.git
-      version: 1.0.8-0
+      version: 1.0.9-0
     source:
       type: git
       url: https://github.com/wg-perception/people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `people` to `1.0.9-0`:
- upstream repository: https://github.com/wg-perception/people.git
- release repository: https://github.com/OSUrobotics/people-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.8-0`
## face_detector

```
* Install missing param directory: face_detector.rgbd.launch fails due to the param folder.
* Contributors: Isaac I.Y. Saito
```
## leg_detector

```
* Fix handling of scans with negative angle increment
  For laser sensors which are mounted upside down. Old code did not generate any clusters in that case.
* Contributors: Timm Linder
```
## people
- No changes
## people_msgs
- No changes
## people_tracking_filter

```
* Update CMakeLists.txt
* Contributors: David Lu!!
```
## people_velocity_tracker

```
* change queue sizes to 10
* Update for Indigo and add unfiltered people velocity launcher
* PEP8 fixes
* Contributors: Aaron Blasdel
```
