### PR TITLE
xacro: 1.9.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11120,7 +11120,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.9.4-0
+      version: 1.9.5-0
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.9.5-0`:
- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.9.4-0`
## xacro

```
* optionally include latest improvements in xacro-jade into xacro-indigo
* Contributors: Morgan Quigley
```
