### PR TITLE
ros_emacs_utils: 0.4.9-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3871,7 +3871,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/code-iai-release/ros_emacs_utils-release.git
-      version: 0.4.8-0
+      version: 0.4.9-0
     source:
       type: git
       url: https://github.com/code-iai/ros_emacs_utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_emacs_utils` to `0.4.9-0`:
- upstream repository: https://github.com/code-iai/ros_emacs_utils.git
- release repository: https://github.com/code-iai-release/ros_emacs_utils-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.4.8-0`
