### PR TITLE
rtmros_nextage: 0.7.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9579,6 +9579,7 @@ repositories:
     release:
       packages:
       - nextage_description
+      - nextage_gazebo
       - nextage_ik_plugin
       - nextage_moveit_config
       - nextage_ros_bridge
@@ -9586,7 +9587,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.7.3-0
+      version: 0.7.4-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.7.4-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.3-0`
## nextage_description

```
* [gazebo] Add non-zero mass so that links are not ignored
* NextageOpen.urdf: add transmission and ros_control
* set depend from nextage_description to nextage_gazebo is not a good idea, nextage_gazbeo should depends on nextage_description
* HEAD_JOINT1_Link is too small, use default settings http://wiki.ros.org/urdf/Tutorials/Adding%20Physical%20and%20Collision%20Properties%20to%20a%20URDF%20Model
* [gazebo] Add non-zero mass so that links are not ignored
* Add Gazebo package. So far model not shown, and model seems to keep falling.
* Contributors: Isaac I.Y. Saito, Kei Okada
```
## nextage_gazebo

```
* need to wait for finishing go_initial.py (https://github.com/tork-a/rtmros_nextage/pull/223/files#diff-16b25951a50b1e80569929d32a09102bR14)
* pass arg GUI
* [gz] Retry tests upon failure
* [gz] Add small unit tests
* [gz] Minor formatting
* [gazebo] Add non-zero mass so that links are not ignored
* update control parameters
* http://answers.ros.org/question/200777/using-both-jointtrajectorycontroller-and-jointpositioncontroller-at-same-time-in-ros_control, we may not need both position controller and trajectory controller
* use NextageOpen name space, use robot name. Not sure if this is necessary
* package.xml: add depends to ros_controllers
* set depend from nextage_description to nextage_gazebo is not a good idea, nextage_gazbeo should depends on nextage_description
* [gazebo] Add non-zero mass so that links are not ignored
* Add Gazebo package. So far model not shown, and model seems to keep falling.
* Contributors: Isaac I.Y. Saito, Kei Okada
```
## nextage_ik_plugin
- No changes
## nextage_moveit_config
- No changes
## nextage_ros_bridge
- No changes
## rtmros_nextage

```
* [gazebo] Add non-zero mass so that links are not ignored
* Contributors: Isaac I.Y. Saito
```
