### PR TITLE
jsk_common: 2.0.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3931,7 +3931,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.0.9-1
+      version: 2.0.11-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common.git
+      version: master
     status: developed
   jsk_common_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.0.11-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.0.9-1`
## dynamic_tf_publisher

```
* remove dynamic_reconfigure.parameter_generator, which only used for rosbuild
* Contributors: Kei Okada
```
## image_view2

```
* Fix header of screenrectangle topic to include frame_id
  Modified:
  - jsk_ros_patch/image_view2/image_view2.cpp
* remove dynamic_reconfigure.parameter_generator, which only used for rosbuild
* [image_view2] Keep publishing test data
* Contributors: Kei Okada, Kentaro Wada, Ryohei Ueda
```
## jsk_common
- No changes
## jsk_data
- No changes
## jsk_network_tools

```
* remove dynamic_reconfigure.parameter_generator, which only used for rosbuild
* Contributors: Kei Okada
```
## jsk_tilt_laser

```
* remove dynamic_reconfigure.parameter_generator, which only used for rosbuild
* CATKIN_INCLUDE_DIRS -> catkin_INCLUDE_DIRS
* Contributors: Kei Okada, Kentaro Wada
```
## jsk_tools
- No changes
## jsk_topic_tools

```
* [jsk_topic_tools] Set property is_initialized
  Modified:
  - jsk_topic_tools/src/jsk_topic_tools/transport.py
* Contributors: Kentaro Wada
```
## multi_map_server

```
* Add include_dirs for multi_map_server
* Contributors: Kentaro Wada
```
## virtual_force_publisher
- No changes
