### PR TITLE
open_street_map: 0.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5994,10 +5994,20 @@ repositories:
       type: git
       url: https://github.com/ros-geographic-info/open_street_map.git
       version: master
+    release:
+      packages:
+      - osm_cartography
+      - route_network
+      - test_osm
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-geographic-info/open_street_map-release.git
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/ros-geographic-info/open_street_map.git
       version: master
+    status: maintained
   opencv3:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `open_street_map` to `0.2.3-0`:
- upstream repository: https://github.com/ros-geographic-info/open_street_map.git
- release repository: https://github.com/ros-geographic-info/open_street_map-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## osm_cartography
- No changes
## route_network
- No changes
## test_osm
- No changes
