### PR TITLE
graph_msgs: 0.1.0-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1118,11 +1118,20 @@ repositories:
       version: 0.2.3-0
     status: developed
   graph_msgs:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/graph_msgs.git
+      version: jade-devel
     release:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/davetcoleman/graph_msgs-release.git
-      version: 0.1.0-0
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/davetcoleman/graph_msgs.git
+      version: jade-devel
+    status: developed
   grasping_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `graph_msgs` to `0.1.0-1`:
- upstream repository: https://github.com/davetcoleman/graph_msgs
- release repository: https://github.com/davetcoleman/graph_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.0-0`
## graph_msgs

```
* Added header / timestamp
* Contributors: Dave Coleman
```
