### PR TITLE
stage: 4.1.1-6 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9580,7 +9580,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/stage-release.git
-      version: 4.1.1-5
+      version: 4.1.1-6
     source:
       type: git
       url: https://github.com/rtv/Stage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `stage` to `4.1.1-6`:
- upstream repository: https://github.com/rtv/Stage.git
- release repository: https://github.com/ros-gbp/stage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `4.1.1-5`
