### PR TITLE
multimaster_fkie: 0.4.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5395,7 +5395,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.4.3-0
+      version: 0.4.4-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.4.4-0`:
- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.4.3-0`
## default_cfg_fkie
- No changes
## master_discovery_fkie
- No changes
## master_sync_fkie
- No changes
## multimaster_fkie
- No changes
## multimaster_msgs_fkie
- No changes
## node_manager_fkie

```
* node_manager_fkie: fixed republish of array values in paraeter dialog
* node_manager_fkie: reviewed the name resolution
* node_manager_fkie: added an IP to hostname resolution
  it is usefull for detection of automatic master_sync start if an IP was
  entered while start of master_discovery
* node_manager_fkie: added a settings parameter 'start_sync_with_discovery'
  The start_sync_with_discovery determine the default behaviour to start
  master_sync with master_discover or not. This presets the 'Start sync'
  parameter in Start-dialog.
* node_manager_fkie: added an option to start master_sync with master_discovery
* node_manager_fkie: added network ID visualization
* node_manager_fkie: fixed joining from discovery dialog
* node_manager_fkie: fixed discovery dialog, which was broken after changes in master_discovery
* node_manager_fkie: highlighted the sync button in ROS network dock
* Contributors: Alexander Tiderko
```
