### PR TITLE
open_karto: 1.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6410,7 +6410,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/open_karto-release.git
-      version: 1.1.2-0
+      version: 1.1.3-0
     source:
       type: git
       url: https://github.com/ros-perception/open_karto.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_karto` to `1.1.3-0`:
- upstream repository: https://github.com/ros-perception/open_karto.git
- release repository: https://github.com/ros-gbp/open_karto-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.2-0`
## open_karto

```
* Link against, and export depend on, boost
* Contributors: Hai Nguyen, Michael Ferguson
```
