### PR TITLE
roswww: 0.1.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3917,7 +3917,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/roswww-release.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/tork-a/roswww.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roswww` to `0.1.6-0`:
- upstream repository: https://github.com/tork-a/roswww.git
- release repository: https://github.com/tork-a/roswww-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.5-0`
## roswww

```
* [sys] Add travis config and small unit tests (#27 <https://github.com/tork-a/roswww/issues/27>)
* [doc] Utilize rosdoc_lite for document generation on ros build farm (#25 <https://github.com/tork-a/roswww/issues/25>)
* Contributors: Isaac I.Y. Saito
```
