### PR TITLE
object_recognition_reconstruction: 0.3.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6038,7 +6038,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_reconstruction-release.git
-      version: 0.3.4-0
+      version: 0.3.5-0
     source:
       type: git
       url: https://github.com/wg-perception/reconstruction.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_reconstruction` to `0.3.5-0`:
- upstream repository: https://github.com/wg-perception/reconstruction.git
- release repository: https://github.com/ros-gbp/object_recognition_reconstruction-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.4-0`
## object_recognition_reconstruction

```
* Fix the bad conversion dependency.
  ecto_image_pipelne is not compiled with PCL anymore, hence the
  loss of the conversions cells. Fixes #6 <https://github.com/wg-perception/reconstruction/issues/6>
* Contributors: Vincent Rabaud
```
