### PR TITLE
dynpick_driver: 0.0.9-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -682,7 +682,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/dynpick_driver-release.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/tork-a/dynpick_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynpick_driver` to `0.0.9-0`:
- upstream repository: https://github.com/tork-a/dynpick_driver.git
- release repository: https://github.com/tork-a/dynpick_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.8-0`
## dynpick_driver

```
* [fix] run.launch not publishing Wrench topic issue.
* [feat] Rename run.launch --> driver.launch
* [sys] add test
* [sys] add travis.yml
* [doc] Switched to sphinx; this doxygen setting seems not working, and the doc we want by rosdoc is not about api docs but rst files. (#20 <https://github.com/tork-a/dynpick_driver/issues/20>)
* Contributors: Kei Okada, Isaac I.Y. Saito
```
