### PR TITLE
im_msgs: 0.0.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -3386,6 +3386,21 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rdc/icart_mini.git
+      version: indigo-devel
+    status: developed
+  im_msgs:
+    doc:
+      type: git
+      url: https://github.com/inomuh/im_msgs.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/inomuh/im_msgs-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/inomuh/im_msgs.git
       version: indigo-devel
     status: developed
   image_common:


### PR DESCRIPTION
Increasing version of package(s) in repository `im_msgs` to `0.0.2-1`:
- upstream repository: https://github.com/inomuh/im_msgs
- release repository: https://github.com/inomuh/im_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## im_msgs

```
* add new msg type im_msgs::WheelVel
* add service and messages
* add service and messages
* 0.0.1
* first commit
* Contributors: Mehmet Akcakoca
```
