### PR TITLE
ros_control: 0.9.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -8659,7 +8659,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.9.3-0
+      version: 0.9.4-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.9.4-0`:
- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.9.3-0`
## controller_interface

```
* Address -Wunused-parameter warnings
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## controller_manager

```
* Fix doSwitch execution point
  The doSwitch method needs to be executed in the update() method,  that is, in
  the real-time path, which is where controller switching actually takes place.
  It was previously done in the switchController callback, which is non real-time.
  In this method controller switching is scheduled, but not actually executed.
  This changeset fixes a bug in which hardware interface  modes could switch
  before controllers, leading to undefined behavior.
* Introduce prepareSwitch, replacement of canSwitch
  RobotHW::prepareSwitch is intended as a substitute for RobotHW::canSwitch.
  The main reasons for the change are a non-const signature to allow
  changing state and a more descriptive name.
  RobotHW::canSwitch will be deprecated in a later ROS distro.
* Address -Wunused-parameter warnings
* Contributors: Adolfo Rodriguez Tsouroukdissian, Mathias Lüdtke
```
## controller_manager_msgs
- No changes
## controller_manager_tests

```
* Cleaner test exit
* Address -Wunused-parameter warnings
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## hardware_interface

```
* Fix doSwitch execution point
  The doSwitch method needs to be executed in the update() method,  that is, in
  the real-time path, which is where controller switching actually takes place.
  It was previously done in the switchController callback, which is non real-time.
  In this method controller switching is scheduled, but not actually executed.
  This changeset fixes a bug in which hardware interface  modes could switch
  before controllers, leading to undefined behavior.
* Introduce prepareSwitch, replacement of canSwitch
  RobotHW::prepareSwitch is intended as a substitute for RobotHW::canSwitch.
  The main reasons for the change are a non-const signature to allow
  changing state and a more descriptive name.
  RobotHW::canSwitch will be deprecated in a later ROS distro.
* Address -Wunused-parameter warnings
* Contributors: Adolfo Rodriguez Tsouroukdissian, Mathias Lüdtke
```
## joint_limits_interface
- No changes
## ros_control
- No changes
## rqt_controller_manager

```
* Added standalone rqt_controller_manager script
* Contributors: Marco Esposito
```
## transmission_interface

```
* Clarify that hardwareInterface element is optional for actuators
* Allow loading transmissions from a vector of TransmissionInfo instances.
* Address -Wunused-parameter warnings
* Contributors: Adolfo Rodriguez Tsouroukdissian, Dave Coleman
```
