### PR TITLE
rospeex: 2.14.2-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8894,7 +8894,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://bitbucket.org/rospeex/rospeex-release.git
-      version: 2.14.2-1
+      version: 2.14.2-2
     source:
       type: git
       url: https://bitbucket.org/rospeex/rospeex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospeex` to `2.14.2-2`:
- upstream repository: https://bitbucket.org/rospeex/rospeex.git
- release repository: https://bitbucket.org/rospeex/rospeex-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.14.2-1`
## rospeex
- No changes
## rospeex_audiomonitor
- No changes
## rospeex_core

```
* Add sr.base, sr.google, sr.microsoft, sr.nict packages to rospeex_core/setup.py
* Modified docomo API and Microsoft API to rospeex_core tests
* Add docomo API and Microsoft API to rospeex_core
```
## rospeex_if

```
* Modified docomo API and Microsoft API to rospeex_core tests
* Add docomo API and Microsoft API to rospeex_core
```
## rospeex_launch

```
* Add docomo API and Microsoft API to rospeex_core
```
## rospeex_msgs
- No changes
## rospeex_samples
- No changes
## rospeex_webaudiomonitor

```
* Update rospeex_webaudiomonitor/CMakeLists.txt
```
