### PR TITLE
hector_models: 0.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2885,7 +2885,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     status: maintained
   hector_navigation:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_models` to `0.4.1-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_models.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.4.0-0`
## hector_components_description

```
* hector_components_description/hector_sensors_description: added xacro namespace prefix to macro calls
* Cleaned up root element xmlns arguments according to http://gazebosim.org/tutorials?tut=ros_urdf#HeaderofaURDFFile
* Added missing xacro namespace prefix to XML tags
* Contributors: Johannes Meyer
```
## hector_models
- No changes
## hector_sensors_description

```
* hector_components_description/hector_sensors_description: added xacro namespace prefix to macro calls
* Cleaned up root element xmlns arguments according to http://gazebosim.org/tutorials?tut=ros_urdf#HeaderofaURDFFile
* hector_sensors_description: removed deprecated plugin parameters and added noise to the hokuyo_utm30lx_model macro (fix #1)
* Contributors: Johannes Meyer
```
## hector_xacro_tools

```
* hector_xacro_tools: fixed invalid brackets in inertial_sphere* xacro macros
* Cleaned up root element xmlns arguments according to http://gazebosim.org/tutorials?tut=ros_urdf#HeaderofaURDFFile
* Added missing xacro namespace prefix to XML tags
* Contributors: Johannes Meyer
```
