### PR TITLE
moveit_simple_grasps: 1.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5218,7 +5218,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/moveit_simple_grasps-release.git
-      version: 1.2.1-0
+      version: 1.3.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_simple_grasps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_simple_grasps` to `1.3.0-0`:
- upstream repository: https://github.com/davetcoleman/moveit_simple_grasps.git
- release repository: https://github.com/davetcoleman/moveit_simple_grasps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.2.1-0`
## moveit_simple_grasps

```
* Z Axis implemented
* Fixed API changes in moveit_visual_tools
* Adding grasp configurations for Romeo, Nao and Pepper
* Update README.md
* Fix install space
* New setRobotStatePreGrasp(), setRobotStateGrasp(), and setRobotState() functions for opening and closing EE
* Fixed test launch
* Added new test functions
* Contributors: Dave Coleman, nlyubova, rheidrich
```
