### PR TITLE
cartesian_msgs: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -936,6 +936,21 @@ repositories:
       url: https://github.com/WPI-RAIL/carl_safety.git
       version: develop
     status: maintained
+  cartesian_msgs:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/cartesian_msgs.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/davetcoleman/cartesian_msgs-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/cartesian_msgs.git
+      version: indigo-devel
+    status: developed
   cassandra_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartesian_msgs` to `0.0.3-0`:
- upstream repository: https://github.com/davetcoleman/cartesian_msgs.git
- release repository: https://github.com/davetcoleman/cartesian_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## cartesian_msgs

```
* catkin lint cleanup
* Contributors: Dave Coleman
```
