### PR TITLE
costmap_converter: 0.0.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -473,7 +473,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/rst-tu-dortmund/costmap_converter-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/rst-tu-dortmund/costmap_converter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `costmap_converter` to `0.0.3-0`:
- upstream repository: https://github.com/rst-tu-dortmund/costmap_converter.git
- release repository: https://github.com/rst-tu-dortmund/costmap_converter-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.2-0`
## costmap_converter

```
* The argument list of the initialize method requires a nodehandle from now on. This facilitates the handling of parameter namespaces for multiple instantiations of the plugin.
* This change is pushed immediately as a single release to avoid API breaks (since version 0.0.2 is not on the official repos up to now).
```
