### PR TITLE
omron: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6065,6 +6065,23 @@ repositories:
       url: https://github.com/davetcoleman/ompl_visual_tools.git
       version: indigo-devel
     status: developed
+  omron:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/omron.git
+      version: indigo-devel
+    release:
+      packages:
+      - omron_os32c_driver
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/omron-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/omron.git
+      version: indigo-devel
+    status: maintained
   open_industrial_ros_controllers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `omron` to `0.1.0-0`:
- upstream repository: https://github.com/ros-drivers/omron.git
- release repository: https://github.com/ros-drivers-gbp/omron-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## omron_os32c_driver

```
* Initial release.
* Contributors: Kareem Shehata, Mike Purvis, Tony Baltovski
```
