### PR TITLE
aruco_mapping: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -366,7 +366,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SmartRoboticSystems/aruco_mapping-release.git
-      version: 1.0.1-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/SmartRoboticSystems/aruco_mapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_mapping` to `1.0.3-0`:
- upstream repository: https://github.com/SmartRoboticSystems/aruco_mapping.git
- release repository: https://github.com/SmartRoboticSystems/aruco_mapping-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.1-0`
## aruco_mapping

```
* updated package.xml
* Contributors: durovsky
```
