### PR TITLE
fetch_tools: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2355,7 +2355,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_tools` to `0.1.2-0`:
- upstream repository: https://github.com/fetchrobotics/fetch_tools.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.1-0`
## fetch_tools

```
* Added three commands:
* Changed one command:
  - fetch sync is now fetch push
* Improved one command:
  - fetch run now supports multiple workspaces
* Contributors: Alex Henning, Michael Ferguson, Aaron Blasdel
```
