### PR TITLE
korg_nanokontrol: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -317,6 +317,21 @@ repositories:
       url: https://github.com/ros-perception/image_common.git
       version: hydro-devel
     status: maintained
+  korg_nanokontrol:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/korg_nanokontrol.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/korg_nanokontrol-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/korg_nanokontrol.git
+      version: master
+    status: maintained
   media_export:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `korg_nanokontrol` to `0.1.2-0`:
- upstream repository: https://github.com/ros-drivers/korg_nanokontrol.git
- release repository: https://github.com/ros-gbp/korg_nanokontrol-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
