### PR TITLE
homer_mapnav: 1.0.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3136,6 +3136,7 @@ repositories:
     release:
       packages:
       - homer_map_manager
+      - homer_mapnav
       - homer_mapnav_msgs
       - homer_mapping
       - homer_nav_libs
@@ -3143,7 +3144,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
-      version: 1.0.15-0
+      version: 1.0.16-0
   homer_object_recognition:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_mapnav` to `1.0.16-0`:
- upstream repository: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_mapnav.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.15-0`
## homer_map_manager
- No changes
## homer_mapnav

```
* moved homer_mapnav metapackage to subfolder
* Contributors: Niklas Yann Wettengel
```
## homer_mapnav_msgs
- No changes
## homer_mapping
- No changes
## homer_nav_libs
- No changes
## homer_navigation
- No changes
