### PR TITLE
nao_robot: 0.5.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5686,7 +5686,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/nao_robot-release.git
-      version: 0.5.12-0
+      version: 0.5.13-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_robot` to `0.5.13-0`:
- upstream repository: https://github.com/ros-naoqi/nao_robot.git
- release repository: https://github.com/ros-naoqi/nao_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.12-0`
## nao_apps
- No changes
## nao_bringup
- No changes
## nao_description

```
* Fix bad arm values.
  This fixes #25 <https://github.com/ros-naoqi/nao_robot/issues/25>.
* Contributors: Vincent Rabaud
```
## nao_robot
- No changes
