### PR TITLE
universal_robot: 1.1.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11355,6 +11355,7 @@ repositories:
       packages:
       - universal_robot
       - ur10_moveit_config
+      - ur3_moveit_config
       - ur5_moveit_config
       - ur_bringup
       - ur_description
@@ -11365,7 +11366,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/universal_robot-release.git
-      version: 1.1.5-0
+      version: 1.1.6-0
     source:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robot` to `1.1.6-0`:
- upstream repository: https://github.com/ros-industrial/universal_robot.git
- release repository: https://github.com/ros-industrial-release/universal_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.1.5-0`
## universal_robot

```
* add moveit_config for ur3
* Contributors: ipa-fxm
```
## ur10_moveit_config

```
* add missing dependency for moveit_simple_controller_manager
* Merge branch 'indigo-devel' of github.com:ros-industrial/universal_robot into ur3_moveit_config
* apply latest setup assistant changes to ur5 and ur10
* Adding comment explaining the choice of default planning algorithm
* Use RRTConnect by default for UR10
  Fixes bug #193 <https://github.com/ros-industrial/universal_robot/issues/193> about slow planning on Indigo
  LBKPIECE1 (the previous default) looks to be the wrong planning algorithm for the robot
  See https://groups.google.com/forum/#!topic/moveit-users/M71T-GaUNgg
* crop ik solutions wrt joint_limits
* set planning time to 0
* reduce planning attempts in moveit rviz plugin
* Contributors: Marco Esposito, ipa-fxm
```
## ur3_moveit_config

```
* add missing dependency for moveit_simple_controller_manager
* apply default RRTConnect to ur3
* add moveit_config for ur3
* Contributors: ipa-fxm
```
## ur5_moveit_config

```
* add missing dependency for moveit_simple_controller_manager
* Merge branch 'indigo-devel' of github.com:ros-industrial/universal_robot into ur3_moveit_config
* apply latest setup assistant changes to ur5 and ur10
* Adding comment explaining the choice of default planning algorithm
* Use RRTConnect by default for UR5
  Fixes bug #193 <https://github.com/ros-industrial/universal_robot/issues/193> about slow planning on Indigo
  LBKPIECE1 (the previous default) looks to be the wrong planning algorithm for the robot
  See https://groups.google.com/forum/#!topic/moveit-users/M71T-GaUNgg
* crop ik solutions wrt joint_limits
* set planning time to 0
* reduce planning attempts in moveit rviz plugin
* Contributors: Marco Esposito, ipa-fxm
```
## ur_bringup

```
* provide launch files for ur3
* Contributors: ipa-fxm
```
## ur_description

```
* unify mesh names
* add color to avoid default color 'red' for collision meshes
* use correct DH parameter + colored meshes
* introducing urdf for ur3 - first draft
* unify common xacro files
* remove obsolete urdf files
* description: add '_joint' suffix to newly introduced joint tags.
  This is more in-line with naming of existing joint tags.
* description: add ROS-I base and tool0 frames. Fix #49 <https://github.com/ros-industrial/universal_robot/issues/49> and #95 <https://github.com/ros-industrial/universal_robot/issues/95>.
  Note that 'base' is essentially 'base_link' but rotated by 180
  degrees over the Z-axis. This is necessary as the visual and
  collision geometries appear to also have their origins rotated
  180 degrees wrt the real robot.
  'tool0' is similar to 'ee_link', but with its orientation such
  that it coincides with an all-zeros TCP setting on the UR
  controller. Users are expected to attach their own TCP frames
  to this frame, instead of updating it (see also [1]).
  [1] http://wiki.ros.org/Industrial/Tutorials/WorkingWithRosIndustrialRobotSupportPackages#Standardised_links_.2BAC8_frames
* description: minor whitespace cleanup of UR5 & 10 xacros.
* regenerate urdf files
* use PositionJointInterface as hardwareInterface in transmissions - affects simulation only
* Contributors: gavanderhoorn, ipa-fxm
```
## ur_driver

```
* Moved SetIO FUN constants from driver.py to relevant srv file for easier interaction from other files
* Merge pull request #170 <https://github.com/ros-industrial/universal_robot/issues/170> from ipa-fxm/prevent_programming
  [Indigo] enable reconfigure and set_param side by side
* Merge pull request #189 <https://github.com/ros-industrial/universal_robot/issues/189> from abubeck/157_for_indigo
  port of PR #157 <https://github.com/ros-industrial/universal_robot/issues/157> to indigo
* catkin_lint
* enable reconfigure and set_param side by side
* port of PR #157 <https://github.com/ros-industrial/universal_robot/issues/157> to indigo
* driver: Factor out __send_message method.
* porting PR #165 <https://github.com/ros-industrial/universal_robot/issues/165> to indigo
* dynamic reconfigure server for prevent_programming
* RobotStateRT V15 added to indigo_devw
* Changed variable params_mult to unique name in each socket_read instance.
* Fixed unpacking of MasterboardData_V30.
* Contributors: Alexander Bubeck, Dan Solomon, Maarten de Vries, Thomas Timm Andersen, Wouter van Oijen, abubeck, ipa-fxm, jeppewalther
```
## ur_gazebo

```
* provide launch files for ur3
* use controller_manager spawn
* allow to start gazebo without gui
* adjust controllers to new hardwareInterface - affects simulation only
* Contributors: ipa-fxm
```
## ur_kinematics

```
* apply ur-kin-constants fix for ur3
* Merge remote-tracking branch 'origin-rosi/indigo-devel' into ur-kin-constants
* ur_kinematics: Move #defines to constants in source file.
* ur_kinematics for ur3
* crop ik solutions wrt joint_limits
* Contributors: Maarten de Vries, ipa-fxm
```
## ur_msgs

```
* Moved SetIO FUN constants from driver.py to relevant srv file for easier interaction from other files
* catkin_lint
* Contributors: Thomas Timm Andersen, ipa-fxm
```
