### PR TITLE
moveit_visual_tools: 3.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2125,6 +2125,21 @@ repositories:
       url: https://github.com/ros-gbp/moveit_ros-release.git
       version: 0.6.5-0
     status: developed
+  moveit_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/moveit_visual_tools.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/davetcoleman/moveit_visual_tools-release.git
+      version: 3.0.0-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/moveit_visual_tools.git
+      version: jade-devel
+    status: developed
   mrpt_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `3.0.0-0`:
- upstream repository: https://github.com/davetcoleman/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## moveit_visual_tools

```
* Release 3.0
* Added travis support
* fix the how to link a demo img
* Updated link to Doxygen API description
* Formatting and better debug output
* Fix hide robot bug
* Remove incompatible humanoid function
* Default color when publishing collision meshes
* Added error check for bad value
* API change for removal of shape_tools
* New publish trajectory line function
* Remove slash from topic name
* Removed mute functionality
* Improved loading efficiency
* publishContactPoints accepts a color
* Change topics to default when opening Rviz
* New publishCollisionMesh() function
* Changed publishCollisionMesh() API
* Renamed publishCollisionRectangle to publishCollisionCuboid()
* Updated rviz_visual_tools API
* New publishMesh from ROS msg function
* publishRobotState() for a RobotStateMsg now allows color
* publishTrajectoryPath() for a ROS msg now requires a RobotState
* New method for attaching collision objects that does not require a publisher
* Specify scene name and cleanup logging
* Fixed error checking for hideRobot() function
* loadTrajectoryPub() allows custom topic
* New publishTrajectoryPoints() function
* New publishContactPoints function
* New publishTrajectoryPath() function
* New getRobotModel() function
* New ability to visualize IK solutions with arbitrary virtual joint
* API Broken: ability to have different end effectors for different arms, auto EE marker loading
* Publish collision meshes
* Added check for virtual joint
* Fixed which arrow gets published
* Publish fixed link arrows to show footstep locations
* Ability to specify robot_state_topic without loading the publisher
* Contributors: Dave Coleman, Daiki Maekawa, simonschmeisser
```
