### PR TITLE
cob_extern: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1241,7 +1241,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_extern-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/ipa320/cob_extern.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_extern` to `0.6.4-0`:
- upstream repository: https://github.com/ipa320/cob_extern.git
- release repository: https://github.com/ipa320/cob_extern-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.3-0`
## cob_extern
- No changes
## libntcan
- No changes
## libpcan
- No changes
## libphidgets

```
* Update header to 2015 version
* Fix checksum for phidgets download
* Remove old checksum
* Upgrade to libphidget_2.1.8.20120716
* Contributors: Alan Meekins
```
