### PR TITLE
homer_gui: 1.0.4-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3096,7 +3096,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_gui.git
-      version: 1.0.3-0
+      version: 1.0.4-1
   homer_mapnav:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_gui` to `1.0.4-1`:
- upstream repository: https://gitlab.uni-koblenz.de/robbie/homer_gui.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_gui.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.3-0`
## homer_gui

```
* splitted Readme file
* moved files to subfolder homer_gui
* Contributors: Niklas Yann Wettengel
```
