### PR TITLE
nerian_sp1: 1.2.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 141: http://ros.org/reps/rep-0141.html
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   fedora:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -2719,7 +2719,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/nerian-vision/nerian_sp1-release.git
-      version: 1.2.1-0
+      version: 1.2.2-0
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_sp1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_sp1` to `1.2.2-0`:
- upstream repository: https://github.com/nerian-vision/nerian_sp1.git
- release repository: https://github.com/nerian-vision/nerian_sp1-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.2.1-0`
## nerian_sp1

```
* Upgraded libvisiontransfer to version 2.1.2
* Contributors: Konstantin Schauwecker
```
