### PR TITLE
navigation: 1.12.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5844,7 +5844,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.12.6-0
+      version: 1.12.7-0
     source:
       type: git
       url: https://github.com/ros-planning/navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.12.7-0`:
- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.12.6-0`
## amcl
- No changes
## base_local_planner
- No changes
## carrot_planner
- No changes
## clear_costmap_recovery
- No changes
## costmap_2d

```
* Fix inflation layer locking
* Contributors: Levon Avagyan
```
## dwa_local_planner
- No changes
## fake_localization
- No changes
## global_planner
- No changes
## map_server
- No changes
## move_base
- No changes
## move_base_msgs
- No changes
## move_slow_and_clear
- No changes
## nav_core
- No changes
## navfn
- No changes
## navigation
- No changes
## robot_pose_ekf
- No changes
## rotate_recovery
- No changes
## voxel_grid
- No changes
