### PR TITLE
orocos_kinematics_dynamics: 1.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -501,6 +501,21 @@ repositories:
       url: https://github.com/ros-gbp/opencv3-release.git
       version: 3.1.0-5
     status: maintained
+  orocos_kinematics_dynamics:
+    release:
+      packages:
+      - orocos_kdl
+      - orocos_kinematics_dynamics
+      - python_orocos_kdl
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/smits/orocos-kdl-release.git
+      version: 1.3.0-0
+    source:
+      type: git
+      url: https://github.com/orocos/orocos_kinematics_dynamics.git
+      version: master
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kinematics_dynamics` to `1.3.0-0`:
- upstream repository: https://github.com/orocos/orocos_kinematics_dynamics.git
- release repository: https://github.com/smits/orocos-kdl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
