### PR TITLE
schunk_grippers: 1.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8995,6 +8995,25 @@ repositories:
       url: https://github.com/ros-gbp/sbpl-release.git
       version: 1.2.0-1
     status: maintained
+  schunk_grippers:
+    doc:
+      type: git
+      url: https://github.com/SmartRoboticSystems/schunk_grippers.git
+      version: master
+    release:
+      packages:
+      - schunk_ezn64
+      - schunk_grippers
+      - schunk_pg70
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/SmartRoboticSystems/schunk_grippers-release.git
+      version: 1.3.2-0
+    source:
+      type: git
+      url: https://github.com/SmartRoboticSystems/schunk_grippers.git
+      version: master
+    status: maintained
   schunk_modular_robotics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_grippers` to `1.3.2-0`:
- upstream repository: https://github.com/SmartRoboticSystems/schunk_grippers.git
- release repository: https://github.com/SmartRoboticSystems/schunk_grippers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## schunk_ezn64

```
* added acknowleding error
* updated launch file
* 1.3.1
* generated CHANGELOGS
* renamed package
* Contributors: durovsky
```
## schunk_grippers

```
* 1.3.1
* fixed CMakelists.txt
* added renamed packages
* generated CHANGELOGS
* Contributors: durovsky
```
## schunk_pg70

```
* updated launch file
* 1.3.1
* generated CHANGELOGS
* renamed package
* Contributors: durovsky
```
