### PR TITLE
python_trep: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6992,7 +6992,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/MurpheyLab/trep-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     status: developed
   qt_gui_core:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `python_trep` to `1.0.2-0`:
- upstream repository: https://github.com/MurpheyLab/trep.git
- release repository: https://github.com/MurpheyLab/trep-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.1-0`
