### PR TITLE
ir_trans_drivers: 0.0.4-3 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3086,7 +3086,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/UC3MSocialRobots/ir_trans_drivers-release.git
-      version: 0.0.4-0
+      version: 0.0.4-3
   ivcon:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ir_trans_drivers` to `0.0.4-3`:
- upstream repository: https://github.com/UC3MSocialRobots/ir_trans_drivers.git
- release repository: https://github.com/UC3MSocialRobots/ir_trans_drivers-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.4-0`
## ir_trans_drivers

```
* updated warning in changelog
* Contributors: Raul Perula-Martinez
```
