### PR TITLE
moveit_robots: 1.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5288,7 +5288,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/moveit_robots-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_robots` to `1.0.4-0`:
- upstream repository: https://github.com/ros-planning/moveit_robots.git
- release repository: https://github.com/tork-a/moveit_robots-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.3-0`
## atlas_moveit_config
- No changes
## atlas_v3_moveit_config
- No changes
## baxter_ikfast_left_arm_plugin
- No changes
## baxter_ikfast_right_arm_plugin
- No changes
## baxter_moveit_config

```
* Added Gripper construction Xacros for Baxter
  baxter.srdf.xacro is now the new "baxter.srdf" (the old one is
  left unchanged for backwards compatibility). The xacro creates the
  standard "no-gripper" Baxter srdf by default, but can enable new
  gripper collision checks if left or right_electric_gripper args are
  set to true. Also, the link used as the kinematic tip for each arm
  (<side>_tip_name) can be set at launch
  - Set the default tip name to be <side>_gripper
  - Now a default end effector sdf takes care of the default <side>_gripper
  collisions
  - Electric Gripper specific collisions use the correct finger link names
  - Fixed a move_group arg value in demo_baxter
  - Removed nefarious planning_context.launch call from move_group.launch
  which would overwrite all args from a previous move_group.launch call
* Contributors: Ian McMahon
```
## clam_moveit_config
- No changes
## iri_wam_moveit_config
- No changes
## moveit_robots

```
* [feat] Added Gripper construction Xacros for Baxter
  baxter.srdf.xacro is now the new "baxter.srdf" (the old one is
  left unchanged for backwards compatibility). The xacro creates the
  standard "no-gripper" Baxter srdf by default, but can enable new
  gripper collision checks if left or right_electric_gripper args are
  set to true. Also, the link used as the kinematic tip for each arm
  (<side>_tip_name) can be set at launch
  - Set the default tip name to be <side>_gripper
  - Now a default end effector sdf takes care of the default <side>_gripper
  collisions
  - Electric Gripper specific collisions use the correct finger link names
  - Fixed a move_group arg value in demo_baxter
  - Removed nefarious planning_context.launch call from move_group.launch
  which would overwrite all args from a previous move_group.launch call
* Contributors: Ian McMahon
```
## r2_moveit_generated
- No changes
