### PR TITLE
ros_comm: 1.11.18-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4088,7 +4088,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.16-0
+      version: 1.11.18-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.18-0`:
- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.11.16-0`
## message_filters

```
* fix compiler warnings
```
## ros_comm
- No changes
## rosbag
- No changes
## rosbag_storage

```
* fix compiler warnings
```
## rosconsole

```
* fix compiler warnings
```
## roscpp

```
* fix CMake warning about non-existing targets
```
## rosgraph
- No changes
## roslaunch
- No changes
## roslz4

```
* fix compiler warnings
```
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy
- No changes
## rosservice
- No changes
## rostest
- No changes
## rostopic
- No changes
## roswtf
- No changes
## topic_tools

```
* fix CMake warning about non-existing targets
```
## xmlrpcpp
- No changes
