### PR TITLE
cob_robots: 0.6.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1360,13 +1360,14 @@ repositories:
       packages:
       - cob_bringup
       - cob_controller_configuration_gazebo
+      - cob_default_robot_behavior
       - cob_default_robot_config
       - cob_hardware_config
       - cob_robots
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.6.4-0
+      version: 0.6.5-0
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.6.5-0`:
- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.4-0`
## cob_bringup

```
* adjust launch file to current head-pc setup
* Merge pull request #448 <https://github.com/ipa320/cob_robots/issues/448> from ipa-nhg/BMSintegration
  added bms driver to bringup
* added bms driver to bringup
* MLR actual version
* Merge branch 'indigo_dev' of github.com:ipa320/cob_robots into feature_canopen_node_name
  Conflicts:
  cob_bringup/drivers/canopen_402.launch
* add missing image_flip nodes to simulation
* adjust launch and yamls
* unify battery_monitor and battery_light_monitor
* rename canopen node and adjust diagnostics
* restructure canopen driver yamls and remove canX yamls
* readded batter_light_monitor to cob4-1 bringup
* Merge branch 'indigo_dev' of github.com:ipa320/cob_robots into feature/battery_light_mode
  Conflicts:
  cob_bringup/robots/cob4-1.xml
  cob_bringup/robots/cob4-2.xml
  cob_bringup/robots/raw3-3.xml
* temporarily do not use head on cob4-2
* temporarily do not use head on cob4-1
* comment overkill
* changed service name remap to component name param
* Merge branch 'indigo_dev' of github.com:ipa-bnm/cob_robots into feature/battery_light_mode
* further tests with torso
* tabs vs spaces
* tabs vs spaces
* use launch arg to switch between old and new base driver
* tabs vs. spaces
* using canopen for base_solo
* update diagnostics analyzer
* add new_base_chain config for cob4-1
* launch ros_canopen for cob4-2 base
* twist_controller base commands cannot go through smoother
* Removed releyboard
* Merge pull request #397 <https://github.com/ipa320/cob_robots/issues/397> from ipa-nhg/NewTorsoPcs
  [cob4-2] New torso pcs
* remap battery_light_monitor topic and service name
* start battery_light_monitor on raw3-3 bringup
* load battery light config to param server
* Update cob4-1.launch
* added battery_light_monitor launch to cob4-1 bringup
* added battery light monitor to cob4-2s bringup
* Revert namespace of sick LMS1xx nodes
* Further files corrected
* Corrected odometry topic remapping, error done in 8868a5c
* Correct LMS1xx topic remapping
* Revert indentation changes.
* Change namespace of parameters for laser scanner driver to work properly.
* base collision observer setup
* Merge remote-tracking branch 'origin/raw3-5_battery_voltage' into update_raw3-5
* Merge branch 'indigo_dev' of github.com:iirob/cob_robots into indigo_dev
* review image_flip parameters
* updated base solo
* emergency_stop_state has to be a global topic
* emergency_stop_state has to be a global topic
* remove env config in all robot launch files
* parameterizable scaling factor
* provide twist_mux topic for base_active mode of twist_controller
* update cob4-3 according to lastest updates in cob_robots (twist_mux, vel_smoother, laser_topics)
* Merge branch 'indigo_dev' of github.com:ipa320/cob_robots into feature_cob4-1_without_arms
* Merge pull request #383 <https://github.com/ipa320/cob_robots/issues/383> from ipa-fxm/restructure_laser_topics_unifier
  Restructure laser topics unifier
* Merge pull request #21 <https://github.com/ipa320/cob_robots/issues/21> from ipa320/indigo_dev
  updates from ipa320
* Merge pull request #36 <https://github.com/ipa320/cob_robots/issues/36> from ipa320/indigo_dev
  updates from ipa320
* add missing exec_depends
* rename laser scanner topics
* prepare remapping for twist_mux in cartesian controller
* fix identation
* fix identation
* Merge pull request #371 <https://github.com/ipa320/cob_robots/issues/371> from ipa-bnm/fix/raw3-1_bringup
  fix raw3-1 bringup
* moved collision_velocity_filter to base namespace
* fix typo
* restructure laser topics
* added collision_velocity_filter to twist_mux
* removed yocs_velocity_smoother dependency
* readded group tag
* changed velocity smoother topic name
* added twist_mux and new velocity_smoother to controller launch
* added velocity_smoother launch file and velocity_smoother configs for all robots
* added twist_mux launch file and twist_mux configs for all robots
* Merge branch 'indigo_dev' into feature/twist_mux_vel_smoother
* added twist_mux and vel smoother dependency
* use correct pc names
* fix machine tag
* use cob4-1 as cob4-2 without arms - copying configuration files
* do not stabelize/deadband spacenav twist
* add scan_unifier for cob4-3
* added dependency to cob_scan_unifier
* Merge pull request #364 <https://github.com/ipa320/cob_robots/issues/364> from ipa-bnm/feature/scan_unifier
  added scan unifier to bringup layer
* added missing exec dependency to cob_default_robot_behaviour
* added cob4-3
* fixed launch tag
* added scan unifier to bringup layer
* changed name relayboard to powerboard
* indentation
* start cob_voltage_monitor instead of simulated relayboard
* remap input topics
* removed prosilica cams from raw3-1 startup
* correct topic remaps
* fix copy-and-paste comment
* remove old teleop leftover
* tabs vs spaces
* remove obsolete argument and remap
* Adapt cob4-6 configuration
* test sensorring cam3d on cob4-2
* removed leading / from tf frame names. They are no longer supported in tf2
* addapt cob4-4 configuration
* use relative namespaces
* added script_server bringup to all robots
* changed base namespace from 'base_controller' to 'base' for cob4 and raw3
* do not respawn phidgets, because if no phidget is connected the driver will restart all the time
* start cob_script_server at bringup because new teleop node needs it
* fix xml format in cartesian_controller.launch
* remove trailing whitespaces
* add nodes for debugging
* added new behavior trigger services
* add launch file for teleop_spacenav
* merge
* use local namespaces
* merge error
* merge error
* updated cob_teleop and renamed behaviour package
* new teleop node
* proper remapping for old_base_driver
* merge
* merge
* fix typo
* new trigger srv and addapted  android.launch file
* fix for int16 overflow in vl mode
* Merge branch 'cob_behaviour' of https://github.com/ipa-cob4-2/cob_robots into indigo_dev
* Adapted launch and params.
* cob_behaviour
* robot test
* added mimic.launch
* cob_behaviour
* last update
* Update raw3-4.xml
* teleop parameters
* defined teleop parameters
* setup cob4-4
* merge
* cob4-4 setup
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_robots into indigo_dev
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_robots into raw3-5_battery_voltage
* Updated data for raw3-5
* Raw3-5 phidgets is read properly, data calcualtion/remapping is corrected.
* Enabled and corrected
* Change file name from laser_lms1xx to sick_lms1xx
* Corrected remapping and cleaned config file.
* laser_rear namespace corrected
* Merge branch 'hydro_dev' into indigo_dev
* Contributors: Benjamin Maidel, Denis Štogl, Felix Messmer, Florian Weisshardt, Marco Bezzon, Nadia Hammoudeh García, bnm, ipa-bnm, ipa-cob4-2, ipa-cob4-4, ipa-fmw, ipa-fxm, ipa-fxm-mb, ipa-nhg
```
## cob_controller_configuration_gazebo

