### PR TITLE
mapviz: 0.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2002,7 +2002,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `0.1.2-0`:
- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.1-0`
## mapviz

```
* Show full path when recording screenshots/movies.
* Fixes a bug in plug-in sorting.
* Sorts topic, plug-in, and frame lists in selection dialogs.
* Contributors: Elliot Johnson, Marc Alban
```
## mapviz_plugins

```
* Enables the possibility to load a one-layer tile set
* Sorts topic, plug-in, and frame lists in selection dialogs.
* Fixes tf plug-in update.
* Contributors: Marc Alban, Vincent Rousseau
```
## multires_image

```
* Enables the possibility to load a one-layer tile set
* Contributors: Vincent Rousseau
```
## tile_map
- No changes
