### PR TITLE
spur: 0.2.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9550,7 +9550,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/spur-release.git
-      version: 0.2.4-0
+      version: 0.2.6-0
     source:
       type: git
       url: https://github.com/tork-a/spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `spur` to `0.2.6-0`:
- upstream repository: https://github.com/tork-a/spur.git
- release repository: https://github.com/tork-a/spur-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.4-0`
## spur

```
* [feat] Brush up laser_scan_matcher usage
* [feat] add calibration
* [fix] spur_controller/joint_state_publisher.py: fix for real robot, which currently does not have configuration setup for upper body
* [fix] parameter tuning for the real robot
* [fix] Install target
* [design] use spur/laser/scan_filtered
* Contributors: TORK 534o, Isaac IY Saito
```
## spur_2dnav

```
* [fix] parameter tuning for the real robot
* Contributors: Isaac IY Saito
```
## spur_bringup

```
* [fix] parameter tuning for the real robot
* [fix] Install target
* Contributors: TORK 534o, Isaac IY Saito
```
## spur_controller

```
* [feat] Brush up laser_scan_matcher usage
* [feat] add calibration
* [fix] spur_controller/joint_state_publisher.py: fix for real robot, which currently does not have configuration setup for upper body
* [design] use spur/laser/scan_filtered
* Contributors: TORK 534o
```
## spur_description
- No changes
## spur_gazebo
- No changes
