### PR TITLE
cob_driver: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1187,15 +1187,18 @@ repositories:
     release:
       packages:
       - cob_base_drive_chain
+      - cob_bms_driver
       - cob_camera_sensors
       - cob_canopen_motor
       - cob_driver
+      - cob_elmo_homing
       - cob_generic_can
       - cob_head_axis
       - cob_light
       - cob_mimic
       - cob_phidgets
       - cob_relayboard
+      - cob_scan_unifier
       - cob_sick_lms1xx
       - cob_sick_s300
       - cob_sound
@@ -1205,7 +1208,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.6.5-0
+      version: 0.6.6-0
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.6.6-0`:
- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.5-0`
## cob_base_drive_chain

```
* changed drive_chains diag name from //base_controller to /base_controller/base_drive_chain_node
* Contributors: bnm
```
## cob_bms_driver

```
* dependency and package cleanup
* remove config and launch as it is added to cob_robots
* adjust version
* move cob_bms_driver to cob_driver
* Contributors: ipa-fxm
```
## cob_camera_sensors
- No changes
## cob_canopen_motor
- No changes
## cob_driver

```
* add to meta-package
* added cob_elmo_homing to meta package
* added scan unifier to metapackage
* Contributors: Benjamin Maidel, Florian Weisshardt, ipa-fxm
```
## cob_elmo_homing

```
* added cob_elmo_homing
* Contributors: Mathias Lüdtke
```
## cob_generic_can

```
* Update accorting to comments from ipa-fxm
* Correction of include and name
* Correct interface.
* compiles...
* Starting with SocketCAN
* Contributors: Denis Štogl
```
## cob_head_axis
- No changes
## cob_light

```
* keep static mode running so they can be stopped, paused and resumed
* fixes
* comments
* param tuning
* implemented new mode glow
* implemented feature to resume modes if modes with higher prio ends + refactored code
* considered #241 <https://github.com/ipa320/cob_driver/issues/241> PR comments
* high distances visualized with a lighter green
* moved light dist approx function to cob_light driver
* wip light_approximation
* Merge branch 'feature/led_offset' into feature/light_approximation
* fix
* added node for scan approxiamtion led visualization
* added param to define led mounting offset
* fixed ms35 controller bug
* Merge branch 'indigo_dev' of github.com:ipa320/cob_driver into indigo_dev
  Conflicts:
  cob_light/CMakeLists.txt
* added headers to add_executable makro for qt_creator visiblity
* Contributors: Benjamin Maidel, bnm
```
## cob_mimic

```
* re-add copying mimic files
* fix action name in test node
* fix mimic shutdown and cleanup
* Update CMakeLists.txt
* add rospy again
* merge
* missed dependencies
* Contributors: Florian Weisshardt, ipa-fmw, ipa-fxm, ipa-nhg
```
## cob_phidgets
- No changes
## cob_relayboard

```
* use aggregated power state message
* tabs vs. spaces
* harmonize publisher queue sizes
* relaynode delete slashes topics
* Contributors: Felix Gruber, ipa-fmw, ipa-fxm
```
## cob_scan_unifier

```
* changed scan_unifier maintainer
* filtered out scan unifier and moved to new directory
* Contributors: Benjamin Maidel
```
## cob_sick_lms1xx

```
* Sick LMS1xx node now uses global NodeHandle
* Resolved problem with tabs and spaces.
* Clean trailing spaces. Convert default frame name to tf2 format (remove "/")
* Revert indentation style as it was
* Correction.
* Corrected revert.
* Revert indentation style as it was
* Node rewritten and publishing on diagnostics topic added.
* Contributors: Denis Štogl
```
## cob_sick_s300

```
* replace spaces by tab
* add try/catch to handle XmlRpc exceptions
* add time stamp to sick s300 diagnostic messages
* adjust filter topics
* Contributors: Frederik Hegger, ipa-fxm
```
## cob_sound

```
* fix sound dependencies
* considered pr comments
* removed debug logging
* start feedback timer only if action is active
* start action server after complete init
* use libvlc for sound play
* merge
* support for other cepstral voices (e.g. german Matthias)
* sound error with Cepstral,use alsa oss
* missed dependencies
* Contributors: Benjamin Maidel, cob4-2, ipa-cob4-2, ipa-fmw, ipa-nhg
```
## cob_undercarriage_ctrl

```
* fix frame id for odometry
* Contributors: ipa-cob4-2
```
## cob_utilities
- No changes
## cob_voltage_control

```
* beautify
* Merge branch 'aggregated_power_message' into feature/raw_batterie_state
  Conflicts:
  cob_voltage_control/common/src/cob_voltage_control_common.cpp
  cob_voltage_control/ros/src/cob_voltage_control_ros.cpp
* voltage and current measurements for raw3-3
* use aggregated power state message
* changed name relayboard to powerboard
* removed debug outputs
* fixed topic names
* Contributors: Benjamin Maidel, ipa-bnm, ipa-fmw
```
