### PR TITLE
ovda_ethernetip: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6337,6 +6337,21 @@ repositories:
       type: git
       url: https://github.com/Oriense/orsens_ros.git
       version: master
+  ovda_ethernetip:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/ovda_ethernetip.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/ovda_ethernetip-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/ovda_ethernetip.git
+      version: indigo-devel
+    status: maintained
   p2os:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ovda_ethernetip` to `0.1.0-0`:
- upstream repository: https://github.com/ros-drivers/ovda_ethernetip.git
- release repository: https://github.com/ros-drivers-gbp/ovda_ethernetip-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## ovda_ethernetip

```
* Initial release.
```
