### PR TITLE
jsk_common: 2.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3718,7 +3718,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.0.4-1
+      version: 2.0.5-0
     status: developed
   jsk_common_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.0.5-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.0.4-1`
## dynamic_tf_publisher
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_data
- No changes
## jsk_network_tools
- No changes
## jsk_tilt_laser
- No changes
## jsk_tools
- No changes
## jsk_topic_tools

```
* [jsk_topic_tools] Rename _util.py -> _utils.py
* [jsk_topic_tools] Also fix import in test_name_util.py: name_util -> name_utils
* [jsk_topic_tools] Fix renamed module import in log_utils: name_util -> name_utils
* Contributors: Iori Kumagai, Kentaro Wada, Yuto Inagaki
```
## multi_map_server
- No changes
## virtual_force_publisher
- No changes
