### PR TITLE
pugixml: 1.7.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7591,7 +7591,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/joselusl/pugixml.git
-      version: 1.7.1
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -7600,7 +7600,7 @@ repositories:
     source:
       type: git
       url: https://github.com/joselusl/pugixml.git
-      version: 1.7.1
+      version: master
     status: developed
   puma_motor_driver:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7587,6 +7587,21 @@ repositories:
       url: https://github.com/ros-drivers/prosilica_gige_sdk.git
       version: hydro-devel
     status: maintained
+  pugixml:
+    doc:
+      type: git
+      url: https://github.com/joselusl/pugixml.git
+      version: 1.7.1
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/joselusl/pugixml-release.git
+      version: 1.7.1-0
+    source:
+      type: git
+      url: https://github.com/joselusl/pugixml.git
+      version: 1.7.1
+    status: developed
   puma_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pugixml` to `1.7.1-0`:
- upstream repository: https://github.com/joselusl/pugixml.git
- release repository: https://github.com/joselusl/pugixml-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## pugixml

```
* updating license and readme
* adding compatibility without ROS
* minor info update. Still need to be updated properly
* upgraded to version 1.7 of pugixml and changed the name
* readme
* first commit
* Contributors: Jose Luis Sanchez Lopez, joselusl
```
