### PR TITLE
libfovis: 0.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4372,7 +4372,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/srv/libfovis-release.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/srv/libfovis.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libfovis` to `0.0.9-0`:
- upstream repository: https://github.com/srv/libfovis.git
- release repository: https://github.com/srv/libfovis-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.8-0`
