### PR TITLE
ros_controllers: 0.10.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3551,6 +3551,34 @@ repositories:
       url: https://github.com/ros-controls/ros_control.git
       version: jade-devel
     status: maintained
+  ros_controllers:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros_controllers.git
+      version: jade-dev
+    release:
+      packages:
+      - diff_drive_controller
+      - effort_controllers
+      - force_torque_sensor_controller
+      - forward_command_controller
+      - gripper_action_controller
+      - imu_sensor_controller
+      - joint_state_controller
+      - joint_trajectory_controller
+      - position_controllers
+      - ros_controllers
+      - rqt_joint_trajectory_controller
+      - velocity_controllers
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/ros_controllers-release.git
+      version: 0.10.0-0
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros_controllers.git
+      version: jade-devel
+    status: maintained
   ros_emacs_utils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.10.0-0`:
- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## diff_drive_controller

```
* Address -Wunused-parameter warnings
* Limit jerk
* Add param velocity_rolling_window_size
* Minor fixes
  1. Coding style
  2. Tolerance to fall-back to Runge-Kutta 2 integration
  3. Remove unused variables
* Fix the following bugs in the testForward test:
  1. Check traveled distance in XY plane
  2. Use expected speed variable on test check
* Add test for NaN
* Add test for bad URDF
* Contributors: Adolfo Rodriguez Tsouroukdissian, Enrique Fernandez, Paul Mathieu
```
## effort_controllers
- No changes
## force_torque_sensor_controller

```
* Address -Wunused-parameter warnings
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## forward_command_controller

```
* Address -Wunused-parameter warnings
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## gripper_action_controller
- No changes
## imu_sensor_controller

```
* Fixed covariances in ImuSensorController::update
* Address -Wunused-parameter warnings
* Contributors: Adolfo Rodriguez Tsouroukdissian, tappan-at-git
```
## joint_state_controller

```
* Address -Wunused-parameter warnings
* Add extra joints support
  Allow to optionally specify a set of extra joints for state publishing that
  are not contained in the JointStateInterface associated to the controller.
  The state of these joints can be specified via ROS parameters, and remains
  constant over time.
* Add test suite
* Migrate to package format2
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## joint_trajectory_controller

```
* Add joint limits spec to rrbot test robot
* Address -Wunused-parameter warnings
* Reset to semantic zero in HardwareInterfaceAdapter for PositionJointInterface
* Contributors: Adolfo Rodriguez Tsouroukdissian, ipa-fxm
```
## position_controllers
- No changes
## ros_controllers
- No changes
## rqt_joint_trajectory_controller

```
* Adapt to new controller_manager_msgs/ControllerState message definition
* Add vertical scrollbar to joints list
  - Add vertical scrollbar to joints list that appears only when required,
  i.e., when the plugin size cannot accommodate all controller joints.
  - Remove vertical spacer at the bottom of the plugin.
* Clear controllers combo on cm change
  Clear the list of running joint trajectory controllers when the
  controller manager selection changes. This prevents potential conflicts when
  multiple controller managers have controllers with the same names.
* Fail gracefully if URDF is not loaded
  Implement lazy loading of joint limits from URDF.
  This allows to start rqt_joint_trajectory_controller on an otherwise empty ROS
  node graph without crashing.
* Save and restore plugin settings
  - Save current controller_manager and controller selection on plugin close
  - Restore last selection if controller manager and controller are running
* Stricter controller validation
  Only display in the controller combo box those controllers that are running
  _and_ have position and velocity limits specified in the URDF. In the absence
  of limits information, it's not posible to properly initialize the GUI sliders.
* Fix broken URDF joint limits parsing
* Don't choke on missing URDF vel limits
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## velocity_controllers
- No changes
