### PR TITLE
aruco_mapping: 1.0.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -118,6 +118,21 @@ repositories:
       url: https://github.com/AutonomyLab/ardrone_autonomy.git
       version: indigo-devel
     status: developed
+  aruco_mapping:
+    doc:
+      type: git
+      url: https://github.com/SmartRoboticSystems/aruco_mapping.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/SmartRoboticSystems/aruco_mapping-release.git
+      version: 1.0.4-0
+    source:
+      type: git
+      url: https://github.com/SmartRoboticSystems/aruco_mapping.git
+      version: master
+    status: maintained
   aruco_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_mapping` to `1.0.4-0`:
- upstream repository: https://github.com/SmartRoboticSystems/aruco_mapping.git
- release repository: https://github.com/SmartRoboticSystems/aruco_mapping-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## aruco_mapping

```
* msg file addopted to  coding style rules
* Contributors: durovsky
```
