### PR TITLE
octomap_mapping: 0.5.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2510,6 +2510,24 @@ repositories:
       url: https://github.com/OctoMap/octomap.git
       version: devel
     status: maintained
+  octomap_mapping:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_mapping.git
+      version: jade-devel
+    release:
+      packages:
+      - octomap_mapping
+      - octomap_server
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_mapping-release.git
+      version: 0.5.3-0
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_mapping.git
+      version: jade-devel
+    status: maintained
   octomap_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping` to `0.5.3-0`:
- upstream repository: https://github.com/OctoMap/octomap_mapping
- release repository: https://github.com/ros-gbp/octomap_mapping-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## octomap_mapping
- No changes
## octomap_server

```
* Fixing PCL linking errors on build farm
```
