### PR TITLE
genpy: 0.5.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -841,7 +841,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.5.5-0
+      version: 0.5.6-0
     source:
       type: git
       url: https://github.com/ros/genpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.5.6-0`:
- upstream repository: git@github.com:ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.5-0`
## genpy

```
* fix handling of dynamic message classes with names containing other message classes as substrings (#40 <https://github.com/ros/genpy/pull/40>)
```
