### PR TITLE
Add support for python-bson, required by rosbridge_library

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -450,6 +450,10 @@ python-argparse:
   osx:
     pip:
       packages: [argparse]
+python-bson:
+  osx:
+    pip:
+      packages: [bson]
 python-cairo:
   osx:
     homebrew:


### PR DESCRIPTION
This adds support for installing the python-bson package on OS X required by [rosbridge_library](https://github.com/RobotWebTools/rosbridge_suite/blob/develop/rosbridge_library/package.xml#L28).

Currently OS X users will recieve the following error when building from source:

```
rosdep install --from-paths src --ignore-src --rosdistro jade -y
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
rosbridge_library: No definition of [python-bson] for OS [osx]
```
