### PR TITLE
visp: 3.0.0-3 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5052,7 +5052,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 2.10.0-4
+      version: 3.0.0-3
     status: maintained
   visp_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `3.0.0-3`:
- upstream repository: https://github.com/lagadic/visp.git
- release repository: https://github.com/lagadic/visp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.10.0-4`
