### PR TITLE
keep build files

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -6,14 +6,26 @@ distributions:
   groovy:
     distribution: [groovy/distribution.yaml]
     distribution_cache: http://ros.org/rosdistro/groovy-cache.yaml.gz
+    doc_builds: [groovy/doc-build.yaml]
+    release_builds: [groovy/release-build.yaml]
+    source_builds: [groovy/source-build.yaml]
   hydro:
     distribution: [hydro/distribution.yaml]
     distribution_cache: http://ros.org/rosdistro/hydro-cache.yaml.gz
+    doc_builds: [hydro/doc-build.yaml]
+    release_builds: [hydro/release-build.yaml]
+    source_builds: [hydro/source-build.yaml]
   indigo:
     distribution: [indigo/distribution.yaml]
     distribution_cache: http://ros.org/rosdistro/indigo-cache.yaml.gz
+    doc_builds: [indigo/doc-build.yaml]
+    release_builds: [indigo/release-build.yaml]
+    source_builds: [indigo/source-build.yaml]
   jade:
     distribution: [jade/distribution.yaml]
     distribution_cache: http://ros.org/rosdistro/jade-cache.yaml.gz
+    doc_builds: [jade/doc-build.yaml]
+    release_builds: [jade/release-build.yaml]
+    source_builds: [jade/source-build.yaml]
 type: index
 version: 3


### PR DESCRIPTION
I am not sure if this fixes the builds on the old farm (http://jenkins.ros.org/job/devel-jade-rospack/ARCH_PARAM=amd64,UBUNTU_PARAM=trusty,label=devel/7/console) and/or if it is a problem for the new farm.
