### PR TITLE
python_qt_binding: 0.2.18-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3602,7 +3602,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/python_qt_binding-release.git
-      version: 0.2.17-0
+      version: 0.2.18-0
     source:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `0.2.18-0`:
- upstream repository: git://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros-gbp/python_qt_binding-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.17-0`
## python_qt_binding

```
* remove LGPL and GPL from licenses, all code is BSD (#27 <https://github.com/ros-visualization/python_qt_binding/issues/27>)
```
