### PR TITLE
geometry: 1.11.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2683,7 +2683,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry-release.git
-      version: 1.11.7-0
+      version: 1.11.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry` to `1.11.8-0`:
- upstream repository: https://github.com/ros/geometry.git
- release repository: https://github.com/ros-gbp/geometry-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.11.7-0`
## eigen_conversions

```
* eigen_conversions: Add conversions for Eigen::Isometry3d
* Contributors: Maarten de Vries
```
## geometry
- No changes
## kdl_conversions
- No changes
## tf

```
* Update assertQuaternionValid to check for NaNs
* Remove outdated manifest loading in python files
* update unit tests to catch https://github.com/ros/geometry_experimental/issues/102
* Contributors: Chris Mansley, Michael Hwang, Tully Foote
```
## tf_conversions

```
* tf_conversions: Add conversion functions for Eigen::Isometry3d
* Remove outdated manifest loading in python files
* Contributors: Maarten de Vries, Michael Hwang
```
