### PR TITLE
industrial_core: 0.4.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3337,7 +3337,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/industrial_core-release.git
-      version: 0.4.1-0
+      version: 0.4.2-0
     source:
       type: git
       url: https://github.com/ros-industrial/industrial_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_core` to `0.4.2-0`:
- upstream repository: https://github.com/ros-industrial/industrial_core.git
- release repository: https://github.com/ros-industrial-release/industrial_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.4.1-0`
## industrial_core

```
* No changes
```
## industrial_deprecated

```
* No changes
```
## industrial_msgs

```
* No changes
```
## industrial_robot_client

```
* Forces the action to wait for half of the duration of the trajectory
  before it begins to check for completition. This prevents the action
  for returning immediately for trajectories that end near the start
  point and are slow to start moving.
* Fix rejected actions when goal requests arrive in between watchdog reset und arrival of next status package
* Contributors: Jonathan Meyer, Shaun Edwards, Simon Schmeisser (isys vision)
```
## industrial_robot_simulator

```
* No change
```
## industrial_trajectory_filters

```
* No change
```
## industrial_utils

```
* No change
```
## simple_message

```
* No change
```
