### PR TITLE
moveit_commander: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5128,7 +5128,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-planning/moveit_commander.git
-      version: hydro-devel
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -5137,7 +5137,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-planning/moveit_commander.git
-      version: hydro-devel
+      version: indigo-devel
     status: maintained
   moveit_core:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5133,7 +5133,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_commander-release.git
-      version: 0.5.7-1
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_commander.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_commander` to `0.6.0-0`:
- upstream repository: https://github.com/ros-planning/moveit_commander.git
- release repository: https://github.com/ros-gbp/moveit_commander-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.7-1`
## moveit_commander

```
* Merge pull request #38  from 130s/doc/python_if
  [RobotCommander] Fill in in-code document where missing.
* [moveit_commander/robot.py] Code cleaning; semi-PEP8.
* Merge pull request #35  from MichaelStevens/set_num_planning_attempts
  adding set_num_planning_attempts to commander interface
* Merge pull request #30 from ymollard/indigo-devel
  Planning scene improvements +  added python wrapper for MoveGroup.asyncExecute()
* Added python wrapper for MoveGroup.asyncExecute()
* Allow to clean all objects in a row
* Allow to attash an existing object without recreating the whole CollisionObject
* Merge pull request #24  from ymollard/hydro-devel
  Allowed user to change the scale of a mesh
* Merge pull request #23  from HumaRobotics/hydro-devel
  Fixed arguments removal in python roscpp_initializer
* Merge pull request #26  from corot/hydro-devel
  Add missing variants of place (PlaceLocation, place anywhere)
* Added a way to change the size of a mesh when grasping
* Allowed user to change the scale of a mesh
* Fixed arguments removal in python roscpp_initializer
* Contributors: Dave Coleman, Ioan A Sucan, Isaac I.Y. Saito, Michael Stevens, Philippe Capdepuy, Yoan Mollard, corot
```
