### PR TITLE
ecl_lite: 0.61.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1976,6 +1976,7 @@ repositories:
     release:
       packages:
       - ecl_config
+      - ecl_console
       - ecl_converters_lite
       - ecl_errors
       - ecl_io
@@ -1985,7 +1986,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_lite-release.git
-      version: 0.61.1-0
+      version: 0.61.3-0
     source:
       type: git
       url: https://github.com/stonier/ecl_lite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_lite` to `0.61.3-0`:
- upstream repository: https://github.com/stonier/ecl_lite.git
- release repository: https://github.com/yujinrobot-release/ecl_lite-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.61.1-0`
## ecl_config

```
* deprecation macro for clang.
```
