### PR TITLE
ax2550: 0.1.1-5 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -447,7 +447,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wjwwood/ax2550-release.git
-      version: 0.1.1-4
+      version: 0.1.1-5
     source:
       type: git
       url: https://github.com/wjwwood/ax2550.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ax2550` to `0.1.1-5`:
- upstream repository: https://github.com/wjwwood/ax2550.git
- release repository: https://github.com/wjwwood/ax2550-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.1-4`
