### PR TITLE
genmsg: 0.5.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2615,7 +2615,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/genmsg-release.git
-      version: 0.5.6-0
+      version: 0.5.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.5.7-0`:
- upstream repository: git@github.com:ros/genmsg.git
- release repository: https://github.com/ros-gbp/genmsg-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.5.6-0`
## genmsg

```
* find_package(catkin) and add run dependency on catkin (#61 <https://github.com/ros/genmsg/issues/61>)
* improve readability of error message
* fix doc for BASE_DIR in add_*_files (#59 <https://github.com/ros/genmsg/issues/59>)
* fix some more minor typos (#56 <https://github.com/ros/genmsg/issues/56>, #57 <https://github.com/ros/genmsg/issues/57>)
```
