### PR TITLE
innok_heros_gazebo: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -3543,7 +3543,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/innokrobotics/innok_heros_gazebo-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/innokrobotics/innok_heros_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `innok_heros_gazebo` to `1.0.3-0`:
- upstream repository: https://github.com/innokrobotics/innok_heros_gazebo.git
- release repository: https://github.com/innokrobotics/innok_heros_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.2-0`
## innok_heros_gazebo

```
* removed run  dependencies from Gazebo in package.xml
* Contributors: Sabrina Heerklotz
```
