### PR TITLE
jackal: 0.5.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3786,10 +3786,11 @@ repositories:
       - jackal_description
       - jackal_msgs
       - jackal_navigation
+      - jackal_tutorials
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.5.1-0
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.5.2-1`:
- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.5.1-0`
## jackal_control

```
* Removed reference to FootprintLayer.
* Increased inflation radius to account for uneven wall in Jackal_world.
* Added pointgrey camera and accessories.
* Improve robot_localiztion params
* Added Sick LMS1XX URDF.
* Fixed example calibration output.
* Added tutorials.
* Contributors: Mike Purvis, Martin Cote, Tony Baltovski, James Servos
```
## jackal_msgs
- No changes
