### PR TITLE
geometric_shapes: 0.4.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -359,6 +359,21 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: indigo-devel
     status: maintained
+  geometric_shapes:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/geometric_shapes-release.git
+      version: 0.4.4-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: indigo-devel
+    status: maintained
   geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.4.4-0`:
- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## geometric_shapes

```
* Merge pull request #37 <https://github.com/ros-planning/geometric_shapes/issues/37> from corot/indigo-devel
  Fix issue #28 <https://github.com/ros-planning/geometric_shapes/issues/28> on small radius cylinders
* Contributors: Dave Coleman, Jorge Santos Simon
```
