### PR TITLE
ypspur: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11246,7 +11246,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/DaikiMaekawa/ypspur-release.git
-      version: 0.0.1-4
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/DaikiMaekawa/ypspur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ypspur` to `0.1.1-0`:
- upstream repository: https://github.com/DaikiMaekawa/ypspur.git
- release repository: https://github.com/DaikiMaekawa/ypspur-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.1-4`
