### PR TITLE
robot_self_filter: 0.1.29-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7839,7 +7839,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/robot_self_filter-gbp.git
-      version: 0.1.28-2
+      version: 0.1.29-0
     source:
       type: git
       url: https://github.com/pr2/robot_self_filter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_self_filter` to `0.1.29-0`:
- upstream repository: https://github.com/pr2/robot_self_filter.git
- release repository: https://github.com/pr2-gbp/robot_self_filter-gbp.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.28-2`
## robot_self_filter

```
* pr2_navigation_self_filter -> robot_self_filter
* Add robot_self_filter namespace before bodies and shapes namespace.
  geometric_shapes package also provides bodies and shapes namespace
  and same classes and functions. If a program is linked with
  geometric_shapes and robot_self_filter, it may cause strange behavior
  because of symbol confliction.
* Contributors: Ryohei Ueda
```
