### PR TITLE
romeo_moveit_config: 0.2.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7978,11 +7978,15 @@ repositories:
       version: indigo
     status: developed
   romeo_moveit_config:
+    doc:
+      type: git
+      url: https://github.com/ros-aldebaran/romeo_moveit_config.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-aldebaran/romeo_moveit_config-release.git
-      version: 0.2.4-0
+      version: 0.2.5-0
     source:
       type: git
       url: https://github.com/ros-aldebaran/romeo_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_moveit_config` to `0.2.5-0`:
- upstream repository: https://github.com/ros-aldebaran/romeo_moveit_config.git
- release repository: https://github.com/ros-aldebaran/romeo_moveit_config-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.4-0`
## romeo_moveit_config

```
* cleaning package.xml
* Configuring sensors to compute the Octomap
* Regenerated with moveit_setup_assistant for the last URDF while naming planning groups to be compatible with romeo_moveit_config
* configuring end-effectors and renaming motor groups to be compatible with MoveIt simple grasps
* Contributors: Natalia Lyubova, Vincent Rabaud
```
