### PR TITLE
mavros: 0.17.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4909,7 +4909,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.16.6-0
+      version: 0.17.0-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.17.0-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.16.6-0`
## libmavconn

```
* rebased with master
* Contributors: francois
```
## mavros

```
* update README
* rebased with master
* Fixed ROS_BREAK
* Updates for ROS_BREAK and code style
* Nitpicks and uncrustify
* Updated frame transformations and added odom publisher to local position plugin
* Contributors: Eddy, Vladimir Ermakov, francois
```
## mavros_extras

```
* rebased with master
* ran uncrustify
* removed duplicate include
* use MarkerArray for vehicle model
* Updated frame transformations and added odom publisher to local position plugin
* Contributors: Eddy, francois
```
## mavros_msgs

```
* rebased with master
* Contributors: francois
```
## test_mavros

```
* rebased with master
* Contributors: francois
```
