### PR TITLE
jsk_robot: 1.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4087,7 +4087,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_robot-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     status: developed
   jsk_roseus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `1.0.4-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.3-0`
## baxtereus

```
* baxtereus/baxter-util.l: fix code to revert the original posture, if ik failed
* test/test-baxter.l: add test to check the robot revert to start posture, if ik failed
* Contributors: Kei Okada
```
## fetcheus

```
* check collad-dom version before convert from urdf to collada
* test/test-fetcheus.l: add test for fetch-interface
* fetch-interface.l : fix robot-move-base-interface.l
* Contributors: Kei Okada
```
## jsk_201504_miraikan
- No changes
## jsk_baxter_desktop
- No changes
## jsk_baxter_startup
- No changes
## jsk_baxter_web
- No changes
## jsk_fetch_startup

```
* fetch_bringup.launch: fix arg boot_sound
* Contributors: Kei Okada
```
## jsk_nao_startup
- No changes
## jsk_pepper_startup

```
* package.xml add naoqi_pose depends to  jsk_pepper_startup
* Contributors: Kei Okada
```
## jsk_pr2_calibration
- No changes
## jsk_pr2_startup
- No changes
## jsk_robot_startup

```
* [jsk_robot_startup] Overwrite pdf threshould was too small: 1e-6->1e-3
* Contributors: Iori Kumagai
```
## jsk_robot_utils
- No changes
## naoeus
- No changes
## naoqieus

```
* [naoqi-interface.l] add angle-ratio parameter to :start-grasp, :stop-grasp
* Contributors: Kanae Kochigami
```
## peppereus
- No changes
## pr2_base_trajectory_action
- No changes
## roseus_remote
- No changes
