### PR TITLE
jsk_model_tools: 0.2.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1683,7 +1683,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.2.2-3
+      version: 0.2.3-0
     status: developed
   jsk_recognition:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.2.3-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.2-3`
## eus_assimp

```
* [eus_assimp] fix function name
* Contributors: Yohei Kakiuchi
```
## euscollada
- No changes
## eusurdf

```
* [eusurdf/textured_models] add iemon/hamburger/wanda to texture_models
* Contributors: Yuki Furuta
```
## jsk_model_tools
- No changes
