### PR TITLE
rospeex: 2.14.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8395,7 +8395,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://bitbucket.org/rospeex/rospeex-release.git
-      version: 2.12.6-0
+      version: 2.14.0-2
     source:
       type: git
       url: https://bitbucket.org/rospeex/rospeex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospeex` to `2.14.0-2`:
- upstream repository: https://bitbucket.org/rospeex/rospeex.git
- release repository: https://bitbucket.org/rospeex/rospeex-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.12.6-0`
## rospeex
- No changes
## rospeex_audiomonitor
- No changes
## rospeex_core

```
* Add error handling to nict speech recognition module
* Changed LOG message level
* Hide NICTmmcvController message
```
## rospeex_if

```
* Add ros topic publisher argument 'queue_size'
```
## rospeex_launch
- No changes
## rospeex_msgs
- No changes
## rospeex_samples
- No changes
## rospeex_webaudiomonitor

```
* Switch websocket library python-autobahn to python-tornado
```
