### PR TITLE
nerian_sp1: 1.2.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2411,7 +2411,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/nerian-vision/nerian_sp1-release.git
-      version: 1.1.2-0
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_sp1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_sp1` to `1.2.0-0`:
- upstream repository: https://github.com/nerian-vision/nerian_sp1.git
- release repository: https://github.com/nerian-vision/nerian_sp1-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.2-0`
## nerian_sp1

```
* Added current release candidate of libvisiontransfer 2.0.0
* Adaptations for libvisiontransfer 2.0.0
* Support transfer of Q matrix
* Contributors: Konstantin Schauwecker
```
