### PR TITLE
romeo_robot: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7989,19 +7989,24 @@ repositories:
       version: master
     status: maintained
   romeo_robot:
+    doc:
+      type: git
+      url: https://github.com/ros-aldebaran/romeo_robot.git
+      version: master
     release:
       packages:
+      - romeo_bringup
       - romeo_dcm_bringup
       - romeo_dcm_control
       - romeo_dcm_driver
       - romeo_dcm_msgs
       - romeo_description
       - romeo_robot
-      - romeo_sensors
+      - romeo_sensors_py
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-aldebaran/romeo_robot-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ros-aldebaran/romeo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_robot` to `0.1.1-0`:
- upstream repository: https://github.com/ros-aldebaran/romeo_robot.git
- release repository: https://github.com/ros-aldebaran/romeo_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.0-0`
## romeo_bringup

```
* add a cHANGELOG for romeo_bringup
* artifically bump romeo_bringup's version for a proper release
* Adding new package romeo_bringup
* Contributors: Vincent Rabaud, nlyubova
* artifically bump romeo_bringup's version for a proper release
* Adding new package romeo_bringup
* Contributors: Vincent Rabaud, nlyubova
```
## romeo_dcm_bringup

```
* Removing the namespace prefix and fixing the head controllers with correct joint names (the HeadYaw joint does not exist)
* Contributors: nlyubova
```
## romeo_dcm_control

```
* adding head and torso controllers
* few changes in arm and hand controllers to make compatible with romeo_moveit_config
* Removing the namespace prefix and fixing the head controllers with correct joint names (the HeadYaw joint does not exist)
* Contributors: nlyubova
```
## romeo_dcm_driver

```
* Adding back eyes joints, otherwise the TF tree is broken
* adding head and torso controllers
* Contributors: nlyubova
```
## romeo_dcm_msgs
- No changes
## romeo_description

```
* update to the latest naoqi_tools script
* Contributors: Vincent Rabaud
```
## romeo_robot
- No changes
## romeo_sensors_py

```
* rename romeo_sensors to romeo_sensors_py
* Contributors: Vincent Rabaud
```
