### PR TITLE
Revert "pyros_setup: 0.0.9-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7475,7 +7475,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/pyros-setup-release.git
-      version: 0.0.9-0
+      version: 0.0.8-0
     status: developed
   pyros_test:
     doc:


### PR DESCRIPTION
Reverts ros/rosdistro#10230

The sourcedeb is failing to build and it consequently keeps trying to rebuild. 
