### PR TITLE
csm: 1.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -507,6 +507,21 @@ repositories:
       url: https://github.com/whoenig/crazyflie_ros.git
       version: master
     status: maintained
+  csm:
+    doc:
+      type: git
+      url: https://github.com/AndreaCensi/csm.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/csm-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/AndreaCensi/csm.git
+      version: master
+    status: maintained
   cv_backports:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `csm` to `1.0.2-0`:
- upstream repository: https://github.com/AndreaCensi/csm.git
- release repository: https://github.com/tork-a/csm-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
