### PR TITLE
ypspur: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11223,7 +11223,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/DaikiMaekawa/ypspur-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/DaikiMaekawa/ypspur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ypspur` to `0.2.1-0`:
- upstream repository: https://github.com/DaikiMaekawa/ypspur.git
- release repository: https://github.com/DaikiMaekawa/ypspur-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.0-0`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ros/rosdistro/9795)

<!-- Reviewable:end -->
