### PR TITLE
Use fltk --devel formula for el capitan

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -89,8 +89,22 @@ flex:
       packages: []
 fltk:
   osx:
-    homebrew:
-      packages: [fltk]
+    "el capitan":
+      homebrew:
+        install_flags: [--devel]
+        packages: [fltk]
+    leopard:
+      homebrew: [fltk]
+    lion:
+      homebrew: [fltk]
+    mavericks:
+      homebrew: [fltk]
+    "mountain lion":
+      homebrew: [fltk]
+    snow:
+      homebrew: [fltk]
+    yosemite:
+      homebrew: [fltk]
 fluid:
   osx:
     homebrew:


### PR DESCRIPTION
because the flak formula either does not compile or function as expected on OS X
versions newer than Yosemite due to an upstream incompatibility.
