### PR TITLE
catkin: 0.6.15-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -301,7 +301,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.6.14-0
+      version: 0.6.15-0
     source:
       type: git
       url: https://github.com/ros/catkin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.6.15-0`:
- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.14-0`
## catkin

```
* adding check to prevent tool cross talk (#743 <https://github.com/ros/catkin/issues/743>)
* only clean the test result ending with .xml of the current project (#737 <https://github.com/ros/catkin/issues/737>)
* fix regression in find_in_workspaces (#739 <https://github.com/ros/catkin/issues/739>)
* fix setup.py package_dir location logic (#751 <https://github.com/ros/catkin/issues/751>)
```
