### PR TITLE
multisense_ros: 3.4.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2005,7 +2005,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
-      version: 3.4.4-0
+      version: 3.4.5-0
     source:
       type: hg
       url: https://bitbucket.org/crl/multisense_ros


### PR DESCRIPTION
Increasing version of package(s) in repository `multisense_ros` to `3.4.5-0`:
- upstream repository: https://bitbucket.org/crl/multisense_ros
- release repository: https://github.com/carnegieroboticsllc/multisense_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `3.4.4-0`
## multisense
- No changes
## multisense_bringup
- No changes
## multisense_cal_check
- No changes
## multisense_description
- No changes
## multisense_lib
- No changes
## multisense_ros

```
* Changed the image encoding types from 8UC1/16UC1 to mono8/mono16.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
