### PR TITLE
md49_base_controller: 0.1.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4885,10 +4885,14 @@ repositories:
       version: indigo-devel
   md49_base_controller:
     release:
+      packages:
+      - md49_base_controller
+      - md49_messages
+      - md49_serialport
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/Scheik/md49_base_controller-release.git
-      version: 0.1.1-0
+      version: 0.1.2-1
     status: developed
   media_export:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `md49_base_controller` to `0.1.2-1`:
- upstream repository: https://github.com/Scheik/md49_base_controller.git
- release repository: https://github.com/Scheik/md49_base_controller-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.1-0`
## md49_base_controller

```
* Add separate package md49_serialport as library for serial communication with md49
* Separated custom messages from md49_base_controller package into its own package md49_messages
* Contributors: Scheik
```
## md49_messages

```
* Separated custom messages used by md49_base_controller package into this package md49_messages
* Contributors: Scheik
```
## md49_serialport

```
* Added this separate package md49_serialport as library for serial communication with md49
* Contributors: Scheik
```
