### PR TITLE
qglv_toolkit: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7183,6 +7183,24 @@ repositories:
       url: https://github.com/MurpheyLab/trep-release.git
       version: 1.0.2-0
     status: developed
+  qglv_toolkit:
+    release:
+      packages:
+      - qglv_extras
+      - qglv_gallery
+      - qglv_opencv
+      - qglv_opengl
+      - qglv_pcl
+      - qglv_toolkit
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/qglv_toolkit-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/yujinrobot/qglv_toolkit.git
+      version: indigo
+    status: developed
   qt_gui_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qglv_toolkit` to `0.1.1-0`:
- upstream repository: https://github.com/yujinrobot/qglv_toolkit.git
- release repository: https://github.com/yujinrobot-release/qglv_toolkit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## qglv_extras

```
* ported from dslam_viewer 0.3.1
```
## qglv_gallery

```
* initial prototype
```
## qglv_opencv

```
* ported from dslam_viewer 0.3.1
```
## qglv_opengl

```
* ported from dslam_viewer 0.3.1
```
## qglv_pcl

```
* ported from dslam_viewer 0.3.1
```
## qglv_toolkit

```
* ported from dslam_viewer 0.3.1
```
