### PR TITLE
jsk_recognition: 0.3.14-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1716,11 +1716,16 @@ repositories:
       version: 0.2.3-0
     status: developed
   jsk_recognition:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_recognition.git
+      version: master
     release:
       packages:
       - checkerboard_detector
       - imagesift
       - jsk_pcl_ros
+      - jsk_pcl_ros_utils
       - jsk_perception
       - jsk_recognition
       - jsk_recognition_msgs
@@ -1729,7 +1734,8 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.8-1
+      version: 0.3.14-0
+    status: developed
   jsk_roseus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.14-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.8-1`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros

```
* add me to maintainer to get jenkins notification
* remove code for groovy, ml_classifier is only available on hydro
* [jsk_pcl_ros] ClusterPointIndicesDecomposer with max/min size
  Modified:
  - jsk_pcl_ros/CMakeLists.txt
  - jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
  - jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
  Added:
  - jsk_pcl_ros/cfg/ClusterPointIndicesDecomposer.cfg
* List missing PointIndicesToMaskImage as nodelet
  this node is moved to jsk_pcl_ros_utils
  but this is necessary for compatibility.
  Modified:
  - jsk_pcl_ros/jsk_pcl_nodelets.xml
* [jsk_pcl_ros] Simplify test case of ExtractIndices.
  Do not depends on test data, just create dummy data in code on the fly.
* [jsk_pcl_ros/ClusterPointIndicesDecomposer] Publish centroid pose_array
  Modified:
  - jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
  - jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
* [jsk_pcl_ros] Publish current tracking status (running or idle)
  from particle_fitler_tracking.
  And add some scripts to visualize them.
* [jsk_pcl_ros] Automatically detect point type in OctreeVoxelGrid
  Modified:
  - doc/jsk_pcl_ros/nodes/octree_voxel_grid.md
  - jsk_pcl_ros/cfg/OctreeVoxelGrid.cfg
  - jsk_pcl_ros/include/jsk_pcl_ros/octree_voxel_grid.h
  - jsk_pcl_ros/src/octree_voxel_grid_nodelet.cpp
  - jsk_recognition_utils/include/jsk_recognition_utils/pcl_ros_util.h
  - jsk_recognition_utils/src/pcl_ros_util.cpp
* [jsk_pcl_ros] Fix indent of linemod_nodelet.cpp
  Modified:
  - jsk_pcl_ros/src/linemod_nodelet.cpp
* [jsk_pcl_ros] Update PlaneSupportedCuboidEstimator to find
  door handle
  Modified:
  - doc/jsk_pcl_ros/nodes/plane_supported_cuboid_estimator.md
  - jsk_pcl_ros/cfg/PlaneSupportedCuboidEstimator.cfg
  - jsk_pcl_ros/include/jsk_pcl_ros/plane_supported_cuboid_estimator.h
  - jsk_pcl_ros/launch/door_handle_detection.launch
  - jsk_pcl_ros/src/plane_supported_cuboid_estimator_nodelet.cpp
* [jsk_pcl_ros] Use jsk_pcl_ros_utils namespace instead of jsk_pcl_ros namespace for jsk_pcl_ros_utils nodelets
* [jsk_pcl_ros/OctreeVoxelGrid] Support coloring marker
  in x and y axis values
* [jsk_pcl_ros] Fix AttentionClipper SEGV by not calling
  publishBoundingBox from camera info callback
* [jsk_pcl_ros/OctreeChangeDetection] Add paper information
* [jsk_pcl_ros] Add new feature to skip tracking according to
  background substraction.
  Sample launch is tabletop_tracking.launch
  Now particle_filter_tracking can skip tracking when object looks stable
  and difference pointcloud (which should be computed by
  octree_change_detector)
  are far from target object.
* [jsk_pcl_ros] Untabify particle_fitler_tracking.h
* [jsk_pcl_ros] Fix euclidean segmentation for empty input.
  If input pointcloud is empty, publish empty result.
* [jsk_pcl_ros] Add marker_color_alpha parameter to change
  octree marker alpha
* [jsk_pcl_ros] Update octree_change_detector.launch by removing
  nodelet manager and machine tag
* Merge pull request #1469 from wkentaro/add-on-init-post-process
  [jsk_pcl_ros] Add onInitPostProcess
