### PR TITLE
underwater_simulation: 1.4.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3864,6 +3864,17 @@ repositories:
       url: https://github.com/ros-drivers/um6.git
       version: indigo-devel
     status: maintained
+  underwater_simulation:
+    release:
+      packages:
+      - underwater_sensor_msgs
+      - underwater_vehicle_dynamics
+      - uwsim
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/uji-ros-pkg/underwater_simulation-release.git
+      version: 1.4.0-0
+    status: maintained
   unique_identifier:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `underwater_simulation` to `1.4.0-0`:
- upstream repository: https://github.com/uji-ros-pkg/underwater_simulation.git
- release repository: https://github.com/uji-ros-pkg/underwater_simulation-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## underwater_sensor_msgs

```
* Added marker service to spawn and modify geometry.
* Contributors: perezsolerj
```
## underwater_vehicle_dynamics
- No changes
## uwsim

```
* Initial support for markers and interactive markers issue #1
* MultibeamSensors now use multiple cameras when the FOV is high in order to avoid eyefish distortions and allow FOV >180º.
* Added xacro support for scene building, some xacro macros created as example
* Added lightRate configuration option, shader projection is no longer affected by lighting
* Support for buried objects and dredging
* Added ARMask to Augmented reality elements such as trails, axis, rangeSensor debug, pointclouds and multibeamSensor debug so they are not showed on virtual cameras
* Added debug visible tag to multibeam sensors (similar to range sensor)
* Added gaussian random noise to camera output through shaders
* Underwater particles are no longer present on multibeamSensor, although it can be activated through XML
* Added ROSPointCloudLoader interface that allows to visualize 3D pointclouds on demand.
* Major update on shader management:
* added timeWindow and restarter (y key) to trajectory trail.
* Bugs and fixes.
* Contributors: David Fornas, Miguel Ribeiro, perezsolerj
```
