### PR TITLE
rosbag_migration_rule: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -120,6 +120,13 @@ repositories:
       url: https://github.com/ros/message_runtime.git
       version: groovy-devel
     status: maintained
+  rosbag_migration_rule:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/rosbag_migration_rule-release.git
+      version: 1.0.0-0
+    status: maintained
   roscpp_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_migration_rule` to `1.0.0-0`:
- upstream repository: https://github.com/ros/rosbag_migration_rule.git
- release repository: https://github.com/ros-gbp/rosbag_migration_rule-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
