### PR TITLE
sophus: 0.9.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3595,6 +3595,17 @@ repositories:
       url: https://github.com/ros-drivers/smart_battery_msgs.git
       version: master
     status: maintained
+  sophus:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/yujinrobot-release/sophus-release.git
+      version: 0.9.0-0
+    source:
+      type: git
+      url: https://github.com/stonier/sophus.git
+      version: jade
+    status: maintained
   spatial_temporal_learning:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `0.9.0-0`:
- upstream repository: https://github.com/stonier/sophus.git
- release repository: https://github.com/yujinrobot-release/sophus-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
