### PR TITLE
lms1xx: 0.1.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1385,7 +1385,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/clearpath-gbp/lms1xx-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/lms1xx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lms1xx` to `0.1.4-0`:
- upstream repository: https://github.com/clearpathrobotics/LMS1xx.git
- release repository: https://github.com/clearpath-gbp/lms1xx-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.3-0`
## lms1xx

```
* Another startup bugfix.
* Contributors: Tony Baltovski
```
