### PR TITLE
denso: 1.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1666,11 +1666,12 @@ repositories:
       - denso_controller
       - denso_launch
       - vs060
+      - vs060_gazebo
       - vs060_moveit_config
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/start-jsk/denso-release.git
-      version: 1.1.1-0
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/start-jsk/denso.git


### PR DESCRIPTION
Increasing version of package(s) in repository `denso` to `1.1.2-0`:
- upstream repository: https://github.com/start-jsk/denso.git
- release repository: https://github.com/start-jsk/denso-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.1-0`
## denso

```
* Add gazebo pkg to the metapkg suite
* Contributors: Isaac I.Y. Saito
```
## denso_controller

```
* use newer api function
* set velocity correctly
* add functions for finalizing things, update recovery procedures
* replace sleep with boost::this_thread::sleep
* add function to reflect real robot state into controller manager
* add emergency_stop variable
* separate a procedure to fill buffer and re-use it
* Contributors: Shohei Fujii
```
## denso_launch

```
* denso_launch/test/vs060.test: move denso_vs060_moveit_demo_test.py to vs060.test
* denso_launch/test/vs060.test: do not have to check over 30sec,we need to wait to starting moveit, and test just for a second
* [vs060] Add simple unit test cases for moveit
* Contributors: Isaac I.Y. Saito, Kei Okada
```
## vs060

```
* vs060_world.launch is no longer requred
* Contributors: Kei Okada
```
## vs060_gazebo

```
* Add vs060_gazebo pkg
* Contributors: MahsaP
```
## vs060_moveit_config

```
* [moveit config] Remove redundant portion in a launch
* Contributors: Isaac I.Y. Saito
```
