### PR TITLE
openni2_camera: 0.2.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2983,6 +2983,17 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/openhrp3-release.git
       version: 3.1.8-0
+  openni2_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/openni2_camera-release.git
+      version: 0.2.5-0
+    status: maintained
   openni_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `0.2.5-0`:
- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros-gbp/openni2_camera-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## openni2_camera

```
* Merge pull request #34 <https://github.com/ros-drivers/openni2_camera/issues/34> from Intermodalics/feature/get_serial_service
  added get_serial service
* Contributors: Michael Ferguson, Ruben Smits
```
