### PR TITLE
cob_control: 0.6.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1161,6 +1161,7 @@ repositories:
       - cob_collision_velocity_filter
       - cob_control
       - cob_control_mode_adapter
+      - cob_control_msgs
       - cob_footprint_observer
       - cob_frame_tracker
       - cob_model_identifier
@@ -1168,10 +1169,11 @@ repositories:
       - cob_omni_drive_controller
       - cob_trajectory_controller
       - cob_twist_controller
+      - cob_undercarriage_ctrl_node
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.6.10-0
+      version: 0.6.11-0
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.6.11-0`:
- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.10-0`
## cob_base_velocity_smoother

```
* fix install tags
* do not install cfg files
* Change author email
* added dep for cfg
* fixed deceleration factor on inactive topic input
* added additional parameter to adjust deceleration to acceleration ratio in safety cases (no topics received, joy deadmean released)
* revert package version
* fixed ros loop
* added new velocity_smoother based on yocs_velocity_smoother
* Contributors: Benjamin Maidel, Florian Weisshardt, ipa-fmw
```
## cob_cartesian_controller

```
* remove lwa4d test scripts
* use ros::Time::now
* use const in function parameters
* remove movePTP
* minor styling
* remove unused Pose parameter
* significantly simplify function parameters for getTrajectory and getProfileTimings
* re-order vel-acc
* get rid of ProfileTimings.ok
* move identical functions to base class
* harmonizing
* remove obsolete calcTe_
* minor styling
* roslint cob_cartesian_controller
* towards code styling consistency
* adjust descriptions ins license plate
* adjust description
* Final version
* Almost finalized version
* Implemented move_circ
* remove obsolete files
* adjust service type in cartesian controller
* LWA4D test scripts
* New quaternion interpolation
* Linear interpolation works fine now. There's still a bug in quaternion interpolation.
* Bug fixes + code reduction
* apply change in parameter name
* code reduction part 2.
* forgot the cpp files
* added new headers
* Code reduction part 1.. there's still a bug in ramp profiles.
* Fixed a bug in sort algorithm and profile interpolation
* new example script
* restructured, introducing base class for profile generator
* renaming: hardware_interface to controller_interface
* update trajectory_hardware_interface
* handle base_compensation in kinematic_extension enum
* implement JointTrajectory hardware_interface for twist_controller
* Contributors: Marco Bezzon, ipa-fxm, ipa-fxm-cm
```
## cob_collision_velocity_filter
- No changes
## cob_control

```
* introducing cob_control_msgs
* add cob_undercarriage_ctrl_node to meta-package
* Contributors: Felix Messmer, ipa-fxm
```
## cob_control_mode_adapter

```
* remove support for interpol_position controller
* fix mode adapter shutdown
* fix typo
* add joint_group_interpol_position_controller to control_mode_adapter
* Contributors: Marco Bezzon, ipa-fxm
```
## cob_control_msgs

```
* add GetObstacleDistance service
* outsource obstacle_distance messages
* introducing cob_control_msgs
* Contributors: ipa-fxm
```
## cob_footprint_observer
- No changes
## cob_frame_tracker

```
* add frameExists check to FrameTracker
* updateMarker on startLookat
* cleanup roslint
* introduce cfg-parameter enable_abortion_checking
* Added waitForTransform in the getTransform function.. It threw an transform exception
* Merge branch 'refactor_profile_generator' of github.com:ipa-fxm-cm/cob_control into test_new_cartesian_controller
  Conflicts:
  cob_frame_tracker/src/cob_frame_tracker.cpp
* parameterizable scaling_factor
* Linear interpolation works fine now. There's still a bug in quaternion interpolation.
* only reset lookat extension
* prepare interactive_frame_target for being used with lookat
* prepare frame_tracker for being used with lookat
* constant publish rate
* working on log output
* parameterizable marker_scale
* re-activate publishHoldTwist, fix typo
* publish ZeroTwist, root/tip frame selection
* introduce scaling_factor and dead_man
* simple spacenav commander
* temporarily undo publishHoldTwist
* Contributors: Marco Bezzon, ipa-fxm, ipa-fxm-cm
```
## cob_model_identifier

```
* working on log output
* Contributors: ipa-fxm
```
## cob_obstacle_distance

```
* outsource obstacle_distance messages
* add missing install tag
* Added method to set drawable again and to avoid drawing of self-collision links.
* Renamings and replaced box with sphere.
* Fixed order of transform and service registration. Additionally added more time to wait for service availability.
* working on marker publisher
* working on log output
* renaming frame - link
* Contributors: Marco Bezzon, ipa-fxm
```
## cob_omni_drive_controller

```
* remove leading slashes and use odom as default
* configurable odometry_controller
* [hotfix] compile error
* Contributors: ipa-fmw, ipa-fxm
```
## cob_trajectory_controller
- No changes
## cob_twist_controller

