### PR TITLE
hakuto: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2802,7 +2802,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/hakuto-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/tork-a/hakuto.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hakuto` to `0.1.4-0`:
- upstream repository: https://github.com/tork-a/hakuto.git
- release repository: https://github.com/tork-a/hakuto-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.3-0`
## hakuto

```
* [improved] Sun light is stronger on the Moon
* [fix] Temporary workaround to Gzweb not showing model (#45 <https://github.com/tork-a/hakuto/issues/45>)
* [fix] Workaround for teleop dying error ( #23 <https://github.com/tork-a/hakuto/issues/23>)
* [sys] all link is rended by texture, so material is not needed
* [sys] mv texture location to materials/textures, see https://bitbucket.org/osrf/gazebo_models/commits/0bde1dbe0cc62cefbcdd4a5a760e4f2e2aeb8bb6
* [doc] Use rosdoc_lite. Add more Gzweb server-side usage
* Contributors: Kei Okada, Isaac I.Y. Saito
```
## tetris_description

```
* [sys] all link is rended by texture, so material is not needed
* [sys] mv texture location to materials/textures, see https://bitbucket.org/osrf/gazebo_models/commits/0bde1dbe0cc62cefbcdd4a5a760e4f2e2aeb8bb6
* Contributors: Kei Okada
```
## tetris_gazebo

```
* [improved] Sun light is stronger on the Moon
* [fix] Temporary workaround to Gzweb not showing model (#45 <https://github.com/tork-a/hakuto/issues/45>)
* Contributors: Kei Okada, Isaac I.Y. Saito
```
## tetris_launch

```
* [improved] Sun light is stronger on the Moon
* [fix] Workaround for teleop dying error ( #23 <https://github.com/tork-a/hakuto/issues/23>)
* [doc] Use rosdoc_lite. Add more Gzweb server-side usage
* Contributors: Kei Okada, Isaac I.Y. Saito
```
