### PR TITLE
costmap_converter: 0.0.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -474,7 +474,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/rst-tu-dortmund/costmap_converter-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/rst-tu-dortmund/costmap_converter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `costmap_converter` to `0.0.5-0`:
- upstream repository: https://github.com/rst-tu-dortmund/costmap_converter.git
- release repository: https://github.com/rst-tu-dortmund/costmap_converter-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.4-0`
## costmap_converter

```
* Major changes regarding the line detection based on the convex hull
  (it should be much more robust now).
* Concave hull plugin added.
* The cluster size can now be limited from above using a specific parameter.
  This implicitly avoids large clusters forming a 'L' or 'U'.
* All parameters can now be adjusted using dynamic_reconfigure (rqt_reconfigure).
* Some parameter names changed.
* Line plugin based on ransac: line inliers must now be placed inbetween the start and end of a line.
```
