### PR TITLE
catkin: 0.7.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -21,7 +21,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.0-1
+      version: 0.7.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.0-2`:
- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.0-1`
## catkin

```
* remove CPATH from setup files (#783 <https://github.com/ros/catkin/issues/783>)
* use NO_MODULE to find exported catkin dependencies (#760 <https://github.com/ros/catkin/issues/760>)
```
