### PR TITLE
mapviz: 0.1.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1804,7 +1804,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `0.1.1-0`:
- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.0-0`
## mapviz

```
* Fixes mapviz launch file frame param
* Marks single argument constructors explicit.
* Contributors: Edward Venator, Marc Alban, Vincent Rousseau
```
## mapviz_plugins

```
* Extensions for geo files (PR #262 <https://github.com/swri-robotics/mapviz/issues/262>)
* Adds a plugin to visualize laser scans.
  Display features are based on the laserscan plugin for rviz:
  * Points can be colored by range, or x/y/z axis
  * Points can be colored by interpolation between two colors or rainbow coloring
* Adds a plugin to visualize sensor_msgs/NavSatFix msgs, based on the old GPSFix plugin
* Contributors: Claudio Bandera, Ed Venator, Vincent Rousseau
```
## multires_image

```
* Use extension from geo file
* Contributors: Vincent Rousseau
```
## tile_map

```
* Mark single argument constructors explicit.
* Contributors: Marc Alban
```
