### PR TITLE
jsk_pr2eus: 0.3.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1760,6 +1760,18 @@ repositories:
       url: https://github.com/tork-a/jsk_model_tools-release.git
       version: 0.2.3-0
     status: developed
+  jsk_pr2eus:
+    release:
+      packages:
+      - jsk_pr2eus
+      - pr2eus
+      - pr2eus_moveit
+      - pr2eus_tutorials
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/jsk_pr2eus-release.git
+      version: 0.3.0-0
+    status: developed
   jsk_recognition:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.3.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_pr2eus
- release repository: https://github.com/tork-a/jsk_pr2eus-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## jsk_pr2eus
- No changes
## pr2eus

```
* add robot-move-base-interface class

    * [robot-interface.l] fix clear-costmap/change-inflation-range to support different move_base node name
    * [robot-interface.l,pr2-interface.l] move clear-costmap and hcange-inflation-range from pr2-interface.l to robot-interface.l
    * [robot-interface.l] check if move-base-trajectory-action is available
    * [robot-interface.l,pr2-interface.l] move odom-callback to robot-move-base-interface class
    * [robot-interface.l] enable to set base_footprint name
    * [test/pr2-ri-test-simple.l] add test for move-to

* Contributors: Kei Okada
```
## pr2eus_moveit
- No changes
## pr2eus_tutorials

```
* add files for reach object demo.
* [pr2eus_tutorials] remove dependency to pr2_gazebo.
* catkinize pr2eus_tutorials
* Contributors: Kei Okada, Masaki Murooka
```
