### PR TITLE
geometry: 1.11.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -311,6 +311,27 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: indigo-devel
     status: maintained
+  geometry:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry.git
+      version: indigo-devel
+    release:
+      packages:
+      - eigen_conversions
+      - geometry
+      - kdl_conversions
+      - tf
+      - tf_conversions
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/geometry-release.git
+      version: 1.11.8-0
+    source:
+      type: git
+      url: https://github.com/ros/geometry.git
+      version: indigo-devel
+    status: maintained
   geometry2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry` to `1.11.8-0`:
- upstream repository: https://github.com/ros/geometry.git
- release repository: https://github.com/ros-gbp/geometry-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## eigen_conversions

```
* eigen_conversions: Add conversions for Eigen::Isometry3d
* Contributors: Maarten de Vries
```
## geometry
- No changes
## kdl_conversions
- No changes
## tf

```
* Update assertQuaternionValid to check for NaNs
* Remove outdated manifest loading in python files
* update unit tests to catch https://github.com/ros/geometry_experimental/issues/102
* Contributors: Chris Mansley, Michael Hwang, Tully Foote
```
## tf_conversions

```
* tf_conversions: Add conversion functions for Eigen::Isometry3d
* Remove outdated manifest loading in python files
* Contributors: Maarten de Vries, Michael Hwang
```
