### PR TITLE
wpi_jaco: 0.0.25-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11701,7 +11701,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/wpi_jaco-release.git
-      version: 0.0.24-0
+      version: 0.0.25-0
     source:
       type: git
       url: https://github.com/RIVeR-Lab/wpi_jaco.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wpi_jaco` to `0.0.25-0`:
- upstream repository: https://github.com/RIVeR-Lab/wpi_jaco.git
- release repository: https://github.com/gt-rail-release/wpi_jaco-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.24-0`
## jaco_description

```
* Merge branch 'develop' of https://github.com/RIVeR-Lab/wpi_jaco into develop
* Added initial support for the Jaco2 arm, see readme for details
* Contributors: David Kent
```
## jaco_interaction

```
* Merge branch 'develop' of https://github.com/RIVeR-Lab/wpi_jaco into develop
* Added initial support for the Jaco2 arm, see readme for details
* Contributors: David Kent
```
## jaco_moveit_config

```
* Merge branch 'develop' of https://github.com/RIVeR-Lab/wpi_jaco into develop
* Added initial support for the Jaco2 arm, see readme for details
* Contributors: David Kent
```
## jaco_sdk

```
* Merge branch 'develop' of https://github.com/RIVeR-Lab/wpi_jaco into develop
* Added initial support for the Jaco2 arm, see readme for details
* Contributors: David Kent
```
## jaco_teleop

```
* Merge branch 'develop' of https://github.com/RIVeR-Lab/wpi_jaco into develop
* Added initial support for the Jaco2 arm, see readme for details
* Contributors: David Kent
```
## mico_description
- No changes
## mico_moveit_config

```
* updated tf error in rviz visualization for mico moveit demo
* Contributors: David Kent
```
## wpi_jaco

```
* Merge branch 'develop' of https://github.com/RIVeR-Lab/wpi_jaco into develop
* Added initial support for the Jaco2 arm, see readme for details
* Contributors: David Kent
```
## wpi_jaco_msgs

```
* Merge branch 'develop' of https://github.com/RIVeR-Lab/wpi_jaco into develop
* Added initial support for the Jaco2 arm, see readme for details
* Contributors: David Kent
```
## wpi_jaco_wrapper

```
* small bugfix on arm initialization status
* Fixed a trajectory following bug involving trajectories coming in from MoveIt
* Bugfix for kinova_gripper param
* Added kinova_gripper parameter, setting it to false will remove the action servers specifically using the two- or three-fingered kinova gripper designed for use with the jaco or mico
* Added initial support for the Jaco2 arm, see readme for details
* Added initial support for the Jaco2 arm, see readme for details
* Contributors: David Kent
```
