### PR TITLE
remove released packages from Jade which fail to build

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -969,11 +969,6 @@ repositories:
       version: indigo
     status: maintained
   freefloating_gazebo:
-    release:
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/TheDash/freefloating_gazebo-gbp.git
-      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/freefloating-gazebo/freefloating_gazebo.git


### PR DESCRIPTION
The following released packages are been removed since they failed to build on the farm for some time without being fixed:
- freefloating_gazebo @PR2-Builder-Bot http://jenkins.ros.org/view/JbinT64/job/ros-jade-freefloating-gazebo_binarydeb_trusty_amd64/
