### PR TITLE
jsk_model_tools: 0.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3887,7 +3887,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     status: developed
   jsk_planning:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.2.3-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.2-0`
## eus_assimp

```
* [eus_assimp] fix function name
* Contributors: Yohei Kakiuchi
```
## euscollada
- No changes
## eusurdf

```
* [eusurdf/textured_models] add iemon/hamburger/wanda to texture_models
* Contributors: Yuki Furuta
```
## jsk_model_tools
- No changes
