### PR TITLE
rospy_message_converter: 0.4.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4241,6 +4241,21 @@ repositories:
       url: https://github.com/rospilot/rospilot.git
       version: master
     status: developed
+  rospy_message_converter:
+    doc:
+      type: git
+      url: https://github.com/baalexander/rospy_message_converter.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/baalexander/rospy_message_converter-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/baalexander/rospy_message_converter.git
+      version: master
+    status: maintained
   rosserial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospy_message_converter` to `0.4.0-0`:
- upstream repository: https://github.com/baalexander/rospy_message_converter.git
- release repository: https://github.com/baalexander/rospy_message_converter-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rospy_message_converter

```
* Adds support for ROS Jade
* Removes support for ROS Groovy and Hydro (EOL)
* Uses single branch for all ROS versions
* Docker support for local development and Travis CI
```
