### PR TITLE
homer_mapnav: 0.0.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3134,16 +3134,10 @@ repositories:
       version: 1.0.6-0
   homer_mapnav:
     release:
-      packages:
-      - homer_map_manager
-      - homer_mapnav_msgs
-      - homer_mapping
-      - homer_nav_libs
-      - homer_navigation
       tags:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
-      version: 1.0.15-0
+      version: 0.0.2-1
   homer_object_recognition:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_mapnav` to `0.0.2-1`:
- upstream repository: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.15-0`
## homer_mapnav

```
* added metapackage
* Updating README.md
* Updating release inc to: 0
* Modified tracks.yaml
* Contributors: Niklas Yann Wettengel, Raphael Memmesheimer
```
