### PR TITLE
freefloating_gazebo: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2398,6 +2398,17 @@ repositories:
       url: https://github.com/kth-ros-pkg/force_torque_tools.git
       version: indigo
     status: maintained
+  freefloating_gazebo:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/TheDash/freefloating_gazebo-gbp.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/freefloating-gazebo/freefloating_gazebo.git
+      version: indigo-devel
+    status: maintained
   freenect_stack:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `freefloating_gazebo` to `1.0.3-0`:
- upstream repository: https://github.com/freefloating-gazebo/freefloating_gazebo.git
- release repository: https://github.com/TheDash/freefloating_gazebo-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
