### PR TITLE
rosh_core: 1.0.9-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3955,6 +3955,25 @@ repositories:
       url: https://github.com/ros-infrastructure/rosdoc_lite.git
       version: master
     status: maintained
+  rosh_core:
+    doc:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_core.git
+      version: hydro-devel
+    release:
+      packages:
+      - rosh
+      - rosh_core
+      - roshlaunch
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/OSUrobotics/rosh_core-release.git
+      version: 1.0.9-0
+    source:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_core.git
+      version: hydro-devel
+    status: maintained
   roslint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_core` to `1.0.9-0`:
- upstream repository: https://github.com/OSUrobotics/rosh_core.git
- release repository: https://github.com/OSUrobotics/rosh_core-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rosh

```
* pass remapping args onto the Node object
* add argument so nodes can be explicitly named
* Contributors: Dan Lazewatsky
```
## rosh_core
- No changes
## roshlaunch
- No changes
