### PR TITLE
roscpp_core: 0.5.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -90,5 +90,26 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: indigo-devel
     status: maintained
+  roscpp_core:
+    doc:
+      type: git
+      url: https://github.com/ros/roscpp_core.git
+      version: indigo-devel
+    release:
+      packages:
+      - cpp_common
+      - roscpp_core
+      - roscpp_serialization
+      - roscpp_traits
+      - rostime
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/roscpp_core-release.git
+      version: 0.5.7-0
+    source:
+      type: git
+      url: https://github.com/ros/roscpp_core.git
+      version: indigo-devel
+    status: maintained
 type: distribution
 version: 2

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -107,6 +107,7 @@ repositories:
       url: https://github.com/ros-gbp/roscpp_core-release.git
       version: 0.5.7-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/roscpp_core.git
       version: indigo-devel


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.5.7-0`:
- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## cpp_common

```
* export symbols for Header (#46 <https://github.com/ros/roscpp_core/pull/46>)
```
## roscpp_serialization

```
* fix serializer bool on ARM (#44 <https://github.com/ros/roscpp_core/pull/44>)
```
## roscpp_traits
- No changes
## rostime

```
* Adjust return value of sleep() function (#45 <https://github.com/ros/roscpp_core/pull/45>)
* fix WallRate(Duration) constructor (#40 <https://github.com/ros/roscpp_core/pull/40>)
```
