### PR TITLE
New rosdep keys for libfcl-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1355,6 +1355,11 @@ libexpat1-dev:
     portage:
       packages: [dev-libs/expat]
   ubuntu: [libexpat1-dev]
+libfcl-dev:
+  arch: [fcl]
+  debian: [libfcl-dev]
+  fedora: [fcl]
+  ubuntu: [libfcl-dev]
 libfftw3:
   arch: [fftw]
   debian: [libfftw3-3, libfftw3-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1358,7 +1358,6 @@ libexpat1-dev:
 libfcl-dev:
   arch: [fcl]
   debian: [libfcl-dev]
-  fedora: [fcl]
   ubuntu: [libfcl-dev]
 libfftw3:
   arch: [fftw]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -171,6 +171,10 @@ libdmtx-dev:
   osx:
     homebrew:
       packages: [libdmtx]
+libfcl-dev:
+  osx:
+    homebrew:
+      packages: [dartsim/dart/fcl]
 libflann:
   osx:
     homebrew:


### PR DESCRIPTION
`libccd` and `fcl` are now included in upstream package managers (Ubuntu W,X) so we don't need to package them separately for Kinetic.

Should resolve https://github.com/ros-gbp/libccd-release/issues/1
