### PR TITLE
[indigo/csm] Correct branch to be used

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1583,7 +1583,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/AndreaCensi/csm.git
-      version: csm_eigen
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -1592,7 +1592,7 @@ repositories:
     source:
       type: git
       url: https://github.com/AndreaCensi/csm.git
-      version: csm_eigen
+      version: master
     status: maintained
   cv_backports:
     release:


### PR DESCRIPTION
I'm not sure why the DEB 1.0.2-2 of this 3rd-party package seems to be working although the branch name is wrong. 
