### PR TITLE
pr2_mechanism_msgs: 1.8.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2832,6 +2832,17 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: indigo-devel
     status: maintained
+  pr2_mechanism_msgs:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
+      version: 1.8.1-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_mechanism_msgs.git
+      version: master
+    status: maintained
   python_ethernet_rmp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_mechanism_msgs` to `1.8.1-0`:
- upstream repository: https://github.com/PR2/pr2_mechanism_msgs.git
- release repository: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
