### PR TITLE
open_karto: 1.1.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3051,6 +3051,17 @@ repositories:
       url: https://github.com/davetcoleman/ompl_visual_tools.git
       version: jade-devel
     status: developed
+  open_karto:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/open_karto.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/open_karto-release.git
+      version: 1.1.3-0
+    status: maintained
   opencv3:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `open_karto` to `1.1.3-0`:
- upstream repository: https://github.com/ros-perception/open_karto.git
- release repository: https://github.com/ros-gbp/open_karto-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## open_karto

```
* Link against, and export depend on, boost
* Contributors: Hai Nguyen, Michael Ferguson
```
