### PR TITLE
Added first of my packages, common-sensors, for pre-release test

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1410,6 +1410,16 @@ repositories:
       url: https://github.com/ros/common_msgs.git
       version: indigo-devel
     status: maintained
+  common_sensors:
+    doc:
+      type: git
+      url: https://github.com/JenniferBuehler/common-sensors.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/JenniferBuehler/common-sensors.git
+      version: master
+    status: developed
   common_tutorials:
     doc:
       type: git


### PR DESCRIPTION
I want to perform a pre-release test before my first official release.

There is a number of packages which I want to add, but because this is the first time I am going through this process, I wanted to try with a simple package first and will then add the others after I know the process.

If I understand correctly, for a pre-release test only the "source" information is required.

Thanks & Kind regards
Jennifer
