### PR TITLE
navigation: 1.13.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2208,7 +2208,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.13.0-0
+      version: 1.13.1-0
     source:
       type: git
       url: https://github.com/ros-planning/navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.13.1-0`:
- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.13.0-0`
## amcl

```
* adds the set_map service to amcl
* fix pthread_mutex_lock on shutdown
* Contributors: Michael Ferguson, Stephan Wirth
```
## base_local_planner

```
* base_local_planner: some fixes in goal_functions
* Merge pull request #348 <https://github.com/ros-planning/navigation/issues/348> from mikeferguson/trajectory_planner_fixes
* fix stuck_left/right calculation
* fix calculation of heading diff
* Contributors: Gael Ecorchard, Michael Ferguson
```
## carrot_planner
- No changes
## clear_costmap_recovery

```
* proper locking during costmap update
* Contributors: Michael Ferguson
```
## costmap_2d

```
* Remove excessive canTransform spam.
* Fix for #382 <https://github.com/ros-planning/navigation/issues/382>
* Republish costmap if origin changes
* Remove Footprint Layer
* Remove extra sign definition and use proper one when padding footprint
* fix plugin warnings on throw, closes #205 <https://github.com/ros-planning/navigation/issues/205>
* initialize publisher variables
* Look for robot_radius when footprint is not set. #206 <https://github.com/ros-planning/navigation/issues/206>
* Add a first_map_only parameter so we keep reusing the first received static map
* Merge pull request #331 <https://github.com/ros-planning/navigation/issues/331> from mikeferguson/static_layer_any_frame
* support rolling static map in any frame
* fix destructor of Costmap2D
* proper locking during costmap update
* do not resize static map when rolling
* Static layer works with rolling window now
* Contributors: Daniel Stonier, David Lu, Jihoon Lee, Michael Ferguson, Rein Appeldoorn, commaster90
```
## dwa_local_planner
- No changes
## fake_localization

```
* More tolerant initial pose transform lookup.
* Contributors: Daniel Stonier
```
## global_planner

```
* Add missing angles dependecy
* Fix for #337 <https://github.com/ros-planning/navigation/issues/337>
* Contributors: David V. Lu!!, Gary Servin
```
## map_server
- No changes
## move_base

```
* Removes installation of nonexistent directories
* use correct size for clearing window
* full name has been required for eons, this code just adds unneeded complexity
* remove ancient conversion scripts from v0.2 to v0.3
* proper locking during costmap update
* Contributors: Michael Ferguson, Thiago de Freitas Oliveira Araujo
```
## move_slow_and_clear
- No changes
## nav_core

```
* Merge pull request #338 <https://github.com/ros-planning/navigation/issues/338> from mikeferguson/planner_review
* fix doxygen, couple style fixes
* Contributors: Michael Ferguson
```
## navfn

```
* Fix for #337 <https://github.com/ros-planning/navigation/issues/337>
* Contributors: David V. Lu!!
```
## navigation
- No changes
## robot_pose_ekf
- No changes
## rotate_recovery
- No changes
## voxel_grid
- No changes
