### PR TITLE
mrp2_robot: 0.2.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5434,7 +5434,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/milvusrobotics/mrp2_robot-release.git
-      version: 0.2.1-0
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/milvusrobotics/mrp2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrp2_robot` to `0.2.1-1`:
- upstream repository: https://github.com/milvusrobotics/mrp2_robot.git
- release repository: https://github.com/milvusrobotics/mrp2_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.1-0`
## mrp2_bringup

```
* Organized code and structure
* Directory structure update
* Initial commit
* Contributors: Akif, MRP2 Development
```
## mrp2_display

```
* Organized code and structure
* Contributors: Akif
```
## mrp2_hardware

```
* Organized code and structure
* Package information update
* Initial commit
* Contributors: Akif, MRP2 Development
```
## mrp2_robot

```
* Package information update
* Initial commit
* Contributors: Akif
```
