### PR TITLE
cob_manipulation: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1274,19 +1274,21 @@ repositories:
       version: indigo_release_candidate
     release:
       packages:
+      - cob_collision_monitor
       - cob_grasp_generation
       - cob_kinematics
       - cob_lookat_action
       - cob_manipulation
       - cob_moveit_config
       - cob_moveit_interface
+      - cob_obstacle_distance_moveit
       - cob_pick_place_action
       - cob_tactiletools
       - cob_tray_monitor
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_manipulation-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/ipa320/cob_manipulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_manipulation` to `0.6.4-0`:
- upstream repository: https://github.com/ipa320/cob_manipulation.git
- release repository: https://github.com/ipa320/cob_manipulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.3-0`
## cob_collision_monitor

```
* explicit name for the collision_monitor plugin
* add launch file for standalone collision_monitor node
* introducing default values for parameter circumpassing fcl bug
* Fixed typo, i was missing in lib path
* removed most auto-generted comments
* added cob_collision_monitor package
* Contributors: Mathias Lüdtke, ipa-fxm, ipa-mdl
```
## cob_grasp_generation
- No changes
## cob_kinematics
- No changes
## cob_lookat_action
- No changes
## cob_manipulation

```
* update meta-package
* Contributors: ipa-fxm
```
## cob_moveit_config

```
* make 'robot' argument optenv
* add support for fake_execution and sensor input, more consistent with latest moveit_setup_assistant structure
* add octomap updater sensor configuration
* remove schunk arm moveit configs
* update moveit_configs
* explicit name for the collision_monitor plugin
* Contributors: ipa-fxm
```
## cob_moveit_interface
- No changes
## cob_obstacle_distance_moveit

```
* use messages and services from new package cob_control_msgs
* removing license
* move obstacle_distance into new package cob_obstacle_distance_moveit
* Contributors: ipa-fxm
```
## cob_pick_place_action
- No changes
## cob_tactiletools
- No changes
## cob_tray_monitor
- No changes
