### PR TITLE
mavros: 0.16.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4740,7 +4740,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.15.0-0
+      version: 0.16.0-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.16.0-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.15.0-0`
## libmavconn
- No changes
## mavros

```
* lib: Update ArduCopter mode list
* plugin: sys_status #423 <https://github.com/mavlink/mavros/issues/423>: set_mode set arming and HIL flags based on previous state
* lib #423 <https://github.com/mavlink/mavros/issues/423>: Save base_mode in UAS.
* Finalized local position topic names
* readme: add link to catkin-tools docs
* readme #409 <https://github.com/mavlink/mavros/issues/409>: merge mavlink and mavros installation instruction
* Fixed redundant rotation of IMU data and redundant orientation data
* plugin: setpoint_raw fix #418 <https://github.com/mavlink/mavros/issues/418>: add attitude raw setpoint
  Related #402 <https://github.com/mavlink/mavros/issues/402>.
* Added velocity output of FCU's local position estimate to ROS node
* plugin: sys_status fix #417 <https://github.com/mavlink/mavros/issues/417>: remove APM statustext quirk
* plugin: waypoint fix #414 <https://github.com/mavlink/mavros/issues/414>: remove GOTO service.
  It is replaced with more standard global setpoint messages.
* plugin: setpoint_raw fix #415 <https://github.com/mavlink/mavros/issues/415>: add global position target support
  Related to #402 <https://github.com/mavlink/mavros/issues/402>.
* plugin: command fix #407 <https://github.com/mavlink/mavros/issues/407>: remove guided_enable sevice
* plugin: setpoint_raw #402 <https://github.com/mavlink/mavros/issues/402>: implement loopback.
* plugin: setpoint_raw #402 <https://github.com/mavlink/mavros/issues/402>: Initial import.
* readme fix #410 <https://github.com/mavlink/mavros/issues/410>: use only catkin tool
* readme: add defaults for URL
* pass new extended state to ros
* python: add util to convert pymavlink message to Mavlink.msg
* python: convert input to bytearray
* python: add payload convertion util
* gcs_bridge #394 <https://github.com/mavlink/mavros/issues/394>: enable both UDPROS and TCPROS transports
* EL: add try-except on handlers
* event_launcher: show logfile path
* event_launcher #386 <https://github.com/mavlink/mavros/issues/386>: expand shell vars for logfile
* Mavros library depends on mavros_msgs headers
  Adding this dependency makes sure that mavros_msgs message headers are
  generated before the mavros library is built, since it needs those
  headers.
* Contributors: Andreas Antener, Eddy, Jon Binney, Vladimir Ermakov
```
## mavros_extras

```
* gcs_bridge #394 <https://github.com/mavlink/mavros/issues/394>: enable both UDPROS and TCPROS transports
* extras fix #392 <https://github.com/mavlink/mavros/issues/392>: add additional subscription for PoseWithCovarianceStamped
* Contributors: Vladimir Ermakov
```
## mavros_msgs

```
* msgs #418 <https://github.com/mavlink/mavros/issues/418>: add message for attitude setpoints
* plugin: waypoint fix #414 <https://github.com/mavlink/mavros/issues/414>: remove GOTO service.
  It is replaced with more standard global setpoint messages.
* msgs #415 <https://github.com/mavlink/mavros/issues/415>: Add message for raw global setpoint
* msgs #402 <https://github.com/mavlink/mavros/issues/402>: PositionTarget message type
* setting constant values and reference docs
* pass new extended state to ros
* msgs #371 <https://github.com/mavlink/mavros/issues/371>: add missing message
* msgs #371 <https://github.com/mavlink/mavros/issues/371>: add HomePosition message
* Contributors: Andreas Antener, Vladimir Ermakov
```
## test_mavros
- No changes
