### PR TITLE
hpcl_rtt was renamed to micros_rtt

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2962,21 +2962,6 @@ repositories:
       url: https://github.com/ros-gbp/household_objects_database_msgs-release.git
       version: 0.1.1-2
     status: maintained
-  hpcl_rtt:
-    doc:
-      type: git
-      url: https://github.com/sukha-cn/hpcl_rtt.git
-      version: master
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/sukha-cn/hpcl_rtt-release.git
-      version: 0.0.4-1
-    source:
-      type: git
-      url: https://github.com/sukha-cn/hpcl_rtt.git
-      version: master
-    status: developed
   hrpsys:
     doc:
       type: git


### PR DESCRIPTION
Hello.
hpcl_rtt was renamed to micros_rtt, the new package has been merged. 
I think the old one need to be deleted manually.
