### PR TITLE
eigen_stl_containers: 0.1.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -175,6 +175,12 @@ repositories:
       url: https://github.com/ros/dynamic_reconfigure.git
       version: master
     status: maintained
+  eigen_stl_containers:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/eigen_stl_containers-release.git
+      version: 0.1.5-0
   gencpp:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -176,11 +176,19 @@ repositories:
       version: master
     status: maintained
   eigen_stl_containers:
+    doc:
+      type: git
+      url: https://github.com/ros/eigen_stl_containers.git
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/eigen_stl_containers-release.git
       version: 0.1.5-0
+    source:
+      type: git
+      url: https://github.com/ros/eigen_stl_containers.git
+      version: master
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigen_stl_containers` to `0.1.5-0`:
- upstream repository: https://github.com/ros/eigen_stl_containers
- release repository: https://github.com/ros-gbp/eigen_stl_containers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## eigen_stl_containers

```
* Merge pull request #3 <https://github.com/ros/eigen_stl_containers/issues/3> from scpeters/patch-1
  add links to repository and issue tracker
* add links to repository and issue tracker
* Added tag 0.1.4 for changeset 27d05d1c09b5
* Contributors: Ioan Sucan, Steven Peters, William Woodall
```
