### PR TITLE
care_o_bot: 0.6.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -874,7 +874,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/care-o-bot-release.git
-      version: 0.6.3-0
+      version: 0.6.5-0
     status: maintained
   carl_bot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `care_o_bot` to `0.6.5-0`:
- upstream repository: https://github.com/ipa320/care-o-bot.git
- release repository: https://github.com/ipa320/care-o-bot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.3-0`
## care_o_bot
- No changes
## care_o_bot_desktop

```
* comment dependency
* Contributors: ipa-fxm
```
## care_o_bot_robot
- No changes
## care_o_bot_simulation
- No changes
