### PR TITLE
innok_heros_control: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3427,6 +3427,11 @@ repositories:
       type: git
       url: https://github.com/innokrobotics/innok_heros_control.git
       version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/innokrobotics/innok_heros_control-release.git
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/innokrobotics/innok_heros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `innok_heros_control` to `1.0.3-0`:
- upstream repository: https://github.com/innokrobotics/innok_heros_control.git
- release repository: https://github.com/innokrobotics/innok_heros_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## innok_heros_control

```
* Fixed CMakeLists.txt
* Contributors: Sabrina Heerklotz
```
