### PR TITLE
rviz: 1.11.9-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3526,7 +3526,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.11.8-0
+      version: 1.11.9-0
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.11.9-0`:
- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.8-0`
## rviz

```
* Updated warning message to indicate triangle count is a 32bit integer, and not 16bit.
* Fixed the error checking of large STL files.
* Smoothed updates for map display plugin.
  Map displays previously only updated when receiving a message. This means that
  if your fixed frame was base_link, the costmaps would not move appropriately
  around the robot unless a message was received in order to update the transform
  that should be applied to the scene. For global costmaps, this is a slow
  update and for static maps, this never happened.
  This fixes that by hooking into rviz' periodic call to continuously update the
  transform to be applied to the scene.
* Displays are not disabled if associated Panel becomes invisible.
  Otherwise the state between Panel & Display becomes inconsistent.
  Fixed symptom:
  When loading a configuration that contains a disabled CameraDisplay,
  during the configuration of the panel(the camera render widget),
  the panel is set visible for a very short period of time.
  Because of the missing logic, the CameraDisplay is enabled
  together with the panel, but the Display remains enabled
  after the Panel is set invisible. One ends up with an enabled
  (and subscribed) CameraDisplay without the corresponding RenderWidget,
  even so the configuration specified that the Display is not enabled.
* Removed shortkeys from ``shortkey_to_tool_map_``
  this should fix #880 <https://github.com/ros-visualization/rviz/issues/880>
* Contributors: Daniel Stonier, Henning Deeken, Jonathan Meyer, Michael Görner, William Woodall
```
