### PR TITLE
multimaster_fkie: 0.5.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5704,7 +5704,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.5.2-0
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.5.3-0`:
- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.5.2-0`
## default_cfg_fkie
- No changes
## master_discovery_fkie
- No changes
## master_sync_fkie
- No changes
## multimaster_fkie

```
* node_manager_fkie: fix remote start
* Contributors: Alexander Tiderko
```
## multimaster_msgs_fkie
- No changes
## node_manager_fkie

```
* node_manager_fkie: fix remote start
* Contributors: Alexander Tiderko
```
