### PR TITLE
moveit_sim_controller: 0.0.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2309,6 +2309,21 @@ repositories:
       url: https://github.com/ros-gbp/moveit_ros-release.git
       version: 0.6.5-0
     status: developed
+  moveit_sim_controller:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/moveit_sim_controller.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/davetcoleman/moveit_sim_controller-release.git
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/moveit_sim_controller.git
+      version: jade-devel
+    status: developed
   moveit_visual_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_sim_controller` to `0.0.4-0`:
- upstream repository: https://github.com/davetcoleman/moveit_sim_controller.git
- release repository: https://github.com/davetcoleman/moveit_sim_controller-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## moveit_sim_controller

```
* Improved rosparam_shortcuts api
* Fixed initialization of default joint positions
* Fix travis
* Contributors: Dave Coleman
```
