### PR TITLE
removing swri_roscpp from indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4670,7 +4670,6 @@ repositories:
       - swri_math_util
       - swri_opencv_util
       - swri_prefix_tools
-      - swri_roscpp
       - swri_serial_util
       - swri_string_util
       - swri_system_util


### PR DESCRIPTION
re: https://github.com/swri-robotics/marti_common/issues/279

Its sourcedeb is failing. 
http://jenkins.ros.org/view/Isrc/job/ros-indigo-swri-roscpp_sourcedeb/41/console
http://54.183.26.131:8080/view/Isrc_uT/job/Isrc_uT__swri_roscpp__ubuntu_trusty__source/73/console
