### PR TITLE
adding missing rules for Xenial and Wily

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -130,6 +130,12 @@ assimp:
     vivid:
       apt:
         packages: [libassimp-dev]
+    wily:
+      apt:
+        packages: [libassimp-dev]
+    xenial:
+      apt:
+        packages: [libassimp-dev]
 assimp-dev:
   arch: [assimp]
   debian:
@@ -174,6 +180,12 @@ assimp-dev:
       apt:
         packages: [libassimp-dev]
     vivid:
+      apt:
+        packages: [libassimp-dev]
+    wily:
+      apt:
+        packages: [libassimp-dev]
+    xenial:
       apt:
         packages: [libassimp-dev]
 atlas:
@@ -338,6 +350,12 @@ boost:
       apt:
         packages: [libboost-all-dev]
     vivid:
+      apt:
+        packages: [libboost-all-dev]
+    wily:
+      apt:
+        packages: [libboost-all-dev]
+    xenial:
       apt:
         packages: [libboost-all-dev]
 box2d-dev:
@@ -1239,6 +1257,8 @@ libconsole-bridge-dev:
     trusty: [libconsole-bridge-dev]
     utopic: [libconsole-bridge-dev]
     vivid: [libconsole-bridge-dev]
+    wily: [libconsole-bridge-dev]
+    xenial: [libconsole-bridge-dev]
 libdbus-dev:
   arch: [dbus-core]
   debian: [libdbus-1-dev]
@@ -1775,6 +1795,8 @@ libogre-dev:
     trusty: [libogre-1.8-dev]
     utopic: [libogre-1.9-dev]
     vivid: [libogre-1.9-dev]
+    wily: [libogre-1.9-dev]
+    xenial: [libogre-1.9-dev]
 libois-dev:
   arch: [ois]
   debian: [libois-dev]
@@ -2374,6 +2396,8 @@ liburdfdom-dev:
     trusty: [liburdfdom-dev]
     utopic: [liburdfdom-dev]
     vivid: [liburdfdom-dev]
+    wily: [liburdfdom-dev]
+    xenial: [liburdfdom-dev]
 liburdfdom-headers-dev:
   arch: [urdfdom-headers]
   debian: [liburdfdom-headers-dev]
@@ -2384,6 +2408,8 @@ liburdfdom-headers-dev:
     trusty: [liburdfdom-headers-dev]
     utopic: [liburdfdom-headers-dev]
     vivid: [liburdfdom-headers-dev]
+    wily: [liburdfdom-headers-dev]
+    xenial: [liburdfdom-headers-dev]
 liburdfdom-tools:
   arch: [urdfdom]
   debian: [liburdfdom-tools]
@@ -2634,6 +2660,8 @@ lz4:
     trusty: [liblz4-dev]
     utopic: [liblz4-dev]
     vivid: [liblz4-dev]
+    wily: [liblz4-dev]
+    xenial: [liblz4-dev]
 m4:
   arch: [m4]
   debian: [m4]
@@ -3668,6 +3696,8 @@ yaml-cpp:
     trusty_python3: [libyaml-cpp-dev]
     utopic: [libyaml-cpp-dev]
     vivid: [libyaml-cpp-dev]
+    wily: [libyaml-cpp-dev]
+    xenial: [libyaml-cpp-dev]
 yasm:
   arch: [yasm]
   debian: [yasm]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -19,6 +19,7 @@ ipython:
     utopic: [ipython]
     vivid: [ipython]
     wily: [ipython]
+    xenial: [ipython]
 libgv-python:
   ubuntu: [libgv-python]
 paramiko:
@@ -42,6 +43,8 @@ paramiko:
     trusty: [python-paramiko]
     utopic: [python-paramiko]
     vivid: [python-paramiko]
+    wily: [python-paramiko]
+    xenial: [python-paramiko]
 pyros-setup-pip:
   ubuntu:
     pip:
@@ -84,6 +87,10 @@ python:
     trusty_python3: [python3-dev]
     utopic: [python-dev]
     vivid: [python-dev]
+    wily: [python-dev]
+    wily_python3: [python3-dev]
+    xenial: [python-dev]
+    xenial_python3: [python3-dev]
 python-alembic:
   fedora: [python-alembic]
   ubuntu:
