### PR TITLE
mrp2_robot: 0.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5548,7 +5548,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/milvusrobotics/mrp2_robot-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/milvusrobotics/mrp2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrp2_robot` to `0.2.4-0`:
- upstream repository: https://github.com/milvusrobotics/mrp2_robot.git
- release repository: https://github.com/milvusrobotics/mrp2_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.3-0`
## mrp2_bringup

```
* Updated launch option for sonar
* Added seperate sonar package
* Updated package informations
* Added display launch
* Merged dev-ekf
* Fixed hardware comm
* Organized config files
* Contributors: Akif, MRP2 Dev
```
## mrp2_display

```
* Updated package informations
* Added display launch
* Fixed display driver serial.
* Merged dev-ekf
* Fixed hardware comm
* New driver for mrp display
* Contributors: Akif, Bolkar Altuntas, MRP2 Dev
```
## mrp2_hardware

```
* Added udev for debian
* Added seperate sonar package
* Updated launch option for sonar
* Added seperate sonar package
* Updated package informations
* Updated dependencies
* Fixed display driver serial.
* Fixed hardware comm
* Fixed checksum bug.
* Contributors: Akif, Akif Hacinecipoglu, Bolkar Altuntas, MRP2 Dev
```
## mrp2_robot

```
* Updated package informations
* Updated dependencies
* Contributors: Akif, MRP2 Dev
```
