### PR TITLE
common_sensors: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1411,6 +1411,21 @@ repositories:
       url: https://github.com/ros/common_msgs.git
       version: indigo-devel
     status: maintained
+  common_sensors:
+    doc:
+      type: git
+      url: https://github.com/JenniferBuehler/common-sensors.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/JenniferBuehler/common-sensors-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/JenniferBuehler/common-sensors.git
+      version: master
+    status: developed
   common_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_sensors` to `0.1.0-0`:
- upstream repository: https://github.com/JenniferBuehler/common-sensors.git
- release repository: https://github.com/JenniferBuehler/common-sensors-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## common_sensors

```
* Added sources to repository
* Contributors: Jennifer Buehler
```
