### PR TITLE
image_common: 1.11.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3369,7 +3369,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/image_common-release.git
-      version: 1.11.8-0
+      version: 1.11.9-0
     source:
       type: git
       url: https://github.com/ros-perception/image_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `1.11.9-0`:
- upstream repository: https://github.com/ros-perception/image_common.git
- release repository: https://github.com/ros-gbp/image_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.8-0`
## camera_calibration_parsers

```
* Add python wrapper for readCalibration.
  Reads .ini or .yaml calibration file and returns camera name and sensor_msgs/cameraInfo.
* Use $catkin_EXPORTED_TARGETS
* Contributors: Jochen Sprickerhof, Markus Roth
```
## camera_info_manager
- No changes
## image_common
- No changes
## image_transport

```
* fix linkage in tutorials
* Use $catkin_EXPORTED_TARGETS
* Contributors: Jochen Sprickerhof, Vincent Rabaud
```
## polled_camera
- No changes
