### PR TITLE
remove forte_rc_robot from index due to continuously failing builds.

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2447,7 +2447,6 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ingeniarius-ltd/forte_rc_robot-release.git
-      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/ingeniarius-ltd/forte_rc_robot.git


### PR DESCRIPTION
This reverts #10035
