### PR TITLE
hokuyo3d: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2971,6 +2971,21 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
       version: 0.3.2-0
     status: maintained
+  hokuyo3d:
+    doc:
+      type: git
+      url: https://github.com/at-wat/hokuyo3d.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/at-wat/hokuyo3d-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/at-wat/hokuyo3d.git
+      version: indigo-devel
+    status: developed
   hokuyo_node:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hokuyo3d` to `0.1.0-0`:
- upstream repository: https://github.com/at-wat/hokuyo3d.git
- release repository: https://github.com/at-wat/hokuyo3d-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## hokuyo3d

```
* direct PointCloud2 message encoding
* adds list of contributors
* adds feature to publish PointCloud2 message
  "~/hokuyo_cloud" and "~/hokuyo_cloud2" are published on demand.
  Added pursuant to yukkysaito's request.
* adds parameter to set data output cycle
  ~output_cycle (string, default: field)
  Sets output timing to end of frame, field or line.
  Added pursuant to yukkysaito's request.
* Add invalid range parameter
  This commit is modified for merging by at-wat.
  Parameter name invalid_range was changed to range_min.
* fixes a bug in which output data doesn't have all points
  Fixed pursuant to yukkysaito's report.
* code refactoring
* skips invalid data without 'VSSP' mark
* stops data stream correctly before exit
* scales aux data
* estimates real measurement time from timestamp
* receives aux data and publishes Imu and MagneticField message
* add README.md
* Initial commit
* Contributors: Atsushi Watanabe, yukihiro saito
```
