### PR TITLE
random_numbers: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -720,6 +720,21 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: kinetic-devel
     status: maintained
+  random_numbers:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/random_numbers-release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: master
+    status: maintained
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `random_numbers` to `0.3.1-0`:
- upstream repository: https://github.com/ros-planning/random_numbers
- release repository: https://github.com/ros-gbp/random_numbers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## random_numbers

```
* Merge pull request #10 <https://github.com/ros-planning/random_numbers/issues/10> from jspricke/cmake_lib
  Use catkin variables for install dirs
* Contributors: Dave Coleman, Jochen Sprickerhof
```
