### PR TITLE
naoqi_driver: 0.5.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2602,7 +2602,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_driver-release.git
-      version: 0.5.6-0
+      version: 0.5.7-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_driver` to `0.5.7-0`:
- upstream repository: https://github.com/ros-naoqi/alrosbridge.git
- release repository: https://github.com/ros-naoqi/naoqi_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.6-0`
## naoqi_driver

```
* Fix termination issues (#62 <https://github.com/ros-naoqi/naoqi_driver/pull/62>)

    * Fix deadlock in audio termination
      Calling subscribe or unsubscribe while the callback is being called
      is already protected on naoqi side. So no need to protect it on the bridge
      side, this is what previously led to a deadlock.
      We only need mutex protection on configuration variable (publishing,
      recording, logging) and also make sure calling subscribe and unsubscribe
      at the same time is not possible (even though this is also protected in
      naoqi).
      Change-Id: Iae604c047046fec9e24832dd4df5017ff4ae724f
    * Do not use qi::import for retrieving naoqi_driver
      Change-Id: I1443ce10576f10ceda5041139c90a3df2e65f043
    * unsubscribe each events
    * Fix stopService being called twice
    * Do not create info converter if not necessary
    * Fix segfault on termination

* #58 <https://github.com/ros-naoqi/naoqi_driver/pull/58> is not compatible with previous version... (#60 <https://github.com/ros-naoqi/naoqi_driver/pull/60>)
* Add tactile and bumper in boot_config.json  (#59 <https://github.com/ros-naoqi/naoqi_driver/pull/59>)
* fix when no name space is found (#58 <https://github.com/ros-naoqi/naoqi_driver/pull/58>)
* use template for TouchEventRegister
* use template class(TouchEventConverter) in conveerters/touch.{cpp,hpp}
* add touch event and converters
* Contributors: Kei Okada, Surya Ambrose, Vincent Rabaud
```
