### PR TITLE
Add vivid definition for python-h5py and python-zmq

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -606,6 +606,7 @@ python-h5py:
     saucy: [python-h5py]
     trusty: [python-h5py]
     trusty_python3: [python3-h5py]
+    vivid: [python-h5py]
 python-httplib2:
   debian: [python-httplib2]
   fedora: [python-httplib2]
@@ -2108,6 +2109,7 @@ python-zmq:
     saucy: [python-zmq]
     trusty: [python-zmq]
     trusty_python3: [python3-zmq]
+    vivid: [python-zmq]
 xdot:
   fedora: [python-xdot]
   ubuntu: [xdot]


### PR DESCRIPTION
python-h5py and python-zmq definitions for Ubuntu Vivid (15.04)
