### PR TITLE
jsk_recognition: 0.3.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3312,7 +3312,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     status: maintained
   jsk_robot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.2-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.1-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros

```
* [jsk_pcl_ros] use arguments in order to change a behavior
* [jsk_pcl_ros] remove unused arguments
* [jsk_pcl_ros] remove unused white spaces
* Contributors: eisoku9618
```
## jsk_perception

```
* [jsk_perception] Ignore autogenerated files
* [jsk_perception] Use histograms to compute distance in TabletopColorDifferenceLikelihood
* Contributors: Ryohei Ueda
```
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## jsk_recognition_utils

```
* add yaml-cpp to depends
* Merge pull request #1151 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/1151> from garaemon/use-histograms
  [jsk_perception] Use histograms to compute distance in TabletopColorDifferenceLikelihood
* [jsk_perception] Use histograms to compute distance in TabletopColorDifferenceLikelihood
* Contributors: Kei Okada, Ryohei Ueda
```
## resized_image_transport
- No changes
