### PR TITLE
stage: 4.1.1-3 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3673,7 +3673,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/stage-release.git
-      version: 4.1.1-2
+      version: 4.1.1-3
     source:
       type: git
       url: https://github.com/rtv/Stage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `stage` to `4.1.1-3`:
- upstream repository: https://github.com/rtv/Stage.git
- release repository: https://github.com/ros-gbp/stage-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `4.1.1-2`
