### PR TITLE
rail_manipulation_msgs: 0.0.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -3592,7 +3592,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/gt-rail-release/rail_manipulation_msgs-release.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/GT-RAIL/rail_manipulation_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_manipulation_msgs` to `0.0.8-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_manipulation_msgs.git
- release repository: https://github.com/gt-rail-release/rail_manipulation_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.7-0`
## rail_manipulation_msgs

```
* Update README.md
* Update package.xml
* Added grasping state message
* Consolidated some messages with carl_moveit for more general use
* Added (optional) speed and force parameters to the gripper goal
* Contributors: David Kent
```
