### PR TITLE
jsk_3rdparty: 2.0.12-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3670,6 +3670,7 @@ repositories:
       - mini_maxwell
       - nlopt
       - opt_camera
+      - pgm_learner
       - rospatlite
       - rosping
       - rostwitter
@@ -3678,7 +3679,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.0.11-1
+      version: 2.0.12-1
     status: developed
   jsk_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.0.12-1`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.0.11-1`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## collada_urdf_jsk_patch
- No changes
## downward

```
* package.xml : downward uses time command on running (https://github.com/jsk-ros-pkg/jsk_planning/pull/30#issuecomment-146065373)
* Contributors: Kei Okada
```
## ff
- No changes
## ffha
- No changes
## jsk_3rdparty
- No changes
## julius
- No changes
## laser_filters_jsk_patch
- No changes
## libcmt
- No changes
## libsiftfast
- No changes
## mini_maxwell
- No changes
## nlopt

```
* [nlopt] Stop compiling with octave
  Fixes #39 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/39>
  This is because there is an error while compiling nlopt with octave on
  Indigo Ubuntu 14.04.
* Contributors: Kentaro Wada
```
## opt_camera
- No changes
## pgm_learner

```
* pgm_learner/package.xml : bad version number
* [pgm_learner/euslisp/*-sample.l] refactor sample lisp codes
  [pgm_learner/euslisp/pgm-learner-client.l] add graph visualization for lg bayesian graph
* [pgm_learner/scripts/pgm_learner_server.py] add debug logging
* [pgm_learner/README.md] remove achieved TODO
* [pgm_learner/euslisp/pgm-learner-client.l] add graph visualization of lg-bayesian-graph
* [pgm_learner/euslisp/pgm-learner-client.l] fix: use remove-duplicates to fetch unique node names instead of unique
* [pgm_learner/euslisp/pgm-learner-client.l] disable validation
* [pgm_learner] add pgm_learner package
* Contributors: Furushchev, Kei Okada
```
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## sklearn
- No changes
## voice_text
- No changes
