### PR TITLE
ubiquity_launches: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11000,11 +11000,15 @@ repositories:
       version: toolchain-2.8
     status: maintained
   ubiquity_launches:
+    doc:
+      type: git
+      url: https://github.com/UbiquityRobotics/ubiquity_launches.git
+      version: 0.2.1
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/ubiquity_launches-release.git
-      version: 0.1.1-0
+      version: 0.2.1-0
     status: developed
   ubiquity_motor:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `ubiquity_launches` to `0.2.1-0`:
- upstream repository: https://github.com/UbiquityRobotics/ubiquity_launches.git
- release repository: https://github.com/UbiquityRobotics-release/ubiquity_launches-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.1-0`
## ubiquity_launches

```
* Restore motor_node which was deleted
* Contributors: Rohan Agrawal
```
