### PR TITLE
rviz_visual_tools: 2.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4607,7 +4607,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/davetcoleman/rviz_visual_tools-release.git
-      version: 2.0.1-0
+      version: 2.0.2-0
     source:
       type: git
       url: https://github.com/davetcoleman/rviz_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `2.0.2-0`:
- upstream repository: https://github.com/davetcoleman/rviz_visual_tools.git
- release repository: https://github.com/davetcoleman/rviz_visual_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.0.1-0`
## rviz_visual_tools

```
* Formatting
* Removed unused var
* roslint fixes
* Contributors: Dave Coleman
```
