### PR TITLE
Adding drc_hubo to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1865,6 +1865,15 @@ repositories:
       type: git
       url: https://github.com/ZhuangYanDLUT/dlut_vision.git
       version: indigo-devel
+  drc_hubo:
+    doc:
+      type: git
+      url: https://github.com/JeongsooLim/drc_hubo.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/JeongsooLim/drc_hubo.git
+      version: indigo-devel
   driver_common:
     doc:
       type: git


### PR DESCRIPTION
I'd like drc_hubo to be indexed and documented on ros.org.
