### PR TITLE
Adding dynamicvoronoi to documentation index for distro: another try

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1713,6 +1713,15 @@ repositories:
       url: https://github.com/ros/dynamic_reconfigure.git
       version: master
     status: maintained
+  dynamicvoronoi:
+    doc:
+      type: git
+      url: https://github.com/frontw/dynamicvoronoi.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/frontw/dynamicvoronoi.git
+      version: master
   dynamixel_motor:
     doc:
       type: git


### PR DESCRIPTION
Please add dynamicvoronoi to documentation index for distro.
I want to publish catkinized version of http://wiki.ros.org/dynamicvoronoi which I use in another package.
