### PR TITLE
ecl_lite: 0.61.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -608,6 +608,27 @@ repositories:
       url: https://github.com/arebgun/dynamixel_motor.git
       version: master
     status: maintained
+  ecl_lite:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
+      version: indigo
+    release:
+      packages:
+      - ecl_config
+      - ecl_converters_lite
+      - ecl_errors
+      - ecl_io
+      - ecl_lite
+      - ecl_sigslots_lite
+      - ecl_time_lite
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_lite-release.git
+      version: 0.61.1-0
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
   ecl_tools:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -629,6 +629,8 @@ repositories:
     source:
       type: git
       url: https://github.com/stonier/ecl_lite.git
+      version: indigo
+    status: developed
   ecl_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_lite` to `0.61.1-0`:
- upstream repository: https://github.com/stonier/ecl_lite.git
- release repository: https://github.com/yujinrobot-release/ecl_lite-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## ecl_errors

```
* Add a missing virtual destructor
```
## ecl_time_lite

```
* support get_date_string on macosx.
```
