### PR TITLE
pr2_mechanism: 1.8.16-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3040,6 +3040,24 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: indigo-devel
     status: maintained
+  pr2_mechanism:
+    release:
+      packages:
+      - pr2_controller_interface
+      - pr2_controller_manager
+      - pr2_hardware_interface
+      - pr2_mechanism
+      - pr2_mechanism_diagnostics
+      - pr2_mechanism_model
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_mechanism-release.git
+      version: 1.8.16-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_mechanism.git
+      version: indigo-devel
+    status: maintained
   pr2_mechanism_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_mechanism` to `1.8.16-0`:
- upstream repository: https://github.com/pr2/pr2_mechanism.git
- release repository: https://github.com/pr2-gbp/pr2_mechanism-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
