### PR TITLE
bond_core: 1.7.17-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -28,6 +28,27 @@ repositories:
       url: https://github.com/ros/actionlib.git
       version: indigo-devel
     status: maintained
+  bond_core:
+    doc:
+      type: git
+      url: https://github.com/ros/bond_core.git
+      version: master
+    release:
+      packages:
+      - bond
+      - bond_core
+      - bondcpp
+      - bondpy
+      - smclib
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/bond_core-release.git
+      version: 1.7.17-0
+    source:
+      type: git
+      url: https://github.com/ros/bond_core.git
+      version: master
+    status: maintained
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.7.17-0`:
- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## bond

```
* update maintainer
* Contributors: Mikael Arguedas
```
## bond_core

```
* update maintainer
* Contributors: Mikael Arguedas
```
## bondcpp

```
* update maintainer
* Contributors: Mikael Arguedas
```
## bondpy

```
* Queue size for a publisher #10 <https://github.com/ros/bond_core/issues/10>
  Squash the warning.
* update maintainer
* Made code a bit more readable #12 <https://github.com/ros/bond_core/pull/12>
* made local timer a member so we can cancel it during shutdown #11 <https://github.com/ros/bond_core/pull/11>
* Contributors: Daniel Stonier, Esteve Fernandez, Hugo Boyer, Mikael Arguedas
```
## smclib

```
* update maintainer
* Contributors: Mikael Arguedas
```
