### PR TITLE
message_generation: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -136,6 +136,21 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: indigo-devel
     status: maintained
+  message_generation:
+    doc:
+      type: git
+      url: https://github.com/ros/message_generation.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/message_generation-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/ros/message_generation.git
+      version: jade-devel
+    status: maintained
   message_runtime:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_generation` to `0.3.0-0`:
- upstream repository: https://github.com/ros/message_generation.git
- release repository: https://github.com/ros-gbp/message_generation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
