### PR TITLE
jsk_roseus: 1.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3851,7 +3851,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.4.0-0
+      version: 1.4.1-0
     status: maintained
   jsk_smart_apps:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.4.1-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.4.0-0`
## jsk_roseus
- No changes
## roseus

```
* euslisp/actionlib.l

    * euslisp/actionlib.l: set queue_size following to action_server_imp.h and action_client_imp.h #396 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/396> (https://github.com/ros/actionlib/blob/indigo-devel/include/actionlib/server/action_server_imp.h#L121, https://github.com/ros/actionlib/blob/indigo-devel/include/actionlib/client/action_client.h#L210)
    * euslisp/actionlib.l : wait-for-goal: returns nil when no goal is found (https://github.com/jsk-ros-pkg/jsk_roseus/pull/410)
    * euslisp/actionlib.l : goal_id must be unique : set goal_id to use current nsec

* roseus/utils

    * [roseus/euslisp/roseus-utils.l] fix typo message type

* cmake/get_all_depends.py

    * hot fix until https://github.com/jsk-ros-pkg/geneus/pull/42 has released

* test

    * test-simple-client-*500.test: add test to run simple-client with high-speed status
    * test/test-timer.l: surpress output message
    * test/test-tf.l: surpress output message
    * test/test-actionlib.l: surpress output message
    * test/test-add-two-ints.l use ros-info instead of warning-message to suppress message
    * test/add-two-ints-{client,server}.l use ros-info instead of warning-message to suppress the message
    * 00x-fibonacci-test-{1,2}.launch: fibonacci_{server,client}.py is not longer avilable, use fibonacci_{server,client}
    * test/test-genmsg.catkin.test: disable --remove-message test, which does not work on paralllel execution
    * test/test-genmsg: add debug message
    * test/test-actionlib.l: :wait-for-results returns nil when no goal has been sent
    * test/test-actionlib.l: simple-action-client must be a global variable
    * test/test-actionlib.l: add test to run send-goal twice with difference client instance
    * roseus/test/test-actionlib.test: re-enable test-actionlib.test, which is disabled since groovy

* Contributors: Yuki Furuta, Kamada Hitoshi, Kei Okada, Kentaro Wada, Ryohei Ueda, Shunichi Nozawa
```
## roseus_mongo

```
* [roseus_mongo/test/test_mongo_client.test] add missing machine tag for localhost
* [roseus_mongo] test with new mongodb_store; more loose condition to enable limit option
* [roseus_mongo/test/temp_mongodb_store.xml] update launch file path with fix https://github.com/strands-project/mongodb_store/pull/151
  [roseus_mongo/test/test_mongo_client_hydro.test] moved deprecated test launch file for hydro
  [roseus_mongo/CMakeLists.txt] updated to test only CATKIN_ENABLE_TESTING; check mongodb_store version and switch test launch file
* [roseus_mongo/test/test-mongo-client.l] limit test for indigo later only
  [roseus_mongo/euslisp/mongo-client.l] limit ':limit' option only for indigo and later
* Contributors: Kei Okada, Yuki Furuta
```
## roseus_smach

```
* [roseus_smach/src/state-machine.l] another impl for #383 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/383>
* Contributors: Yuki Furuta
```
## roseus_tutorials

```
* add more depends
* roseus_tutorials : use face_detection in opencv_apps
* Contributors: Kei Okada
```
