### PR TITLE
moveit_sim_controller: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5345,7 +5345,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/moveit_sim_controller-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_sim_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_sim_controller` to `0.0.5-0`:
- upstream repository: https://github.com/davetcoleman/moveit_sim_controller.git
- release repository: https://github.com/davetcoleman/moveit_sim_controller-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.4-0`
## moveit_sim_controller

```
* Fixed deprecated API for rosparam_shortcuts
* Contributors: Dave Coleman
```
