### PR TITLE
rtabmap and rtabmap_ros: 0.10.10-0 in '[indigo|jade]/distribution.yaml'

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8957,7 +8957,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.10.4-0
+      version: 0.10.10-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -8972,7 +8972,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.10.4-0
+      version: 0.10.10-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3536,7 +3536,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.10.4-1
+      version: 0.10.10-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -3551,7 +3551,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.10.4-0
+      version: 0.10.10-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
 Increasing version of package(s) in repositories `rtabmap` and `rtabmap_ros` to `0.10.10-0`:
- upstream repository: https://github.com/introlab/rtabmap.git, https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap-release.git, https://github.com/introlab/rtabmap_ros-release.git
- distro file: `indigo/distribution.yaml` and `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.10.4`
