### PR TITLE
linux_networking: 1.0.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4347,6 +4347,31 @@ repositories:
       type: git
       url: https://github.com/srv/libvlfeat.git
       version: master
+  linux_networking:
+    release:
+      packages:
+      - access_point_control
+      - asmach
+      - asmach_tutorials
+      - ddwrt_access_point
+      - hostapd_access_point
+      - ieee80211_channels
+      - linksys_access_point
+      - linux_networking
+      - multi_interface_roam
+      - network_control_tests
+      - network_detector
+      - network_monitor_udp
+      - network_traffic_control
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/TheDash/linux_networking-release.git
+      version: 1.0.11-0
+    source:
+      type: git
+      url: https://github.com/pr2/linux_networking.git
+      version: hydro-devel
+    status: maintained
   linux_peripheral_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `linux_networking` to `1.0.11-0`:
- upstream repository: https://github.com/PR2/linux_networking.git
- release repository: https://github.com/TheDash/linux_networking-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
