### PR TITLE
Add gcc-arm-none-eabi package to base

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -788,6 +788,11 @@ gazebo5:
   fedora: [gazebo]
   gentoo: [sci-electronics/gazebo]
   ubuntu: [gazebo5]
+gcc-arm-none-eabi:
+  arch: [gcc-arm-none-eabi]
+  debian: [gcc-arm-none-eabi]
+  fedora: [arm-none-eabi-gcc-cs]
+  ubuntu: [gcc-arm-none-eabi]
 gcc-avr:
   arch: [avr-gcc]
   debian: [gcc-avr]


### PR DESCRIPTION
https://launchpad.net/gcc-arm-embedded
