### PR TITLE
fetch_ros: 0.7.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2334,7 +2334,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
-      version: 0.7.0-0
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.7.1-0`:
- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.0-0`
## fetch_calibration
- No changes
## fetch_depth_layer

```
* add parameters for topic names
* add support for static camera based on tf transform
* Improved local costmap clearing by considering all points for clearance.
* re-license fetch_depth_layer as BSD
* Contributors: Marek Fiser, Michael Ferguson
```
## fetch_description

```
* update torso throw to match rev2 hardware
* make laser actually level
* update gripper model
* Contributors: Michael Ferguson
```
## fetch_maps
- No changes
## fetch_moveit_config
- No changes
## fetch_navigation
- No changes
## fetch_teleop
- No changes
