### PR TITLE
maggie_drivers: 0.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3960,7 +3960,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/UC3MSocialRobots/maggie_drivers-release.git
-      version: 0.0.3-1
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/UC3MSocialRobots/maggie_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `maggie_drivers` to `0.0.4-0`:
- upstream repository: https://github.com/UC3MSocialRobots/maggie_drivers.git
- release repository: https://github.com/UC3MSocialRobots/maggie_drivers-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.3-1`
## maggie_drivers

```
* updated warnings in changelogs
* Contributors: Raul Perula-Martinez
```
## maggie_ir_drivers

```
* updated warnings in changelogs
* updated dependency
* Contributors: Raul Perula-Martinez
```
## maggie_labjack_drivers

```
* updated warnings in changelogs
* Contributors: Raul Perula-Martinez
```
## maggie_motor_drivers

```
* updated warnings in changelogs
* Contributors: Raul Perula-Martinez
```
## maggie_rfid_drivers

```
* updated warnings in changelogs
* Contributors: Raul Perula-Martinez
```
## maggie_serial_comm_drivers

```
* updated warnings in changelogs
* Contributors: Raul Perula-Martinez
```
