### PR TITLE
odva_ethernetip: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6043,6 +6043,21 @@ repositories:
       url: https://github.com/ros-visualization/oculus_sdk.git
       version: hydro-devel
     status: maintained
+  odva_ethernetip:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/odva_ethernetip.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/odva_ethernetip-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/odva_ethernetip.git
+      version: indigo-devel
+    status: maintained
   ohm_tsd_slam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `odva_ethernetip` to `0.1.1-0`:
- upstream repository: https://github.com/ros-drivers/odva_ethernetip.git
- release repository: https://github.com/ros-drivers-gbp/odva_ethernetip-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## odva_ethernetip

```
* Fixed library name.
* Contributors: Tony Baltovski
```
