### PR TITLE
mrp2_common: 0.2.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5400,6 +5400,27 @@ repositories:
       url: https://github.com/davetcoleman/moveit_visual_tools.git
       version: indigo-devel
     status: developed
+  mrp2_common:
+    doc:
+      type: git
+      url: https://github.com/milvusrobotics/mrp2_common.git
+      version: indigo-devel
+    release:
+      packages:
+      - mrp2_analyzer
+      - mrp2_common
+      - mrp2_control
+      - mrp2_description
+      - mrp2_navigation
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/milvusrobotics/mrp2_common-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/milvusrobotics/mrp2_common.git
+      version: indigo-devel
+    status: developed
   mrpt_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrp2_common` to `0.2.1-1`:
- upstream repository: https://github.com/milvusrobotics/mrp2_common.git
- release repository: https://github.com/milvusrobotics/mrp2_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## mrp2_analyzer

```
* Organized code and structure
* Package information update
* Initial commit
* Contributors: Akif
```
## mrp2_common

```
* Package information update
* Initial commit
* Contributors: Akif
```
## mrp2_control

```
* Merged config files
* Directory structure update
* Initial commit
* Contributors: Akif, MRP2 Development, orhangazi44
```
## mrp2_description

```
* Organized code and structure
* Directory structure update
* Initial commit
* Contributors: Akif
```
## mrp2_navigation

```
* Organized code and structure
* Directory structure update
* Initial commit
* Contributors: Akif, orhangazi44
```