* [jsk_pcl_ros] use <arg> to pass input point cloud
* [jsk_pcl_ros] Add onInitPostProcess
  Modified:
  - jsk_pcl_ros/src/add_color_from_image_nodelet.cpp
  - jsk_pcl_ros/src/attention_clipper_nodelet.cpp
  - jsk_pcl_ros/src/bilateral_filter_nodelet.cpp
  - jsk_pcl_ros/src/border_estimator_nodelet.cpp
  - jsk_pcl_ros/src/bounding_box_filter_nodelet.cpp
  - jsk_pcl_ros/src/boundingbox_occlusion_rejector_nodelet.cpp
  - jsk_pcl_ros/src/capture_stereo_synchronizer_nodelet.cpp
  - jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
  - jsk_pcl_ros/src/collision_detector_nodelet.cpp
  - jsk_pcl_ros/src/color_histogram_matcher_nodelet.cpp
  - jsk_pcl_ros/src/colorize_random_points_RF_nodelet.cpp
  - jsk_pcl_ros/src/convex_connected_voxels_nodelet.cpp
  - jsk_pcl_ros/src/depth_calibration_nodelet.cpp
  - jsk_pcl_ros/src/depth_image_creator_nodelet.cpp
  - jsk_pcl_ros/src/edge_depth_refinement_nodelet.cpp
  - jsk_pcl_ros/src/edgebased_cube_finder_nodelet.cpp
  - jsk_pcl_ros/src/environment_plane_modeling_nodelet.cpp
  - jsk_pcl_ros/src/euclidean_cluster_extraction_nodelet.cpp
  - jsk_pcl_ros/src/extract_cuboid_particles_top_n_nodelet.cpp
  - jsk_pcl_ros/src/extract_indices_nodelet.cpp
  - jsk_pcl_ros/src/feature_registration_nodelet.cpp
  - jsk_pcl_ros/src/find_object_on_plane_nodelet.cpp
  - jsk_pcl_ros/src/fisheye_sphere_publisher_nodelet.cpp
  - jsk_pcl_ros/src/geometric_consistency_grouping_nodelet.cpp
  - jsk_pcl_ros/src/grid_sampler_nodelet.cpp
  - jsk_pcl_ros/src/handle_estimator_nodelet.cpp
  - jsk_pcl_ros/src/heightmap_converter_nodelet.cpp
  - jsk_pcl_ros/src/heightmap_morphological_filtering_nodelet.cpp
  - jsk_pcl_ros/src/heightmap_time_accumulation_nodelet.cpp
  - jsk_pcl_ros/src/heightmap_to_pointcloud_nodelet.cpp
  - jsk_pcl_ros/src/hinted_handle_estimator_nodelet.cpp
  - jsk_pcl_ros/src/hinted_plane_detector_nodelet.cpp
  - jsk_pcl_ros/src/hinted_stick_finder_nodelet.cpp
  - jsk_pcl_ros/src/icp_registration_nodelet.cpp
  - jsk_pcl_ros/src/incremental_model_registration_nodelet.cpp
  - jsk_pcl_ros/src/interactive_cuboid_likelihood_nodelet.cpp
  - jsk_pcl_ros/src/intermittent_image_annotator_nodelet.cpp
  - jsk_pcl_ros/src/joint_state_static_filter_nodelet.cpp
  - jsk_pcl_ros/src/keypoints_publisher_nodelet.cpp
  - jsk_pcl_ros/src/kinfu_nodelet.cpp
  - jsk_pcl_ros/src/line_segment_collector_nodelet.cpp
  - jsk_pcl_ros/src/line_segment_detector_nodelet.cpp
  - jsk_pcl_ros/src/mask_image_cluster_filter_nodelet.cpp
  - jsk_pcl_ros/src/moving_least_square_smoothing_nodelet.cpp
  - jsk_pcl_ros/src/multi_plane_sac_segmentation_nodelet.cpp
  - jsk_pcl_ros/src/normal_direction_filter_nodelet.cpp
  - jsk_pcl_ros/src/normal_estimation_integral_image_nodelet.cpp
  - jsk_pcl_ros/src/normal_estimation_omp_nodelet.cpp
  - jsk_pcl_ros/src/octomap_server_contact_nodelet.cpp
  - jsk_pcl_ros/src/octree_change_publisher_nodelet.cpp
  - jsk_pcl_ros/src/octree_voxel_grid_nodelet.cpp
  - jsk_pcl_ros/src/organize_pointcloud_nodelet.cpp
  - jsk_pcl_ros/src/organized_edge_detector_nodelet.cpp
  - jsk_pcl_ros/src/organized_multi_plane_segmentation_nodelet.cpp
  - jsk_pcl_ros/src/organized_pass_through_nodelet.cpp
  - jsk_pcl_ros/src/organized_pointcloud_to_point_indices_nodelet.cpp
  - jsk_pcl_ros/src/parallel_edge_finder_nodelet.cpp
  - jsk_pcl_ros/src/particle_filter_tracking_nodelet.cpp
  - jsk_pcl_ros/src/plane_supported_cuboid_estimator_nodelet.cpp
  - jsk_pcl_ros/src/pointcloud_localization_nodelet.cpp
  - jsk_pcl_ros/src/region_growing_multiple_plane_segmentation_nodelet.cpp
  - jsk_pcl_ros/src/region_growing_segmentation_nodelet.cpp
  - jsk_pcl_ros/src/resize_points_publisher_nodelet.cpp
  - jsk_pcl_ros/src/roi_clipper_nodelet.cpp
  - jsk_pcl_ros/src/selected_cluster_publisher_nodelet.cpp
  - jsk_pcl_ros/src/snapit_nodelet.cpp
  - jsk_pcl_ros/src/supervoxel_segmentation_nodelet.cpp
  - jsk_pcl_ros/src/tilt_laser_listener_nodelet.cpp
  - jsk_pcl_ros/src/torus_finder_nodelet.cpp
  - jsk_pcl_ros/src/uniform_sampling_nodelet.cpp
  - jsk_pcl_ros/src/voxel_grid_downsample_decoder_nodelet.cpp
  - jsk_pcl_ros/src/voxel_grid_downsample_manager_nodelet.cpp
  - jsk_pcl_ros/src/voxel_grid_large_scale_nodelet.cpp
