### PR TITLE
roboteq: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7659,7 +7659,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/roboteq-release.git
-      version: 0.1.2-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/g/roboteq.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roboteq` to `0.2.0-0`:
- upstream repository: https://github.com/g/roboteq.git
- release repository: https://github.com/clearpath-gbp/roboteq-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.2-0`
## roboteq_diagnostics
- No changes
## roboteq_driver

```
* Explicit stop commands at 10Hz when uncommanded.
* Add option to command position control, specifying separate sets of constants in MBS.
* Fixed channel.cpp line 85 to properly pass variable relevent to channel
* Contributors: Mike Purvis, Thomas Watters
```
## roboteq_msgs

```
* Add mode for stop, clear control constants; this is an MD5 breakage for Indigo.
* Contributors: Mike Purvis
```
