### PR TITLE
ros_control_boilerplate: 0.1.4-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3733,7 +3733,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/davetcoleman/ros_control_boilerplate-release.git
-      version: 0.1.4-0
+      version: 0.1.4-1
     source:
       type: git
       url: https://github.com/davetcoleman/ros_control_boilerplate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control_boilerplate` to `0.1.4-1`:
- upstream repository: https://github.com/davetcoleman/ros_control_boilerplate.git
- release repository: https://github.com/davetcoleman/ros_control_boilerplate-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.4-0`
## ros_control_boilerplate

```
* Added missing dependency on sensor_msgs
* Contributors: Dave Coleman
```
