### PR TITLE
Adding depth_nav_tools to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1650,6 +1650,16 @@ repositories:
       url: https://github.com/start-jsk/denso.git
       version: indigo-devel
     status: developed
+  depth_nav_tools:
+    doc:
+      type: git
+      url: https://github.com/mdrwiega/depth_nav_tools.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/mdrwiega/depth_nav_tools.git
+      version: indigo-devel
+    status: developed
   depthcloud_encoder:
     doc:
       type: git


### PR DESCRIPTION
I would like depth_nav_tools to be indexed and documented on ros.org.
