### PR TITLE
openni_camera: 1.9.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2900,7 +2900,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/openni_camera-release.git
-      version: 1.9.3-0
+      version: 1.9.4-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_camera` to `1.9.4-0`:
- upstream repository: https://github.com/ros-drivers/openni_camera.git
- release repository: https://github.com/ros-gbp/openni_camera-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.9.3-0`
## openni_camera

```
* Remove unneeded dependency (libopenni-sensor-primesense-dev is an internal plugin).
* Contributors: Jochen Sprickerhof
```
