### PR TITLE
stage: 4.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -715,7 +715,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/stage-release.git
-      version: 4.1.1-0
+      version: 4.1.1-1
     source:
       type: git
       url: https://github.com/ros-gbp/stage-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `stage` to `4.1.1-1`:
- upstream repository: https://github.com/rtv/Stage.git
- release repository: https://github.com/ros-gbp/stage-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `4.1.1-0`
