### PR TITLE
stage: 4.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -598,6 +598,21 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: jade-devel
     status: maintained
+  stage:
+    doc:
+      type: git
+      url: https://github.com/ros-gbp/stage-release.git
+      version: release/kinetic/stage
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/stage-release.git
+      version: 4.1.1-0
+    source:
+      type: git
+      url: https://github.com/ros-gbp/stage-release.git
+      version: release/kinetic/stage
+    status: maintained
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stage` to `4.1.1-0`:
- upstream repository: https://github.com/rtv/Stage.git
- release repository: https://github.com/ros-gbp/stage-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
