### PR TITLE
grid_map: 1.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1217,6 +1217,19 @@ repositories:
       type: git
       url: https://github.com/ethz-asl/grid_map.git
       version: master
+    release:
+      packages:
+      - grid_map
+      - grid_map_core
+      - grid_map_demos
+      - grid_map_filters
+      - grid_map_loader
+      - grid_map_msgs
+      - grid_map_visualization
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ethz-asl/grid_map-release.git
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/ethz-asl/grid_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `1.1.0-0`:
- upstream repository: https://github.com/ethz-asl/grid_map.git
- release repository: https://github.com/ethz-asl/grid_map-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## grid_map

```
* added installation instructions in CMakeLists
* new conversion from grid map to image
* general improvements and bugfixes
```
## grid_map_core

```
* added installation instructions in CMakeLists
* new ellipse iterator tool
* general improvements and bugfixes
```
## grid_map_demos

```
* added installation instructions in CMakeLists
* updated demo for new ellipse iterator tool
* general improvements and bugfixes
```
## grid_map_filters

```
* added installation instructions in CMakeLists
* general improvements and bugfixes
```
## grid_map_loader

```
* added installation instructions in CMakeLists
* general improvements and bugfixes
```
## grid_map_msgs

```
* added new srv definition for processing of grid map files
* general improvements and bugfixes
```
## grid_map_visualization

```
* added installation instructions in CMakeLists
* general improvements and bugfixes
```
