### PR TITLE
add python-texttable for fedra

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1897,6 +1897,7 @@ python-termcolor:
     utopic: [python-termcolor]
     vivid: [python-termcolor]
 python-texttable:
+  fedora: [python-texttable]
   osx:
     pip:
       packages: [texttable]


### PR DESCRIPTION
bloom requires ubuntu and fedra for release job (@wkentaro)
https://admin.fedoraproject.org/pkgdb/package/python-texttable/
