### PR TITLE
tiago_robot: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9626,6 +9626,16 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git
       version: indigo-devel
+    release:
+      packages:
+      - tiago_bringup
+      - tiago_controller_configuration
+      - tiago_description
+      - tiago_robot
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pal-gbp/tiago_robot-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_robot` to `0.0.1-0`:
- upstream repository: https://github.com/pal-robotics/tiago_robot
- release repository: https://github.com/pal-gbp/tiago_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## tiago_bringup

```
* First tiago release
* Contributors: Bence Magyar
```
## tiago_controller_configuration

```
* First tiago release
* Contributors: Bence Magyar
```
## tiago_description

```
* First tiago release
* Contributors: Bence Magyar
```
## tiago_robot

```
* First tiago release
* Contributors: Bence Magyar
```
