### PR TITLE
ecl_manipulation: 0.60.1-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2004,7 +2004,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_manipulation-release.git
-      version: 0.60.0-1
+      version: 0.60.1-2
     source:
       type: git
       url: https://github.com/stonier/ecl_manipulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_manipulation` to `0.60.1-2`:
- upstream repository: https://github.com/stonier/ecl_manipulation.git
- release repository: https://github.com/yujinrobot-release/ecl_manipulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.60.0-1`
