### PR TITLE
openni_camera: 1.9.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6661,7 +6661,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/openni_camera-release.git
-      version: 1.9.4-3
+      version: 1.9.5-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_camera` to `1.9.5-0`:
- upstream repository: https://github.com/ros-drivers/openni_camera.git
- release repository: https://github.com/ros-gbp/openni_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.9.4-3`
## openni_camera

```
* [feat] Updated max drop rate
* [sys] Added log4cxx missing explicit linkage #44 <https://github.com/ros-drivers/openni_camera/issues/44>
* Contributors: Francois-Michel De Rainville, Isaac IY Saito, Leopold Palomo-Avellaneda, Isaac I.Y. Saito
```
