### PR TITLE
industrial_core: 0.4.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1541,6 +1541,30 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: indigo-devel
     status: maintained
+  industrial_core:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/industrial_core.git
+      version: jade
+    release:
+      packages:
+      - industrial_core
+      - industrial_deprecated
+      - industrial_msgs
+      - industrial_robot_client
+      - industrial_robot_simulator
+      - industrial_trajectory_filters
+      - industrial_utils
+      - simple_message
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-industrial-release/industrial_core-release.git
+      version: 0.4.3-0
+    source:
+      type: git
+      url: https://github.com/ros-industrial/industrial_core.git
+      version: jade
+    status: maintained
   interactive_marker_proxy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_core` to `0.4.3-0`:
- upstream repository: https://github.com/ros-industrial/industrial_core.git
- release repository: https://github.com/ros-industrial-release/industrial_core-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## industrial_core

```
* No changes
```
## industrial_deprecated

```
* No changes
```
## industrial_msgs

```
* No changes
```
## industrial_robot_client

```
* Start checking for trajectory completion as soon as the first moving status arrives
* Contributors: Simon Schmeisser
```
## industrial_robot_simulator

```
* No changes
```
## industrial_trajectory_filters

```
* No changes
```
## industrial_utils

```
* No changes
```
## simple_message

```
* No changes
```
