### PR TITLE
remove released packages from Indigo which fail to build

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2451,11 +2451,6 @@ repositories:
       url: https://github.com/ingeniarius-ltd/forte_rc_robot.git
       version: indigo-devel
   freefloating_gazebo:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/TheDash/freefloating_gazebo-gbp.git
-      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/freefloating-gazebo/freefloating_gazebo.git
@@ -2781,15 +2776,6 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/mikeferguson/grasping_msgs-gbp.git
       version: 0.3.1-0
-    status: developed
-  graspit_ros:
-    release:
-      packages:
-      - graspit
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/graspit_ros-release.git
-      version: 0.3.2-0
     status: developed
   grid_map:
     doc:
@@ -5035,11 +5021,6 @@ repositories:
       type: git
       url: https://github.com/yincanben/micros_dynamic_objects_filter.git
       version: master
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/yincanben/micros_dynamic_objects_filter-release.git
-      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/yincanben/micros_dynamic_objects_filter.git
@@ -6692,11 +6673,6 @@ repositories:
       type: git
       url: https://github.com/najkirdneh/pcan_topics.git
       version: master
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/najkirdneh/pcan_topics-release.git
-      version: 1.0.11-0
     source:
       type: git
       url: https://github.com/najkirdneh/pcan_topics.git


### PR DESCRIPTION
The following released packages are been removed since they failed to build on the farm for some time without being fixed:
- freefloating_gazebo @PR2-Builder-Bot http://jenkins.ros.org/view/IbinT64/job/ros-indigo-freefloating-gazebo_binarydeb_trusty_amd64/
- graspit @mateiciocarlie http://jenkins.ros.org/view/IbinT64/job/ros-indigo-graspit_binarydeb_trusty_amd64/
- micros_dynamic_objects_filter @yincanben http://jenkins.ros.org/view/IbinT64/job/ros-indigo-micros-dynamic-objects-filter_binarydeb_trusty_amd64/
- pcan_topics @najkirdneh http://jenkins.ros.org/view/IbinT64/job/ros-indigo-pcan-topics_binarydeb_trusty_amd64/
