### PR TITLE
moveit_ros: 0.7.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5311,7 +5311,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.6.5-0
+      version: 0.7.0-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ros` to `0.7.0-0`:
- upstream repository: https://github.com/ros-planning/moveit_ros.git
- release repository: https://github.com/ros-gbp/moveit_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.5-0`
## moveit_ros

```
* Removed trailing whitespace from entire repository
* Contributors: Dave Coleman
```
## moveit_ros_benchmarks

```
* Removed trailing whitespace from entire repository
* Adding tf dep fixes
* Contributors: Dave Coleman, Mr-Yellow
```
## moveit_ros_benchmarks_gui

```
* Removed trailing whitespace from entire repository
* Contributors: Dave Coleman
```
## moveit_ros_manipulation

```
* Removed trailing whitespace from entire repository
* Contributors: Dave Coleman
```
## moveit_ros_move_group

```
* Removed trailing whitespace from entire repository
* Fixed bug(?) in move_group::MoveGroupKinematicsService::computeIK link name selection.
* Contributors: Dave Coleman, Mihai Pomarlan
```
## moveit_ros_perception

```
* Removed trailing whitespace from entire repository
* Added missing dependency on moveit_msgs package
* Contributors: Andriy Petlovanyy, Dave Coleman, dg
```
## moveit_ros_planning

```
* Removed trailing whitespace from entire repository
* fixed segfault on shutdown
  use of pluginlib's createUnmanagedInstance() is strongly discouraged:
  http://wiki.ros.org/class_loader#Understanding_Loading_and_Unloading
  here, the kinematics plugin libs were unloaded before destruction of corresponding pointers
* Deprecate shape_tools
* CurrentStateMonitor no longer requires hearing mimic joint state values.
* Fix crash due to robot state not getting updated (moveit_ros #559)
* Contributors: Dave Coleman, Dave Hershberger, Robert Haschke, kohlbrecher
```
## moveit_ros_planning_interface

```
* Removed trailing whitespace from entire repository
* new method MoveGroup::getDefaultPlannerId(const std::string &group)
  ... to retrieve default planner config from param server
  moved corresponding code from rviz plugin to MoveGroup interface
  to facilitate re-use
* adding set_num_planning_attempts to python interface
* Added python wrapper for setMaxVelocityScalingFactor
* saves robot name to db from moveit. also robot name accessible through robot interface python wrapper
* adding set_num_planning_attempts to python interface
* Added python wrapper for MoveGroup.asyncExecute()
* Add retime_trajectory to moveit python wrapper
* add getHandle to move_group_interface
* Updated documentation on move() to inform the user that an asynchronus spinner is required. Commonly new users don't do this and move() blocks permanently
* Contributors: Dave Coleman, Dave Hershberger, Kei Okada, Michael Stevens, Robert Haschke, Sachin Chitta, Scott, Yoan Mollard, dg, ferherranz
```
## moveit_ros_robot_interaction

```
* Removed trailing whitespace from entire repository
* further adapted marker size computation
  - drop largest extension dimension (-> use cross-section size of elongated link)
  - for an end-effector group, consider the sizes of individual links
  instead of the overall size of all links (which becomes huge very fast)
  - enlarge marker size by factor of 1.5 when there is only a single eef marker
* reworked computeLinkMarkerSize()
  compute size such that the marker sphere will cover
  - a spherical link geometry -> AABB.maxCoeff
  - a cubical link geometry -> AABB.norm
  -> use average of both values
  Virtual links (without any shape) will have a size of AABB of zero dims.
  In this case use the dimensions of the closest parent link instead.
* improved computation of interactive marker size
  - use parent_link if group == parent_group
  - scale smaller than 5cm is clipped to 5cm instead of using default
  - clarified size computation, using diameter of AABB
* fixing error caused by BOOST_STATIC_ASSERT
* Fixed compile error caused by BOOST_STATIC_ASSERT in kinematic_options.cpp
  Added kinematics::DiscretizationMethods::DiscretizationMethod to QO_FIELDS in kinematic_options.cpp.
  At pull request #581, type of discretization_method was set to int. Changed it to proper type.
* reinstated changes related to the updates in the  moveit_core::KinematicsBase interface
* adds the 'returns_approximate_solution' entry so that it is compatible with the changes in kinematics::KinematicsBase class in the moveit_core repo
* Contributors: Daichi Yoshikawa, Dave Coleman, Robert Haschke, Sachin Chitta, jrgnicho
```
## moveit_ros_visualization

