### PR TITLE
dynamic_reconfigure: 1.5.43-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -645,7 +645,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.5.42-0
+      version: 1.5.43-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.5.43-0`:
- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.5.42-0`
## dynamic_reconfigure

```
* add devel space to Python environment to allow .cfg files to import them #60 <https://github.com/ros/dynamic_reconfigure/issues/60>
* Contributors: Dirk Thomas
```
