### PR TITLE
update libvtk-java for xenial and wily

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2530,15 +2530,7 @@ libvtk-java:
   debian: [libvtk-java]
   fedora: [vtk-java]
   gentoo: [sci-libs/vtk]
-  ubuntu:
-    lucid: [libvtk-java]
-    precise: [libvtk-java]
-    quantal: [libvtk-java]
-    raring: [libvtk-java]
-    saucy: [libvtk-java]
-    trusty: [libvtk-java]
-    utopic: [libvtk-java]
-    vivid: [libvtk-java]
+  ubuntu: [libvtk-java]
 libvtk-qt:
   arch: [vtk]
   debian: [libvtk5-qt4-dev]


### PR DESCRIPTION
I collapsed it because it's been the same since lucid and we don't support anything older.

See: http://packages.ubuntu.com/xenial/libvtk-java
