### PR TITLE
jsk_apc: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3863,6 +3863,22 @@ repositories:
       url: https://github.com/tork-a/jsk_3rdparty-release.git
       version: 2.0.13-0
     status: developed
+  jsk_apc:
+    release:
+      packages:
+      - jsk_2015_05_baxter_apc
+      - jsk_2016_01_baxter_apc
+      - jsk_apc
+      - jsk_apc2015_common
+      - jsk_apc2016_common
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/jsk_apc-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/start-jsk/jsk_apc.git
+      version: master
   jsk_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_apc` to `0.2.0-0`:
- upstream repository: https://github.com/start-jsk/jsk_apc.git
- release repository: https://github.com/tork-a/jsk_apc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## jsk_2015_05_baxter_apc

```
* Update APC 2015 for Advanced Robtoics Paper

    * Update rvizconfig for segmentation in bin
    * Update README for pick-and-verify
    * Know gripper status in control
    * Does not generate json when exists
    * Update json file with more jsons
    * Use verify-object for if grasped with point cloud
    * More jsons for pick-and-verify experiments
    * Add json files for 2016_ar
    * Fix number of trials
    * Abondont oreo
    * Update layout1
    * Update rviz config
    * Improve pick for vertical objects
    * Abondon difficult objects
    * Fix return traj speed
    * Improve picking motion
    * Large queue size
    * Use machine
    * Launch kinect2 on setup
    * Rename setup files
    * Larger queue_size
    * Swap kinect2
    * Improve return motion
    * Add limit
    * Update eps
    * Initialize tolerance
    * Stop grasp if needed
    * Remove wall picking avoidance
    * Revert avoid shelf pose
    * Euclid k cluster in main.launch
    * Fix pick-object for grasped
    * Unregister in euclid_k_clustering
    * Add catkin_INCLUDE_DIRS for std_msgs/Bool.h
    * Disable test for recognition
    * Fix roslaunch args for recognition test
    * Pass manager as argument
    * Pass manager as argument for torso
    * Update segmentation in bin gtol
    * Add layout1.json
    * Stop grasp unless grasped in bin
    * Update rviz
    * Update kinect2_head tf
    * Stable euclid k clustering
    * Detect object in bin with size feature
    * Clear params for euclid clustering
    * Stat object sizes
    * Approach to center of mass
    * EuclidKClustering with number of objects in bin
    * Use kinect2_torso for verification
    * Faster verify picked-object with pick-and-verify
    * Each view hand pose
    * In-hand object recognition with kinect2_torso
    * Input image argument for recognition_in_hand
    * Update kinect2_torso_rgb_optical_frame tf
    * More queue_size in extract_indices for bin
    * Update how to launch gazebo for APC2015

