### PR TITLE
cob_command_tools: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1122,7 +1122,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.4-0`:
- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.3-0`
## cob_command_gui

```
* undo pop-up related changes
* only show MessagDialog for init and recover
* calling sss.commands in thread with MessageDialog
* Contributors: ipa-fxm
```
## cob_command_tools
- No changes
## cob_dashboard

```
* use aggregated power message
* Contributors: ipa-fmw
```
## cob_interactive_teleop
- No changes
## cob_monitoring

```
* stop charging mode if no more power_state msgs received
* fix node and class name
* fix emergency_stop_monitor
* parameter name consistency
* fix script
* configurable battery thresholds
* parameter for enabling sound and light
* combine battery_light_monitor and battery_monitor
* add say output to battery_light_monitor
* added actionlib exec dep and install tag
* fixes
* fix
* fix
* use cob_lights track_id in battery light monitor
* adapted em stop monitor to new cob_light
* fixes due to cob_light changes
* changes due to cob_lights refactor
* implemented compatibility for non addressable led bands
* switched from info to debug message
* switched from action to service
* added monitor to switch cobs light if charging
* set queue size to 1
* Update emergency_stop_monitor.py
* fixed em stop monitor
* removed configuration files
* fixes type conversion in ddwrt
* Contributors: Benjamin Maidel, Florian Weisshardt, ipa-bnm, ipa-cob4-2, ipa-fxm, ipa-nhg
```
## cob_script_server

```
* undo pop-up related changes
* indentation fixes
* more verbose action_handle (takes an additional string in set_failed())
  more consistent usage of action_handle throughout code
* cleanup action_handle
* parameter for enabling sound and light
* allow passing of component_name to sss.say
* use modes definition instead of magic numbers
* Merge branch 'indigo_dev' into fix/refactor_light
  Conflicts:
  cob_teleop/ros/src/cob_teleop.cpp
* reduce timeout for all wait_for_server calls
* fixes due to cob_light changes
* shorten timeout
* fix CMakeLists.txt
* add dependency to actionlib
* fix ScriptAction include in cob_teleop
* fix sss error handling for light
* Merge branch 'fix_teleop' into fix_sss
* set zero velocity and acceleration for all trajectory points
* fix actionhandle for trigger
* deleted script_server tests from launch file
* Contributors: Benjamin Maidel, Florian Köhler, Florian Weisshardt, ipa-cob4-2, ipa-fmw, ipa-fxm
```
## cob_teleop

```
* reduce terminal output
* changes for new message structure and concurrent mode
* compile fixes because of changes in cob_light
* swap say-setLight execution order2
* introduce enable params, styling, consistency, beautifying
* add catkin include dirs
* adapt twist_mux topic names according to https://github.com/ipa320/orga/pull/1#issuecomment-159195427
* added apply_ramp parameter to switch velocity smoothing on teleop side on and off (if velocity_smoother is active teleop do not need to smooth)
* changed keyboard default topic to twist_mux input
* Merge branch 'fix_teleop' of https://github.com/ipa-fmw/cob_command_tools into fix_teleop
* announce 'go' after init all
* tabs vs. spaces
* replace string before passing to say
* change speach output
* enable speach for default position mode
* cob_teleop: disable light, encapsulate say and use deadman button to enable mode switch
* Fix typo
* added tag exported targets
* deleted config folder
* change frequencies
* removed configuration files
* use light action server
* first robot test
* global ns for actions
* cob_teleop review
* updated package.axml and CMakeLists
* fisrt testable version
* adapt the node for other robots
* beautify
* update
* update
* new node
* Contributors: Benjamin Maidel, Florian Weisshardt, Marco Bezzon, ipa-fmw, ipa-fxm, ipa-nhg
```
