### PR TITLE
jsk_recognition: 0.3.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3952,7 +3952,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.15-0
+      version: 0.3.16-0
     status: developed
   jsk_robot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.16-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.15-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros

```
* [jsk_pcl_ros/CMakeLists.txt] call one of find_package or pkg_check_modules for robot_self_filter.
* Contributors: Masaki Murooka
```
## jsk_pcl_ros_utils
- No changes
## jsk_perception

```
* Merge pull request #1531 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/1531> from k-okada/sed_package_xml
  .travis.yml: sed package.xml to use opencv3
* remove image_view2 from find_package(catkin)
* [jsk_perception/CMakeLists.txt] call one of find_package or pkg_check_modules for robot_self_filter.
* [jsk_perception] Set queue_size=1 for tile_image.py
* [jsk_perception] Fix variable names in edge_detector.cpp
* [jsk_perception] Publish result after initialization
* Contributors: Kei Okada, Masaki Murooka, Ryohei Ueda
```
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## jsk_recognition_utils
- No changes
## resized_image_transport
- No changes
