### PR TITLE
jsk_roseus: 1.3.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3691,7 +3691,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.3.7-0
+      version: 1.3.8-0
     status: maintained
   jsk_smart_apps:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.3.8-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.3.7-0`
## jsk_roseus
- No changes
## roseus

```
* [roseus] Add test to read ros parameter with default value 1000 times
* [roseus] Use COPYOBJ instead of copyobj to copy object of default
  parameter in ros::get-param
* fix ros::resolve-path returns nil for non existing package name
* add test for ros::resolve-path
* [euslisp/roseus.l] compile when loaded as package://
* [euslisp/roseus.l] fix roseus-add-files to use normal compile-file-if-src-newer
* [test/test-compile-message.l] add test for compiling message
* Contributors: Kei Okada, Ryohei Ueda, Yohei Kakiuchi
```
## roseus_mongo

```
* [roseus_mongo] fix replicate function (send-goal did not send-goal
* [roseus_mongo/euslisp/mongo-client-sample.l] fix: update sample
* Contributors: Yuki Furuta
```
## roseus_smach
- No changes
## roseus_tutorials
- No changes
