### PR TITLE
interactive_world: 0.0.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -3643,7 +3643,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/interactive_world-release.git
-      version: 0.0.10-0
+      version: 0.0.11-0
     source:
       type: git
       url: https://github.com/GT-RAIL/interactive_world.git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_world` to `0.0.11-0`:
- upstream repository: https://github.com/WPI-RAIL/interactive_world.git
- release repository: https://github.com/gt-rail-release/interactive_world-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.10-0`
## informed_object_search

```
* Update package.xml
* small edits to server
* Contributors: David Kent, Russell Toris
```
## interactive_world

```
* Update package.xml
* Contributors: David Kent
```
## interactive_world_msgs

```
* Update package.xml
* small edits to server
* Contributors: David Kent, Russell Toris
```
## interactive_world_parser

```
* Update package.xml
* Contributors: David Kent
```
## interactive_world_tools

```
* Updated messages to use rail_manipulation_msgs insted of carl_moveit
* Update package.xml
* small edits to server
* Contributors: David Kent, Russell Toris
```
## jinteractiveworld

```
* Update package.xml
* Contributors: David Kent
```
## spatial_world_model

```
* Update package.xml
* small edits to server
* Contributors: David Kent, Russell Toris
```
