### PR TITLE
brics_actuator: 0.7.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -645,7 +645,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wnowak/brics_actuator-release.git
-      version: 0.1.0-0
+      version: 0.7.0-0
   bride:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `brics_actuator` to `0.7.0-0`:
- upstream repository: https://github.com/wnowak/brics_actuator.git
- release repository: https://github.com/wnowak/brics_actuator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.0-0`
