### PR TITLE
update index.yaml to REP 143

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,31 +1,19 @@
 %YAML 1.1
 # ROS index file
-# see REP 141: http://ros.org/reps/rep-0141.html
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 distributions:
   groovy:
-    distribution: groovy/distribution.yaml
+    distribution: [groovy/distribution.yaml]
     distribution_cache: http://ros.org/rosdistro/groovy-cache.yaml.gz
-    doc_builds: [groovy/doc-build.yaml]
-    release_builds: [groovy/release-build.yaml]
-    source_builds: [groovy/source-build.yaml]
   hydro:
-    distribution: hydro/distribution.yaml
+    distribution: [hydro/distribution.yaml]
     distribution_cache: http://ros.org/rosdistro/hydro-cache.yaml.gz
-    doc_builds: [hydro/doc-build.yaml]
-    release_builds: [hydro/release-build.yaml]
-    source_builds: [hydro/source-build.yaml]
   indigo:
-    distribution: indigo/distribution.yaml
+    distribution: [indigo/distribution.yaml]
     distribution_cache: http://ros.org/rosdistro/indigo-cache.yaml.gz
-    doc_builds: [indigo/doc-build.yaml]
-    release_builds: [indigo/release-build.yaml]
-    source_builds: [indigo/source-build.yaml]
   jade:
-    distribution: jade/distribution.yaml
+    distribution: [jade/distribution.yaml]
     distribution_cache: http://ros.org/rosdistro/jade-cache.yaml.gz
-    doc_builds: [jade/doc-build.yaml]
-    release_builds: [jade/release-build.yaml]
-    source_builds: [jade/source-build.yaml]
 type: index
-version: 2
+version: 3

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4283,6 +4283,7 @@ repositories:
       url: https://github.com/ros-gbp/rospack-release.git
       version: 2.2.5-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/rospack.git
       version: indigo-devel

--- a/test/test_url_validity.py
+++ b/test/test_url_validity.py
@@ -35,8 +35,9 @@ def get_all_distribution_filenames(url=None):
     distribution_filenames = []
     i = rosdistro.get_index(url)
     for d in i.distributions.values():
-        dpath = os.path.abspath(urlparse(d['distribution']).path)
-        distribution_filenames.append(dpath)
+        for f in d['distribution']:
+            dpath = os.path.abspath(urlparse(f).path)
+            distribution_filenames.append(dpath)
     return distribution_filenames
 
 
@@ -47,8 +48,9 @@ def get_eol_distribution_filenames(url=None):
     i = rosdistro.get_index(url)
     for d_name, d in i.distributions.items():
         if d_name in EOL_DISTROS:
-            dpath = os.path.abspath(urlparse(d['distribution']).path)
-            distribution_filenames.append(dpath)
+            for f in d['distribution']:
+                dpath = os.path.abspath(urlparse(f).path)
+                distribution_filenames.append(dpath)
     return distribution_filenames
 
 


### PR DESCRIPTION
This needs an announcement on ros-users when being merged.

After this has been merged we can start using the new features in distribution files: http://www.ros.org/reps/rep-0143.html#distribution-file

This PR already enables PR jobs for the ROS core repos which have tests.

We should consider:
- enabling `test_pull_requests` for more ROS base repos
- disabled `test_commits` for repos which "devel" jobs will conceptionally never succeed on the farm (the ones which are currently just broken can still be disabled in the build files)
