### PR TITLE
Add python-redis-pip to python packages

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1439,6 +1439,10 @@ python-redis:
     raring: [python-redis]
     saucy: [python-redis]
     trusty: [python-redis]
+python-redis-pip:
+  ubuntu:
+    pip:
+      packages: [redis]
 python-requests:
   debian: [python-requests]
   fedora: [python-requests]


### PR DESCRIPTION
The apt package for python-redis installs redis-py 2.7.2 (last updated 2012) and doesn't include a bunch of bug fixes and useful features.

The pip package has the more recent redis-py 2.10.3 (updated 8/2014).
