### PR TITLE
robot_model: 1.11.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8104,13 +8104,14 @@ repositories:
       - collada_urdf
       - joint_state_publisher
       - kdl_parser
+      - kdl_parser_py
       - robot_model
       - urdf
       - urdf_parser_plugin
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.11.8-0
+      version: 1.11.9-0
     source:
       type: git
       url: https://github.com/ros/robot_model.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.11.9-0`:
- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.8-0`
## collada_parser

```
* Add Jackie as a maintainer
* Contributors: Jackie Kay
```
## collada_urdf

```
* Add Jackie as a maintainer
* Contributors: Jackie Kay
```
## joint_state_publisher

```
* Add Jackie as a maintainer
* Contributors: Jackie Kay
```
## kdl_parser

```
* Add Jackie as a maintainer
* Add COM import test
* [kdl_parser] remove spurious newline
* [kdl_parser] Fix bug in importing com if inertia and link frames are different
* test_robot.urdf: fix indentation
* Fix values in kdl_parser test
* Revert debug statements in kdl_parser.cpp
* Overhaul tests in urdf
* Contributors: Jackie Kay, Silvio Traversaro, Steven Peters
```
## kdl_parser_py

```
* kdl_parser_py: run_depend on urdfdom_py
* Remove dependency in urdf_parser_py
* kdl_parser: Adding python kdl parser
* Contributors: Jackie Kay, Jonathan Bohren, Steven Peters
* kdl_parser_py: run_depend on urdfdom_py
* Remove dependency in urdf_parser_py
* kdl_parser: Adding python kdl parser
* Contributors: Jackie Kay, Jonathan Bohren, Steven Peters
```
## robot_model

```
* Add Jackie as a maintainer
* add liburdfdom-tools as a run dependency of robot_model
* Contributors: Jackie Kay
```
## urdf

```
* Add Jackie as a maintainer
* test_robot.urdf: fix indentation
* Overhaul tests in urdf
* Contributors: Jackie Kay, Steven Peters
```
## urdf_parser_plugin

```
* Add Jackie as a maintainer
* Contributors: Jackie Kay
```
