### PR TITLE
homer_robot_face: 1.0.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2943,7 +2943,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_robot_face.git
-      version: 1.0.1-1
+      version: 1.0.2-1
   household_objects_database:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_robot_face` to `1.0.2-1`:
- upstream repository: https://gitlab.uni-koblenz.de/robbie/homer_robot_face.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_robot_face.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.1-1`
