### PR TITLE
moveit_visual_tools: 3.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5235,7 +5235,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 3.0.0-0
+      version: 3.0.1-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `3.0.1-0`:
- upstream repository: https://github.com/davetcoleman/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `3.0.0-0`
## moveit_visual_tools

```
* catkin lint cleanup
* Fix travis
* Contributors: Dave Coleman
```
