### PR TITLE
scan_tools: 0.2.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3696,6 +3696,30 @@ repositories:
       url: https://github.com/ros-gbp/sbpl-release.git
       version: 1.2.0-3
     status: maintained
+  scan_tools:
+    doc:
+      type: git
+      url: https://github.com/ccny-ros-pkg/scan_tools.git
+      version: indigo
+    release:
+      packages:
+      - laser_ortho_projector
+      - laser_scan_matcher
+      - laser_scan_sparsifier
+      - laser_scan_splitter
+      - ncd_parser
+      - polar_scan_matcher
+      - scan_to_cloud_converter
+      - scan_tools
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/scan_tools-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/ccny-ros-pkg/scan_tools.git
+      version: indigo
+    status: maintained
   schunk_grippers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `scan_tools` to `0.2.1-0`:
- upstream repository: https://github.com/ccny-ros-pkg/scan_tools.git
- release repository: https://github.com/tork-a/scan_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## laser_ortho_projector

```
* [feat] added support for IMU message for orientation in laser_ortho_projector. The imu topic is imu/data
* [fix] PCL dependency Hydro onward
* [sys] Catkinization: laser_ortho_projector
* Contributors: Ivan Dryanovski, Miguel Sarabia, Enrique Fernández Perdomo
```
## laser_scan_matcher

```
* [feat] Update gmapping demo as well.
* [feat] removed vgf filter, added xy filtering. added vgf on point cloud input for scan_matcher, vgf on point cloud input for scan_matcher
* [feat] removing pose2dstamped message type, now using posestamped
* [fix] PCL dependency Hydro onward
* [fix] rotation update check
* [fix] possible memory leak introduced by keyframe feature
* [doc] replaces tabs and fixes imu <-> odom topic comment
* [sys] cleaning
* [sys] Replace demo.vcg with a demo.rviz
* [sys] Small tweaks to CMakeLists.txt and package.xml files
* [sys] Catkinization: laser_scan_matcher (csm integrated as external project
* [sys] laser_scan_matcher: Remove CSM search in CMakeLists.txt
  Since the csm package exports the CFLAGS and LFLAGS, we do not need to
  explicitly search for the paths.
* [sys] launch files use rosbag api for fuerte
* [sys] imu topic renamed to imu/data
* Contributors: Daniel Axtens, Ivan Dryanovski, Kartik Mohta, Miguel Sarabia, Stephan Wirth, Enrique Fernández Perdomo
```
## laser_scan_sparsifier

```
* [sys] Catkinizing: laser_scan_sparsifier
* [sys] renamed skip to step parameter in scan sparsifier
* Contributors: Ivan Dryanovski, Miguel Sarabia
```
## laser_scan_splitter

```
* [sys] Catkinization: laser_scan_splitter
* Contributors: Ivan Dryanovski, Miguel Sarabia
```
## ncd_parser

```
* [doc] README files to contain catkin instructions
* [sys] Catkinization: ncd_parser
* [sys] Small tweaks to CMakeLists.txt and package.xml files
* Contributors: Ivan Dryanovski, Miguel Sarabia
```
## polar_scan_matcher

```
* [feat] added polar scan matcher
* [feat] added imu option to PSM, made CSM and PSM look similar
* [feat] added demo dir to CSM,
* [fix] PSM launch file
* [sys] ROS Hydro compatible
* [sys] Cleaning
* [sys] correct license and references to PSM and CSM
* Contributors: Daniel Axtens, Ivan Dryanovski
```
## scan_to_cloud_converter

```
* [fix] PCL dependency Hydro onward
* [sys] Catkinization
* Contributors: Ivan Dryanovski, Miguel Sarabia, Enrique Fernández Perdomo
```
## scan_tools

```
* [feat] Released into ROS Indigo and Jade
* [feat] Update gmapping demo as well.
* [feat] added support for IMU message for orientation in laser_ortho_projector. The imu topic is imu/data* [feat] removed vgf filter, added xy filtering. added vgf on point cloud input for scan_matcher, vgf on point cloud input for scan_matcher
* [feat] removing pose2dstamped message type, now using posestamped
* [feat] added polar scan matcher
* [feat] added imu option to PSM, made CSM and PSM look similar
* [feat] added demo dir to CSM,
* [fix] rotation update check
* [fix] possible memory leak introduced by keyframe feature
* [fix] PSM launch file
* [doc] updated manifest of scan_to_cloud_converter
* [doc] README files to contain catkin instructions
* [doc] replaces tabs and fixes imu <-> odom topic comment
* [sys] Catkinization
* [sys] Moved from robotics.ccny.cuny.edu
* [sys] ROS Hydro compatible
* [sys] correct license and references to PSM and CSM
* [sys] Small tweaks to CMakeLists.txt and package.xml files
* [sys] renamed skip to step parameter in scan sparsifier
* [sys] cleaning
* [sys] Replace demo.vcg with a demo.rviz
* [sys] Small tweaks to CMakeLists.txt and package.xml files
* [sys] laser_scan_matcher: Remove CSM search in CMakeLists.txt
  Since the csm package exports the CFLAGS and LFLAGS, we do not need to
  explicitly search for the paths.
* [sys] launch files use rosbag api for fuerte
* [sys] imu topic renamed to imu/data
* Contributors: Ivan Dryanovski, Miguel Sarabia, Daniel Axtens, Kartik Mohta, Miguel Sarabia, Stephan Wirth, Enrique Fernandez, Isaac I.Y. Saito
```
