### PR TITLE
audio_common: 0.2.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -187,7 +187,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.2.9-0
+      version: 0.2.10-0
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.2.10-0`:
- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.9-0`
## audio_capture
- No changes
## audio_common
- No changes
## audio_common_msgs
- No changes
## audio_play
- No changes
## sound_play

```
* Issue: The error checks for missing publisher/action client in sendMsg were inverted.
  The non-blocking brach tested the action client while the blocking branch
  tested the publisher.
  Fix: Inverted the blocking boolean for both branchs.
* sound_play: Fix build with -DCATKIN_ENABLE_TESTING=OFF.
  https://bugs.gentoo.org/show_bug.cgi?id=567466
* Contributors: Alexis Ballier, Neowizard
```
