### PR TITLE
romeo_robot: 0.1.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8493,17 +8493,13 @@ repositories:
     release:
       packages:
       - romeo_bringup
-      - romeo_dcm_bringup
-      - romeo_dcm_control
-      - romeo_dcm_driver
-      - romeo_dcm_msgs
       - romeo_description
       - romeo_robot
       - romeo_sensors_py
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-aldebaran/romeo_robot-release.git
-      version: 0.1.3-0
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/ros-aldebaran/romeo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_robot` to `0.1.3-1`:
- upstream repository: https://github.com/ros-aldebaran/romeo_robot.git
- release repository: https://github.com/ros-aldebaran/romeo_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.3-0`
## romeo_bringup

```
* fixing romeo_bringup launch and romeo_sensors_py to get data from all cameras
* adding details to the package description
* Contributors: nlyubova
```
## romeo_description

```
* fixing romeo_bringup launch and romeo_sensors_py to get data from all cameras
* Contributors: nlyubova
```
## romeo_robot
- No changes
## romeo_sensors_py

```
* fixing romeo_bringup launch and romeo_sensors_py to get data from all cameras
* Contributors: nlyubova
```
