### PR TITLE
pepper_moveit_config: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6775,7 +6775,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_moveit_config-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
   pepper_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_moveit_config` to `0.0.4-0`:
- upstream repository: https://github.com/nlyubova/pepper_moveit_config.git
- release repository: https://github.com/ros-naoqi/pepper_moveit_config-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.3-0`
## pepper_moveit_config

```
* remove pepper_meshes from dependency because license not displayed on buildfarm
* Contributors: Mikael Arguedas
```
