### PR TITLE
mavros: 0.17.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5066,7 +5066,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.17.0-0
+      version: 0.17.1-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.17.1-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.17.0-0`
## libmavconn

```
* MAVConnSerial: Stop io_service before closing serial device (Fixes #130 <https://github.com/mavlink/mavros/issues/130>)
  The serial device was closed before calling io_service.stop() so io_service::run() never returned, leading to hang on join in MAVConnSerial::close()

      Backtrace:
  #0  0x00007f80217e966b in pthread_join (threadid=140188059690752, thread_return=0x0) at pthread_join.c:92
  #1  0x00007f80215602d7 in std::thread::join() ()
  #2  0x00007f8020ccc674 in mavconn::MAVConnSerial::close() ()
  #3  0x00007f8020ccc6f5 in mavconn::MAVConnSerial::~MAVConnSerial() ()
  #4  0x00007f8020cc7b2e in boost::detail::sp_counted_impl_pd<mavconn::MAVConnSerial*, boost::detail::sp_ms_deleter<mavconn::MAVConnSerial> >::dispose() ()
  #5  0x000000000040ee0a in boost::detail::sp_counted_base::release() [clone .part.27] [clone .constprop.472] ()
  #6  0x000000000041eb22 in mavros::MavRos::~MavRos() ()
  #7  0x000000000040eb38 in main ()

* Contributors: Kartik Mohta
```
## mavros

```
* lib: Add QLAND mode of APM:Plane
  https://github.com/mavlink/mavlink/commit/a0ed95c3a7d97a8f8d86ce3f95c4bf269f439c46
* Update contributing guide
  We forgot to mention uncrustify commit.
* Treat submarine vehicles like copter vehicles
* Contributors: Josh Villbrandt, Vladimir Ermakov
```
## mavros_extras

```
* ran uncrustify
* fixed typos
* use CUBE_LIST for faster rendering
* limit track size
* use local variable
* fixed indentation
* added rc modes
* moved rc to rc_override_control()
* replaced tabulations with spaces (4)
* introducing RC modes
* fixed
* quality added
* added visualization for local setpoints
* Contributors: Joey Gong, francois
```
## mavros_msgs
- No changes
## test_mavros
- No changes
