### PR TITLE
moveit_visual_tools: 3.0.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 141: http://ros.org/reps/rep-0141.html
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   fedora:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -2381,7 +2381,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 3.0.2-0
+      version: 3.0.5-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `3.0.5-0`:
- upstream repository: https://github.com/davetcoleman/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `3.0.2-0`
## moveit_visual_tools

```
* Updated README
* Better comment
* Contributors: Dave Coleman
```
