### PR TITLE
willow_maps: 1.0.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10386,7 +10386,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/willow_maps-release.git
-      version: 1.0.2-0
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/pr2/willow_maps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `willow_maps` to `1.0.2-1`:
- upstream repository: https://github.com/pr2/willow_maps.git
- release repository: https://github.com/ros-gbp/willow_maps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.2-0`
## willow_maps
- No changes
