### PR TITLE
mavros: 0.16.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4757,7 +4757,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.16.2-0
+      version: 0.16.3-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.16.3-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.16.2-0`
## libmavconn
- No changes
## mavros

```
* use safe methods to get imu data in local_position plugin
* Contributors: Andreas Antener
```
## mavros_extras
- No changes
## mavros_msgs
- No changes
## test_mavros
- No changes
