### PR TITLE
jsk_visualization: 1.0.26-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3908,7 +3908,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.25-0
+      version: 1.0.26-0
     status: developed
   jskeus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.26-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.25-0`
## jsk_interactive
- No changes
## jsk_interactive_marker

```
* [jsk_interactive_marker] add initialization for marker control
* [jsk_interactive_marker] Add ~force_to_replan service interface to
  footstep marker
* Contributors: Ryohei Ueda, Yu Ohara
```
## jsk_interactive_test
- No changes
## jsk_rqt_plugins

```
* [jsk_rqt_plugins] Advertise service after initialized
* Contributors: Kentaro Wada
```
## jsk_rviz_plugins

```
* [jsk_rviz_plugins] Install icons
* [jsk_rviz_plugins] add landing_time_detector to display early landing/taking-off
* [jsk_rviz_plugins/motor_states_temparature_decomposer] Decrease cpu load
  by queue_size=1.
  Fix for joints which does not have limit attribute.
* [jsk_rviz_plugins] Add ~parent_link parameter for contact_state_publisher
* [jsk_rviz_plugins] Add dynamic_reconfigure API to ContactStateMarker
* [jsk_rviz_plugins] Check size of likelihood and labels of PolygonArray
* [jsk_rviz_plugins/contact_state_marker.py] Support origin attribute of
  visual tag
* [jsk_rviz_plugins] update ambient sound visual paramter
* [jsk_rviz_plugins] contact_state_marker.py to visualize hrpsys_ros_bridge/ContactStatesStamped
* [jsk_rviz_plugins] Add script to publish marker of a robot link with
  specified color
* Contributors: Eisoku Kuroiwa, Kentaro Wada, Ryohei Ueda, Yuto Inagaki
```
## jsk_visualization
- No changes
