### PR TITLE
rosconsole_bridge: 0.4.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -257,6 +257,20 @@ repositories:
       url: https://github.com/ros-gbp/rosbag_migration_rule-release.git
       version: 1.0.0-0
     status: maintained
+  rosconsole_bridge:
+    doc:
+      type: git
+      url: https://github.com/ros/rosconsole_bridge.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/rosconsole_bridge-release.git
+      version: 0.4.3-0
+    source:
+      type: git
+      url: https://github.com/ros/rosconsole_bridge.git
+      version: indigo-devel
   roscpp_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole_bridge` to `0.4.3-0`:
- upstream repository: https://github.com/ros/rosconsole_bridge.git
- release repository: https://github.com/ros-gbp/rosconsole_bridge-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rosconsole_bridge

```
* use catkin variables for install dirs (#9 <https://github.com/ros/rosconsole_bridge/issues/9>)
```
