### PR TITLE
husky: 0.2.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3215,7 +3215,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.2.6-0
+      version: 0.2.7-0
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.2.7-0`:
- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.6-0`
## husky_control

```
* Update localization.yaml
* Update localization.yaml
* Remapping the move_base topic to be compatible with cpr autonomy core.
* Contributors: Peiyi Chen, Tom Moore
```
## husky_description

```
* Fixed indent.
* Added Sick LMS1XX URDF.
* Contributors: Tony Baltovski
```
## husky_msgs
- No changes
## husky_navigation

```
* Removed move_base topic remap so it publishes to just cmd_vel to avoid confusion.
* Remapping the move_base topic to be compatible with cpr autonomy core.
* Contributors: Peiyi Chen
```
## husky_ur5_moveit_config
- No changes
