### PR TITLE
denso: 1.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1691,7 +1691,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/start-jsk/denso-release.git
-      version: 1.1.2-0
+      version: 1.1.3-0
     source:
       type: git
       url: https://github.com/start-jsk/denso.git


### PR DESCRIPTION
Increasing version of package(s) in repository `denso` to `1.1.3-0`:
- upstream repository: https://github.com/start-jsk/denso.git
- release repository: https://github.com/start-jsk/denso-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.2-0`
## denso
- No changes
## denso_controller

```
* call ROS_FATAL before exitting
* do not print server:,,, udp_timeout:... for dryrun mode
* Contributors: Kei Okada
```
## denso_launch

```
* param name have cheanged single -> maxboard
* fix xtion settings for hydro+
* denso_launch: mv catkin.cmake -> CMakeList.txt
* add publish_simple_scene.py and fix test code
* remove demo_simulation_noenvironment: default launch is denso_vs060_moveit_demo_simulation.launch for dryrun, (i think...)
* Contributors: Kei Okada
```
## vs060

```
* wait for move_group
* add publish_simple_scene.py and fix test code
* add dummy root link, since we had "The root link BASE has an inertia specified in the URDF, but KDL does not support a root link with an inertia.  As a workaround, you can add an extra dummy link to your URDF." warning
* Contributors: Kei Okada
```
## vs060_gazebo

```
* [vs060_gazebo] package.xml improvement (correction, description, sort in alphabetical order)
* Contributors: Isaac I.Y. Saito
```
## vs060_moveit_config

```
* add move_group/MoveGroupGetPlanningSceneService @ move_group.launch
* remove demo_simulation_noenvironment: default launch is denso_vs060_moveit_demo_simulation.launch for dryrun, (i think...)
* update rviz view (add loop, alpha for robot model)
* use RRT Connect as default planner
* update planner configs
* fix for "Group 'manipulator_flange' is not a chain" error message
* Contributors: Kei Okada
```
