### PR TITLE
vision_opencv: 1.11.12-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5416,7 +5416,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.11.11-0
+      version: 1.11.12-0
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.11.12-0`:
- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.11.11-0`
## cv_bridge

```
* Fix my typo
* Remove another eval
  Because cvtype2_to_dtype_with_channels('8UCimport os; os.system("rm -rf /")') should never have a chance of happening.
* Remove eval, and other fixes
  Also, extend from object, so as not to get a python 2.2-style class, and use the new-style raise statement
* Contributors: Eric Wieser
```
## image_geometry

```
* issue #117 <https://github.com/ros-perception/vision_opencv/issues/117> pull request #118 <https://github.com/ros-perception/vision_opencv/issues/118> check all distortion coefficients to see if rectification ought to be done
* Contributors: Lucas Walter
```
## opencv_apps

```
* relax test condition
* fix test hz to 5 hz, tested on core i7 3.2G
* Refactor opencv_apps to remove duplicated codes to handle connection of
  topics.
  1. Add opencv_apps::Nodelet class to handle connection and disconnection of
  topics.
  2. Update nodelets of opencv_apps to inhereit opencv_apps::Nodelet class
  to remove duplicated codes.
* Contributors: Kei Okada, Ryohei Ueda
```
## vision_opencv
- No changes
