### PR TITLE
ros_control_boilerplate: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8356,6 +8356,21 @@ repositories:
       url: https://github.com/ros-controls/ros_control.git
       version: indigo-devel
     status: developed
+  ros_control_boilerplate:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/ros_control_boilerplate.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/davetcoleman/ros_control_boilerplate-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/ros_control_boilerplate.git
+      version: indigo-devel
+    status: developed
   ros_controllers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control_boilerplate` to `0.1.3-0`:
- upstream repository: https://github.com/davetcoleman/ros_control_boilerplate.git
- release repository: https://github.com/davetcoleman/ros_control_boilerplate-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## ros_control_boilerplate

```
* Fix catkin lint errors
* Added FindGflags directly to this repo
* Minor fix
* Updated README
* Contributors: Dave Coleman
```
