### PR TITLE
romeo_moveit_actions: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8449,7 +8449,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/nlyubova/romeo_moveit_actions-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
+    source:
+      type: git
+      url: https://github.com/nlyubova/romeo_moveit_actions.git
+      version: master
     status: developed
   romeo_moveit_config:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_moveit_actions` to `0.0.7-0`:
- upstream repository: https://github.com/nlyubova/romeo_moveit_actions.git
- release repository: https://github.com/nlyubova/romeo_moveit_actions-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.6-0`
## romeo_moveit_actions

```
* Merge pull request #1 <https://github.com/nlyubova/romeo_moveit_actions/issues/1> from IanTheEngineer/remove_shape_tools
  Convert deprecated shape_tools dependency
* Convert deprecated shape_tools dependency
  shape_tools functionality was merged into geometric_shapes:
  https://github.com/ros-planning/geometric_shapes/pull/32
  and removed from moveit_core
  https://github.com/ros-planning/moveit_core/pull/242
  which caused this issue.
  This commit updates the pick and place tutorial and adds
  geometric_shapes to the package.xml and CMakeLists.txt to
  prevent the ROS buildfarm from failing to build this package.
* Contributors: Ian McMahon, Natalia Lyubova
```
