### PR TITLE
ar_track_alvar: 0.5.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -65,7 +65,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ar_track_alvar-release.git
-      version: 0.5.1-0
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/sniekum/ar_track_alvar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar` to `0.5.3-0`:
- upstream repository: https://github.com/sniekum/ar_track_alvar
- release repository: https://github.com/ros-gbp/ar_track_alvar-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.1-0`
## ar_track_alvar

```
* [feat] New bool-Topic to enable/disable the marker detection (#70 <https://github.com/sniekum/ar_track_alvar/issues/70>)
* [feat] added public way to set intrinsicCalibration for Camera class
* [fix] not publishing marker that are facing in the same direction as the camera.
* [sys] removed duplicate code for image subscription
* Contributors: Nikolas Engelhard, Scott Niekum
```
