### PR TITLE
rtmros_nextage: 0.7.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9488,7 +9488,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.7.2-0
+      version: 0.7.3-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.7.3-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.2-0`
## nextage_description
- No changes
## nextage_ik_plugin
- No changes
## nextage_moveit_config

```
* [fix] Unnecessarily complicated dependency
* [test] Add simple tests for MoveIt
* [sys] Minor dependency update
* [doc] Fix wrong URL
* Contributors: Isaac I.Y. Saito, Kei Okada
```
## nextage_ros_bridge

```
* [sys] clean up nxo.test
* Contributors: Kei Okada, Isaac I.Y. Saito
```
## rtmros_nextage

```
* [fix] Unnecessarily complicated dependency
* [test] Add simple tests for MoveIt
* [sys] clean up .launch and .test files
* [doc] Fix wrong URL
* Contributors: Kei Okada, Isaac I.Y. Saito
```
