### PR TITLE
denso: 1.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1644,7 +1644,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/start-jsk/denso-release.git
-      version: 1.1.0-0
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/start-jsk/denso.git


### PR DESCRIPTION
Increasing version of package(s) in repository `denso` to `1.1.1-0`:
- upstream repository: https://github.com/start-jsk/denso.git
- release repository: https://github.com/start-jsk/denso-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.0-0`
## denso

```
* [fix] Always run in a dryrun mode (fix #62 <https://github.com/start-jsk/denso/issues/62>)
* Contributors: Shohei Fujii
```
## denso_controller

```
* [fix] Always run in a dryrun mode (fix #62 <https://github.com/start-jsk/denso/issues/62>)
* Contributors: Shohei Fujii
```
## denso_launch
- No changes
## vs060
- No changes
## vs060_moveit_config
- No changes
