### PR TITLE
rqt: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -896,7 +896,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `0.3.1-0`:
- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros-gbp/rqt-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.0-0`
## rqt_gui
- No changes
## rqt_gui_cpp

```
* add missing build dependency
```
## rqt_gui_py
- No changes
