### PR TITLE
add time for fedra and debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3288,6 +3288,8 @@ texmaker:
   fedora: [texmaker]
   ubuntu: [texmaker]
 time:
+  debian: [time]
+  fedora: [time]
   ubuntu: [time]
 tinyxml:
   arch: [tinyxml]


### PR DESCRIPTION
https://github.com/ros/rosdistro/pull/9604 missing fedora/debian entry

https://admin.fedoraproject.org/pkgdb/package/time/
https://packages.debian.org/jessie/time
