### PR TITLE
catkin: 0.6.18-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -346,7 +346,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.6.16-0
+      version: 0.6.18-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.6.18-0`:
- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.16-0`
## catkin

```
* expose format 2 style dependencies as CMake variables (#787 <https://github.com/ros/catkin/issues/787>)
```
