### PR TITLE
teleop_twist_keyboard: 0.6.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5165,7 +5165,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/teleop_twist_keyboard-release.git
-      version: 0.5.0-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_keyboard` to `0.6.0-0`:
- upstream repository: https://github.com/ros-teleop/teleop_twist_keyboard.git
- release repository: https://github.com/ros-gbp/teleop_twist_keyboard-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.5.0-0`
## teleop_twist_keyboard

```
* Better instruction formatting
* support holonomic base, send commmand with keyboard down
* Fixing queue_size warning
* Create README.md
* Update the description string in package.xml
* Contributors: Austin, Kei Okada, LiohAu, Mike Purvis, kk6axq, trainman419
```
