### PR TITLE
qt_gui_core: 0.2.30-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3655,7 +3655,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.2.29-0
+      version: 0.2.30-0
     source:
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.2.30-0`:
- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.29-0`
## qt_dotgraph

```
* use same color for arrows as for the edge (#60 <https://github.com/ros-visualization/qt_gui_core/issues/60>)
* add ability to specify tooltips for nodes (#61 <https://github.com/ros-visualization/qt_gui_core/pull/61>)
```
## qt_gui

```
* add X11 threading for ssh display (#62 <https://github.com/ros-visualization/qt_gui_core/pull/62>)
* allow renaming dock widgets (#63 <https://github.com/ros-visualization/qt_gui_core/pull/63>)
```
## qt_gui_app
- No changes
## qt_gui_cpp
- No changes
## qt_gui_py_common
- No changes
