### PR TITLE
dji_onboardsdk_ros: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1831,7 +1831,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/dji-sdk/Onboard-SDK-ROS-Release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/dji-sdk/Onboard-SDK-ROS.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dji_onboardsdk_ros` to `0.1.3-0`:
- upstream repository: https://github.com/dji-sdk/Onboard-SDK-ROS.git
- release repository: https://github.com/dji-sdk/Onboard-SDK-ROS-Release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.2-0`
