### PR TITLE
mrp2_common: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5510,7 +5510,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/milvusrobotics/mrp2_common-release.git
-      version: 0.2.1-1
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/milvusrobotics/mrp2_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrp2_common` to `0.2.2-0`:
- upstream repository: https://github.com/milvusrobotics/mrp2_common.git
- release repository: https://github.com/milvusrobotics/mrp2_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.1-1`
## mrp2_analyzer

```
* Updated package informations
* Contributors: Akif
```
## mrp2_common

```
* Updated package informations
* Updated dependencies
* Contributors: Akif, MRP2 Dev
```
## mrp2_control

```
* Updated package informations
* Merged controls.yaml
* Updated parameters
* Changed config naming
* Configuration files seperated for amcl and gmapping. Fixed params. Updated maps.
* Contributors: Akif, MRP2 Dev, orhangazi44
```
## mrp2_description

```
* Fixed laser viz
* Added sonar sensors to URDF
* Updated package informations
* Updated parameters
* Contributors: Akif, MRP2 Dev
```
## mrp2_navigation

```
* Updated package informations
* Updated parameters
* Configuration files seperated for amcl and gmapping. Fixed params. Updated maps.
* Fixed params. Updated launch files. Added new maps.
* Contributors: Akif, MRP2 Dev, orhangazi44
```
