### PR TITLE
homer_gui: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3091,6 +3091,12 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_android_speech.git
       version: 0.0.2-0
+  homer_gui:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://gitlab.uni-koblenz.de/robbie/homer_gui.git
+      version: 1.0.3-0
   homer_mapnav:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_gui` to `1.0.3-0`:
- upstream repository: https://gitlab.uni-koblenz.de/robbie/homer_gui.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_gui.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## homer_gui

```
* removed door_detection_messages dependency
* Contributors: Niklas Yann Wettengel
```
