### PR TITLE
libccd-dev: new rosdep key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1242,6 +1242,11 @@ libcap2-bin:
   arch: [libcap]
   fedora: [libcap]
   ubuntu: [libcap2-bin]
+libccd-dev:
+  arch: [libccd]
+  debian: [libccd-dev]
+  fedora: [libccd]
+  ubuntu: [libccd-dev]
 libcegui-mk2-dev:
   arch: [cegui]
   debian: [libcegui-mk2-dev]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -155,6 +155,10 @@ jasper:
   osx:
     homebrew:
       packages: [jasper]
+libccd-dev:
+  osx:
+    homebrew:
+      packages: [homebrew/science/libccd]
 libconsole-bridge-dev:
   osx:
     homebrew:


### PR DESCRIPTION
This will replace the libccd ROS package.

subset of #10874 
