### PR TITLE
jsk_model_tools: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3817,7 +3817,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     status: developed
   jsk_planning:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.2.2-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.1-0`
## eus_assimp
- No changes
## euscollada
- No changes
## eusurdf

```
* [textured_models/room73b2-hitachi-fiesta-refrigerator-0] transparent inside board of fridge
* [textured_models/room73b2-georgia-emerald-mountain-0] add texture of georgia can
* [textured_models/room73b2-hitachi-fiesta-refrigerator-0/model.urdf] update to more realistic physics parameters
* [textured_models] add georgia can
* [CMakeLists.txt] install eusurdf/worlds directory
* [CMakeLists.txt] add roseus to run_depend. use environment variable to get eusdir. call roseus without rosrun.
* [eusurdf] add textured_models/
* Contributors: Yuki Furuta, Masaki Murooka
```
## jsk_model_tools
- No changes
