### PR TITLE
romeo_moveit_actions: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8323,6 +8323,13 @@ repositories:
       url: https://github.com/robotics-in-concert/rocon_tutorials.git
       version: indigo
     status: developed
+  romeo_moveit_actions:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/nlyubova/romeo_moveit_actions-release.git
+      version: 0.0.6-0
+    status: developed
   romeo_moveit_config:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_moveit_actions` to `0.0.6-0`:
- upstream repository: https://github.com/nlyubova/romeo_moveit_actions.git
- release repository: https://github.com/nlyubova/romeo_moveit_actions-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## romeo_moveit_actions

```
* fixing visualization of geometric shapes and cleaning
* renaming the package to romeo_moveit_actions
* 0.0.5
* adding changelogs
* 0.0.4
* adding changelogs
* fixing with changes in moveit visual tools
* Contributors: nlyubova
```
