### PR TITLE
nao_moveit_config: 0.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5676,7 +5676,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/nao_moveit_config-release.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_moveit_config` to `0.0.9-0`:
- upstream repository: https://github.com/ros-nao/nao_moveit_config.git
- release repository: https://github.com/ros-naoqi/nao_moveit_config-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.8-0`
## nao_moveit_config

```
* remove nao_meshes from dependency because license not displayed on buildfarm
* Contributors: Mikael Arguedas
```
