### PR TITLE
Adding mapir-ros-pkg to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4782,6 +4782,16 @@ repositories:
       url: https://github.com/ros-planning/map_store.git
       version: hydro-devel
     status: maintained
+  mapir-ros-pkg:
+    doc:
+      type: git
+      url: https://github.com/MAPIRlab/mapir-ros-pkg
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/MAPIRlab/mapir-ros-pkg
+      version: master
+    status: maintained
   mapviz:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4782,14 +4782,14 @@ repositories:
       url: https://github.com/ros-planning/map_store.git
       version: hydro-devel
     status: maintained
-  mapir-ros-pkg:
+  mapir-ros-pkgs:
     doc:
       type: git
-      url: https://github.com/MAPIRlab/mapir-ros-pkg
+      url: https://github.com/MAPIRlab/mapir-ros-pkgs.git
       version: indigo-devel
     source:
       type: git
-      url: https://github.com/MAPIRlab/mapir-ros-pkg
+      url: https://github.com/MAPIRlab/mapir-ros-pkgs.git
       version: master
     status: maintained
   mapviz:


### PR DESCRIPTION
I'd like mapir-ros-pkgs to be indexed and documented on ros.org
