### PR TITLE
mavlink: 2016.4.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -471,6 +471,13 @@ repositories:
       url: https://github.com/ros-drivers/korg_nanokontrol.git
       version: master
     status: maintained
+  mavlink:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: 2016.4.4-0
+    status: maintained
   md49_base_controller:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2016.4.4-0`:
- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/mavlink/mavlink-gbp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
