### PR TITLE
csm: 1.0.2-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1562,7 +1562,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/csm-release.git
-      version: 1.0.2-1
+      version: 1.0.2-2
     source:
       type: git
       url: https://github.com/AndreaCensi/csm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `csm` to `1.0.2-2`:
- upstream repository: https://github.com/AndreaCensi/csm.git
- release repository: https://github.com/tork-a/csm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.2-1`
