### PR TITLE
moveit_commander: 0.5.7-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5125,7 +5125,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_commander-release.git
-      version: 0.5.7-0
+      version: 0.5.7-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_commander.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_commander` to `0.5.7-1`:
- upstream repository: https://github.com/ros-planning/moveit_commander.git
- release repository: https://github.com/ros-gbp/moveit_commander-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.7-0`
## moveit_commander

```
* Merge pull request #21 <https://github.com/ros-planning/moveit_commander/issues/21> from pirobot/hydro-devel
  Added set_support_surface_name function to move_group.py
* Added set_support_surface_name function to move_group.py
* Contributors: Patrick Goebel, Sachin Chitta
```
