### PR TITLE
mrp2_simulator: 0.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5567,7 +5567,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/milvusrobotics/mrp2_simulator-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/milvusrobotics/mrp2_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrp2_simulator` to `0.2.3-0`:
- upstream repository: https://github.com/milvusrobotics/mrp2_simulator.git
- release repository: https://github.com/milvusrobotics/mrp2_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.2-0`
## mrp2_gazebo

```
* Updated package informations
* Organized config files
* Contributors: Akif
```
## mrp2_hardware_gazebo

```
* Updated package informations
* Contributors: Akif
```
## mrp2_simulator

```
* Updated package informations
* Contributors: Akif
```
