### PR TITLE
uwsim_osgbullet: 3.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10372,7 +10372,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uji-ros-pkg/uwsim_osgbullet-release.git
-      version: 3.0.1-0
+      version: 3.0.1-1
     status: maintained
   uwsim_osgocean:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_osgbullet` to `3.0.1-1`:
- upstream repository: https://github.com/uji-ros-pkg/uwsim_osgbullet.git
- release repository: https://github.com/uji-ros-pkg/uwsim_osgbullet-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `3.0.1-0`
