### PR TITLE
marti_common: 0.0.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4485,6 +4485,34 @@ repositories:
       url: https://github.com/ros-planning/map_store.git
       version: hydro-devel
     status: maintained
+  marti_common:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: indigo-devel
+    release:
+      packages:
+      - marti_data_structures
+      - swri_console_util
+      - swri_geometry_util
+      - swri_image_util
+      - swri_math_util
+      - swri_opencv_util
+      - swri_prefix_tools
+      - swri_serial_util
+      - swri_string_util
+      - swri_system_util
+      - swri_transform_util
+      - swri_yaml_util
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_common-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: indigo-devel
+    status: developed
   marti_messages:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.0.2-1`:
- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## marti_data_structures
- No changes
## swri_console_util

```
* Renames console util to swri_console util. Refs #231 <https://github.com/swri-robotics/marti_common/issues/231>.
* Contributors: Edward Venator
```
## swri_geometry_util

```
* Renames geometry_util package to swri_geometry_util. Refs #231 <https://github.com/swri-robotics/marti_common/issues/231>.
* Contributors: Edward Venator
```
## swri_image_util

```
* Renames opencv_util package to swri_opencv_util. Refs #231 <https://github.com/swri-robotics/marti_common/issues/231>
* Renames math_util to swri_math_util. Refs #231 <https://github.com/swri-robotics/marti_common/issues/231>.
* Renames image_util package to swri_image_util. Refs #231 <https://github.com/swri-robotics/marti_common/issues/231>.
* Contributors: Edward Venator
```
## swri_math_util

```
* Renames math_util to swri_math_util. Refs #231 <https://github.com/swri-robotics/marti_common/issues/231>.
* Contributors: Edward Venator
```
## swri_opencv_util

```
* Renames opencv_util package to swri_opencv_util. Refs #231 <https://github.com/swri-robotics/marti_common/issues/231>
* Contributors: Edward Venator
```
## swri_prefix_tools

```
* Renames prefix_tools to swri_prefix_tools. Refs #231 <https://github.com/swri-robotics/marti_common/issues/231>.
* Contributors: Edward Venator
```
## swri_serial_util

```
* Renames serial_util to swri_serial_util. Refs #231 <https://github.com/swri-robotics/marti_common/issues/231>.
* Contributors: Edward Venator
```
## swri_string_util

```
* Renames string_util to swri_string_util. Refs #231 <https://github.com/swri-robotics/marti_common/issues/231>.
* Contributors: Edward Venator
```
## swri_system_util

```
* Renames system_util to swri_system_util. Refs #231 <https://github.com/swri-robotics/marti_common/issues/231>.
* Contributors: Edward Venator
```
## swri_transform_util

```
* Renames yaml_util to swri_yaml_util. Refs #231 <https://github.com/swri-robotics/marti_common/issues/231>.
* Renames transform_util to swri_transform_util. Refs #231 <https://github.com/swri-robotics/marti_common/issues/231>.
* Contributors: Edward Venator
```
## swri_yaml_util

```
* Renames yaml_util to swri_yaml_util. Refs #231 <https://github.com/swri-robotics/marti_common/issues/231>.
* Contributors: Edward Venator
```
