### PR TITLE
 virtual/python-imaging -> dev-python/pillow for Gentoo

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -631,7 +631,7 @@ python-imaging:
     schrödinger’s: [python-pillow, python-pillow-qt]
     spherical: [python-imaging]
   freebsd: [py27-imaging]
-  gentoo: [virtual/python-imaging]
+  gentoo: [dev-python/pillow]
   macports: [py27-pil]
   opensuse: [python-imaging]
   rhel: [python-imaging]


### PR DESCRIPTION
See #10584
