### PR TITLE
pr2_hack_the_future: 1.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6963,7 +6963,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_hack_the_future-release.git
-      version: 1.0.9-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/PR2/pr2_hack_the_future.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_hack_the_future` to `1.1.0-0`:
- upstream repository: https://github.com/PR2/pr2_hack_the_future.git
- release repository: https://github.com/pr2-gbp/pr2_hack_the_future-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.9-0`
## hack_the_web_program_executor
- No changes
## pr2_hack_the_future
- No changes
## pr2_joint_teleop
- No changes
## pr2_simple_interface
- No changes
## program_queue
- No changes
## queue_web
- No changes
## rviz_backdrop

```
* install the plugin description xml, fixes #2 <https://github.com/PR2/pr2_hack_the_future/issues/2>
* Contributors: William Woodall
```
## slider_gui
- No changes
