### PR TITLE
Update debian rosdep rule for libjpeg-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1644,7 +1644,9 @@ libjackson-json-java:
   ubuntu: [libjackson-json-java]
 libjpeg:
   arch: [libjpeg-turbo]
-  debian: [libjpeg8-dev]
+  debian:
+    jessie: [libjpeg62-turbo-dev]
+    wheezy: [libjpeg8-dev]
   fedora: [libjpeg-turbo-devel]
   gentoo: [media-libs/libjpeg-turbo]
   macports: [jpeg]


### PR DESCRIPTION
It's a dummy package and the provider changed from libjpeg8-dev to libjpeg62-turbo-dev

https://packages.debian.org/search?searchon=names&keywords=libjpeg
https://packages.debian.org/jessie/libjpeg62-turbo-dev
