### PR TITLE
rtmros_hironx: 1.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9565,7 +9565,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.3-0
+      version: 1.1.4-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.4-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.3-0`
## hironx_calibration
- No changes
## hironx_moveit_config

```
* [sys][moveit config] Enable unit test for ROS_Client-RobotCommander integration
  Missing dependency
* Contributors: Isaac I.Y. Saito
```
## hironx_ros_bridge

```
* [fix] servoOn debug msg failure (#425 <https://github.com/start-jsk/rtmros_hironx/issues/425>)
* [fix][ROS_Client] Implement missing methods #421 <https://github.com/start-jsk/rtmros_hironx/issues/421>
* [feat][ROS_Client] ROS client now Inherits moveitcommander.RobotCommander class.
* [feat][hironx/rqt dashboard] Add HiroNXO specific commands
* Contributors: Kei Okada, pazeshun, Isaac I.Y. Saito,
```
## rtmros_hironx

```
* [fix] servoOn debug msg failure (#425 <https://github.com/start-jsk/rtmros_hironx/issues/425>)
* [fix][ROS_Client] Implement missing methods #421 <https://github.com/start-jsk/rtmros_hironx/issues/421>
* [feat][ROS_Client] ROS client now Inherits moveitcommander.RobotCommander class.
* [feat][hironx/rqt dashboard] Add HiroNXO specific commands
* [sys][moveit config] Enable unit test for ROS_Client-RobotCommander integration. Missing dependency
* Contributors: Kei Okada, pazeshun, Isaac I.Y. Saito,
```
