### PR TITLE
ros_comm: 1.11.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7842,7 +7842,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.13-0
+      version: 1.11.14-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.14-0`:
- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.13-0`
## message_filters
- No changes
## ros_comm
- No changes
## rosbag

```
* reduce memory usage by using slots for IndexEntry types (#613 <https://github.com/ros/ros_comm/pull/613>)
* remove duplicate topics (#647 <https://github.com/ros/ros_comm/issues/647>)
* better exception when calling get_start_time / get_end_time on empty bags (#657 <https://github.com/ros/ros_comm/pull/657>)
* make support for lz4 in rosbag optional (#642 <https://github.com/ros/ros_comm/pull/642>)
* fix handling of "play --topics" (#620 <https://github.com/ros/ros_comm/issues/620>)
```
## rosbag_storage
- No changes
## rosconsole

```
* avoid redefining ROS_ASSERT_ENABLED (#628 <https://github.com/ros/ros_comm/pull/628>)
```
## roscpp

```
* add optional reset argument to Timer::setPeriod() (#590 <https://github.com/ros/ros_comm/issues/590>)
* add getParam() and getParamCached() for float (#621 <https://github.com/ros/ros_comm/issues/621>, #623 <https://github.com/ros/ros_comm/issues/623>)
* use explicit bool cast to compile with C++11 (#632 <https://github.com/ros/ros_comm/pull/632>)
```
## rosgraph

```
* create a symlink to the latest log directory (#659 <https://github.com/ros/ros_comm/pull/659>)
```
## roslaunch

```
* add more information when test times out
```
## roslz4
- No changes
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy

```
* fix memory/thread leak with QueuedConnection (#661 <https://github.com/ros/ros_comm/pull/661>)
* fix signaling already shutdown to client hooks with the appropriate signature (#651 <https://github.com/ros/ros_comm/issues/651>)
* fix bug with missing current logger levels (#631 <https://github.com/ros/ros_comm/pull/631>)
```
## rosservice
- No changes
## rostest

```
* add --local option to rostest (#137 <https://github.com/ros/ros_comm/issues/137>)
* fix location of rosunit result files generated by rostests (#668 <https://github.com/ros/ros_comm/pull/668>)
```
## rostopic

```
* support specifying multiple array indices (#606 <https://github.com/ros/ros_comm/pull/606>)
* fix string type check if variable is unicode
```
## roswtf

```
* add optional dependency on geneus to make roswtf tests pass in jade
```
## topic_tools

```
* new tool "relay_field" which allows relay topic fields to another topic (#639 <https://github.com/ros/ros_comm/pull/639>)
* allow transform to be used with ros arguments and in a launch file (#644 <https://github.com/ros/ros_comm/issues/644>)
* add --wait-for-start option to transform script (#646 <https://github.com/ros/ros_comm/pull/646>)
```
## xmlrpcpp
- No changes
