### PR TITLE
Adding rangeonly_driver to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7495,6 +7495,12 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  rangeonly_driver:
+    source:
+      type: git
+      url: https://github.com/felramfab/rangeonly_driver.git
+      version: indigo
+    status: developed
   razer_hydra:
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7496,6 +7496,10 @@ repositories:
       version: master
     status: maintained
   rangeonly_driver:
+    doc:
+      type: git
+      url: https://github.com/felramfab/rangeonly_driver.git
+      version: indigo
     source:
       type: git
       url: https://github.com/felramfab/rangeonly_driver.git


### PR DESCRIPTION
I'd like rangeonly_driver to be indexed and documented on ros.org.
