### PR TITLE
pepper_moveit_config: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6775,7 +6775,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_moveit_config-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
   pepper_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_moveit_config` to `0.0.3-0`:
- upstream repository: https://github.com/nlyubova/pepper_moveit_config.git
- release repository: https://github.com/ros-naoqi/pepper_moveit_config-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.2-0`
## pepper_moveit_config

```
* update dependency list
* fixing controllers names
* Merge pull request #3 <https://github.com/ros-naoqi/pepper_moveit_config/issues/3> from 130s/add/botharms
  Add botharms MoveGroup and a simple unit test
* Merge pull request #2 <https://github.com/ros-naoqi/pepper_moveit_config/issues/2> from 130s/selectable_moveitconfig
  Accept .rviz file as an argument
* Add the simplest unit test
* Allow no RViz gui mode
* Add both_arms Move Group
* Accept .rviz file as an argument
* Merge pull request #1 <https://github.com/ros-naoqi/pepper_moveit_config/issues/1> from keulYSMB/master
  added the version argument and use xacro command instead of one globa…
* added the version argument and use xacro command instead of one global URDF file to allow different configurations
* fixing the repository path
* fixing kinematics params
* Contributors: Isaac I.Y. Saito, Mikael Arguedas, Natalia Lyubova, nlyubova
```
