### PR TITLE
Add rule for python-box2d

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -221,6 +221,8 @@ python-bluez:
     trusty: [python-bluez]
     utopic: [python-bluez]
     vivid: [python-bluez]
+python-box2d:
+  ubuntu: [python-box2d]
 python-bs4:
   ubuntu: [python-bs4]
 python-bson:


### PR DESCRIPTION
[box2d](http://box2d.org/) is a `c++` library for two dimensional physics
simulation.  The [python-box2d](https://github.com/pybox2d/pybox2d) package
provides python bindings for `box2d`, and is available in the Ubuntu
repositories for all currently supported releases (including precise, trusty,
vivid, and wily).
