### PR TITLE
rosparam_shortcuts: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8877,6 +8877,21 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: indigo-devel
     status: maintained
+  rosparam_shortcuts:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/rosparam_shortcuts.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/davetcoleman/rosparam_shortcuts-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/rosparam_shortcuts.git
+      version: indigo-devel
+    status: developed
   rospeex:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_shortcuts` to `0.0.2-0`:
- upstream repository: https://github.com/davetcoleman/rosparam_shortcuts.git
- release repository: https://github.com/davetcoleman/rosparam_shortcuts-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rosparam_shortcuts

```
* Initial release
* Contributors: Dave Coleman
```
