### PR TITLE
homer_mapnav: 1.0.1-5 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3028,11 +3028,15 @@ repositories:
   homer_mapnav:
     release:
       packages:
+      - homer_map_manager
       - homer_mapnav_msgs
+      - homer_mapping
+      - homer_nav_libs
+      - homer_navigation
       tags:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
-      version: 1.0.1-2
+      version: 1.0.1-5
   homer_object_recognition:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_mapnav` to `1.0.1-5`:
- upstream repository: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.1-2`
## homer_map_manager

```
* init
* Contributors: Raphael Memmesheimer
```
## homer_mapnav_msgs

```
* init
* Contributors: Raphael Memmesheimer
```
## homer_mapping

```
* init
* Contributors: Raphael Memmesheimer
```
## homer_nav_libs

```
* init
* Contributors: Raphael Memmesheimer
```
## homer_navigation

```
* init
* Contributors: Raphael Memmesheimer
```
