### PR TITLE
slam_karto: 0.7.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10174,7 +10174,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/slam_karto-release.git
-      version: 0.7.2-0
+      version: 0.7.3-0
     source:
       type: git
       url: https://github.com/ros-perception/slam_karto.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_karto` to `0.7.3-0`:
- upstream repository: https://github.com/ros-perception/slam_karto.git
- release repository: https://github.com/ros-gbp/slam_karto-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.2-0`
## slam_karto

```
* fixed the upside-down detection
* update maintainer email
* Contributors: Michael Ferguson, mgerdzhev
```
