### PR TITLE
romeo_robot: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8296,7 +8296,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-aldebaran/romeo_robot-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/ros-aldebaran/romeo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_robot` to `0.1.3-0`:
- upstream repository: https://github.com/ros-aldebaran/romeo_robot.git
- release repository: https://github.com/ros-aldebaran/romeo_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.2-0`
## romeo_bringup

```
* fixing romeo_bringup launch and romeo_sensors_py to get data from all cameras
* adding details to the package description
* Contributors: nlyubova
```
## romeo_dcm_bringup
- No changes
## romeo_dcm_control

```
* excluding torso controller for a moment
* Contributors: nlyubova
```
## romeo_dcm_driver

```
* excluding torso controller for a moment
* Contributors: nlyubova
```
## romeo_dcm_msgs
- No changes
## romeo_description

```
* fixing romeo_bringup launch and romeo_sensors_py to get data from all cameras
* Contributors: nlyubova
```
## romeo_robot
- No changes
## romeo_sensors_py

```
* fixing romeo_bringup launch and romeo_sensors_py to get data from all cameras
* Contributors: nlyubova
```
