### PR TITLE
open_karto: 1.1.3-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3060,7 +3060,11 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/open_karto-release.git
-      version: 1.1.3-0
+      version: 1.1.3-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/open_karto.git
+      version: indigo-devel
     status: maintained
   opencv3:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `open_karto` to `1.1.3-1`:
- upstream repository: https://github.com/ros-perception/open_karto.git
- release repository: https://github.com/ros-gbp/open_karto-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.3-0`
## open_karto

```
* Link against, and export depend on, boost
* Contributors: Hai Nguyen, Michael Ferguson
```
