### PR TITLE
jsk_recognition: 0.3.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3914,7 +3914,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.10-0
+      version: 0.3.11-0
     status: developed
   jsk_robot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.11-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.10-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros

```
* [jsk_pcl_ros] Do not include pcl headers in polygon_array_wrapper and polygon_array_unwrapper
* [jsk_pcl_ros] Remove ccache prefix
* [jsk_pcl_ros] Cache test_data to ROS home
  Modified:
  jsk_pcl_ros/scripts/install_test_data.py
* [jsk_pcl_ros] Remove build_check.cpp.in
* Contributors: Kentaro Wada, Ryohei Ueda
```
## jsk_perception

```
* [jsk_perception] slic as submodule
* Contributors: Ryohei Ueda
```
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## jsk_recognition_utils
- No changes
## resized_image_transport
- No changes
