### PR TITLE
actionlib: 1.11.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -92,6 +92,7 @@ repositories:
       url: https://github.com/ros-gbp/actionlib-release.git
       version: 1.11.5-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/actionlib.git
       version: indigo-devel

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -90,7 +90,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.11.3-0
+      version: 1.11.5-0
     source:
       type: git
       url: https://github.com/ros/actionlib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.11.5-0`:
- upstream repository: git@github.com:ros/actionlib.git
- release repository: https://github.com/ros-gbp/actionlib-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.11.3-0`
## actionlib

```
* update maintainer
* Merge pull request #42 <https://github.com/ros/actionlib/issues/42> from jonbinney/python3-compat
  Python 3 compatibility changes
* More readable iteration in state name lookup
* Update syntax for exception handling
* Iterate over dictionary in python3 compatible way
* Use absolute imports for python3 compatibility
* Merge pull request #39 <https://github.com/ros/actionlib/issues/39> from clearpathrobotics/action-fixup
  Minor improvements
* Enable UI feedback for preempt-requested goal in axserver.py
* Clean up axclient.py initialization to allow starting before actionserver, requires action type passed in
* Add hashes to ServerGoalHandle and ClientGoalHandles
* Contributors: Esteve Fernandez, Jon Binney, Mikael Arguedas, Paul Bovbel
```
