### PR TITLE
tf_keyboard_cal: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10479,7 +10479,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/tf_keyboard_cal-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/davetcoleman/tf_keyboard_cal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf_keyboard_cal` to `0.0.5-0`:
- upstream repository: https://github.com/davetcoleman/tf_keyboard_cal.git
- release repository: https://github.com/davetcoleman/tf_keyboard_cal-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.4-0`
## tf_keyboard_cal

```
* Fix roslaunch file
* Updated README
* Contributors: Dave Coleman
```
