### PR TITLE
nao_robot: 0.5.13-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2527,7 +2527,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/nao_robot-release.git
-      version: 0.5.12-0
+      version: 0.5.13-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_robot` to `0.5.13-0`:
- upstream repository: https://github.com/ros-naoqi/nao_robot.git
- release repository: https://github.com/ros-naoqi/nao_robot-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.12-0`
## nao_apps
- No changes
## nao_bringup
- No changes
## nao_description

```
* Fix bad arm values.
  This fixes #25 <https://github.com/ros-naoqi/nao_robot/issues/25>.
* Contributors: Vincent Rabaud
```
## nao_robot
- No changes
