### PR TITLE
homer_mapnav: 1.0.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3068,7 +3068,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
-      version: 1.0.13-0
+      version: 1.0.14-0
   homer_object_recognition:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_mapnav` to `1.0.14-0`:
- upstream repository: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.13-0`
## homer_map_manager

```
* moved header files to include directory
* Contributors: Niklas Yann Wettengel
```
## homer_mapnav_msgs
- No changes
## homer_mapping

```
* moved header files to include directory
* Contributors: Niklas Yann Wettengel
```
## homer_nav_libs

```
* moved header files to include directory
* Contributors: Niklas Yann Wettengel
```
## homer_navigation

```
* moved header files to include directory
* modified include path
* Contributors: Niklas Yann Wettengel
```
