### PR TITLE
Revert "re-enable eus_qp"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3712,7 +3712,6 @@ repositories:
       packages:
       - contact_states_observer
       - eus_nlopt
-      - eus_qp
       - eus_qpoases
       - joy_mouse
       - jsk_calibration


### PR DESCRIPTION
Reverts ros/rosdistro#9739

@k-okada 

The build is still failing: http://54.183.26.131:8080/job/Ibin_uT32__eus_qp__ubuntu_trusty_i386__binary/19/console

```
00:06:30.307    cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=None -DCATKIN_BUILD_BINARY_PACKAGE=1 -DCMAKE_INSTALL_PREFIX=/opt/ros/indigo -DCMAKE_PREFIX_PATH=/opt/ros/indigo
00:06:31.195 -- The C compiler identification is GNU 4.8.4
00:06:31.603 -- The CXX compiler identification is GNU 4.8.4
00:06:31.772 -- Check for working C compiler: /usr/lib/ccache/i686-linux-gnu-gcc
00:06:32.752 -- Check for working C compiler: /usr/lib/ccache/i686-linux-gnu-gcc -- works
00:06:32.781 -- Detecting C compiler ABI info
00:06:33.219 -- Detecting C compiler ABI info - done
00:06:33.300 -- Check for working CXX compiler: /usr/lib/ccache/i686-linux-gnu-g++
00:06:33.950 -- Check for working CXX compiler: /usr/lib/ccache/i686-linux-gnu-g++ -- works
00:06:33.952 -- Detecting CXX compiler ABI info
00:06:34.589 -- Detecting CXX compiler ABI info - done
00:06:34.612 -- Using CATKIN_DEVEL_PREFIX: /tmp/binarydeb/ros-indigo-eus-qp-0.1.7/obj-i686-linux-gnu/devel
00:06:34.612 -- Using CMAKE_PREFIX_PATH: /opt/ros/indigo
00:06:34.613 -- This workspace overlays: /opt/ros/indigo
00:06:34.650 -- Found PythonInterp: /usr/bin/python (found version "2.7.6") 
00:06:34.651 -- Using PYTHON_EXECUTABLE: /usr/bin/python
00:06:34.651 -- Using Debian Python package layout
00:06:34.652 -- Using empy: /usr/bin/empy
00:06:34.854 -- Using CATKIN_ENABLE_TESTING: ON
00:06:34.855 -- Skip enable_testing() when building binary package
00:06:34.855 -- Using CATKIN_TEST_RESULTS_DIR: /tmp/binarydeb/ros-indigo-eus-qp-0.1.7/obj-i686-linux-gnu/test_results
00:06:34.905 -- Looking for include file pthread.h
00:06:35.028 -- Looking for include file pthread.h - found
00:06:35.029 -- Looking for pthread_create
00:06:35.173 -- Looking for pthread_create - not found
00:06:35.173 -- Looking for pthread_create in pthreads
00:06:35.235 -- Looking for pthread_create in pthreads - not found
00:06:35.236 -- Looking for pthread_create in pthread
00:06:35.323 -- Looking for pthread_create in pthread - found
00:06:35.324 -- Found Threads: TRUE  
00:06:35.326 -- Found gtest sources under '/usr/src/gtest': gtests will be built
00:06:35.328 -- Using Python nosetests: /usr/bin/nosetests-2.7
00:06:35.401 -- catkin 0.6.15
00:06:35.671 CMake Warning at /opt/ros/indigo/share/catkin/cmake/catkinConfig.cmake:81 (find_package):
00:06:35.671   Could not find a package configuration file provided by "rostest" with any
00:06:35.671   of the following names:
00:06:35.671 
00:06:35.671     rostestConfig.cmake
00:06:35.671     rostest-config.cmake
00:06:35.671 
00:06:35.671   Add the installation prefix of "rostest" to CMAKE_PREFIX_PATH or set
00:06:35.671   "rostest_DIR" to a directory containing one of the above files.  If
00:06:35.671   "rostest" provides a separate development package or SDK, be sure it has
00:06:35.671   been installed.
00:06:35.671 Call Stack (most recent call first):
00:06:35.671   CMakeLists.txt:5 (find_package)
00:06:35.671 
00:06:35.671 
00:06:35.783 -- Found PkgConfig: /usr/bin/pkg-config (found version "0.26") 
00:06:35.785 -- checking for module 'eigen3'
00:06:35.809 --   found eigen3, version 3.2.0
00:06:35.862 -- Found Eigen: /usr/include/eigen3  
00:06:35.863 -- Eigen found (include: /usr/include/eigen3)
00:06:36.094 CMake Error at CMakeLists.txt:23 (add_rostest):
00:06:36.094   Unknown CMake command "add_rostest".
00:06:36.094 
00:06:36.094 
00:06:36.096 -- Configuring incomplete, errors occurred!
```
