### PR TITLE
cob_navigation: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1306,11 +1306,10 @@ repositories:
       - cob_navigation_global
       - cob_navigation_local
       - cob_navigation_slam
-      - cob_scan_unifier
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_navigation-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/ipa320/cob_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_navigation` to `0.6.4-0`:
- upstream repository: https://github.com/ipa320/cob_navigation.git
- release repository: https://github.com/ipa320/cob_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.3-0`
## cob_linear_nav
- No changes
## cob_mapping_slam

```
* restructure laser topics
* removed scan_unifier from cob_navigation
* Contributors: Benjamin Maidel, ipa-fxm
```
## cob_navigation

```
* removed scan_unifier from cob_navigation
* Contributors: Benjamin Maidel
```
## cob_navigation_config

```
* restructure laser topics
* removed scan_unifier from cob_navigation
* Contributors: Benjamin Maidel, ipa-fxm
```
## cob_navigation_global

```
* remove slashes from frame_ids
* restructure laser topics
* adapt twist_mux topic names according to https://github.com/ipa320/orga/pull/1#issuecomment-159195427
* moved collision_velocity_filter to base namespace
* changed 2dnav_linear twist topic to twist_mux input topic
* changed base command topic names to twist_mux topic input
* removed scan_unifier from cob_navigation
* Remap to command_safe for linear nav
  see discussion in https://github.com/ipa320/cob_navigation/pull/54
* removed global prefix
* use base  new name spaces
* Contributors: Benjamin Maidel, Florian Weisshardt, ipa-fmw, ipa-fxm, ipa-mig, ipa-nhg
```
## cob_navigation_local

```
* restructure laser topics
* adapt twist_mux topic names according to https://github.com/ipa320/orga/pull/1#issuecomment-159195427
* changed base command topic names to twist_mux topic input
* Contributors: Benjamin Maidel, ipa-fmw, ipa-fxm
```
## cob_navigation_slam

```
* restructure laser topics
* Contributors: ipa-fxm
```
