### PR TITLE
multimaster_fkie: 0.5.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2469,7 +2469,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.4.4-0
+      version: 0.5.0-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.5.0-0`:
- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.4.4-0`
## default_cfg_fkie

```
* default_cfg_fkie: added 'load_params_at_start' parameter.
  On start of default_cfg_fkie all parameters are loaded into ROS
  parameter server. If this parameter is set to False the parameter are
  loaded on first run of an included node.
* mulitmaster_fkie: fixed the missing leading SEP by groups
* Contributors: Alexander Tiderko
```
## master_discovery_fkie

```
* master_discovery: fixed avg. network load calculation, added checks for some parameters
* multimaster_fkie: Set correct logging level to warning
* Contributors: Alexander Tiderko, Gary Servin
```
## master_sync_fkie
- No changes
## multimaster_fkie

```
New Features:
* node_manager_fkie: the start with different ROS_MASTER_URI
* node_manager_fkie: added parameter to disable the highlighting of xml blocks
* node_manager_fkie: added ROS-Launch tags to context menu in XML editor
* node_manager_fkie: mark XML tag blocks
* node_manager_fkie: show the filename in the XML editor dialog title
* node_manager_fkie: close configuration items are now sorted
* node_manager_fkie: the confirmation dialog at exit can be deaktivated
  to stop all nodes and roscore or shutdown the host you can use the close
  button of each master
* node_manager_fkie: allow to shutdown localhost
* node_manager_fkie: shows 'advanced start' button also if the selected node laready runs
* default_cfg_fkie: added 'load_params_at_start' parameter.
  On start of default_cfg_fkie all parameters are loaded into ROS
  parameter server. If this parameter is set to False the parameter are
  loaded on first run of an included node.
Fixes:
* node_manager_fkie: fixed print XML content in echo_dialog
* node_manager_fkie: avoids the print of an error, while loads a wrongs file on start of the node_manager
* node_manager_fkie: fixed check of running remote roscore
* node_manager_fkie: fixed problem while echo topics on remote hosts
* node_manager_fkie: changed cursor position in XML editor after open node configuration
* node_manager_fkie: fixed replay of topics with array elements
* node_manager_fkie: fixed close process while start/stop nodes
* node_manager_fkie: fixed namespace of capability groups, fixed the missing leading SEP
* node_manager_fkie: fixed - avoid transmition of some included/changed but not needed files to remote host
* node_manager_fkie: fixed start node after a binary was selected from multiple binaries
* node_manager_fkie: removed "'now' FIX" while publish messages to topics
* node_manager_fkie: fixed log format on remote hosts
* master_discovery: fixed avg. network load calculation, added checks for some parameters
* multimaster_fkie: Set correct logging level to warning
* Contributors: Alexander Tiderko, Gary Servin
```
## multimaster_msgs_fkie
- No changes
## node_manager_fkie

```
New Features:
* node_manager_fkie: the start with different ROS_MASTER_URI
* node_manager_fkie: added parameter to disable the highlighting of xml blocks
* node_manager_fkie: added ROS-Launch tags to context menu in XML editor
* node_manager_fkie: mark XML tag blocks
* node_manager_fkie: show the filename in the XML editor dialog title
* node_manager_fkie: close configuration items are now sorted
* node_manager_fkie: the confirmation dialog at exit can be deaktivated
  to stop all nodes and roscore or shutdown the host you can use the close
  button of each master
* node_manager_fkie: allow to shutdown localhost
* node_manager_fkie: shows 'advanced start' button also if the selected node laready runs
Fixes:
* node_manager_fkie: fixed print XML content in echo_dialog
* node_manager_fkie: avoids the print of an error, while loads a wrongs file on start of the node_manager
* node_manager_fkie: fixed check of running remote roscore
* node_manager_fkie: fixed problem while echo topics on remote hosts
* node_manager_fkie: changed cursor position in XML editor after open node configuration
* node_manager_fkie: fixed replay of topics with array elements
* node_manager_fkie: fixed close process while start/stop nodes
* node_manager_fkie: fixed namespace of capability groups, fixed the missing leading SEP
* node_manager_fkie: fixed - avoid transmition of some included/changed but not needed files to remote host
* node_manager_fkie: fixed start node after a binary was selected from multiple binaries
* node_manager_fkie: removed "'now' FIX" while publish messages to topics
* node_manager_fkie: fixed log format on remote hosts
* Contributors: Alexander Tiderko
```
