### PR TITLE
micros_dynamic_objects_filter: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4848,6 +4848,21 @@ repositories:
       url: https://github.com/orocos-gbp/metaruby-release.git
       version: 1.0.0-3
     status: maintained
+  micros_dynamic_objects_filter:
+    doc:
+      type: git
+      url: https://github.com/yincanben/micros_dynamic_objects_filter.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yincanben/micros_dynamic_objects_filter-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/yincanben/micros_dynamic_objects_filter.git
+      version: master
+    status: developed
   micros_rtt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `micros_dynamic_objects_filter` to `0.0.2-0`:
- upstream repository: https://github.com/yincanben/micros_dynamic_objects_filter.git
- release repository: https://github.com/yincanben/micros_dynamic_objects_filter-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
