### PR TITLE
romeo_moveit_config: 0.2.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8464,7 +8464,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-aldebaran/romeo_moveit_config-release.git
-      version: 0.2.5-0
+      version: 0.2.6-0
     source:
       type: git
       url: https://github.com/ros-aldebaran/romeo_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_moveit_config` to `0.2.6-0`:
- upstream repository: https://github.com/ros-aldebaran/romeo_moveit_config.git
- release repository: https://github.com/ros-aldebaran/romeo_moveit_config-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.5-0`
## romeo_moveit_config

```
* update dependency list
* Contributors: Mikael Arguedas
```
