### PR TITLE
openni_camera: 1.9.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2441,6 +2441,21 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/openhrp3-release.git
       version: 3.1.8-0
+  openni_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni_camera.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/openni_camera-release.git
+      version: 1.9.3-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni_camera.git
+      version: indigo-devel
+    status: maintained
   openrtm_aist:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_camera` to `1.9.3-0`:
- upstream repository: https://github.com/ros-drivers/openni_camera.git
- release repository: https://github.com/ros-gbp/openni_camera-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## openni_camera

```
* [fix] Remove several using namespace std
  - They cause compilation failure (on OS X 10.9 with clang defaulting
  to C++11)
  - Failure occurs because unique_lock and friends is both in namespace
  std and namespace boost.
* [fix] Don't pass unsafe strings as format strings for printing
  Doing so causes build errors under -Werror=format-security. If there
  were to be a % (percent symbol) in the exception string (whether
  intentional, malicious or otherwise), the print function could
  expose memory or cause segfaults.
* [fix] #28 <https://github.com/ros-drivers/openni_camera/issues/28>, properly parse device_id with only numbers
  The fix checks wherever an string device_id parameter is set
  or a device_id integer parameter is set. If both are missing
  it opens the first device found. If integer device_id is set
  then it parses it to string and load continues as if string
  version was set.
* [sys] Add travis config for indigo, jade
* [sys] Update maintainer
* Contributors: Emili Boronat, Nikolaus Demmel, Scott K Logan, Isaac I.Y. Saito
```
