### PR TITLE
ar_track_alvar_msgs: 0.5.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -58,6 +58,21 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  ar_track_alvar_msgs:
+    doc:
+      type: git
+      url: https://github.com/sniekum/ar_track_alvar_msgs.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/ar_track_alvar_msgs-release.git
+      version: 0.5.1-0
+    source:
+      type: git
+      url: https://github.com/sniekum/ar_track_alvar_msgs.git
+      version: indigo-devel
+    status: maintained
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar_msgs` to `0.5.1-0`:
- upstream repository: https://github.com/sniekum/ar_track_alvar_msgs.git
- release repository: https://github.com/ros-gbp/ar_track_alvar_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## ar_track_alvar_msgs

```
* Release into Jade ROS
* Contributors: Isaac IY Saito
```
