### PR TITLE
ros_comm: 1.11.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8009,7 +8009,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.14-0
+      version: 1.11.15-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.15-0`:
- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.14-0`
## message_filters

```
* add unregister() method to message_filter.Subscriber (#683 <https://github.com/ros/ros_comm/pull/683>)
```
## ros_comm
- No changes
## rosbag

```
* add option --prefix for prefixing output topics (#626 <https://github.com/ros/ros_comm/pull/626>)
```
## rosbag_storage
- No changes
## rosconsole
- No changes
## roscpp

```
* fix crash in onRetryTimer() callback (#577 <https://github.com/ros/ros_comm/issues/577>)
```
## rosgraph
- No changes
## roslaunch

```
* improve performance by reusing the rospack instance across nodes with the same default environment (#682 <https://github.com/ros/ros_comm/pull/682>)
```
## roslz4
- No changes
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy

```
* validate name after remapping (#669 <https://github.com/ros/ros_comm/pull/669>)
```
## rosservice
- No changes
## rostest
- No changes
## rostopic

```
* add warning to rostopic hz about simulated time (#672 <https://github.com/ros/ros_comm/pull/672>)
```
## roswtf
- No changes
## topic_tools
- No changes
## xmlrpcpp
- No changes
