### PR TITLE
orocos_toolchain: 2.8.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6491,7 +6491,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/orocos-gbp/orocos_toolchain-release.git
-      version: 2.8.0-0
+      version: 2.8.2-0
     status: maintained
   orogen:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_toolchain` to `2.8.2-0`:
- upstream repository: https://github.com/orocos-toolchain/orocos_toolchain.git
- release repository: https://github.com/orocos-gbp/orocos_toolchain-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.8.0-0`
