### PR TITLE
csm: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1553,6 +1553,21 @@ repositories:
       url: https://github.com/etsardou/crsm-slam-ros-pkg-release.git
       version: 1.0.3-0
     status: maintained
+  csm:
+    doc:
+      type: git
+      url: https://github.com/AndreaCensi/csm.git
+      version: csm_eigen
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/csm-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/AndreaCensi/csm.git
+      version: csm_eigen
+    status: maintained
   cv_backports:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `csm` to `1.0.1-0`:
- upstream repository: https://github.com/AndreaCensi/csm.git
- release repository: https://github.com/tork-a/csm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
