### PR TITLE
pr2_props_stack: 1.0.4-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7117,7 +7117,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_props_stack-release.git
-      version: 1.0.4-0
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/pr2/pr2_props_stack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_props_stack` to `1.0.4-1`:
- upstream repository: https://github.com/pr2/pr2_props_stack.git
- release repository: https://github.com/pr2-gbp/pr2_props_stack-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.4-0`
