### PR TITLE
jsk_recognition: 0.3.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3312,7 +3312,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.3-0
+      version: 0.3.4-0
     status: maintained
   jsk_robot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.4-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.3-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros

```
* Swap doc soft links (to make 'Edit on GitHub' work)
* ColorizeFloatImage correct image link
  Closes https://github.com/jsk-ros-pkg/jsk_recognition/issues/1165
* Contributors: Kentaro Wada
```
## jsk_perception

```
* Swap doc soft links (to make 'Edit on GitHub' work)
* ColorizeFloatImage correct image link
  Closes https://github.com/jsk-ros-pkg/jsk_recognition/issues/1165
* Contributors: Kentaro Wada
```
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## jsk_recognition_utils

```
* Merge pull request #1168 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/1168> from k-okada/add_yaml
  jsk_recognition_utils: forget to add include to install
* jsk_recognition_utils: forget to add include to install
* [jsk_recognition_utils/README] Add link to doxygen documentation
* [jsk_recognition_utils/Line] Add documentation
* Contributors: Kei Okada, Ryohei Ueda
```
## resized_image_transport
- No changes
