### PR TITLE
pr2_common_actions: 0.0.5-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6452,7 +6452,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_common_actions-release.git
-      version: 0.0.5-2
+      version: 0.0.5-3
     source:
       type: git
       url: https://github.com/pr2/pr2_common_actions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common_actions` to `0.0.5-3`:
- upstream repository: https://github.com/PR2/pr2_common_actions.git
- release repository: https://github.com/pr2-gbp/pr2_common_actions-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.5-2`
## joint_trajectory_action_tools
- No changes
## joint_trajectory_generator
- No changes
## pr2_arm_move_ik

```
* fix: use undefined function
* Contributors: Furushchev
```
## pr2_common_action_msgs
- No changes
## pr2_common_actions
- No changes
## pr2_tilt_laser_interface
- No changes
## pr2_tuck_arms_action
- No changes
