### PR TITLE
image_common: 1.11.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -216,6 +216,27 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: indigo-devel
     status: maintained
+  image_common:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_common.git
+      version: hydro-devel
+    release:
+      packages:
+      - camera_calibration_parsers
+      - camera_info_manager
+      - image_common
+      - image_transport
+      - polled_camera
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/image_common-release.git
+      version: 1.11.10-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/image_common.git
+      version: hydro-devel
+    status: maintained
   message_generation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `1.11.10-0`:
- upstream repository: https://github.com/ros-perception/image_common.git
- release repository: https://github.com/ros-gbp/image_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## camera_calibration_parsers

```
* Add install target for python wrapper library
* Only link against needed Boost libraries
  9829b02 introduced a python dependency into find_package(Boost..) which
  results in ${Boost_LIBRARIES} containing boost_python and such a
  dependency to libpython at link time. With this patch we only link
  against the needed libraries.
* Contributors: Jochen Sprickerhof, Vincent Rabaud
```
## camera_info_manager
- No changes
## image_common
- No changes
## image_transport
- No changes
## polled_camera
- No changes
