### PR TITLE
jsk_apc: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3863,6 +3863,19 @@ repositories:
       url: https://github.com/tork-a/jsk_3rdparty-release.git
       version: 2.0.13-0
     status: developed
+  jsk_apc:
+    release:
+      packages:
+      - jsk_2015_05_baxter_apc
+      - jsk_2016_01_baxter_apc
+      - jsk_apc
+      - jsk_apc2015_common
+      - jsk_apc2016_common
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/jsk_apc-release.git
+      version: 0.2.2-0
+    status: developed
   jsk_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_apc` to `0.2.2-0`:
- upstream repository: https://github.com/start-jsk/jsk_apc.git
- release repository: https://github.com/tork-a/jsk_apc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## jsk_2015_05_baxter_apc

```
* fix gmail for iory and wkentaro
* Contributors: Kei Okada
```
## jsk_2016_01_baxter_apc
- No changes
## jsk_apc

```
* fix gmail for iory and wkentaro
* Contributors: Kei Okada
```
## jsk_apc2015_common

```
* fix gmail for iory and wkentaro
* Contributors: Kei Okada
```
## jsk_apc2016_common

```
* fix gmail for iory and wkentaro
* Contributors: Kei Okada
```
