### PR TITLE
Adding iav_depthimage_to_laserscan to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3230,6 +3230,16 @@ repositories:
       url: https://github.com/code-iai-release/iai_common_msgs-release.git
       version: 0.0.5-1
     status: developed
+  iav_depthimage_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/iav-student/iav_depthimage_to_laserscan.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/iav-student/iav_depthimage_to_laserscan.git
+      version: indigo-devel
+    status: maintained
   icart_mini:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3234,11 +3234,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/iav-student/iav_depthimage_to_laserscan.git
-      version: indigo-devel
+      version: master
     source:
       type: git
       url: https://github.com/iav-student/iav_depthimage_to_laserscan.git
-      version: indigo-devel
+      version: master
     status: maintained
   icart_mini:
     doc:


### PR DESCRIPTION
I'd like iav_depthimage_to_laserscan to be indexed and documented on ros.org.
