### PR TITLE
rgbd_launch: 2.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7559,7 +7559,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rgbd_launch-release.git
-      version: 2.1.0-0
+      version: 2.1.1-0
     source:
       type: git
       url: https://github.com/ros-drivers/rgbd_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rgbd_launch` to `2.1.1-0`:
- upstream repository: https://github.com/ros-drivers/rgbd_launch.git
- release repository: https://github.com/ros-gbp/rgbd_launch-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.1.0-0`
## rgbd_launch

```
* 1st ROS Jade release
* [feat] Add convert_metric nodes to depth_registered.launch.xml (#13 <https://github.com/ros-drivers/rgbd_launch/issues/13> from kbogert/hydro-devel)
* [feat] Add the metric nodes to output a depth image
* [fix] Merge pull request #1 <https://github.com/ros-drivers/rgbd_launch/issues/1> from piyushk/piyush/kbogert-depth-registered-metric
  fixed rect convert metric to conform to both s/w and h/w pipelines. fixe...
* Contributors: Kenneth Bogert, Piyush Khandelwal
```
