### PR TITLE
sick_tim: 0.0.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4097,6 +4097,21 @@ repositories:
       url: https://github.com/ros-gbp/shape_tools-release.git
       version: 0.2.1-0
     status: maintained
+  sick_tim:
+    doc:
+      type: git
+      url: https://github.com/uos/sick_tim.git
+      version: jade
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/uos-gbp/sick_tim-release.git
+      version: 0.0.6-0
+    source:
+      type: git
+      url: https://github.com/uos/sick_tim.git
+      version: jade
+    status: developed
   sicktoolbox:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_tim` to `0.0.6-0`:
- upstream repository: https://github.com/uos/sick_tim
- release repository: https://github.com/uos-gbp/sick_tim-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## sick_tim

```
* First release into Jade
* Create sick_tim571_2050001.launch
  This launch file can be used directly to connect to TIM571 devices.
  See #28 <https://github.com/uos/sick_tim/issues/28>.
* Contributors: Martin Günther, sacuar
```
