### PR TITLE
jsk_common_msgs: 2.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -317,6 +317,20 @@ repositories:
       url: https://github.com/ros-perception/image_common.git
       version: hydro-devel
     status: maintained
+  jsk_common_msgs:
+    release:
+      packages:
+      - jsk_common_msgs
+      - jsk_footstep_msgs
+      - jsk_gui_msgs
+      - jsk_hark_msgs
+      - posedetection_msgs
+      - speech_recognition_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/jsk_common_msgs-release.git
+      version: 2.0.1-0
+    status: developed
   korg_nanokontrol:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common_msgs` to `2.0.1-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common_msgs
- release repository: https://github.com/tork-a/jsk_common_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## jsk_common_msgs
- No changes
## jsk_footstep_msgs

```
* [jsk_footstep_msgs] support multi legs in Footstep.msg keeping backwardcompatibility
* Contributors: Eisoku Kuroiwa
```
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## posedetection_msgs

```
* include/posedetection_msgs/feature0d_to_image.h: add cv.hpp
* CMakeLists.txt : remove posedetection_msgs depends on OpenCV; remove opencv from catkin_package, what provide opencv to catkin_LIBRARIES
* Contributors: Kei Okada
```
## speech_recognition_msgs
- No changes
