### PR TITLE
uwsim_osgbullet: 3.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3941,6 +3941,13 @@ repositories:
       url: https://github.com/uji-ros-pkg/uwsim_bullet-release.git
       version: 2.82.1-0
     status: maintained
+  uwsim_osgbullet:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/uji-ros-pkg/uwsim_osgbullet-release.git
+      version: 3.0.1-0
+    status: maintained
   uwsim_osgocean:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_osgbullet` to `3.0.1-0`:
- upstream repository: https://github.com/uji-ros-pkg/uwsim_osgbullet.git
- release repository: https://github.com/uji-ros-pkg/uwsim_osgbullet-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
