### PR TITLE
Upload ardone2control to documentation index for ros indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -316,16 +316,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/tn0432/ardrone2control.git
-      version: indigo
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/tn0432/ardrone2control.git
-      version: 1.0.0
+      version: indigo-devel
     source:
       type: git
       url: https://github.com/tn0432/ardrone2control.git
-      version: indigo
+      version: indigo-devel
     status: developed
   ardrone_autonomy:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -312,6 +312,21 @@ repositories:
       url: https://github.com/vanadiumlabs/arbotix_ros-release.git
       version: 0.10.0-0
     status: maintained
+  ardrone2control:
+    doc:
+      type: git
+      url: https://github.com/tn0432/ardrone2control.git
+      version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tn0432/ardrone2control.git
+      version: 1.0.0
+    source:
+      type: git
+      url: https://github.com/tn0432/ardrone2control.git
+      version: indigo
+    status: developed
   ardrone_autonomy:
     doc:
       type: git


### PR DESCRIPTION
I would like ardone2control to be indexed and documented for ros indigo
