### PR TITLE
rail_collada_models: 0.0.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -3577,7 +3577,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/gt-rail-release/rail_collada_models-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/GT-RAIL/rail_collada_models.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_collada_models` to `0.0.5-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_collada_models.git
- release repository: https://github.com/gt-rail-release/rail_collada_models-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.4-0`
## rail_collada_models

```
* Update README.md
* Update package.xml
* added models
* added models
* books
* Contributors: David Kent, Russell Toris
```
