### PR TITLE
jaco_gazebo: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -3758,7 +3758,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/jaco_gazebo-release.git
-      version: 0.0.1-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/GT-RAIL/jaco_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jaco_gazebo` to `0.0.3-0`:
- upstream repository: https://github.com/WPI-RAIL/jaco_gazebo.git
- release repository: https://github.com/gt-rail-release/jaco_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.1-0`
## jaco_gazebo

```
* Update .travis.yml
* Contributors: David Kent
```