* [jsk_pcl_ros] Support approximate sync and queue_size configuration
  Modified:
  - jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
  - jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
* [jsk_pcl_ros] Do not create tf::TransformBroadcaster in ClusterPointIndideceDecomposer
  if not necessary
  Modified:
  - jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
  - jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
* [jsk_pcl_ros] Init icp after advertise all the topics
  Modified:
  - jsk_pcl_ros/include/jsk_pcl_ros/icp_registration.h
  - jsk_pcl_ros/src/icp_registration_nodelet.cpp
  - jsk_pcl_ros/src/torus_finder_nodelet.cpp
* [jsk_pcl_ros] Fix to wait for initialization until start recognition in TorusFinder
  Modified:
  - jsk_pcl_ros/include/jsk_pcl_ros/torus_finder.h
  - jsk_pcl_ros/src/octree_voxel_grid_nodelet.cpp
* [jsk_pcl_ros] Publish current resolution of octree
  Modified:
  - doc/jsk_pcl_ros/nodes/octree_voxel_grid.md
  - jsk_pcl_ros/include/jsk_pcl_ros/octree_voxel_grid.h
* [jsk_pcl_ros] Better test names
  Modified:
  - jsk_pcl_ros/test/test_attention_clipper.test
  - jsk_pcl_ros/test/test_extract_indices.test
* [jsk_pcl_ros] Add ~marker_color to OctreeVoxelGrid
  Modified:
  - doc/jsk_pcl_ros/nodes/octree_voxel_grid.md
  - jsk_pcl_ros/cfg/OctreeVoxelGrid.cfg
  - jsk_pcl_ros/include/jsk_pcl_ros/octree_voxel_grid.h
  - jsk_pcl_ros/src/octree_voxel_grid_nodelet.cpp
* [jsk_pcl_ros] Publish computation time in icp_registration and torus_finder
  Modified:
  - doc/jsk_pcl_ros/nodes/icp_registration.md
  - doc/jsk_pcl_ros/nodes/torus_f_inder.md
  - jsk_pcl_ros/include/jsk_pcl_ros/icp_registration.h
  - jsk_pcl_ros/include/jsk_pcl_ros/torus_finder.h
  - jsk_pcl_ros/src/icp_registration_nodelet.cpp
  - jsk_pcl_ros/src/torus_finder_nodelet.cpp
  - jsk_recognition_utils/include/jsk_recognition_utils/time_util.h
