### PR TITLE
marti_common: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4507,7 +4507,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 0.0.2-1
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.0.3-0`:
- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.2-1`
## marti_data_structures
- No changes
## swri_console_util

```
* Correct OpenCV rosdep key
* Contributors: Jerry Towler
```
## swri_geometry_util

```
* Format package files
* Clean up dependencies
  Remove unneeded ones, add required ones not specified
* Contributors: Jerry Towler
```
## swri_image_util

```
* Fixes missing depend on swri_opencv_util in swri_image_util.
* Clean up dependencies
  Remove unneeded ones, add required ones not specified
* Contributors: Ed Venator, Jerry Towler
```
## swri_math_util

```
* Format package files
* Contributors: Jerry Towler
```
## swri_opencv_util

```
* Clean up dependencies
  Remove unneeded ones, add required ones not specified
* Contributors: Jerry Towler
```
## swri_prefix_tools
- No changes
## swri_serial_util

```
* Fixes missing boost dependency in swri_serial_util.
  Refs #234 <https://github.com/swri-robotics/marti_common/issues/234>.
* Contributors: Ed Venator
```
## swri_string_util
- No changes
## swri_system_util

```
* Format package files
* Clean up dependencies
  Remove unneeded ones, add required ones not specified
* Contributors: Jerry Towler
```
## swri_transform_util
- No changes
## swri_yaml_util

```
* Fixes missing yaml-cpp dependency in swri_yaml_util.
  Refs #233 <https://github.com/swri-robotics/marti_common/issues/233>.
* Contributors: Ed Venator
```
