### PR TITLE
image_common: 1.11.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1497,7 +1497,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/image_common-release.git
-      version: 1.11.8-0
+      version: 1.11.10-0
     source:
       type: git
       url: https://github.com/ros-perception/image_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `1.11.10-0`:
- upstream repository: https://github.com/ros-perception/image_common.git
- release repository: https://github.com/ros-gbp/image_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.8-0`
## camera_calibration_parsers

```
* Add install target for python wrapper library
* Only link against needed Boost libraries
  9829b02 introduced a python dependency into find_package(Boost..) which
  results in ${Boost_LIBRARIES} containing boost_python and such a
  dependency to libpython at link time. With this patch we only link
  against the needed libraries.
* Contributors: Jochen Sprickerhof, Vincent Rabaud
```
## camera_info_manager
- No changes
## image_common
- No changes
## image_transport
- No changes
## polled_camera
- No changes
