### PR TITLE
jsk_roseus: 1.5.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4104,7 +4104,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.4.1-0
+      version: 1.5.0-0
     status: maintained
   jsk_smart_apps:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.5.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.4.1-0`
## jsk_roseus
- No changes
## roseus

```
* support dictionary for set-param

    * roseus.cpp: SET_ROS_PARAM clean up error message
    * roseus.cpp: fix typo, unkown -> unknown
    * roseus.cpp: (ros::set-param): support to set directory
    * test/param-test.l : add test for set-param
    * test/param-test.l: display parameters

* misc updates

    * cmake/roseus.cmake: quiet find_pakcage, this may fail for the first time
    * test/test-genmsg.sh: add include_directories(${catkin_INCLUDE_DIRS})
    * [roseus] Retry 3 times actionlib test

* image conversion

    * [roseus/euslisp/roseus-utils.l] add image conversion to ros msg
      [roseus/test/test-roseus.l] add test for image conversion
      [roseus/test/test-roseus.test] use virtual display for test with viewer
      [.travis.yml] install xvfb before_install to launch X server on test

* Contributors: Furushchev, Kei Okada, Ryohei Ueda
```
## roseus_mongo

```
* {roseus_smach, roseus_mongo}/README.md: fix section/subsection
* Contributors: Kei Okada
```
## roseus_smach

```
* {roseus_smach, roseus_mongo}/README.md: fix section/subsection
* [roseus_smach/src/state-machine-utils.l] fix: smach connection from/to nil state
* Contributors: Kei Okada, Yuki Furuta
```
## roseus_tutorials
- No changes
