### PR TITLE
openni_launch: 1.9.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2766,6 +2766,21 @@ repositories:
       url: https://github.com/ros-drivers/openni_camera.git
       version: indigo-devel
     status: maintained
+  openni_launch:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni_launch.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/openni_launch-release.git
+      version: 1.9.7-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni_launch.git
+      version: indigo-devel
+    status: maintained
   openrtm_aist:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_launch` to `1.9.7-0`:
- upstream repository: https://github.com/ros-drivers/openni_launch.git
- release repository: https://github.com/ros-gbp/openni_launch-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## openni_launch

```
* 1st ROS Jade release
* [sys] Add a simple travis config
* Contributors: Isaac I.Y. Saito
```
