### PR TITLE
jsk_control: 0.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3731,11 +3731,13 @@ repositories:
       version: master
     release:
       packages:
+      - contact_states_observer
       - eus_nlopt
       - eus_qp
       - eus_qpoases
       - joy_mouse
       - jsk_calibration
+      - jsk_control
       - jsk_footstep_controller
       - jsk_footstep_planner
       - jsk_ik_server
@@ -3743,7 +3745,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_control-release.git
-      version: 0.1.6-0
+      version: 0.1.7-0
     status: developed
   jsk_model_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_control` to `0.1.7-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_control.git
- release repository: https://github.com/tork-a/jsk_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.6-0`

## eus_nlopt

```
* use ftol xtol values in coresolver initialization
* Remove manifest.xml and Makefile and use catkin style filesystem
* Contributors: Ryohei Ueda, Shintaro Noda
```

## eus_qp

```
* [3rdparty/eiquadprog.hpp] using std::abs instead of internal::abs
* CMakeLists.txt: using test as execute name may confuse system
* [eus_qp/euslisp/model-predictive-control.l] Support output variables in evaluation
* [eus_qp/euslisp/model-predictive-control.l] Return world input value (wrench)
* [eus_qp/euslisp/contact-optimization.l, model-predictive-control.l, test-model-predictive-control.l] Fix bug of mpc inequality-matrix contact coords and update samples
* [eus_qp/euslisp/*model-predictive-control.l, test/test_model_predictive_control.*, CMakeLists.txt] Add model predictive control from Nagasaka'2012 and add examples and tests.
* [eus_qp/euslisp/contact-optimization.l, eus_qp/euslisp/test-contact-wrench-opt.l] Add no-contact constraint and tests
* [../../eus_qp/euslisp/contact-optimization.l,test-eus-qpoases.l,eus-qpoases.l] Rename solve-qpoases => solve-qpoases-qp and remain solve-qpoases for backward compatibility with warning.
* Remove manifest.xml and Makefile and use catkin style filesystem
* Rename samplerobot demo function add infeasible sample. Add to rostest.
* Do not use immediate value for max demo function num
* Add test for force min violation
* Add inequality constraint violation mode if user set min-inequality-violation-weight.
* add sample for testing sliding contact constraint
* add translational sliding constraint to contact-optimization.l
* Add min-max constraint
* Use contact-constraint-vector-list
* Update test for test-contact-wrench-opt.l
* Add demo programe for all contact constraints
* Rename friction contact constraint
* Add constraint vector and use constraint-matrix slots variable
* Fix order of drawing
* Fix force color
* Add test for wrench contact application
* Add contact optimization application using euslisp qp calculation
* Contributors: Kei Okada, Ryohei Ueda, Shunichi Nozawa, Masaki Murooka
```

## eus_qpoases

```
* [eus_qpoases] use ExternalProject instead of mk
* [eus_qpoases/euslisp/eus-qpoases.l] Check equality usage and use state-dim and inequality-dim.
* [../../eus_qp/euslisp/contact-optimization.l,test-eus-qpoases.l,eus-qpoases.l] Rename solve-qpoases => solve-qpoases-qp and remain solve-qpoases for backward compatibility with warning.
* [../src/eus_qpoases.cpp,../test/eus-qpoases.test.l,test-eus-qpoases.l,eus-qpoases.l] Add LP solver using qpOASES and add samples and tests.
* [../src/eus_qpoases.cpp,../test/eus-qpoases.test.l,test-eus-qpoases.l,eus-qpoases.l] Add LP solver using qpOASES and add samples and tests.
* [eus_qpoases/euslisp/eus-qpoases.l] Add argument matrix size check
* Remove manifest.xml and Makefile and use catkin style filesystem
* Add comments for qp functions
* Add demo-eus-qpOASES4 for force infeasible problem.
* Print debug message by default. If you want to disable it, :debug nil
* Add debug print check
* Added install rules for qpoases headers and libs to catkin cmake-file.
* require rostest in cmake files
* add rostest declaration
* intial commit of test dir and test files, check euslisp/test-eus-qpoases.l all functions, and if there are at least one failure, then test would be failed
* test functions return test results
* [eus_qpoases] add dependencies to linqpOASES
* Contributors: Yuki Furuta, Georg Bartels, Ryohei Ueda, Shunichi Nozawa, Shintaro Noda
```

