### PR TITLE
tf_keyboard_cal: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10323,11 +10323,19 @@ repositories:
       version: develop
     status: maintained
   tf_keyboard_cal:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/tf_keyboard_cal.git
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/tf_keyboard_cal-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/tf_keyboard_cal.git
+      version: indigo-devel
     status: developed
   threemxl:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `tf_keyboard_cal` to `0.0.4-0`:
- upstream repository: https://github.com/davetcoleman/tf_keyboard_cal.git
- release repository: https://github.com/davetcoleman/tf_keyboard_cal-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.3-0`
## tf_keyboard_cal

```
* catkin lint cleanup
* Fixed travis
* Contributors: Dave Coleman
```
