### PR TITLE
robot_self_filter: 0.1.27-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7829,6 +7829,17 @@ repositories:
       url: https://github.com/WPI-RAIL/robot_pose_publisher.git
       version: develop
     status: maintained
+  robot_self_filter:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pr2-gbp/robot_self_filter-gbp.git
+      version: 0.1.27-1
+    source:
+      type: git
+      url: https://github.com/pr2/robot_self_filter.git
+      version: indigo-devel
+    status: maintained
   robot_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_self_filter` to `0.1.27-1`:
- upstream repository: https://github.com/pr2/robot_self_filter.git
- release repository: https://github.com/pr2-gbp/robot_self_filter-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
