### PR TITLE
wireless: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10404,7 +10404,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/wireless-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/wireless.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless` to `0.0.6-0`:
- upstream repository: https://github.com/clearpathrobotics/wireless
- release repository: https://github.com/clearpath-gbp/wireless-release
- distro file: indigo/distribution.yaml
- bloom version: 0.0.6-0
- previous version for package: 0.0.5-0
# wireless_watcher
- Added queue_size parameter to publishers
