### PR TITLE
rtmros_hironx: 1.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9565,7 +9565,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.4-0
+      version: 1.1.5-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.5-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.4-0`
## hironx_calibration
- No changes
## hironx_moveit_config

```
* [feat][ROS_CLient] Upperbody move group.
* [feat] Rename both arms group to adjust to that of NEXTAGE Open.
* [feat] Add torso and head move groups.
* [feat] Factory-init pose for MoveIt! reserved pose.
* Contributors: Isaac I.Y. Saito
```
## hironx_ros_bridge

```
* [feat][moveit config, ROS_CLient] Upperbody move group. Add more fundamental command.
* [feat][moveit config, ROS_CLient] More fundamental command.
* [feat][moveit config] Factory-init pose for MoveIt! reserved pose.
* [feat] Rename both arms group to adjust to that of NEXTAGE Open.
* [feat][ROS_Client] Exporting move group members publicly.
* [feat][ROS_Client] Remove some standalone methods that are less maintained. Instead, utilize more from MoveIt! RobotCommander and MoveitCommander.
* Contributors: Isaac I.Y. Saito
```
## rtmros_hironx

```
* [feat][moveit config, ROS_CLient] Upperbody move group. Add more fundamental command.
* [feat][ROS_CLient] More fundamental commands.
* [feat][moveit config] Factory-init pose for MoveIt! reserved pose.
* [feat] Rename both arms group to adjust to that of NEXTAGE Open.
* [feat][ROS_Client] Exporting move group members publicly.
* [feat][ROS_Client] Remove some standalone methods that are less maintained. Instead, utilize more from MoveIt! RobotCommander and MoveitCommander.
* Contributors: Isaac I.Y. Saito
```
