### PR TITLE
graspit_tools: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2798,7 +2798,7 @@ repositories:
   graspit_tools:
     doc:
       type: git
-      url: https://github.com/JenniferBuehler/graspit-pkgs.wiki.git
+      url: https://github.com/JenniferBuehler/graspit-pkgs.git
       version: master
     release:
       packages:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2795,6 +2795,28 @@ repositories:
       url: https://github.com/mikeferguson/grasping_msgs-gbp.git
       version: 0.3.1-0
     status: developed
+  graspit_tools:
+    doc:
+      type: git
+      url: https://github.com/JenniferBuehler/graspit-pkgs.wiki.git
+      version: master
+    release:
+      packages:
+      - grasp_planning_graspit
+      - grasp_planning_graspit_msgs
+      - grasp_planning_graspit_ros
+      - graspit_tools
+      - jaco_graspit_sample
+      - urdf2graspit
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/JenniferBuehler/graspit-pkgs-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/JenniferBuehler/graspit-pkgs.git
+      version: master
+    status: developed
   grid_map:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `graspit_tools` to `0.1.1-0`:
- upstream repository: https://github.com/JenniferBuehler/graspit-pkgs.git
- release repository: https://github.com/JenniferBuehler/graspit-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
