### PR TITLE
PACKAGE: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10,6 +10,23 @@ release_platforms:
   - saucy
   - trusty
 repositories:
+  PACKAGE:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/ros_control_boilerplate.git
+      version: indigo-devel
+    release:
+      packages:
+      - ros_control_boilerplate
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/davetcoleman/ros_control_boilerplate-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/ros_control_boilerplate.git
+      version: indigo-devel
+    status: developed
   aau_multi_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `PACKAGE` to `0.1.0-0`:
- upstream repository: https://github.com/davetcoleman/ros_control_boilerplate.git
- release repository: https://github.com/davetcoleman/ros_control_boilerplate-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## ros_control_boilerplate

```
* Initial release of ros_control_boilerplate
* Contributors: Dave Coleman
```
