### PR TITLE
innok_heros_description: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3437,6 +3437,11 @@ repositories:
       type: git
       url: https://github.com/innokrobotics/innok_heros_description.git
       version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/innokrobotics/innok_heros_description-release.git
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/innokrobotics/innok_heros_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `innok_heros_description` to `1.0.2-0`:
- upstream repository: https://github.com/innokrobotics/innok_heros_description.git
- release repository: https://github.com/innokrobotics/innok_heros_description-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## innok_heros_description

```
* Fixed CMakeLists.txt
* Contributors: Sabrina Heerklotz
```
