### PR TITLE
romeo_moveit_config: 0.2.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3444,6 +3444,21 @@ repositories:
       url: https://github.com/g/roboteq.git
       version: master
     status: maintained
+  romeo_moveit_config:
+    doc:
+      type: git
+      url: https://github.com/ros-aldebaran/romeo_moveit_config.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-aldebaran/romeo_moveit_config-release.git
+      version: 0.2.5-0
+    source:
+      type: git
+      url: https://github.com/ros-aldebaran/romeo_moveit_config.git
+      version: master
+    status: maintained
   romeo_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_moveit_config` to `0.2.5-0`:
- upstream repository: https://github.com/ros-aldebaran/romeo_moveit_config.git
- release repository: https://github.com/ros-aldebaran/romeo_moveit_config-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## romeo_moveit_config

```
* cleaning package.xml
* Configuring sensors to compute the Octomap
* Regenerated with moveit_setup_assistant for the last URDF while naming planning groups to be compatible with romeo_moveit_config
* configuring end-effectors and renaming motor groups to be compatible with MoveIt simple grasps
* Contributors: Natalia Lyubova, Vincent Rabaud
```
