### PR TITLE
designator_integration: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1712,10 +1712,14 @@ repositories:
       version: indigo-devel
   designator_integration:
     release:
+      packages:
+      - designator_integration
+      - designator_integration_cpp
+      - designator_integration_lisp
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/code-iai-release/designator_integration-release.git
-      version: 0.0.1-0
+      version: 0.0.3-0
     status: developed
   diagnostics:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `designator_integration` to `0.0.3-0`:
- upstream repository: https://github.com/code-iai/designator_integration.git
- release repository: https://github.com/code-iai-release/designator_integration-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.0.1-0`
## designator_integration
- No changes
## designator_integration_cpp
- No changes
## designator_integration_lisp
- No changes
