### PR TITLE
common_msgs: 1.12.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -81,6 +81,7 @@ repositories:
       url: https://github.com/ros-gbp/common_msgs-release.git
       version: 1.12.4-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/common_msgs.git
       version: jade-devel

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -59,6 +59,32 @@ repositories:
       url: https://github.com/ros/cmake_modules.git
       version: 0.4-devel
     status: maintained
+  common_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros/common_msgs.git
+      version: jade-devel
+    release:
+      packages:
+      - actionlib_msgs
+      - common_msgs
+      - diagnostic_msgs
+      - geometry_msgs
+      - nav_msgs
+      - sensor_msgs
+      - shape_msgs
+      - stereo_msgs
+      - trajectory_msgs
+      - visualization_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/common_msgs-release.git
+      version: 1.12.4-0
+    source:
+      type: git
+      url: https://github.com/ros/common_msgs.git
+      version: jade-devel
+    status: maintained
   dynamic_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.12.4-0`:
- upstream repository: git@github.com:ros/common_msgs.git
- release repository: https://github.com/ros-gbp/common_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## actionlib_msgs
- No changes
## common_msgs
- No changes
## diagnostic_msgs

```
* diagnostic_msgs: Add messages for service used to add diagnostics to aggregator
* Contributors: Michal Staniaszek
```
## geometry_msgs

```
* clarify the definition of a Vector3
* Contributors: Vincent Rabaud
```
## nav_msgs
- No changes
## sensor_msgs

```
* added type mapping and support for different types of points in point clouds
* remove boost dependency fixes #81 <https://github.com/ros/common_msgs/issues/81>
* adding a BatteryState message
* fix iterator doc
* remove warning due to anonymous namespace
* Contributors: Sebastian Pütz, Tully Foote, Vincent Rabaud
```
## shape_msgs
- No changes
## stereo_msgs
- No changes
## trajectory_msgs
- No changes
## visualization_msgs
- No changes
