### PR TITLE
mrp2_robot: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5400,6 +5400,26 @@ repositories:
       url: https://github.com/davetcoleman/moveit_visual_tools.git
       version: indigo-devel
     status: developed
+  mrp2_robot:
+    doc:
+      type: git
+      url: https://github.com/milvusrobotics/mrp2_robot.git
+      version: indigo-devel
+    release:
+      packages:
+      - mrp2_bringup
+      - mrp2_display
+      - mrp2_hardware
+      - mrp2_robot
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/milvusrobotics/mrp2_robot-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/milvusrobotics/mrp2_robot.git
+      version: indigo-devel
+    status: developed
   mrpt_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrp2_robot` to `0.2.1-0`:
- upstream repository: https://github.com/milvusrobotics/mrp2_robot.git
- release repository: https://github.com/milvusrobotics/mrp2_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## mrp2_bringup

```
* Organized code and structure
* Directory structure update
* Initial commit
* Contributors: Akif, MRP2 Development
```
## mrp2_display

```
* Organized code and structure
* Contributors: Akif
```
## mrp2_hardware

```
* Organized code and structure
* Package information update
* Initial commit
* Contributors: Akif, MRP2 Development
```
## mrp2_robot

```
* Package information update
* Initial commit
* Contributors: Akif
```
