### PR TITLE
pugixml: 1.7.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3539,6 +3539,21 @@ repositories:
       url: https://github.com/pr2/pr2_mechanism_msgs.git
       version: master
     status: maintained
+  pugixml:
+    doc:
+      type: git
+      url: https://github.com/joselusl/pugixml.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/joselusl/pugixml-release.git
+      version: 1.7.1-0
+    source:
+      type: git
+      url: https://github.com/joselusl/pugixml.git
+      version: master
+    status: developed
   python_ethernet_rmp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pugixml` to `1.7.1-0`:
- upstream repository: https://github.com/joselusl/pugixml.git
- release repository: https://github.com/joselusl/pugixml-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## pugixml

```
* updating license and readme
* adding compatibility without ROS
* minor info update. Still need to be updated properly
* upgraded to version 1.7 of pugixml and changed the name
* readme
* first commit
* Contributors: Jose Luis Sanchez Lopez, joselusl
```
