### PR TITLE
naoqi_libqi: 2.5.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5893,7 +5893,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/libqi-release.git
-      version: 2.3.0-1
+      version: 2.5.0-0
     status: maintained
   naoqi_libqicore:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqi` to `2.5.0-0`:
- upstream repository: https://github.com/aldebaran/libqi.git
- release repository: https://github.com/ros-naoqi/libqi-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.3.0-1`
