### PR TITLE
Removed pip-related entries from python-autobahn in rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -122,37 +122,15 @@ python-argparse:
       packages: []
 python-autobahn:
   debian: [python-autobahn]
-  fedora:
-    pip:
-      packages: [autobahn]
-  osx:
-    pip:
-      packages: [autobahn]
   ubuntu:
-    lucid:
-      pip:
-        packages: [autobahn]
-    maverick:
-      pip:
-        packages: [autobahn]
-    natty:
-      pip:
-        packages: [autobahn]
-    oneiric:
-      pip:
-        packages: [autobahn]
-    precise:
-      pip:
-        packages: [autobahn]
-    quantal:
-      pip:
-        packages: [autobahn]
-    raring:
-      pip:
-        packages: [autobahn]
-    saucy:
-      pip:
-        packages: [autobahn]
+    lucid: []
+    maverick: []
+    natty: []
+    oneiric: []
+    precise: []
+    quantal: []
+    raring: []
+    saucy: []
     trusty: [python-autobahn]
     utopic: [python-autobahn]
     vivid: [python-autobahn]


### PR DESCRIPTION
According to the comments in https://github.com/ros/rosdistro/pull/9154 and https://github.com/ros/rosdistro/pull/9428 , pip installation entries for python-autobahn are removed. 
