### PR TITLE
fetch_ros: 0.7.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2199,13 +2199,14 @@ repositories:
       - fetch_calibration
       - fetch_depth_layer
       - fetch_description
+      - fetch_maps
       - fetch_moveit_config
       - fetch_navigation
       - fetch_teleop
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
-      version: 0.6.2-0
+      version: 0.7.0-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.7.0-0`:
- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.2-0`
## fetch_calibration

```
* added support for ground plane calibration
* Contributors: Niharika Arora
```
## fetch_depth_layer
- No changes
## fetch_description

```
* update limits of wrist flex
* remove duplicated inertia entries, fixes #14 <https://github.com/fetchrobotics/fetch_ros/issues/14>
* Contributors: Michael Ferguson
```
## fetch_maps

```
* Create fetch_maps package
* Contributors: Aaron Blasdel, Michael Ferguson
```
## fetch_moveit_config

```
* fix dependency issue with run/test duplication
* add missing moveit_python depend
* fix name of gripper fingers in fake controllers
* Contributors: Michael Ferguson
```
## fetch_navigation

```
* Use fetch_maps package for maps
* Allow overriding of move base & amcl param files
* Contributors: Aaron Blasdel, Ian Danforth
```
## fetch_teleop

```
* Require deadman to be held while tucking
* add missing moveit_python depend
* Contributors: Alex Henning, Michael Ferguson
```
