### PR TITLE
robot_state_publisher: 1.11.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7668,7 +7668,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/robot_state_publisher-release.git
-      version: 1.10.4-0
+      version: 1.11.0-0
     source:
       type: git
       url: https://github.com/ros/robot_state_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `1.11.0-0`:
- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros-gbp/robot_state_publisher-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.10.4-0`
## robot_state_publisher

```
* Merge pull request #28 <https://github.com/ros/robot_state_publisher/issues/28> from clearpathrobotics/tf2-static
  Port to tf2 and enable using static broadcaster
* Merge pull request #32 <https://github.com/ros/robot_state_publisher/issues/32> from shadow-robot/fix_issue#19 <https://github.com/shadow-robot/fix_issue/issues/19>
  Check URDF to distinguish fixed joints from floating joints. Floating joint are ignored by the publisher.
* Merge pull request #26 <https://github.com/ros/robot_state_publisher/issues/26> from xqms/remove-debug
  get rid of argv[0] debug output on startup
* Contributors: David Lu!!, Ioan A Sucan, Jackie Kay, Max Schwarz, Paul Bovbel, Remo Diethelm, Toni Oliver
```
