### PR TITLE
maggie_drivers: 0.0.3-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3960,7 +3960,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/UC3MSocialRobots/maggie_drivers-release.git
-      version: 0.0.2-0
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/UC3MSocialRobots/maggie_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `maggie_drivers` to `0.0.3-1`:
- upstream repository: https://github.com/UC3MSocialRobots/maggie_drivers.git
- release repository: https://github.com/UC3MSocialRobots/maggie_drivers-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.2-0`
## maggie_drivers
- No changes
## maggie_ir_drivers

```
* updated dependencies to 3rd party of ir controller
* updated log info by debug
* Contributors: Raul Perula-Martinez, Raúl Pérula-Martínez
```
## maggie_labjack_drivers

```
* updated old attempt
* updated log info by debug
* Contributors: Raul Perula-Martinez, Raúl Pérula-Martínez
```
## maggie_motor_drivers

```
* updated dependencies
* updated log info by debug
* Contributors: Raul Perula-Martinez, Raúl Pérula-Martínez
```
## maggie_rfid_drivers
- No changes
## maggie_serial_comm_drivers
- No changes
