### PR TITLE
nerian_sp1: 1.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5382,7 +5382,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/nerian-vision/nerian_sp1-release.git
-      version: 1.1.0-0
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_sp1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_sp1` to `1.1.1-0`:
- upstream repository: https://github.com/nerian-vision/nerian_sp1.git
- release repository: https://github.com/nerian-vision/nerian_sp1-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.0-0`
## nerian_sp1

```
* Updated to libvisiontransfer 1.0.2
* Contributors: Konstantin Schauwecker
```
