### PR TITLE
aruco_mapping: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -357,6 +357,21 @@ repositories:
       url: https://github.com/ROS-PSE/arni.git
       version: master
     status: maintained
+  aruco_mapping:
+    doc:
+      type: git
+      url: https://github.com/SmartRoboticSystems/aruco_mapping.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/SmartRoboticSystems/aruco_mapping-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/SmartRoboticSystems/aruco_mapping.git
+      version: master
+    status: maintained
   aruco_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_mapping` to `1.0.1-0`:
- upstream repository: https://github.com/SmartRoboticSystems/aruco_mapping.git
- release repository: https://github.com/SmartRoboticSystems/aruco_mapping-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## aruco_mapping

```
* 1.0.0
* CHANGELOG
* fix
* adding CHANGELOG
* removed pal_vision_segmentation dependency
* Contributors: durovsky
```
