### PR TITLE
ecto_ros: 0.4.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -806,7 +806,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ecto_ros-release.git
-      version: 0.4.6-0
+      version: 0.4.8-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto_ros` to `0.4.8-0`:
- upstream repository: https://github.com/plasmodic/ecto_ros.git
- release repository: https://github.com/ros-gbp/ecto_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.4.6-0`
## ecto_ros

```
* reenable some tests
* fix constness
* Expose tcp_nodelay parameter for subscribers.
* cleaner dependency handling
* Contributors: Daniel Stonier, Vincent Rabaud
```
