### PR TITLE
head_pose_estimation: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2915,6 +2915,21 @@ repositories:
       url: https://github.com/pal-robotics/head_action.git
       version: indigo-devel
     status: maintained
+  head_pose_estimation:
+    doc:
+      type: git
+      url: https://github.com/OSUrobotics/ros-head-tracking.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/OSUrobotics/head_pose_estimation-release.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/OSUrobotics/ros-head-tracking.git
+      version: hydro-devel
+    status: maintained
   hector_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `head_pose_estimation` to `1.0.3-0`:
- upstream repository: https://github.com/OSUrobotics/ros-head-tracking.git
- release repository: https://github.com/OSUrobotics/head_pose_estimation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## head_pose_estimation

```
* cleanup
* remove unused launch files
* Contributors: Dan Lazewatsky
```
