### PR TITLE
resource_retriever: 1.12.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -346,6 +346,12 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: indigo-devel
     status: maintained
+  resource_retriever:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/resource_retriever-release.git
+      version: 1.12.0-0
   ros:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -347,11 +347,19 @@ repositories:
       version: indigo-devel
     status: maintained
   resource_retriever:
+    doc:
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/resource_retriever-release.git
       version: 1.12.0-0
+    source:
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: kinetic-devel
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `1.12.0-0`:
- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros-gbp/resource_retriever-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## resource_retriever

```
* resource_retriever: adding missing dep
  Using the python resource_retriever requires the python-urlgrabber system dependency: http://rosindex.github.io/d/python-urlgrabber/
* Contributors: Jonathan Bohren
```
