### PR TITLE
rospeex: 2.14.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8894,7 +8894,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://bitbucket.org/rospeex/rospeex-release.git
-      version: 2.14.3-0
+      version: 2.14.4-0
     source:
       type: git
       url: https://bitbucket.org/rospeex/rospeex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospeex` to `2.14.4-0`:
- upstream repository: https://bitbucket.org/rospeex/rospeex.git
- release repository: https://bitbucket.org/rospeex/rospeex-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.14.3-0`
## rospeex
- No changes
## rospeex_audiomonitor
- No changes
## rospeex_core

```
* Remove python-httplib2 from rospeex_core/package.xml
```
## rospeex_if
- No changes
## rospeex_launch
- No changes
## rospeex_msgs
- No changes
## rospeex_samples
- No changes
## rospeex_webaudiomonitor
- No changes
