### PR TITLE
rviz_visual_tools: 2.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
-# ROS distribution file
-# see REP 141: http://ros.org/reps/rep-0141.html
+# ROS distribution fil
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   fedora:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -9801,7 +9801,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/rviz_visual_tools-release.git
-      version: 2.0.3-0
+      version: 2.1.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/rviz_visual_tools.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,5 +1,5 @@
 %YAML 1.1
-# ROS distribution fil
+# ROS distribution file
 # see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `2.1.0-0`:
- upstream repository: https://github.com/davetcoleman/rviz_visual_tools.git
- release repository: https://github.com/davetcoleman/rviz_visual_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.0.3-0`
## rviz_visual_tools

```
* Allow publishArrow functions to specify ID
* Contributors: Dave Coleman
```
