### PR TITLE
add Fedora 23

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -504,6 +504,7 @@ python-flake8:
   fedora:
     '21': [python-flake8]
     '22': [python-flake8]
+    '23': [python-flake8]
     heisenbug: [python-flake8]
   ubuntu:
     trusty: [python-flake8]
@@ -626,6 +627,7 @@ python-imaging:
   fedora:
     '21': [python-pillow, python-pillow-qt]
     '22': [python-pillow, python-pillow-qt]
+    '23': [python-pillow, python-pillow-qt]
     beefy: [python-imaging]
     heisenbug: [python-pillow, python-pillow-qt]
     schrödinger’s: [python-pillow, python-pillow-qt]
@@ -1843,6 +1845,7 @@ python-tilestache:
   fedora:
     '21': [python-tilestache]
     '22': [python-tilestache]
+    '23': [python-tilestache]
     heisenbug: [python-tilestache]
     schrödinger’s: [python-tilestache]
   ubuntu: [tilestache]


### PR DESCRIPTION
Fixes
rosbag: No definition of [python-imaging] for OS version [23]
