### PR TITLE
jsk_control: 0.1.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3712,6 +3712,7 @@ repositories:
       packages:
       - contact_states_observer
       - eus_nlopt
+      - eus_qp
       - eus_qpoases
       - joy_mouse
       - jsk_calibration
@@ -3723,7 +3724,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_control-release.git
-      version: 0.1.7-0
+      version: 0.1.8-0
     status: developed
   jsk_model_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_control` to `0.1.8-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_control.git
- release repository: https://github.com/tork-a/jsk_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.7-0`
## eus_nlopt
- No changes
## eus_qp

```
* Merge pull request #512 <https://github.com/jsk-ros-pkg/jsk_control/issues/512> from k-okada/fix_error
  package.xml: add rostest to build_depend of eus_qp
* package.xml: add rostest to build_depend of eus_qp
* Contributors: Kei Okada
```
## eus_qpoases
- No changes
## joy_mouse
- No changes
## jsk_calibration
- No changes
## jsk_footstep_controller
- No changes
## jsk_footstep_planner
- No changes
## jsk_ik_server
- No changes
## jsk_teleop_joy
- No changes
