### PR TITLE
mavros: 0.16.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2000,7 +2000,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.16.3-0
+      version: 0.16.4-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.16.4-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.16.3-0`
## libmavconn

```
* libmavconn #452 <https://github.com/mavlink/mavros/issues/452>: remove pixhawk, add paparazzi dialects.
  Mavlink package provide information about known dialects,
  so we do not touch mavlink_dialect.h selection ifs.
* Contributors: Vladimir Ermakov
```
## mavros

```
* scripts: checkid: be always verbose, add --follow
* scripts: fix copyright indent
* scripts: mavcmd: Fix bug: param7 not passed to service call!
* scripts #382 <https://github.com/mavlink/mavros/issues/382>: Add ID checker script.
  It is not complete, but i hope it helps in current state.
* scripts: mavcmd: Add support for broadcast requests
* event_launcher: fix bug: Trigger service server is not saved in Launcher
  Also fixes: environment variables may contain ~ (user dir) in expansion.
* using timestamp from mavlink message
* Update mavlink message documentation links
* lib: update MAV_TYPE stringify
* lib: Add RATTITUDE PX4 mode
* remove "altitude_" prefix from members
* updated copyright
* implemented altitude plugin
* Contributors: Andreas Antener, Vladimir Ermakov
```
## mavros_extras
- No changes
## mavros_msgs

```
* Update mavlink message documentation links
* remove "altitude_" prefix from members
* implemented altitude plugin
* Contributors: Andreas Antener, Vladimir Ermakov
```
## test_mavros

```
* updated local position subscription topic
* Contributors: Andreas Antener
```
