### PR TITLE
rviz: 1.11.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3632,7 +3632,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.11.9-0
+      version: 1.11.10-0
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.11.10-0`:
- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.9-0`
## rviz

```
* Fixed Qt assertions triggered in debug build of Qt.
* build: Use PKG_CONFIG_EXECUTABLE
  Instead of using a hard-coded pkg-config to make cross-compiling
  possible where the pkg-config binary is host-prefixed (e.g.
  armv7-unknown-linux-pkg-config when cross-compiling for armv7)
* Fix #911 <https://github.com/ros-visualization/rviz/issues/911> #616 <https://github.com/ros-visualization/rviz/issues/616> : TF Segfaults on reset/update
  Do not needlessly delete tree_property_ elements, update them instead.
  Most likely fixes #808 <https://github.com/ros-visualization/rviz/issues/808> too.
* python_bindings: sip: Use CATKIN_PACKAGE_LIB_DESTINATION instead of hardcoded lib.
  Fixes build with libdir != lib.
  https://bugs.gentoo.org/show_bug.cgi?id=561480
* Contributors: Alexis Ballier, Arnaud TANGUY, Dave Hershberger, Marvin Schmidt, William Woodall
```
