### PR TITLE
evapc_ros: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2016,7 +2016,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/inomuh/evapc_ros-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/inomuh/evapc_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `evapc_ros` to `0.0.4-0`:
- upstream repository: https://github.com/inomuh/evapc_ros
- release repository: https://github.com/inomuh/evapc_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.3-0`
## evapc_ros
- No changes
## evarobot_description

```
* Add hector_gazebo_plugins to dependencies of evarobot_description
* Contributors: Mehmet Akcakoca
```
## evarobot_navigation
- No changes
## evarobot_pose_ekf
- No changes
## evarobot_slam
- No changes
## evarobot_state_publisher
- No changes
## impc_msgs
- No changes
