### PR TITLE
head_pose_estimation: 1.0.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1243,6 +1243,21 @@ repositories:
       url: https://github.com/g/grizzly.git
       version: indigo-devel
     status: maintained
+  head_pose_estimation:
+    doc:
+      type: git
+      url: https://github.com/OSUrobotics/ros-head-tracking.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/OSUrobotics/head_pose_estimation-release.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/OSUrobotics/ros-head-tracking.git
+      version: hydro-devel
+    status: maintained
   heatmap:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `head_pose_estimation` to `1.0.3-0`:
- upstream repository: https://github.com/OSUrobotics/ros-head-tracking.git
- release repository: https://github.com/OSUrobotics/head_pose_estimation-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## head_pose_estimation

```
* cleanup
* remove unused launch files
* Contributors: Dan Lazewatsky
```
