### PR TITLE
Add python-pytest

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1366,6 +1366,10 @@ python-pyside.qtuitools:
     utopic_python3: [python3-pyside.qtuitools]
     vivid: [python-pyside.qtuitools]
     vivid_python3: [python3-pyside.qtuitools]
+python-pytest:
+  debian: [python-pytest]
+  fedora: [python-pytest]
+  ubuntu: [python-pytest]
 python-pyudev:
   debian: [python-pyudev]
   fedora: [python-pyudev]


### PR DESCRIPTION
I checked ubuntu versions trusty, vivid, and wily. Also I fired up the latest debian / fedora docker images and verified the package name remains the same. Hopefully this will all work.
