### PR TITLE
Removing rostful_node

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8929,12 +8929,6 @@ repositories:
       url: https://gitlab.com/OvGU-ESS/rosshell.git
       version: master
     status: maintained
-  rostful_node:
-    source:
-      type: git
-      url: https://github.com/asmodehn/rostful-node.git
-      version: indigo-devel
-    status: developed
   roswww:
     doc:
       type: git


### PR DESCRIPTION
It hasn't been building properly for a while, and the original repo has changed a lot ( and was renamed ).
I ll re-add the new package as soon as it s a bit more stable...
