### PR TITLE
moveit_plugins: 0.5.6-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5217,7 +5217,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_plugins-release.git
-      version: 0.5.6-1
+      version: 0.5.6-2
     source:
       type: git
       url: https://github.com/ros-planning/moveit_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_plugins` to `0.5.6-2`:
- upstream repository: https://github.com/ros-planning/moveit_plugins.git
- release repository: https://github.com/ros-gbp/moveit_plugins-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.6-1`
## moveit_fake_controller_manager
- No changes
## moveit_plugins
- No changes
## moveit_simple_controller_manager

```
* Allow simple controller manager to ignore virtual joints without failing
* Contributors: Dave Coleman
```
