### PR TITLE
rosemacs-el is only available on l,o,p

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2976,7 +2976,10 @@ redis-server:
 robotino-api2:
   ubuntu: [robotino-api2]
 rosemacs-el:
-  ubuntu: [rosemacs-el]
+  ubuntu:
+    lucid: [rosemacs-el]
+    oneiric: [rosemacs-el]
+    precise: [rosemacs-el]
 ruby:
   arch: [ruby]
   debian: [ruby1.8-dev, libruby1.8, rubygems1.8]


### PR DESCRIPTION
see http://packages.ros.org/ros-shadow-fixed/ubuntu/pool/main/r/rosemacs-el/, 
from inidigo, we'll use ros-indigo-rosemacs (https://github.com/moesenle/rosemacs-debs/issues/3)
