### PR TITLE
Adding mapir-ros-pkg to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4782,6 +4782,16 @@ repositories:
       url: https://github.com/ros-planning/map_store.git
       version: hydro-devel
     status: maintained
+  mapir-ros-pkg:
+    doc:
+      type: git
+      url: https://github.com/MAPIRlab/mapir-ros-pkg
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/MAPIRlab/mapir-ros-pkg
+      version: master
+    status: maintained
   mapviz:
     doc:
       type: git


### PR DESCRIPTION
I'd like mapir-ros-pkg to be indexed and documented on ros-org
