### PR TITLE
jsk_recognition: 0.3.13-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3906,6 +3906,7 @@ repositories:
       - checkerboard_detector
       - imagesift
       - jsk_pcl_ros
+      - jsk_pcl_ros_utils
       - jsk_perception
       - jsk_recognition
       - jsk_recognition_msgs
@@ -3914,7 +3915,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.11-0
+      version: 0.3.13-1
     status: developed
   jsk_robot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.13-1`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.11-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros

```
* [jsk_pcl_ros] Longer timelimit
* [jsk_pcl_ros] jsk_pcl_ros::SetPointCloud2 -> jsk_recognition_msgs::SetPointCloud2
* Contributors: Ryohei Ueda
```
## jsk_pcl_ros_utils

```
* [jsk_pcl_ros_utils] Remove jsk_pcl_ros_base
* Contributors: Ryohei Ueda
```
## jsk_perception
- No changes
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## jsk_recognition_utils
- No changes
## resized_image_transport
- No changes
