### PR TITLE
ubiquity_motor: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10286,7 +10286,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/UbiquityRobotics/ubiquity_motor.git
+      version: 0.3.1
     status: developed
   ublox:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ubiquity_motor` to `0.3.1-0`:
- upstream repository: https://github.com/UbiquityRobotics/ubiquity_motor.git
- release repository: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.0-0`
## ubiquity_motor

```
* fixed install rules for Cmake
* added license to test code
* Contributors: Rohan Agrawal
```
