### PR TITLE
moveit_simple_actions: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5175,6 +5175,17 @@ repositories:
       url: https://github.com/ros-planning/moveit_setup_assistant.git
       version: indigo-devel
     status: maintained
+  moveit_simple_actions:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/nlyubova/moveit_simple_actions-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/nlyubova/moveit_simple_actions.git
+      version: master
+    status: maintained
   moveit_simple_grasps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_simple_actions` to `0.0.3-0`:
- upstream repository: https://github.com/nlyubova/moveit_simple_actions
- release repository: https://github.com/nlyubova/moveit_simple_actions-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
