### PR TITLE
mavlink: 2015.10.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1570,7 +1570,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: 2015.9.9-0
+      version: 2015.10.10-0
     status: maintained
   mavros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2015.10.10-0`:
- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/mavlink/mavlink-gbp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2015.9.9-0`
