### PR TITLE
ecl_manipulation: 0.60.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -670,6 +670,25 @@ repositories:
       url: https://github.com/stonier/ecl_lite.git
       version: indigo
     status: developed
+  ecl_manipulation:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_manipulation.git
+      version: indigo
+    release:
+      packages:
+      - ecl
+      - ecl_manipulation
+      - ecl_manipulators
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_manipulation-release.git
+      version: 0.60.0-0
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_manipulation.git
+      version: indigo
+    status: developed
   ecl_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_manipulation` to `0.60.0-0`:
- upstream repository: https://github.com/stonier/ecl_manipulation.git
- release repository: https://github.com/yujinrobot-release/ecl_manipulation-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
