### PR TITLE
jsk_common: 2.0.4-2 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1534,7 +1534,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.0.3-0
+      version: 2.0.4-2
     status: developed
   jsk_common_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.0.4-2`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.0.3-0`
## dynamic_tf_publisher

```
* [dynamic_tf_publisher] Moreh helpful debug message and fix several typos
* [dynamic_tf_publisher] Use with to acquire lock
* [dynamic_tf_publisher] Advertise services at the last of initialization
* [dynamic_tf_publisher] Check service collision in launching tf_publish
* Contributors: Ryohei Ueda
```
## image_view2

```
* [image_view2] Visualize depth image
* [image_view2] Describe about msg types with topics
* [image_view2] Describe about some publising topics
* [image_view2] Publish cropped image with roi Currently this is only work with rectangle mode.
* [image_view2] Describe ~interactive_mode actual value
* [image_view2] Add document about grabcut rect interaction
* [image_view2] Add document about grabcut interaction
* [image_view2] Add document about poly interaction
* [image_view2] Add document about line interaction
* [image_view2] Add documentation about rectangle mode interaction
* [image_view2] Add document about subscribing topics and advertising services
* [image_view2] Fix typo in document: ImageMarker -> ImageMarker2
* [image_view2] Add README.md
* Contributors: Kei Okada, Kentaro Wada, Ryohei Ueda
```
## jsk_common
- No changes
## jsk_data

```
* [jsk_data/hrp2_rosbag_always.sh] Record capture points
* [jsk_data] Add stamp to file basename
* [jsk_data] Add flake8 code style check
* [jsk_data] Change path of tests for python package
* [jsk_data/launch] add urata_record.launch
* [jsk_data] Correctly gets selected file by percol
* [jsk_data] Describe about downloading large file from Google Drive
* [jsk_data] Add odom topics to be recorded by rosbag
* [jsk_data] Record PC voltage
* [jsk_data] Add shm_servo_state to rosbag always
* [jsk_data] Add rosbag_always.py document
* add new subscribe topic
* [jsk_data] Select filename at getting with jsk_data  Closes #1141 <https://github.com/jsk-ros-pkg/jsk_common/issues/1141>
* [jsk_data] Documentation about $ jsk_data cli
* [jsk_data] Refactor: add cmd_pubinfo to __all__
* [jsk_data] Select filename with percol in pubinfo
* [jsk_data] add camera parm to pr2_play.launch
* [jsk_data] Estimate filename if longer than 40
  Because gdrive does not return full title if it is longer than 40 Closes #1155 <https://github.com/jsk-ros-pkg/jsk_common/issues/1155>
* [jsk_data] returning files does not work for zsh comp
* [jsk_data] Add file completion in bash
* [jsk_data] Refactor: indentation and comment
* [jsk_data] Display view url by pubinfo
* [jsk_data] Check existence of .ssh/config
* [jsk_data] Config key check when getting config from .ssh/config Closes #1137 <https://github.com/jsk-ros-pkg/jsk_common/issues/1137>
* [jsk_data] Refactor cmd_put with google_drive_download_url
* [jsk_data] Add pubinfo subcommand
* [jsk_data] Remove old Makefile
* [jsk_data] Remove old jsk_data shell function
* [jsk_data] Add completion script for jsk_data
* [jsk_data] Add jsk_data command
* [jsk_data] Show size of files when listing remote bag files
* Add jsk_data function to handle data from anywhere
* [jsk_data] Record pgain and dgain in case something happens
* [jsk_tools] Use roslaunch internaly in rosbag_always.py in order to enable respawning
* [jsk_data/hrp2_rosbag_always.sh] Record more topics
* [jsk_tools] Record /urata_status topic in hrp2_rosbag_always.sh
* [jsk_data] Popup notification on desktop when removing a bag file
* [jsk_data] Handle bag files correctly with multiple ordered index
* [jsk_data/rosbag_always.py] Supress message about directory size and colorize message about removing bag files
* [jsk_data] Add more topics to record in hrp2_rosbag_always.sh
* Contributors: Kentaro Wada, Ryohei Ueda, Yusuke Oshiro, Yuto Inagaki, Eisoku Kuroiwa, Iori Yanokura
```
## jsk_network_tools

