### PR TITLE
catkin_pure_python: 0.0.2-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1025,7 +1025,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/catkin_pure_python-release.git
-      version: 0.0.2-1
+      version: 0.0.2-2
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pure_python.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pure_python` to `0.0.2-2`:
- upstream repository: https://github.com/asmodehn/catkin_pure_python.git
- release repository: https://github.com/asmodehn/catkin_pure_python-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.2-1`
## catkin_pure_python

```
* cleaning up cmake ouput. fixing install sys pip path and pippkg path.
* Merge pull request #2 <https://github.com/asmodehn/catkin_pure_python/issues/2> from asmodehn/install_rules
  Install rules
* improve pip finding. fixed install.
* restructuring to get install running same code as devel
* adding git ignore and cmake file for building mypippkg test
* removed ROS dependency on cookiecutter since we need to get it from pip.
* added travis build status
* fixing default argument for catkin_pip_package
  fixing catkin_pure_python test build.
* attempting to fix nose and tests...
* improved environment detection and setup.
* improved readme
* fixed changelog
* Contributors: AlexV
```
