### PR TITLE
uga_tum_ardrone: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10785,7 +10785,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/thinclab/uga_tum_ardrone-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/thinclab/uga_tum_ardrone.git


### PR DESCRIPTION
Increasing version of package(s) in repository `uga_tum_ardrone` to `0.0.2-0`:
- upstream repository: https://github.com/thinclab/uga_tum_ardrone.git
- release repository: https://github.com/thinclab/uga_tum_ardrone-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.1-0`
## uga_tum_ardrone

```
* Depend on GLUT, blas, and OpenGL to fix PTAM build errors
* Contributors: Kenneth Bogert
```
