### PR TITLE
Adding ardrone2islab to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -312,6 +312,12 @@ repositories:
       url: https://github.com/vanadiumlabs/arbotix_ros-release.git
       version: 0.10.0-0
     status: maintained
+  ardrone2islab:
+    source:
+      type: git
+      url: https://github.com/tn0432/ardrone2islab.git
+      version: master
+    status: developed
   ardrone_autonomy:
     doc:
       type: git


### PR DESCRIPTION
I would like ardrone2islab to be indexed and documented for indigo
