### PR TITLE
grid_map: 1.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2824,7 +2824,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-asl/grid_map-release.git
-      version: 1.1.0-0
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/ethz-asl/grid_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `1.1.1-0`:
- upstream repository: https://github.com/ethz-asl/grid_map.git
- release repository: https://github.com/ethz-asl/grid_map-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.0-0`
## grid_map

```
* Changes to CMakeLists.txt to enable compatibility with Ubuntu Saucy.
```
## grid_map_core

```
* Changes to CMakeLists.txt to enable compatibility with Ubuntu Saucy.
```
## grid_map_demos

```
* Changes to CMakeLists.txt to enable compatibility with Ubuntu Saucy.
```
## grid_map_filters

```
* Changes to CMakeLists.txt to enable compatibility with Ubuntu Saucy.
```
## grid_map_loader

```
* Changes to CMakeLists.txt to enable compatibility with Ubuntu Saucy.
```
## grid_map_msgs
- No changes
## grid_map_visualization

```
* Changes to CMakeLists.txt to enable compatibility with Ubuntu Saucy.
```