## joy_mouse

- No changes

## jsk_calibration

```
* [jsk_calibration] Fix typo in README
* Contributors: Ryohei Ueda
```

## jsk_footstep_controller

```
* [jsk_footstep_controller] Fix typo: init_odom -> odom_init
* [jsk_footstep_controller] Updated README.md for init_odom
* [jsk_footstep_controller] Fix model file loading
* [jsk_footstep_controller] Add invert_tf option to broadcast odom_init as parent of odom
* not call tf if tilt is absent
* [jsk_footstep_controller] Normalize torque with max-joint-torque and use
  squared norm to be propotional to temperature
* [jsk_footstep_controller] Add sample launch file for root-height.l
* [jsk_footstep_controller] Publish plotting data when computing root height
* [jsk_footstep_controller] Publish /odom_init_trigger when robot stands
  on the ground at the first frame
* [jsk_footstep_controller] Compute root-link height according to torque
  and manipulability. Original version is implemented by Masaki Murooka
  and interface of function is modified to use as library.
* fix function name. weight -> root
* change footcoords param use_imu->false
* [jsk_footstep_planner] Add start-abc button for planner gui using with simulator
* [jsk_footstep_controller] Cleanup and omit a lot of features of footstep controller and confirmed with
  hrpsys/gazebo simulation
* [jsk_footstep_controller/footcoords] Add ~use_imu and ~use_imu_yaw to take
  into account orientation from IMU as well as translation of /odom
* [jsk_footstep_controller] Say something when robot stands on the ground
* [jsk_footstep_planner, controller] Add rviz GUI set for playing with footstep planner
* [jsk_footstep_controller] Launch stabilizer_watcher on HRP2 and JAXON
* [jsk_footstep_controller/footcoords] Use correct timestamp for zmp tf frame
* [jsk_footstep_controller/footcoords] Publish zmp as tf for visualization.
  DO NOT USE THIS FRAME FOR PERCEPTION AND PLANNING because the timestamp is not reliable
* [jsk_footstep_controller/footcoords] Add odom_init frame which holds the pose when robot is put on the ground
* [jsk_footstep_controller/footcoords] Publish body_on_odom frame, which should be useful to represent
  sensordate in "Robot-centric-perspective"
* [jsk_footstep_controller] Add simple-footstep-controller as the most simplest footstep controller using
  :set-foot-steps
* [jsk_footstep_controller/footcoords] Remove odom_root frame
* [jsk_control/footcoords] Use lfsensor and rfsensor
* [jsk_footstep_controller] Add odometry estimation based on leg kinematics.
  Three types of naive algorithm are implemented:
  1) Estimate support leg from force sensors and keep support leg during double stance phase
  2) Estimate support leg from force sensors and change support leg during double stance phase by leg forces
  3) Estimate support leg from force sensors and change support leg during double stance phase by zmp
* [jsk_footstep_controller] Remove catkin.cmake and use CMakeLists.txt only
* [jsk_footstep_controller] Publish synchronized forces from foot_coords and
  subscribe it from foot_coords internally.
  Update alpha (low pass filter parameter) to 0.1 from 0.5.
  Update queu length not to drop messages.
* [jsk_footstep_controller] Update parmeter files about footstep configuration
* [jsk_footstep_controller] Add script to generate footstep parameter from
  euslisp models
* [jsk_footstep_controller/footstep_visualizer] Visualize zmp
* [jsk_footstep_planner, jsk_footstep_controller] Support HRP2JSKNT
* [jsk_footstep_planner, jsk_footstep_controller] Add USE_JOY option
* [jsk_footstep_planner, jsk_footstep_controller] Refactor launch file and
  add no_recog.launch
* [jsk_footstep_controller] Move robot-boundingbox.l from drc_task_common
* [jsk_footstep_controller/footstep_visualizer] Reverse position of left
  and right
* [jsk_footstep_controller/footstep_visualizer] Use BGRA8 to represent
  footstep location and COP position
* [jsk_footstep_controller] Add new script to visualize cop of each leg
* [jsk_footstep_controller] Add script to dump mocap output
* Contributors: MasakiMurooka, Ryohei Ueda, Yu Ohara, Iori Kumagai
```

