### PR TITLE
md49_base_controller: 0.1.4-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4884,6 +4884,10 @@ repositories:
       url: https://github.com/mikeferguson/maxwell.git
       version: indigo-devel
   md49_base_controller:
+    doc:
+      type: git
+      url: https://github.com/Scheik/md49_base_controller.git
+      version: master
     release:
       packages:
       - md49_base_controller
@@ -4892,7 +4896,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/Scheik/md49_base_controller-release.git
-      version: 0.1.3-0
+      version: 0.1.4-1
+    source:
+      type: git
+      url: https://github.com/Scheik/md49_base_controller.git
+      version: master
     status: developed
   media_export:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `md49_base_controller` to `0.1.4-1`:
- upstream repository: https://github.com/Scheik/md49_base_controller.git
- release repository: https://github.com/Scheik/md49_base_controller-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.3-0`
## md49_base_controller

```
* No changes, keep release on track with md49_base_controller
* Contributors: Fabian Prinzing
```
## md49_messages

```
* No changes, keep release on track with md49_base_controller
* Contributors: Fabian Prinzing
```
## md49_serialport

```
* Update md49_serialport CMakeLists.txt: Marked header files for installation
* Contributors: Fabian Prinzing
```
