### PR TITLE
ros_controllers: 0.9.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -8702,7 +8702,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.9.2-0
+      version: 0.9.3-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.9.3-0`:
- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.9.2-0`
## diff_drive_controller

```
* Reduced pedantry, redundancy.
* Added tests for the odom_frame_id parameter.
* Parameterized diff_drive_controller's odom_frame_id
* add check for multiple publishers on cmd_vel
* Address -Wunused-parameter warnings
* Limit jerk
* Add param velocity_rolling_window_size
* Minor fixes
  1. Coding style
  2. Tolerance to fall-back to Runge-Kutta 2 integration
  3. Remove unused variables
* Fix forward test
  Fix the following bugs in the testForward test:
  1. Check traveled distance in XY plane
  2. Use expected speed variable on test check
* Add test for NaN
* Add test for bad URDF
  This unit test exercises a controller load failure caused by
  a wrong wheel geometry. The controller requires that wheels be
  modeled by cylinders, while the bad URDF uses spheres.
* Contributors: Adolfo Rodriguez Tsouroukdissian, Bence Magyar, Enrique Fernandez, Eric Tappan, Karsten Knese, Paul Mathieu, tappan-at-git
```
## effort_controllers
- No changes
## force_torque_sensor_controller

```
* Address -Wunused-parameter warnings
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## forward_command_controller

```
* Address -Wunused-parameter warnings
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## gripper_action_controller
- No changes
## imu_sensor_controller

```
* Fixed covariances in ImuSensorController::update
* Address -Wunused-parameter warnings
* Contributors: Adolfo Rodriguez Tsouroukdissian, tappan-at-git
```
## joint_state_controller

```
* Address -Wunused-parameter warnings
* Add extra joints support
  Allow to optionally specify a set of extra joints for state publishing that
  are not contained in the JointStateInterface associated to the controller.
  The state of these joints can be specified via ROS parameters, and remains
  constant over time.
* Add test suite
* Migrate to package format2
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## joint_trajectory_controller

```
* Add joint limits spec to rrbot test robot
* Address -Wunused-parameter warnings
* reset to semantic zero in HardwareInterfaceAdapter for PositionJointInterface
* Contributors: Adolfo Rodriguez Tsouroukdissian, ipa-fxm
```
## position_controllers
- No changes
## ros_controllers
- No changes
## rqt_joint_trajectory_controller

```
* Add vertical scrollbar to joints list
* Clear controllers combo on cm change
  Clear the list of running joint trajectory controllers when the
  controller manager selection changes. This prevents potential conflicts when
  multiple controller managers have controllers with the same names.
* Fail gracefully if URDF is not loaded
* Save and restore plugin settings
* Stricter controller validation
* Fix broken URDF joint limits parsing
* Add controller resources query
* Don't choke on missing URDF vel limits
* Contributors: Adolfo Rodriguez Tsouroukdissian
```
## velocity_controllers
- No changes
