### PR TITLE
rospack: 2.2.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9304,7 +9304,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
-      version: 2.2.5-0
+      version: 2.2.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.2.6-0`:
- upstream repository: https://github.com/ros/rospack.git
- release repository: https://github.com/ros-gbp/rospack-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.2.5-0`
## rospack

```
* fix memory leak in Rosstackage::addStackage (#59 <https://github.com/ros/rospack/issues/59>)
* return false in depsOnDetail if the package name in rospack plugins can not be found (#51 <https://github.com/ros/rospack/issues/51>)
* #undef symbols before #defining them to avoid preprocessor warnings in the case that they were already #defined (#50 <https://github.com/ros/rospack/issues/50>)
```
