### PR TITLE
rosparam_shortcuts: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8959,7 +8959,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/rosparam_shortcuts-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/davetcoleman/rosparam_shortcuts.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_shortcuts` to `0.0.6-0`:
- upstream repository: https://github.com/davetcoleman/rosparam_shortcuts.git
- release repository: https://github.com/davetcoleman/rosparam_shortcuts-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.5-0`
## rosparam_shortcuts

```
* Added example code
* Contributors: Dave Coleman
```
