### PR TITLE
roscpp_core: 0.5.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9077,7 +9077,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.5.6-0
+      version: 0.5.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.5.7-0`:
- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.5.6-0`
## cpp_common

```
* export symbols for Header (#46 <https://github.com/ros/roscpp_core/pull/46>)
```
## roscpp_serialization

```
* fix serializer bool on ARM (#44 <https://github.com/ros/roscpp_core/pull/44>)
```
## roscpp_traits
- No changes
## rostime

```
* Adjust return value of sleep() function (#45 <https://github.com/ros/roscpp_core/pull/45>)
* fix WallRate(Duration) constructor (#40 <https://github.com/ros/roscpp_core/pull/40>)
```
