### PR TITLE
multisense_ros: 3.4.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2488,7 +2488,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
-      version: 3.4.6-0
+      version: 3.4.7-0
     source:
       type: hg
       url: https://bitbucket.org/crl/multisense_ros


### PR DESCRIPTION
Increasing version of package(s) in repository `multisense_ros` to `3.4.7-0`:
- upstream repository: https://bitbucket.org/crl/multisense_ros
- release repository: https://github.com/carnegieroboticsllc/multisense_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `3.4.6-0`
## multisense

```
* Add in support for MultiSense DeviceStatus messages. Revised the cal_check utility to remove the Matlab dependency.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
## multisense_bringup

```
* Add in support for MultiSense DeviceStatus messages. Revised the cal_check utility to remove the Matlab dependency.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
## multisense_cal_check

```
* Add in support for MultiSense DeviceStatus messages. Revised the cal_check utility to remove the Matlab dependency.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
## multisense_description

```
* Add in support for MultiSense DeviceStatus messages. Revised the cal_check utility to remove the Matlab dependency.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
## multisense_lib

```
* Add in support for MultiSense DeviceStatus messages. Revised the cal_check utility to remove the Matlab dependency.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
## multisense_ros

```
* Add in support for MultiSense DeviceStatus messages. Revised the cal_check utility to remove the Matlab dependency.
* Contributors: Matt Alvarado <mailto:malvarado@carnegierobotics.com>
```
