### PR TITLE
vision_visp: 0.9.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5056,7 +5056,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.8.0-0
+      version: 0.9.0-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.9.0-0`:
- upstream repository: https://github.com/lagadic/vision_visp.git
- release repository: https://github.com/lagadic/vision_visp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.8.0-0`
## vision_visp

```
* jade-0.8.0
* Prepare changelogs
* Fix doc url location
* 0.7.3
* Prepare changelogs
* indigo-0.7.2
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_auto_tracker

```
* Fix catkin_lint error and issues
* Compat with ViSP 3.0.0
* Fix to build with ViSP 2.10.0 when VISP_BUILD_DEPRECATED=OFF
* jade-0.8.0
* Prepare changelogs
* Contributors: Aurelien Yol, Fabien Spindler
```
## visp_bridge

```
* Fix catkin_lint error and issues
* Changed input to conversion functions to const
* jade-0.8.0
* Prepare changelogs
* Contributors: Fabien Spindler, Riccardo Spica
```
## visp_camera_calibration

```
* Fix catkin_lint error and issues
* Fix to build with ViSP 2.10.0 when VISP_BUILD_DEPRECATED=OFF
* jade-0.8.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_hand2eye_calibration

```
* Fix catkin_lint error and issues
* jade-0.8.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_tracker

```
* Fix catkin_lint error and issues
* Compat with ViSP 3.0.0
* Fix to build with ViSP 2.10.0 when VISP_BUILD_DEPRECATED=OFF
* Fix bug to display the last computed pose in the tracker client.
* Improve data synchronization test based only on pose, klt points, and moving edges features
* Make ROS warn messages more explicit
* Make dynamic reconfigure working with ViSP 2.9.0.
  Ensure that the image is ready (test image size != 0) during dynamic reconfigure initialisation.
* Use VP_VERSION_INT
* Fix compat with ViSP 2.9.0. Fix ROS_INFO message. Code indentation.
* Improve ROS debug messages to be more generic.
  Remove parameters that should not be modified by the user in dynamic reconfigure files.
* Improve viewer node to handle dynamic reconfigure modifications.
  Modify tutorials so that they use the new functionnalities.
* Fix bug in visp_tracker_client to work without visp_tracker_viewer.
* jade-0.8.0
* Prepare changelogs
* Remove useless call to setKltOpencv and setMovingEdge (as it is done by default by the reconfigure server).
  Remove useless vpKltOpencv and vpMe variables.
* Modify dynamic reconfigure files to suppressed deprecated values.
  Adapt library to work with those modifications.
  Fix ROS debug message error.
* Reorganise ROS debug message to display trackers, edges and KLT parameters value.
* Contributors: Aurelien Yol, Fabien Spindler
```
