### PR TITLE
rtmros_hironx: 1.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9076,7 +9076,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.0-0
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.1-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.0-0`
## hironx_calibration

```
* [fix] Install a missing launch file
* Contributors: Isaac I.Y. Saito
```
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* [improved] Elaborate print message upon hands servo-on failure
* [fix] Disable EKF that causes unnecessary error (unless robot moves)
* Contributors: Isaac I.Y. Saito
```
## rtmros_hironx

```
* [improved] Elaborate print message upon hands servo-on failure
* [fix] Disable EKF that causes unnecessary error (unless robot moves)
* [fix] Install a missing launch file (hironx_calibration)
* Contributors: Isaac I.Y. Saito
```
