### PR TITLE
industrial_core: 0.5.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1559,7 +1559,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-industrial-release/industrial_core-release.git
-      version: 0.4.3-0
+      version: 0.5.0-0
     source:
       type: git
       url: https://github.com/ros-industrial/industrial_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_core` to `0.5.0-0`:
- upstream repository: https://github.com/ros-industrial/industrial_core.git
- release repository: https://github.com/ros-industrial-release/industrial_core-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.4.3-0`
## industrial_core

```
* No changes
```
## industrial_deprecated

```
* No changes
```
## industrial_msgs

```
* No changes
```
## industrial_robot_client

```
* Start checking for trajectory completion as soon as the first moving status arrives
* Forces the action to wait for half of the duration of the trajectory
  before it begins to check for completition. This prevents the action
  for returning immediately for trajectories that end near the start
  point and are slow to start moving.
* Merge pull request #115 <https://github.com/shaun-edwards/industrial_core/issues/115> from Jmeyer1292/issue#114 <https://github.com/Jmeyer1292/issue/issues/114>`__start_tolerance_check Issue`#114 <https://github.com/shaun-edwards/industrial_core/issues/114> - Action Server withinGoalConstraints check removal
* Revert "Revert "Merge pull request #113 <https://github.com/shaun-edwards/industrial_core/issues/113> from simonschmeisser/indigo""
  This reverts commit fb28e26fdbd3c316941d4d66af2f1c9b5410cb0d.
* Removed withinTolerance check from the accept function
* Contributors: Jonathan Meyer, Shaun Edwards, Simon Schmeisser
```
## industrial_robot_simulator

```
* Added industrial_robot_client test depends as a workaround to test failures
* Updated industrial_robot_simulator package.xml to version 2 format
* Contributors: Shaun Edwards
```
## industrial_trajectory_filters

```
* No changes
```
## industrial_utils

```
* No changes
```
## simple_message

```
* Switch ByteArray to <deque> for internal buffer
  - enables dynamic sizing, for larger messages
  * up to INT_MAX, which is unadvised
  - allows efficient data access at front/rear of msgs
  - maintains same external API
  * getRawDataPtr() is deprecated (not contiguous memory)
  - bugFix: SimpleSocket::receiveBytes() buffer-size check
  - update unit tests to handle ByteArray.MaxSize==INT_MAX
* Contributors: Jeremy Zoss
```
