### PR TITLE
rail_pick_and_place: 1.1.9-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3656,7 +3656,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/gt-rail-release/rail_pick_and_place-release.git
-      version: 1.1.7-0
+      version: 1.1.9-0
     source:
       type: git
       url: https://github.com/GT-RAIL/rail_pick_and_place.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_pick_and_place` to `1.1.9-0`:
- upstream repository: https://github.com/WPI-RAIL/rail_pick_and_place.git
- release repository: https://github.com/gt-rail-release/rail_pick_and_place-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.7-0`
## graspdb

```
* Update package.xml
* Contributors: David Kent
```
## rail_grasp_collection

```
* Update package.xml
* Contributors: David Kent
```
## rail_pick_and_place

```
* Update package.xml
* Contributors: David Kent
```
## rail_pick_and_place_msgs

```
* Update package.xml
* Contributors: David Kent
```
## rail_pick_and_place_tools

```
* Update package.xml
* Contributors: David Kent
```
## rail_recognition

```
* Removed opencv_nonfree features
* Update package.xml
* Updates to suppor the Kinect2, switched to more minimal object set for demonstration purposes
* Contributors: David Kent
```
