### PR TITLE
ecl_core: 0.61.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1950,7 +1950,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_core-release.git
-      version: 0.61.8-0
+      version: 0.61.9-0
     source:
       type: git
       url: https://github.com/stonier/ecl_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_core` to `0.61.9-0`:
- upstream repository: https://github.com/stonier/ecl_core.git
- release repository: https://github.com/yujinrobot-release/ecl_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.61.8-0`
## ecl_core_apps

```
* improved output of the quatnerion-yaw utilities
```
