### PR TITLE
Add pyvirtualdisplay to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1388,6 +1388,10 @@ python-pyuserinput:
   ubuntu:
     pip:
       packages: [PyUserInput]
+python-pyvirtualdisplay-pip:
+  ubuntu:
+    pip:
+      packages: [pyvirtualdisplay]
 python-qt-bindings:
   arch: [python2-pyqt4]
   debian:


### PR DESCRIPTION
"pyvirtualdisplay is a python wrapper for Xvfb, Xephyr and Xvnc."
This can be used for GUI testing, and there only seems to be a pip distribution.
