### PR TITLE
iai_common_msgs: 0.0.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3189,13 +3189,14 @@ repositories:
       - json_prolog_msgs
       - mln_robosherlock_msgs
       - person_msgs
+      - planning_msgs
       - saphari_msgs
       - scanning_table_msgs
       - sherlock_sim_msgs
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/code-iai-release/iai_common_msgs-release.git
-      version: 0.0.5-0
+      version: 0.0.5-1
     status: developed
   icart_mini:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `iai_common_msgs` to `0.0.5-1`:
- upstream repository: https://github.com/code-iai/iai_common_msgs.git
- release repository: https://github.com/code-iai-release/iai_common_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.0.5-0`
## data_vis_msgs

```
* added messages for Task tree visualization
* Added data_vis_msgs/Speech message dedicated for the visualization of speech.
* Added data_vis_msgs/Speech message dedicated for the visualization of speech.
* Contributors: Asil Kaan Bozcuoglu, Daniel Beßler
```
## designator_integration_msgs
- No changes
## dna_extraction_msgs
- No changes
## grasp_stability_msgs
- No changes
## iai_common_msgs

```
* Added json_prolog_msgs to metapackage.
* Person msgs part of iai_common_msgs
* Contributors: Georg Bartels, Jan Winkler
```
## iai_content_msgs
- No changes
## iai_control_msgs

```
* Added a state message for multi-joint velocity-resolved controllers which allow commanding impedances.
* Contributors: Georg Bartels
```
## iai_kinematics_msgs
- No changes
## iai_robosherlock_actions
- No changes
## iai_urdf_msgs
- No changes
## iai_wsg_50_msgs
- No changes
## json_prolog_msgs

```
* Catkinized json_prolog_msgs.
* Copied over json_prolog_msgs from knworob.
* Contributors: Georg Bartels
```
## mln_robosherlock_msgs
- No changes
## person_msgs
- No changes
## planning_msgs
- No changes
## saphari_msgs
- No changes
## scanning_table_msgs
- No changes
## sherlock_sim_msgs
- No changes
