### PR TITLE
jsk_model_tools: 0.1.13-3 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1407,7 +1407,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.1.13-2
+      version: 0.1.13-3
     status: developed
   jsk_roseus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.1.13-3`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.13-2`
## eus_assimp

```
* move functions to jskeus
* add function for glvertices
* fix minor bugs
* move functions to jskeus
* add dump-glvertices-to-wrl for creating wrl mesh file from glvertices
* 0.1.12
* update CHANGELOG (For releasing 0.1.12 DRC Final version)
* [jsk_model_tools] remove old rosmake files
* Contributors: Kei Okada, Yohei Kakiuchi, Iori Yanokura
```
## euscollada

```
* return if key not found
* fix for yaml file without sensors
* [euscollada] Fix replace_xmls syntax in add_sensor_to_collada.py
  1. Force to use string. yaml parser automatically parse digit numbers as
  integer or float. OTH, minidom parser always outputs everything in
  string.
  We force to convert yaml parser's output into string value.
  2. Raise exception if there is no tag section.
  3. Do not remove parent node if replaced_attribute_value syntax is used
* [euscollada] Support xml force-replacing in add_sensor_to_collada.py
* fix reading texture coords
* [euscollada/src/euscollada-robot*.l] Always make pqpmodel for detailed shape according to https://github.com/euslisp/jskeus/pull/232
* 0.1.12
* update CHANGELOG (For releasing 0.1.12 DRC Final version)
* [src/collada2eus.cpp] on newer yaml, doc["angle-vector"]["reset-pose"] did not raise error
* [jsk_model_tools] remove old rosmake files
* [collada2eus.cpp] do not exit when polylistElementCound or polygoneElementCount is 0
* [euscollada/src/collada2eus.cpp] super ugry hack untilyaml-cpp 0.5.2
* [collada2eus] set verbose=true when --verbose
* [euscollada] Removed unnecessary fprintf in collada2eus.cpp
* [euscollada] Add size check to end-coords translation/rotation because undefiend limb end-coords transformation/rotation breaks matching of parentheses in yaml-cpp 0.5.
* Contributors: Kei Okada, MasakiMurooka, Ryohei Ueda, Shunichi Nozawa, Yohei Kakiuchi, Iori Kumagai, Iori Yanokura
```
## eusurdf

```
* [eusurdf/package.xml] export gazebo_model_path for gazebo_ros
* 

    * [eusurdf] remove rosbuild related scripts
  revert travis
* generate random tmp directory to avoid overwrite
* fix to use no rospack find nor rosrun for eusurdf
* convert models when catkin build
* add files to convert irtmodel to urdf
* delete converted urdf models in models directory.
* Contributors: Yuki Furuta, Masaki Murooka
* [eusurdf/package.xml] export gazebo_model_path for gazebo_ros
* 

    * [eusurdf] remove rosbuild related scripts
  revert travis
* generate random tmp directory to avoid overwrite
* fix to use no rospack find nor rosrun for eusurdf
* convert models when catkin build
* add files to convert irtmodel to urdf
* delete converted urdf models in models directory.
* Contributors: Yuki Furuta, Masaki Murooka
```
## jsk_model_tools

```
* 0.1.12
* update CHANGELOG (For releasing 0.1.12 DRC Final version)
* Contributors: Iori Yanokura
```
