### PR TITLE
destruction_scenarios: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1766,6 +1766,21 @@ repositories:
       url: https://github.com/code-iai-release/designator_integration-release.git
       version: 0.0.3-0
     status: developed
+  destruction_scenarios:
+    doc:
+      type: git
+      url: https://github.com/roboptics/destruction_scenarios.git
+      version: 1.0.0
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/roboptics/destruction_scenarios.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/roboptics/destruction_scenarios.git
+      version: 1.0.0
+    status: developed
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `destruction_scenarios` to `1.0.0-0`:
- upstream repository: https://github.com/roboptics/destruction_scenarios.git
- release repository: https://github.com/roboptics/destruction_scenarios.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
