### PR TITLE
jsk_visualization: 1.0.29-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4123,7 +4123,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.28-0
+      version: 1.0.29-0
     status: developed
   jskeus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.29-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.28-0`
## jsk_interactive
- No changes
## jsk_interactive_marker

```
* remove dynamic_reconfigure.parameter_generator, which only used for rosbuild
* [jsk_interactive_marker/euslisp] add transformable-object-util.
* [jsk_interactive_marker] Add document (JP) about how to use moveit_msgs/DisplayRobotState
* Contributors: Kei Okada, Masaki Murooka, Ryohei Ueda
```
## jsk_interactive_test
- No changes
## jsk_rqt_plugins
- No changes
## jsk_rviz_plugins

```
* remove dynamic_reconfigure.parameter_generator, which only used for rosbuild
* [jsk_rviz_plugins] Do not show unnecessary properties of CameraInfo
* [jsk_rviz_plugins] Delete property in OverlayDiagnosticDisplay
* [jsk_rviz_plugins/OverlayDiagnostics] Add new style
* [jsk_rviz_plugins/OverlayPicker] Align to grid in pressing shift key
* Contributors: Kei Okada, Ryohei Ueda
```
## jsk_visualization
- No changes
