### PR TITLE
jsk_recognition: 0.3.13-2 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1651,6 +1651,7 @@ repositories:
       - checkerboard_detector
       - imagesift
       - jsk_pcl_ros
+      - jsk_pcl_ros_utils
       - jsk_perception
       - jsk_recognition
       - jsk_recognition_msgs
@@ -1659,7 +1660,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.8-1
+      version: 0.3.13-2
   jsk_roseus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.13-2`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.8-1`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros

```
* [jsk_pcl_ros] Longer timelimit
* [jsk_pcl_ros] jsk_pcl_ros::SetPointCloud2 -> jsk_recognition_msgs::SetPointCloud2
* Contributors: Ryohei Ueda
```
## jsk_pcl_ros_utils

```
* [jsk_pcl_ros_utils] Remove jsk_pcl_ros_base
* Contributors: Ryohei Ueda
```
## jsk_perception
- No changes
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## jsk_recognition_utils
- No changes
## resized_image_transport
- No changes
