### PR TITLE
marti_common: 0.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4828,7 +4828,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.0.8-0`:
- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.7-0`
## marti_data_structures
- No changes
## swri_console_util
- No changes
## swri_geometry_util
- No changes
## swri_image_util

```
* Fixes nodelet description for normalize_response.
* Tweaks contrast stretching to increase blending of min/max bounds across grid.
* Removes some C-style casts.
* Adds parameters for masking out over exposed areas out of the contrast stretch processing.
* Adds normalize response image normalization method.
* Contributors: Marc Alban
```
## swri_math_util

```
* Refactors RANSAC matching code to use more matrix operations.
* Contributors: Marc Alban
```
## swri_opencv_util

```
* Marks some constructors explicit.
* Refactors RANSAC matching code to use more matrix operations.
* Fixes bugs in FitRigidTransform2d.
  The main problem was that reshape was being used incorrectly, causing the
  points to get shuffled around.  Once that was fixed, it was clear that
  the rotation should not be inverted.  Also adds a comment to clarify
  the significance of the returned transform.
* Contributors: Elliot Johnson, Marc Alban
```
## swri_prefix_tools
- No changes
## swri_roscpp

```
* Makes swri::Subscriber's assignment operator return a value.
  According to the C++ spec, assignment operators must return a reference to the
  current object (*this). swri::Subscriber's assignment operator was not
  returning a value, which works in GCC, but not Clang. GCC would do the right
  thing for you, but Clang will compile the code but generate a SIGILL
  exception at runtime. This is easily fixed by manually returning *this.
* Contributors: P. J. Reed
```
## swri_serial_util
- No changes
## swri_string_util
- No changes
## swri_system_util
- No changes
## swri_transform_util

```
* Accounts for non-zero reference angles when calculating orientations to and from WGS84.
* Publishes origin with east orientation (0 yaw) by default.
* Supports arbitrary local_xy reference angles.
  * The reference heading is renamed to reference angle.
  * It's not recommended to set a non-zero reference angle.
  * Adds a parameter to ignore the reference heading for backwards compatibility.
* Fixes backwards compatibility issue with swri_yaml_cpp call.
* Contributors: Kris Kozak, Marc Alban
```
## swri_yaml_util
- No changes
