### PR TITLE
homer_object_recognition: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3093,7 +3093,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_object_recognition.git
-      version: 0.0.3-0
+      version: 0.0.4-0
   household_objects_database:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_object_recognition` to `0.0.4-0`:
- upstream repository: https://gitlab.uni-koblenz.de/robbie/homer_object_recognition.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_object_recognition.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.3-0`
## or_libs

```
* moved header files to include directory + install()
* Contributors: Niklas Yann Wettengel
```
## or_msgs
- No changes
## or_nodes

```
* moved header files to include directory + install()
* Contributors: Niklas Yann Wettengel
```
