### PR TITLE
python-urlgrabber for u-x

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2154,17 +2154,9 @@ python-ujson:
     pip:
       packages: [ujson]
 python-urlgrabber:
+  debian: [python-urlgrabber]
   fedora: [python-urlgrabber]
-  ubuntu:
-    lucid: [python-urlgrabber]
-    maverick: [python-urlgrabber]
-    natty: [python-urlgrabber]
-    oneiric: [python-urlgrabber]
-    precise: [python-urlgrabber]
-    quantal: [python-urlgrabber]
-    raring: [python-urlgrabber]
-    saucy: [python-urlgrabber]
-    trusty: [python-urlgrabber]
+  ubuntu: [python-urlgrabber]
 python-usb:
   debian: [python-usb]
   fedora: [pyusb]


### PR DESCRIPTION
http://old-releases.ubuntu.com/ubuntu/pool/main/u/urlgrabber/ for utopic?

http://packages.ubuntu.com/search?keywords=python-usb