* [jsk_pcl_ros/OctreeVoxelGrid] Relay original pointcloud if ~resolution=0
  Modified:
  - doc/jsk_pcl_ros/nodes/octree_voxel_grid.md
  - jsk_pcl_ros/src/octree_voxel_grid_nodelet.cpp
* [jsk_pcl_ros] Add ~point_type parameter to octree voxel grid
  Modified:
  - doc/jsk_pcl_ros/nodes/octree_voxel_grid.md
  - jsk_pcl_ros/cfg/OctreeVoxelGrid.cfg
  - jsk_pcl_ros/include/jsk_pcl_ros/octree_voxel_grid.h
  - jsk_pcl_ros/src/octree_voxel_grid_nodelet.cpp
* [jsk_pcl_ros] Support offset specifying by geometry_msgs/PoseStamped in ICPRegistration
  Modified:
  - doc/index.rst
  - doc/jsk_pcl_ros/nodes/icp_registration.md
  - jsk_pcl_ros/include/jsk_pcl_ros/icp_registration.h
  - jsk_pcl_ros/src/icp_registration_nodelet.cpp
  - jsk_pcl_ros_utils/CMakeLists.txt
  - jsk_pcl_ros_utils/jsk_pcl_nodelets.xml
  Added:
  - doc/jsk_pcl_ros_utils/index.rst
  - doc/jsk_pcl_ros_utils/nodes/pointcloud_relative_form_pose_stamped.md
  - jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_relative_from_pose_stamped.h
  - jsk_pcl_ros_utils/src/pointcloud_relative_from_pose_stamped_nodelet.cpp
* [jsk_pcl_ros] More useful message in extract_top_polygon_likelihood.py
  Modified:
  - jsk_pcl_ros/scripts/extract_top_polygon_likelihood.py
* [jsk_pcl_ros -> jsk_pcl_ros_utils] Left migration of PointIndicesToMaskImage
  Modified:
  jsk_pcl_ros/jsk_pcl_nodelets.xml
  jsk_pcl_ros_utils/jsk_pcl_nodelets.xml
* Merge pull request #1426 from wkentaro/merge-sklearn-to-jsk-perception
  Merge sklearn to jsk_perception
* [jsk_pcl_ros] Do not call callback until initialization done
  Modified:
  - jsk_pcl_ros/include/jsk_pcl_ros/region_growing_multiple_plane_segmentation.h
  - jsk_pcl_ros/include/jsk_pcl_ros/torus_finder.h
  - jsk_pcl_ros/src/region_growing_multiple_plane_segmentation_nodelet.cpp
  - jsk_pcl_ros/src/torus_finder_nodelet.cpp
* [jsk_pcl_ros/MultiPlaneExtraction] Call onInitPostProcess
  Modified:
  - jsk_pcl_ros/src/multi_plane_extraction_nodelet.cpp
* [jsk_pcl_ros] Option keep_organized as dynamic parameter
  Modified:
  - jsk_pcl_ros/cfg/MultiPlaneExtraction.cfg
  - jsk_pcl_ros/src/multi_plane_extraction_nodelet.cpp
* [jsk_pcl_ros/MultiPlaneExtraction] Add option keep_organized: true
  Modified:
  - jsk_pcl_ros/include/jsk_pcl_ros/multi_plane_extraction.h
  - jsk_pcl_ros/src/multi_plane_extraction_nodelet.cpp
* [jsk_pcl_ros] Add dynamic_reconfigure API to extract_top_polygon_likelihood.py
  Modified:
  - jsk_pcl_ros/CMakeLists.txt
  - jsk_pcl_ros/scripts/extract_top_polygon_likelihood.py
  Added:
  - jsk_pcl_ros/cfg/ExtractTopPolygonLikelihood.cfg
* [jsk_pcl_ros] Rational test_name for euclidean_clustering
  Modified:
  - jsk_pcl_ros/test/test_euclidean_segmentation.test
* Merge sklearn to jsk_perception
  Modified:
  jsk_pcl_ros/CMakeLists.txt
  jsk_pcl_ros/package.xml
  jsk_perception/package.xml
  Added:
  jsk_perception/node_scripts/random_forest_server.py
  jsk_perception/sample/random_forest_client_sample.py
  jsk_perception/sample/random_forest_sample.launch
  jsk_perception/sample/random_forest_sample_data_x.txt
  jsk_perception/sample/random_forest_sample_data_y.txt
