### PR TITLE
marti_common: 0.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1473,6 +1473,34 @@ repositories:
       url: https://github.com/ros-gbp/manipulation_msgs-release.git
       version: 0.2.0-0
     status: maintained
+  marti_common:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: jade-devel
+    release:
+      packages:
+      - marti_data_structures
+      - swri_console_util
+      - swri_geometry_util
+      - swri_image_util
+      - swri_math_util
+      - swri_opencv_util
+      - swri_prefix_tools
+      - swri_serial_util
+      - swri_string_util
+      - swri_system_util
+      - swri_transform_util
+      - swri_yaml_util
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_common-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: jade-devel
+    status: developed
   marti_messages:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.1.0-0`:
- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## marti_data_structures
- No changes
## swri_console_util
- No changes
## swri_geometry_util

```
* Removes deprecated Eigen cmake module. (Issue #245 <https://github.com/swri-robotics/marti_common/issues/245>)
* Contributors: Edward Venator
```
## swri_image_util

```
* Removes deprecated Eigen cmake module. (Issue #245 <https://github.com/swri-robotics/marti_common/issues/245>)
* Contributors: Edward Venator
```
## swri_math_util
- No changes
## swri_opencv_util
- No changes
## swri_prefix_tools
- No changes
## swri_serial_util
- No changes
## swri_string_util
- No changes
## swri_system_util
- No changes
## swri_transform_util

```
* Updates lot_lon_tf_echo to use geometry_msgs/PoseStamped.
  See issue #246 <https://github.com/evenator/marti_common/issues/246>
* Removes dependency on gps_common
  The gps_common package was removed in ROS Jade, so a different message
  type is needed for the local XY origin message. (Issue #246 <https://github.com/swri-robotics/marti_common/issues/246>).
  This replaces the gps_common/GPSFix message with a
  geometry_msgs/PoseStamped message. The latitude is stored in
  pose.position.y, the longitude is stored in pose.position.x, and the
  altitude is stored in pose.position.z. As before, the local xy frame is
  fixed in rotation such that the Z axis points away from the center of
  the Earth and the Y axis points north. However, the choice of
  geometry_msgs/PoseStamped allows for headings to be added in the future.
* Refactors initialize origin and fixes a bug.
* Contributors: Edward Venator
```
## swri_yaml_util
- No changes
