### PR TITLE
ros_tutorials: 0.7.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -394,6 +394,26 @@ repositories:
       url: https://github.com/ros/ros_comm_msgs.git
       version: indigo-devel
     status: maintained
+  ros_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ros_tutorials
+      - roscpp_tutorials
+      - rospy_tutorials
+      - turtlesim
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_tutorials-release.git
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: kinetic-devel
+    status: maintained
   rosbag_migration_rule:
     release:
       tags:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -410,6 +410,7 @@ repositories:
       url: https://github.com/ros-gbp/ros_tutorials-release.git
       version: 0.7.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/ros_tutorials.git
       version: kinetic-devel


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `0.7.0-0`:
- upstream repository: git@github.com:ros/ros_tutorials.git
- release repository: https://github.com/ros-gbp/ros_tutorials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## ros_tutorials
- No changes
## roscpp_tutorials
- No changes
## rospy_tutorials

```
* fix minor misleading comment (#27 <https://github.com/ros/ros_tutorials/pull/27>)
```
## turtlesim

```
* add kinetic image
* update to Qt5
* fix size of Jade image to not exceed other images in order to not get positioned incorrectly
* fix compiler warnings
```
