### PR TITLE
rqt_pr2_dashboard: 0.2.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8971,7 +8971,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
-      version: 0.2.8-0
+      version: 0.2.9-0
     source:
       type: git
       url: https://github.com/pr2/rqt_pr2_dashboard.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_pr2_dashboard` to `0.2.9-0`:
- upstream repository: https://github.com/ros-visualization/rqt_pr2_dashboard.git
- release repository: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.8-0`
