### PR TITLE
mrpt_navigation: 0.1.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2447,7 +2447,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `0.1.6-0`:
- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.5-0`
## mrpt_bridge

```
* New ObservationRangeBeacon message.
* More descriptive error msgs
* Contributors: Jose Luis Blanco, Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco, Logrus, Raphael Zack
```
## mrpt_local_obstacles

```
* fix build with latest mrpt version
* Contributors: Jose Luis Blanco
```
## mrpt_localization

```
* New support for range-only (RO) localization
* fix build against mrpt <1.3.0
* Contributors: Jose Luis Blanco, Jose Luis Blanco-Claraco, Raphael Zack
```
## mrpt_map

```
* build fixes
* Contributors: Jose Luis Blanco
```
## mrpt_msgs

```
* New range-only msgs
* Contributors: Raphael Zack
```
## mrpt_navigation

```
* New support for range-only (RO) localization
* fix build against mrpt <1.3.0
```
## mrpt_rawlog

```
* added a launch file that plays a range-only rawlog
* Added in beacon publisher capabilities
* fix build with latest mrpt version
* update stamp with ros time now
  - since no clock recorded, tf/msgs published in the past, complains from everywhere
  - todo : extrapolate time between first/last msg stamp and pub clock
* default laser frame if msg_laser_ has none
* Contributors: Jeremie Deray, Jose Luis Blanco, Raphael Zack
```
## mrpt_reactivenav2d

```
* more build fixes
* reactivenav: more complete template config file
* Contributors: Jose Luis Blanco
```
## mrpt_tutorials
- No changes
