### PR TITLE
change branch name of evapc_ros

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2173,7 +2173,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/inomuh/evapc_ros.git
-      version: eva50
+      version: indigo-devel
     release:
       packages:
       - evapc_ros
@@ -2192,7 +2192,7 @@ repositories:
     source:
       type: git
       url: https://github.com/inomuh/evapc_ros.git
-      version: eva50
+      version: indigo-devel
     status: developed
   evapi_ros:
     doc:


### PR DESCRIPTION
i'd like to change branch name of evapc_ros.
