### PR TITLE
GeographicLib support

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1351,6 +1351,8 @@ libgazebo5-dev:
   gentoo: [sci-electronics/gazebo]
   ubuntu: [libgazebo5-dev]
 libgeographic-dev:
+  fedora: [geographiclib]
+  gentoo: [sci-geosciences/geographiclib]
   ubuntu: [libgeographic-dev]
 libgeos++-dev:
   ubuntu: [libgeos++-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1350,6 +1350,8 @@ libgazebo5-dev:
   fedora: [gazebo-devel]
   gentoo: [sci-electronics/gazebo]
   ubuntu: [libgazebo5-dev]
+libgeographic-dev:
+  ubuntu: [libgeographic-dev]
 libgeos++-dev:
   ubuntu: [libgeos++-dev]
 libgflags-dev:


### PR DESCRIPTION
Adding rosdep rules for GeographicLib.  GeographicLib contains some geodetic calculations that are available in python-pyproj, but unavailable to C++ code since the version of proj.4 baked into python-pyroj is different than the version of proj.4 available as a system library. 
