### PR TITLE
schunk_grippers: 1.3.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8092,6 +8092,25 @@ repositories:
         release: release/hydro/{package}/{version}
       url: https://github.com/ros-gbp/sbpl-release.git
       version: 1.1.4-1
+  schunk_grippers:
+    doc:
+      type: git
+      url: https://github.com/durovsky/schunk_grippers.git
+      version: master
+    release:
+      packages:
+      - schunk_ezn64
+      - schunk_grippers
+      - schunk_pg70
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/SmartRoboticSystems/schunk_grippers-release.git
+      version: 1.3.1-0
+    source:
+      type: git
+      url: https://github.com/durovsky/schunk_grippers.git
+      version: master
+    status: developed
   schunk_modular_robotics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_grippers` to `1.3.1-0`:
- upstream repository: https://github.com/durovsky/schunk_grippers
- release repository: https://github.com/SmartRoboticSystems/schunk_grippers-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## schunk_ezn64

```
* renamed package
* Contributors: durovsky
```
## schunk_grippers

```
* added metapackage
* Contributors: durovsky
```
## schunk_pg70

```
* renamed package
* Contributors: durovsky
```
