### PR TITLE
micros_rtt: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4664,6 +4664,21 @@ repositories:
       url: https://github.com/orocos-gbp/metaruby-release.git
       version: 1.0.0-3
     status: maintained
+  micros_rtt:
+    doc:
+      type: git
+      url: https://github.com/sukha-cn/micros_rtt.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/sukha-cn/micros_rtt-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/sukha-cn/micros_rtt.git
+      version: master
+    status: developed
   microstrain_3dmgx2_imu:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `micros_rtt` to `0.1.0-0`:
- upstream repository: https://github.com/sukha-cn/micros_rtt.git
- release repository: https://github.com/sukha-cn/micros_rtt-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## micros_rtt

```
* Add inter-process transport for local comunication.
* optimize code structure.
* fix exist bugs.
* Contributors: sukha-cn
```
