### PR TITLE
Remove ypspur

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11669,17 +11669,6 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/youbot-release/youbot_simulation-release.git
       version: 0.8.0-0
-  ypspur:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/DaikiMaekawa/ypspur-release.git
-      version: 0.2.2-0
-    source:
-      type: git
-      url: https://github.com/DaikiMaekawa/ypspur.git
-      version: master
-    status: maintained
   yujin_maps:
     doc:
       type: git


### PR DESCRIPTION
It is failing to build on all platforms and appears to be cloning in the build process which is sometime inaccessible. 

This is often hanging not just failing causing time out on our buildfarm costing a lot of cycle time.

Broken builds: 
http://jenkins.ros.org/view/IbinS32/job/devel-indigo-ypspur/
http://jenkins.ros.org/view/IbinS32/job/ros-indigo-ypspur_binarydeb_saucy_i386/
http://jenkins.ros.org/view/IbinS32/job/ros-indigo-ypspur_binarydeb_saucy_amd64/
http://jenkins.ros.org/view/IbinS32/job/ros-indigo-ypspur_binarydeb_trusty_i386/
http://jenkins.ros.org/view/IbinS32/job/ros-indigo-ypspur_binarydeb_trusty_amd64/

And on the new infrastructure: 
http://54.183.26.131:8080/job/Ibin_uS32__ypspur__ubuntu_saucy_i386__binary/
http://54.183.26.131:8080/job/Ibin_uS64__ypspur__ubuntu_saucy_amd64__binary/
http://54.183.26.131:8080/job/Ibin_uT32__ypspur__ubuntu_trusty_i386__binary/
http://54.183.26.131:8080/job/Ibin_uT64__ypspur__ubuntu_trusty_amd64__binary/
http://54.183.26.131:8080/job/Ibin_arm_uThf__ypspur__ubuntu_trusty_armhf__binary/

@DaikiMaekawa FYI
