### PR TITLE
laser_filters: 1.8.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1897,7 +1897,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/laser_filters.git
-      version: jade-devel
+      version: indigo-devel
     release:
       tags:
         release: release/jade/{package}/{version}
@@ -1906,7 +1906,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git
-      version: jade-devel
+      version: indigo-devel
     status: maintained
   laser_geometry:
     doc:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1902,7 +1902,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/laser_filters-release.git
-      version: 1.8.0-1
+      version: 1.8.1-0
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `1.8.1-0`:
- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros-gbp/laser_filters-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.8.0-1`
## laser_filters

```
* Remove deprecated warning from footprint filter
* catkin_make requires cmake_modules in run_depends
* Restore cmake_modules build dependency
* Update package.xml
* Update maintainer email address
* Add Travis CI config
* Update scan_to_scan_filter_chain.cpp
* only publish result if filter succeeded
* Contributors: Isaac I.Y. Saito, Jon Binney, Jonathan Binney, Kei Okada, Naveed Usmani, asimay
```
