### PR TITLE
scan_tools: 0.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10000,7 +10000,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/scan_tools-release.git
-      version: 0.3.0-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/scan_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scan_tools` to `0.3.2-0`:
- upstream repository: https://github.com/ccny-ros-pkg/scan_tools.git
- release repository: https://github.com/tork-a/scan_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.0-0`
## laser_ortho_projector
- No changes
## laser_scan_matcher

```
* [feat] Publish Poses with Covariance (#44 <https://github.com/ccny-ros-pkg/scan_tools/pull/44>)
* [sys] Remove csm cmake macro; csm is now built upstream since (#31 <https://github.com/ccny-ros-pkg/scan_tools/pull/45>)
* Contributors: Eric Tappan, Isaac I.Y. Saito
```
## laser_scan_sparsifier
- No changes
## laser_scan_splitter
- No changes
## ncd_parser
- No changes
## polar_scan_matcher
- No changes
## scan_to_cloud_converter
- No changes
## scan_tools

```
* [feat][laser_scan_matcher] Publish Poses with Covariance (#44 <https://github.com/ccny-ros-pkg/scan_tools/pull/44>)
* [sys][laser_scan_matcher] Remove csm cmake macro; csm is now built upstream since (#31 <https://github.com/ccny-ros-pkg/scan_tools/pull/45>)
* Contributors: Eric Tappan, Isaac I.Y. Saito
```
