### PR TITLE
robot_model: 1.11.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8114,7 +8114,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.11.9-0
+      version: 1.11.10-0
     source:
       type: git
       url: https://github.com/ros/robot_model.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.11.10-0`:
- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.9-0`
## collada_parser
- No changes
## collada_urdf
- No changes
## joint_state_publisher
- No changes
## kdl_parser
- No changes
## kdl_parser_py

```
* Remove cmake_modules dependency
* Contributors: Jackie Kay
```
## robot_model
- No changes
## urdf
- No changes
## urdf_parser_plugin
- No changes
