### PR TITLE
jsk_3rdparty: 2.0.13-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1576,7 +1576,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.0.12-1
+      version: 2.0.13-0
     status: developed
   jsk_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.0.13-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.0.12-1`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## collada_urdf_jsk_patch
- No changes
## downward
- No changes
## ff
- No changes
## ffha

```
* [ffha] Use http instead of https
  closes https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/45
  Modified:
  3rdparty/ffha/Makefile
* Contributors: Ryohei Ueda
```
## jsk_3rdparty
- No changes
## julius
- No changes
## libcmt
- No changes
## libsiftfast
- No changes
## mini_maxwell
- No changes
## nlopt
- No changes
## opt_camera
- No changes
## pgm_learner

```
* [pgm_learner] Depends on rostest
  closes #46 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/46>
  Modified:
  pgm_learner/package.xml
* Contributors: Kei Okada, Ryohei Ueda
```
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## voice_text
- No changes
