### PR TITLE
graspit_tools: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2815,7 +2815,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/JenniferBuehler/graspit-pkgs-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/JenniferBuehler/graspit-pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graspit_tools` to `0.1.3-0`:
- upstream repository: https://github.com/JenniferBuehler/graspit-pkgs.git
- release repository: https://github.com/JenniferBuehler/graspit-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.2-0`
## grasp_planning_graspit

```
* changed catkin_package system depends to names in rosdep
* Adapted cmake file to for jenkins, and removed c++11 flag, which required fixing two little things in sources
* Contributors: Jennifer Buehler
```
## grasp_planning_graspit_msgs
- No changes
## grasp_planning_graspit_ros

```
* added launch directory installs
* Adapted cmake file to for jenkins, and removed c++11 flag, which required fixing two little things in sources
* Contributors: Jennifer Buehler
```
## graspit_tools
- No changes
## jaco_graspit_sample

```
* added launch directory installs
* Contributors: Jennifer Buehler
```
## urdf2graspit

```
* changed catkin_package system depends to names in rosdep
* added launch directory installs
* Contributors: Jennifer Buehler
```
