### PR TITLE
jsk_planning: 0.1.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3879,7 +3879,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_planning-release.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     status: developed
   jsk_pr2eus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_planning` to `0.1.6-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_planning
- release repository: https://github.com/tork-a/jsk_planning-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.5-0`
## jsk_planning
- No changes
## pddl_msgs
- No changes
## pddl_planner

```
* pddl_planner: mv demos/sample-pddl/README README.md
* pddl_planner/demos/sample-pddl: add sample-client.py and its test to test-sample-pddl.test
* demos/sample-pddl/{sample-problem.pddl, README}: fix problem.pddl which fails on downward, and added to README
* add test for demos/sample-pddl directory
* [pddl_planner/CMakeLists.txt] add test to install
* [pddl/pddl_planner/package.xml] add time to run_depend for downward on hydro
* [pddl_planner] add test for pddl_planner
* Contributors: Yuki Furuta, Kei Okada
```
## pddl_planner_viewer
- No changes
## task_compiler

```
* [task_compiler/CMakeLists.txt&package.xml] add roseus_smach to build_depend
* [task_compiler] add task_compiler test for solving plan and manage actions
* Contributors: Yuki Furuta
```
