### PR TITLE
fetch_msgs: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2328,7 +2328,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_msgs-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_msgs` to `0.6.1-0`:
- upstream repository: https://github.com/fetchrobotics/fetch_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.0-0`
## fetch_auto_dock_msgs
- No changes
## fetch_driver_msgs

```
* add new action for disabling charging
* add notes on charging_mode
* Contributors: Michael Ferguson
```
