### PR TITLE
jsk_recognition: 0.3.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3312,7 +3312,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     status: maintained
   jsk_robot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.1-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.0-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros

```
* [jsk_pcl_ros, jsk_perception] Fix dependency of jsk_recognition_utils for child packages
  like jsk_rviz_plugins
* Contributors: Ryohei Ueda
```
## jsk_perception

```
* [jsk_pcl_ros, jsk_perception] Fix dependency of jsk_recognition_utils for child packages
  like jsk_rviz_plugins
* Contributors: Ryohei Ueda
```
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## jsk_recognition_utils

```
* Add README.md to jsk_recognition_utils
* Contributors: Ryohei Ueda
```
## resized_image_transport
- No changes
