### PR TITLE
marti_common: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4665,6 +4665,7 @@ repositories:
       - swri_math_util
       - swri_opencv_util
       - swri_prefix_tools
+      - swri_roscpp
       - swri_serial_util
       - swri_string_util
       - swri_system_util
@@ -4673,7 +4674,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.0.6-0`:
- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.5-0`
## marti_data_structures
- No changes
## swri_console_util
- No changes
## swri_geometry_util
- No changes
## swri_image_util

```
* Image normalization now supports normalization to a min/max range.
* Contributors: Marc Alban
```
## swri_math_util

```
* Minor change: marks single-argument constructor for Ransac explicit.
* Contributors: Marc Alban
```
## swri_opencv_util
- No changes
## swri_prefix_tools

```
* Properly installs prefix scripts to the package share destination.
* Contributors: Edward Venator
```
## swri_roscpp

```
* First release of swri_roscpp
* Contributors: Edward Venator
```
## swri_serial_util
- No changes
## swri_string_util
- No changes
## swri_system_util
- No changes
## swri_transform_util

```
* Adds a GetTF method to transform_util::Transform.
* Properly installs the initialize_origin.py node.
* Add extension type (e.g. png) in geo file
* Contributors: Edward Venator, P. J. Reed, Vincent Rousseau
```
## swri_yaml_util
- No changes
