### PR TITLE
jsk_model_tools: 0.2.2-3 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1628,7 +1628,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.1.13-4
+      version: 0.2.2-3
     status: developed
   jsk_recognition:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.2.2-3`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.13-4`
## eus_assimp
- No changes
## euscollada
- No changes
## eusurdf

```
* [textured_models/room73b2-hitachi-fiesta-refrigerator-0] transparent inside board of fridge
* [textured_models/room73b2-georgia-emerald-mountain-0] add texture of georgia can
* [textured_models/room73b2-hitachi-fiesta-refrigerator-0/model.urdf] update to more realistic physics parameters
* [textured_models] add georgia can
* [CMakeLists.txt] install eusurdf/worlds directory
* [CMakeLists.txt] add roseus to run_depend. use environment variable to get eusdir. call roseus without rosrun.
* [eusurdf] add textured_models/
* Contributors: Yuki Furuta, Masaki Murooka
```
## jsk_model_tools
- No changes
