### PR TITLE
cv_camera: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1564,6 +1564,21 @@ repositories:
       url: https://github.com/stonier/cv_backports.git
       version: indigo
     status: maintained
+  cv_camera:
+    doc:
+      type: git
+      url: https://github.com/OTL/cv_camera.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/OTL/cv_camera-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/OTL/cv_camera.git
+      version: master
+    status: developed
   cyton_gamma_1500_description:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cv_camera` to `0.1.0-0`:
- upstream repository: https://github.com/OTL/cv_camera
- release repository: https://github.com/OTL/cv_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## cv_camera

```
* Fix opencv2 to libopencv-dev
* Contributors: Takashi Ogura
```
