### PR TITLE
robot_model: 1.12.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -764,6 +764,30 @@ repositories:
       type: git
       url: https://github.com/ros/resource_retriever.git
       version: kinetic-devel
+  robot_model:
+    doc:
+      type: git
+      url: https://github.com/ros/robot_model.git
+      version: kinetic-devel
+    release:
+      packages:
+      - collada_parser
+      - collada_urdf
+      - joint_state_publisher
+      - kdl_parser
+      - kdl_parser_py
+      - robot_model
+      - urdf
+      - urdf_parser_plugin
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/robot_model-release.git
+      version: 1.12.0-0
+    source:
+      type: git
+      url: https://github.com/ros/robot_model.git
+      version: kinetic-devel
+    status: maintained
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.12.0-0`:
- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## kdl_parser_py
- No changes