@@ -91,6 +98,7 @@ python-alembic:
     utopic: [python-alembic]
     vivid: [python-alembic]
     wily: [python-alembic]
+    xenial: [python-alembic]
 python-amqp:
   fedora: [python-amqp]
   ubuntu:
@@ -98,6 +106,7 @@ python-amqp:
     utopic: [python-amqp]
     vivid: [python-amqp]
     wily: [python-amqp]
+    xenial: [python-amqp]
 python-argcomplete:
   fedora: [python-argcomplete]
   ubuntu: [python-argcomplete]
@@ -193,6 +202,7 @@ python-babel:
     utopic: [python-babel]
     vivid: [python-babel]
     wily: [python-babel]
+    xenial: [python-babel]
 python-beautifulsoup:
   arch: [python2-beautifulsoup3]
   debian: [python-beautifulsoup]
@@ -281,6 +291,10 @@ python-catkin-pkg:
     trusty_python3: [python3-catkin-pkg]
     utopic: [python-catkin-pkg]
     vivid: [python-catkin-pkg]
+    wily: [python-catkin-pkg]
+    wily_python3: [python3-catkin-pkg]
+    xenial: [python-catkin-pkg]
+    xenial_python3: [python3-catkin-pkg]
 python-catkin-tools:
   fedora: [python-catkin_tools]
   osx:
@@ -368,6 +382,8 @@ python-coverage:
     trusty_python3: [python3-coverage]
     utopic: [python-coverage]
     vivid: [python-coverage]
+    wily: [python-coverage]
+    xenial: [python-coverage]
 python-cpplint:
   debian:
     pip:
@@ -494,6 +510,8 @@ python-empy:
     trusty: [python-empy]
     utopic: [python-empy]
     vivid: [python-empy]
+    wily: [python-empy]
+    xenial: [python-empy]
 python-enum:
   fedora: [python-enum]
   ubuntu:
@@ -529,6 +547,7 @@ python-evdev:
     utopic: [python-evdev]
     vivid: [python-evdev]
     wily: [python-evdev]
+    xenial: [python-evdev]
 python-flake8:
   fedora:
     '21': [python-flake8]
@@ -687,6 +706,10 @@ python-imaging:
     trusty_python3: [python3-imaging]
     utopic: [python-imaging]
     vivid: [python-imaging]
+    wily: [python-imaging]
+    wily_python3: [python3-imaging]
+    xenial: [python-imaging]
+    xenial_python3: [python3-imaging]
 python-impacket:
   debian: [python-impacket]
   fedora: [python-impacket]
@@ -834,6 +857,10 @@ python-mock:
     trusty_python3: [python3-mock]
     utopic: [python-mock]
     vivid: [python-mock]
+    wily: [python-mock]
+    wily_python3: [python3-mock]
+    xenial: [python-mock]
+    xenial_python3: [python3-mock]
 python-msgpack:
   debian: [python-msgpack]
   fedora: [python-msgpack]
@@ -904,6 +931,10 @@ python-netifaces:
     trusty_python3: [python3-netifaces]
     utopic: [python-netifaces]
     vivid: [python-netifaces]
+    wily: [python-netifaces]
+    wily_python3: [python3-netifaces]
+    xenial: [python-netifaces]
+    xenial_python3: [python3-netifaces]
 python-networkx:
   fedora: [python-networkx]
   ubuntu:
@@ -939,6 +970,10 @@ python-nose:
     trusty_python3: [python3-nose]
     utopic: [python-nose]
     vivid: [python-nose]
+    wily: [python-nose]
+    wily_python3: [python3-nose]
+    xenial: [python-nose]
+    xenial_python3: [python3-nose]
 python-numpy:
   arch: [python2-numpy]
   debian: [python-numpy]
@@ -961,6 +996,8 @@ python-numpy:
     trusty_python3: [python3-numpy]
     utopic: [python-numpy]
     vivid: [python-numpy]
+    wily: [python-numpy]
+    xenial: [python-numpy]
 python-oauth2:
   debian: [python-oauth2]
   fedora: [python-oauth2]
@@ -1041,6 +1078,8 @@ python-paramiko:
     trusty: [python-paramiko]
     utopic: [python-paramiko]
     vivid: [python-paramiko]
