### PR TITLE
rgbd_launch: 2.2.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3257,7 +3257,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rgbd_launch-release.git
-      version: 2.1.1-0
+      version: 2.2.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/rgbd_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rgbd_launch` to `2.2.0-0`:
- upstream repository: https://github.com/ros-drivers/rgbd_launch.git
- release repository: https://github.com/ros-gbp/rgbd_launch-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.1.1-0`
## rgbd_launch

```
* 1st release into ROS Jade
* [feat] Adjust to tf2 (#18 <https://github.com/ros-drivers/rgbd_launch/issues/18>)
* [sys] travis enabled
* Contributors: Daiki Maekawa, Isaac I.Y. Saito
```
