### PR TITLE
navigation_2d: 0.1.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2650,6 +2650,31 @@ repositories:
       url: https://github.com/ros-planning/navigation.git
       version: jade-devel
     status: maintained
+  navigation_2d:
+    doc:
+      type: git
+      url: https://github.com/skasperski/navigation_2d.git
+      version: jade
+    release:
+      packages:
+      - nav2d
+      - nav2d_exploration
+      - nav2d_karto
+      - nav2d_localizer
+      - nav2d_msgs
+      - nav2d_navigator
+      - nav2d_operator
+      - nav2d_remote
+      - nav2d_tutorials
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/skasperski/navigation_2d-release.git
+      version: 0.1.4-0
+    source:
+      type: git
+      url: https://github.com/skasperski/navigation_2d.git
+      version: jade
+    status: maintained
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_2d` to `0.1.4-0`:
- upstream repository: https://github.com/skasperski/navigation_2d.git
- release repository: https://github.com/skasperski/navigation_2d-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
