### PR TITLE
md49_base_controller: 0.1.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   debian:
@@ -361,6 +361,25 @@ repositories:
       url: https://github.com/ros-drivers/korg_nanokontrol.git
       version: master
     status: maintained
+  md49_base_controller:
+    doc:
+      type: git
+      url: https://github.com/Scheik/md49_base_controller.git
+      version: kinetic-devel
+    release:
+      packages:
+      - md49_base_controller
+      - md49_messages
+      - md49_serialport
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Scheik/md49_base_controller-release.git
+      version: 0.1.4-0
+    source:
+      type: git
+      url: https://github.com/Scheik/md49_base_controller.git
+      version: kinetic-devel
+    status: developed
   media_export:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `md49_base_controller` to `0.1.4-0`:
- upstream repository: https://github.com/Scheik/md49_base_controller.git
- release repository: https://github.com/Scheik/md49_base_controller-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## md49_base_controller

```
* No changes, keep release on track with md49_base_controller
* Contributors: Fabian Prinzing
```
## md49_messages

```
* No changes, keep release on track with md49_base_controller
* Contributors: Fabian Prinzing
```
## md49_serialport

```
* Update md49_serialport CMakeLists.txt: Marked header files for installation
* Contributors: Fabian Prinzing
```
