### PR TITLE
ros_numpy: 0.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8938,6 +8938,20 @@ repositories:
       type: git
       url: https://github.com/RodBelaFarin/ros_in_hand_scanner.git
       version: master
+  ros_numpy:
+    doc:
+      type: git
+      url: https://github.com/eric-wieser/ros_numpy.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/eric-wieser/ros_numpy-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/eric-wieser/ros_numpy.git
+      version: master
   ros_openlighting:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_numpy` to `0.0.1-1`:
- upstream repository: https://github.com/eric-wieser/ros_numpy.git
- release repository: https://github.com/eric-wieser/ros_numpy-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
