### PR TITLE
orne_maps: 0.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6024,6 +6024,17 @@ repositories:
       url: https://github.com/RIVeR-Lab/orientus_driver.git
       version: hydro-devel
     status: maintained
+  orne_maps:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/open-rdc/orne_maps-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/open-rdc/orne_maps.git
+      version: master
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orne_maps` to `0.0.1-1`:
- upstream repository: https://github.com/open-rdc/orne_maps
- release repository: https://github.com/open-rdc/orne_maps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
