### PR TITLE
fetch_ros: 0.7.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2350,7 +2350,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
-      version: 0.7.2-0
+      version: 0.7.3-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.7.3-0`:
- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.2-0`
## fetch_calibration
- No changes
## fetch_depth_layer
- No changes
## fetch_description
- No changes
## fetch_maps

```
* 3_1_16 new map
* Contributors: Aaron Blasdel
```
## fetch_moveit_config
- No changes
## fetch_navigation

```
* Update to new maps
* Contributors: Aaron Blasdel
```
## fetch_teleop
- No changes
