### PR TITLE
rtmros_nextage: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9042,7 +9042,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.6.4-0
+      version: 0.6.6-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.6.6-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.4-0`
## nextage_description
- No changes
## nextage_ik_plugin
- No changes
## nextage_moveit_config

```
* [feat] Add torso, head, and (whole) upperbody Move Group
* [fix] Correct param file names for OMPL
* Contributors: Isaac I.Y. Saito
```
## nextage_ros_bridge
- No changes
## rtmros_nextage

```
* [feat] Add torso, head, and (whole) upperbody Move Group
* [fix] Correct param file names for OMPL
* Contributors: Isaac I.Y. Saito
```
