### PR TITLE
visualization_tutorials: 0.9.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4059,7 +4059,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/visualization_tutorials-release.git
-      version: 0.9.1-0
+      version: 0.9.2-0
     source:
       type: git
       url: https://github.com/ros-visualization/visualization_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_tutorials` to `0.9.2-0`:
- upstream repository: https://github.com/ros-visualization/visualization_tutorials.git
- release repository: https://github.com/ros-gbp/visualization_tutorials-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.9.1-0`
## interactive_marker_tutorials

```
* Removed deprecated imports.
* Fix Python InteractiveMarkers tutorials to use the correct frame names.
* Updated ``simple_marker.cpp`` by including the time stamp.
  Without the time stamp the cube does not show up in rviz and reports an error.
* Contributors: Javier V. Gomez, Robert Haschke, agoudar
```
## librviz_tutorial
- No changes
## rviz_plugin_tutorials
- No changes
## rviz_python_tutorial
- No changes
## visualization_marker_tutorials
- No changes
## visualization_tutorials
- No changes
