### PR TITLE
orne_maps: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6211,7 +6211,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/open-rdc/orne_maps-release.git
-      version: 0.0.1-1
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/open-rdc/orne_maps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `orne_maps` to `0.1.1-0`:
- upstream repository: https://github.com/open-rdc/orne_maps
- release repository: https://github.com/open-rdc/orne_maps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.1-1`
