### PR TITLE
moveit_robots: 1.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5297,7 +5297,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/moveit_robots-release.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_robots` to `1.0.5-0`:
- upstream repository: https://github.com/ros-planning/moveit_robots.git
- release repository: https://github.com/tork-a/moveit_robots-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.4-0`
## atlas_moveit_config
- No changes
## atlas_v3_moveit_config
- No changes
## baxter_ikfast_left_arm_plugin
- No changes
## baxter_ikfast_right_arm_plugin
- No changes
## baxter_moveit_config

```
* [fix] Update ompl_planning.yaml to set default planning config, which is supported on moveit 0.7 (moveit_ros/pull/625 <https://github.com/ros-planning/moveit_ros/pull/625>)
* Contributors: Kei Okada
```
## clam_moveit_config
- No changes
## iri_wam_moveit_config
- No changes
## moveit_robots

```
* [fix] Update ompl_planning.yaml to set default planning config, which is supported on moveit 0.7 (moveit_ros/pull/625 <https://github.com/ros-planning/moveit_ros/pull/625>)
* Contributors: Kei Okada
```
## r2_moveit_generated
- No changes
