### PR TITLE
message_runtime: 0.4.12-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -90,6 +90,21 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: indigo-devel
     status: maintained
+  message_runtime:
+    doc:
+      type: git
+      url: https://github.com/ros/message_runtime.git
+      version: groovy-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/message_runtime-release.git
+      version: 0.4.12-0
+    source:
+      type: git
+      url: https://github.com/ros/message_runtime.git
+      version: groovy-devel
+    status: maintained
   roscpp_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_runtime` to `0.4.12-0`:
- upstream repository: https://github.com/ros/message_runtime.git
- release repository: https://github.com/ros-gbp/message_runtime-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
