### PR TITLE
vision_opencv: 1.11.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10944,7 +10944,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.11.8-0
+      version: 1.11.9-0
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.11.9-0`:
- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.8-0`
## cv_bridge

```
* deal with endianness
* add cvtColorForDisplay
* Improved efficiency by using toCvShare instead of toCvCopy.
* Add format enum for easy use and choose format.
* fix compilation warnings
* start to extend the cv_bridge with cvCompressedImage class, that will convert from cv::Mat opencv images to CompressedImage ros messages and vice versa
* Contributors: Carlos Costa, Vincent Rabaud, talregev
```
## image_geometry

```
* add a condition if D=None
* fix compilation warnings
* Contributors: Vincent Rabaud, YuOhara
```
## opencv_apps

```
* Accept grayscale images as input as well
* Add format enum for easy use and choose format.
* Contributors: Felix Mauch, talregev
```
## vision_opencv

```
* Add opencv_apps to vision_opencv dependency
* Contributors: Ryohei Ueda
```
