### PR TITLE
remove not existing repos from Indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1653,21 +1653,11 @@ repositories:
       type: git
       url: https://github.com/HumaRobotics/darwin_gazebo.git
       version: master
-  demo_lidar:
-    doc:
-      type: git
-      url: https://github.com/jizhang-cmu/demo_lidar.git
-      version: indigo
   demo_pioneer:
     doc:
       type: git
       url: https://github.com/lagadic/demo_pioneer.git
       version: master
-  demo_rgbd:
-    doc:
-      type: git
-      url: https://github.com/jizhang-cmu/demo_rgbd.git
-      version: indigo
   denso:
     doc:
       type: git


### PR DESCRIPTION
The following repositories are been removed since they don't exist anymore:
- demo_lidar @jizhang-cmu
- demo_rgbd @jizhang-cmu
