### PR TITLE
Adding iav_depthimage_to_laserscan to documentation index for distro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2839,12 +2839,6 @@ repositories:
       url: https://github.com/code-iai/iai_common_msgs.git
       version: master
     status: developed
-  iav_depthimage_to_laserscan:
-    doc:
-      type: git
-      url: https://github.com/iav-student/iav_depthimage_to_laserscan.git
-      version: hydro
-    status: maintained
   iiwa:
     release:
       tags:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2840,7 +2840,7 @@ repositories:
       version: master
     status: developed
   iav_depthimage_to_laserscan:
-    doc:
+    source:
       type: git
       url: https://github.com/iav-student/iav_depthimage_to_laserscan.git
       version: master

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2843,7 +2843,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/iav-student/iav_depthimage_to_laserscan.git
-      version: hydro-devel
+      version: hydro
     source:
       type: git
       url: https://github.com/iav-student/iav_depthimage_to_laserscan.git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2839,6 +2839,12 @@ repositories:
       url: https://github.com/code-iai/iai_common_msgs.git
       version: master
     status: developed
+  iav_depthimage_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/iav-student/iav_depthimage_to_laserscan.git
+      version: master
+    status: maintained
   iiwa:
     release:
       tags:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2844,10 +2844,6 @@ repositories:
       type: git
       url: https://github.com/iav-student/iav_depthimage_to_laserscan.git
       version: hydro
-    source:
-      type: git
-      url: https://github.com/iav-student/iav_depthimage_to_laserscan.git
-      version: master
     status: maintained
   iiwa:
     release:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2839,6 +2839,16 @@ repositories:
       url: https://github.com/code-iai/iai_common_msgs.git
       version: master
     status: developed
+  iav_depthimage_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/iav-student/iav_depthimage_to_laserscan.git
+      version: hydro-devel
+    source:
+      type: git
+      url: https://github.com/iav-student/iav_depthimage_to_laserscan.git
+      version: master
+    status: maintained
   iiwa:
     release:
       tags:


### PR DESCRIPTION
I'd like iav_depthimage_to_laserscan to be indexed and documented on ros.org.
