### PR TITLE
cv_camera: 0.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -489,6 +489,21 @@ repositories:
       url: https://github.com/yujinrobot-release/cv_backports-release.git
       version: 0.1.3-0
     status: maintained
+  cv_camera:
+    doc:
+      type: git
+      url: https://github.com/OTL/cv_camera.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/OTL/cv_camera-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/OTL/cv_camera.git
+      version: master
+    status: developed
   demo_pioneer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cv_camera` to `0.1.0-0`:
- upstream repository: https://github.com/OTL/cv_camera
- release repository: https://github.com/OTL/cv_camera-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## cv_camera

```
* Fix opencv2 to libopencv-dev
* Contributors: Takashi Ogura
```
