### PR TITLE
p2os: 2.0.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2633,7 +2633,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
-      version: 2.0.2-0
+      version: 2.0.3-0
     source:
       type: git
       url: https://github.com/allenh1/p2os.git


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `2.0.3-0`:
- upstream repository: https://github.com/allenh1/p2os
- release repository: https://github.com/allenh1/p2os-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.0.2-0`
## p2os_doc
- No changes
## p2os_driver

```
* Reformatted code style.
* Cleaned up the driver.
* Contributors: Hunter Allen
```
## p2os_launch
- No changes
## p2os_msgs
- No changes
## p2os_teleop
- No changes
## p2os_urdf

```
* Updated p2os_urdf's build dependencies. Fixes #39 <https://github.com/allenh1/p2os/issues/39>
* Updated the pioneer3at URDF xacro file. Fixes #38 <https://github.com/allenh1/p2os/issues/38>
* Cleaned up the publisher file.
* Contributors: Hunter Allen
```
