### PR TITLE
python_qt_binding: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -637,6 +637,21 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: indigo-devel
     status: maintained
+  python_qt_binding:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/python_qt_binding-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: kinetic-devel
+    status: maintained
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `0.3.0-0`:
- upstream repository: git://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros-gbp/python_qt_binding-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## python_qt_binding

```
* switch to Qt5 (#30 <https://github.com/ros-visualization/python_qt_binding/issues/30>)
* print full stacktrace
```
