### PR TITLE
jsk_visualization: 1.0.30-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4150,7 +4150,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.29-0
+      version: 1.0.30-0
     status: developed
   jskeus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.30-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.29-0`
## jsk_interactive
- No changes
## jsk_interactive_marker
- No changes
## jsk_interactive_test
- No changes
## jsk_rqt_plugins
- No changes
## jsk_rviz_plugins

```
* use jsk_rviz_plugins::StringStamped instead of roseus::StringStamped, to remove roseus depends
* add rviz_DEFAULT_PLUGIN_LIBRARIES:  see https://github.com/ros-visualization/rviz/pull/979
* Contributors: Kei Okada
```
## jsk_visualization
- No changes
