### PR TITLE
ubiquity_motor: 0.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11082,11 +11082,15 @@ repositories:
       version: 0.2.1-0
     status: developed
   ubiquity_motor:
+    doc:
+      type: git
+      url: https://github.com/UbiquityRobotics/ubiquity_motor.git
+      version: 0.4.0
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
-      version: 0.3.2-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/ubiquity_motor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ubiquity_motor` to `0.4.0-0`:
- upstream repository: https://github.com/UbiquityRobotics/ubiquity_motor.git
- release repository: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.3.2-0`
## ubiquity_motor

```
* Cleanup deps, have motor_node be linked to shared lib
* Update Copyright Dates
* Removed old motor_unit_test
* Moved motor_message_test
* Make the serial thread loop at the passed in value instead of always 1000
* Add interruption point to Serial Thread
* Comment out serial tests
* Added motor_serial_tests
* Always print firmware version
* fix up code that checks a firmware version response
* Using Async Spinner instead of roscontrol thread
* more command grouping
* reduced unnecessary output locking
  using bool method like tony did with input
* reduce locking by grouping commands to send together
* Contributors: Rohan Agrawal
```
