### PR TITLE
carl_demos: 0.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -882,7 +882,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/carl_demos-release.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/GT-RAIL/carl_demos.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_demos` to `0.0.9-0`:
- upstream repository: https://github.com/WPI-RAIL/carl_demos.git
- release repository: https://github.com/gt-rail-release/carl_demos-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.8-0`
## carl_demos

```
* Update .travis.yml
* Update .travis.yml
* Update .travis.yml
* Update .travis.yml
* Update .travis.yml
* Update README.md
* Update package.xml
* Merge branch 'develop' of github.com:WPI-RAIL/carl_demos into develop
* Updates for new rail_manipulation_msgs
* Contributors: David Kent
```
