### PR TITLE
rosh_desktop_plugins: 1.0.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3974,6 +3974,25 @@ repositories:
       url: https://github.com/OSUrobotics/rosh_core.git
       version: hydro-devel
     status: maintained
+  rosh_desktop_plugins:
+    doc:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_desktop_plugins.git
+      version: master
+    release:
+      packages:
+      - rosh_desktop
+      - rosh_desktop_plugins
+      - rosh_visualization
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/OSUrobotics/rosh_desktop_plugins-release.git
+      version: 1.0.4-0
+    source:
+      type: git
+      url: https://github.com/OSUrobotics/rosh_desktop_plugins.git
+      version: master
+    status: maintained
   rosh_robot_plugins:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosh_desktop_plugins` to `1.0.4-0`:
- upstream repository: https://github.com/OSUrobotics/rosh_desktop_plugins.git
- release repository: https://github.com/OSUrobotics/rosh_desktop_plugins-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rosh_desktop
- No changes
## rosh_desktop_plugins
- No changes
## rosh_visualization

```
* undo commit that happened on the wrong branch
* Contributors: Dan Lazewatsky
```
