### PR TITLE
Revert "pyros_setup: 0.0.10-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7535,7 +7535,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/pyros-setup-release.git
-      version: 0.0.10-0
+      version: 0.0.8-0
     status: developed
   pyros_test:
     doc:


### PR DESCRIPTION
Reverts ros/rosdistro#10348

The sourcedebs are failing. 
