### PR TITLE
Adding kml_util to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4226,15 +4226,6 @@ repositories:
       type: git
       url: https://github.com/silviomaeta/kml_util.git
       version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/silviomaeta/kml_util.git
-      version: 0.1.0
-    source:
-      type: git
-      url: https://github.com/silviomaeta/kml_util.git
-      version: indigo-devel
     status: maintained
   kobuki:
     doc:
@@ -7031,15 +7022,6 @@ repositories:
     status: developed
   plot_util:
     doc:
-      type: git
-      url: https://github.com/silviomaeta/plot_util.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/silviomaeta/plot_util.git
-      version: 0.1.0-0
-    source:
       type: git
       url: https://github.com/silviomaeta/plot_util.git
       version: indigo-devel

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7029,6 +7029,21 @@ repositories:
       url: https://github.com/pal-robotics/play_motion.git
       version: indigo-devel
     status: developed
+  plot_util:
+    doc:
+      type: git
+      url: https://github.com/silviomaeta/plot_util.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/silviomaeta/plot_util.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/silviomaeta/plot_util.git
+      version: indigo-devel
+    status: maintained
   pluginlib:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4225,8 +4225,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/silviomaeta/kml_util.git
-      version: indigo-devel
-    status: maintained
+      version: master
   kobuki:
     doc:
       type: git
@@ -7024,8 +7023,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/silviomaeta/plot_util.git
-      version: indigo-devel
-    status: maintained
+      version: master
   pluginlib:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4130,6 +4130,21 @@ repositories:
       url: https://github.com/kf/kingfisher.git
       version: indigo-devel
     status: maintained
+  kml_util:
+    doc:
+      type: git
+      url: https://github.com/silviomaeta/kml_util.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/silviomaeta/kml_util.git
+      version: 0.1.0
+    source:
+      type: git
+      url: https://github.com/silviomaeta/kml_util.git
+      version: indigo-devel
+    status: maintained
   kobuki:
     doc:
       type: git


### PR DESCRIPTION
I'd like to have kml_util indexed and documented in ros.org site.
