### PR TITLE
fanuc: 0.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2146,6 +2146,34 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/fanuc.git
       version: indigo
+    release:
+      packages:
+      - fanuc
+      - fanuc_driver
+      - fanuc_lrmate200ic5h_moveit_config
+      - fanuc_lrmate200ic5l_moveit_config
+      - fanuc_lrmate200ic_moveit_config
+      - fanuc_lrmate200ic_moveit_plugins
+      - fanuc_lrmate200ic_support
+      - fanuc_m10ia_moveit_config
+      - fanuc_m10ia_moveit_plugins
+      - fanuc_m10ia_support
+      - fanuc_m16ib20_moveit_config
+      - fanuc_m16ib_moveit_plugins
+      - fanuc_m16ib_support
+      - fanuc_m20ia10l_moveit_config
+      - fanuc_m20ia_moveit_config
+      - fanuc_m20ia_moveit_plugins
+      - fanuc_m20ia_support
+      - fanuc_m430ia2f_moveit_config
+      - fanuc_m430ia2p_moveit_config
+      - fanuc_m430ia_moveit_plugins
+      - fanuc_m430ia_support
+      - fanuc_resources
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-industrial-release/fanuc-release.git
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/ros-industrial/fanuc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fanuc` to `0.4.0-0`:
- upstream repository: https://github.com/ros-industrial/fanuc.git
- release repository: https://github.com/ros-industrial-release/fanuc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## fanuc

```
* first Indigo release.
* remove assets package (#149 <https://github.com/ros-industrial/fanuc/issues/149>).
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_driver

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* document launch file arguments (#165 <https://github.com/ros-industrial/fanuc/issues/165>).
* use multi-arg install rule instead of for-loop.
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_lrmate200ic5h_moveit_config

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* document launch file arguments (#165 <https://github.com/ros-industrial/fanuc/issues/165>).
* document potential poor planning perf of LBKPIECE1 in MoveIt configuration packages.
* update MoveIt configurations for Indigo release.
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_lrmate200ic5l_moveit_config

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* document launch file arguments (#165 <https://github.com/ros-industrial/fanuc/issues/165>).
* document potential poor planning perf of LBKPIECE1 in MoveIt configuration packages.
* update MoveIt configurations for Indigo release.
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_lrmate200ic_moveit_config

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* document launch file arguments (#165 <https://github.com/ros-industrial/fanuc/issues/165>).
* document potential poor planning perf of LBKPIECE1 in MoveIt configuration packages.
* update MoveIt configurations for Indigo release.
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_lrmate200ic_moveit_plugins

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_lrmate200ic_support

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* document launch file arguments (#165 <https://github.com/ros-industrial/fanuc/issues/165>).
* use multi-arg install rule instead of for-loop.
* use Roboguide colours for meshes where appropriate (#166 <https://github.com/ros-industrial/fanuc/issues/166>).
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_m10ia_moveit_config

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* document launch file arguments (#165 <https://github.com/ros-industrial/fanuc/issues/165>).
* document potential poor planning perf of LBKPIECE1 in MoveIt configuration packages.
* update MoveIt configurations for Indigo release.
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_m10ia_moveit_plugins

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_m10ia_support

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* document launch file arguments (#165 <https://github.com/ros-industrial/fanuc/issues/165>).
* use multi-arg install rule instead of for-loop.
* use Roboguide colours for meshes where appropriate (#166 <https://github.com/ros-industrial/fanuc/issues/166>).
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_m16ib20_moveit_config

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* document launch file arguments (#165 <https://github.com/ros-industrial/fanuc/issues/165>).
* document potential poor planning perf of LBKPIECE1 in MoveIt configuration packages.
* update MoveIt configurations for Indigo release.
  Note: link_3 gets added to the 'disabled' set for base_link in the collision matrix.
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_m16ib_moveit_plugins

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_m16ib_support

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* document launch file arguments (#165 <https://github.com/ros-industrial/fanuc/issues/165>).
* use multi-arg install rule instead of for-loop.
* use Roboguide colours for meshes where appropriate (#166 <https://github.com/ros-industrial/fanuc/issues/166>).
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_m20ia10l_moveit_config

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* document launch file arguments (#165 <https://github.com/ros-industrial/fanuc/issues/165>).
* document potential poor planning perf of LBKPIECE1 in MoveIt configuration packages.
* update MoveIt configurations for Indigo release.
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_m20ia_moveit_config

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* document launch file arguments (#165 <https://github.com/ros-industrial/fanuc/issues/165>).
* document potential poor planning perf of LBKPIECE1 in MoveIt configuration packages.
* update MoveIt configurations for Indigo release.
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_m20ia_moveit_plugins

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_m20ia_support

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* document launch file arguments (#165 <https://github.com/ros-industrial/fanuc/issues/165>).
* use multi-arg install rule instead of for-loop.
* use Roboguide colours for meshes where appropriate (#166 <https://github.com/ros-industrial/fanuc/issues/166>).
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_m430ia2f_moveit_config

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* document launch file arguments (#165 <https://github.com/ros-industrial/fanuc/issues/165>).
* document potential poor planning perf of LBKPIECE1 in MoveIt configuration packages.
* update MoveIt configurations for Indigo release.
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_m430ia2p_moveit_config

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* document launch file arguments (#165 <https://github.com/ros-industrial/fanuc/issues/165>).
* document potential poor planning perf of LBKPIECE1 in MoveIt configuration packages.
* update MoveIt configurations for Indigo release.
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_m430ia_moveit_plugins

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_m430ia_support

```
* first Indigo release.
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* document launch file arguments (#165 <https://github.com/ros-industrial/fanuc/issues/165>).
* remove illegal characters from launch file argument documentation strings (#176 <https://github.com/ros-industrial/fanuc/issues/176>).
* use multi-arg install rule instead of for-loop.
* use Roboguide colours for meshes where appropriate (#166 <https://github.com/ros-industrial/fanuc/issues/166>).
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
## fanuc_resources

```
* first Indigo release.
* remove assets package (#149 <https://github.com/ros-industrial/fanuc/issues/149>).
* upgrade manifests to package format 2 (#115 <https://github.com/ros-industrial/fanuc/issues/115>).
* general cleanup of XML files (launch, manifests, roslaunch tests, xacros).
* add ROS Index tags to package manifests (#147 <https://github.com/ros-industrial/fanuc/issues/147>).
* add Roboguide colours to the set of shared resources.
* for a complete list of changes see the commit log for 0.4.0 <https://github.com/ros-industrial/fanuc/compare/0.3.2...0.4.0>.
```
