### PR TITLE
openni_launch: 1.9.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6210,11 +6210,12 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/openni_launch-release.git
-      version: 1.9.5-0
+      version: 1.9.7-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni_launch.git
       version: indigo-devel
+    status: maintained
   openrtm_aist:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_launch` to `1.9.7-0`:
- upstream repository: https://github.com/ros-drivers/openni_launch.git
- release repository: https://github.com/ros-gbp/openni_launch-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.9.5-0`
## openni_launch

```
* 1st ROS Jade release
* [sys] Add a simple travis config
* Contributors: Isaac I.Y. Saito
```
