### PR TITLE
romeo_moveit_actions: 0.0.7-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -8456,11 +8456,15 @@ repositories:
       version: indigo
     status: developed
   romeo_moveit_actions:
+    doc:
+      type: git
+      url: https://github.com/ros-aldebaran/romeo_moveit_actions.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/nlyubova/romeo_moveit_actions-release.git
-      version: 0.0.7-0
+      version: 0.0.7-2
     source:
       type: git
       url: https://github.com/nlyubova/romeo_moveit_actions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_moveit_actions` to `0.0.7-2`:
- upstream repository: https://github.com/nlyubova/romeo_moveit_actions.git
- release repository: https://github.com/nlyubova/romeo_moveit_actions-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.7-0`
## romeo_moveit_actions

```
* Merge pull request #1 <https://github.com/nlyubova/romeo_moveit_actions/issues/1> from IanTheEngineer/remove_shape_tools
  Convert deprecated shape_tools dependency
* Convert deprecated shape_tools dependency
  shape_tools functionality was merged into geometric_shapes:
  https://github.com/ros-planning/geometric_shapes/pull/32
  and removed from moveit_core
  https://github.com/ros-planning/moveit_core/pull/242
  which caused this issue.
  This commit updates the pick and place tutorial and adds
  geometric_shapes to the package.xml and CMakeLists.txt to
  prevent the ROS buildfarm from failing to build this package.
* Contributors: Ian McMahon, Natalia Lyubova
```
