### PR TITLE
rtmros_nextage: 0.7.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9586,7 +9586,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.7.4-0
+      version: 0.7.5-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.7.5-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.4-0`
## nextage_description

```
* [fix] fix namespace so that existing app can operate the robot on Gazebo
* Contributors: Kei Okada
```
## nextage_gazebo

```
* [fix] fix namespace so that existing app can operate the robot on Gazebo
* Contributors: Kei Okada
```
## nextage_ik_plugin
- No changes
## nextage_moveit_config
- No changes
## nextage_ros_bridge
- No changes
## rtmros_nextage

```
* [fix] fix namespace so that existing app can operate the robot on Gazebo
* Contributors: Kei Okada
```
