### PR TITLE
navigation_tutorials: 0.2.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2785,7 +2785,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/navigation_tutorials-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/ros-planning/navigation_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_tutorials` to `0.2.3-0`:
- upstream repository: https://github.com/ros-planning/navigation_tutorials.git
- release repository: https://github.com/ros-gbp/navigation_tutorials-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.2-0`
