### PR TITLE
tf_keyboard_cal: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10290,6 +10290,13 @@ repositories:
       url: https://github.com/RobotWebTools/tf2_web_republisher.git
       version: develop
     status: maintained
+  tf_keyboard_cal:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/davetcoleman/tf_keyboard_cal-release.git
+      version: 0.0.3-0
+    status: developed
   threemxl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf_keyboard_cal` to `0.0.3-0`:
- upstream repository: https://github.com/davetcoleman/tf_keyboard_cal.git
- release repository: https://github.com/davetcoleman/tf_keyboard_cal-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## tf_keyboard_cal

```
* Rename dependency ros_param_shortcuts to rosparam_shortcuts
* Contributors: Dave Coleman
```
