### PR TITLE
mapviz: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4799,7 +4799,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `0.0.4-0`:
- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.3-0`
## mapviz

```
* Show full path when recording screenshots/movies.
* Fixes a bug in plug-in sorting.
* Sorts topic, plug-in, and frame lists in selection dialogs.
* Fixes mapviz launch file frame parameter
* Marks single argument constructors explicit.
* Contributors: Edward Venator, Elliot Johnson, Marc Alban, Vincent Rousseau
```
## mapviz_plugins

```
* Fixes bad package names in includes.
* Backports navsat plug-in from jade.
* Sorts topic, plug-in, and frame lists in selection dialogs.
* Fixes tf plug-in update.
* Adds a plugin to visualize laser scans based on the laserscan plugin for rviz:
  * Points can be colored by range, or x/y/z axis
  * Points can be colored by interpolation between two colors or rainbow coloring
* Enables the possibility to load one layer tile set
* Contributors: Edward Venator, Marc Alban, P. J. Reed, Vincent Rousseau
```
## multires_image

```
* Uses file extension from geo file
* Enables the possibility to load one-layer tile set
* Contributors: Vincent Rousseau
```
## tile_map

```
* Marks single argument constructors explicit.
* Contributors: Marc Alban
```
