### PR TITLE
pid: 0.0.9-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3175,7 +3175,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/AndyZelenak/pid-release.git
-      version: 0.0.7-0
+      version: 0.0.9-0
     source:
       type: git
       url: https://bitbucket.org/AndyZe/pid.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pid` to `0.0.9-0`:
- upstream repository: https://bitbucket.org/AndyZe/pid
- release repository: https://github.com/AndyZelenak/pid-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.7-0`
## pid

```
* Merged in bouchier/pid (pull request #1)
  Add dynamic reconfigure for Kx, change plant setpoint
* add dynamic reconfigure for Kx, change plant setpoint
* Contributors: AndyZe, Paul Bouchier
```
