### PR TITLE
moveit_simple_actions: 0.0.4-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5275,7 +5275,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/nlyubova/moveit_simple_actions-release.git
-      version: 0.0.5-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/nlyubova/moveit_simple_actions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_simple_actions` to `0.0.4-1`:
- upstream repository: https://github.com/nlyubova/moveit_simple_actions
- release repository: https://github.com/nlyubova/moveit_simple_actions-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.5-1`
## moveit_simple_actions

```
* fixing with changes in moveit visual tools
* Contributors: Natalia Lyubova
```
