### PR TITLE
genpy: 0.5.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1075,7 +1075,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.5.7-0
+      version: 0.5.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.5.8-0`:
- upstream repository: git@github.com:ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.5.7-0`
## genpy

```
* right align nsec fields of timestamps (#45 <https://github.com/ros/genpy/issues/45>)
* fix order of imports in generated init files deterministic (#44 <https://github.com/ros/genpy/issues/44>)
* fix exception handling code using undefined variable (#42 <https://github.com/ros/genpy/issues/42>)
* add test for expected exception when serializing wrong type
```
