### PR TITLE
cartesian_msgs: 0.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -312,6 +312,21 @@ repositories:
       url: https://github.com/WPI-RAIL/carl_estop.git
       version: develop
     status: maintained
+  cartesian_msgs:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/cartesian_msgs.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/davetcoleman/cartesian_msgs-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/cartesian_msgs.git
+      version: jade-devel
+    status: developed
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartesian_msgs` to `0.0.2-0`:
- upstream repository: https://github.com/davetcoleman/cartesian_msgs.git
- release repository: https://github.com/davetcoleman/cartesian_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## cartesian_msgs

```
* Initial release
* Contributors: Dave Coleman
```
