### PR TITLE
image_transport_plugins: 1.9.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3412,7 +3412,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/image_transport_plugins-release.git
-      version: 1.9.2-0
+      version: 1.9.3-0
     source:
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `1.9.3-0`:
- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros-gbp/image_transport_plugins-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.9.2-0`
## compressed_depth_image_transport

```
* Refactor the codec into its own .h and .cpp.
* remove useless tf dependencies
* Contributors: Mac Mason, Vincent Rabaud
```
## compressed_image_transport

```
* remove useless tf dependencies
* Using cfg-defined constants
* Changed flag name, and corrected typo in flag use.
* using IMREAD flags.
* Updated for indigo-devel
* Contributors: Cedric Pradalier, Vincent Rabaud
```
## image_transport_plugins
- No changes
## theora_image_transport

```
* remove useless tf dependencies
* Contributors: Vincent Rabaud
```
