### PR TITLE
ros_emacs_utils: 0.4.8-0 in 'jade/distribution.yaml'

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3053,6 +3053,27 @@ repositories:
       url: https://github.com/ros/ros_comm_msgs.git
       version: indigo-devel
     status: maintained
+  ros_emacs_utils:
+    doc:
+      type: git
+      url: https://github.com/code-iai/ros_emacs_utils.git
+      version: master
+    release:
+      packages:
+      - ros_emacs_utils
+      - rosemacs
+      - roslisp_repl
+      - slime_ros
+      - slime_wrapper
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/code-iai-release/ros_emacs_utils-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/code-iai/ros_emacs_utils.git
+      version: master
+    status: maintained
   ros_ethernet_rmp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository ros_emacs_utils to 0.4.8-0:

upstream repository: https://github.com/code-iai/ros_emacs_utils.git
release repository: https://github.com/code-iai-release/ros_emacs_utils-release.git
distro file: jade/distribution.yaml
bloom version: 0.5.20
previous version for package: null
