### PR TITLE
ackermann_msgs: 1.0.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -77,7 +77,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/ackermann_msgs-release.git
-      version: 0.9.1-0
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/ackermann_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ackermann_msgs` to `1.0.0-1`:
- upstream repository: https://github.com/ros-drivers/ackermann_msgs.git
- release repository: https://github.com/ros-drivers-gbp/ackermann_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.9.1-0`
## ackermann_msgs

```
* Changed the version to 1.0.0.
```
