### PR TITLE
cit_adis_imu: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -961,6 +961,17 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: indigo-devel
     status: maintained
+  cit_adis_imu:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/open-rdc/cit_adis_imu-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/open-rdc/cit_adis_imu.git
+      version: indigo-devel
+    status: developed
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cit_adis_imu` to `0.0.2-0`:
- upstream repository: https://github.com/open-rdc/cit_adis_imu.git
- release repository: https://github.com/open-rdc/cit_adis_imu-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ros/rosdistro/9810)

<!-- Reviewable:end -->
