### PR TITLE
ueye_cam: 1.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10246,7 +10246,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/anqixu/ueye_cam-release.git
-      version: 1.0.11-0
+      version: 1.0.12-0
     source:
       type: git
       url: https://github.com/anqixu/ueye_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `1.0.12-0`:
- upstream repository: https://github.com/anqixu/ueye_cam.git
- release repository: https://github.com/anqixu/ueye_cam-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.11-0`
## ueye_cam

```
* fixed binning IS_INVALID_BUFFER_SIZE bug
* Modified nodelet to use camera timestamp instead of wall clock time
* Fix for new upstream dir name on ARM
* Contributors: Alejandro Merello, Anqi Xu, Scott K Logan
```
