### PR TITLE
jsk_common: 2.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3718,7 +3718,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.0.5-0
+      version: 2.0.6-0
     status: developed
   jsk_common_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.0.6-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.0.5-0`
## dynamic_tf_publisher
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_data
- No changes
## jsk_network_tools
- No changes
## jsk_tilt_laser
- No changes
## jsk_tools

```
* [jsk_tools] Add tool to test published topic (check msg comes)
* [jsk_tools] Set parent class as object and return bool in check()
* Contributors: Kentaro Wada
```
## jsk_topic_tools
- No changes
## multi_map_server
- No changes
## virtual_force_publisher
- No changes
