### PR TITLE
homer_mapnav: 1.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3053,7 +3053,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
-      version: 1.0.5-0
+      version: 1.0.6-0
   homer_object_recognition:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_mapnav` to `1.0.6-0`:
- upstream repository: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.5-0`
## homer_map_manager

```
* removed env HOMER_DIR from CMakeLists.txt
* Contributors: Niklas Yann Wettengel
```
## homer_mapnav_msgs
- No changes
## homer_mapping

```
* removed env HOMER_DIR from CMakeLists.txt
* Contributors: Niklas Yann Wettengel
```
## homer_nav_libs

```
* added export tags
* added eigen as run_depend
* removed env HOMER_DIR from CMakeLists.txt
* Contributors: Niklas Yann Wettengel
```
## homer_navigation

```
* removed env HOMER_DIR from CMakeLists.txt
* Contributors: Niklas Yann Wettengel
```
