### PR TITLE
ompl_visual_tools: 2.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6117,7 +6117,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/ompl_visual_tools-release.git
-      version: 2.3.0-0
+      version: 2.3.1-0
     source:
       type: git
       url: https://github.com/davetcoleman/ompl_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl_visual_tools` to `2.3.1-0`:
- upstream repository: https://github.com/davetcoleman/ompl_rviz_viewer.git
- release repository: https://github.com/davetcoleman/ompl_visual_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.3.0-0`
## ompl_visual_tools

```
* catkin lint cleanup
* Contributors: Dave Coleman
```
