### PR TITLE
ypspur: 0.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10720,6 +10720,21 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/youbot-release/youbot_simulation-release.git
       version: 0.8.0-0
+  ypspur:
+    doc:
+      type: git
+      url: https://github.com/DaikiMaekawa/ypspur-release
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/DaikiMaekawa/ypspur-release
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/DaikiMaekawa/ypspur-release
+      version: master
+    status: maintained
   yujin_maps:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10766,10 +10766,6 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/DaikiMaekawa/ypspur-release.git
       version: 0.0.1-1
-    source:
-      type: git
-      url: https://github.com/DaikiMaekawa/ypspur-release.git
-      version: upstream
     status: maintained
   yujin_maps:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -915,6 +915,16 @@ repositories:
       url: https://github.com/WPI-RAIL/carl_safety.git
       version: develop
     status: maintained
+  cassandra_ros:
+    doc:
+      type: git
+      url: https://gitlab.com/OvGU-ESS/cassandra_ros.git
+      version: master
+    source:
+      type: git
+      url: https://gitlab.com/OvGU-ESS/cassandra_ros.git
+      version: master
+    status: maintained
   catkin:
     doc:
       type: git
@@ -7656,6 +7666,26 @@ repositories:
       url: https://github.com/ros/ros.git
       version: indigo-devel
     status: maintained
+  rosR:
+    doc:
+      type: git
+      url: https://gitlab.com/OvGU-ESS/rosR.git
+      version: master
+    source:
+      type: git
+      url: https://gitlab.com/OvGU-ESS/rosR.git
+      version: master
+    status: maintained
+  rosR_demos:
+    doc:
+      type: git
+      url: https://gitlab.com/OvGU-ESS/rosR_demos.git
+      version: master
+    source:
+      type: git
+      url: https://gitlab.com/OvGU-ESS/rosR_demos.git
+      version: master
+    status: maintained
   ros_arduino_bridge:
     doc:
       type: git
@@ -8400,6 +8430,16 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/rosserial.git
       version: indigo-devel
+    status: maintained
+  rosshell:
+    doc:
+      type: git
+      url: https://gitlab.com/OvGU-ESS/rosshell.git
+      version: master
+    source:
+      type: git
+      url: https://gitlab.com/OvGU-ESS/rosshell.git
+      version: master
     status: maintained
   rostful_node:
     release:
@@ -10721,19 +10761,15 @@ repositories:
       url: https://github.com/youbot-release/youbot_simulation-release.git
       version: 0.8.0-0
   ypspur:
-    doc:
-      type: git
-      url: https://github.com/DaikiMaekawa/ypspur-release
-      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/DaikiMaekawa/ypspur-release
+      url: https://github.com/DaikiMaekawa/ypspur-release.git
       version: 0.0.1-1
     source:
       type: git
-      url: https://github.com/DaikiMaekawa/ypspur-release
-      version: master
+      url: https://github.com/DaikiMaekawa/ypspur-release.git
+      version: upstream
     status: maintained
   yujin_maps:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ypspur` to `0.0.1-1`:
- upstream repository: https://openspur.org/repos/yp-spur.git
- release repository: https://github.com/DaikiMaekawa/ypspur-release
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
