### PR TITLE
imu_tools: 1.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3240,7 +3240,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.0.6-0
+      version: 1.0.8-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/imu_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.0.8-0`:
- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.6-0`
## imu_complementary_filter
- No changes
## imu_filter_madgwick
- No changes
## imu_tools

```
* Add imu_complementary_filter to meta package
* Contributors: Martin Günther
```
## rviz_imu_plugin
- No changes