```
* [jsk_network_tools] Disable test
* [jsk_network_tools] Do not run rostest unless CATKIN_ENABLE_TESTING is false
* [jsk_topic_tools] Add name attribute to test node
* [jsk_network_tools] Depends on roscpp and rospy
* [jsk_network_tools/silverhammer_highspeed_internal_receiver] Chop msg.data length to actual received size
* [jsk_network_tools] Update last_received_seq_id correctly at first time
* [jsk_network_tools] Add kbps and mbps unit to network_status
* [jsk_network_tools] Add ${hostname}/nonlocal/{receive, transmit} topics to accumurate all the communication amount except for localhost
* [jsk_network_tools] Add C++ implementation of silverhammer_highspeed_receiver. It cooperates with python thin wrapper and bridged via ros between them.
* Contributors: Ryohei Ueda
```
## jsk_tilt_laser

```
* [jsk_tilt_laser] Remove image_rect pipeline temporary because of high load. It is needed to be tuned.
* [jsk_tilt_laser] Add image_rect multi_resolution pipeline
* [jsk_tilt_laser] Add NODELET_INDEX options to use same manager with different rosparam by nodelets_i
* [jsk_tilt_laser] Separate left camera stereo image pipeline
* [jsk_tilt_laser] Include for multi resolution image for right camera
* [jsk_tilt_laser] Add viewer to check multisense local topics
* [jsk_tilt_laser] Specify twist_frame_id of multisense laser to publish velocity
* [jsk_tilt_laser] Add run_distance_filters argument to disable filtering based on distance
* Contributors: Ryohei Ueda, hrpuser, iori
```
## jsk_tools

```
* [jsk_topic_tools/rosping_existence] Speak dead nodes
* [jsk_tools] Remove test stdout space, This should be reasonable because rosparam also strip parameter,   automatically.
* [jsk_tools] Warning about designed for test.  After long discussion at #1216 <https://github.com/jsk-ros-pkg/jsk_common/issues/1216>
* [jsk_tools] test_stdout.py tests each lines
* [jsk_tools] Add delay_timestamp.py
* [jsk_tools] Install run_tmux for gdb debugging. That is described here:  http://wiki.ros.org/roslaunch/Tutorials/Roslaunch%20Nodes%20in%20Valgrind%20or%20GDB
* [jsk_tools] Add rosrecord shell function
* [jsk_tools] Set calc_md5.py to correct dir (src)
* [jsk_tools] Add ~shell param for test_stdout.py
* [jsk_tools] FIx dot.emacs to run euslisp correctly
* [jsk_tools] Add test utility node test_stdout
* [jsk_tools] Add ntp_monitor to local_pc_monitor
* [jsk_tools] add rosbag_record_interactive. select topic using zenity and record them
* [jsk_tools] show minorticks and grid
* [jsk_tools] Correct order of ROS_IP in list of hostname -I.  Closes #1170 <https://github.com/jsk-ros-pkg/jsk_common/issues/1170>
* [jsk_tools] Add document about roscore_regardless.py
* [jsk_tools] Commandline tool for selection with percol
* [jsk_tools] Add completion for restart_travis
* [jsk_tools] Add documentation for restart_travis
* [jsk_tools] Add restart_travis function
* [jsk_tools] Disable vi-mode in tmux
* [jsk_tools] Add document about tmux.conf
* [jsk_tools] New users to force_to_rename_changelog_user.py.
* Remove no need stdout in rossetip
* [jsk_tools] Add document about inferior-lisp-mode
* [jsk_tools] Write to stderr when rossetip fails
* [jsk_tools] Do not create duplicated inferior-lisp buffer
* [jsk_tools/force_to_rename_changelog_user.py] New 3 users
* [jsk_tools] Use keyboard to toggle legend
* [jsk_common/bag_plotter] Optimize bag parsing speed by topics keyword of read_messages method
* [jsk_tools] Add rosemacs-el to dependency
* [jsk_tools/bag_plotter] Synchronize x axis zoom/pan and add cheap button to toggle legend
* [jsk_tools/bag_plotter] Toggle legend by clicking
* [jsk_tools/bag_plotter] Support manual layout of figures
* [jsk_tools/bag_plotter] Support plotting of array
* [jsk_tools/bag_plotter] Support multiple bag files
* [jsk_tools/bag_plotter.py] Support --duration and --start option
* [jsk_tools/bag_plotter] Use interactive mode of matplotlib to enable Ctrl-C
* [jsk_tools] use hostname to search ip
* [jsk_tools] Add dot-files directory, which is copied from JSK internal svn, to share common setup in shared-users
* Contributors: Eisoku Kuroiwa, Yuki Furuta, Kentaro Wada, Ryohei Ueda
```
## jsk_topic_tools

