### PR TITLE
homer_object_recognition: 0.0.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2935,7 +2935,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_object_recognition.git
-      version: 0.0.2-0
+      version: 0.0.2-1
   homer_robot_face:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_object_recognition` to `0.0.2-1`:
- upstream repository: https://gitlab.uni-koblenz.de/robbie/homer_object_recognition.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_object_recognition.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.2-0`
## or_libs

```
* big bang
* Contributors: Raphael Memmesheimer
```
## or_msgs

```
* big bang
* Contributors: Raphael Memmesheimer
```
## or_nodes

```
* big bang
* Contributors: Raphael Memmesheimer
```
