### PR TITLE
innok_heros_description: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3587,7 +3587,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/innokrobotics/innok_heros_description-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/innokrobotics/innok_heros_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `innok_heros_description` to `1.0.3-0`:
- upstream repository: https://github.com/innokrobotics/innok_heros_description.git
- release repository: https://github.com/innokrobotics/innok_heros_description-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.2-0`
## innok_heros_description

```
* added missing run_depend
* added joint_state_publisher to get correct tf when launching RViz
* Contributors: Sabrina Heerklotz
```
