### PR TITLE
rtmros_hironx: 1.1.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9578,7 +9578,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.5-0
+      version: 1.1.6-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.6-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.5-0`
## hironx_calibration
- No changes
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* [fix] calibration bug (checkEncoders) #227 <https://github.com/tork-a/rtmros_nextage/issues/227>
* Contributors: Isaac I.Y. Saito, Hajime Saito
```
## rtmros_hironx

```
* [fix] calibration bug (checkEncoders) #227 <https://github.com/tork-a/rtmros_nextage/issues/227>
* Contributors: Isaac I.Y. Saito, Hajime Saito
```
