### PR TITLE
md49_base_controller: 0.1.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2094,6 +2094,25 @@ repositories:
       url: https://github.com/mavlink/mavros.git
       version: master
     status: developed
+  md49_base_controller:
+    doc:
+      type: git
+      url: https://github.com/Scheik/md49_base_controller.git
+      version: jade-devel
+    release:
+      packages:
+      - md49_base_controller
+      - md49_messages
+      - md49_serialport
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/Scheik/md49_base_controller-release.git
+      version: 0.1.4-0
+    source:
+      type: git
+      url: https://github.com/Scheik/md49_base_controller.git
+      version: jade-devel
+    status: developed
   media_export:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `md49_base_controller` to `0.1.4-0`:
- upstream repository: https://github.com/Scheik/md49_base_controller.git
- release repository: https://github.com/Scheik/md49_base_controller-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## md49_base_controller

```
* No changes, keep release on track with md49_base_controller
* Contributors: Fabian Prinzing
```
## md49_messages

```
* No changes, keep release on track with md49_base_controller
* Contributors: Fabian Prinzing
```
## md49_serialport

```
* Update md49_serialport CMakeLists.txt: Marked header files for installation
* Contributors: Fabian Prinzing
```
