### PR TITLE
grid_map: 1.2.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -1226,11 +1226,12 @@ repositories:
       - grid_map_filters
       - grid_map_loader
       - grid_map_msgs
+      - grid_map_ros
       - grid_map_visualization
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ethz-asl/grid_map-release.git
-      version: 1.1.3-0
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/ethz-asl/grid_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `1.2.0-0`:
- upstream repository: https://github.com/ethz-asl/grid_map.git
- release repository: https://github.com/ethz-asl/grid_map-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.3-0`
## grid_map

```
* Added new package grid_map as metapackage (#34 <https://github.com/ethz-asl/grid_map/issues/34>).
```
## grid_map_core

```
* Improved efficiency for the Grid Map iterator (speed increase of 10x for large maps) (#45 <https://github.com/ethz-asl/grid_map/issues/45>).
* New iterator_benchmark demo to exemplify the usage of the iterators and their computational performance (#45 <https://github.com/ethz-asl/grid_map/issues/45>).
* Added new method to set the position of a grid map (#42 <https://github.com/ethz-asl/grid_map/pull/42>).
* Added new move_demo to illustrate the difference between the move and setPosition method.
* Fixed behavior of checkIfPositionWithinMap() in edge cases (#41 <https://github.com/ethz-asl/grid_map/issues/41>).
* Updated documentation for spiral and ellipse iterator, and iterator performance.
* const correctness for grid's getSubmap.
* Cleanup of arguments and return types.
* Contributors: Péter Fankhauser, Christos Zalidis, Daniel Stonier
```
## grid_map_demos

```
* New iterator_benchmark demo to exemplify the usage of the iterators and their computational performance.
* Added new move_demo to illustrate the difference between the move and setPosition method.
* Contributors: Péter Fankhauser, Christos Zalidis, Daniel Stonier
```
## grid_map_filters
- No changes
## grid_map_loader

```
* Changed the package name from grid_map to grid_map_ros and made grid_map a metapackage (#34 <https://github.com/ethz-asl/grid_map/issues/34>).
* Contributors: Peter Fankhauser
```
## grid_map_msgs

```
* [grid_map_msgs] package exports
* Contributors: Daniel Stonier
```
## grid_map_ros

```
* Changed the package name from grid_map to grid_map_ros and made grid_map a metapackage (#34 <https://github.com/ethz-asl/grid_map/issues/34>).
* Added new occupancy grid to grid map converter (#33 <https://github.com/ethz-asl/grid_map/issues/33>).
* Contributors: Peter Fankhauser
```
## grid_map_visualization

```
* Changed the package name from grid_map to grid_map_ros and made grid_map a metapackage (#34 <https://github.com/ethz-asl/grid_map/issues/34>).
* Contributors: Peter Fankhauser
```
