### PR TITLE
xacro: 1.10.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4072,7 +4072,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.10.5-0
+      version: 1.10.6-0
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.10.6-0`:
- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.10.5-0`
## xacro

```
* use correct catkin environment for cmake dependency checking
* fixed dependency definition for cmake usage
* Contributors: Robert Haschke
```
