### PR TITLE
husky_robot: 0.2.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3252,7 +3252,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_robot-release.git
-      version: 0.2.4-0
+      version: 0.2.5-0
     source:
       type: git
       url: https://github.com/husky/husky_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_robot` to `0.2.5-0`:
- upstream repository: https://github.com/husky/husky_robot.git
- release repository: https://github.com/clearpath-gbp/husky_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.4-0`
## husky_base

```
* Fix absolute value to handle negative rollover readings effectively
* Another bitwise fix, now for x86.
* Formatting
* Fix length complement check.
  There's a subtle difference in how ~ is implemented in aarch64 which
  causes this check to fail. The new implementation should work on x86
  and ARM.
* Contributors: Mike Purvis, Paul Bovbel
```
## husky_bringup
- No changes
## husky_robot
- No changes
