### PR TITLE
ntpd_driver: 1.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5620,7 +5620,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/vooon/ntpd_driver-release.git
-      version: 1.1.1-0
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/vooon/ntpd_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ntpd_driver` to `1.2.0-0`:
- upstream repository: https://github.com/vooon/ntpd_driver.git
- release repository: https://github.com/vooon/ntpd_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.1-0`
## ntpd_driver

```
* #2 <https://github.com/vooon/ntpd_driver/issues/2>: allow both UDPROS and TCPROS
* Contributors: Vladimir Ermakov
```
