### PR TITLE
mastering_ros_demo_pkg: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4651,6 +4651,12 @@ repositories:
       url: https://github.com/swri-robotics/marti_messages.git
       version: indigo-devel
     status: developed
+  mastering_ros_demo_pkg:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/qboticslabs/demo_pkg-release.git
+      version: 0.0.2-0
   mav_comm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mastering_ros_demo_pkg` to `0.0.2-0`:
- upstream repository: https://github.com/qboticslabs/mastering_ros_demo_pkg.git
- release repository: https://github.com/qboticslabs/demo_pkg-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## mastering_ros_demo_pkg

```
* Update code, remove CHANGELOg
* Contributors: lentin
```
