### PR TITLE
rqt: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -882,6 +882,26 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: jade-devel
     status: maintained
+  rqt:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: kinetic-devel
+    release:
+      packages:
+      - rqt
+      - rqt_gui
+      - rqt_gui_cpp
+      - rqt_gui_py
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: kinetic-devel
+    status: maintained
   serial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `0.3.0-0`:
- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros-gbp/rqt-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rqt_gui

```
* switch to Qt5 (#106 <https://github.com/ros-visualization/rqt/pull/106>)
```
## rqt_gui_cpp

```
* switch to Qt5 (#106 <https://github.com/ros-visualization/rqt/pull/106>)
```
## rqt_gui_py

```
* switch to Qt5 (#106 <https://github.com/ros-visualization/rqt/pull/106>)
```
