### PR TITLE
roslint: 0.11.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -494,6 +494,21 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: kinetic-devel
     status: maintained
+  roslint:
+    doc:
+      type: git
+      url: https://github.com/ros/roslint.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/roslint-release.git
+      version: 0.11.0-0
+    source:
+      type: git
+      url: https://github.com/ros/roslint.git
+      version: master
+    status: maintained
   roslisp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslint` to `0.11.0-0`:
- upstream repository: https://github.com/ros/roslint.git
- release repository: https://github.com/ros-gbp/roslint-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## roslint

```
* Add Alex Henning as maintainer
* Moved default flags for cpplint from cmake file to cpplint script to have centralized place for such flag.
* Set the python max-line-length to 120, allows rosrun roslint pep8 to run with the expected settings.
* Fixes issue #40 <https://github.com/ros/roslint/issues/40>.
* Contributors: Alex Henning, Andriy Petlovanyy, Mike Purvis
```
