### PR TITLE
Update portage dependencies (argparse, rosdep)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1520,7 +1520,7 @@ python-responses-pip:
 python-rosdep:
   debian: [python-rosdep]
   fedora: [python-rosdep]
-  gentoo: [dev-python/rosdep]
+  gentoo: [dev-util/rosdep]
   osx:
     pip:
       packages: [rosdep]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -96,7 +96,7 @@ python-argparse:
     squeeze: [python-argparse]
     wheezy: [python-argparse]
   fedora: [python]
-  gentoo: [dev-python/argparse]
+  gentoo: [python]
   macports: [py27-argparse]
   opensuse: [python-argparse]
   ubuntu:


### PR DESCRIPTION
Argparse is a default module shipped with python and such contains no builds/does not require any.

rosdep is not a part of `python-dev` anymore but rather `dev-util`