* Update for real demo on Jan 2016
  * Upgrade baxter_simulator 0.9.0 -> 0.9.1.1
  * Add gazebo vacuum gripper plugin
  * Add movie of real demo
  * Documentation how to run demo on real and sim world
  * Update demo_1.json
  * Do not verify_object unless grasping objects
  * Update real_demo.rviz
  * Remove no need tmp baxter_common version specification
  * Add README for jsk_2015_05_baxter_apc
  * Use jsk_recognition_msgs/ClassificationResult for color_hist
  * Fix wait-for-opposite-arm
  * Add sample of picking with clustering points
  * Update color_histogram object recognition for multi regions
  * Use boost_object_recognition in object_recognition
  * Update boost object recognition as transport
  * Fix color_object_matcher as transport
  * Boost object recognition
  * [jsk_2015_05_baxter_apc] Add place-object methodModified:
  - jsk_2015_05_baxter_apc/euslisp/jsk_2015_05_baxter_apc/baxter-interface.l

    * Launch visualize_json.py
    * Add queue_size option for recognitions
    * Update demo_1.json
    * Add option of queue_size
    * Update demo-1 json
    * Add INPUT_DEPTH arg for torso kinect2
    * Update tf of kinect2 torso
    * Fix opencl error on kinect2 head
    * Rename function name object_list -> get_object_list
    * Add demo_1.json
      Added:
      - jsk_2015_05_baxter_apc/json/demo_1.json
    * Respawn object recognition nodes
      Modified:
      - jsk_2015_05_baxter_apc/launch/include/object_recognition.launch
    * Longer spin off for object grasped
      Modified:
      - jsk_2015_05_baxter_apc/euslisp/jsk_2015_05_baxter_apc/baxter-interface.l
      - jsk_2015_05_baxter_apc/euslisp/main.l
    * Add picking method with solidity rag merging and its example
    * Launch solidity_rag_merge for grasp planning with vacuum gripper
    * Update kinect2_head position on 2016-01-27
    * Update self filter padding
    * Remove kiva_pod joint_states
    * Update kinect2_torso tf
    * Add in_bin_vision.launch
    * Update ik to bin
    * Faster verify pose
    * [jsk_2015_05_baxter_apc] Do not depends on mahotas
    * [jsk_2015_05_baxter_apc] Extract the cached test_data
    * [jsk_2015_05_baxter_apc] Fix broken topic names
    * [jsk_2015_05_baxter_apc] Test time-limit 60 -> 360
    * [jsk_2015_05_baxter_apc] Add jsk_tools as test_depend
    * [jsk_2015_05_baxter_apc] Use cached test_data
    * [jsk_2015_05_baxter_apc] Use bof_object_matcher in jsk_perception
    * [jsk_2015_05_baxter_apc] Real demo rviz config
    * Add retry 3 for recognition test by BOF
    * Update gazebo_demo.rviz
    * Add fold/reset/untuck pose script
    * Add FIXME
    * Minor change of apc_gazebo world
    * Update rviz config for gazebo demo
    * Fix typo
    * Add rviz config for gazebo
    * Add visualization script on rviz
    * Put objects in all bins
    * [jsk_2015_05_baxter_apc] Add order-bin and stage to the world
    * [jsk_2015_05_baxter_apc] Add paper mate
    * Remove no need static
    * [jsk_2015_05_baxter_apc] Fixed end effector and baxter base
    * Fix eus for gazebo
    * [jsk_2015_05_baxter_apc] Move interactive_marker config
    * [jsk_2015_05_baxter_apc] Fix transform world to base invalid arg
    * [jsk_2015_05_baxter_apc] Set camera_name
    * Adjust kinect
    * [jsk_2015_05_baxter_apc] Put kiva correct place and safety glass also
    * [jsk_2015_05_baxter_apc] Fix typo
    * Add left state publisher
    * Set /apc_on_gazebo param
    * [jsk_2015_05_baxter_apc] Rename to baxter_sim.launch
    * [jsk_2015_05_baxter_apc] Add gazebo mode vacuum gripper
    * Update test_data
    * [jsk_2015_05_baxter_apc] Refactr urdf files
    * [jsk_2015_05_baxter_apc] Add fold-pose-back.l
    * [jsk_2015_05_baxter_apc] Add right_end_effector and vacuum_gripper
    * Recognize bins at first
    * Adjust kiva pos
    * Enhance picking
    * Fix bbox x, z comparison
    * Recognize bins at first
    * Adjust kiva pos
    * Enhance picking
    * Fix bbox x, z comparison
    * [jsk_2015_05_baxter_apc] Pass timestamp to recognition method
    * [jsk_2015_05_baxter_apc] Adjust place-object-pose
    * [jsk_2015_05_baxter_apc] Adjust place-object-pose
    * Use robot_self_filter package
    * [jsk_2015_05_baxter_apc] Remove approximate_sync (no need)
      This is no need with change in
      PR2/pr2_navigation/pr2_navigation_self_filter
      Related to https://github.com/PR2/pr2_navigation/pull/24

