### PR TITLE
[rosdep/base] Add cwiid and cwiid-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -510,6 +510,20 @@ cvs:
     portage:
       packages: [dev-vcs/cvs]
   ubuntu: [cvs]
+cwiid:
+  arch: [cwiid]
+  debian: [libcwiid1]
+  fedora: [cwiid]
+  gentoo: [app-misc/cwiid]
+  opensuse: [libcwiid1]
+  ubuntu: [libcwiid1]
+cwiid-dev:
+  arch: [cwiid]
+  debian: [libcwiid-dev]
+  fedora: [cwiid-devel]
+  gentoo: [app-misc/cwiid]
+  opensuse: [libcwiid-devel]
+  ubuntu: [libcwiid-dev]
 daemontools:
   arch: [daemontools]
   debian: [daemontools]


### PR DESCRIPTION
Added C language version of the Wiimote library.
Both standalone library for running and development
flavor for building from source.

Needed for upstreaming new C implementation of ROS Wiimote node.
