### PR TITLE
filters: 1.7.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -219,6 +219,21 @@ repositories:
       type: git
       url: https://github.com/ros/eigen_stl_containers.git
       version: master
+  filters:
+    doc:
+      type: git
+      url: https://github.com/ros/filters.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/filters-release.git
+      version: 1.7.4-1
+    source:
+      type: git
+      url: https://github.com/ros/filters.git
+      version: hydro-devel
+    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `1.7.4-1`:
- upstream repository: https://github.com/ros/filters.git
- release repository: https://github.com/ros-gbp/filters-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
