### PR TITLE
catkin_pure_python: 0.0.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1016,6 +1016,21 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: indigo-devel
     status: maintained
+  catkin_pure_python:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/catkin_pure_python.git
+      version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/catkin_pure_python-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/asmodehn/catkin_pure_python.git
+      version: indigo
+    status: developed
   cit_adis_imu:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pure_python` to `0.0.2-1`:
- upstream repository: https://github.com/asmodehn/catkin_pure_python.git
- release repository: https://github.com/asmodehn/catkin_pure_python-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## catkin_pure_python

```
* cleaning up cmake ouput. fixing install sys pip path and pippkg path.
* Merge pull request #2 <https://github.com/asmodehn/catkin_pure_python/issues/2> from asmodehn/install_rules
  Install rules
* improve pip finding. fixed install.
* restructuring to get install running same code as devel
* adding git ignore and cmake file for building mypippkg test
* removed ROS dependency on cookiecutter since we need to get it from pip.
* added travis build status
* fixing default argument for catkin_pip_package
  fixing catkin_pure_python test build.
* attempting to fix nose and tests...
* improved environment detection and setup.
* improved readme
* fixed changelog
* Contributors: AlexV
```
