### PR TITLE
python-pygame for all Ubuntu versions

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1265,18 +1265,7 @@ python-pydot:
 python-pygame:
   debian: [python-pygame]
   fedora: [pygame-devel]
-  ubuntu:
-    lucid: [python-pygame]
-    maverick: [python-pygame]
-    natty: [python-pygame]
-    oneiric: [python-pygame]
-    precise: [python-pygame]
-    quantal: [python-pygame]
-    raring: [python-pygame]
-    saucy: [python-pygame]
-    trusty: [python-pygame]
-    utopic: [python-pygame]
-    vivid: [python-pygame]
+  ubuntu: [python-pygame]
 python-pygithub3:
   ubuntu:
     pip:


### PR DESCRIPTION
pygame is necessary for korg_nanokontrol, and it's the same dependency name on all versions of Ubuntu.

**squish**
