### PR TITLE
scan_tools: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9332,15 +9332,17 @@ repositories:
     release:
       packages:
       - laser_ortho_projector
+      - laser_scan_matcher
       - laser_scan_sparsifier
       - laser_scan_splitter
       - ncd_parser
       - polar_scan_matcher
       - scan_to_cloud_converter
+      - scan_tools
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/scan_tools-release.git
-      version: 0.2.1-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/scan_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scan_tools` to `0.3.0-0`:
- upstream repository: https://github.com/ccny-ros-pkg/scan_tools.git
- release repository: https://github.com/tork-a/scan_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.1-0`
## laser_ortho_projector
- No changes
## laser_scan_matcher

```
* [feat] Allow choosing between geometry_msgs/Twist and geometry_msgs/TwistStamped (fix #21 <https://github.com/ccny-ros-pkg/scan_tools/issues/21>)
* [sys][laser_scan_matcher] Depends on DEB version of CSM; it is no longer built upon compile time
* [sys][laser_scan_matcher] Add simplest unit test
* [feat][laser_scan_matcher, demo.launch] Arg for whether to use RViz or not
* Contributors: Kei Okada, Jorge Santos Simón, Isaac I.Y. Saito
```
## laser_scan_sparsifier
- No changes
## laser_scan_splitter
- No changes
## ncd_parser
- No changes
## polar_scan_matcher
- No changes
## scan_to_cloud_converter
- No changes
## scan_tools

```
* [feat] Allow choosing between geometry_msgs/Twist and geometry_msgs/TwistStamped (fix #21 <https://github.com/ccny-ros-pkg/scan_tools/issues/21>)
* [sys][laser_scan_matcher] Depends on DEB version of CSM; it is no longer built upon compile time
* [sys][laser_scan_matcher] Add simplest unit test
* [feat][laser_scan_matcher, demo.launch] Arg for whether to use RViz or not
* Contributors: Kei Okada, Jorge Santos Simón, Isaac I.Y. Saito
```
