### PR TITLE
schunk_grippers: 1.3.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9091,7 +9091,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SmartRoboticSystems/schunk_grippers-release.git
-      version: 1.3.4-0
+      version: 1.3.7-0
     source:
       type: git
       url: https://github.com/SmartRoboticSystems/schunk_grippers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_grippers` to `1.3.7-0`:
- upstream repository: https://github.com/SmartRoboticSystems/schunk_grippers.git
- release repository: https://github.com/SmartRoboticSystems/schunk_grippers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.3.4-0`
## schunk_ezn64

```
* fixed wrong getParam names
* Contributors: durovsky
```
## schunk_grippers
- No changes
## schunk_pg70

```
* fixed wrong getParam names
* Contributors: durovsky
```
