### PR TITLE
romeo_robot: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7822,11 +7822,12 @@ repositories:
       - romeo_dcm_driver
       - romeo_dcm_msgs
       - romeo_description
+      - romeo_robot
       - romeo_sensors
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-aldebaran/romeo_robot-release.git
-      version: 0.0.13-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/ros-aldebaran/romeo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_robot` to `0.1.0-0`:
- upstream repository: https://github.com/ros-aldebaran/romeo_robot.git
- release repository: https://github.com/ros-aldebaran/romeo_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.13-0`
## romeo_dcm_bringup
- No changes
## romeo_dcm_control
- No changes
## romeo_dcm_driver
- No changes
## romeo_dcm_msgs
- No changes
## romeo_description

```
* update to the latest Romeo URDF
* do not forget the cap
* update to the latest urdf from doc_urdf in NAOqi
* update with the latest generated URDF
* Contributors: Vincent Rabaud
```
## romeo_robot
- No changes
## romeo_sensors

```
* update the maintainer and make it architecture independent
* fix dependencies
* Contributors: Vincent Rabaud
```
