### PR TITLE
move rosdistro distribution_caches to the new farm

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -5,15 +5,15 @@
 distributions:
   groovy:
     distribution: [groovy/distribution.yaml]
-    distribution_cache: http://ros.org/rosdistro/groovy-cache.yaml.gz
+    distribution_cache: http://repositories.ros.org/rosdistro_cache/groovy-cache.yaml.gz
   hydro:
     distribution: [hydro/distribution.yaml]
-    distribution_cache: http://ros.org/rosdistro/hydro-cache.yaml.gz
+    distribution_cache: http://repositories.ros.org/rosdistro_cache/hydro-cache.yaml.gz
   indigo:
     distribution: [indigo/distribution.yaml]
-    distribution_cache: http://ros.org/rosdistro/indigo-cache.yaml.gz
+    distribution_cache: http://repositories.ros.org/rosdistro_cache/indigo-cache.yaml.gz
   jade:
     distribution: [jade/distribution.yaml]
-    distribution_cache: http://ros.org/rosdistro/jade-cache.yaml.gz
+    distribution_cache: http://repositories.ros.org/rosdistro_cache/jade-cache.yaml.gz
 type: index
 version: 3


### PR DESCRIPTION
Indigo and Jade are being generated in that location. 

I copied Groovy and Hydro into that folder for consistency. 

@dirk-thomas for review
