### PR TITLE
youbot_driver_ros_interface: 1.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11414,7 +11414,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/youbot-release/youbot_driver_ros_interface-release.git
-      version: 1.1.0-0
+      version: 1.1.1-0
   youbot_simulation:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `youbot_driver_ros_interface` to `1.1.1-0`:
- upstream repository: https://github.com/youbot/youbot_driver_ros_interface.git
- release repository: https://github.com/youbot-release/youbot_driver_ros_interface-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.0-0`
