### PR TITLE
moveit_resources: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5263,7 +5263,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_resources-release.git
-      version: 0.5.0-0
+      version: 0.6.0-0
     status: maintained
   moveit_robots:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `0.6.0-0`:
- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros-gbp/moveit_resources-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.0-0`
## moveit_resources

```
* Don't make include dir into build
* Place include folder in the devel space instead of the build space
  fixes #5 .
* Add travis indicator
* added branch name to build status
* added travis build status indicator in README.md
* Merge pull request #3 from ros-planning/add-travis
  added travis support
* Contributors: Dave Coleman, Dave Hershberger, Nantas Nardelli, isucan
```
