### PR TITLE
turtlebot_simulator: 2.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9966,7 +9966,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_simulator-release.git
-      version: 2.2.1-0
+      version: 2.2.2-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_simulator` to `2.2.2-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_simulator.git
- release repository: https://github.com/turtlebot-release/turtlebot_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.2.1-0`
## turtlebot_gazebo
- No changes
## turtlebot_simulator
- No changes
## turtlebot_stage

```
* view frame is now base_link closes #51 <https://github.com/turtlebot/turtlebot_simulator/issues/51>
* Contributors: Jihoon Lee
```
## turtlebot_stdr
- No changes
