### PR TITLE
mrp2_desktop: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5528,7 +5528,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/milvusrobotics/mrp2_desktop-release.git
-      version: 0.2.1-2
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/milvusrobotics/mrp2_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrp2_desktop` to `0.2.2-0`:
- upstream repository: https://github.com/milvusrobotics/mrp2_desktop.git
- release repository: https://github.com/milvusrobotics/mrp2_desktop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.1-2`
## mrp2_desktop

```
* Updated package informations
* Contributors: Akif
```
## mrp2_viz

```
* Updated package informations
* Contributors: Akif
```
