### PR TITLE
rosparam_shortcuts: 0.1.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4244,7 +4244,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/davetcoleman/rosparam_shortcuts-release.git
-      version: 0.0.5-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/davetcoleman/rosparam_shortcuts.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_shortcuts` to `0.1.1-0`:
- upstream repository: https://github.com/davetcoleman/rosparam_shortcuts.git
- release repository: https://github.com/davetcoleman/rosparam_shortcuts-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.5-0`
## rosparam_shortcuts

```
* Fixed CMake build
* Ran roslint
* Ran catkin lint
* Updated example
* Contributors: Dave Coleman
```
