### PR TITLE
Revert "jackal: 0.5.2-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3786,11 +3786,10 @@ repositories:
       - jackal_description
       - jackal_msgs
       - jackal_navigation
-      - jackal_tutorials
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.5.2-0
+      version: 0.5.1-0
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Reverts ros/rosdistro#10866

The Saucy branches are missing for this release.
