### PR TITLE
force_torque_tools: 1.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -962,7 +962,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/force_torque_tools-release.git
-      version: 1.0.1-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/kth-ros-pkg/force_torque_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `force_torque_tools` to `1.1.0-0`:
- upstream repository: https://github.com/kth-ros-pkg/force_torque_tools.git
- release repository: https://github.com/tork-a/force_torque_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.1-0`
## force_torque_sensor_calib

```
* [sys] Updated for jade and k-turtle eigen dependency (#12 <https://github.com/kth-ros-pkg/force_torque_tools/pull/12> and discussion #11 <https://github.com/kth-ros-pkg/force_torque_tools/issues/11>)
* Contributors: Aris Synodinos
```
## force_torque_tools

```
* [sys] Updated for jade and k-turtle eigen dependency (#12 <https://github.com/kth-ros-pkg/force_torque_tools/pull/12> and discussion #11 <https://github.com/kth-ros-pkg/force_torque_tools/issues/11>)
* Contributors: Aris Synodinos
```
## gravity_compensation
- No changes
