### PR TITLE
ypspur: 0.0.1-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10817,7 +10817,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/DaikiMaekawa/ypspur-release.git
-      version: 0.0.1-2
+      version: 0.0.1-3
     status: maintained
   yujin_maps:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ypspur` to `0.0.1-3`:
- upstream repository: https://openspur.org/repos/yp-spur.git
- release repository: https://github.com/DaikiMaekawa/ypspur-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.1-2`
