### PR TITLE
Revert "robot_state_publisher: 1.11.0-0 in 'indigo/distribution.yaml'…

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7668,7 +7668,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/robot_state_publisher-release.git
-      version: 1.11.0-0
+      version: 1.10.4-0
     source:
       type: git
       url: https://github.com/ros/robot_state_publisher.git


### PR DESCRIPTION
Reverts ros/rosdistro#9697 This version conflicts with Jade.
