### PR TITLE
Added libpcl-all-dev dep for OS X El Capitan

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -249,6 +249,10 @@ libpcl-all:
       depends: [libpcl-all-dev]
 libpcl-all-dev:
   osx:
+    "el capitan":
+      homebrew:
+        install_flags: [--HEAD]
+        packages: [homebrew/science/pcl]
     leopard:
       homebrew: [homebrew/science/pcl]
     lion:


### PR DESCRIPTION
Resolve libpcl-all-dev with homebrew  for OS X El Capitan support.
