### PR TITLE
cob_common: 0.6.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1143,7 +1143,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.6.4-0
+      version: 0.6.5-0
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.6.5-0`:
- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.4-0`
## cob_common
- No changes
## cob_description

```
* fix cob3_tray_3dof meshes
* harmonize simulated cam3d topic namespaces
* restructure simulated lasers and laser topic names
* remove obsolete sensors
* Missed $ key
* added asus sensorring description
* Updated topic name
* added sick sensorring description
* fix joint origins for torsos
* Merge branch 'indigo_dev' into fix_torso_urdf
* fix torso joint orientation in urdf
* Contributors: Nadia Hammoudeh García, ipa-fxm, ipa-nhg
```
## cob_msgs

```
* Update package.xml
* cleanup dashboard message
* rework messages
* remove unused messages
* Contributors: Florian Weisshardt, ipa-fmw
```
## cob_srvs
- No changes
## raw_description

```
* restructure simulated lasers and laser topic names
* fixed copy paste error for base_short laser mounting position
* Contributors: Benjamin Maidel, ipa-fxm
```
