### PR TITLE
hector_gazebo: 0.3.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2853,7 +2853,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
-      version: 0.3.6-0
+      version: 0.3.7-0
     status: maintained
   hector_localization:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_gazebo` to `0.3.7-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.6-0`
## hector_gazebo
- No changes
## hector_gazebo_plugins

```
* gazebo_ros_force_based_move: Disable odom tf publishing if set in sdf params
* gazebo_ros_force_based_move: Add plugin for applying forces based on cmd_vel input (allows simulation of tracked vehicles)
* hector_gazebo_plugins/hector_gazebo_thermal_camera: switch to cmake configuration for gazebo and added OGRE include directories required for CameraPlugin.hh
* Contributors: Johannes Meyer, kohlbrecher
```
## hector_gazebo_thermal_camera

```
* hector_gazebo_plugins/hector_gazebo_thermal_camera: switch to cmake configuration for gazebo and added OGRE include directories required for CameraPlugin.hh
* Contributors: Johannes Meyer
```
## hector_gazebo_worlds
- No changes
## hector_sensors_gazebo
- No changes
