### PR TITLE
rviz: 1.11.14-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4845,7 +4845,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.11.12-0
+      version: 1.11.14-0
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.11.14-0`:
- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.11.12-0`
## rviz

```
* Added the ``rviz_QT_VERSION`` cmake variable that exports the Qt version used by rviz.
* Changed the way ``rviz_DEFAULT_PLUGIN_LIBRARIES`` is set so it works with ``catkin_make`` too.
* Contributors: William Woodall
```
