### PR TITLE
Adding my_repo_name to documentation index for distro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -258,6 +258,16 @@ repositories:
       url: https://github.com/vanadiumlabs/arbotix_ros-release.git
       version: 0.9.2-0
     status: maintained
+  ardrone2control:
+    doc:
+      type: git
+      url: https://github.com/tn0432/ardrone2control.git
+      version: hydro-devel
+    source:
+      type: git
+      url: https://github.com/tn0432/ardrone2control.git
+      version: hydro-devel
+    status: developed
   ardrone_autonomy:
     doc:
       type: git


### PR DESCRIPTION
I 'd like ardrone2control to be indexed and documented on ros.org. 
