### PR TITLE
pointgrey_camera_driver: 0.12.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6635,13 +6635,14 @@ repositories:
     release:
       packages:
       - image_exposure_msgs
+      - pointgrey_camera_description
       - pointgrey_camera_driver
       - statistics_msgs
       - wfov_camera_msgs
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
-      version: 0.11.0-0
+      version: 0.12.1-0
     source:
       type: git
       url: https://github.com/ros-drivers/pointgrey_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointgrey_camera_driver` to `0.12.1-0`:
- upstream repository: https://github.com/ros-drivers/pointgrey_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.11.0-0`
## image_exposure_msgs
- No changes
## pointgrey_camera_description

```
* Added description for bumblebee2 and flea3.
* Contributors: Tony Baltovski
```
## pointgrey_camera_driver

```
* Depend on curl to pull in ca-certificates.
* Specify color coding. Without the format7 color coding specified, the driver will crash.
* Adds the vendor ID for Startech-brand Firewire interface cards.  This is necessary for accessing the camera(s) connected through the card.
* Removing check for number of subscribers to publish raw image.
* Support cameras with high framerate.
* Contributors: Jeff Schmidt, Konrad Banachowicz, Mike Purvis
```
## statistics_msgs
- No changes
## wfov_camera_msgs
- No changes
