### PR TITLE
audio_common: 0.2.9-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -187,7 +187,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.2.8-0
+      version: 0.2.9-0
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.2.9-0`:
- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.8-0`
## audio_capture

```
* [audio_capture] add error handler
* [audio_capture] add option to publish captured audio data as wav format
* Fixed memory leak (see #18 <https://github.com/ros-drivers/audio_common/issues/18>).
* Removed trailing whitespace.
* Contributors: Felix Duvallet, Furushchev
```
## audio_common
- No changes
## audio_common_msgs
- No changes
## audio_play
- No changes
## sound_play

```
* [soundplay_node] fix resources not being released on dict cleanup
  This was resulting in the number of sink inputs reaching the maximum threshold,
  (32 on ubuntu 14.04 with pulseaudio 4.0) after which no more sounds could be
  played by the node. It would only happen if the rate of sounds being played was
  slower than the dictionary cleanup.
* depend on actionlib.
* Introduce unit test to ensure soundclient is started correctly.
* Example of using the explicit blocking parameter to override the class setting.
* SoundClient can also explicitly specify whether or not to block while playing the sound.
  Each play/repeat/say/... method can take an option blocking=True|False argument (using **kwargs), which over-rides the class-wide setting.
  Conflicts:
  sound_play/src/sound_play/libsoundplay.py
* do both in same script.
* Added script showing the various blocking/non-blocking ways of using SoundClient.
* removed trailing whitespace only
  Conflicts:
  sound_play/scripts/say.py
* loginfo -> logdebug.
* Enable blocking calls inside libsoundplay's SoundClient.
  This makes use of the actionlib interface provided by soundplay_node, by ensuring SoundClient receives a response before returning.
  Turn this on by: SoundClient(blocking=true).
  Conflicts:
  sound_play/src/sound_play/libsoundplay.py
* Use new-style python classes (inherits from object).
  Conflicts:
  sound_play/src/sound_play/libsoundplay.py
* removed trailing whitespace.
  Conflicts:
  sound_play/src/sound_play/libsoundplay.py
* Revert "Set the volume in each of the sound_play actionlib tests."
  This reverts commit 55ab08c882809fc6d21affb849a7dac9f1901867.
  Indigo-devel does not have the volume API
* Set the volume in each of the sound_play actionlib tests.
  This makes the script actually play the sounds it requests.
* Specify queue size explicitly.
  Removed warning message printed each time soundplay_node was started.
* remove trailing whitespace only.
* Fix wiki links
* Contributors: David V. Lu, Felix Duvallet, Michal Staniaszek, trainman419
```
