### PR TITLE
urdfdom_py: 0.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -555,6 +555,21 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  urdfdom_py:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: 0.3.2
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/urdfdom_py-release.git
+      version: 0.3.2-0
+    source:
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: indigo-devel
+    status: maintained
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_py` to `0.3.2-0`:
- upstream repository: https://github.com/ros/urdf_parser_py/
- release repository: https://github.com/ros-gbp/urdfdom_py-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
