### PR TITLE
ros_tutorials: 0.6.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4231,7 +4231,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ros_tutorials-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `0.6.2-0`:
- upstream repository: git@github.com:ros/ros_tutorials.git
- release repository: https://github.com/ros-gbp/ros_tutorials-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.1-0`
## ros_tutorials
- No changes
## roscpp_tutorials
- No changes
## rospy_tutorials

```
* fix minor misleading comment (#27 <https://github.com/ros/ros_tutorials/pull/27>)
```
## turtlesim

```
* fix size of Jade image to not exceed other images in order to not get positioned incorrectly
* fix compiler warnings
```
