### PR TITLE
pepper_meshes: 0.2.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3250,7 +3250,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_meshes-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_meshes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_meshes` to `0.2.2-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_meshes.git
- release repository: https://github.com/ros-naoqi/pepper_meshes-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.1-0`
## pepper_meshes

```
* fixed folder names in CMakeLists
* Contributors: Mikael Arguedas
```
