### PR TITLE
diagnostics: 1.8.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -189,6 +189,29 @@ repositories:
       url: https://github.com/ros/common_tutorials.git
       version: hydro-devel
     status: maintained
+  diagnostics:
+    doc:
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: indigo-devel
+    release:
+      packages:
+      - diagnostic_aggregator
+      - diagnostic_analysis
+      - diagnostic_common_diagnostics
+      - diagnostic_updater
+      - diagnostics
+      - self_test
+      - test_diagnostic_aggregator
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/diagnostics-release.git
+      version: 1.8.9-0
+    source:
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: indigo-devel
+    status: maintained
   dynamic_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `1.8.9-0`:
- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros-gbp/diagnostics-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## diagnostic_aggregator

```
* Add version dependencies in package.xml
* Add version check in cmake
* Add functionality for dynamically adding analyzers
* Contributors: Michal Staniaszek, trainman419
```
## diagnostic_analysis
- No changes
## diagnostic_common_diagnostics
- No changes
## diagnostic_updater
- No changes
## diagnostics
- No changes
## self_test
- No changes
## test_diagnostic_aggregator

```
* Add version dependencies in package.xml
* Contributors: trainman419
```
