### PR TITLE
rosh_robot_plugins: 1.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3955,6 +3955,26 @@ repositories:
       url: https://github.com/ros-infrastructure/rosdoc_lite.git
       version: master
     status: maintained
+  rosh_robot_plugins:
+    doc:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_robot_plugins.git
+      version: master
+    release:
+      packages:
+      - rosh_common
+      - rosh_geometry
+      - rosh_robot
+      - rosh_robot_plugins
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/OSUrobotics/rosh_robot_plugins-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_robot_plugins.git
+      version: master
+    status: maintained
   roslint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_robot_plugins` to `1.0.2-0`:
- upstream repository: https://github.com/OSUrobotics/rosh_robot_plugins.git
- release repository: https://github.com/OSUrobotics/rosh_robot_plugins-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rosh_common
- No changes
## rosh_geometry

```
* Prevent beginning of tf frame names from being lost in ipython tab completion
* Fix error creating QuaternionStamped
* Contributors: Dan Lazewatsky
```
## rosh_robot
- No changes
## rosh_robot_plugins

```
* fix maintainer
* Remove "rosh" run depend
  Fixes wiki package header for this and rosh
* Contributors: Dan Lazewatsky
```
