### PR TITLE
nodelet_core: 1.9.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2847,6 +2847,7 @@ repositories:
       url: https://github.com/ros-gbp/nodelet_core-release.git
       version: 1.9.4-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2845,7 +2845,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.9.3-0
+      version: 1.9.4-0
     source:
       type: git
       url: https://github.com/ros/nodelet_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.4-0`:
- upstream repository: https://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.9.3-0`
## nodelet

```
* update maintainer
* Contributors: Mikael Arguedas
```
## nodelet_core

```
* update maintainer
* Contributors: Mikael Arguedas
```
## nodelet_topic_tools

```
* update maintainer
* Contributors: Mikael Arguedas
```
