### PR TITLE
pyros_test: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7486,7 +7486,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/pyros-test-release.git
-      version: 0.0.1-1
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/asmodehn/pyros-test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_test` to `0.0.2-0`:
- upstream repository: https://github.com/asmodehn/pyros-test.git
- release repository: https://github.com/asmodehn/pyros-test-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.1-1`
