### PR TITLE
md49_base_controller: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4866,6 +4866,25 @@ repositories:
       type: git
       url: https://github.com/mikeferguson/maxwell.git
       version: indigo-devel
+  md49_base_controller:
+    doc:
+      type: git
+      url: https://github.com/Scheik/md49_base_controller.git
+      version: master
+    release:
+      packages:
+      - custom_messages
+      - md49_base_controller
+      - serialport
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/Scheik/md49_base_controller.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/Scheik/md49_base_controller.git
+      version: master
+    status: developed
   media_export:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `md49_base_controller` to `0.1.0-0`:
- upstream repository: https://github.com/Scheik/md49_base_controller.git
- release repository: https://github.com/Scheik/md49_base_controller.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
