### PR TITLE
jsk_robot: 0.0.11-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3339,6 +3339,8 @@ repositories:
       - jsk_pr2_startup
       - jsk_robot_startup
       - jsk_robot_utils
+      - naoeus
+      - naoqieus
       - peppereus
       - pr2_base_trajectory_action
       - roseus_remote


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `0.0.11-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.11-0`
