### PR TITLE
moveit_sim_controller: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5317,7 +5317,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/moveit_sim_controller-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_sim_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_sim_controller` to `0.0.4-0`:
- upstream repository: https://github.com/davetcoleman/moveit_sim_controller.git
- release repository: https://github.com/davetcoleman/moveit_sim_controller-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.3-0`
## moveit_sim_controller

```
* Improved rosparam_shortcuts api
* Fixed initialization of default joint positions
* Fix travis
* Contributors: Dave Coleman
```
