### PR TITLE
scan_tools: 0.3.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4516,15 +4516,17 @@ repositories:
     release:
       packages:
       - laser_ortho_projector
+      - laser_scan_matcher
       - laser_scan_sparsifier
       - laser_scan_splitter
       - ncd_parser
       - polar_scan_matcher
       - scan_to_cloud_converter
+      - scan_tools
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/scan_tools-release.git
-      version: 0.2.1-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/scan_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scan_tools` to `0.3.1-0`:
- upstream repository: https://github.com/ccny-ros-pkg/scan_tools.git
- release repository: https://github.com/tork-a/scan_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.1-0`
## laser_ortho_projector
- No changes
## laser_scan_matcher

```
* [sys] Remove obsolete dependency. Alphabetize.
* Contributors: Isaac I.Y. Saito
```
## laser_scan_sparsifier
- No changes
## laser_scan_splitter
- No changes
## ncd_parser
- No changes
## polar_scan_matcher
- No changes
## scan_to_cloud_converter
- No changes
## scan_tools

```
* [sys] Remove obsolete dependency. Alphabetize.
* Contributors: Isaac I.Y. Saito
```
