### PR TITLE
mavros: 0.16.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4919,7 +4919,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.16.4-0
+      version: 0.16.5-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.16.5-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.16.4-0`
## libmavconn
- No changes
## mavros

```
* scripts: mavwp #465 <https://github.com/mavlink/mavros/issues/465>: Remove WaypointGOTO from scrips and python library
* node: Report mavlink package version
* lib: Add APM:Plane QuadPlane modes.
  Sync with: https://github.com/mavlink/mavlink/commit/1fc4aef08a54130f297943c246f95b8c7e37b1bf
* readme: pixhawk dialect removed.
* Contributors: Vladimir Ermakov
```
## mavros_extras
- No changes
## mavros_msgs
- No changes
## test_mavros
- No changes
