### PR TITLE
Remove broken jobs

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2763,11 +2763,6 @@ repositories:
       url: https://github.com/Hacks4ROS-release/h4r_thermapp_camera.git
       version: 0.0.3-0
   h4r_x52_joyext:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/Hacks4ROS-release/h4r_x52_joyext.git
-      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/Hacks4ROS/h4r_x52_joyext.git
@@ -3012,11 +3007,7 @@ repositories:
   homer_mapnav:
     release:
       packages:
-      - homer_map_manager
       - homer_mapnav_msgs
-      - homer_mapping
-      - homer_nav_libs
-      - homer_navigation
       tags:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
@@ -3024,21 +3015,11 @@ repositories:
   homer_object_recognition:
     release:
       packages:
-      - or_libs
       - or_msgs
-      - or_nodes
       tags:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_object_recognition.git
       version: 0.0.2-1
-  homer_robot_face:
-    release:
-      packages:
-      - robot_face
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://gitlab.uni-koblenz.de/robbie/homer_robot_face.git
-      version: 1.0.2-2
   household_objects_database:
     release:
       tags:
@@ -3200,10 +3181,8 @@ repositories:
       packages:
       - combine_dr_measurements
       - force_rotate_recovery
-      - icart_mini
       - icart_mini_control
       - icart_mini_description
-      - icart_mini_driver
       - icart_mini_gazebo
       - icart_mini_navigation
       - waypoints_navigation
@@ -3722,7 +3701,6 @@ repositories:
     release:
       packages:
       - eus_nlopt
-      - eus_qp
       - eus_qpoases
       - joy_mouse
       - jsk_calibration
@@ -5525,13 +5503,6 @@ repositories:
       url: https://github.com/paulbovbel/nav2_platform.git
       version: hydro-devel
     status: maintained
-  nav_pcontroller:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/code-iai-release/nav_pcontroller-release.git
-      version: 0.1.1-0
-    status: developed
   navigation:
     doc:
       type: git
@@ -5641,13 +5612,9 @@ repositories:
       version: indigo_dev
     release:
       packages:
-      - neo_base_mp_400
-      - neo_base_mp_500
       - neo_msgs
       - neo_platformctrl_diff
       - neo_platformctrl_mecanum
-      - neo_relayboard
-      - neo_watchdogs
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/neobotix/neo_driver-release.git
@@ -6338,7 +6305,6 @@ repositories:
       - p2os_launch
       - p2os_msgs
       - p2os_teleop
-      - p2os_urdf
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
@@ -6471,9 +6437,7 @@ repositories:
       - ndt_map_builder
       - ndt_mcl
       - ndt_registration
-      - ndt_rviz_visualisation
       - ndt_visualisation
-      - perception_oru
       - sdf_tracker
       tags:
         release: release/indigo/{package}/{version}
@@ -7083,7 +7047,6 @@ repositories:
       - joint_qualification_controllers
       - pr2_bringup_tests
       - pr2_counterbalance_check
-      - pr2_motor_diagnostic_tool
       - pr2_self_test
       - pr2_self_test_msgs
       tags:
@@ -7244,12 +7207,9 @@ repositories:
       version: indigo
     release:
       packages:
-      - qglv_extras
       - qglv_gallery
       - qglv_opencv
       - qglv_opengl
-      - qglv_pcl
-      - qglv_toolkit
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/qglv_toolkit-release.git
@@ -8285,7 +8245,6 @@ repositories:
       packages:
       - lighting_msgs
       - lighting_tools
-      - ola_ros
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/sevenbitbyte/ros_openlighting-release.git
@@ -8844,11 +8803,6 @@ repositories:
       version: master
     status: maintained
   rostful_node:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/asmodehn/rostful-node-release.git
-      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/asmodehn/rostful-node.git
@@ -9362,13 +9316,11 @@ repositories:
     release:
       packages:
       - laser_ortho_projector
-      - laser_scan_matcher
       - laser_scan_sparsifier
       - laser_scan_splitter
       - ncd_parser
       - polar_scan_matcher
       - scan_to_cloud_converter
-      - scan_tools
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/scan_tools-release.git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1135,11 +1135,6 @@ repositories:
       type: git
       url: https://github.com/eybee/heatmap.git
       version: jade-devel
-    release:
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/eybee/heatmap-release.git
-      version: 0.2.4-2
     source:
       type: git
       url: https://github.com/eybee/heatmap.git
@@ -2629,7 +2624,6 @@ repositories:
       - p2os_launch
       - p2os_msgs
       - p2os_teleop
-      - p2os_urdf
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
@@ -3845,13 +3839,11 @@ repositories:
     release:
       packages:
       - laser_ortho_projector
-      - laser_scan_matcher
       - laser_scan_sparsifier
       - laser_scan_splitter
       - ncd_parser
       - polar_scan_matcher
       - scan_to_cloud_converter
-      - scan_tools
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/scan_tools-release.git


### PR DESCRIPTION
We have a lot of repeatedly failing jobs that we're trying to rebuild ever night. This will stop them from trying to build until they are rereleased. 
