### PR TITLE
[indigo, iot_bridge] Remove its older name openhab_bridge for consistency.

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6297,12 +6297,6 @@ repositories:
       url: https://github.com/wg-perception/opencv_candidate.git
       version: master
     status: maintained
-  openhab_bridge:
-    source:
-      type: git
-      url: https://github.com/corb555/openhab_bridge.git
-      version: master
-    status: maintained
   openhrp3:
     doc:
       type: git


### PR DESCRIPTION
https://github.com/ros/rosdistro/pull/8804 Although looks like renamed to `iot_bridge`, a piece of `openhab_bridge` still remains. I wonder if this has something to do with [iot_bridge wiki page](http://wiki.ros.org/iot_bridge) hasn't been generated (its doc status mentions `indigo: Cannot load information on name: openhab_bridge, distro: indigo`). 

Hopefully removing `openhab_bridge` will resolve it.

CC @corb555
