### PR TITLE
catkin: 0.6.17-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -992,7 +992,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.6.16-0
+      version: 0.6.17-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.6.17-0`:
- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.6.16-0`
## catkin

```
* fix docs: nosetest target names use periods (#781 <https://github.com/ros/catkin/issues/781>)
* add custom message explaining CMake find_package error messages (#780 <https://github.com/ros/catkin/issues/780>)
* fix regression with DESTDIR introduced in 0.6.16 (#755 <https://github.com/ros/catkin/issues/755>)
* avoid adding nonexistent paths to environment variables (#777 <https://github.com/ros/catkin/issues/777>)
* ensure that Python install destination exists (#775 <https://github.com/ros/catkin/issues/775>, https://github.com/ros/catkin/issues/776)
* set commonly predefines attributes when interrogating setup.py files (#770 <https://github.com/ros/catkin/issues/770>)
* align Python script directory recommendations with REP-0008 (#769 <https://github.com/ros/catkin/issues/769>)
* fix default value for _workspaces in find_in_workspaces (#768 <https://github.com/ros/catkin/issues/768>)
* improve robustness of exec call interogating setup.py files (#766 <https://github.com/ros/catkin/issues/766>)
* fix reinstalling Python files installed by catkin_install_python after modifying them (#764 <https://github.com/ros/catkin/issues/764>)
* fix project specific clean_test_results targets (#762 <https://github.com/ros/catkin/issues/762>)
* update generated CMake API
```
