### PR TITLE
Fixed/renamed rosdep entry for omniorb-idl

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2931,11 +2931,11 @@ omniorb:
     trusty: [omniorb, omniidl, omniorb-nameserver, libomniorb4-dev]
     utopic: [omniorb, omniidl, omniorb-nameserver, libomniorb4-dev]
     vivid: [omniorb, omniidl, omniorb-nameserver, libomniorb4-dev]
-omniorb4-idl:
+omniorb-idl:
   arch: [omniorb]
   debian: [omniorb-idl]
   fedora: [omniORB-devel]
-  ubuntu: [omniorb4-idl]
+  ubuntu: [omniorb-idl]
 opende:
   arch: [ode]
   fedora: [ode]


### PR DESCRIPTION
I would need a rosdep entry for the Ubuntu package `omniorb-idl`.

The original entry `omniorb4-idl` was added back in 2012 in https://github.com/ros/rosdistro/commit/94dd9ce4c76472d742e8281b4ca9176d99b23109. The package was renamed to `omniorb-idl` since Ubuntu 11.04, which still provided `omniorb4-idl` as a transitional package.

Renaming the key to `omniorb-idl` might break existing packages, but because the Ubuntu package name was wrong anyway after 11.04, I do not think that there are any released packages using that key. Not specifying a version number in the rosdep name is more in line with other rosdep entries like `omniorb`.

I verified that the referenced packages exist in current Debian, Fedora and ArchLinux releases, too.
