### PR TITLE
ros: 1.11.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8637,7 +8637,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.11.11-0
+      version: 1.11.12-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.11.12-0`:
- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.11.11-0`
## mk
- No changes
## rosbash

```
* add roscat to display file contents (#99 <https://github.com/ros/ros/pull/99>)
* roszsh: Ignore hidden files and directory in completion (#100 <https://github.com/ros/ros/pull/100>)
```
## rosboost_cfg
- No changes
## rosbuild
- No changes
## rosclean
- No changes
## roscreate
- No changes
## roslang
- No changes
## roslib

```
* expose an API (ros::package::getPlugins) which can map multiple export values to one package name (#103 <https://github.com/ros/ros/issues/103>)
```
## rosmake
- No changes
## rosunit

```
* add ability to load tests using dotnames in rosunit (#101 <https://github.com/ros/ros/issues/101>)
```
