### PR TITLE
destruction_scenarios-release: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1786,8 +1786,6 @@ repositories:
     status: developed
   destruction_scenarios:
     release:
-      packages:
-      - destruction_scenarios
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/roboptics/destruction_scenarios-release.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1784,6 +1784,14 @@ repositories:
       url: https://github.com/code-iai-release/designator_integration-release.git
       version: 0.0.3-0
     status: developed
+  destruction_scenarios-release:
+    release:
+      packages:
+      - destruction_scenarios
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/roboptics/destruction_scenarios-release.git
+      version: 1.0.0-0
   diagnostics:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1784,7 +1784,7 @@ repositories:
       url: https://github.com/code-iai-release/designator_integration-release.git
       version: 0.0.3-0
     status: developed
-  destruction_scenarios-release:
+  destruction_scenarios:
     release:
       packages:
       - destruction_scenarios


### PR DESCRIPTION
Increasing version of package(s) in repository `destruction_scenarios-release` to `1.0.0-0`:
- upstream repository: https://github.com/roboptics/destruction_scenarios.git
- release repository: https://github.com/roboptics/destruction_scenarios-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
