### PR TITLE
innok_heros_gazebo: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3467,6 +3467,11 @@ repositories:
       type: git
       url: https://github.com/innokrobotics/innok_heros_gazebo.git
       version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/innokrobotics/innok_heros_gazebo-release.git
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/innokrobotics/innok_heros_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `innok_heros_gazebo` to `1.0.2-0`:
- upstream repository: https://github.com/innokrobotics/innok_heros_gazebo.git
- release repository: https://github.com/innokrobotics/innok_heros_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## innok_heros_gazebo

```
* Fixed CMakeLists.txt
* Contributors: Sabrina Heerklotz
```
