### PR TITLE
qglv_toolkit: 0.1.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7229,7 +7229,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/qglv_toolkit-release.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/yujinrobot/qglv_toolkit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qglv_toolkit` to `0.1.6-0`:
- upstream repository: https://github.com/yujinrobot/qglv_toolkit.git
- release repository: https://github.com/yujinrobot-release/qglv_toolkit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.5-0`
## qglv_extras

```
* legacy support on old versions is 203xx, not 20304.
```
## qglv_gallery

```
* legacy support on old versions is 203xx, not 20304.
```
