### PR TITLE
xacro: 1.11.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -774,5 +774,20 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: kinetic
     status: maintained
+  xacro:
+    doc:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/xacro-release.git
+      version: 1.11.0-0
+    source:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: kinetic-devel
+    status: developed
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.11.0-0`:
- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## xacro

```
* added short option -i as alternative to --inorder
* refactored main to fix #122, #107
* added xacro indicator to error message to fix #123
* moved banner generation to process_file()
* removed special (but obsolete) output handling for just_includes mode
* moved core processing pipeline into function process_file()
* improved documentation: more comments, input_file -> input_file_name
* fix #120: handle non-space whitespace characters in params string
* extended tests to handle non-space whitespace characters in params string
* always store macros with xacro: prefix in front: #118
* fix #115: enforce xacro namespace usage with --xacro-ns option
* apply correct checking for include tags, and extend testcase
* allow (one-level) nested expression/extension evaluation
* Contributors: Robert Haschke, Morgan Quigley
```
