### PR TITLE
rtmros_nextage: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8910,13 +8910,14 @@ repositories:
     release:
       packages:
       - nextage_description
+      - nextage_ik_plugin
       - nextage_moveit_config
       - nextage_ros_bridge
       - rtmros_nextage
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.6.2-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.6.4-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.2-0`
## nextage_description
- No changes
## nextage_ik_plugin

```
* [feat] Add IKFast plugin. Kinematics solver is now selectable in Moveit launch
* Contributors: Isaac IY Saito
```
## nextage_moveit_config

```
* [feat] Add IKFast plugin. Kinematics solver is now selectable in Moveit launch
* Contributors: Isaac IY Saito
```
## nextage_ros_bridge

```
* [feat.] Add launch file for AR alvar
* Contributors: Ryu Yamamoto
```
## rtmros_nextage
- No changes
