### PR TITLE
ecto: 0.6.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1929,7 +1929,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ecto-release.git
-      version: 0.6.10-0
+      version: 0.6.11-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto` to `0.6.11-0`:
- upstream repository: https://github.com/plasmodic/ecto.git
- release repository: https://github.com/ros-gbp/ecto-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.10-0`
## ecto

```
* minor doc syntax fixes
* saner installation instructions from source.
* add missing includes to make headers compile standalone
  - add cstddef to introduce std::size_t
  - add parameters.hpp to its implementation (works because of #pragma once)
* fix bsd-license check script
  Not all Copyright is (1.) from 2011 and (2.) by Willow Garage
  autofix is undefined if ECTO_LICENSE_AUTOFIX is not exported.
* Re-add thread library to linker list
  Regression caused by 8e354b5aa8281ea8117fc93adb290998b7810be7
* docs about various entities that affect graph execution, also other minor cleanups.
  Removed the redundancies in the install docs (2x install instructions and 2x dependencies)
  and cleaned the place up a bit.
* Provide test for ecto::BREAK return value.
* implement ecto::BREAK behavior
  This patch makes ecto schedule the next iteration
  through the plasm with ecto::BREAK as discussed in
  https://github.com/plasmodic/ecto/issues/251
* remove some old Willow Garage URLs
* update doc's url
* Contributors: Daniel Stonier, Michael Görner, Po-Jen Lai, Scott K Logan, Vincent Rabaud, v4hn
```
