### PR TITLE
pid: 0.0.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6900,7 +6900,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/AndyZelenak/pid-release.git
-      version: 0.0.14-1
+      version: 0.0.15-0
     source:
       type: git
       url: https://bitbucket.org/AndyZe/pid.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pid` to `0.0.15-0`:
- upstream repository: https://bitbucket.org/AndyZe/pid
- release repository: https://github.com/AndyZelenak/pid-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.14-1`
## pid

```
* Fixing header "include" error, possible dynamic_reconfigure errors.
* Contributors: Andy Zelenak
```
