### PR TITLE
image_pipeline: 1.12.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3461,7 +3461,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/image_pipeline-release.git
-      version: 1.12.15-0
+      version: 1.12.16-0
     source:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `1.12.16-0`:
- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros-gbp/image_pipeline-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.12.15-0`
## camera_calibration

```
* clean OpenCV dependency in package.xml
* Contributors: Vincent Rabaud
```
## depth_image_proc

```
* check number of channels before the process
* search minimum value with OpenCV
* Use OpenCV to be faster
* Add a feature for a depth image to crop foremost image
* Contributors: Kenta Yonekura
```
## image_pipeline
- No changes
## image_proc

```
* clean OpenCV dependency in package.xml
* issue #180 <https://github.com/ros-perception/image_pipeline/issues/180> Check if all distortion coefficients are zero.
  Test with:
  rostest --reuse-master --text image_proc test_rectify.xml
  Can also test interactively with vimjay image_rect.launch, which brings up an rqt gui and camera info distortion coefficients can be dynamically reconfigured.
* Add a feature to crop the largest valid (non zero) area
  Remove unnecessary headers
  change a filename to fit for the ROS convention
* Contributors: Kenta Yonekura, Lucas Walter, Vincent Rabaud
```
## image_rotate

```
* clean OpenCV dependency in package.xml
* Contributors: Vincent Rabaud
```
## image_view

```
* Remove code for roslib on .cfg files
  Closes #185 <https://github.com/ros-perception/image_pipeline/issues/185>
* add cv::waitKey for opencv3 installed from source to fix freezing issue
* when no image is saved, do not save camera info
  When the images are not recorded because "save_all_image" is false and "save_image_service" is false, the frame count should not be incremented and the camera info should not be written to disk.
* Add std_srvs to catkin find_package()
* Contributors: Jeremy Kerfs, Jochen Sprickerhof, Kentaro Wada, Krishneel
```
## stereo_image_proc

```
* clean OpenCV dependency in package.xml
* Contributors: Vincent Rabaud
```
