### PR TITLE
marti_messages: 0.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2124,7 +2124,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_messages-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `0.0.2-0`:
- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.1-0`
## marti_can_msgs
- No changes
## marti_common_msgs

```
* Adds a KeyValue message. KeyValue stores a pair of Strings for a map-like
  data structure.
* Adds a stamped byte array
* Contributors: Elliot Johnson, Jerry Towler
```
## marti_nav_msgs

```
* Adds Route, RoutePoint, and RoutePosition messages
  Route and RoutePoint are very general messages to define a sequence of
  achievable poses for a vehicle along with arbitrary metadata about the
  route and the point itself.
* Contributors: Jerry Towler
```
## marti_perception_msgs
- No changes
## marti_sensor_msgs
- No changes
## marti_visualization_msgs

```
* Adds documentation to the textured marker message.
* Contributors: Marc Alban
```
