### PR TITLE
wireless: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10483,7 +10483,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/wireless-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/wireless.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless` to `0.0.7-0`:
- upstream repository: https://github.com/clearpathrobotics/wireless.git
- release repository: https://github.com/clearpath-gbp/wireless-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.6-0`
## wireless_msgs

```
* Added frequency to watcher node
* Contributors: Alex Bencz
```
## wireless_watcher

```
* Added frequency to watcher node
* Contributors: Alex Bencz
```
