### PR TITLE
graspit_tools: 0.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2892,7 +2892,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/JenniferBuehler/graspit-pkgs-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/JenniferBuehler/graspit-pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graspit_tools` to `0.1.5-0`:
- upstream repository: https://github.com/JenniferBuehler/graspit-pkgs.git
- release repository: https://github.com/JenniferBuehler/graspit-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.4-0`
## grasp_planning_graspit

```
* Added pre-grasp state computation
* Added helper class EigenGraspPlannerClient and some example grasp results for Jaco
* Now supports an extra auto-grasp as finalization of planning, and control of how many results are saved
* Fixed broken hand transform which was returned for resulting grasps
* Added means to save a Grasp.msg and added a table obstacle
* Contributors: Jennifer Buehler
```
## grasp_planning_graspit_msgs

```
* Added helper class EigenGraspPlannerClient and some example grasp results for Jaco
* Contributors: Jennifer Buehler
```
## grasp_planning_graspit_ros

```
* Added pre-grasp state computation
* Added helper class EigenGraspPlannerClient and some example grasp results for Jaco
* Now support addition of an auto-grasp as finalization of grasp planning, and control of how many results are saved
* Added means to save a Grasp.msg and added a table obstacle
* Contributors: Jennifer Buehler
```
## graspit_tools
- No changes
## jaco_graspit_sample

```
* Added pre-grasp state computation
* Added helper class EigenGraspPlannerClient and some example grasp results for Jaco
* Added means to save a Grasp.msg and added a table obstacle
* Contributors: Jennifer Buehler
```
## urdf2graspit

```
* Small fix: create mesh directory if the mesh filename implies more directories
* Contributors: Jennifer Buehler
```
