### PR TITLE
squirrel_common: 0.0.1-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10258,6 +10258,29 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/sql_database-release.git
       version: 0.4.9-0
+  squirrel_common:
+    release:
+      packages:
+      - squirrel_3d_mapping_msgs
+      - squirrel_common
+      - squirrel_kclhand_msgs
+      - squirrel_localizer_msgs
+      - squirrel_manipulation_msgs
+      - squirrel_mhand_msgs
+      - squirrel_object_perception_msgs
+      - squirrel_person_tracker_msgs
+      - squirrel_planning_knowledge_msgs
+      - squirrel_prediction_msgs
+      - squirrel_rgbd_mapping_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/squirrel-project/squirrel_common-release.git
+      version: 0.0.1-2
+    source:
+      type: git
+      url: https://github.com/squirrel-project/squirrel_common.git
+      version: 0.0.1-2
+    status: maintained
   sr_config:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `squirrel_common` to `0.0.1-2`:
- upstream repository: https://github.com/squirrel-project/squirrel_common.git
- release repository: https://github.com/squirrel-project/squirrel_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
