### PR TITLE
termcolor: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10114,6 +10114,13 @@ repositories:
       url: https://github.com/Terabee/terarangerone-ros.git
       version: master
     status: maintained
+  termcolor:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/termcolor-release.git
+      version: 1.0.0-0
+    status: maintained
   tf2_web_republisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `termcolor` to `1.0.0-0`:
- upstream repository: https://github.com/stonier/termcolor.git
- release repository: https://github.com/yujinrobot-release/termcolor-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
