### PR TITLE
Adding patrolling_sim repo to documentation index for hydro and indigo

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5423,6 +5423,12 @@ repositories:
       url: https://github.com/pal-robotics/pal_vision_segmentation.git
       version: hydro-devel
     status: maintained
+  patrolling_sim:
+    doc:
+      type: git
+      url: https://github.com/davidbsp/patrolling_sim.git
+      version: master
+    status: maintained
   pcl:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6557,6 +6557,12 @@ repositories:
       url: https://github.com/allenh1/p2os.git
       version: master
     status: developed
+  patrolling_sim:
+    doc:
+      type: git
+      url: https://github.com/davidbsp/patrolling_sim.git
+      version: master
+    status: maintained
   pcan_topics:
     doc:
       type: git


### PR DESCRIPTION
I'd like my repo to be indexed and documented on ros.org. Thanks!
