### PR TITLE
freefloating_gazebo: 1.0.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -925,6 +925,17 @@ repositories:
       url: https://github.com/kth-ros-pkg/force_torque_tools.git
       version: indigo
     status: maintained
+  freefloating_gazebo:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/TheDash/freefloating_gazebo-gbp.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/freefloating-gazebo/freefloating_gazebo.git
+      version: jade-devel
+    status: maintained
   gazebo_ros_pkgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `freefloating_gazebo` to `1.0.3-0`:
- upstream repository: https://github.com/freefloating-gazebo/freefloating_gazebo.git
- release repository: https://github.com/TheDash/freefloating_gazebo-gbp.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
