### PR TITLE
moveit_simple_actions: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5216,11 +5216,15 @@ repositories:
       version: indigo-devel
     status: maintained
   moveit_simple_actions:
+    doc:
+      type: git
+      url: https://github.com/nlyubova/moveit_simple_actions/blob/master/README.rst
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/nlyubova/moveit_simple_actions-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/nlyubova/moveit_simple_actions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_simple_actions` to `0.0.4-0`:
- upstream repository: https://github.com/nlyubova/moveit_simple_actions
- release repository: https://github.com/nlyubova/moveit_simple_actions-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.3-0`
## moveit_simple_actions

```
* fixing with changes in moveit visual tools
* Contributors: Natalia Lyubova
```