* Contributors: Eisoku Kuroiwa, Kei Okada, Kentaro Wada, Ryohei Ueda, Iori Kumagai
```
## jsk_pcl_ros_utils

```
* Add ~queue_size option for synchronization
  Modified:
  - jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/point_indices_to_mask_image.h
  - jsk_pcl_ros_utils/src/point_indices_to_mask_image_nodelet.cpp
* Merge pull request #1504 from garaemon/tracking-velocity
  [jsk_pcl_ros] Publish current tracking status (running or idle) from     particle_fitler_tracking.
* [jsk_pcl_ros_utils] Add CloudOnPlane and scripts to visualize them
* [jsk_pcl_ros] Publish current tracking status (running or idle)
  from particle_fitler_tracking.
  And add some scripts to visualize them.
* [jsk_pcl_ros_utils] Use jsk_pcl_utils prefix instead of jsk_pcl to prevent namespace conflict with jsk_pcl nodelets
* [jsk_pcl_ros_utils] Support inliers in plane rejector
  Modified:
  - jsk_pcl_ros_utils/cfg/PlaneRejector.cfg
  - jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/plane_rejector.h
  - jsk_pcl_ros_utils/src/plane_rejector_nodelet.cpp
* [jsk_pcl_ros_utils] Document about LabelToClusterPointIndices
* [jsk_pcl_ros_utils] Add doc symlink
  Added:
  - jsk_pcl_ros_utils/doc
* [jsk_pcl_ros_utils] Add label to cluster point indices
  Modified:
  - jsk_pcl_ros_utils/CMakeLists.txt
  - jsk_pcl_ros_utils/jsk_pcl_nodelets.xml
  Added:
  - jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/label_to_cluster_point_indices.h
  - jsk_pcl_ros_utils/src/label_to_cluster_point_indices_nodelet.cpp
* [jsk_pcl_ros_utils] Remove sklearn from build_depend
  Modified:
  - jsk_pcl_ros_utils/package.xml
  - jsk_pcl_ros_utils/CMakeLists.txt
* [jsk_pcl_ros] Support offset specifying by geometry_msgs/PoseStamped in ICPRegistration
  Modified:
  - doc/index.rst
  - doc/jsk_pcl_ros/nodes/icp_registration.md
  - jsk_pcl_ros/include/jsk_pcl_ros/icp_registration.h
  - jsk_pcl_ros/src/icp_registration_nodelet.cpp
  - jsk_pcl_ros_utils/CMakeLists.txt
  - jsk_pcl_ros_utils/jsk_pcl_nodelets.xml
  Added:
  - doc/jsk_pcl_ros_utils/index.rst
  - doc/jsk_pcl_ros_utils/nodes/pointcloud_relative_form_pose_stamped.md
  - jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_relative_from_pose_stamped.h
  - jsk_pcl_ros_utils/src/pointcloud_relative_from_pose_stamped_nodelet.cpp
* [jsk_pcl_ros -> jsk_pcl_ros_utils] Left migration of PointIndicesToMaskImage
  Modified:
  jsk_pcl_ros/jsk_pcl_nodelets.xml
  jsk_pcl_ros_utils/jsk_pcl_nodelets.xml
* Contributors: Kentaro Wada, Ryohei Ueda, Iori Kumagai
```
## jsk_perception

```
* Merge pull request #1513 from garaemon/bounding-box-to-rect-array
  [jsk_perception] BoundingBoxToRectArray and rect_array_to_image_marker.py
* Add ~queue_size option for synchronization
  Modified:
  - jsk_perception/include/jsk_perception/apply_mask_image.h
  - jsk_perception/src/apply_mask_image.cpp
* [jsk_perception/ApplyMask] Add option to clip mask image
  Modified:
  - jsk_perception/include/jsk_perception/apply_mask_image.h
  - jsk_perception/src/apply_mask_image.cpp
* [jsk_perception/tile_image.py] Add ~no_sync parameter to disable
  synchronization of input topics.
* [jsk_perception] Skip for empty sift features
  Modified:
  - jsk_perception/node_scripts/bof_histogram_extractor.py
* [jsk_perception] BoundingBoxToRectArray and rect_array_to_image_marker.py
* [jsk_perception] [kalman-filtered-objectdetection-marker.l] fix code
* added default num_threads_ value and modified readme.md
* Merge branch 'master' of https://github.com/jsk-ros-pkg/jsk_recognition into saliency_map_generator
  Conflicts:
  jsk_perception/CMakeLists.txt