```
* [jsk_topic_tools] test related things in CATKIN_ENABLE_TESTING block
* [jsk_topic_tools] Test warnNoRemap  Closes jsk-ros-pkg/jsk_recognition#1322 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/1322>
* [jsk_topic_tools/rosping_existence] Speak dead nodes
* Use gcc -z defs to check undefined symbols in shared objects  Related to https://github.com/jsk-ros-pkg/jsk_recognition/pull/1330
* [jsk_topic_tools] Retry to 3 times
* [jsk_topic_tools] Test rosparam_utils.cpp with gtest
* [jsk_topic_tools] Test warn_no_remap
* [jsk_topic_tools] Test jsk_topic_tools.log_util
* [jsk_topic_tools] Test jsk_topic_tools.name_util
* [jsk_topic_tools] add_library src/log_utils.cpp
* build_depend -> test_depend roscpp_tutorials
* Reasonable connection num for connection_based_nodelet
* [jsk_topic_tools] Use retry for <test> tag
* Refactor test_hz_measure.py as good example
* Refactor test_connection.py as good example
* Refactor: test_block.py as good example
* [jsk_topic_tools] display input/output by --inout
* [jsk_topic_tools] Fix style (indent)
* [jsk_topic_tools] Follow name rule *_utils.py
* [jsk_topic_tools] warnNoRemap for cpp nodes
* Generate Documentation for jsk_topic_tools
* [jsk_topic_tools] Function to warn with no remappings
* [jsk_topic_tools] Correctly return instance
* [jsk_topic_tools] Retry test max to 3 times
* [jsk_topic_tools] add topic_statistics.py
* [jsk_topic_tools] Correctly unsubscribe with multiple publishers
* [jsk_topic_tools] ``add_rostest`` problem should be fixed in latest catkin For https://github.com/jsk-ros-pkg/jsk_common/pull/1178#issuecomment-147396447
* [jsk_topic_tools] Describe about ~always_subscribe in warning
* [jsk_topic_tools] Add ~always_subscribe param for ConnectionBasedTransport
* [jsk_topic_tools] Correctly set connection status
* [jsk_topic_tools] Add log_utils.py
* [jsk_topic_tools] Add python-enum34 as run_depend
* [jsk_topic_tools] List depends in alphabetical order
* [jsk_topic_tools] Test ConnectionBasedTransport
* [jsk_topic_tools] Test ConnectionBasedNodelet with rostest
* [jsk_topic_tools] Rename to test_connection_based_nodelet.test
* [jsk_topic_tools] Python ConnectionBasedTransport
* [jsk_topic_tools] Utility to publish PoseStamped with given static transformation
* [jsk_topic_tools/ConnectionBasedNodelet] Read verbose_connection as well as ~verbose_connection
* [jsk_topic_tools/ConnectionBasedNodelet] ~verbose_connection parameter to print verbose messages about connection
* [jsk_topic_tools] Ros error for rosparam type conversion
* [jsk_topic_tools] Warn when no connection in a few sec Closes #1132 <https://github.com/jsk-ros-pkg/jsk_common/issues/1132>  The warning message should be write with ROS_INFO,  for no many warning when running with roslaunch.
* [jsk_topic_tools] Supress output messages from testing
* [jsk_topic_tools] Depends on roscpp and rostime explicitly
* [jsk_topic_tools] Faster implementation of test_topic_compare.py by removing magic sleep
* [jsk_topic_tools/ConnectionBasedNodelet] Add latch option to advertise template method
* [jsk_topic_tools/LightweightThrottle] Clean-up codes and added some comments
* [jsk_topic_tools] Add readme about standalone_complexed_nodelet
* [jsk_topic_tools] check /run_id param to know roscore is restarted or not
* [jsk_topic_tools/standalone_complexed_nodelet] Fix handling of reampping name resolvance
* [jsk_topic_tools] Add space after [functionname]
* Contributors: Yuki Furuta, Kei Okada, Kentaro Wada, Ryohei Ueda
```
## multi_map_server
- No changes
## virtual_force_publisher
- No changes
