### PR TITLE
mavros: 0.15.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1517,7 +1517,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.14.2-0
+      version: 0.15.0-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.15.0-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.14.2-0`
## libmavconn
- No changes
## mavros

```
* lib: fix timesync uninit bug.
  Uninitialized variable caused wrong timestamps with APM.
* python #286 <https://github.com/mavlink/mavros/issues/286>: use checksum - save ticks
* script #385 <https://github.com/mavlink/mavros/issues/385>: output to log-file
* script #385 <https://github.com/mavlink/mavros/issues/385>: remove RosrunHandler and RoslaunchHandler
* script #385 <https://github.com/mavlink/mavros/issues/385>: attempt to implement rosrun fails.
  ROSLaunch class wants all node operations from main thread.
  That is not possible.
* script #385 <https://github.com/mavlink/mavros/issues/385>: fix shell-killer, but logging are broken and removed
* script #385 <https://github.com/mavlink/mavros/issues/385>: shell-launcher now works!
* script #385 <https://github.com/mavlink/mavros/issues/385>: add example configuration
* script #385 <https://github.com/mavlink/mavros/issues/385>: shell handler done. next - rosparam handling
* script #385 <https://github.com/mavlink/mavros/issues/385>: starting work on simple shell launcher
* scripts: starting event_launcher
* python: Remove unneded slice operation. Fix copyright year.
  list[:len(list)] is equal to list, but creates new list with data
  from that slice.
* updated mavlink byte buffer conversion
* plugin: manual_control: Use shared pointer message
  Fix alphabetic order of msgs.
* python: add helper for converting mavros_msgs/Mavlink to pymavlink
* Add MANUAL_CONTROL handling with new plugin
* Contributors: Andreas Antener, Vladimir Ermakov, v01d
```
## mavros_extras

```
* extras #387 <https://github.com/mavlink/mavros/issues/387>: fix header stamp in joint_states
* extras fix #387 <https://github.com/mavlink/mavros/issues/387>: SSP node done.
* extras #387 <https://github.com/mavlink/mavros/issues/387>: subscriber works, node almost done
* extras #387 <https://github.com/mavlink/mavros/issues/387>: load URDF
* extras #387 <https://github.com/mavlink/mavros/issues/387>: initial import of servo_status_publisher
* Contributors: Vladimir Ermakov
```
## mavros_msgs

```
* msgs #286 <https://github.com/mavlink/mavros/issues/286>: fix bug with packet header.
* msgs #286 <https://github.com/mavlink/mavros/issues/286>: Add valid flag and checksum to Mavlink.msg
* plugin: manual_control: Use shared pointer message
  Fix alphabetic order of msgs.
* removed old commend in .msg file
* Add MANUAL_CONTROL handling with new plugin
* Contributors: Vladimir Ermakov, v01d
```
## test_mavros

```
* test: update readme
* test: add required plugins
* test: new test for local_position + SSP (#387 <https://github.com/mavlink/mavros/issues/387>) + URDF
* test: add schematic plane urdf
* Contributors: Vladimir Ermakov
```
