### PR TITLE
ardrone_autonomy: 1.4.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -78,6 +78,11 @@ repositories:
       type: git
       url: https://github.com/AutonomyLab/ardrone_autonomy.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/AutonomyLab/ardrone_autonomy-release.git
+      version: 1.4.1-0
     source:
       type: git
       url: https://github.com/AutonomyLab/ardrone_autonomy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ardrone_autonomy` to `1.4.1-0`:
- upstream repository: https://github.com/AutonomyLab/ardrone_autonomy.git
- release repository: https://github.com/AutonomyLab/ardrone_autonomy-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## ardrone_autonomy

```
* Enable realtime navdata/video in sample launch file
* Fix integer only values for odom.pose.z (fixes #155 <https://github.com/AutonomyLab/ardrone_autonomy/issues/155>) (hattip to @alexjung)
* Use tf_prefix parameter for multiple drone settings (fixes #156 <https://github.com/AutonomyLab/ardrone_autonomy/issues/156>)
  - Use tf_prefix to prefix tf frame names
  - Update single and multiple drone launch files to demo the usage
* Add example launch file for multiple drones.
* Publish TF at the same rate as odometry
* Contributors: Jacob Perron, Mani Monajjemi, Matias N. (v01d)
```
