### PR TITLE
romeo_robot: 0.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3444,6 +3444,30 @@ repositories:
       url: https://github.com/g/roboteq.git
       version: master
     status: maintained
+  romeo_robot:
+    doc:
+      type: git
+      url: https://github.com/ros-aldebaran/romeo_robot.git
+      version: master
+    release:
+      packages:
+      - romeo_bringup
+      - romeo_dcm_bringup
+      - romeo_dcm_control
+      - romeo_dcm_driver
+      - romeo_dcm_msgs
+      - romeo_description
+      - romeo_robot
+      - romeo_sensors_py
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-aldebaran/romeo_robot-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/ros-aldebaran/romeo_robot.git
+      version: master
+    status: maintained
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_robot` to `0.1.2-0`:
- upstream repository: https://github.com/ros-aldebaran/romeo_robot.git
- release repository: https://github.com/ros-aldebaran/romeo_robot-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## romeo_bringup
- No changes
## romeo_dcm_bringup
- No changes
## romeo_dcm_control
- No changes
## romeo_dcm_driver
- No changes
## romeo_dcm_msgs
- No changes
## romeo_description
- No changes
## romeo_robot

```
* fix dependency
* Contributors: Vincent Rabaud
```
## romeo_sensors_py
- No changes
