### PR TITLE
moveit_pr2: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5249,7 +5249,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_pr2-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_pr2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_pr2` to `0.6.2-0`:
- upstream repository: https://github.com/ros-planning/moveit_pr2.git
- release repository: https://github.com/ros-gbp/moveit_pr2-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.1-0`
## moveit_pr2

```
* Convert deprecated shape_tools dependency to geometric_shapes
* Install move_group_python_interface_tutorial.py
* pr2_moveit_tutorials/package.xml add run_depends
  on pr2 kinematics, moveit config, and moveit plugins
* Contributors: Ian McMahon, Steven Peters
```
## pr2_moveit_config
- No changes
## pr2_moveit_plugins

```
* Fix message dependencies.
* Contributors: Christian Dornhege
```
## pr2_moveit_tutorials

```
* Convert deprecated shape_tools dependency to geometric_shapes
  for pick and place tutorial
* Install move_group_python_interface_tutorial.py in tutorials
* pr2_moveit_tutorials/package.xml add run_depends
  on pr2 kinematics, moveit config, and moveit plugins in tutorials
* Contributors: Ian McMahon, Steven Peters
```
