### PR TITLE
angles: 1.9.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -180,11 +180,12 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry_angles_utils-release.git
-      version: 1.9.9-0
+      version: 1.9.10-0
     source:
       type: git
       url: https://github.com/ros/angles.git
       version: master
+    status: maintained
   app_manager:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `angles` to `1.9.10-0`:
- upstream repository: https://github.com/ros/angles
- release repository: https://github.com/ros-gbp/geometry_angles_utils-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.9.9-0`
## angles

```
* Export architecture_independent flag in package.xml
* Simply and improve performance of shortest_angular_distance(). adding two unit test cases
* check for CATKIN_ENABLE_TESTING
* Contributors: Derek King, Lukas Bulwahn, Scott K Logan, Tully Foote
```
