### PR TITLE
ecl_core: 0.61.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1962,7 +1962,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_core-release.git
-      version: 0.61.6-1
+      version: 0.61.7-0
     source:
       type: git
       url: https://github.com/stonier/ecl_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_core` to `0.61.7-0`:
- upstream repository: https://github.com/stonier/ecl_core.git
- release repository: https://github.com/yujinrobot-release/ecl_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.61.6-1`
## ecl_geometry

```
* avoid cubic spline calculations when incoming data has only one point
```
## ecl_linear_algebra

```
* transitively export c++11 requirement instead of forcing users to do it
```