* [jsk_perception] Except index error on SolidityRagMerge
  Modified:
  - jsk_perception/node_scripts/solidity_rag_merge.py
* parallelized main loop
* [jsk_perception/bof_histogram_extractor.py] Skip if only background image
* [jsk_perception] Skip empty image
* [jsk_perception] Publish info in sample launch file
  Modified:
  - jsk_perception/sample/publish_fixed_images.launch
* [jsk_perception] Stop using deprecated PLUGINLIB_DECLARE_CLASS
  Modified:
  - jsk_perception/src/color_histogram.cpp
  - jsk_perception/src/edge_detector.cpp
  - jsk_perception/src/hough_circles.cpp
  - jsk_perception/src/sparse_image_decoder.cpp
  - jsk_perception/src/sparse_image_encoder.cpp
* [jsk_perception] Add solidity_rag_merge
  This is to find image region with high solidity.
  Firstly, I will use this for vacuum gripper's approach point
  decision making.
  Added:
  - jsk_perception/node_scripts/solidity_rag_merge.py
* [jsk_perception] Set header correctly
  Modified:
  - jsk_perception/node_scripts/label_image_decomposer.py
* Merge pull request #1457 from wkentaro/fix-unconfigured-cmake-packagexml
  [jsk_perception] Fix unconfigured cmake and manifest
* Merge pull request #1455 from wkentaro/publish-label-fg-bg
  [jsk_perception] Publish label fg/bg decomposed masks
* [jsk_perception] Check ROS_DISTRO for find_package of robot_self_filter
* [jsk_perception] Fix unconfigured cmake and manifest
  Modified:
  - jsk_perception/CMakeLists.txt
  - jsk_perception/package.xml
* [jsk_perception] Keep original encoding and scale to visualize
  Modified:
  - jsk_perception/node_scripts/label_image_decomposer.py
* [jsk_perception] ColorizeLabels info -> debug
  Modified:
  - jsk_perception/src/colorize_labels.cpp
* [jsk_perception] Add roslint_cpp not as rostest
  Modified:
  jsk_perception/CMakeLists.txt
* [jsk_perception] Publish label fg/bg decomposed masks
  Modified:
  - jsk_perception/node_scripts/label_image_decomposer.py
* Merge pull request #1398 from wkentaro/roslint-test-for-node-scripts
  [jsk_perception] Run roslint for python code
* [jsk_perception] Visualize label in label_image_decomposer.py
  Modified:
  - jsk_perception/node_scripts/label_image_decomposer.py
* [jsk_perception] Read reference color histogram from a yaml file in PolygonArrayColorLikelihood
  to avoid race condition between input topics
  Modified:
  - doc/jsk_perception/nodes/polygon_array_color_likelihood.md
  - jsk_perception/CMakeLists.txt
  - jsk_perception/include/jsk_perception/polygon_array_color_likelihood.h
  - jsk_perception/package.xml
  - jsk_perception/src/polygon_array_color_likelihood.cpp
* [jsk_perception] Keep original resolution if all the input images has
  same shape and add ~draw_input_topic parameter to draw topic name on
  the tiled images
  Modified:
  - jsk_perception/node_scripts/tile_image.py
  - jsk_recognition_utils/python/jsk_recognition_utils/visualize.py
* Merge pull request #1426 from wkentaro/merge-sklearn-to-jsk-perception
  Merge sklearn to jsk_perception
* [jsk_perception] Add basic_2d_features.launch to overview
  effective technique
  Added:
  - jsk_perception/launch/basic_2d_features.launch
* [jsk_perception] Run roslint for python code
* Merge pull request #1438 from wkentaro/image-to-label
  [jsk_perception] Add image_to_label.py
* [jsk_perception] Use StrictVersions instead of ROS_DISTRO
  Modified:
  - jsk_perception/node_scripts/tile_image.py
* [jsk_perception/label_image_decomposer.py] Fix typo
  Modified:
  - jsk_perception/node_scripts/label_image_decomposer.py
* [jsk_perception/label_image_decomposer.py] Can specify queue_size
  Modified:
  - jsk_perception/node_scripts/label_image_decomposer.py
* [jsk_perception] Fix typo
  Modified:
  - jsk_perception/node_scripts/label_image_decomposer.py
