### PR TITLE
marti_common: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4485,6 +4485,34 @@ repositories:
       url: https://github.com/ros-planning/map_store.git
       version: hydro-devel
     status: maintained
+  marti_common:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: indigo-devel
+    release:
+      packages:
+      - console_util
+      - geometry_util
+      - image_util
+      - marti_data_structures
+      - math_util
+      - opencv_util
+      - prefix_tools
+      - serial_util
+      - string_util
+      - system_util
+      - transform_util
+      - yaml_util
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_common-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: indigo-devel
+    status: developed
   marti_messages:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.0.1-0`:
- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
