### PR TITLE
oculus_sdk: 0.2.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5648,6 +5648,21 @@ repositories:
       url: https://github.com/OctoMap/octomap_rviz_plugins.git
       version: indigo-devel
     status: maintained
+  oculus_sdk:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/oculus_sdk.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/thedash/oculus_sdk-release.git
+      version: 0.2.6-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/oculus_sdk.git
+      version: hydro-devel
+    status: maintained
   ohm_tsd_slam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `oculus_sdk` to `0.2.6-0`:
- upstream repository: https://github.com/ros-visualization/oculus_sdk.git
- release repository: https://github.com/thedash/oculus_sdk-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
