### PR TITLE
ros_comm: 1.11.16-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3465,7 +3465,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.15-0
+      version: 1.11.16-0
     source:
       type: git
       url: https://github.com/ros/ros_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.16-0`:
- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.15-0`
## message_filters
- No changes
## ros_comm
- No changes
## rosbag

```
* show size unit for --size of rosbag record in help string (#697 <https://github.com/ros/ros_comm/pull/697>)
```
## rosbag_storage
- No changes
## rosconsole
- No changes
## roscpp

```
* add getROSArg function (#694 <https://github.com/ros/ros_comm/pull/694>)
```
## rosgraph
- No changes
## roslaunch

```
* add -w and -t options (#687 <https://github.com/ros/ros_comm/pull/687>)
* fix missing minimum version for rospkg dependency (#693 <https://github.com/ros/ros_comm/issues/693>)
```
## roslz4
- No changes
## rosmaster

```
* add -w and -t options (#687 <https://github.com/ros/ros_comm/pull/687>)
```
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy

```
* catch ROSInterruptException from rospy timers when shutting down (#690 <https://github.com/ros/ros_comm/pull/690>)
```
## rosservice
- No changes
## rostest
- No changes
## rostopic
- No changes
## roswtf
- No changes
## topic_tools
- No changes
## xmlrpcpp
- No changes