```
* add missing image_flip nodes to simulation
* add default_robot_behavior to cob4-1 and cob4-2
* add 3dof head for cob4-1 within simulation only
* add scan unifier to simulated robots
* update cob4-3 according to lastest updates in cob_robots (twist_mux, vel_smoother, laser_topics)
* Merge branch 'indigo_dev' of github.com:ipa320/cob_robots into feature_cob4-1_without_arms
* restructure laser topics
* minor indentation issue
* use cob4-1 as cob4-2 without arms - copying configuration files
* added cob4-3
* remove simulated fake_diagnostics
* consistent arg usage for raw
* Merge branch 'hydro_dev' into indigo_dev
* Contributors: Denis Štogl, Florian Weisshardt, ipa-fmw, ipa-fxm, ipa-nhg
```
## cob_default_robot_behavior

```
* adjust cob_default_robot_behavior to new sss.say
* tabs vs. spaces
* apply changes to cob4-1 too
* fix PR remarks
* Update trigger_srvs_cob4-2.py
* fix service responses
* make executable
* use cob4-1 as cob4-2 without arms - copying configuration files
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_robots into indigo_dev
* fix behaviour
* divide pick trigger service
* added new behavior trigger services
* updated cob_teleop and renamed behaviour package
* Contributors: Florian Weisshardt, ipa-cob4-2, ipa-fmw, ipa-fxm, ipa-nhg
```
## cob_default_robot_config

