### PR TITLE
jsk_model_tools: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3758,7 +3758,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.1.13-0
+      version: 0.2.0-0
     status: developed
   jsk_planning:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.2.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.13-0`
## eus_assimp

```
* move to 0.2.0, which only available from indigo
* [eus_assimp] Add .gitignore
* Contributors: Kentaro Wada
```
## euscollada

```
* move to 0.2.0, which only available from indigo
* keep backward compatibility, add glvertices slot to collada-body
* [euscollada/src/euscollada-robot.l] use-6dof-joint-leg-gain nil by default
* make qpqmodel with glvertices
* merge euscollada-robot.l
* fix large matrix
* [euscollada/src/euscollada-robot_urdfmodel.l, euscollada-robot.l] Add arugment to use 6dof-joint leg weighing for evaluate the influence with it and without it.
* [euscollada] Compare rosversion using the alphabetical order
* fix typo
* use changes for using glbody in irtgl.l
* Contributors: Kentaro Wada, Shunichi Nozawa, Yohei Kakiuchi
```
## eusurdf

```
* move to 0.2.0, which only available from indigo
* add instruction of converting eus->urdf
* modify sample usage comment of irteus2urdf-for-gazebo.
* use the resolved path of ros package to find eusurdf directory when path is nil. You can pass eusurdf path as argument to run in catkin build.
* add .gitignore to keep model directory
* generate model directory if not found.
* delete manifest.xml for gazebo model directory.
* Contributors: Masaki Murooka
```
## jsk_model_tools

```
* move to 0.2.0, which only available from indigo
```
