### PR TITLE
Remove ovda_ethernetip

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6359,21 +6359,6 @@ repositories:
       type: git
       url: https://github.com/Oriense/orsens_ros.git
       version: master
-  ovda_ethernetip:
-    doc:
-      type: git
-      url: https://github.com/ros-drivers/ovda_ethernetip.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-drivers-gbp/ovda_ethernetip-release.git
-      version: 0.1.0-0
-    source:
-      type: git
-      url: https://github.com/ros-drivers/ovda_ethernetip.git
-      version: indigo-devel
-    status: maintained
   p2os:
     doc:
       type: git


### PR DESCRIPTION
Going to re-add as odva_ethernetip. (cf. https://www.odva.org/)
