### PR TITLE
visualization_osg: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10429,7 +10429,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uji-ros-pkg/visualization_osg-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     status: maintained
   visualization_rwt:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_osg` to `1.0.2-0`:
- upstream repository: https://github.com/uji-ros-pkg/visualization_osg.git
- release repository: https://github.com/uji-ros-pkg/visualization_osg-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.1-0`
## osg_interactive_markers

```
* Changed return type to object, as osg was internally creating a copy (temporary reference return)
* Now mesh interactive markers autoscale to mesh size.
* Contributors: perezsolerj
```
## osg_markers

```
* Fixed return to temporary object, marker was returning references to copied objects
* Fixed some issues with color in markers
* Now mesh interactive markers autoscale to mesh size.
* Contributors: perezsolerj
```
## osg_utils
- No changes
## visualization_osg
- No changes
