### PR TITLE
rtmros_common: 1.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9368,7 +9368,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.3.0-0
+      version: 1.3.1-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.3.1-0`:
- upstream repository: https://github.com/start-jsk/rtmros_common.git
- release repository: https://github.com/tork-a/rtmros_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.3.0-0`
## hrpsys_ros_bridge

```
* deb release only targeting to indigo
* Fix for travis testing

    * [hrpsys_ros_bridge/test/test-samplerobot.test] Use joint_states instead of odom to check tf because joint_states is more related with tf and [Hz] printing. than odom #880 <https://github.com/start-jsk/rtmros_common/pull/880>
    * [hrpsys_ros_bridge/test/test-samplerobot.test] Increase hzerror according to https://github.com/start-jsk/rtmros_common/issues/877#issuecomment-164669534. Current worst travis hz seem to be more than 300[Hz], so set 200[Hz] error. #879 <https://github.com/start-jsk/rtmros_common/pull/879>
    * catkin.cmake: use ccache only for CI environment #872 <https://github.com/start-jsk/rtmros_common/pull/872>
    * add depends from AutoBalancerService.hh to StabilizerService.hh #872 <https://github.com/start-jsk/rtmros_common/pull/872>
    * [hrpsys_ros_bridge/test/hrpsys-samples/test_samplerobot_euslisp_unittests.launch] Increase time-limit for autobalancer euslisp test #879 <https://github.com/start-jsk/rtmros_common/pull/879>

* Fasten script excution

    * [hrpsys_ros_bridge/scripts/sensor_ros_bridge_connect.py] Reduce unnecessary waiting for sensor port rosbridge connection. #879 <https://github.com/start-jsk/rtmros_common/pull/879>

* Bug fix

    * [hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp] Initialize prev_odom_acquired flag. #879 <https://github.com/start-jsk/rtmros_common/pull/879>

* Add euslisp new example and update for example conf setting

    * [hrpsys_ros_bridge/test/hrpsys-samples/samplerobot-stabilizer.l] Add Stabilizer + loadPattern example for euslisp interface. #875 <https://github.com/start-jsk/rtmros_common/pull/875>
    * [hrpsys_ros_bridge/catkin.cmake] Add Sequencer's optionalData setting for sample conf files. #875 <https://github.com/start-jsk/rtmros_common/pull/875>

* Contributors: Kei Okada, Shunichi Nozawa
```
## hrpsys_tools

```
* deb release only targeting to indigo
```
## openrtm_ros_bridge

```
* deb release only targeting to indigo
```
## openrtm_tools

```
* deb release only targeting to indigo
```
## rosnode_rtc

```
* deb release only targeting to indigo
```
## rtmbuild

```
* deb release only targeting to indigo
```
## rtmros_common

```
* deb release only targeting to indigo
```