```
* proper stop, init and recover via command_gui
* remove pick from command gui
* fix head positions
* add 3dof head for cob4-1 within simulation only
* update cob4-3 according to lastest updates in cob_robots (twist_mux, vel_smoother, laser_topics)
* adapt twist_mux topic names according to https://github.com/ipa320/orga/pull/1#issuecomment-159195427
* changed base_configurations to twist_mux input topic
* remove pick from knoeppkes
* use cob4-1 as cob4-2 without arms - copying configuration files
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_robots into indigo_dev
* remove show gripper
* added cob4-3
* upload correct light params
* modified default colors, more yellow looking color
* fix behaviour
* remove lookat
* fix and consistent services and topics in base config
* arm calibration
* arm calibration and adapted the default positions
* divide pick trigger service
* wave without side start
* added led_off configuration for all robots equiped with lights
* changed base namespace from 'base_controller' to 'base' for cob4 and raw3
* all raws still use old namespace for base
* raws bases still use old namespace '/base_controller' instead of '/base/driver'
* corrected light_configuration.yaml
* added new behavior trigger services
* updated cob_teleop and renamed behaviour package
* more parameter updates for cob4-2
* merge
* robot test
* cob_behaviour
* right arm mount position and removed arm trajectories
* Contributors: Benjamin Maidel, ipa-bnm, ipa-cob3-9, ipa-cob4-2, ipa-fmw, ipa-fxm, ipa-nhg
```
## cob_hardware_config

