### PR TITLE
Adding tuw_visual_marker to documentation index for distro jade

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4534,6 +4534,16 @@ repositories:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/topic_proxy.git
       version: master
+  tuw_visual_marker:
+    doc:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_visual_marker.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_visual_marker.git
+      version: master
+    status: maintained
   twist_mux:
     doc:
       type: git


### PR DESCRIPTION
Hi, I moved to an other work group and so I like to move parts of the v4r_ros repo to the tuw_visual_marker repository. Soon I will remove my work from git@github.com:v4r-tuwien/v4r_ros.git
