### PR TITLE
Adding patrolling_sim repo to documentation index for indigo and jade

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6557,6 +6557,12 @@ repositories:
       url: https://github.com/allenh1/p2os.git
       version: master
     status: developed
+  patrolling_sim:
+    doc:
+      type: git
+      url: https://github.com/davidbsp/patrolling_sim.git
+      version: master
+    status: maintained
   pcan_topics:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3053,6 +3053,12 @@ repositories:
       url: https://github.com/allenh1/p2os.git
       version: master
     status: developed
+  patrolling_sim:
+    doc:
+      type: git
+      url: https://github.com/davidbsp/patrolling_sim.git
+      version: master
+    status: maintained
   pcl_conversions:
     doc:
       type: git


### PR DESCRIPTION
I'd like my repo to be indexed and documented on ros.org. Thanks!
