### PR TITLE
homer_gui: 1.0.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3111,7 +3111,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_gui.git
-      version: 1.0.4-1
+      version: 1.0.5-1
   homer_mapnav:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_gui` to `1.0.5-1`:
- upstream repository: https://gitlab.uni-koblenz.de/robbie/homer_gui.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_gui.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.4-1`
## homer_gui

```
* added dependency pcl
* Contributors: Niklas Yann Wettengel
```