```
* use lowercase instead capital letters for the analyzers
* cob4-6 has not base light
* deleted unused parameter
* added BMS to diagnostics
* readded scanners yaml files
* added bms driver to bringup
* MLR actual version
* remove joint_group_interpol_position_controller
* enable velocity sensor for um2 mode
* sort by priority
* fix priority conflict
* disable abortion checking as default
* set old hardcoded default values in yaml for backwards compatibility
* parameter name consistency
* fix parameters
* configurable battery thresholds
* adjust launch and yamls
* rename canopen node and adjust diagnostics
* restructure canopen driver yamls and remove canX yamls
* changed service name remap to component name param
* further tests with torso
* enable sound and light for teleop for cob4
* apply torso updates to cob4-2 config
* finalize symlinks
* Update twist_mux_locks.yaml
* Update twist_mux_locks.yaml
* Merge pull request #429 <https://github.com/ipa320/cob_robots/issues/429> from ipa-fmw/feature/cob4-1
  comment head in cob4-1
* use base_link as root
* use JointGroupVelocityController for TwistController for Torso
* cleanup teleop parameters (unused button parameters)
* comment head config in teleop
* comment head config in diagnostics analyzer
* reduce deceleration factor
* set lock priority for twistmux
* use softlinks for most configs
* delete unused base ini files (not used any more using canopen driver)
* delete old and unused base velocity smoother config
* Merge pull request #414 <https://github.com/ipa320/cob_robots/issues/414> from ipa-fmw/feature/cob4-1
  add 3dof head for cob4-1 within simulation only
* update diagnostics analyzer
* add new_base_chain config for cob4-1
* canopen config for old cob4-2 base using new joint names
* remove obsolete robot_modules.yaml files
* remove head config from cob4-2
* fix typo
* add 3dof head for cob4-1 within simulation only
* configure lookat offset
* update cartesian parameters for torso
* new serial for new phidget board + sensor naming for battery_light_monitor
* added battery_light_monitor config
* ros_canopen config for cob4-2 base
* tf2 compatible frames
* Revert some paramters
* Revert some paramters
* revert raw3-4 conf file
* Merge remote-tracking branch 'origin/raw3-5_battery_voltage' into update_raw3-5
* Merge branch 'indigo_dev' of github.com:iirob/cob_robots into indigo_dev
* update diagnostics analyzer for cob4-6
* update diagnostics analyzer for cob4-4
* update diagnostics analyzer for cob4-3
* updated rviz configuration
* review image_flip parameters
* New torso pcs
* integrate twist_mux into base diagnostics for all robots
* integrate twist_mux into base diagnostics
* integrate twist_mux into base diagnostics
* remove head and arms from teleop config
* remove simulated diagnostics from analyzer
* optimize parameter for torso cartesian controller
* provide twist_mux topic for base_active mode of twist_controller
* update cob4-3 according to lastest updates in cob_robots (twist_mux, vel_smoother, laser_topics)
* Merge branch 'indigo_dev' of github.com:ipa320/cob_robots into feature_cob4-1_without_arms
* add missing scan_unifier_config.yaml file for cob3-9
* rename laser scanner topics
* rename laser scanner topics
* set ramp parameter for all robots
* adapt twist_mux topic names according to https://github.com/ipa320/orga/pull/1#issuecomment-159195427
* velocity_smoother params adjustments (tested on raw3-3)
* added additional parameter to velocity_smoother (decel_factor_safe) and dissabled teleops ramp
* restructure laser topics
* added collision_velocity_filter to twist_mux
* adjusted velocity_smoother params on raw3-3
* moved twist_mux config to common folder and added softlinks for robot specific config
* use correct dcf file
* changed teleop configs base command topic to new twist_mux topic
* added velocity_smoother launch file and velocity_smoother configs for all robots
* added twist_mux launch file and twist_mux configs for all robots
* use correct pc names
* do  not use velocity controllers for Elmo devices
* use cob4-1 as cob4-2 without arms - copying configuration files
* update cartesian controller configs
* cartesian parameter updates for video shooting
* remove obsolete mu
* use STACK_OF_TASK as default
* disable acceleration limiter as default
* update limiter parameters
* scan unifier config files missed
* add scan_unifier for cob4-3
* Update teleop.yaml
* Update cob4-3.urdf.xacro
* Updated test file, robot name wrong
* added cob4-3
* removed torso from robot_modules config
* added scan unifier to bringup layer
* added led offset param to torso light config
* changed rplidar orientation
* cleaned config files
* cleaned up diagnostics analyzer config for raw3-3
* corrected phidgets config for raw3-3
* Merge pull request #349 <https://github.com/ipa320/cob_robots/issues/349> from ipa-nhg/sensorring
  [cob4-2] Sensorring with asus camera
* remove lookat
* remove obsolete parameter
* added sensorring diagnostics
* Adapt cob4-6 configuration
* test sensorring cam3d on cob4-2
* added kinect to sensorring
* same base diagnostics analyzer params for all robs because base_drive_chain driver was fixed
* cob4-4 and cob4-6 use ipa-mdl's base controller. This sends correct diagnostics
* Merge branch 'indigo_dev' of github.com:ipa320/cob_robots into fix/base_configuration
  Conflicts:
  cob_hardware_config/cob4-4/config/diagnostics_analyzers.yaml
* Merge branch 'indigo_dev' of github.com:ipa-bnm/cob_robots into fix/base_configuration
* removed comment
* wrong parameter vel_from_device
* addapt cob4-4 configuration
* arm calibration
* arm calibration and adapted the default positions
* adapted diagnostic analyzers base path to new namespaces
* adapted diagnostics analyzer to new base namespaces
* add footprint parameters for all cob4s and unify config
* changed base namespace from 'base_controller' to 'base' for cob4 and raw3
* sync cob4-1 and cob4-2
* use folded position as default
* use action server light
* using light service
* added new behavior trigger services
* renaming: hardware_interface to controller_interface
* introducing joint_group_interpol_position_controller
* add joint_group_interpol_position_controller
* enable GPM with CA as default
* base_compensation now selectable throuth kinematic_extension
* renaming frame - link
* parameterizable marker_scale
* less strict abortion checking for actived publishHoldTwist
* added white spaces
* apply relevant parameter updates for cob4-1
* cartessian controller updates cob4-2
* exponential smoothing for velocities in torso joint_states
* correct drive_modes for torso
* updated cob_teleop and renamed behaviour package
* new teleop node
* calibration update
* more parameter updates for cob4-2
* fixed some warnings
* Update gripper_driver.yaml
* merge
* emergency stop monitor parameters
* fix for int16 overflow in vl mode
* fix for int16 overflow in vl mode
* Changed structure of self-collision yaml. Now only the components given here are considered for self-collision.
* Added more links to ignore.
* Corrected order and naming.
* Made k_H smaller. Because adapted constraints.
* Adapted launch and params.
* cob_behaviour
* added safety marker
* added mlr rviz default configuration
* last update
* needed effort limits
* setup cob4-4
* cob4-4 setup
* merge
* merge
* Merge branch 'indigo_dev' of github.com:ipa-nhg/cob_robots into indigo_dev
* renamed torso urdfs
* Updated data for raw3-5
* Update footprint_observer_params.yaml
* Merge pull request #1 <https://github.com/ipa320/cob_robots/issues/1> from ipa-nhg/indigo_dev
  update ipa320
* right arm mount position and removed arm trajectories
* Added config files
* Raw3-5 phidgets is read properly, data calcualtion/remapping is corrected.
* Changed path to pcan device
* Corrected remapping and cleaned config file.
* Contributors: Benjamin Maidel, Denis Štogl, Felix Messmer, Florian Weisshardt, Mathias Lüdtke, Nadia Hammoudeh García, bnm, ipa-bnm, ipa-cob3-9, ipa-cob4-2, ipa-cob4-4, ipa-fmw, ipa-fxm, ipa-fxm-mb, ipa-nhg
```
## cob_robots

```
* cob_behaviour
* cob_behaviour
* Contributors: ipa-cob4-2
```
