### PR TITLE
leap_motion: 0.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4423,7 +4423,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/leap_motion-release.git
-      version: 0.0.8-1
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/ros-drivers/leap_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leap_motion` to `0.0.9-0`:
- upstream repository: https://github.com/ros-drivers/leap_motion
- release repository: https://github.com/ros-gbp/leap_motion-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.8-1`
## leap_motion

```
* [feat] Added individual coordinates for each finger bone (#23 <https://github.com/ros-drivers/leap_motion/issues/23>)
* [feat] Better way of parameter declaration (#17 <https://github.com/ros-drivers/leap_motion/issues/17>)
* [sys] Update travis conf to Ubuntu Trusty and ROS I-J (#22 <https://github.com/ros-drivers/leap_motion/issues/22>)
* Contributors: Isaac I.Y. Saito, Tu-Hoa Pham
```
