### PR TITLE
imu_tools: 1.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3233,13 +3233,14 @@ repositories:
       version: indigo
     release:
       packages:
+      - imu_complementary_filter
       - imu_filter_madgwick
       - imu_tools
       - rviz_imu_plugin
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/imu_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.0.6-0`:
- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.5-0`
## imu_complementary_filter

```
* Add new package: imu_complementary_filter
* Contributors: Roberto G. Valentini, Martin Günther, Michael Görner
```
## imu_filter_madgwick

```
* Split ImuFilter class into ImuFilter and ImuFilterRos in order to
  have a C++ API to the Madgwick algorithm
* Properly install header files.
* Contributors: Martin Günther, Michael Stoll
```
## imu_tools
- No changes
## rviz_imu_plugin
- No changes
