### PR TITLE
std_msgs: 0.5.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5049,7 +5049,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/std_msgs-release.git
-      version: 0.5.9-0
+      version: 0.5.10-0
     source:
       type: git
       url: https://github.com/ros/std_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `std_msgs` to `0.5.10-0`:
- upstream repository: git@github.com:ros/std_msgs.git
- release repository: https://github.com/ros-gbp/std_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.5.9-0`
