### PR TITLE
robbie_architecture: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7676,6 +7676,12 @@ repositories:
       url: https://github.com/WPI-RAIL/rmp_msgs.git
       version: develop
     status: maintained
+  robbie_architecture:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://gitlab.uni-koblenz.de/robbie/robbie_architecture.git
+      version: 1.0.1-0
   robo_rescue:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robbie_architecture` to `1.0.1-0`:
- upstream repository: https://gitlab.uni-koblenz.de/robbie/robbie_architecture.git
- release repository: https://gitlab.uni-koblenz.de/robbie/robbie_architecture.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## robbie_architecture

```
* added robbie_architecture
* Contributors: Niklas Yann Wettengel
```
