### PR TITLE
robot_controllers: 0.4.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7775,7 +7775,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
-      version: 0.4.2-0
+      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/fetchrobotics/robot_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_controllers` to `0.4.3-1`:
- upstream repository: https://github.com/fetchrobotics/robot_controllers.git
- release repository: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.4.2-0`
## robot_controllers

```
* fix path/goal tolerance preparation
* Contributors: Michael Ferguson
```
## robot_controllers_interface

```
* add mainpage to doxygen
* Contributors: Michael Ferguson
```
## robot_controllers_msgs
- No changes
