### PR TITLE
Adding create_autonomy to documentation index for indigo and jade

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1625,6 +1625,16 @@ repositories:
       url: https://github.com/whoenig/crazyflie_ros.git
       version: master
     status: maintained
+  create_autonomy:
+    doc:
+      type: git
+      url: https://github.com/AutonomyLab/create_autonomy.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/AutonomyLab/create_autonomy.git
+      version: indigo-devel
+    status: developed
   crsm_slam:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -546,6 +546,16 @@ repositories:
       url: https://github.com/whoenig/crazyflie_ros.git
       version: master
     status: maintained
+  create_autonomy:
+    doc:
+      type: git
+      url: https://github.com/AutonomyLab/create_autonomy.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/AutonomyLab/create_autonomy.git
+      version: indigo-devel
+    status: developed
   csm:
     doc:
       type: git


### PR DESCRIPTION
I'd like create_autonomy to be indexed and documented on ros.org. Thanks!
