### PR TITLE
tiago_simulation: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9646,6 +9646,15 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/tiago_simulation.git
       version: indigo-devel
+    release:
+      packages:
+      - tiago_gazebo
+      - tiago_hardware_gazebo
+      - tiago_simulation
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pal-gbp/tiago_simulation-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_simulation` to `0.0.1-0`:
- upstream repository: https://github.com/pal-robotics/tiago_simulation
- release repository: https://github.com/pal-gbp/tiago_simulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## tiago_gazebo

```
* Update maintainer email
* Update package xmls
* First tiago release
* Contributors: Bence Magyar
```
## tiago_hardware_gazebo

```
* Update maintainer email
* Update package xmls
* First tiago release
* Contributors: Bence Magyar
```
## tiago_simulation

```
* Update maintainer email
* Update package xmls
* First tiago release
* Contributors: Bence Magyar
```
