### PR TITLE
add debian jessie to release platforms for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3,6 +3,8 @@
 # see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
+  debian:
+  - jessie
   fedora:
   - '23'
   - '24'


### PR DESCRIPTION
This will allow us to turn it on in the future.
