### PR TITLE
ros_control_boilerplate: 0.1.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8379,6 +8379,23 @@ repositories:
       url: https://github.com/ros-controls/ros_controllers.git
       version: indigo-devel
     status: developed
+  ros_control_boilerplate:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/ros_control_boilerplate.git
+      version: indigo-devel
+    release:
+      packages:
+      - ros_control_boilerplate
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/davetcoleman/ros_control_boilerplate-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/ros_control_boilerplate.git
+      version: indigo-devel
+    status: developed
   ros_emacs_utils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `PACKAGE` to `0.1.0-1`:
- upstream repository: https://github.com/davetcoleman/ros_control_boilerplate.git
- release repository: https://github.com/davetcoleman/ros_control_boilerplate-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## ros_control_boilerplate

```
* Initial release of ros_control_boilerplate
* Contributors: Dave Coleman
```
