### PR TITLE
mrp2_desktop: 0.2.1-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5400,6 +5400,24 @@ repositories:
       url: https://github.com/davetcoleman/moveit_visual_tools.git
       version: indigo-devel
     status: developed
+  mrp2_desktop:
+    doc:
+      type: git
+      url: https://github.com/milvusrobotics/mrp2_desktop.git
+      version: indigo-devel
+    release:
+      packages:
+      - mrp2_desktop
+      - mrp2_viz
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/milvusrobotics/mrp2_desktop-release.git
+      version: 0.2.1-2
+    source:
+      type: git
+      url: https://github.com/milvusrobotics/mrp2_desktop.git
+      version: indigo-devel
+    status: developed
   mrpt_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrp2_desktop` to `0.2.1-2`:
- upstream repository: https://github.com/milvusrobotics/mrp2_desktop.git
- release repository: https://github.com/milvusrobotics/mrp2_desktop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## mrp2_desktop

```
* Package information update
* Initial commit
* Contributors: Akif
```
## mrp2_viz

```
* Package information update
* RViz configs added
* Contributors: Akif
```
