### PR TITLE
jsk_recognition: 0.3.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3318,7 +3318,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.5-0
+      version: 0.3.6-0
     status: maintained
   jsk_robot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.6-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.5-0`
## checkerboard_detector
- No changes
## imagesift

```
* [imagesift] Add doc
* [imagesift] Add comments on sample launch
* Contributors: Kentaro Wada
```
## jsk_pcl_ros

```
* [jsk_pcl_ros] Do not compile build_check.cpp in normal compilation time,
  just in run_tests
* Contributors: Ryohei Ueda
```
## jsk_perception
- No changes
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## jsk_recognition_utils
- No changes
## resized_image_transport
- No changes
