### PR TITLE
perception_oru: 1.0.29-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6302,6 +6302,24 @@ repositories:
       url: https://github.com/dillenberger/pepperl_fuchs.git
       version: master
     status: maintained
+  perception_oru:
+    release:
+      packages:
+      - ndt_costmap
+      - ndt_feature_reg
+      - ndt_fuser
+      - ndt_map
+      - ndt_map_builder
+      - ndt_mcl
+      - ndt_registration
+      - ndt_rviz_visualisation
+      - ndt_visualisation
+      - perception_oru
+      - sdf_tracker
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tstoyanov/perception_oru-release.git
+      version: 1.0.29-0
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_oru` to `1.0.29-0`:
- upstream repository: /home/tsv/code/workspace-perception/src/perception_oru
- release repository: https://github.com/tstoyanov/perception_oru-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## ndt_costmap

```
* removed outdated opencv2 dependency
* Contributors: Todor Stoyanov
```
## ndt_feature_reg

```
*non-free features from opencv are used, you may need to build from source in ubuntu
* Contributors: Henrik Andreasson, Todor Stoyanov
```
## ndt_fuser

```
*major code refactoring
* Contributors: Todor Stoyanov
```
## ndt_map

```
* removed outdated opencv2 dependency
* major refactoring of source code, be warned
* Contributors: Todor Stoyanov
```
## ndt_map_builder

```
* package builds, still outdated functionalities. check ndt_fuser for building maps instead
* Contributors: Todor Stoyanov
```
## ndt_mcl

```
* major code refactoring of MCL
* Contributors: Todor Stoyanov, Tomasz Kucner
```
## ndt_registration

```
*major refactoring
* Contributors: Henrik Andreasson
```
## ndt_rviz_visualisation

```
* rviz plugin bug fix: now it looks that elipsoids are correctly orientaded
* Contributors: Tomasz Kucner
```
## ndt_visualisation

```
* Fixed transform error in the orbit camera.
* Added check to avoid duplicate drawing objects.
* Added new functionalities to the visualization class.
*removed dependency on mrpt
* Contributors: Henrik Andreasson, Todor Stoyanov
```
## perception_oru

```
* major refactoring of code. templates are gone. opencv from source is needed for non-free features in ndt_feature_reg
```
## sdf_tracker

```
* removed outdated opencv2 dependency
* Contributors: Todor Stoyanov
```
