### PR TITLE
nodelet_core: 1.9.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6123,6 +6123,7 @@ repositories:
       url: https://github.com/ros-gbp/nodelet_core-release.git
       version: 1.9.4-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6121,7 +6121,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.9.3-0
+      version: 1.9.4-0
     source:
       type: git
       url: https://github.com/ros/nodelet_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.4-0`:
- upstream repository: git://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.9.3-0`
## nodelet

```
* update maintainer
* Contributors: Mikael Arguedas
```
## nodelet_core

```
* update maintainer
* Contributors: Mikael Arguedas
```
## nodelet_topic_tools

```
* update maintainer
* Contributors: Mikael Arguedas
```
