### PR TITLE
screen_grab: 0.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4773,6 +4773,21 @@ repositories:
       url: https://github.com/SmartRoboticSystems/schunk_grippers.git
       version: master
     status: maintained
+  screen_grab:
+    doc:
+      type: git
+      url: https://github.com/lucasw/screen_grab.git
+      version: 0.0.2
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/lucasw/screen_grab-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/lucasw/screen_grab.git
+      version: master
+    status: developed
   serial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `screen_grab` to `0.0.2-0`:
- upstream repository: https://github.com/lucasw/screen_grab.git
- release repository: https://github.com/lucasw/screen_grab-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## screen_grab
- No changes
