### PR TITLE
genmsg: 0.5.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -39,6 +39,7 @@ repositories:
       url: https://github.com/ros-gbp/genmsg-release.git
       version: 0.5.7-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/genmsg.git
       version: indigo-devel

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -28,5 +28,20 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: kinetic-devel
     status: maintained
+  genmsg:
+    doc:
+      type: git
+      url: https://github.com/ros/genmsg.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/genmsg-release.git
+      version: 0.5.7-0
+    source:
+      type: git
+      url: https://github.com/ros/genmsg.git
+      version: indigo-devel
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.5.7-0`:
- upstream repository: git@github.com:ros/genmsg.git
- release repository: https://github.com/ros-gbp/genmsg-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## genmsg

```
* find_package(catkin) and add run dependency on catkin (#61 <https://github.com/ros/genmsg/issues/61>)
* improve readability of error message
* fix doc for BASE_DIR in add_*_files (#59 <https://github.com/ros/genmsg/issues/59>)
* fix some more minor typos (#56 <https://github.com/ros/genmsg/issues/56>, #57 <https://github.com/ros/genmsg/issues/57>)
```
