### PR TITLE
qt_gui_core: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -652,6 +652,28 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: kinetic-devel
     status: maintained
+  qt_gui_core:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: kinetic-devel
+    release:
+      packages:
+      - qt_dotgraph
+      - qt_gui
+      - qt_gui_app
+      - qt_gui_core
+      - qt_gui_cpp
+      - qt_gui_py_common
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/qt_gui_core-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: kinetic-devel
+    status: maintained
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.3.0-0`:
- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## qt_dotgraph

```
* switch to Qt5 (#64 <https://github.com/ros-visualization/qt_gui_core/pull/64>)
```
## qt_gui

```
* switch to Qt5 (#64 <https://github.com/ros-visualization/qt_gui_core/pull/64>)
```
## qt_gui_app

```
* switch to Qt5 (#64 <https://github.com/ros-visualization/qt_gui_core/pull/64>)
```
## qt_gui_cpp

```
* switch to Qt5 (#64 <https://github.com/ros-visualization/qt_gui_core/pull/64>)
```
## qt_gui_py_common

```
* switch to Qt5 (#64 <https://github.com/ros-visualization/qt_gui_core/pull/64>)
```
