### PR TITLE
octomap: 1.7.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -415,7 +415,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/OctoMap/octomap.git
-      version: 1.7.1
+      version: v1.7.1
     release:
       packages:
       - dynamic_edt_3d

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -411,6 +411,25 @@ repositories:
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel
     status: maintained
+  octomap:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap.git
+      version: 1.7.1
+    release:
+      packages:
+      - dynamic_edt_3d
+      - octomap
+      - octovis
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/octomap-release.git
+      version: 1.7.1-0
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap.git
+      version: devel
+    status: developed
   opencv3:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap` to `1.7.1-0`:
- upstream repository: https://github.com/OctoMap/octomap.git
- release repository: https://github.com/ros-gbp/octomap-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
