### PR TITLE
navigation: 1.12.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5560,7 +5560,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.12.4-0
+      version: 1.12.5-0
     source:
       type: git
       url: https://github.com/ros-planning/navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.12.5-0`:
- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.12.4-0`
## amcl
- No changes
## base_local_planner

```
* base_local_planner: some fixes in goal_functions
* Contributors: Gael Ecorchard
```
## carrot_planner
- No changes
## clear_costmap_recovery
- No changes
## costmap_2d

```
* Remove canTransform spam.
* Fix for #382 <https://github.com/ros-planning/navigation/issues/382>
* Republish costmap if origin changes
* Remove extra sign definition and use proper one when padding footprint
* Remove Footprint Layer
* fix plugin warnings on throw, closes #205 <https://github.com/ros-planning/navigation/issues/205>
* initialize publisher variables
* Contributors: Daniel Stonier, David Lu, Michael Ferguson
```
## dwa_local_planner
- No changes
## fake_localization

```
* More tolerant initial pose transform lookup.
* Contributors: Daniel Stonier
```
## global_planner

```
* Add missing angles dependecy
* Contributors: Gary Servin
```
## map_server
- No changes
## move_base
- No changes
## move_base_msgs
- No changes
## move_slow_and_clear
- No changes
## nav_core
- No changes
## navfn
- No changes
## navigation
- No changes
## robot_pose_ekf
- No changes
## rotate_recovery
- No changes
## voxel_grid
- No changes
