### PR TITLE
ecl_tools: 0.61.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -608,6 +608,25 @@ repositories:
       url: https://github.com/arebgun/dynamixel_motor.git
       version: master
     status: maintained
+  ecl_tools:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: indigo
+    release:
+      packages:
+      - ecl_build
+      - ecl_license
+      - ecl_tools
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_tools-release.git
+      version: 0.61.1-0
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: indigo
+    status: developed
   ecto:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_tools` to `0.61.1-0`:
- upstream repository: https://github.com/stonier/ecl_tools.git
- release repository: https://github.com/yujinrobot-release/ecl_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## ecl_build

```
* ecl_detect_filesystem cmake macro added.
```
