### PR TITLE
message_multiplexing: 0.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5085,11 +5085,10 @@ repositories:
       - mm_messages
       - mm_mux_demux
       - mm_radio
-      - mm_vision_msgs
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/message_multiplexing-release.git
-      version: 0.2.1-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/stonier/message_multiplexing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_multiplexing` to `0.2.3-0`:
- upstream repository: https://github.com/stonier/message_multiplexing.git
- release repository: https://github.com/yujinrobot-release/message_multiplexing-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.1-0`
