### PR TITLE
jsk_3rdparty: 2.0.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3587,7 +3587,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.0.10-0
+      version: 2.0.11-0
     status: developed
   jsk_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.0.11-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.0.10-0`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## collada_urdf_jsk_patch
- No changes
## downward

```
* [travis.yml&downward] install time from rosdep instead of travis.yml
* Contributors: Yuki Furuta, Ryohei Ueda
```
## ff
- No changes
## ffha
- No changes
## jsk_3rdparty
- No changes
## julius
- No changes
## libcmt
- No changes
## libsiftfast
- No changes
## mini_maxwell
- No changes
## nlopt
- No changes
## opt_camera
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## sklearn
- No changes
## voice_text
- No changes
