### PR TITLE
ypspur: 0.0.1-4 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11128,7 +11128,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/DaikiMaekawa/ypspur-release.git
-      version: 0.0.1-3
+      version: 0.0.1-4
+    source:
+      type: git
+      url: https://github.com/DaikiMaekawa/ypspur.git
+      version: master
     status: maintained
   yujin_maps:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ypspur` to `0.0.1-4`:
- upstream repository: https://github.com/DaikiMaekawa/ypspur
- release repository: https://github.com/DaikiMaekawa/ypspur-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.1-3`
