### PR TITLE
ackermann_msgs: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12,6 +12,21 @@ release_platforms:
   - wily
   - xenial
 repositories:
+  ackermann_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/ackermann_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/ackermann_msgs-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/ackermann_msgs.git
+      version: master
+    status: maintained
   actionlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ackermann_msgs` to `1.0.1-0`:
- upstream repository: https://github.com/ros-drivers/ackermann_msgs.git
- release repository: https://github.com/ros-drivers-gbp/ackermann_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## ackermann_msgs

```
* Removed Jim Rothrock from the maintainer list. Changed the version to 1.0.1.
```
