### PR TITLE
jsk_recognition: 0.3.8-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3869,7 +3869,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.6-0
+      version: 0.3.8-1
     status: developed
   jsk_robot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.8-1`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.6-0`
## checkerboard_detector
- No changes
## imagesift

```
* Use ccache if installed to make it fast to generate object file
* Contributors: Kentaro Wada
```
## jsk_pcl_ros

```
* [jsk_pcl_ros] Remove lisp-style comments
* [jsk_pcl_ros] Add Failure flag to Torus message
* [jsk_pcl_ros] Remove unused codes
* [jsk_pcl_ros] Make test for euclidean segmentation reliable
* [jsk_pcl_ros] Make test for euclidean segmentation reliable
* [jsk_pcl_ros] Add jsk_tools as test_depend
* [jsk_pcl_ros/organized_multi_plane_segmentation.launch] Remove rqt_robot_monitor
* [jsk_pcl_ros] Use patched ExtractIndices on pcl
  Closes https://github.com/jsk-ros-pkg/jsk_recognition/issues/1337
* Use pcl::PointCloud2 for various Point types
  Closes #1304 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/1304>
* Use ccache if installed to make it fast to generate object file
* [jsk_pcl_ros] Make test for euclidean segmentation reliable
* [jsk_pcl_ros/ParticleFilterTracking] Publish RMS error of distance and angle
* [jsk_pcl_ros/ParticleFilterTracking] Do not use pcl_ros::PCLNodelet
  in order to remove dependency to tf if possible
* [jsk_pcl_ros/ParticleFilterTracking] Measure computation time
* [jsk_recognition_utils, jsk_pcl_ros] Measure time to compute
  NormalEstimationOMP and RegionGriwongMultiplePlaneSegmentation.
  Add utility class to measure time: jsk_recognition_utils::WallDurationTimer
* [jsk_pcl_ros] Remove no need image files
* [jsk_pcl_ros/launch/hsi_color_filter.launch] Add suffix for manager name to enable multiple hsi_color_filter.launch. Previously, manager name conflict occurred.
* fix the ros message package in test_contact_sensor.py
* use shared ptr for self_mask instance.
* [jsk_pcl_ros] ExtractIndices keep_organized test
* Revert "Use pcl::PointCloud2 for various Point types"
  This reverts commit dc615cb15ea16beb7a95b7f5b472e57611890a37.
* merge origin/master
* fix coding style.
* use OctreePointCloud function instead of OctreePointCloudCompression.
* use VoxelGrid filter to remove duplicate cloud outputed from octree compression.
* publish OctreeVoxelGrid as marker.
* introduce dynamic reconfigure into OctreeVoxelGrid to set resolution.
* add sample launch file of octree_voxel_grid.
* add octree_voxel_grid nodelet.
* Contributors: Kentaro Wada, Ryohei Ueda, Shunichi Nozawa, Masaki Murooka
```
## jsk_perception

```
* [jsk_perception] Add CATKIN_ENABLE_TESTING if block
* Use ccache if installed to make it fast to generate object file
* [jsk_perception] Refactor publish_fixed_images.launch and fix test
* [jsk_perception] Test split_fore_background.py
* [jsk_perception] Fix header of split_fore_background
* [jsk_perception] Refactor publish_fixed_images.launch and fix test
* [jsk_perception] Specify encoding by rosparam in image_publisher.py
* [jsk_perception] Refactor image_publisher.py
* [jsk_perception] Fix supported encodings of split_fore_background.py
  It supports both 16UC1 and 32FC1.
* [jsk_perception] Fix supported encodings of split_fore_background.py
  It supports both 16UC1 and 32FC1.
* [jsk_perception] Add warnNoRemap in ``subscribe()``
* [split fore background] add conversion for depth image format 32FC1
* [jsk_perception] Set frame_id by rosparam
* [jsk_perception] Publish mask also in SplitForeBackground
* add applying blur to output image on edge detector
* [jsk_perception] Split FG/BG with local depth max
* Contributors: Kei Okada, Kentaro Wada, Shingo Kitagawa, Yohei Kakiuchi
```
## jsk_recognition
- No changes
## jsk_recognition_msgs

```
* [jsk_pcl_ros] Add Failure flag to Torus message
* Remove types on docs for jsk_pcl_ros
  See http://docs.ros.org/indigo/api/jsk_recognition_msgs/html/index-msg.html for message types
* Contributors: Kentaro Wada, Ryohei Ueda
```
## jsk_recognition_utils

```
* Use ccache if installed to make it fast to generate object file
* [jsk_recognition_utils, jsk_pcl_ros] Measure time to compute
  NormalEstimationOMP and RegionGriwongMultiplePlaneSegmentation.
  Add utility class to measure time: jsk_recognition_utils::WallDurationTimer
* [jsk_recognition_utils] Split fore/background with depth
* Contributors: Kei Okada, Kentaro Wada, Ryohei Ueda
```
## resized_image_transport

```
* Use ccache if installed to make it fast to generate object file
* Contributors: Kentaro Wada
```
