### PR TITLE
geometry_experimental has been renamed to geometry2

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1384,7 +1384,7 @@ repositories:
   geometry_experimental:
     doc:
       type: git
-      url: https://github.com/ros/geometry-experimental.git
+      url: https://github.com/ros/geometry2.git
       version: groovy-devel
     release:
       packages:

--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1397,7 +1397,7 @@ repositories:
       - tf2_tools
       tags:
         release: release/groovy/{package}/{version}
-      url: https://github.com/ros-gbp/geometry_experimental-release.git
+      url: https://github.com/ros-gbp/geometry2-release.git
       version: 0.3.7-0
     status: developed
   geometry_tutorials:

--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -1369,19 +1369,7 @@ repositories:
       url: http://kforge.ros.org/geometry/geometry
       version: default
     status: maintained
-  geometry_angles_utils:
-    release:
-      packages:
-      - angles
-      tags:
-        release: release/groovy/{package}/{version}
-      url: https://github.com/ros-gbp/geometry_angles_utils-release.git
-      version: 1.9.8-0
-    source:
-      type: git
-      url: https://github.com/ros/angles.git
-      version: master
-  geometry_experimental:
+  geometry2:
     doc:
       type: git
       url: https://github.com/ros/geometry2.git
@@ -1400,6 +1388,18 @@ repositories:
       url: https://github.com/ros-gbp/geometry2-release.git
       version: 0.3.7-0
     status: developed
+  geometry_angles_utils:
+    release:
+      packages:
+      - angles
+      tags:
+        release: release/groovy/{package}/{version}
+      url: https://github.com/ros-gbp/geometry_angles_utils-release.git
+      version: 1.9.8-0
+    source:
+      type: git
+      url: https://github.com/ros/angles.git
+      version: master
   geometry_tutorials:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2246,7 +2246,7 @@ repositories:
   geometry_experimental:
     doc:
       type: git
-      url: https://github.com/ros/geometry-experimental.git
+      url: https://github.com/ros/geometry2.git
       version: hydro-devel
     release:
       packages:
@@ -2265,7 +2265,7 @@ repositories:
       version: 0.4.12-0
     source:
       type: git
-      url: https://github.com/ros/geometry_experimental.git
+      url: https://github.com/ros/geometry2.git
       version: hydro-devel
     status: maintained
   geometry_tutorials:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2227,23 +2227,7 @@ repositories:
       url: https://github.com/ros/geometry.git
       version: hydro-devel
     status: maintained
-  geometry_angles_utils:
-    doc:
-      type: git
-      url: https://github.com/ros/angles.git
-      version: master
-    release:
-      packages:
-      - angles
-      tags:
-        release: release/hydro/{package}/{version}
-      url: https://github.com/ros-gbp/geometry_angles_utils-release.git
-      version: 1.9.9-0
-    source:
-      type: git
-      url: https://github.com/ros/angles.git
-      version: master
-  geometry_experimental:
+  geometry2:
     doc:
       type: git
       url: https://github.com/ros/geometry2.git
@@ -2268,6 +2252,22 @@ repositories:
       url: https://github.com/ros/geometry2.git
       version: hydro-devel
     status: maintained
+  geometry_angles_utils:
+    doc:
+      type: git
+      url: https://github.com/ros/angles.git
+      version: master
+    release:
+      packages:
+      - angles
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/ros-gbp/geometry_angles_utils-release.git
+      version: 1.9.9-0
+    source:
+      type: git
+      url: https://github.com/ros/angles.git
+      version: master
   geometry_tutorials:
     release:
       packages:

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -2261,7 +2261,7 @@ repositories:
       - tf2_tools
       tags:
         release: release/hydro/{package}/{version}
-      url: https://github.com/ros-gbp/geometry_experimental-release.git
+      url: https://github.com/ros-gbp/geometry2-release.git
       version: 0.4.12-0
     source:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2753,7 +2753,7 @@ repositories:
       url: https://github.com/ros/geometry.git
       version: indigo-devel
     status: maintained
-  geometry_experimental:
+  geometry2:
     doc:
       type: git
       url: https://github.com/ros/geometry2.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2773,7 +2773,7 @@ repositories:
       - tf2_tools
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/geometry_experimental-release.git
+      url: https://github.com/ros-gbp/geometry2-release.git
       version: 0.5.13-0
     source:
       test_pull_requests: true

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2756,7 +2756,7 @@ repositories:
   geometry_experimental:
     doc:
       type: git
-      url: https://github.com/ros/geometry_experimental.git
+      url: https://github.com/ros/geometry2.git
       version: indigo-devel
     release:
       packages:
@@ -2778,7 +2778,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ros/geometry_experimental.git
+      url: https://github.com/ros/geometry2.git
       version: indigo-devel
     status: maintained
   geometry_tutorials:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1171,7 +1171,7 @@ repositories:
       - tf2_tools
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/geometry_experimental-release.git
+      url: https://github.com/ros-gbp/geometry2-release.git
       version: 0.5.13-0
     source:
       test_pull_requests: true

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1154,7 +1154,7 @@ repositories:
   geometry_experimental:
     doc:
       type: git
-      url: https://github.com/ros/geometry_experimental.git
+      url: https://github.com/ros/geometry2.git
       version: indigo-devel
     release:
       packages:
@@ -1176,7 +1176,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ros/geometry_experimental.git
+      url: https://github.com/ros/geometry2.git
       version: indigo-devel
     status: maintained
   geometry_tutorials:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1151,7 +1151,7 @@ repositories:
       url: https://github.com/ros/geometry.git
       version: indigo-devel
     status: maintained
-  geometry_experimental:
+  geometry2:
     doc:
       type: git
       url: https://github.com/ros/geometry2.git


### PR DESCRIPTION
This changes all urls referring to the old repos to point to the new ones. It's just a url change and I changed the older distros for clarity. (Note github redirects everything successfully at the moment.)

Because of changing the older distros it will fail the checks for changes to old distros, but since there are no changes to the content it's fine to override that check. It's not nuanced enough to catch this case. 
