### PR TITLE
added innok_heros_simulation to Indigo for pre-release test

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3403,6 +3403,16 @@ repositories:
       url: https://github.com/innokrobotics/innok_heros_lights.git
       version: indigo
     status: maintained
+  innok_heros_simulation:
+    doc:
+      type: git
+      url: https://github.com/innokrobotics/innok_heros_simulation.git
+      version: indigo
+    source:
+      type: git
+      url: https://github.com/innokrobotics/innok_heros_simulation.git
+      version: indigo
+    status: maintained
   interaction_cursor_3d:
     release:
       packages:


### PR DESCRIPTION
I'd like to added innok_heros_simulation to Indigo for pre-release test
