### PR TITLE
hector_worldmodel: 0.3.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2974,7 +2974,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
-      version: 0.3.2-0
+      version: 0.3.3-0
     status: maintained
   hokuyo3d:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_worldmodel` to `0.3.3-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_worldmodel.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.2-0`
## hector_object_tracker

```
* added barrels to launch file
* changed max height to 0.2
* Reduce max height
* changed min height for target
* -Update sick robot day 2014 params
* -Rename launch file
* -Change settings for SRD2014
* launch file for turtlebot added
* Contributors: Christian Rose, Dorothea Koert, Stefan Kohlbrecher
```
## hector_worldmodel
- No changes
## hector_worldmodel_geotiff_plugins
- No changes
## hector_worldmodel_msgs
- No changes
