### PR TITLE
sophus_ros_toolkit: 0.1.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10233,7 +10233,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/sophus_ros_toolkit-release.git
-      version: 0.1.0-1
+      version: 0.1.0-2
     source:
       type: git
       url: https://github.com/stonier/sophus_ros_toolkit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus_ros_toolkit` to `0.1.0-2`:
- upstream repository: https://github.com/stonier/sophus_ros_toolkit.git
- release repository: https://github.com/yujinrobot-release/sophus_ros_toolkit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.0-1`
## sophus_ros_conversions

```
* eigen/sophus <-> geometry_msg conversions
```
