### PR TITLE
geometry2: 0.5.13-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -311,6 +311,33 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: indigo-devel
     status: maintained
+  geometry2:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry2.git
+      version: indigo-devel
+    release:
+      packages:
+      - geometry_experimental
+      - tf2
+      - tf2_bullet
+      - tf2_eigen
+      - tf2_geometry_msgs
+      - tf2_kdl
+      - tf2_msgs
+      - tf2_py
+      - tf2_ros
+      - tf2_sensor_msgs
+      - tf2_tools
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/geometry2-release.git
+      version: 0.5.13-0
+    source:
+      type: git
+      url: https://github.com/ros/geometry2.git
+      version: indigo-devel
+    status: maintained
   image_common:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -318,7 +318,6 @@ repositories:
       version: indigo-devel
     release:
       packages:
-      - geometry_experimental
       - tf2
       - tf2_bullet
       - tf2_eigen


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.5.13-0`:
- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## tf2
- No changes
## tf2_bullet

```
* Don't export catkin includes
  They only point to the temporary include in the build directory.
* Contributors: Jochen Sprickerhof
```
## tf2_eigen

```
* Added missing inline
* Added unit test
  - Testing conversion to msg forward/backward
* Added eigenTotransform function
* Contributors: Davide Tateo, boris-il-forte
```
## tf2_geometry_msgs

```
* Add missing python_orocos_kdl dependency
* make example into unit test
* vector3 not affected by translation
* Contributors: Daniel Claes, chapulina
```
## tf2_kdl

```
* converting python test script into unit test
* Don't export catkin includes
* Contributors: Jochen Sprickerhof, Tully Foote
```
## tf2_msgs
- No changes
## tf2_py
- No changes
## tf2_ros

```
* fix documentation warnings
* Adding tests to package
* Contributors: Laurent GEORGE, Vincent Rabaud
```
## tf2_sensor_msgs

```
* add missing Python runtime dependency
* fix wrong comment
* Adding tests to package
* Fixing do_transform_cloud for python
  The previous code was not used at all (it was a mistake in the __init__.py so
  the do_transform_cloud was not available to the python users).
  The python code need some little correction (e.g there is no method named
  read_cloud but it's read_points for instance, and as we are in python we can't
  use the same trick as in c++ when we got an immutable)
* Contributors: Laurent GEORGE, Vincent Rabaud
```
## tf2_tools

```
* casted el to string in view_frames
* Contributors: g_gemignani
```
