### PR TITLE
robot_model: 1.11.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2886,7 +2886,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.11.7-0
+      version: 1.11.8-0
     source:
       type: git
       url: https://github.com/ros/robot_model.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.11.8-0`:
- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.7-0`
## collada_parser
- No changes
## collada_urdf

```
* Removed pcre hack for newer released collada-dom.
* Contributors: Kei Okada
```
## joint_state_publisher
- No changes
## kdl_parser
- No changes
## robot_model
- No changes
## urdf

```
* Removed pcre hack for newer released collada-dom.
* Fixed link order of libpcrecpp.
* Contributors: Kei Okada
```
## urdf_parser_plugin
- No changes
