### PR TITLE
mrp2_simulator: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5400,6 +5400,25 @@ repositories:
       url: https://github.com/davetcoleman/moveit_visual_tools.git
       version: indigo-devel
     status: developed
+  mrp2_simulator:
+    doc:
+      type: git
+      url: https://github.com/milvusrobotics/mrp2_simulator.git
+      version: indigo-devel
+    release:
+      packages:
+      - mrp2_gazebo
+      - mrp2_hardware_gazebo
+      - mrp2_simulator
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/milvusrobotics/mrp2_simulator-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/milvusrobotics/mrp2_simulator.git
+      version: indigo-devel
+    status: developed
   mrpt_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrp2_simulator` to `0.2.1-0`:
- upstream repository: https://github.com/milvusrobotics/mrp2_simulator.git
- release repository: https://github.com/milvusrobotics/mrp2_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## mrp2_gazebo

```
* Organized code and structure
* Initial commit
* Contributors: Akif
```
## mrp2_hardware_gazebo

```
* Organized code and structure
* Package information update
* Initial commit
* Contributors: Akif
```
## mrp2_simulator

```
* Package information update
* Initial commit
* Contributors: Akif
```
