### PR TITLE
moveit_robots: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4858,6 +4858,31 @@ repositories:
       url: https://github.com/ros-gbp/moveit_resources-release.git
       version: 0.5.0-0
     status: maintained
+  moveit_robots:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_robots.git
+      version: master
+    release:
+      packages:
+      - atlas_moveit_config
+      - atlas_v3_moveit_config
+      - baxter_ikfast_left_arm_plugin
+      - baxter_ikfast_right_arm_plugin
+      - baxter_moveit_config
+      - clam_moveit_config
+      - iri_wam_moveit_config
+      - moveit_robots
+      - r2_moveit_generated
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/moveit_robots-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_robots.git
+      version: master
+    status: maintained
   moveit_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_robots` to `1.0.2-0`:
- upstream repository: https://github.com/ros-planning/moveit_robots.git
- release repository: https://github.com/tork-a/moveit_robots-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