* Recognition in bin for APC2015
  * [jsk_2015_05_baxter_apc] Run main as script
  * [jsk_2015_05_baxter_apc] Add script to move arm and do verify pose
  * Add timeout
  * Add mahotas as run_depend
  * Remove duplicate rostest declaration
  * Add gdown as run_depend
  * Run depends on imagesift
  * [jsk_2015_05_baxter_apc] Run test actually
  * [jsk_2015_05_baxter_apc] Make color_object_matcher as transport
  * [jsk_2015_05_baxter_apc] Test recognitioin in hand
  * Rename scripts -> node_scripts
  * [jsk_2015_05_baxter_apc] Update kinect2_torso tf
  * [jsk_2015_05_baxter_apc] fix approach to object
  * [jsk_2015_05_baxter_apc] Fix return object avoid shelf
  * [jsk_2015_05_baxter_apc] Fix typo
  * [jsk_2015_05_baxter_apc] Custom baxter urdf for gazebo world
  * jsk_2015_apc_common -> jsk_apc2015_common
  * Add catkin_lint
  * [jsk_2015_05_baxter_apc] Fix return height
  * [jsk_2015_05_baxter_apc] Work :try-to-pick
  * [jsk_2015_05_baxter_apc] Go to wait after all orders
  * [jsk_2015_05_baxter_apc] Add doura.launch
  * [jsk_2015_05_baxter_apc] Update segmentation_in_bin.rviz
  * [jsk_2015_05_baxter_apc] Remove self filter from baxter.launch
  * [jsk_2015_05_baxter_apc] Make faster localization in handuse self_filter in bottom

    * [jsk_2015_05_baxter_apc] Specify max_depth in kinect2_bridge.launch
      Remove points_reachable
    * Revert "[jsk_2015_05_baxter_apc] filter by x"
      This reverts commit 590ad8d96b56a72ba47eb5bd1864b51657ff56df.
    * [jsk_2015_05_baxter_apc] Visualize objects and bins
    * [jsk_2015_05_baxter_apc] Fix :get-next-order
    * [jsk_2015_05_baxter_apc] filter by x
    * [jsk_2015_05_baxter_apc] Split segmentation in bin for atof and gtol
    * [jsk_2015_05_baxter_apc] Add kiva_pod_state.launch
    * [jsk_2015_05_baxter_apc] See same package config dir
    * [jsk_2015_05_baxter_apc] Add rvizconfig to adjust kiva pod
    * [jsk_2015_05_baxter_apc] Update box position for g to l
    * [jsk_2015_05_baxter_apc] Segmentation for A to F
    * [jsk_2015_05_baxter_apc] 1.2 passthrough z
    * [jsk_2015_05_baxter_apc] Use self_filtered points
    * [jsk_2015_05_baxter_apc] min_size 200 -> 500
    * [jsk_2015_05_baxter_apc] Initialize param in main.launch
    * [jsk_2015_05_baxter_apc] Stop using kiva_pod_filter
    * [jsk_2015_05_baxter_apc] Fix verify-object
    * [jsk_2015_05_baxter_apc] Remove timeout in recognize-object-in-hand
    * [jsk_2015_05_baxter_apc] pick wall near object
    * [jsk_2015_05_baxter_apc] stop-grasp to place
    * [jsk_2015_05_baxter_apc] middle is right work
    * [jsk_2015_05_baxter_apc] left_process -> left_hand
    * [jsk_2015_05_baxter_apc] typo
    * [jsk_2015_05_baxter_apc] typo
    * [jsk_2015_05_baxter_apc] typo
    * [jsk_2015_05_baxter_apc] Fix typo
    * [jsk_2015_05_baxter_apc] namespace change
    * [jsk_2015_05_baxter_apc] Add :try-to-pick-in-bin
    * [jsk_2015_05_baxter_apc] Add :try-to-pick-object
    * [jsk_2015_05_baxter_apc] Archive test file
    * [jsk_2015_05_baxter_apc] Archive test file
    * [jsk_2015_05_baxter_apc] Archive test file
    * [jsk_2015_05_baxter_apc] Fix main params
    * [jsk_2015_05_baxter_apc] z direction pick object
    * [jsk_2015_05_baxter_apc] Stop using one-shot-publish
    * [jsk_2015_05_baxter_apc] Fix include path
    * [jsk_2015_05_baxter_apc] Fix tf-transform
    * [jsk_2015_05_baxter_apc] :recognize-object-in-bin topic change
    * [jsk_2015_05_baxter_apc] :recognize-bin-boxes topic change
    * [jsk_2015_05_baxter_apc] Update setup.launch for latest software
    * [jsk_2015_05_baxter_apc] Refactor baxter.launch
    * [jsk_2015_05_baxter_apc] Add segmentation_in_bin.launch
    * [jsk_2015_05_baxter_apc] Remove object_segmentation.launch
    * [jsk_2015_05_baxter_apc] Add segmentation_in_hand.launch
    * [jsk_2015_05_baxter_apc] Move deprecated launch files
    * [jsk_2015_05_baxter_apc] Move meshes location
    * [jsk_2015_05_baxter_apc] Remove upload_baxter.launch
    * [jsk_2015_05_baxter_apc] Launch vacuum_gripper in baxter.launch
    * [jsk_2015_05_baxter_apc] Rename to vacuum_gripper.launch
    * [jsk_2015_05_baxter_apc] Add self_filter.launch
    * [jsk_2015_05_baxter_apc] Filter reachable clouds
    * [jsk_2015_05_baxter_apc] Remove base_footprint
    * [jsk_2015_05_baxter_apc] Add jsk_rqt_plugins to run_depend
    * [jsk_2015_05_baxter_apc] Archive motion codes
    * [jsk_2015_05_baxter_apc] Archive setup_params.py
    * [jsk_2015_05_baxter_apc] Refactor mainloop
    * [jsk_2015_05_baxter_apc] Remove speak-en
    * [jsk_2015_05_baxter_apc] Use one-shot-subscribe to get bin_contents
    * [jsk_2015_05_baxter_apc] Use one-shot-subscribe in :get-work-orders
    * [jsk_2015_05_baxter_apc] Use one-shot-subscribe in recognize-objects-in-bin
    * [jsk_2015_05_baxter_apc] arm-symbol-to-str -> arm-symbol2str
    * [jsk_2015_05_baxter_apc] Use one-shot-publish to control gripper
    * [jsk_2015_05_baxter_apc] Add _ prefix for slots
    * [jsk_2015_05_baxter_apc] Use one-shot-subscribe for recognize-bin-boxes
    * [jsk_2015_05_baxter_apc] Add get-a-work-order
    * [jsk_2015_05_baxter_apc] Add :wait-for-user-input-to-start
    * [jsk_2015_05_baxter_apc] symbol2str, str2symbol
    * [jsk_2015_05_baxter_apc] Add :get-target-bin
    * [jsk_2015_05_baxter_apc] kinect2 -> kinect2_head
    * [jsk_2015_05_baxter_apc] Add concatenate_clouds.launch
    * [jsk_2015_05_baxter_apc] Remove kinect2_tf.launch
    * [jsk_2015_05_baxter_apc] Archive robot-recognition.l
    * [jsk_2015_05_baxter_apc] Methodize real-sim-end-coords-diff
    * [jsk_2015_05_baxter_apc] Rename robot-main.l -> main.l
    * [jsk_2015_05_baxter_apc] Methodize graspingp
    * [jsk_2015_05_baxter_apc] Methodize verify-object
    * [jsk_2015_05_baxter_apc] Remove robot-init.l
    * [jsk_2015_05_baxter_apc] Remove utils.l and robot-utils.l
    * [jsk_2015_05_baxter_apc] Adjust kinect2_head tf
    * Add object_segmentation.launch
    * Update kinect2 torso tf
    * Use cpu for kinect2 torso
    * [jsk_2015_05_baxter_apc] Add roslaunch for kinect2_head
    * arg default -> value
    * [jsk_2015_05_baxter_apc] Add iai_kinect2 in rosinstall
    * [jsk_2015_05_baxter_apc] roslaunch for kinect2_torso
      Closes #907 <https://github.com/start-jsk/jsk_apc/issues/907>
      Closes #909 <https://github.com/start-jsk/jsk_apc/issues/909>
    * [jsk_2015_05_baxter_apc] Error catch when object cloud is not found
    * [jsk_2015_05_baxter_apc] Fix test for new *ri* :pick-object
    * [jsk_2015_05_baxter_apc] Add pick-object method
    * Flexible env var for APC shelf model for Gazebo
    * Pick object from object :z axis
    * Improve ik for bin entrance
    * [jsk_2015_05_baxter_apc] Remove robot-input
    * Add :avoid-shelf-pose to avoid shelf collision
    * Add :arm-symbol-to-str
    * (:ik-avs->object-in-bin) to pick object
    * Recognize bin boxes once and memorize these position
    * Refactor: Remove baxter :locate from robot-init
    * bin-entrance is half of dim-x distance from the center
    * [jsk_2015_05_baxter_apc] Remove update-score
    * [jsk_2015_05_baxter_apc] Remove robot-communication.l
    * [jsk_2015_05_baxter_apc] Remove (return-object)
    * Refactor: Remove orderbin
    * Refactor: Remove visualization lines
    * Refactor: Remove *tfb*
    * (move-for-verification) -> (send *ri* :move-arm-body->head-view-point)
    * [jsk_2015_05_baxter_apc] remove (look-at-other-side)
    * [jsk_2015_05_baxter_apc] remove (look-at-other-side)
    * [jsk_2015_05_baxter_apc] Remove (rotate-wrist)
    * (place-object) -> (send *ri* :move-arm-body->order-bin)
    * (send *ri* :move-to-bin) -> (send *ri* :move-arm-body->bin)
    * [jsk_2015_05_baxter_apc] Use :hard-coded-pose method
    * [jsk_2015_05_baxter_apc] Use :l/r-reverse
    * [jsk_2015_05_baxter_apc] Add .gitignore to test dir
    * [jsk_2015_05_baxter_apc] Add TODO for baxter location
    * [jsk_2015_05_baxter_apc] Download rosbag and make the test passes
    * [jsk_2015_05_baxter_apc] Remove :untuck-pose
    * [jsk_2015_05_baxter_apc] Fix bin-box using copy-object
    * [jsk_2015_05_baxter_apc] Remove move-to-target-bin function
    * [jsk_2015_05_baxter_apc] Remove position decision tool
    * [jsk_2015_05_baxter_apc] Complete :move-to-bin method
    * [jsk_2015_05_baxter_apc] Remove untuck-pose
    * [jsk_2015_05_baxter_apc] Remove fold-to-keep-object-av
    * [jsk_2015_05_baxter_apc] (load "..") -> (require "..")
    * [jsk_2015_05_baxter_apc] Refactor: (apc-init)
    * [jsk_2015_05_baxter_apc] Refactor: remove (fold-pose-back)
    * [jsk_2015_05_baxter_apc] Remove fold-pose-* functions
    * [jsk_2015_05_baxter_apc] Add :fold-pose-* methods
    * [jsk_2015_05_baxter_apc] fix path and name changed class
    * [jsk_2015_05_baxter_apc] Add subclasses
    * [jsk_2015_05_baxter_apc] robot-interface.l -> baxter-interface.l
    * [jsk_2015_05_baxter_apc] Add baxter-interface.l
    * [jsk_2015_05_baxter_apc] move model
    * [jsk_2015_05_baxter_apc] Move rosinstall to package dir
    * [jsk_2015_05_baxter_apc] run_depend jsk_pcl_ros
    * [jsk_2015_05_baxter_apc] Use jsk_2015_apc_common.data:object_list
    * Move mesh files jsk_2015_05_baxter_apc -> jsk_2015_apc_common
    * Adjust kinect2 tf and baxter custom link after calibration of kinect2
    * Publish tf's at launch of baxter.launch
    * Rename pkg: jsk_2014_picking_challenge -> jsk_2015_05_baxter_apc

