### PR TITLE
robbie_architecture: 1.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7733,7 +7733,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/robbie_architecture.git
-      version: 1.0.6-0
+      version: 1.0.7-0
   robo_rescue:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robbie_architecture` to `1.0.7-0`:
- upstream repository: https://gitlab.uni-koblenz.de/robbie/robbie_architecture.git
- release repository: https://gitlab.uni-koblenz.de/robbie/robbie_architecture.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.6-0`
## robbie_architecture

```
* install headers
* Contributors: Niklas Yann Wettengel
```
