### PR TITLE
ros: 1.11.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7925,7 +7925,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.11.9-0
+      version: 1.11.10-0
     source:
       type: git
       url: https://github.com/ros/ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.11.10-0`:
- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.9-0`
## mk
- No changes
## rosbash

```
* fix zsh rosservice completion (#92 <https://github.com/ros/ros/pull/92>)
```
## rosboost_cfg
- No changes
## rosbuild
- No changes
## rosclean
- No changes
## roscreate
- No changes
## roslang
- No changes
## roslib

```
* improve performance by caching the package mapping in the rospack instance (#95 <https://github.com/ros/ros/pull/95>)
```
## rosmake
- No changes
## rosunit
- No changes
