### PR TITLE
grid_map: 1.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1229,7 +1229,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ethz-asl/grid_map-release.git
-      version: 1.1.1-0
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/ethz-asl/grid_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `1.1.2-0`:
- upstream repository: https://github.com/ethz-asl/grid_map.git
- release repository: https://github.com/ethz-asl/grid_map-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.1-0`
## grid_map

```
* Should fix errors on build server regarding Eigen3 and visualization_msgs dependencies.
```
## grid_map_core

```
* Should fix errors on build server regarding Eigen3 and visualization_msgs dependencies.
```
## grid_map_demos

```
* Should fix errors on build server regarding Eigen3 and visualization_msgs dependencies.
```
## grid_map_filters

```
* Should fix errors on build server regarding Eigen3 and visualization_msgs dependencies.
```
## grid_map_loader

```
* Should fix errors on build server regarding Eigen3 and visualization_msgs dependencies.
```
## grid_map_msgs

```
* Should fix errors on build server regarding Eigen3 and visualization_msgs dependencies.
```
## grid_map_visualization

```
* Should fix errors on build server regarding Eigen3 and visualization_msgs dependencies.
```
