### PR TITLE
robot_pose_publisher: 0.2.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6616,7 +6616,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/wpi-rail-release/robot_pose_publisher-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/robot_pose_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_pose_publisher` to `0.2.4-0`:
- upstream repository: https://github.com/WPI-RAIL/robot_pose_publisher.git
- release repository: https://github.com/wpi-rail-release/robot_pose_publisher-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.3-0`
## robot_pose_publisher

```
* Update README.md
* Update package.xml
* fixed dox file
* fixed readme
* travis edit
* Contributors: David Kent, Russell Toris
```
