### PR TITLE
camera1394stereo: 1.0.3-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -773,7 +773,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/srv/camera1394stereo-release.git
-      version: 1.0.3-0
+      version: 1.0.3-2
     source:
       type: git
       url: https://github.com/srv/camera1394stereo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera1394stereo` to `1.0.3-2`:
- upstream repository: https://github.com/srv/camera1394stereo.git
- release repository: https://github.com/srv/camera1394stereo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.3-0`
