### PR TITLE
pyros_test released for all distros

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7465,7 +7465,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/pyros-test-release.git
-      version: 0.0.1-0
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/asmodehn/pyros-test.git


### PR DESCRIPTION
My first release was again yujinrobot/rosdistro which had only the trusty distribution released and therefore proper tags for other distros were not created in the release repo.

This release is against the OSRF rosdistro ( although I didn't test anything other than trusty - mostly relying on python to take care of porting for me )
