### PR TITLE
python_qt_binding: 0.2.19-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3643,7 +3643,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/python_qt_binding-release.git
-      version: 0.2.18-0
+      version: 0.2.19-0
     source:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `0.2.19-0`:
- upstream repository: git://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros-gbp/python_qt_binding-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.18-0`
## python_qt_binding

```
* add QtWidgets for forward compatibility with Qt5, it only allows writing plugins targeting both version but not to make this branch compatible with Qt5 (#31 <https://github.com/ros-visualization/python_qt_binding/issues/31>)
* fix check if sip is available
* print full stacktrace
```
