### PR TITLE
youbot_driver: 1.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4298,5 +4298,11 @@ repositories:
       url: https://github.com/ros/xacro.git
       version: jade-devel
     status: developed
+  youbot_driver:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/youbot-release/youbot_driver-release.git
+      version: 1.1.0-0
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `youbot_driver` to `1.1.0-0`:
- upstream repository: https://github.com/youbot/youbot_driver.git
- release repository: https://github.com/youbot-release/youbot_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
