### PR TITLE
cob_simulation: 0.6.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1385,7 +1385,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_simulation-release.git
-      version: 0.6.4-0
+      version: 0.6.5-0
     source:
       type: git
       url: https://github.com/ipa320/cob_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.6.5-0`:
- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.4-0`
## cob_bringup_sim

```
* fix install tags and dependencies
* fix move_object script
* Update move.py
* added people, move.py and changed model names
* added people and the possibility to move objects
* enable other gazebo worlds packages
* remove robot_id
* better default robot_id
* delete two_robots.launch
* Merge pull request #91 <https://github.com/ipa320/cob_simulation/issues/91> from ipa-mig-mc/fix/issue_number_90_missing_import_roslib
  added import roslib to spawn_object.py and did corresponding addition…
* launch file for spawning two robots
* added import roslib to spawn_object.py and did corresponding addition to packages.xml
* space
* nicer structure
* Revert "spawn two robots"
  This reverts commit b66aa13d920824a052d398dd8b49cb52c2c4a155.
* spawn two robots
* Contributors: Felix Gruber, Felix Messmer, Florian Weisshardt, hannes, ipa-fmw, ipa-fxm, ipa-mig-mc
```
## cob_gazebo

```
* fix dependency
* remove robot_id
* better default robot_id
* new line
* tf_prefix in higher level
* better diff
* nicer structure
* Revert "spawn two robots"
  This reverts commit b66aa13d920824a052d398dd8b49cb52c2c4a155.
* spawn two robots
* Contributors: Felix Gruber, Florian Weisshardt, ipa-fxm
```
## cob_gazebo_objects

```
* add launch file
* add urdf and stl
* add ikea kallax mesh
* fix man urdfs
* fix meshes
* old objects deleted
* added people, move.py and changed model names
* added people and the possibility to move objects
* Contributors: Florian Weisshardt, hannes, ipa-fxm
```
## cob_gazebo_worlds

```
* enable other gazebo worlds packages
* remove robot_id
* changed color of boxes on the belt to grey
* nicer structure
* changed name of the environment to automotive-assembly-line
* added hardwareInterface tag in Joint section of belt_trans transmission description
* minor code cleanup
* added model files which were left out in previous commit
* added objects to the environment
* successful integration of bmw-assembly into cob_simulation
* error state: problem with loading joint controller
* Contributors: Felix Gruber, ipa-fmw, ipa-fxm, ipa-mig-mc
```
## cob_simulation
- No changes
