### PR TITLE
uwsim_osgworks: 3.0.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3948,6 +3948,13 @@ repositories:
       url: https://github.com/uji-ros-pkg/uwsim_osgocean-release.git
       version: 1.0.3-0
     status: maintained
+  uwsim_osgworks:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/uji-ros-pkg/uwsim_osgworks-release.git
+      version: 3.0.3-0
+    status: maintained
   vicon_bridge:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_osgworks` to `3.0.3-0`:
- upstream repository: https://github.com/uji-ros-pkg/uwsim_osgworks.git
- release repository: https://github.com/uji-ros-pkg/uwsim_osgworks-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
