### PR TITLE
jsk_demos: 0.0.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3885,6 +3885,18 @@ repositories:
       url: https://github.com/tork-a/jsk_control-release.git
       version: 0.1.8-0
     status: developed
+  jsk_demos:
+    release:
+      packages:
+      - drc_com_common
+      - elevator_move_base_pr2
+      - jsk_demo_common
+      - jsk_maps
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/jsk_demos-release.git
+      version: 0.0.3-1
+    status: developed
   jsk_model_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_demos` to `0.0.3-1`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_demos.git
- release repository: https://github.com/tork-a/jsk_demos-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## drc_com_common
- No changes
## elevator_move_base_pr2

```
* [elevator_move_base_pr2/src/database-interface.l] add logging feature for elevator demo
* Contributors: Yuki Furuta
```
## jsk_demo_common

```
* [jsk_demo_common] fix wrong code
* Merge pull request #1124 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1124> from h-kamada/add_reset_pose
  pr2-action.l: apply reset-pose before open-fridge-func
* pr2-action.l: apply reset-pose before open-fridge-func
* [detect_cans] async join based parallel state-machine
* Contributors: Kamada Hitoshi, Kei Okada, Yuki Furuta
```
## jsk_maps

```
* add keepout maps
* use queue_size=1
* add depends to jsk_rviz_plugins
* [jsk_maps/src/eng2-scene.l] add /eng2/8f/room83b1-front spot
* Contributors: Yuki Furuta, Kei Okada
```
