### PR TITLE
moveit_visual_tools: 3.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5394,7 +5394,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 3.0.2-0
+      version: 3.0.3-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `3.0.3-0`:
- upstream repository: https://github.com/davetcoleman/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `3.0.2-0`
## moveit_visual_tools

```
* Renamed test to demo
* New publishTrajectoryLine() function
* Fix travis
* Deprecated loadEEMarker() that uses string
* Formatted code
* Switched from MOVEIT deprecated to RVIZ_VISUAL_TOOLS deprecated
* Fixed shared_robot_state to initialize correctly every time
* Switched to using name_ variables
* Add error checks to publishTrajectoryLine
* Added ability for publishTrajectoryLine to clear all previous markers
* Contributors: Dave Coleman
```
