### PR TITLE
homer_mapnav: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3036,7 +3036,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
-      version: 1.0.1-5
+      version: 1.0.2-0
   homer_object_recognition:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_mapnav` to `1.0.2-0`:
- upstream repository: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.1-5`
## homer_map_manager

```
* added Maintainers
* added cmake_modules build dependency
* added raphael as maintainer
* Contributors: Niklas Yann Wettengel, Raphael Memmesheimer
```
## homer_mapnav_msgs

```
* added cmake_modules as build dependency in package.xml
* added Maintainers
* added raphael as maintainer
* Contributors: Niklas Yann Wettengel, Raphael Memmesheimer
```
## homer_mapping

```
* added cmake_modules as build dependency in package.xml
* added Maintainers
* Contributors: Niklas Yann Wettengel
```
## homer_nav_libs

```
* added cmake_modules as build dependency in package.xml
* added Maintainers
* removed components
* Raphael as maintainer added
* Contributors: Niklas Yann Wettengel, Raphael Memmesheimer
```
## homer_navigation

```
* added cmake_modules as build dependency in package.xml
* added Maintainers
* Contributors: Niklas Yann Wettengel
```
