### PR TITLE
graspit_tools: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2811,7 +2811,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/JenniferBuehler/graspit-pkgs-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/JenniferBuehler/graspit-pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graspit_tools` to `0.1.2-0`:
- upstream repository: https://github.com/JenniferBuehler/graspit-pkgs.git
- release repository: https://github.com/JenniferBuehler/graspit-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.1-0`
## grasp_planning_graspit
- No changes
## grasp_planning_graspit_msgs
- No changes
## grasp_planning_graspit_ros
- No changes
## graspit_tools
- No changes
## jaco_graspit_sample
- No changes
## urdf2graspit
- No changes
