### PR TITLE
vision_visp: 0.9.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11142,7 +11142,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.8.1-0
+      version: 0.9.0-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.9.0-0`:
- upstream repository: https://github.com/lagadic/vision_visp.git
- release repository: https://github.com/lagadic/vision_visp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.8.1-0`
## vision_visp

```
* indigo-0.8.1
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_auto_tracker

```
* Fix catkin_lint errors and warnings
* Compat with ViSP 3.0.0
* Fix to build with ViSP 2.10.0 when VISP_BUILD_DEPRECATED=OFF
* indigo-0.8.1
* Prepare changelogs
* Contributors: Aurelien Yol, Fabien Spindler
```
## visp_bridge

```
* Fix catkin_lint errors and warnings
* Changed input to conversion functions to const
* indigo-0.8.1
* Prepare changelogs
* Contributors: Fabien Spindler, Riccardo Spica
```
## visp_camera_calibration

```
* Fix catkin_lint errors and warnings
* Fix to build with ViSP 2.10.0 when VISP_BUILD_DEPRECATED=OFF
* Fix to build with ViSP 2.10.0 when VISP_BUILD_DEPRECATED=OFF
* indigo-0.8.1
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_hand2eye_calibration

```
* Fix catkin_lint errors and warnings
* indigo-0.8.1
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_tracker

```
* Fix catkin_lint errors and warnings
* Compat with ViSP 3.0.0
* Fix to build with ViSP 2.10.0 when VISP_BUILD_DEPRECATED=OFF
* indigo-0.8.1
* Prepare changelogs
* Contributors: Aurelien Yol, Fabien Spindler
```
