### PR TITLE
jsk_pr2eus: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4033,10 +4033,11 @@ repositories:
       - jsk_pr2eus
       - pr2eus
       - pr2eus_moveit
+      - pr2eus_tutorials
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_pr2eus-release.git
-      version: 0.2.1-0
+      version: 0.3.0-0
     status: developed
   jsk_recognition:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.3.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_pr2eus
- release repository: https://github.com/tork-a/jsk_pr2eus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.1-0`
## jsk_pr2eus
- No changes
## pr2eus

```
* add robot-move-base-interface class

    * [robot-interface.l] fix clear-costmap/change-inflation-range to support different move_base node name
    * [robot-interface.l,pr2-interface.l] move clear-costmap and hcange-inflation-range from pr2-interface.l to robot-interface.l
    * [robot-interface.l] check if move-base-trajectory-action is available
    * [robot-interface.l,pr2-interface.l] move odom-callback to robot-move-base-interface class
    * [robot-interface.l] enable to set base_footprint name
    * [test/pr2-ri-test-simple.l] add test for move-to

* Contributors: Kei Okada
```
## pr2eus_moveit
- No changes
## pr2eus_tutorials

```
* add files for reach object demo.
* [pr2eus_tutorials] remove dependency to pr2_gazebo.
* catkinize pr2eus_tutorials
* Contributors: Kei Okada, Masaki Murooka
```
