### PR TITLE
underwater_simulation: 1.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10830,7 +10830,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uji-ros-pkg/underwater_simulation-release.git
-      version: 1.4.0-1
+      version: 1.4.1-0
     status: maintained
   unique_identifier:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `underwater_simulation` to `1.4.1-0`:
- upstream repository: https://github.com/uji-ros-pkg/underwater_simulation.git
- release repository: https://github.com/uji-ros-pkg/underwater_simulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.4.0-1`
## underwater_sensor_msgs
- No changes
## underwater_vehicle_dynamics
- No changes
## uwsim

```
* Can use package:// to resolve ROS package location for meshes
* Can use package:// to pull a urdf from a ROS package
* Fixed transform publishing to fit the new robotpublisher interface
* Contributors: Bence Magyar, perezsolerj
```
