### PR TITLE
moveit_sim_controller: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5215,6 +5215,21 @@ repositories:
       url: https://github.com/ros-planning/moveit_setup_assistant.git
       version: indigo-devel
     status: maintained
+  moveit_sim_controller:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/moveit_sim_controller.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/davetcoleman/moveit_sim_controller-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/moveit_sim_controller.git
+      version: indigo-devel
+    status: developed
   moveit_simple_actions:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_sim_controller` to `0.0.3-0`:
- upstream repository: https://github.com/davetcoleman/moveit_sim_controller.git
- release repository: https://github.com/davetcoleman/moveit_sim_controller-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## moveit_sim_controller

```
* Fix missing dep
* Contributors: Dave Coleman
```
