### PR TITLE
moveit_simple_grasps: 1.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5220,7 +5220,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/moveit_simple_grasps-release.git
-      version: 1.3.0-0
+      version: 1.3.1-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_simple_grasps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_simple_grasps` to `1.3.1-0`:
- upstream repository: https://github.com/davetcoleman/moveit_simple_grasps.git
- release repository: https://github.com/davetcoleman/moveit_simple_grasps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.3.0-0`
## moveit_simple_grasps

```
* catkin lint cleanup
* Contributors: Dave Coleman
```
