### PR TITLE
marti_messages: 0.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1473,6 +1473,28 @@ repositories:
       url: https://github.com/ros-gbp/manipulation_msgs-release.git
       version: 0.2.0-0
     status: maintained
+  marti_messages:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: indigo-devel
+    release:
+      packages:
+      - marti_can_msgs
+      - marti_common_msgs
+      - marti_nav_msgs
+      - marti_perception_msgs
+      - marti_sensor_msgs
+      - marti_visualization_msgs
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_messages-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: indigo-devel
+    status: developed
   mav_comm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `0.0.1-0`:
- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
