### PR TITLE
fetch_gazebo: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2149,7 +2149,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_gazebo-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_gazebo` to `0.6.2-0`:
- upstream repository: https://github.com/fetchrobotics/fetch_gazebo.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.1-0`
## fetch_gazebo

```
* Fixed number of samples for the laser scanner
  Real laser scan has 662 samples
* Update test_zone.sdf, had two </world> tag
* Contributors: Alex Henning, Kei Okada
```
## fetch_gazebo_demo
- No changes
