### PR TITLE
dynamic_reconfigure: 1.5.42-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -643,7 +643,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.5.39-2
+      version: 1.5.42-0
     source:
       type: git
       url: https://github.com/ros/dynamic_reconfigure.git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -645,6 +645,7 @@ repositories:
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
       version: 1.5.42-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/dynamic_reconfigure.git
       version: master


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.5.42-0`:
- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.5.39-2`
## dynamic_reconfigure

```
* fix Python environment to make it work on the first run #59 <https://github.com/ros/dynamic_reconfigure/issues/59>
* Contributors: Dirk Thomas
```
