### PR TITLE
ros_comm: 1.12.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -369,7 +369,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.17-0
+      version: 1.12.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.12.0-0`:
- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.11.17-0`
## message_filters
- No changes
## ros_comm
- No changes
## rosbag

```
* add missing parameter to AdvertiseOptions::createAdvertiseOptions (#733 <https://github.com/ros/ros_comm/issues/733>)
```
## rosbag_storage
- No changes
## rosconsole

```
* make LogAppender and Token destructor virtual (#729 <https://github.com/ros/ros_comm/issues/729>)
```
## roscpp

```
* improve TopicManager::instance (#770 <https://github.com/ros/ros_comm/issues/770>)
* change return value of param() to bool (#753 <https://github.com/ros/ros_comm/issues/753>)
```
## rosgraph
- No changes
## roslaunch
- No changes
## roslz4
- No changes
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy
- No changes
## rosservice
- No changes
## rostest
- No changes
## rostopic
- No changes
## roswtf
- No changes
## topic_tools
- No changes
## xmlrpcpp
- No changes
