### PR TITLE
optitrack: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5323,6 +5323,17 @@ repositories:
       url: https://github.com/ros-gbp/openslam_gmapping-release.git
       version: 0.1.0-2
     status: maintained
+  optitrack:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/crigroup/optitrack-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/crigroup/optitrack.git
+      version: hydro-devel
+    status: developed
   optris_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `optitrack` to `0.1.0-0`:
- upstream repository: https://github.com/crigroup/optitrack.git
- release repository: https://github.com/crigroup/optitrack-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## optitrack

```
* Initial release
* Contributors: fsuarez6
```
