### PR TITLE
multimaster_fkie: 0.4.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2160,7 +2160,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.4.2-0
+      version: 0.4.3-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.4.3-0`:
- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.4.2-0`
## default_cfg_fkie
- No changes
## master_discovery_fkie

```
* master_discovery_fkie: fixed compatibility to older versions
* master_fiscovery_fkie: integrated pull request #24 <https://github.com/fkie/multimaster_fkie/issues/24>
  Thanks for creating the PR to @garyservin and @mikeodr!
  The change lets you define an interface by ~interface, ROS_IP envar
  or append the interface to multicast group like
  mailto:226.0.0.0@192.168.101.10. The master_discovery then binds to the
  specified interface and creates also an unicast interface for active
  requests on communication problems or if ~robot_hosts are defined.
  Now you can also disable the multicast communication by setting
  ~send_mcast to false. In this case the requests are send to hosts
  defined in ~robot_hosts.
* master_discovery_fkie: fixed the 'local' assignment while updateInfo()
* master_discovery_fkie: adopt some changes from pull request #24 <https://github.com/fkie/multimaster_fkie/issues/24>
  Thanks to @garyservin for pull request #24 <https://github.com/fkie/multimaster_fkie/issues/24>:
  * Don't exit if we're on localhost, just log a warning
  * Added support for different logging levels in master_monitor:
  currently all logs are marked as warnings, where some should be marked
  as errors.
* multimaster_fkie: reduced logs and warnings on stop nodes while closing node_manager
* multimaster_fkie: reduced logging of exceptions
* master_discovery_fkie: spaces and typos removed
* master_discovery_fkie: fixed link quality calculation
* Contributors: Alexander Tiderko
```
## master_sync_fkie

```
* master_discovery_fkie: adopt some changes from pull request #24 <https://github.com/fkie/multimaster_fkie/issues/24>
  Thanks to @garyservin for pull request #24 <https://github.com/fkie/multimaster_fkie/issues/24>:
  * Added support for different logging levels in master_monitor:
  currently all logs are marked as warnings, where some should be marked
  as errors.
* Contributors: Alexander Tiderko
```
## multimaster_fkie
- No changes
## multimaster_msgs_fkie
- No changes
## node_manager_fkie

```
* node_manager_fkie: start rviz now as NO rqt plugin
* node_manager_fkie: fixed the sort of paramerter in add parameter dialog
* node_manager_fkie: adapt the chagnes in master_discovery_fkie
* node_manager_fkie: fixed the tooltip of the buttons in the description dock
* node_manager_fkie: stop /master_discovery node before poweroff host to avoid timout problems
* multimaster_fkie: reduced logs and warnings on stop nodes while closing node_manager
* node_manager_fkie: added a new button for call service
* node_manager_fkie: added a "copy log path to clipboard" button
* node_manager_fkie: fixed the displayed count of nodes with launch files in description dock
* node_manager_fkie: fixed errors showed while stop nodes on close
* multimaster_fkie: reduced logging of exceptions
* node_manager_fkie: added poweroff command to the host description
* node_manager_fkie: added tooltips to the buttons in description dock
* node_manager_fkie: replaced some icons
* node_manager_fkie: added advanced start link to set console format and loglevel while start of nodes
* node_manager_fkie: skip commented nodes while open a configuration for a selected node
* node_manager_fkie: fixed xml editor; some lines was hide
* node_manager_fkie: added ctrl+shift+slash to shortcuts for un/comment text in editor
  *some small changes in find dialog
* Contributors: Alexander Tiderko
```
