### PR TITLE
rovio: 0.2.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7596,7 +7596,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/wpi-rail-release/rovio-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/WPI-RAIL/rovio.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rovio` to `0.2.2-0`:
- upstream repository: https://github.com/wpi-rail/rovio.git
- release repository: https://github.com/wpi-rail-release/rovio-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.1-0`
## rovio

```
* Update package.xml
* Contributors: David Kent
```
## rovio_av

```
* Update package.xml
* Contributors: David Kent
```
## rovio_ctrl

```
* Update package.xml
* Contributors: David Kent
```
## rovio_shared

```
* Update package.xml
* Contributors: David Kent
```
