### PR TITLE
evarobot_simulator: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2202,6 +2202,24 @@ repositories:
       url: https://github.com/inomuh/evapi_ros.git
       version: eva50
     status: developed
+  evarobot_simulator:
+    doc:
+      type: git
+      url: https://github.com/inomuh/evarobot_simulator.git
+      version: indigo-devel
+    release:
+      packages:
+      - evarobot_gazebo
+      - evarobot_simulator
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/inomuh/evarobot_simulator-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/inomuh/evarobot_simulator.git
+      version: indigo-devel
+    status: developed
   executive_smach:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `evarobot_simulator` to `0.0.1-0`:
- upstream repository: https://github.com/inomuh/evarobot_simulator
- release repository: https://github.com/inomuh/evarobot_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## evarobot_gazebo

```
* add interactive marker twist
* add interactive marker twist
* move rviz to evarobot_viz
* fix SensorModelConfig.h path
* first_commit
* Contributors: Mehmet Akcakoca
```
## evarobot_simulator

```
* first_commit
* Contributors: Mehmet Akcakoca
```