+    wily: [python-paramiko]
+    xenial: [python-paramiko]
 python-passlib:
   fedora: [python-passlib]
   ubuntu: [python-passlib]
@@ -1200,6 +1239,8 @@ python-pydot:
     trusty: [python-pydot]
     utopic: [python-pydot]
     vivid: [python-pydot]
+    wily: [python-pydot]
+    xenial: [python-pydot]
 python-pygame:
   debian: [python-pygame]
   fedora: [pygame-devel]
@@ -1252,6 +1293,8 @@ python-pygraphviz:
     trusty: [python-pygraphviz]
     utopic: [python-pygraphviz]
     vivid: [python-pygraphviz]
+    wily: [python-pygraphviz]
+    xenial: [python-pygraphviz]
 python-pykalman:
   debian:
     pip:
@@ -1540,6 +1583,8 @@ python-requests:
     vivid_python3: [python3-requests]
     wily: [python-requests]
     wily_python3: [python3-requests]
+    xenial: [python-requests]
+    xenial_python3: [python3-requests]
 python-responses-pip:
   ubuntu:
     pip:
@@ -1564,6 +1609,10 @@ python-rosdep:
     trusty_python3: [python3-rosdep]
     utopic: [python-rosdep]
     vivid: [python-rosdep]
+    wily: [python-rosdep]
+    wily_python3: [python3-rosdep]
+    xenial: [python-rosdep]
+    xenial_python3: [python3-rosdep]
 python-rosdistro:
   debian: [python-rosdistro]
   fedora: [python-rosdistro]
@@ -1631,7 +1680,13 @@ python-rospkg:
     trusty: [python-rospkg]
     trusty_python3: [python3-rospkg]
     utopic: [python-rospkg]
+    utopic_python3: [python3-rospkg]
     vivid: [python-rospkg]
+    vivid_python3: [python3-rospkg]
+    wily: [python-rospkg]
+    wily_python3: [python3-rospkg]
+    xenial: [python-rospkg]
+    xenial_python3: [python3-rospkg]
 python-rrdtool:
   ubuntu:
     lucid: [python-rrdtool]
@@ -1772,6 +1827,10 @@ python-sip:
     trusty_python3: [python3-sip-dev]
     utopic: [python-sip-dev]
     vivid: [python-sip-dev]
+    wily: [python-sip-dev]
+    wily_python3: [python3-sip-dev]
+    xenial: [python-sip-dev]
+    xenial_python3: [python3-sip-dev]
 python-sip4:
   fedora: [sip]
   macports: [py27-sip4]
@@ -1780,6 +1839,7 @@ python-six:
     trusty: [python-six]
     vivid: [python-six]
     wily: [python-six]
+    xenial: [python-six]
     xenial: [python-six]
 python-skimage:
   osx:
@@ -1803,6 +1863,7 @@ python-sklearn:
     utopic: [python-sklearn]
     vivid: [python-sklearn]
     wily: [python-sklearn]
+    xenial: [python-sklearn]
 python-slacker-cli:
   osx:
     pip:
@@ -1939,6 +2000,7 @@ python-texttable:
     utopic: [python-texttable]
     vivid: [python-texttable]
     wily: [python-texttable]
+    xenial: [python-texttable]
 python-tftpy:
   fedora: [python-tftpy]
   ubuntu: [python-tftpy]
@@ -2148,6 +2210,8 @@ python-websocket:
     vivid_python3: [python3-websocket]
     wily: [python-websocket]
     wily_python3: [python3-websocket]
+    xenial: [python-websocket]
+    xenial_python3: [python3-websocket]
 python-werkzeug:
   fedora: [python-werkzeug]
   ubuntu: [python-werkzeug]
@@ -2191,6 +2255,10 @@ python-yaml:
     trusty_python3: [python3-yaml]
     utopic: [python-yaml]
     vivid: [python-yaml]
+    wily: [python-yaml]
+    wily_python3: [python3-yaml]
+    xenial: [python-yaml]
+    xenial_python3: [python3-yaml]
 python-zmq:
   debian: [python-zmq]
   fedora: [python-zmq]


### PR DESCRIPTION
This is probably necessary to get any where with releasing Kinetic packages. I discovered these while building Jade from source on Xenial.