* Contributors: Isaac IY Saito, Kentaro Wada
```
## jsk_2016_01_baxter_apc

```
* Try APC2016 with program for APC2015
  * Json file for picking: Layout1
  * Add Shared files for jsk_2016_01_baxter_apcModified:
  - jsk_2016_01_baxter_apc/README.md
* Semi for 2015B4
  * apc_pick modified
  * json files for simulation added
  * documentation added
  * add interface_generator
  * [2016 apc] rename launch file
  * change baxter software version
  * rm json file
  * stow recognition modified
  * [2016apc] modify stow recognition launch file
  * [2016apc] modify viz-recog.l and add json
  * [2016apc] add stow recognition launch
  * [2016apc] add visualize program for recognition
  * Add kinect2_external
  * [2016 apc] modify stow_kiva.world.erb for stow tasks
  * add initial camera position
  * add kiva_stow and baxter_stow
  * add ruby to build depend for erb
  * add jsk_2016_01_baxter_apc
* Contributors: Heecheol Kim, Kei Okada, Kentaro Wada, Shingo Kitagawa, Masahiro Bando
```
## jsk_apc

```
* jsk_2015_apc_common -> jsk_apc2015_common
* [jsk_apc] Add jsk_2015_apc_common to run_depend
* [jsk_apc] Add Metapackage
* Contributors: Kentaro Wada
```
## jsk_apc2015_common

```
* Fix for APC2016
  * Dynamic visualization for given number of bin_contentsModified:
  - jsk_apc2015_common/src/jsk_apc2015_common/__init__.py
