### PR TITLE
Correct spelling of ubuntu for python-jasmine-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -667,7 +667,7 @@ python-itsdangerous:
   fedora: [python-itsdangerous]
   ubuntu: [python-itsdangerous]
 python-jasmine-pip:
-  ubutnu:
+  ubuntu:
     pip:
       packages: [jasmine]
 python-jinja2:


### PR DESCRIPTION
This was a silly typo.

@tfoote: @mikeferguson tells me that the build probably shouldn't have passed in the first place with the typo, and to let you know that your tests might not be working completely.
