### PR TITLE
ackermann_msgs: 1.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -20,7 +20,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-drivers-gbp/ackermann_msgs-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/ros-drivers/ackermann_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ackermann_msgs` to `1.0.1-0`:
- upstream repository: https://github.com/ros-drivers/ackermann_msgs.git
- release repository: https://github.com/ros-drivers-gbp/ackermann_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.0-0`
## ackermann_msgs

```
* Removed Jim Rothrock from the maintainer list. Changed the version to 1.0.1.
```
