### PR TITLE
urdfdom_py: 0.3.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11191,11 +11191,19 @@ repositories:
       version: master
     status: maintained
   urdfdom_py:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: 0.3.1
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/urdfdom_py-release.git
-      version: 0.3.0-2
+      version: 0.3.1-1
+    source:
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: indigo-devel
     status: maintained
   urg_c:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_py` to `0.3.1-1`:
- upstream repository: https://github.com/ros/urdf_parser_py/
- release repository: https://github.com/ros-gbp/urdfdom_py-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.0-2`
## urdfdom_py

```
* Add travis
* Add package.xml for ROS release
* Tweak CMakeLists to reflect migration from urdfdom
* Contributors: Jackie Kay
```
