### PR TITLE
oculus_rviz_plugins: 0.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5648,6 +5648,17 @@ repositories:
       url: https://github.com/OctoMap/octomap_rviz_plugins.git
       version: indigo-devel
     status: maintained
+  oculus_rviz_plugins:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/thedash/oculus_rviz_plugins-release.git
+      version: 0.0.9-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/oculus_rviz_plugins.git
+      version: groovy-devel
+    status: maintained
   oculus_sdk:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `oculus_rviz_plugins` to `0.0.9-0`:
- upstream repository: https://github.com/ros-visualization/oculus_rviz_plugins.git
- release repository: https://github.com/thedash/oculus_rviz_plugins-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
