### PR TITLE
Adding forte_rc_robot to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2431,7 +2431,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ingeniarius-ltd/forte_rc_robot-release.git
-      version: 1.0.1-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/ingeniarius-ltd/forte_rc_robot.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2417,6 +2417,25 @@ repositories:
       url: https://github.com/kth-ros-pkg/force_torque_tools.git
       version: indigo
     status: maintained
+  forte_rc_robot:
+    doc:
+      type: git
+      url: https://github.com/ingeniarius-ltd/forte_rc_robot.git
+      version: indigo
+    release:
+      packages:
+      - forte_rc_description
+      - forte_rc_driver
+      - forte_rc_robot
+      - forte_rc_teleop
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ingeniarius-ltd/forte_rc_robot-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/ingeniarius-ltd/forte_rc_robot.git
+      version: indigo
   freefloating_gazebo:
     release:
       tags:


### PR DESCRIPTION
Please, i'd like forte_rc_robot to be indexed and documented on ros.org.
