### PR TITLE
jsk_model_tools: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3775,7 +3775,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     status: developed
   jsk_planning:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.2.1-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.0-0`
## eus_assimp
- No changes
## euscollada
- No changes
## eusurdf

```
* package.xml; we nee do rosrun to generate models
* generate eus model and convert it to urdf from voxel grid
* use the resolved path of ros package to find eusurdf directory when path is nil. You can pass eusurdf path as argument to run in catkin build.
* add generate-model-from-voxel.l to generate eus cube list from voxel.
* Contributors: Kei Okada, Masaki Murooka
```
## jsk_model_tools
- No changes
