### PR TITLE
Adding trac_ik to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10197,6 +10197,15 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/topic_proxy-release.git
       version: 0.1.1-0
     status: maintained
+  trac_ik:
+    doc:
+      type: git
+      url: https://bitbucket.org/traclabs/trac_ik.git
+      version: master
+    source:
+      type: git
+      url: https://bitbucket.org/traclabs/trac_ik.git
+      version: master
   tum_ardrone:
     doc:
       type: git


### PR DESCRIPTION
I'd like trac_ik to be indexed and documented on ros.org
