### PR TITLE
evapc_ros: 0.0.6-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2177,16 +2177,18 @@ repositories:
     release:
       packages:
       - evapc_ros
+      - evapc_start
       - evarobot_description
+      - evarobot_diagnostics
       - evarobot_navigation
       - evarobot_pose_ekf
       - evarobot_slam
       - evarobot_state_publisher
-      - impc_msgs
+      - evarobot_viz
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/inomuh/evapc_ros-release.git
-      version: 0.0.5-0
+      version: 0.0.6-1
     source:
       type: git
       url: https://github.com/inomuh/evapc_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `evapc_ros` to `0.0.6-1`:
- upstream repository: https://github.com/inomuh/evapc_ros
- release repository: https://github.com/inomuh/evapc_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.5-0`
## evapc_ros

```
* add dependency for evarobot_viz
* move im_msgs package from evapc_ros to im_msgs stack
* change dependencies
* changelog
* Contributors: Mehmet Akcakoca
```
## evapc_start

```
* install scripts folder
* add script which gives permission to sensor
* add sync.launch which opens master_discovery and master_sync
* add sync.launch which opens master_discover and master_sync
* add master_discovery and master_sync launch files
* update
* add scripts to change root of lidar and laser sensor drivers
* add launch files for hokuyo laser
* add comment for using sudo command without password
* use openni2 instead of openni for asus xtion
* add new launch file to run lidar with master_discovery
* add demo start launch file
* add changelog
* configure dependencies
* first commit
* Contributors: Mehmet Akcakoca
* configure dependencies
* first commit
* Contributors: Mehmet Akcakoca
```
## evarobot_description

```
* modify robot model for new mesh files
* separate gazebo libraries from evarobot_description
* change odom frame id (odom_combined) in gazebo plugin
* include config file
* configure dependencies
* delete unused lines
* delete unused meshes
* add dae version of wheel
* fix communication problem with evarobot
* changes for multi evarobot
* change stl with dae
* modify for multi evarobot
* changes for multi evarobot in gazebo
* change .stl with collada
* Add argument world_path
* changelog
* fix warning GetValueDouble -> Get<double>
* Contributors: Mehmet Akcakoca
* fix warning GetValueDouble -> Get<double>
* Contributors: Mehmet Akcakoca
```
## evarobot_diagnostics

```
* add changelog
* configure dependencies
* first commit
* Contributors: Mehmet Akcakoca
* configure dependencies
* first commit
* Contributors: Mehmet Akcakoca
```
## evarobot_navigation

```
* update params
* update params
* update params
* update params
* update params
* new map
* decrease map size
* decrease map size
* remove rviz file from install
* move rviz to evarobot_viz
* add sync.launch and move rviz to evarobot_viz
* add sync.launch and move rviz to evarobot_viz
* add sync.launch which opens master_discovery and master_sync
* add sync.launch which opens master_discovery and master_sync
* separate gazebo libraries from evarobot_description
* add master_discovery and master_sync launch files
* add exploration
* rename move_base.launh as move_base_sim.launch
* rename move_base.launch as move_base_sim.launch
* update
* modifiy params in consequence of realtime tests
* delete width and height since they are also in move_base_sim/real launch files
* comment configuration for non-static global map
* decrease obstacle_range, raytrace_range and inflation_radius
* add run_dependencies for exploration
* move amcl launcher to evarobot_navigation.launch
* rename move_base launch file as move_base_sim.launch
* remove rviz launcher
* add move_base to required packages list
* add scripts file to installing
* call global_localization service in launch file
* update rviz
* update move_base params
* change odom frame as odom_combined
* modify in real-time tests
* modify in real-time tests
* modify odom frame as odom_combined
* add new map of inovasyon muhendislik
* configure dependencies
* remove sensor namespace
* Update navigation params
* changelog
* Contributors: Mehmet Akcakoca
```
## evarobot_pose_ekf

```
* change freq and debug false
* configure dependencies
* remap imu topic name & enable self_diagnose
* changelog
* Contributors: Mehmet Akcakoca
```
## evarobot_slam

```
* decrease map size
* decrease map size
* new map
* remove rviz folder
* move rviz to evarobot_viz
* add sync.launch and move rviz to evarobot_viz
* move rviz to evarobot_viz
* add sync.launch and move rviz to evarobot_viz
* add sync.launch which opens master_discovery and master_sync
* add master_discovery and master_sync launch files
* add gmapping
* comment configurations for multi robot
* modify odom frame as odom_combined
* add new gazebo slam map
* add robotmodel to rviz
* modified new rviz
* comment lidar which is run by pc on the evarobot
* fix master_discovery dependency
* configure dependencies
* delete hector_slam rviz
* change odom frame
* new rviz
* tested realtime slam
* new demo slam map
* Update SLAM map
* changelog
* Contributors: Mehmet Akcakoca
```
## evarobot_state_publisher

```
* remove rviz folder
* move rviz to evarobot_viz
* delete unused folder
* add run_depend for joint_state_publisher
* add joint_state_publisher launcher
* configure dependencies
* add tf_prefix & disable odom_to_base
* changelog
* Contributors: Mehmet Akcakoca
```
## evarobot_viz

```
* modify rviz file
* move rviz to evarobot_viz
* Contributors: Mehmet Akcakoca
* modify rviz file
* move rviz to evarobot_viz
* Contributors: Mehmet Akcakoca
```
