### PR TITLE
rospilot: 1.1.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4372,7 +4372,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/rospilot/rospilot-release.git
-      version: 1.1.0-1
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/rospilot/rospilot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot` to `1.1.1-0`:
- upstream repository: https://github.com/rospilot/rospilot.git
- release repository: https://github.com/rospilot/rospilot-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.0-1`
## rospilot

```
* Copy files to /etc as part of setup script instead of package install
* Fix warnings and installation of mapnik files
* Add missing python-serial dependency
* Cleanup linking of libturbojpeg
  This should fix compiling on other platforms like x86_32
* Contributors: Christopher Berner
```
