### PR TITLE
pluginlib: 1.10.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7032,7 +7032,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.10.1-0
+      version: 1.10.2-0
     source:
       type: git
       url: https://github.com/ros/pluginlib.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7034,6 +7034,7 @@ repositories:
       url: https://github.com/ros-gbp/pluginlib-release.git
       version: 1.10.2-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/pluginlib.git
       version: indigo-devel


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.10.2-0`:
- upstream repository: https://github.com/ros/pluginlib
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.10.1-0`
## pluginlib

```
* update maintainer
* Merge pull request #35 <https://github.com/ros/pluginlib/issues/35> from jspricke/license_fix
  Remove Boost Software License from license tag
* Remove Boost Software License from license tag
  The Boost Software License was only in there for Poco, as can be seen in
  6e0659f. As Poco was removed in 44ab6fb and all remaining Files have a
  BSD header, let's remove the Boost tag as well, to be consistent.
* Merge pull request #34 <https://github.com/ros/pluginlib/issues/34> from ros/throw_exception_invalid_library
  Fix wrong package name test
* Throw an exception if ClassLoader can't be instantiated due to an invalid package name
* Merge pull request #33 <https://github.com/ros/pluginlib/issues/33> from clearpathrobotics/getName-split-fix
  Add ":" to split function within getName.
* Add ":" to split function within getName.
  getName split wasn't supporting :: as the delimiter for the package name and
  the plugin name.
* Contributors: Esteve Fernandez, Jochen Sprickerhof, Mikael Arguedas, Mike O'Driscoll
```
