### PR TITLE
mapviz: 0.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1473,6 +1473,26 @@ repositories:
       url: https://github.com/ros-gbp/manipulation_msgs-release.git
       version: 0.2.0-0
     status: maintained
+  mapviz:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/mapviz.git
+      version: jade-devel
+    release:
+      packages:
+      - mapviz
+      - mapviz_plugins
+      - multires_image
+      - tile_map
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/mapviz-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/mapviz.git
+      version: jade-devel
+    status: developed
   marti_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `0.1.0-0`:
- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## mapviz
- No changes
## mapviz_plugins

```
* Removes gps plugin, since gps_common is not in ROS Jade. See issue
  #238 <https://github.com/swri-robotics/mapviz/issues/238>.
* Contributors: Edward Venator
```
## multires_image
- No changes
## tile_map
- No changes
