### PR TITLE
jsk_visualization: 1.0.25-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3782,7 +3782,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.24-0
+      version: 1.0.25-0
     status: developed
   jskeus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.25-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.24-0`
## jsk_interactive
- No changes
## jsk_interactive_marker

```
* change service -> topic
* add right click config with yaml
* [jsk_interactive_markers] Ignore rvizconfig generated at build time
* Contributors: Kentaro Wada, Yu Ohara
```
## jsk_interactive_test
- No changes
## jsk_rqt_plugins

```
* [jsk_rqt_plugins] Fit line to date by ransac
* [jsk_rqt_plugins] Move README to sphinx + readthedocs
* Contributors: Kentaro Wada, Ryohei Ueda
```
## jsk_rviz_plugins

```
* [jsk_rviz_plugins] Fix font size of PeoplePositionMeasurementArray
* [jsk_rviz_plugins] Add script for diagnostics sample
* [jsk_rviz_plugins] Compile PeoplePositionMeasurementArrayDisplay
* [jsk_rviz_plugins/VideoCapture] Check file permission to write correctly
* [jsk_rviz_plugins] Use readthedocs to document
* [jsk_rviz_plugins] Add index page for sphinx + readthedocs
* [jsk_rviz_plugins] Use jsk_recognition_utils instead of jsk_pcl_ros to
  speed up compilation
* Contributors: Kentaro Wada, Ryohei Ueda
```
## jsk_visualization
- No changes
