### PR TITLE
Adding in_hand_scanner_ros to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8736,7 +8736,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/RodBelaFarin/ros_in_hand_scanner.git
-      version: developed
+      version: master
   ros_openlighting:
     release:
       packages:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8732,6 +8732,11 @@ repositories:
       url: https://github.com/WPI-RAIL/ros_ethernet_rmp.git
       version: develop
     status: maintained
+  ros_in_hand_scanner:
+    doc:
+      type: git
+      url: https://github.com/RodBelaFarin/ros_in_hand_scanner.git
+      version: developed
   ros_openlighting:
     release:
       packages:


### PR DESCRIPTION
I'd like my in_hand_scanner_ros package to be indexed and documented on ros.org.
