### PR TITLE
oxford_gps_eth: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6452,6 +6452,21 @@ repositories:
       type: git
       url: https://github.com/Oriense/orsens_ros.git
       version: master
+  oxford_gps_eth:
+    doc:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/oxford_gps_eth
+      version: default
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
+      version: 0.0.1-0
+    source:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/oxford_gps_eth
+      version: default
+    status: maintained
   p2os:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `oxford_gps_eth` to `0.0.1-0`:
- upstream repository: https://bitbucket.org/DataspeedInc/oxford_gps_eth
- release repository: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## oxford_gps_eth

```
* Ready for public release
* Contributors: Kevin Hallenbeck
```
