### PR TITLE
Add libpng++-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1871,6 +1871,8 @@ libphonon-dev:
   ubuntu:
     apt:
       packages: [libphonon-dev]
+libpng++-dev:
+  ubuntu: [libpng++-dev]
 libpng12-dev:
   arch: [libpng]
   debian: [libpng12-dev]


### PR DESCRIPTION
PNG++ is a wrapper library for libpng that makes it much easier to work with PNGs in C++.
