### PR TITLE
unique_identifier: 1.0.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   debian:
@@ -596,6 +596,25 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
+      version: master
+    status: maintained
+  unique_identifier:
+    doc:
+      type: git
+      url: https://github.com/ros-geographic-info/unique_identifier.git
+      version: master
+    release:
+      packages:
+      - unique_id
+      - unique_identifier
+      - uuid_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-geographic-info/unique_identifier-release.git
+      version: 1.0.5-0
+    source:
+      type: git
+      url: https://github.com/ros-geographic-info/unique_identifier.git
       version: master
     status: maintained
   urdfdom_py:


### PR DESCRIPTION
Increasing version of package(s) in repository `unique_identifier` to `1.0.5-0`:
- upstream repository: https://github.com/ros-geographic-info/unique_identifier.git
- release repository: https://github.com/ros-geographic-info/unique_identifier-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## unique_id
- No changes
## unique_identifier
- No changes
## uuid_msgs
- No changes
