### PR TITLE
people: 1.0.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3139,6 +3139,28 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: indigo-devel
     status: maintained
+  people:
+    doc:
+      type: git
+      url: https://github.com/wg-perception/people.git
+      version: indigo-devel
+    release:
+      packages:
+      - face_detector
+      - leg_detector
+      - people
+      - people_msgs
+      - people_tracking_filter
+      - people_velocity_tracker
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/OSUrobotics/people-release.git
+      version: 1.0.10-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/people.git
+      version: indigo-devel
+    status: maintained
   pepper_meshes:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `people` to `1.0.10-0`:
- upstream repository: https://github.com/wg-perception/people.git
- release repository: https://github.com/OSUrobotics/people-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
