### PR TITLE
pr2_self_test: 1.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6828,7 +6828,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/TheDash/pr2_self_test-release.git
-      version: 1.0.11-0
+      version: 1.0.12-0
     source:
       type: git
       url: https://github.com/PR2/pr2_self_test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_self_test` to `1.0.12-0`:
- upstream repository: https://github.com/PR2/pr2_self_test.git
- release repository: https://github.com/TheDash/pr2_self_test-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.11-0`
