### PR TITLE
Added rosdep keys for libsvm3 and libsvm-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2281,6 +2281,12 @@ libstdc++5:
       packages: [virtual/libstdc++]
   opensuse: [libstdc++33]
   ubuntu: [libstdc++5]
+libsvm-dev:
+  debian: [libsvm-dev]
+  ubuntu: [libsvm-dev]
+libsvm3:
+  debian: [libsvm3]
+  ubuntu: [libsvm3]
 libsvn-dev:
   fedora: [subversion-devel]
   ubuntu: [libsvn-dev]


### PR DESCRIPTION
Package for SVM classifiers (c/cpp, python, matlab, etc.).
