### PR TITLE
naoqi_driver: 0.5.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5672,7 +5672,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_driver-release.git
-      version: 0.5.5-0
+      version: 0.5.6-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_driver` to `0.5.6-0`:
- upstream repository: https://github.com/ros-naoqi/alrosbridge.git
- release repository: https://github.com/ros-naoqi/naoqi_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.5-0`
## naoqi_driver

```
* register audio_enabled only when audio is set enabled
* launch/naoqi_driver.launch : support nao_port
* fixing body temperature for Romeo
* missing romeo.urdf
* update to the latest URDF
* call startPublishing instaed of set true to publish_enabled_
* update to the latest urdf
* add subscribers/speech.cpp
* converters/joint_state.cpp: support mimic joint tf publisher
* Contributors: Karsten Knese, Kei Okada, Surya Ambrose, Vincent Rabaud, nlyubova
```
