### PR TITLE
hector_localization: 0.2.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1191,6 +1191,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
+      version: 0.2.1-0
     status: maintained
   hector_models:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_localization` to `0.2.1-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_localization.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## hector_localization
- No changes
## hector_pose_estimation
- No changes
## hector_pose_estimation_core

```
* hector_pose_estimation_core: use FindEigen3.cmake provided by Eigen
* Contributors: Johannes Meyer
```
## message_to_tf

```
* Update error message
* Add TransformStamped as an input type
* Contributors: Paul Bovbel
```
