### PR TITLE
mrp2_robot: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5434,7 +5434,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/milvusrobotics/mrp2_robot-release.git
-      version: 0.2.1-1
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/milvusrobotics/mrp2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrp2_robot` to `0.2.2-0`:
- upstream repository: https://github.com/milvusrobotics/mrp2_robot.git
- release repository: https://github.com/milvusrobotics/mrp2_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.1-1`
