### PR TITLE
genpy: 0.5.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -44,5 +44,20 @@ repositories:
       url: https://github.com/ros/genmsg.git
       version: indigo-devel
     status: maintained
+  genpy:
+    doc:
+      type: git
+      url: https://github.com/ros/genpy.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/genpy-release.git
+      version: 0.5.8-0
+    source:
+      type: git
+      url: https://github.com/ros/genpy.git
+      version: indigo-devel
+    status: maintained
 type: distribution
 version: 2

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -55,6 +55,7 @@ repositories:
       url: https://github.com/ros-gbp/genpy-release.git
       version: 0.5.8-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/genpy.git
       version: indigo-devel


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.5.8-0`:
- upstream repository: git@github.com:ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## genpy

```
* right align nsec fields of timestamps (#45 <https://github.com/ros/genpy/issues/45>)
* fix order of imports in generated init files deterministic (#44 <https://github.com/ros/genpy/issues/44>)
* fix exception handling code using undefined variable (#42 <https://github.com/ros/genpy/issues/42>)
* add test for expected exception when serializing wrong type
```
