### PR TITLE
roswww: 0.1.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3368,6 +3368,21 @@ repositories:
       url: https://github.com/ros-drivers/rosserial.git
       version: jade-devel
     status: maintained
+  roswww:
+    doc:
+      type: git
+      url: https://github.com/tork-a/roswww.git
+      version: develop
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/roswww-release.git
+      version: 0.1.5-0
+    source:
+      type: git
+      url: https://github.com/tork-a/roswww.git
+      version: develop
+    status: maintained
   rqt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roswww` to `0.1.5-0`:
- upstream repository: https://github.com/tork-a/roswww.git
- release repository: https://github.com/tork-a/roswww-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## roswww

```
* Install missing launch directory
* Contributors: Jihoon Lee
```
