### PR TITLE
image_common: 1.11.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1358,7 +1358,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/image_common-release.git
-      version: 1.11.7-0
+      version: 1.11.8-0
     source:
       type: git
       url: https://github.com/ros-perception/image_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `1.11.8-0`:
- upstream repository: https://github.com/ros-perception/image_common.git
- release repository: https://github.com/ros-gbp/image_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.7-0`
## camera_calibration_parsers

```
* Remove no-longer-neccessary flags to allow OS X to use 0.3 and 0.5 of yaml-cpp.
* remove buggy CMake message
* Contributors: Helen Oleynikova, Vincent Rabaud
```
## camera_info_manager

```
* fix compilation on Fedora, fixes #42 <https://github.com/ros-perception/image_common/issues/42>
* Contributors: Vincent Rabaud
```
## image_common
- No changes
## image_transport
- No changes
## polled_camera
- No changes
