### PR TITLE
audio_common: 0.2.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -167,7 +167,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.2.7-0
+      version: 0.2.8-0
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.2.8-0`:
- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.7-0`
