### PR TITLE
diagnostics: 1.8.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1783,7 +1783,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/diagnostics-release.git
-      version: 1.8.8-0
+      version: 1.8.9-0
     source:
       type: git
       url: https://github.com/ros/diagnostics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `1.8.9-0`:
- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros-gbp/diagnostics-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.8.8-0`
## diagnostic_aggregator

```
* Add version dependencies in package.xml
* Add version check in cmake
* Add functionality for dynamically adding analyzers
* Contributors: Michal Staniaszek, trainman419
```
## diagnostic_analysis
- No changes
## diagnostic_common_diagnostics
- No changes
## diagnostic_updater
- No changes
## diagnostics
- No changes
## self_test
- No changes
## test_diagnostic_aggregator

```
* Add version dependencies in package.xml
* Contributors: trainman419
```
