### PR TITLE
ros_comm_msgs: 1.11.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4083,7 +4083,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm_msgs-release.git
-      version: 1.11.1-0
+      version: 1.11.2-0
     source:
       type: git
       url: https://github.com/ros/ros_comm_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm_msgs` to `1.11.2-0`:
- upstream repository: https://github.com/ros/ros_comm_msgs.git
- release repository: https://github.com/ros-gbp/ros_comm_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.11.1-0`
## rosgraph_msgs
- No changes
## std_srvs

```
* add SetBool service (#7 <https://github.com/ros/ros_comm_msgs/pull/7>)
```
