### PR TITLE
open_industrial_ros_controllers: 1.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6059,7 +6059,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/start-jsk/open_industrial_ros_controllers.git
-      version: hydro-devel
+      version: indigo-devel
     release:
       packages:
       - open_controllers_interface
@@ -6067,11 +6067,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/start-jsk/open_industrial_ros_controllers-release.git
-      version: 0.1.4-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/start-jsk/open_industrial_ros_controllers.git
-      version: hydro-devel
+      version: indigo-devel
     status: developed
   open_karto:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `open_industrial_ros_controllers` to `1.1.0-0`:
- upstream repository: https://github.com/start-jsk/open-industrial-ros-controllers.git
- release repository: https://github.com/start-jsk/open_industrial_ros_controllers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.4-0`
## open_controllers_interface

```
* indent warning output
* minor fix
* add a boilerplait for recovering controller
* g_halt_motors_ is not used
* do not use raw pointer
* follow standard c++ style class member naming
* add initializeCM virtual function for pre/post-processing by successor
* Contributors: Shohei Fujii
```
## open_industrial_ros_controllers
- No changes
