### PR TITLE
octomap: 1.7.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -424,7 +424,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/octomap-release.git
-      version: 1.7.1-0
+      version: 1.7.2-0
     source:
       type: git
       url: https://github.com/OctoMap/octomap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap` to `1.7.2-0`:
- upstream repository: https://github.com/OctoMap/octomap.git
- release repository: https://github.com/ros-gbp/octomap-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.7.1-0`
