### PR TITLE
fulanghua_navigation: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2432,6 +2432,24 @@ repositories:
       url: https://github.com/paulbovbel/frontier_exploration.git
       version: indigo-devel
     status: maintained
+  fulanghua_navigation:
+    release:
+      packages:
+      - fulanghua_ekf_2d
+      - fulanghua_evaluator
+      - fulanghua_navigation
+      - fulanghua_srvs
+      - fulanghua_static_path_publisher
+      - fulanghua_waypoints_nav
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/DaikiMaekawa/fulanghua_navigation-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/DaikiMaekawa/fulanghua_navigation.git
+      version: 0.0.1
+    status: developed
   gazebo2rviz:
     source:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2436,7 +2436,6 @@ repositories:
     release:
       packages:
       - fulanghua_ekf_2d
-      - fulanghua_evaluator
       - fulanghua_navigation
       - fulanghua_srvs
       - fulanghua_static_path_publisher

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2448,7 +2448,7 @@ repositories:
     source:
       type: git
       url: https://github.com/DaikiMaekawa/fulanghua_navigation.git
-      version: 0.0.1
+      version: indigo-devel
     status: developed
   gazebo2rviz:
     source:


### PR DESCRIPTION
Increasing version of package(s) in repository `fulanghua_navigation` to `0.0.1-0`:
- upstream repository: https://github.com/DaikiMaekawa/fulanghua_navigation.git
- release repository: https://github.com/DaikiMaekawa/fulanghua_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ros/rosdistro/9881)

<!-- Reviewable:end -->
