### PR TITLE
industrial_core: 0.4.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3483,7 +3483,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/industrial_core-release.git
-      version: 0.4.2-0
+      version: 0.4.3-0
     source:
       type: git
       url: https://github.com/ros-industrial/industrial_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_core` to `0.4.3-0`:
- upstream repository: https://github.com/ros-industrial/industrial_core.git
- release repository: https://github.com/ros-industrial-release/industrial_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.4.2-0`
## industrial_core

```
* No changes
```
## industrial_deprecated

```
* No changes
```
## industrial_msgs

```
* No changes
```
## industrial_robot_client

```
* Start checking for trajectory completion as soon as the first moving status arrives
* Contributors: Simon Schmeisser
```
## industrial_robot_simulator

```
* No changes
```
## industrial_trajectory_filters

```
* No changes
```
## industrial_utils

```
* No changes
```
## simple_message

```
* No changes
```
