### PR TITLE
Fixing definition of argparse for gentoo.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -96,7 +96,7 @@ python-argparse:
     squeeze: [python-argparse]
     wheezy: [python-argparse]
   fedora: [python]
-  gentoo: [virtual/python-argparse]
+  gentoo: [dev-python/argparse]
   macports: [py27-argparse]
   opensuse: [python-argparse]
   ubuntu:


### PR DESCRIPTION
Fixes #9570
