### PR TITLE
common_tutorials: 0.1.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -123,6 +123,27 @@ repositories:
       url: https://github.com/ros/common_msgs.git
       version: jade-devel
     status: maintained
+  common_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/common_tutorials.git
+      version: hydro-devel
+    release:
+      packages:
+      - actionlib_tutorials
+      - common_tutorials
+      - nodelet_tutorial_math
+      - pluginlib_tutorials
+      - turtle_actionlib
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/common_tutorials-release.git
+      version: 0.1.8-0
+    source:
+      type: git
+      url: https://github.com/ros/common_tutorials.git
+      version: hydro-devel
+    status: maintained
   dynamic_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_tutorials` to `0.1.8-0`:
- upstream repository: https://github.com/ros/common_tutorials.git
- release repository: https://github.com/ros-gbp/common_tutorials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## actionlib_tutorials

```
* update package maintainer.
* Use _EXPORTED_TARGETS target suffix instead of _generate_messages_cpp
* Contributors: Daniel Stonier, Esteve Fernandez
```
## common_tutorials

```
* update package maintainer.
* Contributors: Daniel Stonier
```
## nodelet_tutorial_math

```
* update package maintainer.
* Contributors: Daniel Stonier
```
## pluginlib_tutorials

```
* update package maintainer.
* Contributors: Daniel Stonier
```
## turtle_actionlib

```
* update package maintainer.
* Use _EXPORTED_TARGETS target suffix instead of _generate_messages_cpp
* changed shape_server code to run with the hydro mversion of turtlesim ("geometry_msgs/Twist" nad cmd_vel)
* Contributors: Benjamin Brieber, Daniel Stonier, Esteve Fernandez
```