## jsk_footstep_planner

```
* [jsk_footstep_planner] Add &allow-other-keys to
  fullbody-inverse-kinematics-with-standcoords.
  You can add :collision-check-robot-link-list and so on
* add variables to modify bounding box height
* [jsk_footstep_planner:footplace_sample]add sample file for footplace_manip
* [jsk_footstep_planner:footplace..]merge origin/master
* [jsk_footstep_planner:footplace~] debug output like normak ik
* fix minor bug in fullbody-inverse-kinematics-with-standcoords
* add args for ik with standcoords
* [jsk_footstep_planner] Ignore Z distance in heuristic computation
* Merge pull request #488 <https://github.com/jsk-ros-pkg/jsk_control/issues/488> from garaemon/remove-global-variable
  [jsk_footstep_planner] Remove global variable from footplace planning
* [jsk_footstep_planner] Fix indent of footplace_planner_for_manipulation.l
* [jsk_footstep_planner] Remove global variable from footplace planning
* change name of inverse-reachablity code
* add foot placement coords with ik
* [jsk_footstep_planner] Add script to convert
  jsk_footstep_msgs/FootstepArray to jsk_recognition_msgs/BoundingBox
* [jsk_footstep_controller] Update footstep planner parameter for hrp2
* [jsk_footstep_planner] Verify global location of footstep in projecting
  start and goal footstep
* [jsk_footstep_planner] Add global transition limit to verify global
  location of footstep
* [jsk_footstep_planner/simple_neighbored_graph.h] add missing include string
* change static polygon param
* [jsk_footstep_planner] Do not use jsk_pcl_ros, use jsk_recognition_utils
  instead of it.
  These commits are forgotten in previous commit.
* [jsk_footstep_planner] Use jsk_recognition_utils instead of jsk_pcl_ros
* [jsk_footstep_planner] Update stair model to more difficult one
* [jsk_pcl_ros] Fix handling of --enable_lazy_perception and
  --enable_local_movement options and printout graph info
* [jsk_footstep_planner] Add infoString method to print footstep graph property
* [jsk_pcl_ros] Do not raise exception when cvs has lack data
* [jsk_footstep_planner] Add simple launch file to preview models for benchmarking
* [jsk_footstep_planner] Add --only-save-image option to plotting script
* [jsk_footstep_planner] Add --verbose option to bench_footstep_planner.cpp
* [jsk_footstep_planner] Save to eps figure when visualizing benchmark plot
* [jsk_footstep_planner] build pointcloud model in more wider area
* [jsk_footstep_planner] Check ANNGridCell is already allocated
* [jsk_footstep_planner/bench_footstep_planner] Project start and goal
  footstep before taking benchmark
* [jsk_footstep_planner] Add anonymous flag to ros::init in benchmark program
* [jsk_footstep_planner] Add several args to disable perception and
  run planner with hrpsys/gazebo
* [jsk_footstep_planner] Add start-abc button for planner gui using with simulator
* [jsk_footstep_planner] Update benchmark program to specify a lot of parameters
* [jsk_footstep_controller, jsk_teleop_joy] Use footstep-controller.l and lock/unlock furutaractive
  model during exeucuting footsteps
* [jsk_footstep_planner] Fix indent
* [jsk_footstep_planner] Fix typo: crpping -> cropping
* [jsk_footstep_planner, controller] Add rviz GUI set for playing with footstep planner
* [jsk_footstep_planner] Use odom_init frame to publish plane for unseen region
* [jsk_footstep_controller/footcoords] Add odom_init frame which holds the pose when robot is put on the ground
* [jsk_footstep_planner] Add gaussian pointcloud to pointcloud generator
* Merge pull request #414 <https://github.com/jsk-ros-pkg/jsk_control/issues/414> from garaemon/default-body-on-odom
  [jsk_footstep_planner] Use body_on_odom frame as robot center frame
* [jsk_footstep_planner] Use body_on_odom frame as robot center frame
* [jsk_footstep_planner] Print error message about projection on rviz
* [jsk_footstep_controller] Add simple-footstep-controller as the most simplest footstep controller using
  :set-foot-steps
* [jsk_footstep_planner] Check pointcloud is available before projection
* [jsk_footstep_planner] Cleanup heightmap launch files
* Merge remote-tracking branch 'refs/remotes/origin/master' into crosscheck
* [jsk_footstep_planner] Implement cross check
* [jsk_footstep_planner] Add launch file to run footstep planner with heightmap
  integration
* [jsk_footstep_planner] Add text information on rviz
* [jsk_footstep_planner] Ignore warning message from pcl
* [jsk_footstep_planner] Fix projection around yaw axis orientation
* [jsk_footstep_planner] Add launch file for heightmap mapping
* Merge remote-tracking branch 'refs/remotes/origin/master' into hole-rate
  Conflicts:
  jsk_footstep_planner/src/pointcloud_model_generator.cpp
* [jsk_footstep_planner] Add ~hole_rate to simulate hole in pointcloud
* [jsk_footstep_planner] Publish pointcloud periodically from pointcloud_model_generator_node
* [jsk_footstep_planner] Just use kdtree nearest search in checking
  if footstep is on pointcloud
* [jsk_footstep_planner] add cost_weight and heuristic_weight parameter
* [jsk_footstep_planner] Update pointcloud to show close list and open
  list during planning
* [jsk_footstep_planner] Check value of transition when expanding nodes
* [jsk_footstep_planner] Use center of footprint to check if footprint is on pointcloud
* [jsk_footstep_planner] Project footprint with local search
* [jsk_footstep_planner] Add projection API to c++ footstep planner
* [jsk_footstep_planner] Add more parmeters to dynamic_reconfigure API of
  cpp footstep_planner
* [jsk_footstep_planner] Add perception sample with actionlib interface
* [jsk_footstep_planner] Add actionlib interface to C++ version of
  footstep planner. and add simplest smaple
* [jsk_footstep_planning] Visualize open and close list as pointcloud
* [jsk_footstep_planner] Fix ANNGrid search
* [jsk_footstep_planner] Skip planar region perception if footstep is
  already on pointcloud
* [jsk_footstep_planner] PointCloud approximate search based on 2-D grid
* [jsk_footstep_planner] Implement local movement if footstep is close to
  success of projection to pointcloud
* [jsk_footstep_planner] Check pointcloud model supports footprint
* [jsk_footstep_planner] Do not use SVD in perception
* [jsk_footstep_planner] Re-implement footstepHeuristicStepCost in
  computationally-efficient way.
  1. Do not use Eigen::Affine3f::rotation because it calls SVD internally.
  2. Do not cast to Eigen::AngleAxisf, just use cos(w/2) to compute angle
  from quaternion.
* [jsk_footstep_planner] Add profile function interface
* [jsk_footstep_planner] Add script to plot bench result
* [jsk_footstep_planning] Add program to bench footstep planning speed
* [jsk_footstep_planner] Add demonstration of footstep planning over curved and sloped surface
* [jsk_footstep_planner] Fix orientation of projected footstep
* [jsk_footstep_planner] Add timeout argument to solver
* [jsk_footstep_planner] Fix when footstep failed to project on planar region
* [jsk_footstep_planner] Planning with pointcloud model is implemented.
  We optimized perception phase by lazy-perception-in-planning technique:
  1) Do not detect planar region before planning
  2) Do not detect planar region until accurate pose of footstep is
  required
  3) use 2.5D pointcloud to get candidate pointcloud which footstep is placed on
* [jsk_footstep_planner] Add demo for curved surface
* [jsk_footstep_planner] Interactive demo of C++ footstep planner
* [jsk_footstep_planner] Use FootstepStateDiscreteCloseList for close list
* [jsk_footstep_planner] 2D footstep planning is implemented in C++
* [jsk_footstep_planner] Implement FootstepState and projection to pointcloud
* [jsk_footstep_planner] Add demo directory and install headers and library
* [jsk_footstep_planner] Implement C++ a* solver
* [jsk_footstep_planner] Initial commit of cpp graph library
* [jsk_footstep_planner] Update jaxon_red footprint region
* [jsk_footstep_planner, jsk_footstep_controller] Support HRP2JSKNT
* [jsk_footstep_planner, jsk_footstep_controller] Add USE_JOY option
* [jsk_footstep_planner, jsk_footstep_controller] Refactor launch file and
  add no_recog.launch
* [jsk_footstep_planner] Rename launch file to use ROBOT environment variable
* Contributors: Masaki Murooka, Ryohei Ueda, Yu Ohara, Yuki Furuta, Yusuke Oshiro
```

