### PR TITLE
moveit_plugins: 0.5.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5225,11 +5225,12 @@ repositories:
       packages:
       - moveit_fake_controller_manager
       - moveit_plugins
+      - moveit_ros_control_interface
       - moveit_simple_controller_manager
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_plugins-release.git
-      version: 0.5.6-2
+      version: 0.5.7-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_plugins` to `0.5.7-0`:
- upstream repository: https://github.com/ros-planning/moveit_plugins.git
- release repository: https://github.com/ros-gbp/moveit_plugins-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.6-2`
## moveit_fake_controller_manager
- No changes
## moveit_plugins

```
* added moveit_ros_control_interface to meta-package
* Contributors: Mathias Lüdtke
```
## moveit_ros_control_interface

```
* C++03 conforming nested templates
* fixed typo, added example config
* added brief decription tags
* formatted code to roscpp style
* improved documentation
* introduced getAbsName
* Added missing lock
* pre-allocate handles
* fixed typos
* set version to match the others
* fixed a lot of typos
* Intitial version of moveit_ros_control_interface package
* Contributors: Mathias Lüdtke
```
## moveit_simple_controller_manager

```
* expose headers of moveit_simple_controller_manager
* Removed redundant logging information
* More informative warning message about multi-dof trajectories.
* Contributors: Dave Coleman, Dave Hershberger, Mathias Lüdtke
```
