### PR TITLE
interactive_world: 0.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3757,7 +3757,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/interactive_world-release.git
-      version: 0.0.10-0
+      version: 0.0.12-0
     source:
       type: git
       url: https://github.com/GT-RAIL/interactive_world.git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_world` to `0.0.12-0`:
- upstream repository: https://github.com/WPI-RAIL/interactive_world.git
- release repository: https://github.com/gt-rail-release/interactive_world-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.10-0`
## informed_object_search
- No changes
## interactive_world
- No changes
## interactive_world_msgs
- No changes
## interactive_world_parser
- No changes
## interactive_world_tools

```
* Removes outdated CARL deps
* Contributors: Russell Toris
```
## jinteractiveworld
- No changes
## spatial_world_model
- No changes
