### PR TITLE
geometry_experimental: 0.5.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2711,7 +2711,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry_experimental-release.git
-      version: 0.5.12-0
+      version: 0.5.13-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_experimental` to `0.5.13-0`:
- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry_experimental-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.12-0`
## geometry_experimental

```
* Remove LGPL from license tags
  LGPL was erroneously included in 2a38724. As there are no files with it
  in the package.
* add missing dependencies in the meta-package geometry_experimental
  This partly fixes the doc jobs in #120 <https://github.com/ros/geometry_experimental/issues/120>
* Contributors: Jochen Sprickerhof, Vincent Rabaud
```
## tf2
- No changes
## tf2_bullet

```
* Don't export catkin includes
  They only point to the temporary include in the build directory.
* Contributors: Jochen Sprickerhof
```
## tf2_eigen

```
* Added missing inline
* Added unit test
  - Testing conversion to msg forward/backward
* Added eigenTotransform function
* Contributors: Davide Tateo, boris-il-forte
```
## tf2_geometry_msgs

```
* Add missing python_orocos_kdl dependency
* make example into unit test
* vector3 not affected by translation
* Contributors: Daniel Claes, chapulina
```
## tf2_kdl

```
* converting python test script into unit test
* Don't export catkin includes
* Contributors: Jochen Sprickerhof, Tully Foote
```
## tf2_msgs
- No changes
## tf2_py
- No changes
## tf2_ros

```
* fix documentation warnings
* Adding tests to package
* Contributors: Laurent GEORGE, Vincent Rabaud
```
## tf2_sensor_msgs

```
* add missing Python runtime dependency
* fix wrong comment
* Adding tests to package
* Fixing do_transform_cloud for python
  The previous code was not used at all (it was a mistake in the __init__.py so
  the do_transform_cloud was not available to the python users).
  The python code need some little correction (e.g there is no method named
  read_cloud but it's read_points for instance, and as we are in python we can't
  use the same trick as in c++ when we got an immutable)
* Contributors: Laurent GEORGE, Vincent Rabaud
```
## tf2_tools

```
* casted el to string in view_frames
* Contributors: g_gemignani
```
