### PR TITLE
jsk_robot: 1.0.1-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3934,13 +3934,15 @@ repositories:
       - jsk_pr2_startup
       - jsk_robot_startup
       - jsk_robot_utils
+      - naoeus
+      - naoqieus
       - peppereus
       - pr2_base_trajectory_action
       - roseus_remote
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_robot-release.git
-      version: 0.0.11-0
+      version: 1.0.1-2
     status: developed
   jsk_roseus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `1.0.1-2`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.11-0`
## baxtereus
- No changes
## jsk_201504_miraikan

```
* move jsk_201504_miraikan under jsk_naoqi_robot
```
## jsk_baxter_desktop
- No changes
## jsk_baxter_startup
- No changes
## jsk_baxter_web
- No changes
## jsk_nao_startup

```
* move jsk_nao_startup under jsk_naoqi_robot
```
## jsk_pepper_startup

```
* move jsk_pepper_startup under jsk_naoqi_robot
```
## jsk_pr2_calibration
- No changes
## jsk_pr2_startup

```
* Record battery info before pwer go off #474 <https://github.com/jsk-ros-pkg/jsk_robot/issues/474>
* Contributors:  Chi Wun Au
```
## jsk_robot_startup

```
* [jsk_robot_startup] Fix namespace of param for pointcloud_to_laserscan
* Contributors: Eisoku Kuroiwa
```
## jsk_robot_utils
- No changes
## naoeus

```
* naoeus/nao-interface.l: add nao-robot class and nao function
* naoeus/CMakeLists.txt: fix typo papper_meshes_FOUND -> nao_meshes_FOUND
* naoeus,peppereus: package.xml: fix typo in run_depend, naoqi->naoqieus, nap_apps->nao_apps
* add .gitignore
* add nao-interface.l
* naoeus: add nao.yaml
* naoeus: add test/
* catkinize naoeus
* change to naoqi_msgs from nao_msgs
* delete one of two nao-inits (bug fixed)
* nao servo-on/off extended to hands and start/stop-grasp added #134 <https://github.com/jsk-ros-pkg/jsk_robot/issues/134>
* nao-init added to nao-interface.l
* delete nao-init
* nao-init added
* advertising topic added
* nao speaking function added
* add README.md for nao #118 <https://github.com/jsk-ros-pkg/jsk_robot/issues/118>
* fix nao-interface.l
* add setup file for using alrobotmodel
* Added nao-test-new.l showing a model with the new meshes.
* add ik sample in nao-test.l
* set joint-action-enable nil in simulation
* change pass for nao-interface.l
* change the path naoeus/nao-interface.l to naoeus/euslisp/nao-interface.l
* add patch for nao_description
* add jsk_nao_robot
* Contributors: Kei Okada, Ryohei Ueda, Yohei Kakiuchi, Masahiro Bando, Yusuke Furuta, Satoshi Iwaishi, Kanae Kochigami, Yoshimaru Tanaka
```
## naoqieus

```
* Add new package name naoqieus; move pepper-interface.l to naoqi-interface.l

    * naoqi-interface.l: /cmd_vel is published under global namespace
    * naoqieus: do not run test on hydro
    * add naoqieus/cmake/compile_naoqi_modeol.cmake
    * add naoqieus from peppereus

* Contributors: Kei Okada, Masahiro Bando
```
## peppereus

```
* move peppereus under jsk_naoqi_robot
* naoeus,peppereus: package.xml: fix typo in run_depend, naoqi->naoqieus, nap_apps->nao_apps
* add naoqieus/cmake/compile_naoqi_modeol.cmake
* Contributors: Kei Okada, Masahiro Bando
```
## pr2_base_trajectory_action
- No changes
## roseus_remote
- No changes
