### PR TITLE
robot_self_filter: 0.1.28-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7835,7 +7835,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/robot_self_filter-gbp.git
-      version: 0.1.27-1
+      version: 0.1.28-2
     source:
       type: git
       url: https://github.com/pr2/robot_self_filter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_self_filter` to `0.1.28-2`:
- upstream repository: https://github.com/pr2/robot_self_filter.git
- release repository: https://github.com/pr2-gbp/robot_self_filter-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.27-1`
