### PR TITLE
Adding sdl2 to rosdep/osx-homebrew.yaml

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -649,6 +649,10 @@ sdl-image:
   osx:
     homebrew:
       packages: [sdl_image]
+sdl2:
+  osx:
+    homebrew:
+      packages: [sdl2]
 subversion:
   osx:
     homebrew:


### PR DESCRIPTION
Other OSes supported here:

https://github.com/ros/rosdistro/blob/62bb76db5da2a920a55f888502b13b5ea03dbc12/rosdep/base.yaml#L3110
