### PR TITLE
multimaster_fkie: 0.4.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5215,7 +5215,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.4.1-0
+      version: 0.4.2-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.4.2-0`:
- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.4.1-0`
## default_cfg_fkie
- No changes
## master_discovery_fkie

```
* master_discovery_fkie: fixed the updates of remote nodes registered on local master
* multimaster_fkie: added a possibility to set time on remote host
* node_manager_fkie: added a warning if the time difference to remote host is greater than a defined value (default 3 sec)
* master_discovery_fkie: added @part to define interface with mcast group
* master_discovery_fkie: add posibility to specify the interface to use
* master_discover_fkie: check for local ip addresses to avoid wrong warning messages
* Contributors: Alexander Tiderko
```
## master_sync_fkie
- No changes
## multimaster_fkie
- No changes
## multimaster_msgs_fkie
- No changes
## node_manager_fkie

```
* node_manager_fkie: added further files to change detection
* node_manager_fkie: fixed parameter dialog for some messages e.g. MarkerArray
* node_manager_fkie: shutdown now all nodes and roscore at exit (if selected)
* node_manager_fkie: changed diagnostic visualization
* node_manager_fkie: propagate the diagnostic color of a node to his group
* node_manager_fkie: update the description of selected node after a diagnostic message is recieved
* multimaster_fkie: added a possibility to set time on remote host
* node_manager_fkie: fixed the comparison of host time difference
* node_manager_fkie: added a warning if the time difference to remote host is greater than a defined value (default 3 sec)
* node_manager_fkie: added ControlModifier to package navigation
  Ctrl+DoubleClick:
  * History file: goto the package of the launch file
  * ..: goto root
  * folder: go only one step down, not until first config file
* node_manager_fkie: changed param template for parameter name in editor
* node_manager_fkie: added log button for remote master_discovery
  * show now only the screen log
* node_manager_fkie: fixed save/load in parameter dialog
* node_manager_fkie: fix load parameter with absolute path
* node_manager_fkie: added more info for error while set a parameter with None value
* node_manager_fkie: added icon for rqt plugin
* node_manager_fkie: fixed error which prevent display info and configuration dialogs
* node_manager_fkie: check now for changes of local binaries and ask for restart if these are changed
* node_manager_fkie: fixed problem while publishing to topic with lists and byte values
* node_manager_fkie: added support diagnostics_agg topic
* node_manager_fkie: added a remote script which does not use qt bindings
* Contributors: Alexander Tiderko
```
