### PR TITLE
robot_model: 1.11.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3848,7 +3848,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.11.9-0
+      version: 1.11.10-0
     source:
       type: git
       url: https://github.com/ros/robot_model.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.11.10-0`:
- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.9-0`
## collada_parser
- No changes
## collada_urdf
- No changes
## joint_state_publisher
- No changes
## kdl_parser
- No changes
## kdl_parser_py

```
* Remove cmake_modules dependency
* Contributors: Jackie Kay
```
## robot_model
- No changes
## urdf
- No changes
## urdf_parser_plugin
- No changes
