### PR TITLE
urdfdom_py: 0.3.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5268,11 +5268,19 @@ repositories:
       version: master
     status: maintained
   urdfdom_py:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: 0.3.1
     release:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/urdfdom_py-release.git
-      version: 0.3.0-1
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: indigo-devel
     status: maintained
   urg_c:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_py` to `0.3.1-0`:
- upstream repository: https://github.com/ros/urdf_parser_py/
- release repository: https://github.com/ros-gbp/urdfdom_py-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.0-1`
## urdfdom_py

```
* Add travis
* Add package.xml for ROS release
* Tweak CMakeLists to reflect migration from urdfdom
* Contributors: Jackie Kay
```
