### PR TITLE
keyboard: 0.1.1-3 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1657,6 +1657,21 @@ repositories:
       url: https://github.com/tork-a/jskeus-release.git
       version: 1.0.11-0
     status: developed
+  keyboard:
+    doc:
+      type: git
+      url: https://github.com/lrse/ros-keyboard.git
+      version: 0.1.1
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/lrse-ros-release/keyboard-release.git
+      version: 0.1.1-3
+    source:
+      type: git
+      url: https://github.com/lrse/ros-keyboard.git
+      version: master
+    status: developed
   korg_nanokontrol:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `keyboard` to `0.1.1-3`:
- upstream repository: https://github.com/lrse/ros-keyboard.git
- release repository: https://github.com/lrse-ros-release/keyboard-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## keyboard

```
* README
* stuff
* fix for hydro
* switched from ncurses to SDL
* constants from ncurses
* initial commit
* Contributors: v01d
```
