### PR TITLE
nao_moveit_config: 0.0.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2086,7 +2086,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/nao_moveit_config-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_moveit_config` to `0.0.6-0`:
- upstream repository: https://github.com/ros-nao/nao_moveit_config.git
- release repository: https://github.com/ros-naoqi/nao_moveit_config-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.5-0`
## nao_moveit_config

```
* updating the readme
* fixing the config for the most recent urdf
* add myself as a maintainer
* Contributors: Vincent Rabaud, nlyubova
* add myself as a maintainer
* Contributors: Vincent Rabaud
```
