### PR TITLE
ecto_pcl: 0.4.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -612,7 +612,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ecto_pcl-release.git
-      version: 0.4.2-0
+      version: 0.4.3-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto_pcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto_pcl` to `0.4.3-0`:
- upstream repository: https://github.com/plasmodic/ecto_pcl.git
- release repository: https://github.com/ros-gbp/ecto_pcl-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.4.2-0`
## ecto_pcl

```
* SACSegmentationFromNormals: support input indices
* SACSegmentation: support input indices
* fix SACSegmentation cell
* ConvexHull: add input indices
* remove useless dependency
* clean tests
* Added new parameter to ExtractIndices
  - Added parameter to keep the filtered cloud organized, i.e.,
  coordinates of 'removed' points are set to 'NaN'
* add proper test dependency
* add proper nosetest
* clean extensions
* Contributors: Michael Görner, Sven Albrecht, Vincent Rabaud
```
