### PR TITLE
rqt_robot_plugins: 0.4.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4619,7 +4619,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-      version: 0.4.2-0
+      version: 0.4.3-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins` to `0.4.3-0`:
- upstream repository: https://github.com/ros-visualization/rqt_robot_plugins.git
- release repository: https://github.com/ros-gbp/rqt_robot_plugins-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.4.2-0`
## rqt_moveit
- No changes
## rqt_nav_view
- No changes
## rqt_pose_view
- No changes
## rqt_robot_dashboard

```
* In case where unequal length icon lists were supplied, created
  placeholder did not match spec of list of lists of strings, and caused
  subsequent conditional to fail.
* put topic diagnostic_agg into a global namespace
* Contributors: Eric Relson, Karsten Knese
```
## rqt_robot_monitor
- No changes
## rqt_robot_plugins
- No changes
## rqt_robot_steering
- No changes
## rqt_runtime_monitor

```
* STALE is defined for indigo and later
* Contributors: Michael Ferguson
```
## rqt_rviz

```
* disable ogre-log by default, add command line option to enable it (fix #95 <https://github.com/ros-visualization/rqt_robot_plugins/issues/95>)
* Contributors: Dirk Thomas
```
## rqt_tf_tree

```
* use proper icon for images
* Contributors: Vincent Rabaud
```
