### PR TITLE
sophus_ros_toolkit: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -10222,6 +10222,23 @@ repositories:
       url: https://github.com/yujinrobot-release/sophus-release.git
       version: 0.9.0-2
     status: maintained
+  sophus_ros_toolkit:
+    doc:
+      type: git
+      url: https://github.com/stonier/sophus_ros_toolkit.git
+      version: indigo-devel
+    release:
+      packages:
+      - sophus_ros_conversions
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/sophus_ros_toolkit-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/stonier/sophus_ros_toolkit.git
+      version: indigo-devel
+    status: developed
   sparse_bundle_adjustment:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus_ros_toolkit` to `0.1.0-0`:
- upstream repository: https://github.com/stonier/sophus_ros_toolkit.git
- release repository: https://github.com/yujinrobot-release/sophus_ros_toolkit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## sophus_ros_conversions

```
* eigen/sophus <-> geometry_msg conversions
```
