### PR TITLE
gazebo_ros_pkgs: 2.5.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -989,7 +989,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.5.1-0
+      version: 2.5.2-0
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.5.2-0`:
- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.5.1-0`
## gazebo_msgs

```
* merging from indigo-devel
* 2.4.9
* Generate changelog
* GetModelState modification for jade
* Contributors: John Hsu, Jose Luis Rivero, Markus Bader
```
## gazebo_plugins

```
* Fix row_step of openni_kinect plugin
* remove duplicated code during merge
* merging from indigo-devel
* Merge pull request #368 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/368> from l0g1x/jade-devel
  Covariance for published twist in skid steer plugin
* gazebo_ros_utils.h: include gazebo_config.h
  Make sure to include gazebo_config.h,
  which defines the GAZEBO_MAJOR_VERSION macro
* Fix compiler error with SetHFOV
  In gazebo7, the rendering::Camera::SetHFOV function
  is overloaded with a potential for ambiguity,
  as reported in the following issue:
  https://bitbucket.org/osrf/gazebo/issues/1830
  This fixes the build by explicitly defining the
  Angle type.
* Add missing boost header
  Some boost headers were remove from gazebo7 header files
  and gazebo_ros_joint_state_publisher.cpp was using it
  implicitly.
* Fix gazebo7 build errors
  The SensorPtr types have changed from boost:: pointers
  to std:: pointers,
  which requires boost::dynamic_pointer_cast to change to
  std::dynamic_pointer_cast.
  A helper macro is added that adds a using statement
  corresponding to the correct type of dynamic_pointer_cast.
  This macro should be narrowly scoped to protect
  other code.
* gazebo_ros_utils.h: include gazebo_config.h
  Make sure to include gazebo_config.h,
  which defines the GAZEBO_MAJOR_VERSION macro
* Use Joint::SetParam for joint velocity motors
  Before gazebo5, Joint::SetVelocity and SetMaxForce
  were used to set joint velocity motors.
  The API has changed in gazebo5, to use Joint::SetParam
  instead.
  The functionality is still available through the SetParam API.
  cherry-picked from indigo-devel
  Add ifdefs to fix build with gazebo2
  It was broken by #315 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/315>.
  Fixes #321 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/321>.
* Fix gazebo6 deprecation warnings
  Several RaySensor functions are deprecated in gazebo6
  and are removed in gazebo7.
  The return type is changed to use ignition math
  and the function name is changed.
  This adds ifdef's to handle the changes.
* Fix compiler error with SetHFOV
  In gazebo7, the rendering::Camera::SetHFOV function
  is overloaded with a potential for ambiguity,
  as reported in the following issue:
  https://bitbucket.org/osrf/gazebo/issues/1830
  This fixes the build by explicitly defining the
  Angle type.
* Add missing boost header
  Some boost headers were remove from gazebo7 header files
  and gazebo_ros_joint_state_publisher.cpp was using it
  implicitly.
* Fix gazebo7 build errors
  The SensorPtr types have changed from boost:: pointers
  to std:: pointers,
  which requires boost::dynamic_pointer_cast to change to
  std::dynamic_pointer_cast.
  A helper macro is added that adds a using statement
  corresponding to the correct type of dynamic_pointer_cast.
  This macro should be narrowly scoped to protect
  other code.
* Fix gazebo6 deprecation warnings
  Several RaySensor functions are deprecated in gazebo6
  and are removed in gazebo7.
  The return type is changed to use ignition math
  and the function name is changed.
  This adds ifdef's to handle the changes.
* Publish organized point cloud from openni_kinect plugin
* Added covariance matrix for published twist message in the skid steer plugin, as packages such as robot_localization require an associated non-zero covariance matrix
* Added a missing initialization inside Differential Drive
* 2.4.9
* Generate changelog
* Merge pull request #335 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/335> from pal-robotics-forks/add_range_sensor_plugin
  Adds range plugin for infrared and ultrasound sensors from PAL Robotics
* Import changes from jade-branch
* Add range world and launch file
* Adds range plugin for infrared and ultrasound sensors from PAL Robotics
* Add ifdefs to fix build with gazebo2
  It was broken by #315 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/315>.
  Fixes #321 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/321>.
* Use Joint::SetParam for joint velocity motors
  Before gazebo5, Joint::SetVelocity and SetMaxForce
  were used to set joint velocity motors.
  The API has changed in gazebo5, to use Joint::SetParam
  instead.
  The functionality is still available through the SetParam API.
* Set GAZEBO_CXX_FLAGS to fix c++11 compilation errors
* Contributors: Bence Magyar, John Hsu, Jose Luis Rivero, Kentaro Wada, Krystian, Mirko Ferrati, Steven Peters, hsu
```
## gazebo_ros

```
* merging from indigo-devel
* Merge pull request #302 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/302> from maxbader/jade-devel-GetModelState
  Header for GetModelState service request for jade-devel
* Fix invalid signal name on OS X
  scripts/gazebo: line 30: kill: SIGINT: invalid signal specification
* Fix invalid signal name on OS X
  scripts/gazebo: line 30: kill: SIGINT: invalid signal specification
* Restart package resolving from last position, do not start all over.
* 2.4.9
* Generate changelog
* Import changes from jade-branch
* Add range world and launch file
* fix crash
* Set GAZEBO_CXX_FLAGS to fix c++11 compilation errors
* GetModelState modification for jade
* Contributors: Bence Magyar, Boris Gromov, Guillaume Walck, Ian Chen, John Hsu, Jose Luis Rivero, Markus Bader, Steven Peters, hsu
```
## gazebo_ros_pkgs

```
* merging from indigo-devel
* 2.4.9
* Generate changelog
* Contributors: John Hsu, Jose Luis Rivero
```
