### PR TITLE
jsk_common: 2.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3733,7 +3733,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.0.7-0
+      version: 2.0.8-0
     status: developed
   jsk_common_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.0.8-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.0.7-0`
## dynamic_tf_publisher
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_data

```
* [jsk_data] Add roslint
* Contributors: Kentaro Wada
```
## jsk_network_tools
- No changes
## jsk_tilt_laser
- No changes
## jsk_tools

```
* add rostest package.xml
* Contributors: Kei Okada
```
## jsk_topic_tools

```
* [jsk_topic_tools] Add roslint_cpp for src/log_utils.cpp
* [jsk_topic_tools] Add roslint_python
* [jsk_topic_tools] Refactor CMakeLists.txt by moving rostest find_package
* [jsk_topic_tools] Fix for pep8
* [jsk_topic_tools/ConnectionBasedNodelet] Support image_transport.
  Add advertiseImage and advertiseCamera.
  closes #1198 <https://github.com/jsk-ros-pkg/jsk_common/issues/1198>
* Contributors: Kentaro Wada, Ryohei Ueda
```
## multi_map_server
- No changes
## virtual_force_publisher
- No changes
