### PR TITLE
pr2_controllers: 1.10.13-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3040,6 +3040,28 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: indigo-devel
     status: maintained
+  pr2_controllers:
+    release:
+      packages:
+      - ethercat_trigger_controllers
+      - joint_trajectory_action
+      - pr2_calibration_controllers
+      - pr2_controllers
+      - pr2_controllers_msgs
+      - pr2_gripper_action
+      - pr2_head_action
+      - pr2_mechanism_controllers
+      - robot_mechanism_controllers
+      - single_joint_position_action
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_controllers-release.git
+      version: 1.10.13-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_controllers.git
+      version: indigo-devel
+    status: maintained
   pr2_mechanism:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_controllers` to `1.10.13-0`:
- upstream repository: https://github.com/pr2/pr2_controllers.git
- release repository: https://github.com/pr2-gbp/pr2_controllers-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## ethercat_trigger_controllers

```
* Updated maintainership
* Contributors: dash
```
## joint_trajectory_action
- No changes
## pr2_calibration_controllers

```
* Updated maintainership
* Contributors: dash
```
## pr2_controllers
- No changes
## pr2_controllers_msgs

```
* Updated maintainership
* Contributors: dash
```
## pr2_gripper_action

```
* Updated maintainership
* Contributors: dash
```
## pr2_head_action

```
* Updated maintainership
* Contributors: dash
```
## pr2_mechanism_controllers

```
* Updated maintainership
* Contributors: dash
```
## robot_mechanism_controllers

```
* Updated maintainership
* Contributors: dash
```
## single_joint_position_action

```
* Updated maintainership
* Contributors: dash
```
