### PR TITLE
geometric_shapes: 0.4.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1110,7 +1110,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.4.3-0
+      version: 0.4.4-0
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.4.4-0`:
- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.4.3-0`
## geometric_shapes

```
* Merge pull request #37 <https://github.com/ros-planning/geometric_shapes/issues/37> from corot/indigo-devel
  Fix issue #28 <https://github.com/ros-planning/geometric_shapes/issues/28> on small radius cylinders
* Contributors: Dave Coleman, Jorge Santos Simon
```