```
* Removed trailing whitespace from entire repository
* new method MoveGroup::getDefaultPlannerId(const std::string &group)
  ... to retrieve default planner config from param server
  moved corresponding code from rviz plugin to MoveGroup interface
  to facilitate re-use
* correctly initialize scene robot's parameters after initialization
  - loaded parameters were ignored
  - changed default alpha value to 1 to maintain previous behaviour
* load default_planner_config from default location
  instead of loading from /<ns>/default_planner_config, use
  /<ns>/move_group/<group>/default_planner_config, which is the default
  location for planner_configs too
* Merge pull request #610 : correctly update all markers after robot motion
* fixing conflicts, renaming variable
* Merge pull request #612 from ubi-agni/interrupt-traj-vis
  interrupt trajectory visualization on arrival of new display trajectory
* fixup! cleanup TrajectoryVisualization::update
  only enter visualization loop when displaying_trajectory_message is defined
* added missing initialization
* correctly setAlpha for new trail
* fixed race condition for trajectory-display interruption
  - TrajectoryVisualization::update() switches to new trajectory
  automatically when it has finished displaying the old one
  - TrajectoryVisualization::interruptCurrentDisplay() might interrupt
  this newly started trajectory
  consequences:
  - protect switching of trajectory with mutex
  - interrupt only if trajectory display progressed past first waypoint
  - removed obsolete signal timeToShowNewTrail:
  update() automatically switches and updates trail in sync
* cleanup TrajectoryVisualization::update
  simplified code to switch to new trajectory / start over animation in loop mode
* new GUI property to allow immediate interruption of displayed trajectory
* immediately show trajectory after planning (interrupting current display)
* fix segfault when disabling and re-enabling TrajectoryVisualization
  animating_path was still true causing update() to access
  displaying_trajectory_message, which was reset onDisable().
* update pose of all markers when any marker moved
  Having several end-effector markers attached to a group (e.g. a multi-
  fingered hand having an end-effector per fingertip and an end-effector
  for the hand base), all markers need to update their pose on any motion
  of any marker. In the example: if the hand base is moved, the fingertip
  markers should be moved too.
* use move_group/default_workspace_bounds as a fallback for workspace bounds
* code style cleanup
* fixed tab order of rviz plugin widgets
* load / save rviz' workspace config
* saves robot name to db from moveit. also robot name accessible through robot interface python wrapper
* Added install rule to install moveit_joy.py.
* motion_planning_frame_planning: use /default_planner_config parma to specify default planning algorithm
* Avoid adding a slash if getMoveGroupNS() is empty.
  If the getMoveGroupNS() returns an empty string, ros::names::append() inserts a slash in front of 'right', which changes it to a global name.
  Checking getMoveGroupNS() before calling append removes the issue.
  append() behaviour will not be changed in ros/ros_comm.
* Contributors: Dave Coleman, Jochen Welle, Kei Okada, Robert Haschke, Sachin Chitta, TheDash, dg
```
## moveit_ros_warehouse

```
* Removed trailing whitespace from entire repository
* changed to global node handle so warehouse connection params work correctly
* removed extraneous includes
* added delete and rename
* now takes port + host from param server
* removed defunct code
* checks db connection is good
* services advertised
* Contributors: Dave Coleman, dg
```
