### PR TITLE
removing pyros_setup

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7542,13 +7542,6 @@ repositories:
       url: https://github.com/clearpathrobotics/puma_motor_driver.git
       version: master
     status: maintained
-  pyros_setup:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/asmodehn/pyros-setup-release.git
-      version: 0.0.8-0
-    status: developed
   pyros_test:
     doc:
       type: git


### PR DESCRIPTION
Trying to get the python package directly from pip via rosdep, without the need to catkin build it.
