### PR TITLE
ompl_visual_tools: 2.3.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2822,6 +2822,21 @@ repositories:
       url: https://github.com/ros-gbp/ompl-release.git
       version: 1.0.0003094-2
     status: maintained
+  ompl_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/ompl_visual_tools.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/davetcoleman/ompl_visual_tools-release.git
+      version: 2.3.1-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/ompl_visual_tools.git
+      version: jade-devel
+    status: developed
   opencv3:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl_visual_tools` to `2.3.1-0`:
- upstream repository: https://github.com/davetcoleman/ompl_visual_tools.git
- release repository: https://github.com/davetcoleman/ompl_visual_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## ompl_visual_tools

```
* catkin lint cleanup
* Contributors: Dave Coleman
```
