### PR TITLE
ros_comm: 1.11.17-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -227,6 +227,7 @@ repositories:
       url: https://github.com/ros-gbp/ros_comm-release.git
       version: 1.11.17-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/ros_comm.git
       version: indigo-devel

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -194,6 +194,43 @@ repositories:
       url: https://github.com/ros/ros.git
       version: kinetic-devel
     status: maintained
+  ros_comm:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_comm.git
+      version: indigo-devel
+    release:
+      packages:
+      - message_filters
+      - ros_comm
+      - rosbag
+      - rosbag_storage
+      - rosconsole
+      - roscpp
+      - rosgraph
+      - roslaunch
+      - roslz4
+      - rosmaster
+      - rosmsg
+      - rosnode
+      - rosout
+      - rosparam
+      - rospy
+      - rosservice
+      - rostest
+      - rostopic
+      - roswtf
+      - topic_tools
+      - xmlrpcpp
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_comm-release.git
+      version: 1.11.17-0
+    source:
+      type: git
+      url: https://github.com/ros/ros_comm.git
+      version: indigo-devel
+    status: maintained
   ros_comm_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.17-0`:
- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## message_filters

```
* use boost::make_shared instead of new for constructing boost::shared_ptr (#740 <https://github.com/ros/ros_comm/issues/740>)
* add __getattr__ to handle sub in message_filters as standard one (#700 <https://github.com/ros/ros_comm/pull/700>)
```
## ros_comm
- No changes
## rosbag

```
* use boost::make_shared instead of new for constructing boost::shared_ptr (#740 <https://github.com/ros/ros_comm/issues/740>)
```
## rosbag_storage

```
* use boost::make_shared instead of new for constructing boost::shared_ptr (#740 <https://github.com/ros/ros_comm/issues/740>)
```
## rosconsole

```
* use boost::make_shared instead of new for constructing boost::shared_ptr (#740 <https://github.com/ros/ros_comm/issues/740>)
```
## roscpp

```
* fix order of argument in SubscriberLink interface to match actual implemenation (#701 <https://github.com/ros/ros_comm/issues/701>)
* add method for getting all the parameters from the parameter server as implemented in the rospy client (#739 <https://github.com/ros/ros_comm/issues/739>)
* use boost::make_shared instead of new for constructing boost::shared_ptr (#740 <https://github.com/ros/ros_comm/issues/740>)
* fix max elements param for statistics window (#750 <https://github.com/ros/ros_comm/issues/750>)
* improve NodeHandle constructor documentation (#692 <https://github.com/ros/ros_comm/issues/692>)
```
## rosgraph

```
* fix raising classes not derived from Exception which caused a TypeError (#761 <https://github.com/ros/ros_comm/pull/761>)
* fix handshake header with Python 3 (#759 <https://github.com/ros/ros_comm/issues/759>)
* fix encoding of header fields (#704 <https://github.com/ros/ros_comm/issues/704>)
```
## roslaunch

```
* improve roslaunch-check to not fail if recursive dependencies lack dependencies (#730 <https://github.com/ros/ros_comm/pull/730>)
* add "pass_all_args" attribute to roslaunch "include" tag (#710 <https://github.com/ros/ros_comm/pull/710>)
* fix a typo in unknown host error message (#735 <https://github.com/ros/ros_comm/pull/735>)
* wait for param server to be available before trying to get param (#711 <https://github.com/ros/ros_comm/pull/711>)
```
## roslz4
- No changes
## rosmaster
- No changes
## rosmsg

```
* improve rosmsg show to print error message and return non-zero rc when message is not found (#691 <https://github.com/ros/ros_comm/issues/691>)
```
## rosnode
- No changes
## rosout
- No changes
## rosparam

```
* add support for loading parameters from stdin as well as dumping rosparam to stdout (#686 <https://github.com/ros/ros_comm/pull/686>)
```
## rospy

```
* preserve identity of numpy_msg(T) (#758 <https://github.com/ros/ros_comm/pull/758>)
```
## rosservice
- No changes
## rostest

```
* rostest.rosrun now generates coverage reports (#558 <https://github.com/ros/ros_comm/issues/558>)
* rostest can load tests from a dotted name (#722 <https://github.com/ros/ros_comm/issues/722>)
* include GTEST_INCLUDE_DIRS so that the proper gtest headers are found (#727 <https://github.com/ros/ros_comm/issues/727>)
* rostest: move replacement of slashes after ARGS handling (#721 <https://github.com/ros/ros_comm/pull/721>)
```
## rostopic

```
* add "rostopic delay" to measure message delay compared to the input from real world (#719 <https://github.com/ros/ros_comm/pull/719>)
* add option to perform keyword substitution for messages published with "rostopic pub" (#702 <https://github.com/ros/ros_comm/pull/702>)
* add wall-time option for rostopic hz (#674 <https://github.com/ros/ros_comm/pull/674>)
```
## roswtf
- No changes
## topic_tools

```
* add --wait-for-start option to relay_field script (#728 <https://github.com/ros/ros_comm/pull/728>)
* use boost::make_shared instead of new for constructing boost::shared_ptr (#740 <https://github.com/ros/ros_comm/issues/740>)
```
## xmlrpcpp
- No changes
