### PR TITLE
ecl_navigation: 0.60.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2022,7 +2022,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_navigation-release.git
-      version: 0.60.0-1
+      version: 0.60.1-1
     source:
       type: git
       url: https://github.com/stonier/ecl_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_navigation` to `0.60.1-1`:
- upstream repository: https://github.com/stonier/ecl_navigation.git
- release repository: https://github.com/yujinrobot-release/ecl_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.60.0-1`
