### PR TITLE
leap_motion: 0.0.9-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1769,6 +1769,21 @@ repositories:
       url: https://github.com/ros-gbp/laser_proc-release.git
       version: 0.1.4-0
     status: maintained
+  leap_motion:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/leap_motion.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/leap_motion-release.git
+      version: 0.0.9-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/leap_motion.git
+      version: master
+    status: maintained
   libccd:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `leap_motion` to `0.0.9-0`:
- upstream repository: https://github.com/ros-drivers/leap_motion
- release repository: https://github.com/ros-gbp/leap_motion-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## leap_motion

```
* [feat] Added individual coordinates for each finger bone (#23 <https://github.com/ros-drivers/leap_motion/issues/23>)
* [feat] Better way of parameter declaration (#17 <https://github.com/ros-drivers/leap_motion/issues/17>)
* [sys] Update travis conf to Ubuntu Trusty and ROS I-J (#22 <https://github.com/ros-drivers/leap_motion/issues/22>)
* Contributors: Isaac I.Y. Saito, Tu-Hoa Pham
```
