### PR TITLE
cartesian_msgs: 0.0.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -321,7 +321,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/davetcoleman/cartesian_msgs-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/davetcoleman/cartesian_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartesian_msgs` to `0.0.3-0`:
- upstream repository: https://github.com/davetcoleman/cartesian_msgs.git
- release repository: https://github.com/davetcoleman/cartesian_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.2-0`
## cartesian_msgs

```
* catkin lint cleanup
* Contributors: Dave Coleman
```
