### PR TITLE
rgbd_launch: 2.1.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3247,6 +3247,21 @@ repositories:
       url: https://github.com/orocos/rFSM.git
       version: master
     status: maintained
+  rgbd_launch:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/rgbd_launch.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/rgbd_launch-release.git
+      version: 2.1.1-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/rgbd_launch.git
+      version: indigo-devel
+    status: maintained
   rmp_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rgbd_launch` to `2.1.1-0`:
- upstream repository: https://github.com/ros-drivers/rgbd_launch.git
- release repository: https://github.com/ros-gbp/rgbd_launch-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rgbd_launch

```
* 1st ROS Jade release
* [feat] Add convert_metric nodes to depth_registered.launch.xml (#13 <https://github.com/ros-drivers/rgbd_launch/issues/13> from kbogert/hydro-devel)
* [feat] Add the metric nodes to output a depth image
* [fix] Merge pull request #1 <https://github.com/ros-drivers/rgbd_launch/issues/1> from piyushk/piyush/kbogert-depth-registered-metric
  fixed rect convert metric to conform to both s/w and h/w pipelines. fixe...
* Contributors: Kenneth Bogert, Piyush Khandelwal
```
