### PR TITLE
Revert "catkin_pure_python: 0.0.1-1 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1016,21 +1016,6 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: indigo-devel
     status: maintained
-  catkin_pure_python:
-    doc:
-      type: git
-      url: https://github.com/asmodehn/catkin_pure_python.git
-      version: indigo
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/asmodehn/catkin_pure_python-release.git
-      version: 0.0.1-1
-    source:
-      type: git
-      url: https://github.com/asmodehn/catkin_pure_python.git
-      version: indigo
-    status: developed
   cit_adis_imu:
     release:
       tags:


### PR DESCRIPTION
Reverts ros/rosdistro#10947

@asmodehn I'm rolling this back as the sourcedeb jobs are failing. 

http://build.ros.org/job/Isrc_uS__catkin_pure_python__ubuntu_saucy__source/1/console

You do not appear to have any saucy tags in your repository. 