```
* reduce output
* outsource obstacle_distance messages
* remove support for interpol_position controller
* debug output
* use joint_group_velocity_controller for torso extension
* verify position limit scaling factor
* fix typo
* fix lookat: do not look backwards
* missing sympy dependency
* add test publisher twist sine
* avoid unecessary service calls to obstacle_distance
* fix collision avoidance dimension segfault
* infinitesiamal threshold for BaseActive
* wider limits
* enforce position limit
* add test_forward_command_sine_node
* cleanup period
* Update test_trajectory_command_sine_node.cpp
* adjust lookat extension limits
* more compact parameter structure
* make lookat linear axis configurable - axis and offset
* cleanup roslint
* add trajectory_command test node
* introduce cfg-parameter integrator_smoothing
* add debug publisher to simpson_integration
* rename member variables
* add q_dot_ik smoothing, adjust parameters
* add timing members for period
* Merge pull request #79 <https://github.com/ipa320/cob_control/issues/79> from ipa-fxm/fix_visualize_twist_marker
  visualize twist marker
* proper reset for ControllerInterfaceJointStates
* visualize angular twist
* fix visualize twist marker
* Fixed the TwistDirection Marker
* use undamped jacobian in nullspace projection
* minor renaming
* roslint cob_twist_controller
* final roslint
* add TimeStamp to trajectory_interface
* also print limiting joint
* prepare remapping for twist_mux in cartesian controller
* add test nodes for SimpsonIntegrator
* reset moving average
* simplify API
* use new API in SimpsonIntegrator
* test new MovingAverage API
* all new MovingAverage API
* saver initialization of weighting
* test scripts for moving_average
* use interpolated position controller
* add more debug scripts
* consider various roslint/styleguide hints
* apply change in parameter name
* fix frame_id in visualizeTwist
* lookat extension fully implemented
* more experiments with reset condition in simpson_integrator
* minor improvement of comment
* fix order of doxygen comment
* fix whitespaces
* move simpson integration to new util class
* prepare structure for lookat
* temporarily disable CA when being used together with KinematicExtensions
* less output
* more consistent code structure for constraints
* remove obsolete return values
* use extension_ratio for all extensions
* wip: consider kinematic_extensions within limiters and constraints - still unstable
* chain not needed in limiters
* resolve hardcoded cycle time in prediction
* proper generation of Jacobian for kinematic extension from urdf
* more generic naming in extension_dof, transform extension_jacobian in extension_urdf
* merge with demo updates
* fix BASE_COMPENSATION
* Fixed order of transform and service registration. Additionally added more time to wait for service availability.
* fix dimension of jac_extension
* merge and roslint
* roslint cob_twist_controller
* draft towards kinematic_extension for COB_TORSO based on URDF
* prepare structure for additional kinematic_extensions
* revert acceleration_limiters impl, class structure only, further consistency changes and cleanup
* progress with acceleration limiters, still wip
* implement acceleration limiter
* pass down whole JointStates structure
* better reset condition
* fix limiter reset, fix service existence, consistency
* prepare structure for acceleration limiters
* temporary cleanup
* do FK_Vel in GPM for debugging
* further debug gpm and self-motion
* add solveTwist duration output
* visualization marker for desired twist direction
* renaming: hardware_interface to controller_interface
* fixes for positional interfaces
* waitForExistence of registerLink service
* wip: use undamped inverse in gpm
* allow to calculate un-damped, un-truncated inverse jacobian
* update octave scripts for testing variants
* working on marker publisher
* working on log output
* update trajectory_hardware_interface
* introduce HardwareInterfacePositionBase, reset Integration on out-dated data
* handle base_compensation in kinematic_extension enum
* renaming frame - link
* Merge branch 'indigo_dev' of github.com:ipa-fxm/cob_control into trajectory_hardware_interface
* 

    * Commented output lines. - Renamed frame_of_interest to link_of_interest.

* Merge branch 'indigo_dev' of github.com:ipa-fxm/cob_control into trajectory_hardware_interface
* implement JointTrajectory hardware_interface for twist_controller
* Contributors: Felix Messmer, Marco Bezzon, ipa-fxm, ipa-fxm-cm, ipa-fxm-mb
```
## cob_undercarriage_ctrl_node

```
* parametrizable odometry tracker in undercarriage_ctrl node
* whitespace fixes
* fix CMakeLists
* ping travis
* [hotfix] compile error
* migrated to OdometryTracker
* migrated to new version of cob_omni_drive_controller
* added cob_undercarriage_ctrl_new by ipa-mig-jg as cob_undercarriage_ctrl_node packge
* Contributors: Florian Weisshardt, Mathias Lüdtke, ipa-fmw, ipa-fxm
```
