### PR TITLE
rtmros_nextage: 0.7.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9608,7 +9608,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.7.5-0
+      version: 0.7.6-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.7.6-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.5-0`
## nextage_description
- No changes
## nextage_gazebo
- No changes
## nextage_ik_plugin
- No changes
## nextage_moveit_config

```
* [fix] Use RRT as default planner (workaround/fix #170 <https://github.com/tork-a/rtmros_nextage/issues/170>)
* Contributors: Isaac I.Y. Saito
```
## nextage_ros_bridge

```
* [improve] better view for hrpsys-simulator
* Contributors: Kei Okada
```
## rtmros_nextage

```
* [fix] Use RRT as default planner (workaround/fix #170 <https://github.com/tork-a/rtmros_nextage/issues/170>)
* [improve] better view for hrpsys-simulator
* Contributors: Kei Okada, Isaac I.Y. Saito
```
