### PR TITLE
ros_control_boilerplate: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8515,7 +8515,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/ros_control_boilerplate-release.git
-      version: 0.2.1-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/ros_control_boilerplate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control_boilerplate` to `0.3.0-0`:
- upstream repository: https://github.com/davetcoleman/ros_control_boilerplate.git
- release repository: https://github.com/davetcoleman/ros_control_boilerplate-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.1-0`
## ros_control_boilerplate

```
* Removed bad reference name
* Switched to using name_
* Record error data
* Disable soft joint limits
* header to debug output
* Added error checking of control loops time
* Fix init() bug
* Contributors: Dave Coleman
```
