### PR TITLE
md49_base_controller: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4867,6 +4867,13 @@ repositories:
       type: git
       url: https://github.com/mikeferguson/maxwell.git
       version: indigo-devel
+  md49_base_controller:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/Scheik/md49_base_controller-release.git
+      version: 0.1.1-0
+    status: developed
   media_export:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `md49_base_controller` to `0.1.1-0`:
- upstream repository: https://github.com/Scheik/md49_base_controller.git
- release repository: https://github.com/Scheik/md49_base_controller-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## md49_base_controller
- No changes
