### PR TITLE
homer_object_recognition: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3072,11 +3072,13 @@ repositories:
   homer_object_recognition:
     release:
       packages:
+      - or_libs
       - or_msgs
+      - or_nodes
       tags:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_object_recognition.git
-      version: 0.0.2-1
+      version: 0.0.3-0
   household_objects_database:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_object_recognition` to `0.0.3-0`:
- upstream repository: https://gitlab.uni-koblenz.de/robbie/homer_object_recognition.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_object_recognition.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.2-1`
## or_libs

```
* added dependecies
* added maintainers + fixed robbie_architecture-includes
* removed tf dependency
* added tf build depend
* Contributors: Niklas Yann Wettengel, Raphael Memmesheimer
```
## or_msgs

```
* added maintainers + fixed robbie_architecture-includes
* Contributors: Niklas Yann Wettengel
```
## or_nodes

```
* added dependecies
* added maintainers + fixed robbie_architecture-includes
* Contributors: Niklas Yann Wettengel
```
