### PR TITLE
pepper_moveit_config: 0.0.4-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3273,6 +3273,21 @@ repositories:
       url: https://github.com/ros-naoqi/pepper_meshes.git
       version: master
     status: maintained
+  pepper_moveit_config:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_moveit_config.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-naoqi/pepper_moveit_config-release.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_moveit_config.git
+      version: master
+    status: maintained
   pepper_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_moveit_config` to `0.0.4-1`:
- upstream repository: https://github.com/ros-naoqi/pepper_moveit_config.git
- release repository: https://github.com/ros-naoqi/pepper_moveit_config-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## pepper_moveit_config

```
* remove pepper_meshes from dependency because license not displayed on buildfarm
* Contributors: Mikael Arguedas
```
