### PR TITLE
pr2_simulator: 2.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7296,7 +7296,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_simulator-release.git
-      version: 2.0.6-0
+      version: 2.0.7-0
     source:
       type: git
       url: https://github.com/PR2/pr2_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_simulator` to `2.0.7-0`:
- upstream repository: https://github.com/pr2/pr2_simulator.git
- release repository: https://github.com/pr2-gbp/pr2_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.0.6-0`
