### PR TITLE
geneus: 2.2.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -142,7 +142,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/geneus-release.git
-      version: 2.2.5-0
+      version: 2.2.5-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/geneus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geneus` to `2.2.5-1`:
- upstream repository: https://github.com/jsk-ros-pkg/geneus
- release repository: https://github.com/tork-a/geneus-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.2.5-0`
## geneus

```
* add status badge to the README.md (#41 <https://github.com/jsk-ros-pkg/geneus/issues/41> )
* .travis.yml: use before_script and script
* .travis.yml: rosdep install with -q (quiet)
* Use package.xml in workspace, not deb installed one (#42 <https://github.com/jsk-ros-pkg/geneus/issues/42> )

    * do not overwrite pkg_map
    * add test code to check #42 <https://github.com/jsk-ros-pkg/geneus/issues/42> isseus
    * geneus_main.py: fix THIS FILE IS AUTOMAATICALLY GENERATED... comment
    * use latest released code

* use indiog/14.04 on travis test #40 <https://github.com/jsk-ros-pkg/geneus/issues/40>

    * add ppa:openrave/release
    * default-ri-test.launch ->default-ri-test.test
    * install default python, use language:generic
    * ros_comm message has been move to ros_comm_msgs
    * use indigo/14.04

* Contributors: Kei Okada
```
