### PR TITLE
ntpd_driver: 1.2.0-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2908,7 +2908,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/vooon/ntpd_driver-release.git
-      version: 1.2.0-0
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/vooon/ntpd_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ntpd_driver` to `1.2.0-1`:
- upstream repository: https://github.com/vooon/ntpd_driver.git
- release repository: https://github.com/vooon/ntpd_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.2.0-0`
## ntpd_driver

```
* #2 <https://github.com/vooon/ntpd_driver/issues/2>: allow both UDPROS and TCPROS
* Contributors: Vladimir Ermakov
```
