### PR TITLE
[rosdep/base] Add libusb-1.0-dev for Fedora 23, 24

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2518,6 +2518,8 @@ libusb-1.0-dev:
   fedora:
     '21': [libusbx-devel]
     '22': [libusbx-devel]
+    '23': [libusbx-devel]
+    '24': [libusbx-devel]
     beefy: [libusb1-devel]
     heisenbug: [libusbx-devel]
     schrödinger’s: [libusbx-devel]


### PR DESCRIPTION
Rationale thanks to @cottsay: https://github.com/ros-drivers/openni_camera/issues/45#issuecomment-204623273

This unblocks https://github.com/ros-drivers/openni_camera/issues/45 (for Kinetic).
