### PR TITLE
jsk_recognition: 0.3.17-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4053,7 +4053,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.16-0
+      version: 0.3.17-0
     status: developed
   jsk_robot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.17-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.16-0`
## checkerboard_detector
- No changes
## imagesift

```
* [imagesift] Set ros node name same to the executable name
* [imagesift] Add ORB detector
* Contributors: Ryohei Ueda
```
## jsk_pcl_ros

```
* remove dynamic_reconfigure.parameter_generator, which only used for rosbuild
* [jsk_pcl_ros/kinfu]add cfg for change kinfu params
* [kinfu]add srv for save mesh
* [kinfu] add initialization when icp is lost
* [jsk_pck_ros] add options not pub tf
* [jsk_pcl_ros/CMakeLists.txt] fix link libraries when building kinfu.
* Contributors: Kei Okada, Masaki Murooka, Yu Ohara
```
## jsk_pcl_ros_utils

```
* remove dynamic_reconfigure.parameter_generator, which only used for rosbuild
* Contributors: Kei Okada
```
## jsk_perception

```
* remove dynamic_reconfigure.parameter_generator, which only used for rosbuild
* [jsk_perception] binpack_rect_array.py to enumerate jsk_recognition_msgs/RectArray
* [jsk_perception] Add selective_search.py
* [jsk_perception] Use timer callback to speed up tile_image with no_sync:=true
* [jsk_perception] Cache concatenated image to speed up
* Contributors: Kei Okada, Ryohei Ueda
```
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## jsk_recognition_utils

```
* [jsk_perception] Use timer callback to speed up tile_image with no_sync:=true
* [jsk_perception] Cache concatenated image to speed up
* Contributors: Ryohei Ueda
```
## resized_image_transport

```
* remove dynamic_reconfigure.parameter_generator, which is only used for rosbuild
* Contributors: Kei Okada
```
