### PR TITLE
removing packages which have never built

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -18,8 +18,6 @@ repositories:
     release:
       packages:
       - adhoc_communication
-      - explorer
-      - map_merger
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/aau-ros/aau_multi_robot-release.git


### PR DESCRIPTION
@aau-ros removing map_merger and explorer which have never built. When you next release the repository they will be added back. 