* Fix for ONEDO 2015 December
  * Visualize bin_contents and work_order with jsonModified:
  - jsk_apc2015_common/src/jsk_apc2015_common/__init__.py
  Added:
  - jsk_apc2015_common/node_scripts/visualize_json.py
  - jsk_apc2015_common/src/jsk_apc2015_common/util.py

    * Use RosPack for data file
    * Rename function name object_list -> get_object_list
    * [jsk_apc2015_common] Add object image files
      Added:
      - jsk_apc2015_common/models/champion_copper_plus_spark_plug/image.jpg
      - jsk_apc2015_common/models/cheezit_big_original/image.jpg
      - jsk_apc2015_common/models/crayola_64_ct/image.jpg
      - jsk_apc2015_common/models/dr_browns_bottle_brush/image.jpg
      - jsk_apc2015_common/models/elmers_washable_no_run_school_glue/image.jpg
      - jsk_apc2015_common/models/expo_dry_erase_board_eraser/image.jpg
      - jsk_apc2015_common/models/feline_greenies_dental_treats/image.jpg
      - jsk_apc2015_common/models/first_years_take_and_toss_straw_cup/image.jpg
      - jsk_apc2015_common/models/genuine_joe_plastic_stir_sticks/image.jpg
      - jsk_apc2015_common/models/highland_6539_self_stick_notes/image.jpg
      - jsk_apc2015_common/models/kiva_pod/image.jpg
      - jsk_apc2015_common/models/kong_air_dog_squeakair_tennis_ball/image.jpg
      - jsk_apc2015_common/models/kong_duck_dog_toy/image.jpg
      - jsk_apc2015_common/models/kong_sitting_frog_dog_toy/image.jpg
      - jsk_apc2015_common/models/kyjen_squeakin_eggs_plush_puppies/image.jpg
      - jsk_apc2015_common/models/laugh_out_loud_joke_book/image.jpg
      - jsk_apc2015_common/models/mark_twain_huckleberry_finn/image.jpg
      - jsk_apc2015_common/models/mead_index_cards/image.jpg
      - jsk_apc2015_common/models/mommys_helper_outlet_plugs/image.jpg
      - jsk_apc2015_common/models/munchkin_white_hot_duck_bath_toy/image.jpg
      - jsk_apc2015_common/models/oreo_mega_stuf/image.jpg
      - jsk_apc2015_common/models/paper_mate_12_count_mirado_black_warrior/image.jpg
      - jsk_apc2015_common/models/rolodex_jumbo_pencil_cup/image.jpg
      - jsk_apc2015_common/models/safety_works_safety_glasses/image.jpg
      - jsk_apc2015_common/models/sharpie_accent_tank_style_highlighters/image.jpg
      - jsk_apc2015_common/models/stanley_66_052/image.jpg
    * Fix collision of apc_order_bin model
    * Add black stage
    * [jsk_apc2015_common] Add apc order bin
    * Add f2.json
    * [jsk_2015_05_baxter_apc] Light mass param
    * less slippely
    * [jsk_apc2015_common] Fix texture png name for mesh models
    * [jsk_apc2015_common] Lighter objects
    * [jsk_apc2015_common] Test jsk_apc2015_common python package
    * [jsk_apc2015_common] Refactor python package
    * [jsk_apc2015_common] Rename to a.json
    * [jsk_apc2015_common] F2 G1 json
    * jsk_2015_apc_common -> jsk_apc2015_common
    * Add catkin_lint
    * [jsk_2015_apc_common] Add credit for gazebo models
    * [jsk_2015_apc_common] Add gazebo model files
    * [jsk_2015_apc_common] Adjust kiva pod
    * [jsk_2015_apc_common] Update json
    * [jsk_2015_05_baxter_apc] Fix main params
    * [jsk_2015_apc_common] Adjust kiva_pod_interactive_marker
    * [jsk_2015_05_baxter_apc] Remove object_segmentation.launch
    * [jsk_2015_apc_common] Update in_bin_each_object.launch
    * [jsk_2015_apc_common] Update in_bin_atof.launch
    * [jsk_2015_apc_common] Update in_bin_atof.launch
    * [jsk_2015_apc_common] Update in_kiva_pod.launch
    * [jsk_2015_apc_common] Add kiva_pod_filter
    * [jsk_2015_apc_common] Adjust kiva_pod
    * [jsk_2015_apc_common] Add install scripts for data
    * [jsk_2015_apc_common] Rename download script
    * [jsk_2015_apc_common] Add bof object recognition test script
    * [jsk_2015_apc_common] Create trained_data/ and dataset/
    * Add option -O create_mask_applied_dataset.py
    * Add download script and README
    * Add script to create mask applied dataset
    * Add arg in roslaunch files
    * [jsk_2015_apc_common] Keep vision timestamp even if transformed
    * [jsk_2015_apc_common] Increase max_size for object cloud
    * [jsk_2015_apc_common] Fix model path for kiva_pod_filter
    * [jsk_2015_apc_common] gazebo_ros to pass models path to gazebo
    * [jsk_2015_apc_common] kiva_pod -> models/kiva_pod
    * [jsk_2015_apc_common] Move kiva_pod to models dir
    * Revert "[jsk_2015_apc_common] Move kiva_pod model files to urdf/ & meshes/"
      This reverts commit 91a818229d2b6e9faa66912bbbef7370941d30f5.
    * [jsk_2015_apc_common] Move kiva_pod model files to urdf/ & meshes/
    * [jsk_2015_apc_common] keep_organized for each cloud in bin
    * [jsk_2015_apc_common] Change launch syntax arg should be capital
    * [jsk_2015_apc_common] Object clouds in each bin
    * [jsk_2015_apc_common] Add object_segmentation.launch
    * [jsk_2015_apc_common] Segmentation of objects in bin_a
    * [jsk_2015_apc_common] stop creating manager in_bin_atof.launch
    * [jsk_2015_apc_common] Create root topics
    * [jsk_2015_apc_common] Extract pc in each a-f bin
    * [jsk_2015_apc_common] Some ns change of in_kiva_pod.launch
    * [jsk_2015_apc_common] Remap to output
    * [jsk_2015_apc_common] Clip clouds in kiva pod
    * [jsk_2015_apc_common] Add jsk_demo_common as run_depend
    * [jsk_2015_apc_common] Filter kiva pod pointcloud
    * [jsk_2015_apc_common] Add kiva_pod urdf model
    * [jsk_2015_apc_common] Add kiva_pod model
    * [jsk_2015_apc_common] Add python package
    * Move mesh files jsk_2015_05_baxter_apc -> jsk_2015_apc_common
    * Add jsk_2015_apc_common for common programs

* Contributors: Kentaro Wada
```
## jsk_apc2016_common

```
* Initialize common package for APC2016
  * Fix version number of jsk_apc2016_common
  * Add object data for APC2016
* Contributors: Kentaro Wada
```
