### PR TITLE
catkin_pure_python: 0.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1016,6 +1016,21 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: indigo-devel
     status: maintained
+  catkin_pure_python:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/catkin_pure_python.git
+      version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/catkin_pure_python-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/asmodehn/catkin_pure_python.git
+      version: indigo
+    status: developed
   cit_adis_imu:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pure_python` to `0.0.1-1`:
- upstream repository: https://github.com/asmodehn/catkin_pure_python.git
- release repository: https://github.com/asmodehn/catkin_pure_python-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## catkin_pure_python

```
* Provides catkin_npm_update_target() and catkin_npm_update_once()
* Contributors: AlexV
```
