### PR TITLE
nodelet_core: 1.9.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -246,6 +246,25 @@ repositories:
       url: https://github.com/ros/message_runtime.git
       version: groovy-devel
     status: maintained
+  nodelet_core:
+    doc:
+      type: git
+      url: https://github.com/ros/nodelet_core.git
+      version: indigo-devel
+    release:
+      packages:
+      - nodelet
+      - nodelet_core
+      - nodelet_topic_tools
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/nodelet_core-release.git
+      version: 1.9.4-0
+    source:
+      type: git
+      url: https://github.com/ros/nodelet_core.git
+      version: indigo-devel
+    status: maintained
   pluginlib:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -261,6 +261,7 @@ repositories:
       url: https://github.com/ros-gbp/nodelet_core-release.git
       version: 1.9.4-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.4-0`:
- upstream repository: https://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## nodelet

```
* update maintainer
* Contributors: Mikael Arguedas
```
## nodelet_core

```
* update maintainer
* Contributors: Mikael Arguedas
```
## nodelet_topic_tools

```
* update maintainer
* Contributors: Mikael Arguedas
```
