### PR TITLE
ueye: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10669,7 +10669,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/kmhallen/ueye-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: hg
       url: https://bitbucket.org/kmhallen/ueye


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye` to `0.0.7-0`:
- upstream repository: https://bitbucket.org/kmhallen/ueye
- release repository: https://github.com/kmhallen/ueye-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.6-0`
## ueye

```
* Fixed frame_id not set properly in stereo node
* Lock stereo threads with a mutex
* Inline functions for Camera class getters
* Removed OpenCV dependency
* Contributors: Kevin Hallenbeck
```
