### PR TITLE
ueye: 0.0.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4686,7 +4686,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/kmhallen/ueye-release.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: hg
       url: https://bitbucket.org/kmhallen/ueye


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye` to `0.0.8-0`:
- upstream repository: https://bitbucket.org/kmhallen/ueye
- release repository: https://github.com/kmhallen/ueye-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.7-0`
## ueye

```
* Forgot to remove cv_bridge in package.xml
* Contributors: Kevin Hallenbeck
```
