### PR TITLE
dynamic_reconfigure: 1.5.42-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -132,7 +132,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.5.41-0
+      version: 1.5.42-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.5.42-0`:
- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.5.41-0`
## dynamic_reconfigure

```
* fix Python environment to make it work on the first run #59 <https://github.com/ros/dynamic_reconfigure/issues/59>
* Contributors: Dirk Thomas
```
