### PR TITLE
python-vtk for wily and xenial

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2192,15 +2192,7 @@ python-vtk:
   arch: [vtk]
   debian: [python-vtk]
   fedora: [vtk-python]
-  ubuntu:
-    lucid: [python-vtk]
-    precise: [python-vtk]
-    quantal: [python-vtk]
-    raring: [python-vtk]
-    saucy: [python-vtk]
-    trusty: [python-vtk]
-    utopic: [python-vtk]
-    vivid: [python-vtk]
+  ubuntu: [python-vtk]
 python-walrus-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
I flattened the rule since it has been the same since lucid and we don't support anything older.
