### PR TITLE
marti_common: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4527,7 +4527,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.0.5-0`:
- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.4-0`
## marti_data_structures
- No changes
## swri_console_util
- No changes
## swri_geometry_util
- No changes
## swri_image_util
- No changes
## swri_math_util
- No changes
## swri_opencv_util
- No changes
## swri_prefix_tools
- No changes
## swri_serial_util
- No changes
## swri_string_util
- No changes
## swri_system_util
- No changes
## swri_transform_util
- No changes
## swri_yaml_util

```
* Adds missing package dependency and find_package() for boost in
  swri_yaml_util. See issue #240 <https://github.com/evenator/marti_common/issues/240>
* Cleans up all catkin_lint by adding a proper package description
  and fixing some formatting in CMakeLists.txt.
* Contributors: Ed Venator
```
