### PR TITLE
ecl_lite: 0.61.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1986,7 +1986,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_lite-release.git
-      version: 0.61.3-0
+      version: 0.61.4-0
     source:
       type: git
       url: https://github.com/stonier/ecl_lite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_lite` to `0.61.4-0`:
- upstream repository: https://github.com/stonier/ecl_lite.git
- release repository: https://github.com/yujinrobot-release/ecl_lite-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.61.3-0`
## ecl_config

```
* macro for use with checking for CXX11
```
## ecl_console

```
* namespaced to within the ecl
* imported from termcolor <https://github.com/ikalnitsky/termcolor> for our low-level cross-compiled embedded projects
```
