### PR TITLE
jsk_pr2eus: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3980,7 +3980,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_pr2eus-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     status: developed
   jsk_recognition:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.2.1-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_pr2eus
- release repository: https://github.com/tork-a/jsk_pr2eus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.0-0`
## jsk_pr2eus
- No changes
## pr2eus

```
* add robot-move-base-interface, which support move_base interface (#208 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/208>)
* [pr2eus/pr2-interface.l] default argument of change-inflation-range 0.55 -> 0.2 according with the change of default value https://github.com/jsk-ros-pkg/jsk_robot/pull/535 (#204 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/204>)
* add :state :gripper method (#190 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/190>)

    * [pr2eus/pr2-interface.l] add :state :gripper method to fetch information of gripper
    * [pr2eus/robot-interface.l] add :gripper virtual method; :state :gripper accessor to :gripper

* fix #179 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/179>

    * [pr2eus/robot-interface.l] add variable to change default look-all behavior on draw-objects
    * [pr2eus/robot-interface.l] add option :look-all when :draw-objects

* [pr2eus/pr2-interface.l] fix gripper method (#201 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/201>)
* [pr2eus/pr2-interface.l] add document of :gripper method (#199 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/199>)
* [pr2eus/robot-interface.l, pr2eus/pr2-interface.l] fix: :wait-interpolation returns :interpolatingp on real robot (#191 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/191>)

    * [pr2eus/pr2-interface.l] :wait-interpolation returns results of :interpolatingp of controllers on real robot
    * [pr2eus/robot-interface.l] :wait-interpolation returns results of :interpolatingp of controllers on real robot

* [pr2eus] add :go-waitp (#196 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/196>)
* add :effort-vector for reading effort of joint_states (#188 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/188> )

    * [pr2eus/robot-interface.l] Revert https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/188 and fix :torque-vector to return joint torques.

* update speak command

    * [speak.l] add default variable for waiting speak
    * [speak.l] add speak backward compatibility
    * [test/speak-test.test] add test for speak.l

* Contributors: Kei Okada, Ryohei Ueda, Shunichi Nozawa, Yohei Kakiuchi, Yuki Furuta, Hitoshi Kamada
```
## pr2eus_moveit
- No changes
