### PR TITLE
rtmros_hironx: 1.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9102,7 +9102,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.1-0
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.2-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.1-0`
## hironx_calibration
- No changes
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* [sys] Add a testcase for checking #335 <https://github.com/start-jsk/rtmros_hironx/issues/335>
* [sys] add DEBUG_HRPSYS argument
* [sys] Remove redundant install rule
* [sys][travis] Drop rosbuild checking for Indigo onward
* Contributors: Isaac I.Y. Saito, Kei Okada
```
## rtmros_hironx

```
* [sys] Add a testcase for checking #335 <https://github.com/start-jsk/rtmros_hironx/issues/335>
* [sys] add DEBUG_HRPSYS argument
* [sys] Remove redundant install rule
* [sys][travis] Drop rosbuild checking for Indigo onward
* Contributors: Isaac I.Y. Saito, Kei Okada
```
