### PR TITLE
laser_filters: 1.7.4-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4405,7 +4405,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/laser_filters-release.git
-      version: 1.7.3-0
+      version: 1.7.4-1
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `1.7.4-1`:
- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros-gbp/laser_filters-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.7.3-0`
## laser_filters

```
* [intensity_filter.h] fix: check if cur_bucket value is out of index of histogram array
* [intensity_filter.h] refactor codes; clearify by using boolean to enable/disable displaying histogram
* scan_to_scan_filter_chain: make tf filter tolerance customizable
  0.03 is completely arbitrary and too small in my case.
* scan2scan filter: only publish result if filter succeeded
* added cartesian box filter
* add check inf or nan of input laser_scan intensities
* scan_to_scan_filter_chain: Only subscribe to /tf if requested by parameter
* Contributors: Furushchev, Jonathan Binney, Kevin Hallenbeck, Sebastian Pütz, Vincent Rabaud, Yuto Inagaki, v4hn
```
