### PR TITLE
pr2_robot: 1.6.10-5 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -7431,7 +7431,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_robot-release.git
-      version: 1.6.10-3
+      version: 1.6.10-5
     source:
       type: git
       url: https://github.com/pr2/pr2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_robot` to `1.6.10-5`:
- upstream repository: https://github.com/pr2/pr2_robot.git
- release repository: https://github.com/pr2-gbp/pr2_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.6.10-3`
