### PR TITLE
Update ffmpeg for Jessie

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -691,7 +691,10 @@ festival-dev:
   ubuntu: [festival-dev]
 ffmpeg:
   arch: [ffmpeg]
-  debian: [ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
+  debian:
+    jessie: [libav-tools, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
+    sid: [ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
+    wheezy: [ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
   fedora: [ffmpeg-devel]
   gentoo:
     portage:


### PR DESCRIPTION
as the ffmpeg package does not exist anymore as mentioned on
https://wiki.debian.org/ffmpeg
