### PR TITLE
rtmros_hironx: 1.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9585,7 +9585,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.6-0
+      version: 1.1.7-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.7-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.6-0`
## hironx_calibration
- No changes
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* [fix] ROS py client gets stuck when ros master is not running (#430 <https://github.com/start-jsk/rtmros_hironx/issues/430>)
* [fix] RTM py client not printing upon checkEncoders failure (#428 <https://github.com/start-jsk/rtmros_hironx/issues/428>)
* Contributors: Isaac I.Y. Saito
```
## rtmros_hironx

```
* [fix] ROS py client gets stuck when ros master is not running (#430 <https://github.com/start-jsk/rtmros_hironx/issues/430>)
* [fix] RTM py client not printing upon checkEncoders failure (#428 <https://github.com/start-jsk/rtmros_hironx/issues/428>)
* Contributors: Isaac I.Y. Saito
```
