### PR TITLE
mavros: 0.16.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2124,7 +2124,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.16.5-0
+      version: 0.16.6-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.16.6-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.16.5-0`
## libmavconn
- No changes
## mavros

```
* node fix #494 <https://github.com/mavlink/mavros/issues/494>: Report FCU firmware type in rosonsole log
* scripts fix #478 <https://github.com/mavlink/mavros/issues/478>: Remove guided_enable garbage.
  I'm missed this when do #407 <https://github.com/mavlink/mavros/issues/407>.
* Contributors: Vladimir Ermakov
```
## mavros_extras

```
* extras: uncrustify
* added tf
* comments
* configurable vehicle model
* Contributors: Vladimir Ermakov, francois
```
## mavros_msgs
- No changes
## test_mavros
- No changes
