### PR TITLE
rospilot: 1.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4331,7 +4331,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/rospilot/rospilot-release.git
-      version: 1.0.3-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/rospilot/rospilot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot` to `1.1.0-0`:
- upstream repository: https://github.com/rospilot/rospilot.git
- release repository: https://github.com/rospilot/rospilot-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.3-0`
## rospilot

```
* Auto-detect camera device path
* Improve video streaming FPS ~2x
* Add support for hardware h264 acceleration on Odroid XU4
* Add FPS counter to camera page
* Contributors: Christopher Berner
```
