### PR TITLE
costmap_converter: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1550,7 +1550,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rst-tu-dortmund/costmap_converter-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/rst-tu-dortmund/costmap_converter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `costmap_converter` to `0.0.4-0`:
- upstream repository: https://github.com/rst-tu-dortmund/costmap_converter.git
- release repository: https://github.com/rst-tu-dortmund/costmap_converter-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.3-0`
## costmap_converter

```
* Fixed conversion from map to world coordinates if the costmap is not quadratic.
```
