### PR TITLE
nao_meshes: 0.1.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5661,7 +5661,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/nao_meshes-release.git
-      version: 0.1.10-0
+      version: 0.1.11-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_meshes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_meshes` to `0.1.11-0`:
- upstream repository: https://github.com/ros-nao/nao_meshes.git
- release repository: https://github.com/ros-naoqi/nao_meshes-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.10-0`
## nao_meshes

```
* fixed folder path + added install rule for texture folder
* Update package.xml
  added myself as a maintainer as requested by vrabaud
* Contributors: Arguedas Mikael, Mikael Arguedas
```
