### PR TITLE
robot_pose_publisher: 0.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -8124,7 +8124,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/robot_pose_publisher-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/GT-RAIL/robot_pose_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_pose_publisher` to `0.2.4-0`:
- upstream repository: https://github.com/WPI-RAIL/robot_pose_publisher.git
- release repository: https://github.com/gt-rail-release/robot_pose_publisher-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.3-0`
## robot_pose_publisher

```
* Update README.md
* Update package.xml
* fixed dox file
* fixed readme
* travis edit
* Contributors: David Kent, Russell Toris
```
