### PR TITLE
Update libqglviewer rules for debian.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2067,7 +2067,9 @@ libqd-dev:
   ubuntu: [libqd-dev]
 libqglviewer-qt4:
   arch: [libqglviewer-qt4]
-  debian: [libqglviewer-qt4-2]
+  debian:
+    jessie: [libqglviewer2]
+    wheezy: [libqglviewer-qt4-2]
   fedora: [libQGLViewer]
   macports: [libQGLViewer]
   ubuntu:
@@ -2086,7 +2088,9 @@ libqglviewer-qt4:
     xenial: [libqglviewer2-qt4]
 libqglviewer-qt4-dev:
   arch: [libqglviewer-qt4]
-  debian: [libqglviewer-qt4-dev]
+  debian:
+    jessie: [libqglviewer-dev]
+    wheezy: [libqglviewer-qt4-dev]
   fedora: [libQGLViewer-devel]
   ubuntu:
     lucid: [libqglviewer-qt4-dev]


### PR DESCRIPTION
The sourcedeb has stayed the same, however the binary packages have been renamed.

Sourcedeb: https://packages.debian.org/source/jessie/libqglviewer

Wheezy binaries:
https://packages.debian.org/wheezy/libqglviewer-qt4-dev
https://packages.debian.org/wheezy/libqglviewer-qt4-2

Jessie equivalents:
https://packages.debian.org/jessie/libqglviewer-dev
https://packages.debian.org/jessie/libqglviewer2

This will fix `octoviz` building on debian: http://54.183.26.131:8080/view/Kbin_dJ64/job/Kbin_dJ64__octovis__debian_jessie_amd64__binary/7/console @ahornung when this is merged if you could rerun bloom that would fix the above build.
