### PR TITLE
ar_track_alvar: 0.5.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -254,7 +254,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ar_track_alvar-release.git
-      version: 0.5.2-0
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/sniekum/ar_track_alvar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar` to `0.5.3-0`:
- upstream repository: https://github.com/sniekum/ar_track_alvar
- release repository: https://github.com/ros-gbp/ar_track_alvar-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.2-0`
## ar_track_alvar

```
* [feat] New bool-Topic to enable/disable the marker detection (#70 <https://github.com/sniekum/ar_track_alvar/issues/70>)
* [feat] added public way to set intrinsicCalibration for Camera class
* [fix] not publishing marker that are facing in the same direction as the camera.
* [sys] removed duplicate code for image subscription
* Contributors: Nikolas Engelhard, Scott Niekum
```
