### PR TITLE
bwi_common: 0.3.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -690,7 +690,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/bwi_common-release.git
-      version: 0.3.6-0
+      version: 0.3.7-0
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi_common` to `0.3.7-0`:
- upstream repository: https://github.com/utexas-bwi/bwi_common.git
- release repository: https://github.com/utexas-bwi-gbp/bwi_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.6-0`
## bwi_common
- No changes
## bwi_gazebo_entities
- No changes
## bwi_interruptable_action_server
- No changes
## bwi_kr_execution
- No changes
## bwi_logging

```
* make logging work, even when installed as a binary package (#32 <https://github.com/jack-oquin/bwi_common/issues/32>)
* add upload option to not delete files copied (#32 <https://github.com/jack-oquin/bwi_common/issues/32>)
* add upload script for bags (#32 <https://github.com/jack-oquin/bwi_common/issues/32>)
* add /diagnostics to default topic list (#32 <https://github.com/jack-oquin/bwi_common/issues/32>)
* create logging directory, if needed (#32 <https://github.com/jack-oquin/bwi_common/issues/32>)
* add wrapper node for rosbag_record (#32 <https://github.com/jack-oquin/bwi_common/issues/32>)
* Contributors: Jack O'Quin
```
## bwi_mapper
- No changes
## bwi_msgs
- No changes
## bwi_planning_common
- No changes
## bwi_rqt_plugins
- No changes
## bwi_scavenger
- No changes
## bwi_tasks
- No changes
## bwi_tools
- No changes
## stop_base

```
* install stop_base nodes (#37 <https://github.com/jack-oquin/bwi_common/issues/37>)
* stop_base: fix broken links in README
* Contributors: Jack O'Quin
```
## utexas_gdc
- No changes
