### PR TITLE
object_recognition_capture: 0.3.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2865,7 +2865,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_capture-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/wg-perception/capture.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_capture` to `0.3.1-0`:
- upstream repository: https://github.com/wg-perception/capture.git
- release repository: https://github.com/ros-gbp/object_recognition_capture-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.0-0`
## object_recognition_capture

```
* Use "mono8" for mask and swap brg to rgb
* Fix encoding when saving bag file
* use catkin macro to install Python scripts
* cleanup tests
* clean build dependencies
* Contributors: JimmyDaSilva, Vincent Rabaud
```
