### PR TITLE
ros: 1.12.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2992,7 +2992,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.12.2-0
+      version: 1.12.3-0
     source:
       type: git
       url: https://github.com/ros/ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.12.3-0`:
- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.12.2-0`
## mk
- No changes
## rosbash

```
* fix roslaunch completion if path contains white spaces (ros/ros_comm#658 <https://github.com/ros/ros_comm/issues/658>)
* add rosconsole tab completion for bash (#86 <https://github.com/ros/ros/pull/86>)
* use --first-only option when calling catkin_find (#83 <https://github.com/ros/ros/issues/83>)
```
## rosboost_cfg
- No changes
## rosbuild

```
* fix rosbuild with newer ld versions (#87 <https://github.com/ros/ros/pull/87>)
```
## rosclean
- No changes
## roscreate
- No changes
## roslang
- No changes
## roslib
- No changes
## rosmake
- No changes
## rosunit
- No changes
