### PR TITLE
rospeex: 2.14.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3872,6 +3872,30 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: indigo-devel
     status: maintained
+  rospeex:
+    doc:
+      type: git
+      url: https://bitbucket.org/rospeex/rospeex.git
+      version: jade
+    release:
+      packages:
+      - rospeex
+      - rospeex_audiomonitor
+      - rospeex_core
+      - rospeex_if
+      - rospeex_launch
+      - rospeex_msgs
+      - rospeex_samples
+      - rospeex_webaudiomonitor
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://bitbucket.org/rospeex/rospeex-release.git
+      version: 2.14.4-0
+    source:
+      type: git
+      url: https://bitbucket.org/rospeex/rospeex.git
+      version: jade
+    status: developed
   rospilot:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rospeex` to `2.14.4-0`:
- upstream repository: https://bitbucket.org/rospeex/rospeex.git
- release repository: https://bitbucket.org/rospeex/rospeex-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rospeex
- No changes
## rospeex_audiomonitor
- No changes
## rospeex_core

```
* Remove python-httplib2 from rospeex_core/package.xml
```
## rospeex_if
- No changes
## rospeex_launch
- No changes
## rospeex_msgs
- No changes
## rospeex_samples
- No changes
## rospeex_webaudiomonitor
- No changes