## jsk_ik_server

```
* [jsk_ik_server] Remove grids which are too near to robot
  in stand location planning
* [jsk_ik_server] Add script to generate reachability images for pr2 and hrp2
* [jsk_ik_server] Implement Brute-force stand location search.
* [jsk_ik_server] Implement stand location planning with taking into
  account range of targets
* [jsk_ik_server] Visualize ik-grid by irtviewer
* [jsk_ik_server] Implement stand location planning based on continuous ik
  grid.
  Currently only position and mean of pdf is taken into account
* [jsk_ik_server] Fix jaxon_ik_evaluation.md to render properly on github
* [jsk_ik_server] Add markdown to visualize ik-grid evaluate
* [jsk_ik_server] Pretty-printing of progress of generating ik grid like
  min-max table generation
* [jsk_ik_server/plot_ik_grid.py] Add second argumment to save image file
  instad of showing plot on GUI
* [jsk_ik_server] Script to visualize reachability in heatmap manner
* [jsk_ik_server] Add ik-evaluation.l to evaluate spacial ik quarity
* Remove manifest.xml and Makefile and use catkin style filesystem
* Contributors: Ryohei Ueda
```

## jsk_teleop_joy

```
* [jsk_teleop_joy/joy_relative_converter.py] add reset command
* [jsk_teleop_joy/scripts/joy_relative_converter.py] fix bug to support buttons
* Revert "[jsk_teleop_joy/scripts/joy_relative_converter.py] fix bug to support buttons"
  This reverts commit 1704b24d2b96aae962e4c87968f68078442417a2.
* [jsk_teleop_joy/scripts/joy_relative_converter.py] fix bug to support buttons
* put most process into class method
  Conflicts:
  jsk_teleop_joy/scripts/joy_relative_converter.py
* instantiate before subscribe
  Conflicts:
  jsk_teleop_joy/scripts/joy_relative_converter.py
* fix bug around page-change
* implement page-change
* add joy_relative_converter
* [jsk_footstep_controller, jsk_teleop_joy] Use footstep-controller.l and lock/unlock furutaractive
  model during exeucuting footsteps
* Remove manifest.xml and Makefile and use catkin style filesystem
* Contributors: Ryohei Ueda, Satoshi Iwaishi
```
