### PR TITLE
vision_opencv: 1.11.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11306,7 +11306,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.11.10-0
+      version: 1.11.11-0
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.11.11-0`:
- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.10-0`
## cv_bridge

```
* clean up the doc files
* fix a few warnings in doc jobs
* Contributors: Vincent Rabaud
```
## image_geometry

```
* clean up the doc files
* fix a few warnings in doc jobs
* Contributors: Vincent Rabaud
```
## opencv_apps

```
* check if opencv_contrib is available
* Use respawn instead of watch
* Contributors: Kei Okada, trainman419
```
## vision_opencv
- No changes
