### PR TITLE
uwsim_osgworks: 3.0.3-2 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3960,7 +3960,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/uji-ros-pkg/uwsim_osgworks-release.git
-      version: 3.0.3-1
+      version: 3.0.3-2
     status: maintained
   vicon_bridge:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_osgworks` to `3.0.3-2`:
- upstream repository: https://github.com/uji-ros-pkg/uwsim_osgworks.git
- release repository: https://github.com/uji-ros-pkg/uwsim_osgworks-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `3.0.3-1`
