### PR TITLE
carl_bot: 0.0.34-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -867,7 +867,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/carl_bot-release.git
-      version: 0.0.33-0
+      version: 0.0.34-0
     source:
       type: git
       url: https://github.com/GT-RAIL/carl_bot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_bot` to `0.0.34-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_bot.git
- release repository: https://github.com/gt-rail-release/carl_bot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.33-0`
## carl_bot

```
* Update package.xml
* Contributors: David Kent
```
## carl_bringup

```
* Update package.xml
* Contributors: David Kent
```
## carl_description

```
* Update package.xml
* Contributors: David Kent
```
## carl_dynamixel

```
* Update package.xml
* Contributors: David Kent
```
## carl_interactive_manipulation

```
* Update package.xml
* Updates for new rail_manipulation_msgs
* Contributors: David Kent
```
## carl_phidgets

```
* Update package.xml
* Contributors: David Kent
```
## carl_teleop

```
* bug fix from teleop cleanup
* updated class name for carl_joy_teleop
* Update package.xml
* Updates for new rail_manipulation_msgs
* Contributors: David Kent
```
## carl_tools

```
* Update CMakeLists.txt
* Update package.xml
* Contributors: David Kent
```
