### PR TITLE
nao_robot: 0.5.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5616,7 +5616,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/nao_robot-release.git
-      version: 0.5.11-0
+      version: 0.5.12-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_robot` to `0.5.12-0`:
- upstream repository: https://github.com/ros-naoqi/nao_robot.git
- release repository: https://github.com/ros-naoqi/nao_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.11-0`
## nao_apps

```
* change from naoqi_driver.cfg to naoqi_driver_py.cfg
* Contributors: Kanae Kochigami
```
## nao_bringup

```
* launch/nao_full.launch : support nao_port in launch/naoqi_driver.launch https://github.com/ros-naoqi/naoqi_driver/pull/52
* Contributors: Kei Okada
```
## nao_description

```
* remove type from naoTransmission
* update the Gazebo .xacro and the corresponding .urdf
* update the .xacro / .urdf to the latest version of naoqi_tools
* Contributors: Mikael Arguedas, Vincent Rabaud
```
## nao_robot
- No changes
