### PR TITLE
pr2_apps: 0.5.21-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7185,7 +7185,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_apps-release.git
-      version: 0.5.18-0
+      version: 0.5.21-0
     source:
       type: git
       url: https://github.com/pr2/pr2_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_apps` to `0.5.21-0`:
- upstream repository: https://github.com/PR2/pr2_apps.git
- release repository: https://github.com/pr2-gbp/pr2_apps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.5.18-0`
