### PR TITLE
ridgeback: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7613,6 +7613,26 @@ repositories:
       url: https://github.com/robotican/ric.git
       version: indigo-devel
     status: maintained
+  ridgeback:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback.git
+      version: indigo-devel
+    release:
+      packages:
+      - ridgeback_control
+      - ridgeback_description
+      - ridgeback_msgs
+      - ridgeback_navigation
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback.git
+      version: indigo-devel
+    status: maintained
   riskrrt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback` to `0.1.0-0`:
- upstream repository: https://github.com/ridgeback/ridgeback.git
- release repository: https://github.com/clearpath-gbp/ridgeback-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## ridgeback_control

```
* Initial ridgeback release.
* Contributors: Mike Purvis, Tony Baltovski
```
## ridgeback_description

```
* Initial ridgeback description release.
* Contributors: Mike Purvis, Tony Baltovski
```
## ridgeback_msgs

```
* Initial ridgeback messages release.
* Contributors: Mike Purvis, Tony Baltovski
```
## ridgeback_navigation

```
* Initial ridgeback release.
* Contributors: Mike Purvis, Tony Baltovski
```
