### PR TITLE
moveit_msgs: 0.7.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5184,7 +5184,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_msgs-release.git
-      version: 0.6.1-0
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_msgs.git
+      version: indigo-devel
     status: maintained
   moveit_planners:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `0.7.0-0`:
- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/ros-gbp/moveit_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.1-0`
## moveit_msgs

```
* add db state
* added services for delete and rename
* added services for warehouse access
* Contributors: Sachin Chitta, dg
```
