### PR TITLE
octomap_msgs: 0.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -460,6 +460,21 @@ repositories:
       url: https://github.com/OctoMap/octomap.git
       version: devel
     status: developed
+  octomap_msgs:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_msgs.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_msgs-release.git
+      version: 0.3.2-0
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_msgs.git
+      version: indigo-devel
+    status: maintained
   opencv3:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_msgs` to `0.3.2-0`:
- upstream repository: https://github.com/OctoMap/octomap_msgs.git
- release repository: https://github.com/ros-gbp/octomap_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## octomap_msgs

```
* Fixing issue octomap_rviz_plugins/#10: Allow deserializing an empty octree
* Contributors: Armin Hornung
```
