### PR TITLE
pepper_moveit_config: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6410,6 +6410,12 @@ repositories:
       url: https://github.com/ros-naoqi/pepper_meshes.git
       version: master
     status: maintained
+  pepper_moveit_config:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/nlyubova/pepper_moveit_config-release.git
+      version: 0.0.2-0
   pepper_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_moveit_config` to `0.0.2-0`:
- upstream repository: https://github.com/nlyubova/pepper_moveit_config.git
- release repository: https://github.com/nlyubova/pepper_moveit_config-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## pepper_moveit_config

```
* Creating moveit config
* Contributors: nlyubova
```
