### PR TITLE
tf_keyboard_cal: 0.0.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4642,6 +4642,21 @@ repositories:
       url: https://github.com/RobotWebTools/tf2_web_republisher.git
       version: develop
     status: maintained
+  tf_keyboard_cal:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/tf_keyboard_cal.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/davetcoleman/tf_keyboard_cal-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/tf_keyboard_cal.git
+      version: jade-devel
+    status: developed
   topic_proxy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf_keyboard_cal` to `0.0.3-0`:
- upstream repository: https://github.com/davetcoleman/tf_keyboard_cal.git
- release repository: https://github.com/davetcoleman/tf_keyboard_cal-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## tf_keyboard_cal

```
* Rename dependency ros_param_shortcuts to rosparam_shortcuts
* Contributors: Dave Coleman
```
