### PR TITLE
ros: 1.12.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4026,7 +4026,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.12.5-0
+      version: 1.12.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.12.6-0`:
- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.12.5-0`
## mk
- No changes
## rosbash

```
* add roscat to display file contents (#99 <https://github.com/ros/ros/pull/99>)
* roszsh: Ignore hidden files and directory in completion (#100 <https://github.com/ros/ros/pull/100>)
```
## rosboost_cfg
- No changes
## rosbuild
- No changes
## rosclean
- No changes
## roscreate
- No changes
## roslang
- No changes
## roslib

```
* expose an API (ros::package::getPlugins) which can map multiple export values to one package name (#103 <https://github.com/ros/ros/issues/103>)
* deprecate API returning incomplete information (#103 <https://github.com/ros/ros/issues/103>)
* allow caching of rospack results (#97 <https://github.com/ros/ros/issues/97>)
```
## rosmake
- No changes
## rosunit

```
* remove invalid characters from XML unit test results (#89 <https://github.com/ros/ros/pull/89>, #108 <https://github.com/ros/ros/pull/108>)
* add ability to load tests using dotnames in rosunit (#101 <https://github.com/ros/ros/issues/101>)
```
