### PR TITLE
Update base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1252,7 +1252,13 @@ libespeak-dev:
   ubuntu: [libespeak-dev]
 libestools-dev:
   fedora: [festival-speechtools-devel]
-  ubuntu: [libestools2.1-dev]
+  ubuntu:
+    saucy: [libestools2.1-dev]
+    trusty: [libestools2.1-dev]
+    utopic: [libestools2.1-dev]
+    vivid: [libestools2.1-dev]
+    wily: [libestools-dev]
+    xenial: [libestools-dev]
 libev-dev:
   arch: [libev]
   debian: [libev-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1252,7 +1252,7 @@ libespeak-dev:
   ubuntu: [libespeak-dev]
 libestools-dev:
   fedora: [festival-speechtools-devel]
-  ubuntu: [libestools-dev]
+  ubuntu: [libestools2.1-dev]
 libev-dev:
   arch: [libev]
   debian: [libev-dev]


### PR DESCRIPTION
libestools-dev is a virtual package. Since the package cannot be found in [1] and in [2] it looks like the script parses a file, where the virtual package is missing I changed the name to libestools2.1-dev

[1] http://jenkins.ros.org/job/ros-indigo-robot-face_binarydeb_trusty_amd64/2/console
[2] https://github.com/smd-ros-devel/catkin-rpms/blob/master/scripts/assert_package_dependencies_present.py
