### PR TITLE
rtmros_gazebo: 0.1.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9742,7 +9742,12 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_gazebo-release.git
-      version: 0.1.9-0
+      version: 0.1.10-0
+    source:
+      type: git
+      url: https://github.com/start-jsk/rtmros_gazebo.git
+      version: master
+    status: developed
   rtmros_hironx:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_gazebo` to `0.1.10-0`:
- upstream repository: https://github.com/start-jsk/rtmros_gazebo.git
- release repository: https://github.com/tork-a/rtmros_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.9-0`
## eusgazebo

```
* Remove rosbuild related files
* rename .test -> .launch in order to avoid test after installation
* Contributors: MasakiMurooka, Ryohei Ueda
```
## hrpsys_gazebo_general

```
* [CMakeLists.txt] hotfix for compiling iob, https://github.com/fkanehiro/hrpsys-base/pull/803
* [hrpsys_gazebo_general] Supress message from SetVelPlugin.cpp
* [hrpsys_gazebo_general/src/IOBPlugin.cpp] add message when timeout loose synchronization
* [hrpsys_gazebo_general] add USE_ROBOT_POSE_EKF and USE_FOOTCOORDS  argument to select how to compute odometry
* [hrpsys_gazebo_general] Use $PROJECT_DIR to specify path to model file
* [hrpsys_gazebo_general/src/SetVelPlugin.cpp] set pose in gazebo loop by SetVelPlugin
* [hrpsys_gazebo_general/launch/samplerobot_hrpsys_bringup.launch] add kinematics mode option to launch file of sample robot in rtmros_gazebo
* [CMakeLists.txt, Makefile] Remove rosbuild related files
* [hrpsys_gazebo_general/scripts/gazebo_robot_kinematics_mode.py] do not disable gravity in kinematics mode
* [hrpsys_gazebo_general/src/IOBPlugin.cpp] add publish stepping
* [hrpsys_gazebo_general/src/IOBPlugin.cpp] add averaging joint effort
* [hrpsys_gazebo_general/cmake/compile_robot_model_for_gazebo.cmake] add auto generation for default robot config file for gazebo
* [hrpsys_gazebo_general/iob/iob.cpp] add loose_synchronize mode to IOBPlugin
* [hrpsys_gazebo_general/iob/iob.cpp] fix for setting gain on velocity feedback mode
* [hrpsys_gazebo_general/iob/iob.cpp] average filtering force sensor
* [hrpsys_gazebo_general] Add BASE_LINK argument
* [hrpsys_gazebo_general/launch/robot_hrpsys_bringup.launch,hrpsys_gazebo_general/scripts/gazebo_robot_kinematics_mode.py] add launch file option and script for gazebo kinematics mode
* [hrpsys_gazebo_general/launch/gazebo_kinect.launch, hrpsys_gazebo_general/launch/gazebo_sensor.launch, hrpsys_gazebo_general/worlds/empty_slow.world] use slow update world file for sensor simulation
* [hrpsys_gazebo_general/launch/robot_hrpsys_bringup.launch] add hrpsys_py argument
* [hrpsys_gazebo_general] Add kinect sensor
  * add PubTfPlugin
  * fix indent of SetVelPlugin
  * add kinect launch file
* Contributors: Masaki Murooka, Ryohei Ueda, Yohei Kakiuchi, Eisoku Kuroiwa, Shintaro Noda
```
## hrpsys_gazebo_msgs

```
* Remove rosbuild related files
* Contributors: Ryohei Ueda
```
## staro_moveit_config
- No changes
