### PR TITLE
relocate docs for utexas-art repository

### DIFF
--- a/doc/electric/art_vehicle.rosinstall
+++ b/doc/electric/art_vehicle.rosinstall
@@ -1,3 +1,3 @@
 - svn:
     local-name: art_vehicle
-    uri: https://utexas-art-ros-pkg.googlecode.com/svn/trunk/stacks/art_vehicle
+    uri: https://github.com/austin-robot/utexas-art-ros-pkg.git

--- a/doc/fuerte/art_vehicle.rosinstall
+++ b/doc/fuerte/art_vehicle.rosinstall
@@ -1,3 +1,3 @@
 - svn:
     local-name: art_vehicle
-    uri: https://utexas-art-ros-pkg.googlecode.com/svn/trunk/stacks/art_vehicle
+    uri: https://github.com/austin-robot/utexas-art-ros-pkg.git


### PR DESCRIPTION
The sources moved from googlecode to github.
