### PR TITLE
Changed installation method for autobahn in rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -121,7 +121,9 @@ python-argparse:
     vivid:
       packages: []
 python-autobahn:
-  debian: [python-autobahn]
+  debian:
+    pip:
+      packages: [autobahn]
   fedora:
     pip:
       packages: [autobahn]
@@ -153,8 +155,12 @@ python-autobahn:
     saucy:
       pip:
         packages: [autobahn]
-    trusty: [python-autobahn]
-    utopic: [python-autobahn]
+    trusty:
+      pip:
+        packages: [autobahn]
+    utopic:
+      pip:
+        packages: [autobahn]
     vivid: [python-autobahn]
 python-avahi:
   arch: [avahi]


### PR DESCRIPTION
I'm working on updating rospeex, multilingual cloud-based speech recognition and synthesis module, and I'd like to use pip for required module (autobahn) instead of apt-get. The reason is as follows.

Based on the comments in the following discussions, I've been trying to use apt-get for installing autobahn.
https://github.com/ros/rosdistro/pull/9154

The problem is that the autobahn package installed by apt-get is sometimes very old (=autobahn-0.5) in Debian and Ubuntu. There are many differences between autobahn-0.5 and autobahn-0.10, and adapting rospeex to both versions will take considerable amount of time.

Considering the fact that pip can install the latest autobahn (and that some packages already use pip even if apt-get can be used), I'd like to install autobahn-0.10 by pip.

By the way, the autobahn versions installed by Ubuntu's apt-get are as follows:
13.10 and earlier: no apt-get package provided for autobahn.
14.04: python-autobahn-0.5
14.10: python-autobahn-0.5
15.04: python-autobahn-0.5
15.10: python-autobahn-0.10
