### PR TITLE
Add python-jsonschema-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -712,6 +712,12 @@ python-jsonref-pip:
   ubuntu:
     pip:
       packages: [jsonref]
+python-jsonschema:
+  ubuntu: [python-jsonschema]
+python-jsonschema-pip:
+  ubuntu:
+    pip:
+      packages: [jsonschema]
 python-kdtree:
   fedora: [libkdtree++-python]
   ubuntu:


### PR DESCRIPTION
Jsonschema is a JSON validation module for python.

The apt version is 2.3.0, but the pip version is 2.5.1, so I've added both to the python index.
