### PR TITLE
Removing evapi_ros release since packages for arm

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2033,23 +2033,6 @@ repositories:
       type: git
       url: https://github.com/inomuh/evapi_ros.git
       version: eva50
-    release:
-      packages:
-      - evarobot_bumper
-      - evarobot_controller
-      - evarobot_driver
-      - evarobot_eio
-      - evarobot_infrared
-      - evarobot_minimu9
-      - evarobot_odometry
-      - evarobot_orientation
-      - evarobot_sonar
-      - evarobot_start
-      - im_msgs
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/inomuh/evapi_ros.git
-      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/inomuh/evapi_ros.git


### PR DESCRIPTION
I'd like to remove evapi_ros release.
