### PR TITLE
marti_common: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4527,7 +4527,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.0.4-0`:
- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.3-0`
## marti_data_structures
- No changes
## swri_console_util
- No changes
## swri_geometry_util

```
* Adds missing tf dependency to swri_geometry_util.
* Contributors: Ed Venator
```
## swri_image_util
- No changes
## swri_math_util
- No changes
## swri_opencv_util
- No changes
## swri_prefix_tools
- No changes
## swri_serial_util
- No changes
## swri_string_util
- No changes
## swri_system_util
- No changes
## swri_transform_util

```
* Fixes missing dependencies. `#239<https://github.com/swri-robotics/marti_common/issues/239>`_.
* Contributors: Ed Venator
```
## swri_yaml_util

```
* Adds boost include directories to yaml_util because yaml-cpp uses boost and doesn't export the include directory.
* Contributors: Ed Venator
```
