### PR TITLE
fetch_ros: 0.7.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2340,7 +2340,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
-      version: 0.7.1-0
+      version: 0.7.2-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.7.2-0`:
- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.1-0`
## fetch_calibration
- No changes
## fetch_depth_layer

```
* Add option to clear with NANs
* Add ROS param clear_with_skipped_rays to re-enable clearing with edge rays
* Add ROS param to control size of skip region on edges
* Change min_clearing_height to -infinity
* Change max_clearing_height to +infinity
* Contributors: Aaron Hoy, Michael Ferguson
```
## fetch_description
- No changes
## fetch_maps
- No changes
## fetch_moveit_config
- No changes
## fetch_navigation

```
* Fix location of recovery behavior parameters in yaml configs
* Contributors: Kei Okada, Michael Ferguson
```
## fetch_teleop
- No changes
