### PR TITLE
ros_control_boilerplate: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8648,7 +8648,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/ros_control_boilerplate-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/davetcoleman/ros_control_boilerplate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control_boilerplate` to `0.3.1-0`:
- upstream repository: https://github.com/davetcoleman/ros_control_boilerplate.git
- release repository: https://github.com/davetcoleman/ros_control_boilerplate-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.0-0`
## ros_control_boilerplate

```
* API deprecation fix for rosparam_shortcuts
* Switched to better use of rosparam_shortcuts
* Ability to record all controller status data, not just at certain frequency
* Contributors: Dave Coleman
```
