### PR TITLE
rtmros_gazebo: 0.1.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9704,6 +9704,21 @@ repositories:
       url: https://github.com/start-jsk/rtmros_common.git
       version: master
     status: developed
+  rtmros_gazebo:
+    doc:
+      type: git
+      url: https://github.com/start-jsk/rtmros_gazebo.git
+      version: master
+    release:
+      packages:
+      - eusgazebo
+      - hrpsys_gazebo_general
+      - hrpsys_gazebo_msgs
+      - staro_moveit_config
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/rtmros_gazebo-release.git
+      version: 0.1.9-0
   rtmros_hironx:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_gazebo` to `0.1.9-0`:
- upstream repository: https://github.com/start-jsk/rtmros_gazebo.git
- release repository: https://github.com/tork-a/rtmros_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## eusgazebo

```
* [eusgazebo] Add roseus to dependency
* Contributors: Ryohei Ueda
```
## hrpsys_gazebo_general

```
* Replace shared_dynamic_cast to dynamic_pointer_cast because shared_dynamic_cast is deprecated from boost 1.53
* [hrpsys_gazebo_general] Use find_package macro to look up collada_jsk_patch package
* [hrpsys_gazebo_general] Fix typo
* [hrpsys_gazebo_general] Fix path for catkin build
* add use_joint_effort for using effort on velocity feedback mode
* Contributors: Ryohei Ueda, YoheiKakiuchi, Iori Kumagai
```
## hrpsys_gazebo_msgs
- No changes
## staro_moveit_config
- No changes
