### PR TITLE
common_msgs: 1.12.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -393,7 +393,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.12.3-0
+      version: 1.12.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.12.4-0`:
- upstream repository: git@github.com:ros/common_msgs.git
- release repository: https://github.com/ros-gbp/common_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.12.3-0`
## actionlib_msgs
- No changes
## common_msgs
- No changes
## diagnostic_msgs

```
* diagnostic_msgs: Add messages for service used to add diagnostics to aggregator
* Contributors: Michal Staniaszek
```
## geometry_msgs

```
* clarify the definition of a Vector3
* Contributors: Vincent Rabaud
```
## nav_msgs
- No changes
## sensor_msgs

```
* added type mapping and support for different types of points in point clouds
* remove boost dependency fixes #81 <https://github.com/ros/common_msgs/issues/81>
* adding a BatteryState message
* fix iterator doc
* remove warning due to anonymous namespace
* Contributors: Sebastian Pütz, Tully Foote, Vincent Rabaud
```
## shape_msgs
- No changes
## stereo_msgs
- No changes
## trajectory_msgs
- No changes
## visualization_msgs
- No changes
