### PR TITLE
pr2_self_test: 1.0.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6780,6 +6780,24 @@ repositories:
       url: https://github.com/pr2/pr2_robot.git
       version: hydro-devel
     status: maintained
+  pr2_self_test:
+    release:
+      packages:
+      - joint_qualification_controllers
+      - pr2_bringup_tests
+      - pr2_counterbalance_check
+      - pr2_motor_diagnostic_tool
+      - pr2_self_test
+      - pr2_self_test_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/TheDash/pr2_self_test-release.git
+      version: 1.0.10-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_self_test.git
+      version: hydro-devel
+    status: maintained
   pr2_shield_teleop:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_self_test` to `1.0.10-0`:
- upstream repository: https://github.com/PR2/pr2_self_test.git
- release repository: https://github.com/TheDash/pr2_self_test-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
