### PR TITLE
rospy_message_converter: 0.4.0-0 in 'indigo/distribution.yaml' 

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9142,7 +9142,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/jihoonl/rospy_message_converter-release.git
-      version: 0.3.0-2
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/baalexander/rospy_message_converter.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9137,16 +9137,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/baalexander/rospy_message_converter.git
-      version: indigo-devel
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/jihoonl/rospy_message_converter-release.git
+      url: https://github.com/baalexander/rospy_message_converter-release.git
       version: 0.4.0-0
     source:
       type: git
       url: https://github.com/baalexander/rospy_message_converter.git
-      version: indigo-devel
+      version: master
     status: maintained
   rosserial:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rospy_message_converter` to `0.4.0-0`:
- upstream repository: https://github.com/baalexander/rospy_message_converter.git
- release repository: https://github.com/baalexander/rospy_message_converter-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.0-2`
## rospy_message_converter

```
* Adds support for ROS Jade
* Removes support for ROS Groovy and Hydro (EOL)
* Uses single branch for all ROS versions
* Docker support for local development and Travis CI
```
