### PR TITLE
rviz: 1.11.11-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4823,7 +4823,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.11.10-0
+      version: 1.11.11-0
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.11.11-0`:
- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.11.10-0`
## rviz

```
* Added Qt version to rosout and help->about.
* Added optional support for Qt5 with continued support for Qt4.
* Fixed a C++11 warning about literals needing a space after them.
* Added a "duplicate" button for duplicating displays.
* Fixed remove display so that it selects another display after removing one (if one is available).
* Fix for #959 <https://github.com/ros-visualization/rviz/issues/959>: jumping marker in MOVE_3D mode
  See pull request: #961 <https://github.com/ros-visualization/rviz/issues/961>
* Added a raw mode for map vizualization.
  See pull request: #972 <https://github.com/ros-visualization/rviz/issues/972>
* Added an option in many of the topic based Displays to prefer UDP/unreliable transport.
  See pull request: #976 <https://github.com/ros-visualization/rviz/issues/976>
* Fixed the marker display to allow namespaces to be enabled/disabled based on the loaded config.
  Also enabled state is stored for each namespace in a map, which is used to lookup the state whenever a namespace is added to the display.
  See pull request: #962 <https://github.com/ros-visualization/rviz/issues/962>
* Fixed crash in ``Display::deleteStatus()`` when no statuses where created beforehand.
  See pull request: #960 <https://github.com/ros-visualization/rviz/issues/960>
* Read-only properties are now no longer editable.
  See pull request: #958 <https://github.com/ros-visualization/rviz/issues/958>
* The binary STL loading logic has been relaxed to support files that contain more data than expected.
  A warning is printed instead of failing with an error now.
  See pull request: #951 <https://github.com/ros-visualization/rviz/issues/951>
* Fixed an issue where tf configurations were not saved and reloaded from the rviz config file.
  See pull request: #946 <https://github.com/ros-visualization/rviz/issues/946>
* Anti-Aliasing (AA) is now enabled by default, but it can be disabled with ``--disable-anti-aliasing``.
  See pull request: #931 <https://github.com/ros-visualization/rviz/issues/931>
  See pull request: #950 <https://github.com/ros-visualization/rviz/issues/950>
* The default plugin shared library is no longer exported via rviz_LIBRARIES, but in stead is now
  in a cmake variable called rviz_DEFAULT_PLUGIN_LIBRARIES.
  See pull request: #948 <https://github.com/ros-visualization/rviz/issues/948>
  See pull request: #979 <https://github.com/ros-visualization/rviz/issues/979>
* Fixed a bug in billboard line generation where a zero point line caused a crash.
  See pull request: #942 <https://github.com/ros-visualization/rviz/issues/942>
* Downsampled maps will now result in a Warning status, previously it was OK.
  See pull request: #934 <https://github.com/ros-visualization/rviz/issues/934>
* The map display will no longer try to transform a map until one has been received.
  See pull request: #932 <https://github.com/ros-visualization/rviz/issues/932>
* Enable antialiasing
* Contributors: Aaron Hoy, Benjamin Chrétien, Chris Mansley, Dave Coleman, David V. Lu!!, Joao Avelino, Jochen Sprickerhof, Kentaro Wada, Martin Pecka, Mike O'Driscoll, Nikolaus Demmel, Robert Haschke, Simon Schmeisser (isys vision), Stephan, Tobias Berling, William Woodall, bponsler, caguero, frosthand
```
