### PR TITLE
roswww: 0.1.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9124,7 +9124,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/roswww-release.git
-      version: 0.1.7-0
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/tork-a/roswww.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roswww` to `0.1.8-0`:
- upstream repository: https://github.com/tork-a/roswww.git
- release repository: https://github.com/tork-a/roswww-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.7-0`
## roswww

```
* [doc] Add rostopic-chat sample #31 <https://github.com/tork-a/roswww/issues/31>
* [sys] Utilize test_depend that is defined in REP-140 #30 <https://github.com/tork-a/roswww/issues/30> from 130s/impr/utilize_testdepend
* Contributors: Kenta Yonekura, Isaac I.Y. Saito
```
