### PR TITLE
Revert "jsk_recognition: 0.3.8-1 in 'jade/distribution.yaml' [bloom]"

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1715,21 +1715,6 @@ repositories:
       url: https://github.com/tork-a/jsk_model_tools-release.git
       version: 0.2.3-0
     status: developed
-  jsk_recognition:
-    release:
-      packages:
-      - checkerboard_detector
-      - imagesift
-      - jsk_pcl_ros
-      - jsk_perception
-      - jsk_recognition
-      - jsk_recognition_msgs
-      - jsk_recognition_utils
-      - resized_image_transport
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.8-1
   jsk_roseus:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#10026

The `jsk_pcl_ros` package has been failing on the new build farm since being added in Jade.

@k-okada please try to fix this build within a few days or I will remove it from the jade distro until someone can fix it.

Thanks.

See:
- http://build.ros.org/job/Jbin_uT64__jsk_pcl_ros__ubuntu_trusty_amd64__binary/
- http://repositories.ros.org/status_page/ros_jade_default.html?q=jsk_pcl_ros
- http://jenkins.ros.org/job/ros-jade-jsk-pcl-ros_binarydeb_trusty_amd64/ (same story with the old farm)
