### PR TITLE
app_manager: 1.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -215,7 +215,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/app_manager-release.git
-      version: 1.0.3-1
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/pr2/app_manager.git


### PR DESCRIPTION
Increasing version of package(s) in repository `app_manager` to `1.0.4-0`:
- upstream repository: https://github.com/pr2/app_manager.git
- release repository: https://github.com/ros-gbp/app_manager-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.3-1`
