### PR TITLE
.: 0.1.27-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10,6 +10,19 @@ release_platforms:
   - saucy
   - trusty
 repositories:
+  .:
+    release:
+      packages:
+      - robot_self_filter
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/robot_self_filter-gbp.git
+      version: 0.1.27-0
+    source:
+      type: git
+      url: https://github.com/pr2/robot_self_filter.git
+      version: indigo-devel
+    status: maintained
   aau_multi_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `.` to `0.1.27-0`:
- upstream repository: https://github.com/pr2/robot_self_filter.git
- release repository: https://github.com/pr2-gbp/robot_self_filter-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
