### PR TITLE
denso: 1.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1689,7 +1689,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/start-jsk/denso-release.git
-      version: 1.1.3-0
+      version: 1.1.4-0
     source:
       type: git
       url: https://github.com/start-jsk/denso.git


### PR DESCRIPTION
Increasing version of package(s) in repository `denso` to `1.1.4-0`:
- upstream repository: https://github.com/start-jsk/denso.git
- release repository: https://github.com/start-jsk/denso-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.3-0`
## denso
- No changes
## denso_controller
- No changes
## denso_launch

```
* fix xtion setings for real robots
* denso_launch/test, move denso_vs060_moveit_demo_test.py and add test for publish_simple_scene.py
* Contributors: Kei Okada
```
## vs060

```
* publish_simple_scene: add missing imports
* Contributors: Kei Okada
```
## vs060_gazebo
- No changes
## vs060_moveit_config

```
* fix xtion settings for real robots
* Contributors: Kei Okada
```
