### PR TITLE
jsk_recognition: 0.3.15-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1734,7 +1734,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.14-0
+      version: 0.3.15-0
     status: developed
   jsk_roseus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.15-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.14-0`
## checkerboard_detector
- No changes
## imagesift

```
* [imagesift] Use ros::WallTime to measure computation time
* Contributors: Ryohei Ueda
```
## jsk_pcl_ros
- No changes
## jsk_pcl_ros_utils
- No changes
## jsk_perception

```
* U and V has strange library options; https://github.com/ros/rosdistro/pull/10436#issuecomment-180763393
* [jsk_perception] Do not subscribe camera info in calc_flow
* [jsk_perception] Add more 2d feature samples
* Fix label probabilities output message
  Modified:
  - jsk_perception/node_scripts/sklearn_classifier.py
* Add queue_size option for bof_histogram_extractor
* Contributors: Kei Okada, Kentaro Wada, Ryohei Ueda
```
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## jsk_recognition_utils
- No changes
## resized_image_transport
- No changes
