### PR TITLE
innok_heros_driver: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3604,7 +3604,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/innokrobotics/innok_heros_driver-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/innokrobotics/innok_heros_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `innok_heros_driver` to `1.0.2-0`:
- upstream repository: https://github.com/innokrobotics/innok_heros_driver.git
- release repository: https://github.com/innokrobotics/innok_heros_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.1-0`
## innok_heros_driver

```
* changed default addresses
* added lights and joy topics, changed watchdog unit
* Contributors: Alwin Heerklotz, Sandra Reitinger
```
