### PR TITLE
ros_control: 0.10.0-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3526,6 +3526,31 @@ repositories:
       url: https://github.com/ros/ros_comm_msgs.git
       version: indigo-devel
     status: maintained
+  ros_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros_control.git
+      version: jade-devel
+    release:
+      packages:
+      - controller_interface
+      - controller_manager
+      - controller_manager_msgs
+      - controller_manager_tests
+      - hardware_interface
+      - joint_limits_interface
+      - ros_control
+      - rqt_controller_manager
+      - transmission_interface
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/ros_control-release.git
+      version: 0.10.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros_control.git
+      version: jade-devel
+    status: maintained
   ros_emacs_utils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.10.0-1`:
- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## controller_interface

```
* Add MultiInterfaceController.
  - Subclass of ControllerBase which allows to claim resources from up to four
  different hardware interfaces.
  Requested hardware interfaces are required by default, but can be made optional
  through a constructor flag.
* Remove getHardwareInterfaceType() pure virtual method from ControllerBase
  class.
  - C++ API break.
  - Controller class still preserves the method, albeit protected and non-virtual.
* Modify controller interfaces to allow for controllers that claim resources
  from more than one hardware interface.
  - C++ API break.
* Address -Wunused-parameter warnings
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## controller_manager

```
* Fix doSwitch execution point
  The doSwitch method needs to be executed in the update() method,  that is, in
  the real-time path, which is where controller switching actually takes place.
* Introduce prepareSwitch, replacement of canSwitch
* Deprecate RobotHW::canSwitch
* Multi-interface controllers
  - C++ API break.
  - Make controller_manager aware of controllers that claim resources from more
  than one hardware interface.
  - Update and extend the corresponding test suite.
* Address -Wunused-parameter warnings
* Contributors: Adolfo Rodriguez Tsouroukdissian, Mathias Lüdtke
```
## controller_manager_msgs

```
* Add helper to query rosparam controller configs
  There is no way to identify uninitialized controllers other than by inspecting
  the ROS parameter server, and looking for the required controller config
  structure, which is the existence of the <ctrl_name>/type parameter.
* Multi-interface controllers
  - Breaks ROS API and (internal) Python API.
  - Modify and extend ROS message definitions to allow for controllers that
  claim resources from more than one hardware interface.
  - Modify Python helpers and update the corresponding test suite to take into
  account above changes.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## controller_manager_tests

```
* Cleaner test exit
* Extend test suite
  - Exercise much more of the controller_manager ROS API.
  - Create multi-interface test controllers and exercise them in tests.
* Address -Wunused-parameter warnings
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## hardware_interface

```
* Fix doSwitch execution point
  The doSwitch method needs to be executed in the update() method,  that is, in
  the real-time path, which is where controller switching actually takes place.
  It was previously done in the switchController callback, which is non real-time.
* Introduce prepareSwitch, replacement of canSwitch
* Add InterfaceManager::getNames
  Add new method that allows to query the names of all interfaces managed by
  an InterfaceManager instance.
* Multi-interface controllers
  - C++ API break.
  - Modify ControllerInfo class to allow controllers to claim resources from
  multiple hardware interfaces.
  - Propagate changes to RobotHW::checkForConflict: Default resource ownsership
  policy is aware of controllers claiming resources from  multiple hardware
  interfaces.
  - Update and extend the corresponding test suite.
* Address -Wunused-parameter warnings
* Contributors: Adolfo Rodriguez Tsouroukdissian, Mathias Lüdtke
```
## joint_limits_interface
- No changes
## ros_control
- No changes
## rqt_controller_manager

```
* Allow running as standalone application
* Multi-interface controllers, UI revamp
  - Make the rqt_controller_manager aware of multi-interface controllers.
  - Reduce the amount of screen real-estate used by the plugin.
  - Make main view read-only.
  - Show uninitialized controllers (fetched from parameter server) in the same
  list as stopped and running controllers.
  - Make less assumptions when finding running controller managers. Use
  existing helpers on controller_mamager_msgs.utils Python module.
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## transmission_interface

```
* Allow loading transmissions from a vector of TransmissionInfo instances.
* Address -Wunused-parameter warnings
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
