### PR TITLE
rqt_pr2_dashboard: 0.2.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8667,6 +8667,17 @@ repositories:
       url: https://github.com/osrf/rqt_graphprofiler.git
       version: master
     status: developed
+  rqt_pr2_dashboard:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
+      version: 0.2.8-0
+    source:
+      type: git
+      url: https://github.com/pr2/rqt_pr2_dashboard.git
+      version: hydro-devel
+    status: maintained
   rqt_robot_plugins:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_pr2_dashboard` to `0.2.8-0`:
- upstream repository: https://github.com/ros-visualization/rqt_pr2_dashboard.git
- release repository: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
