### PR TITLE
uwsim_bullet: 2.82.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3934,6 +3934,13 @@ repositories:
       url: https://github.com/bosch-ros-pkg/usb_cam.git
       version: develop
     status: maintained
+  uwsim_bullet:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/uji-ros-pkg/uwsim_bullet-release.git
+      version: 2.82.1-0
+    status: maintained
   uwsim_osgocean:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_bullet` to `2.82.1-0`:
- upstream repository: https://github.com/uji-ros-pkg/uwsim_bullet.git
- release repository: https://github.com/uji-ros-pkg/uwsim_bullet-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
