### PR TITLE
ros: 1.13.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -189,6 +189,7 @@ repositories:
       url: https://github.com/ros-gbp/ros-release.git
       version: 1.13.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/ros.git
       version: kinetic-devel

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -166,6 +166,33 @@ repositories:
       url: https://github.com/ros/message_runtime.git
       version: groovy-devel
     status: maintained
+  ros:
+    doc:
+      type: git
+      url: https://github.com/ros/ros.git
+      version: kinetic-devel
+    release:
+      packages:
+      - mk
+      - ros
+      - rosbash
+      - rosboost_cfg
+      - rosbuild
+      - rosclean
+      - roscreate
+      - roslang
+      - roslib
+      - rosmake
+      - rosunit
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/ros-release.git
+      version: 1.13.0-0
+    source:
+      type: git
+      url: https://github.com/ros/ros.git
+      version: kinetic-devel
+    status: maintained
   ros_comm_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.13.0-0`:
- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## mk
- No changes
## rosbash
- No changes
## rosboost_cfg
- No changes
## rosbuild
- No changes
## rosclean
- No changes
## roscreate
- No changes
## roslang
- No changes
## roslib

```
* update ROS_DISTRO to kinetic
```
## rosmake
- No changes
## rosunit
- No changes
