### PR TITLE
Adding voronoi_planner to documentation index for distro    

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10315,11 +10315,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/frontw/voronoi_planner.git
-      version: indigo
+      version: master
     source:
       type: git
       url: https://github.com/frontw/voronoi_planner.git
-      version: indigo
+      version: master
   vrep_ros_bridge:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10311,6 +10311,15 @@ repositories:
       type: git
       url: https://github.com/uos/volksbot_driver.git
       version: indigo
+  voronoi_planner:
+    doc:
+      type: git
+      url: https://github.com/frontw/voronoi_planner.git
+      version: indigo
+    source:
+      type: git
+      url: https://github.com/frontw/voronoi_planner.git
+      version: indigo
   vrep_ros_bridge:
     doc:
       type: git


### PR DESCRIPTION
I'd like voronoi_planner to be indexed and documented on ros.org.
