### PR TITLE
moveit_robots: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5094,7 +5094,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/moveit_robots-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_robots` to `1.0.3-0`:
- upstream repository: https://github.com/ros-planning/moveit_robots.git
- release repository: https://github.com/tork-a/moveit_robots-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.2-0`
## atlas_moveit_config
- No changes
## atlas_v3_moveit_config
- No changes
## baxter_ikfast_left_arm_plugin

```
* [fix] Manually move ikfast.h from include/ to include/baxter_ikfast_{left/right}_arm_plugin/include
* Contributors: Kei Okada
```
## baxter_ikfast_right_arm_plugin

```
* [fix] Manually move ikfast.h from include/ to include/baxter_ikfast_{left/right}_arm_plugin/include
* Contributors: Kei Okada
```
## baxter_moveit_config
- No changes
## clam_moveit_config
- No changes
## iri_wam_moveit_config
- No changes
## moveit_robots

```
* [fix] Manually move ikfast.h from include/ to include/baxter_ikfast_{left/right}_arm_plugin/include
* Contributors: Kei Okada
```
## r2_moveit_generated
- No changes
