### PR TITLE
jsk_visualization: 1.0.27-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3925,7 +3925,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.26-0
+      version: 1.0.27-0
     status: developed
   jskeus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.27-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.26-0`
## jsk_interactive
- No changes
## jsk_interactive_marker

```
* Use ccache to make it faster to generate object file
* Contributors: Kentaro Wada
```
## jsk_interactive_test
- No changes
## jsk_rqt_plugins

```
* [jsk_rqt_plugins] Avoid already advertised error for rqt_yn_btn
* Contributors: Kentaro Wada
```
## jsk_rviz_plugins

```
* [jsk_rviz_plugins/BoundingBoxArray] Fix coords orientation.
  closes #528 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/528>
* Use ccache to make it faster to generate object file
* [jsk_rviz_plugins] Empty function implementation for undefined methods
* [jsk_rviz_plugins] Use set_target_properties to set linker flags only
  for libjsk_rviz_plugins.so
* Use gcc -z defs to check undefined symbols in shared objects
* Contributors: Kentaro Wada, Ryohei Ueda
```
## jsk_visualization
- No changes
