### PR TITLE
vision_visp: 0.9.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5074,7 +5074,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.9.0-0
+      version: 0.9.1-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.9.1-0`:
- upstream repository: https://github.com/lagadic/vision_visp.git
- release repository: https://github.com/lagadic/vision_visp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.9.0-0`
## vision_visp

```
* jade-0.9.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_auto_tracker

```
* Revert build_depend visp removal that is mandatory.
* jade-0.9.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_bridge

```
* Revert build_depend visp removal that is mandatory.
* jade-0.9.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_camera_calibration

```
* Revert build_depend visp removal that is mandatory.
* jade-0.9.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_hand2eye_calibration

```
* Revert build_depend visp removal that is mandatory.
* jade-0.9.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_tracker

```
* Revert build_depend visp removal that is mandatory.
* jade-0.9.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
