### PR TITLE
rospack: 2.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -160,6 +160,7 @@ repositories:
       url: https://github.com/ros-gbp/rospack-release.git
       version: 2.3.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/rospack.git
       version: jade-devel

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -149,5 +149,20 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: indigo-devel
     status: maintained
+  rospack:
+    doc:
+      type: git
+      url: https://github.com/ros/rospack.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/rospack-release.git
+      version: 2.3.0-0
+    source:
+      type: git
+      url: https://github.com/ros/rospack.git
+      version: jade-devel
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.3.0-0`:
- upstream repository: https://github.com/ros/rospack.git
- release repository: https://github.com/ros-gbp/rospack-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rospack

```
* allow caching of rospack results (#49 <https://github.com/ros/rospack/issues/49>)
* fix memory leak in Rosstackage::addStackage (#59 <https://github.com/ros/rospack/issues/59>)
* return false in depsOnDetail if the package name in rospack plugins can not be found (#51 <https://github.com/ros/rospack/issues/51>)
* #undef symbols before #defining them to avoid preprocessor warnings in the case that they were already #defined (#50 <https://github.com/ros/rospack/issues/50>)
```
