### PR TITLE
jsk_common_msgs: 2.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3859,7 +3859,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common_msgs-release.git
-      version: 2.0.0-0
+      version: 2.0.1-0
     status: developed
   jsk_control:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common_msgs` to `2.0.1-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common_msgs
- release repository: https://github.com/tork-a/jsk_common_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.0.0-0`
## jsk_common_msgs
- No changes
## jsk_footstep_msgs

```
* [jsk_footstep_msgs] support multi legs in Footstep.msg keeping backwardcompatibility
* Contributors: Eisoku Kuroiwa
```
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## posedetection_msgs

```
* include/posedetection_msgs/feature0d_to_image.h: add cv.hpp
* CMakeLists.txt : remove posedetection_msgs depends on OpenCV; remove opencv from catkin_package, what provide opencv to catkin_LIBRARIES
* Contributors: Kei Okada
```
## speech_recognition_msgs
- No changes
