### PR TITLE
openni2_launch: 0.2.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2994,6 +2994,17 @@ repositories:
       url: https://github.com/ros-gbp/openni2_camera-release.git
       version: 0.2.5-0
     status: maintained
+  openni2_launch:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni2_launch.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/openni2_launch.git
+      version: 0.2.2-0
+    status: maintained
   openni_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_launch` to `0.2.2-0`:
- upstream repository: https://github.com/ros-drivers/openni2_launch.git
- release repository: https://github.com/ros-gbp/openni2_launch.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## openni2_launch

```
* add tf_prefix version, as per #16 <https://github.com/ros-drivers/openni2_launch/issues/16>
* fix #19 <https://github.com/ros-drivers/openni2_launch/issues/19>, reverts #16 <https://github.com/ros-drivers/openni2_launch/issues/16>
* Contributors: Michael Ferguson
```
