### PR TITLE
homer_mapnav: 1.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2925,7 +2925,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
-      version: 1.0.1-0
+      version: 1.0.1-1
   homer_object_recognition:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_mapnav` to `1.0.1-1`:
- upstream repository: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.1-0`
## homer_map_manager

```
* init
* Contributors: Raphael Memmesheimer
```
## homer_mapnav_msgs

```
* init
* Contributors: Raphael Memmesheimer
```
## homer_mapping

```
* init
* Contributors: Raphael Memmesheimer
```
## homer_nav_libs

```
* init
* Contributors: Raphael Memmesheimer
```
## homer_navigation

```
* init
* Contributors: Raphael Memmesheimer
```
