### PR TITLE
Added tu-darmstadt-ros-pkg/hector repositories to jade distribution file

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2891,7 +2891,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/hector_navigation.git
-      version: master
+      version: catkin
   hector_nist_arenas_gazebo:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -449,6 +449,11 @@ repositories:
       url: https://github.com/ros/convex_decomposition.git
       version: indigo-devel
     status: maintained
+  cpp_introspection:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/cpp_introspection.git
+      version: master
   cram_3rdparty:
     doc:
       type: git
@@ -1154,6 +1159,138 @@ repositories:
       type: git
       url: https://github.com/eybee/heatmap.git
       version: jade-devel
+    status: maintained
+  hector_gazebo:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
+      version: jade-devel
+    release:
+      packages:
+      - hector_gazebo
+      - hector_gazebo_plugins
+      - hector_gazebo_thermal_camera
+      - hector_gazebo_worlds
+      - hector_sensors_gazebo
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
+    status: maintained
+  hector_localization:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_localization.git
+      version: catkin
+    release:
+      packages:
+      - hector_localization
+      - hector_pose_estimation
+      - hector_pose_estimation_core
+      - message_to_tf
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
+    status: maintained
+  hector_models:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_models.git
+      version: jade-devel
+    release:
+      packages:
+      - hector_components_description
+      - hector_models
+      - hector_sensors_description
+      - hector_xacro_tools
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
+    status: maintained
+  hector_navigation:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_navigation.git
+      version: catkin
+  hector_nist_arenas_gazebo:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_nist_arenas_gazebo.git
+      version: indigo-devel
+  hector_quadrotor:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor.git
+      version: jade-devel
+    release:
+      packages:
+      - hector_quadrotor
+      - hector_quadrotor_controller
+      - hector_quadrotor_controller_gazebo
+      - hector_quadrotor_demo
+      - hector_quadrotor_description
+      - hector_quadrotor_gazebo
+      - hector_quadrotor_gazebo_plugins
+      - hector_quadrotor_model
+      - hector_quadrotor_pose_estimation
+      - hector_quadrotor_teleop
+      - hector_uav_msgs
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_quadrotor-release.git
+    status: maintained
+  hector_quadrotor_apps:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor_apps.git
+      version: master
+  hector_slam:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git
+      version: catkin
+    release:
+      packages:
+      - hector_compressed_map_transport
+      - hector_geotiff
+      - hector_geotiff_plugins
+      - hector_imu_attitude_to_tf
+      - hector_imu_tools
+      - hector_map_server
+      - hector_map_tools
+      - hector_mapping
+      - hector_marker_drawing
+      - hector_nav_msgs
+      - hector_slam
+      - hector_slam_launch
+      - hector_trajectory_server
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
+    status: maintained
+  hector_vision:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_vision.git
+      version: master
+  hector_visualization:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_visualization.git
+      version: master
+  hector_worldmodel:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_worldmodel.git
+      version: catkin
+    release:
+      packages:
+      - hector_object_tracker
+      - hector_worldmodel
+      - hector_worldmodel_geotiff_plugins
+      - hector_worldmodel_msgs
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
     status: maintained
   hokuyo_node:
     release:
@@ -4163,6 +4300,11 @@ repositories:
       url: https://github.com/RobotWebTools/tf2_web_republisher.git
       version: develop
     status: maintained
+  topic_proxy:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/topic_proxy.git
+      version: master
   twist_mux:
     doc:
       type: git
@@ -4193,6 +4335,11 @@ repositories:
       url: https://github.com/ros-teleop/twist_mux_msgs.git
       version: jade-devel
     status: maintained
+  ublox:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/ublox.git
+      version: catkin
   ueye:
     doc:
       type: hg


### PR DESCRIPTION
...and updated hector_navigation branch for indigo.

I am not sure what exactly is required to add those repositories to the list on http://prerelease.ros.org/jade in order to prepare the jade releases, but I assume the release entries (without a version yet) should do.
