### PR TITLE
homer_robot_face: 1.0.3-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3172,7 +3172,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_robot_face.git
-      version: 1.0.3-0
+      version: 1.0.3-2
   household_objects_database:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_robot_face` to `1.0.3-2`:
- upstream repository: https://gitlab.uni-koblenz.de/robbie/homer_robot_face.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_robot_face.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.3-0`
## robot_face

```
* added maintainers
* updated changelog
* added missing dependencies
* updated package
* removed components
* added cmake_modules to package xml due to build error
* Imported upstream version '1.0.2' of 'upstream'
* Imported upstream version '1.0.1' of 'upstream'
* Contributors: Niklas Yann Wettengel, Raphael Memmesheimer
* added missing dependencies
* updated package
* removed components
* added cmake_modules to package xml due to build error
* Imported upstream version '1.0.2' of 'upstream'
* Imported upstream version '1.0.1' of 'upstream'
* Contributors: Niklas Yann Wettengel, Raphael Memmesheimer
```
