### PR TITLE
Adding behavior_tree to documentation index for hydro and indigo 

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -467,6 +467,16 @@ repositories:
       url: https://github.com/RethinkRobotics/baxter_tools.git
       version: master
     status: developed
+  behavior_tree:
+    doc:
+      type: git
+      url: https://github.com/miccol/ROS-Behavior-Tree
+      version: master
+    source:
+      type: git
+      url: https://github.com/miccol/ROS-Behavior-Tree.git
+      version: master
+    status: developed
   bfl:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -467,16 +467,6 @@ repositories:
       url: https://github.com/RethinkRobotics/baxter_tools.git
       version: master
     status: developed
-  behavior_tree:
-    doc:
-      type: git
-      url: https://github.com/miccol/ROS-Behavior-Tree
-      version: master
-    source:
-      type: git
-      url: https://github.com/miccol/ROS-Behavior-Tree.git
-      version: master
-    status: developed
   bfl:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -616,7 +616,7 @@ repositories:
   behavior_tree:
     doc:
       type: git
-      url: https://github.com/miccol/ROS-Behavior-Tree
+      url: https://github.com/miccol/ROS-Behavior-Tree.git
       version: master
     source:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -613,6 +613,16 @@ repositories:
       url: https://github.com/AutonomyLab/bebop_autonomy.git
       version: indigo-devel
     status: developed
+  behavior_tree:
+    doc:
+      type: git
+      url: https://github.com/miccol/ROS-Behavior-Tree
+      version: master
+    source:
+      type: git
+      url: https://github.com/miccol/ROS-Behavior-Tree.git
+      version: master
+    status: developed
   bfl:
     doc:
       type: git


### PR DESCRIPTION
I would like behavior_tree to be indexed and documented on ros.org
