### PR TITLE
pepper_meshes: 0.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6760,7 +6760,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_meshes-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_meshes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_meshes` to `0.2.3-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_meshes.git
- release repository: https://github.com/ros-naoqi/pepper_meshes-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.2-0`
## pepper_meshes

```
* fixed install rule and flder path
* Update package.xml
  added myself as a maintainer as requested by vrabaud
* Contributors: Arguedas Mikael, Mikael Arguedas
```
