### PR TITLE
qglv_toolkit: 0.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7220,13 +7220,16 @@ repositories:
       version: indigo
     release:
       packages:
+      - qglv_extras
       - qglv_gallery
       - qglv_opencv
       - qglv_opengl
+      - qglv_pcl
+      - qglv_toolkit
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/qglv_toolkit-release.git
-      version: 0.1.3-1
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/yujinrobot/qglv_toolkit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qglv_toolkit` to `0.1.5-0`:
- upstream repository: https://github.com/yujinrobot/qglv_toolkit.git
- release repository: https://github.com/yujinrobot-release/qglv_toolkit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.3-1`
## qglv_pcl

```
* fix missing dependency on pcl_conversions
```
