### PR TITLE
octomap_mapping: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6392,7 +6392,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/octomap_mapping-release.git
-      version: 0.5.3-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/OctoMap/octomap_mapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping` to `0.6.0-0`:
- upstream repository: https://github.com/OctoMap/octomap_mapping
- release repository: https://github.com/ros-gbp/octomap_mapping-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.5.3-0`
## octomap_mapping
- No changes
## octomap_server

```
* Add sensor model parameters to dynamic_reconfigure
* Load map file from rosparam
* Add x and y filter for pointcloud
* Preparations for ColorOctomapServer (compile option, from source)
* Fix iterator in OctomapServer
* TrackingOctomapServer: Publish node center rather than index, prevent from publishing empty cloud
* Contributors: Armin Hornung, Javier V. Gomez, JJeremie Deray, MasakiMurooka, Shohei Fujii, Wolfgang Merkt
```
