### PR TITLE
hector_gazebo: 0.4.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1175,6 +1175,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
+      version: 0.4.0-0
     status: maintained
   hector_localization:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_gazebo` to `0.4.0-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## hector_gazebo
- No changes
## hector_gazebo_plugins

```
* Added proper dependencies for jade and gazebo5. Now compiles and works for gazebo5
* Contributors: L0g1x
```
## hector_gazebo_thermal_camera

```
* Added proper dependencies for jade and gazebo5. Now compiles and works for gazebo5
* Contributors: L0g1x
```
## hector_gazebo_worlds
- No changes
## hector_sensors_gazebo
- No changes
