### PR TITLE
class_loader: 0.3.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -362,8 +362,9 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/class_loader-release.git
-      version: 0.3.2-0
+      version: 0.3.3-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/class_loader.git
       version: indigo-devel


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `0.3.3-0`:
- upstream repository: https://github.com/ros/class_loader
- release repository: https://github.com/ros-gbp/class_loader-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.2-0`
## class_loader

```
* update maintainer
* Merge pull request #26 <https://github.com/ros/class_loader/issues/26> from goldhoorn/indigo-devel
  Added option to disable the catkin build
* Added option to disable the catkin build
* Contributors: Esteve Fernandez, Matthias Goldhoorn, Mikael Arguedas
```
