### PR TITLE
re-enable eus_qp

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3712,6 +3712,7 @@ repositories:
       packages:
       - contact_states_observer
       - eus_nlopt
+      - eus_qp
       - eus_qpoases
       - joy_mouse
       - jsk_calibration


### PR DESCRIPTION
https://github.com/ros/rosdistro/pull/9733 should be fixed in https://github.com/jsk-ros-pkg/jsk_control/pull/511

I'm not hurry so please merge when you're ok.
