### PR TITLE
laser_filtering: 0.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1732,6 +1732,24 @@ repositories:
       url: https://github.com/ros-perception/laser_assembler.git
       version: hydro-devel
     status: maintained
+  laser_filtering:
+    doc:
+      type: git
+      url: https://github.com/DLu/laser_filtering.git
+      version: hydro_devel
+    release:
+      packages:
+      - laser_filtering
+      - map_laser
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wu-robotics/laser_filtering_release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/DLu/laser_filtering.git
+      version: hydro_devel
+    status: maintained
   laser_filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filtering` to `0.0.2-0`:
- upstream repository: https://github.com/DLu/laser_filtering.git
- release repository: https://github.com/wu-robotics/laser_filtering_release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