* [jsk_perception] Fix tile_image.py for hydro.
  1. Disable approximate sync for hydro. it's not supported on hydro
  2. Use PIL.Image.frombytes instead of PIL.Image.fromstring
* [jsk_perception] Add image_to_label.py
  Added:
  - jsk_perception/node_scripts/image_to_label.py
* [jsk_perception] Fix typo in bof_histogram_extractor.py
  Modified:
  - jsk_perception/node_scripts/bof_histogram_extractor.py
* Merge sklearn to jsk_perception
  Modified:
  jsk_pcl_ros/CMakeLists.txt
  jsk_pcl_ros/package.xml
  jsk_perception/package.xml
  Added:
  jsk_perception/node_scripts/random_forest_server.py
  jsk_perception/sample/random_forest_client_sample.py
  jsk_perception/sample/random_forest_sample.launch
  jsk_perception/sample/random_forest_sample_data_x.txt
  jsk_perception/sample/random_forest_sample_data_y.txt
* added param for printing fps to frame
* nodelet for computing image space saliency map
* Contributors: Kamada Hitoshi, Kei Okada, Kentaro Wada, Ryohei Ueda, Krishneel Chaudhary
```
## jsk_recognition
- No changes
## jsk_recognition_msgs

```
* [jsk_perception] BoundingBoxToRectArray and rect_array_to_image_marker.py
* [jsk_pcl_ros] Publish current tracking status (running or idle)
  from particle_fitler_tracking.
  And add some scripts to visualize them.
* [jsk_recognition_msgs] Add min/max fields to  PlotDataArray
* [jsk_recognition_msgs] Update PlotData message to support more 2d plotting
* Contributors: Ryohei Ueda
```
## jsk_recognition_utils

```
* [jsk_recognition_utils] Tile different size images with centerization
  Modified:
  - jsk_recognition_utils/python/jsk_recognition_utils/visualize.py
* [jsk_perception] BoundingBoxToRectArray and rect_array_to_image_marker.py
* jsk_recognition_utils/CMakeLists.txt: include_directories should have include/ before catkin_INCLUDE_DIRS
* Merge remote-tracking branch 'origin/master' into auto-change-point-type
* [jsk_pcl_ros] Publish current tracking status (running or idle)
  from particle_fitler_tracking.
  And add some scripts to visualize them.
* [jsk_pcl_ros] Automatically detect point type in OctreeVoxelGrid
  Modified:
  - doc/jsk_pcl_ros/nodes/octree_voxel_grid.md
  - jsk_pcl_ros/cfg/OctreeVoxelGrid.cfg
  - jsk_pcl_ros/include/jsk_pcl_ros/octree_voxel_grid.h
  - jsk_pcl_ros/src/octree_voxel_grid_nodelet.cpp
  - jsk_recognition_utils/include/jsk_recognition_utils/pcl_ros_util.h
  - jsk_recognition_utils/src/pcl_ros_util.cpp
* [jsk_recognition_utils] Add SeriesedBoolean::isAllTrueFilled method
  to check all the buffer is filled by true
* [jsk_pcl_ros] Fix WallDurationTimer to publish correct average value
* [jsk_pcl_ros] Publish computation time in icp_registration and torus_finder
  Modified:
  - doc/jsk_pcl_ros/nodes/icp_registration.md
  - doc/jsk_pcl_ros/nodes/torus_f_inder.md
  - jsk_pcl_ros/include/jsk_pcl_ros/icp_registration.h
  - jsk_pcl_ros/include/jsk_pcl_ros/torus_finder.h
  - jsk_pcl_ros/src/icp_registration_nodelet.cpp
  - jsk_pcl_ros/src/torus_finder_nodelet.cpp
  - jsk_recognition_utils/include/jsk_recognition_utils/time_util.h
* [jsk_perception] Keep original resolution if all the input images has
  same shape and add ~draw_input_topic parameter to draw topic name on
  the tiled images
  Modified:
  - jsk_perception/node_scripts/tile_image.py
  - jsk_recognition_utils/python/jsk_recognition_utils/visualize.py
* [jsk_perception] Fix tile_image.py for hydro.
  1. Disable approximate sync for hydro. it's not supported on hydro
  2. Use PIL.Image.frombytes instead of PIL.Image.fromstring
* Contributors: Kei Okada, Kentaro Wada, Ryohei Ueda
```
## resized_image_transport
- No changes
