### PR TITLE
moveit_planners: 0.7.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5198,7 +5198,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_planners-release.git
-      version: 0.6.7-0
+      version: 0.7.0-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_planners.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_planners` to `0.7.0-0`:
- upstream repository: https://github.com/ros-planning/moveit_planners.git
- release repository: https://github.com/ros-gbp/moveit_planners-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.7-0`
## moveit_planners
- No changes
## moveit_planners_ompl

```
* Removed trailing whitespace from entire repository
* Fixed include directory order to make ros package shadowing work.
* fixing internal storing of config settings
* Make sure an overlayed OMPL is used instead of the ROS one.
* fix simplifySolutions(bool) setter
  The method simplifySolutions(bool) always set the simplify_solutions member to true and the input variable "flag" was ignored.
  The method is fixed by setting the simplify_solutions member to the value of the input variable "flag".
* changed location of getDefaultPlanner
* Contributors: Bastian Gaspers, Christian Dornhege, Dave Coleman, Dave Hershberger, Sachin Chitta
```
