### PR TITLE
jsk_roseus: 1.3.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3701,7 +3701,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.3.8-0
+      version: 1.3.9-0
     status: maintained
   jsk_smart_apps:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.3.9-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.3.8-0`
## jsk_roseus
- No changes
## roseus

```
* roseus.cpp: add ros::create-timer function
* Contributors: Kei Okada, Ryohei Ueda
```
## roseus_mongo
- No changes
## roseus_smach
- No changes
## roseus_tutorials
- No changes
