### PR TITLE
teleop_tools: 0.2.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4992,12 +4992,13 @@ repositories:
       packages:
       - joy_teleop
       - key_teleop
+      - mouse_teleop
       - teleop_tools
       - teleop_tools_msgs
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/teleop_tools-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `0.2.1-0`:
- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros-gbp/teleop_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.0-0`
## joy_teleop

```
* Add support for services
  it is now possible to asynchronously send service requests on button presses
* Adds queue_size keyword
* Contributors: Bence Magyar, Nils Berg, Enrique Fernandez
```
## key_teleop
- No changes
## mouse_teleop

```
* Add mouse_teleop
* Contributors: Enrique Fernandez
```
## teleop_tools
- No changes
## teleop_tools_msgs

```
* Remove rospy dependency
* Contributors: Bence Magyar
```
