### PR TITLE
gencpp: 0.5.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1014,7 +1014,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/gencpp-release.git
-      version: 0.5.3-0
+      version: 0.5.4-0
     source:
       type: git
       url: https://github.com/ros/gencpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gencpp` to `0.5.4-0`:
- upstream repository: git@github.com:ros/gencpp.git
- release repository: https://github.com/ros-gbp/gencpp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.5.3-0`
## gencpp

```
* fix unused parameter warning (#24 <https://github.com/ros/gencpp/issues/24>)
```
