### PR TITLE
hector_slam: 0.3.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2948,7 +2948,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
-      version: 0.3.3-0
+      version: 0.3.4-0
     status: maintained
   hector_vision:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_slam` to `0.3.4-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.3-0`
## hector_compressed_map_transport
- No changes
## hector_geotiff

```
* Removes trailing spaces and fixes indents
* Contributors: YuK_Ota
```
## hector_geotiff_plugins
- No changes
## hector_imu_attitude_to_tf

```
* hector_imu_attitude_to_tf: fixed default values of the base_frame and base_stabilized_frame parameters (fix #20)
* Contributors: Johannes Meyer
```
## hector_imu_tools

```
* Fix sim setup
* remap for bertl setup
* Contributors: Florian Kunz, kohlbrecher
```
## hector_map_server
- No changes
## hector_map_tools

```
* -Fix severe bug when not using square size maps (would results in completely wrong obstacle distances and coordinates)
* Contributors: Stefan Kohlbrecher
```
## hector_mapping
- No changes
## hector_marker_drawing
- No changes
## hector_nav_msgs

```
* hector_nav_msgs: removed yaw member from GetNormal response
  yaw is implicitly given by the normal vector
* Contributors: Dorothea Koert
```
## hector_slam
- No changes
## hector_slam_launch

```
* Removes trailing spaces and fixes indents
* "rviz_cfg" directory in the repository version.
* Contributors: YuK_Ota, dani-carbonell
```
## hector_trajectory_server
- No changes
