### PR TITLE
dynamic_reconfigure: 1.5.40-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -70,6 +70,7 @@ repositories:
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
       version: 1.5.40-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/dynamic_reconfigure.git
       version: master

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -59,6 +59,21 @@ repositories:
       url: https://github.com/ros/cmake_modules.git
       version: 0.4-devel
     status: maintained
+  dynamic_reconfigure:
+    doc:
+      type: git
+      url: https://github.com/ros/dynamic_reconfigure.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
+      version: 1.5.40-0
+    source:
+      type: git
+      url: https://github.com/ros/dynamic_reconfigure.git
+      version: master
+    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.5.40-0`:
- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## dynamic_reconfigure

```
* updated maintainer
* Contributors: Mikael Arguedas
```
