### PR TITLE
jsk_recognition: 0.3.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3617,7 +3617,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.2-0
+      version: 0.3.3-0
     status: developed
   jsk_robot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.3-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.2-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros

```
* [jsk_pcl_ros] README.md -> readthedocs.org
  Closes #330 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/330>
* Contributors: Kentaro Wada
```
## jsk_perception

```
* [jsk_perception] README.md -> readthedocs.org
* Revert "[jsk_perception] use sphinx for rosdoc"
  This reverts commit 9e4ba233599b21c6422ec9a45f395b460c53264d.
* [jsk_perception/TabletopColorDifferenceLikelihood] Use geo/polygon.h
  instead of geo_util.h
* Contributors: Kentaro Wada, Ryohei Ueda
```
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## jsk_recognition_utils

```
* [jsk_recognition_utils] Depends on visualization_msgs
* [jsk_recognition_utils] Separate grid_plane.h from geo_util.h
* [jsk_recognition_utils] Separate cylinder.h from geo_util.h
* [jsk_recognition_utils] Separate cube.h from geo_util.h
* [jsk_recognition_utils] Separate convex_polygon.h from geo_util.h
* [jsk_recognition_utils] Separate polygon.h from geo_util.h
* [jsk_recognition_utils] Separate plane.h from geo_util.h
* [jsk_recognition_utils] Separate segment.h from geo_util.h
* [jsk_recognition_utils] Separate line.h from geo_util.h
* Contributors: Ryohei Ueda
```
## resized_image_transport
- No changes
