### PR TITLE
vision_opencv: 1.12.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -483,5 +483,24 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  vision_opencv:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: kinetic
+    release:
+      packages:
+      - cv_bridge
+      - image_geometry
+      - vision_opencv
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/vision_opencv-release.git
+      version: 1.12.0-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: kinetic
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.12.0-1`:
- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## cv_bridge

```
* depend on OpenCV3 only
* Contributors: Vincent Rabaud
```
## image_geometry

```
* depend on OpenCV3 only
* Contributors: Vincent Rabaud
```
## vision_opencv

```
* remove opencv_apps from vision_opencv
* Contributors: Vincent Rabaud
```
