### PR TITLE
roswww: 0.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9059,7 +9059,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/roswww-release.git
-      version: 0.1.6-0
+      version: 0.1.7-0
     source:
       type: git
       url: https://github.com/tork-a/roswww.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roswww` to `0.1.7-0`:
- upstream repository: https://github.com/tork-a/roswww.git
- release repository: https://github.com/tork-a/roswww-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.6-0`
## roswww

```
* [fix] Developers don't need to create a sample www directory now that it's installed (#28 <https://github.com/tork-a/roswww/issues/28>)
* [fix][test] Use install space for testing (to capture the issue raised in #28 <https://github.com/tork-a/roswww/issues/28>)
* Contributors: Kenta Yonekura, Isaac I.Y. Saito
```
