### PR TITLE
ros_controllers does not have a jade-dev branch

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4007,7 +4007,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git
-      version: jade-dev
+      version: jade-devel
     release:
       packages:
       - diff_drive_controller


### PR DESCRIPTION
I updated the doc entry to use `jade-devel`. @adolfo-rt
