### PR TITLE
schunk_grippers: 1.3.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3554,6 +3554,25 @@ repositories:
       url: https://github.com/ros-gbp/sbpl-release.git
       version: 1.2.0-3
     status: maintained
+  schunk_grippers:
+    doc:
+      type: git
+      url: https://github.com/SmartRoboticSystems/schunk_grippers.git
+      version: master
+    release:
+      packages:
+      - schunk_ezn64
+      - schunk_grippers
+      - schunk_pg70
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/SmartRoboticSystems/schunk_grippers-release.git
+      version: 1.3.6-0
+    source:
+      type: git
+      url: https://github.com/SmartRoboticSystems/schunk_grippers.git
+      version: master
+    status: maintained
   serial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_grippers` to `1.3.6-0`:
- upstream repository: https://github.com/SmartRoboticSystems/schunk_grippers.git
- release repository: https://github.com/SmartRoboticSystems/schunk_grippers-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## schunk_ezn64

```
* palm link changed to base link
* added standalone visualization xacro model
* Contributors: durovsky
```
## schunk_grippers
- No changes
## schunk_pg70

```
* palm link changed to base link to stay consistent with ezn64
* pg70 find_packages changed to schunk_pg70
* added standalone visualization
* Contributors: durovsky
```
