### PR TITLE
Adding new libraries for Ubuntu

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2171,6 +2171,8 @@ libtool:
     trusty: [libtool, libltdl-dev]
     utopic: [libtool, libltdl-dev, libtool-bin]
     vivid: [libtool, libltdl-dev, libtool-bin]
+libttspico:
+  ubuntu: [libttspico-dev, libttspico-data, libttspico-utils, libttspico0]
 libturbojpeg:
   fedora: [turbojpeg-devel]
   ubuntu: [libturbojpeg]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1075,6 +1075,8 @@ libavahi-core-dev:
   debian: [libavahi-core-dev]
   fedora: [avahi-devel]
   ubuntu: [libavahi-core-dev]
+libbison-dev:
+  ubuntu: [libbison-dev]
 libblas-dev:
   arch: [cblas]
   debian: [libblas-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3026,6 +3026,8 @@ tar:
   opensuse: [libtar-devel]
   rhel: [libtar-devel]
   ubuntu: [libtar-dev]
+tap-plugins:
+  ubuntu: [tap-plugins]
 tbb:
   arch: [intel-tbb]
   debian: [libtbb-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2901,6 +2901,8 @@ spacenavd:
   debian: [spacenavd]
   fedora: [spacenavd]
   ubuntu: [spacenavd]
+speex:
+  ubuntu: [speex]
 sqlite3:
   arch: [sqlite]
   debian: [sqlite3]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -284,6 +284,8 @@ bluez:
   gentoo: [net-wireless/bluez-utils]
   rhel: [bluez-libs]
   ubuntu: [bluez]
+bluez-hcidump:
+  ubuntu: [bluez-hcidump]
 boost:
   arch: [boost]
   cygwin: [libboost-devel, libboost1.40]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1088,6 +1088,10 @@ libbluetooth-dev:
   fedora: [bluez-libs-devel]
   gentoo: [net-wireless/bluez-libs]
   ubuntu: [libbluetooth-dev]
+libboost-random-dev:
+  ubuntu: [libboost-random-dev]
+libboost-random1.46:
+  ubuntu: [libboost-random1.46]
 libcairo2-dev:
   arch: [cairo]
   fedora: [cairo-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1090,8 +1090,10 @@ libbluetooth-dev:
   ubuntu: [libbluetooth-dev]
 libboost-random-dev:
   ubuntu: [libboost-random-dev]
-libboost-random1.46:
-  ubuntu: [libboost-random1.46]
+libboost-random:
+  ubuntu: 
+    precise: [libboost-random1.46]
+    trusty: [libboost-random1.54.0]
 libcairo2-dev:
   arch: [cairo]
   fedora: [cairo-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4,6 +4,8 @@ ace:
   ubuntu: [libace-dev]
 acpi:
   ubuntu: [acpi]
+acpitool:
+  ubuntu: [acpitool]
 alsa-oss:
   arch: [alsa-oss]
   debian: [alsa-oss]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1434,6 +1434,8 @@ libjackson-json-java:
     portage:
       packages: [dev-java/json-simple]
   ubuntu: [libjackson-json-java]
+libjaxp1.3-java:
+  ubuntu: [libjaxp1.3-java]
 libjpeg:
   arch: [libjpeg-turbo]
   debian: [libjpeg8-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1487,6 +1487,8 @@ libjsoncpp-dev:
     portage:
       packages: [dev-libs/jsoncpp]
   ubuntu: [libjsoncpp-dev]
+libjsoncpp0:
+  ubuntu: [libjsoncpp0]
 liblapack-dev:
   arch: [lapack]
   debian: [liblapack-dev]


### PR DESCRIPTION
New libraries:
- libjaxp1.3-java
- libjsoncpp0
- speex
- tap-plugins
- libbison-dev
- libboost-random (libboost-random-dev, libboost-random1.X)
- libttspico (libttspico-dev, libttspico-data, libttspico-utils, libttspico0) 
- bluez-hcidump
- acpitool
