### PR TITLE
Adding new libraries for Ubuntu (fixed)

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1733,6 +1733,7 @@ libjsoncpp:
     precise: [libjsoncpp0]
     trusty: [libjsoncpp0]
     vivid: [libjsoncpp0]
+    wily: [libjsoncpp0v5]
     xenial: [libjsoncpp1]
 libjsoncpp-dev:
   arch: [jsoncpp]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8,7 +8,7 @@ acpi:
   gentoo: [sys-power/acpi]
   ubuntu: [acpi]
 acpitool:
-  ubuntu: 
+  ubuntu:
     precise: [acpitool]
     trusty: [acpitool]
     vivid: [acpitool]
@@ -309,7 +309,7 @@ bluez:
   rhel: [bluez-libs]
   ubuntu: [bluez]
 bluez-hcidump:
-  ubuntu: 
+  ubuntu:
     precise: [bluez-hcidump]
     trusty: [bluez-hcidump]
     wily: [bluez-hcidump]
@@ -1243,7 +1243,7 @@ libavahi-core-dev:
   fedora: [avahi-devel]
   ubuntu: [libavahi-core-dev]
 libbison-dev:
-  ubuntu: 
+  ubuntu:
     precise: [libbison-dev]
     trusty: [libbison-dev]
     vivid: [libbison-dev]
@@ -1675,7 +1675,7 @@ libjackson-json-java:
       packages: [dev-java/json-simple]
   ubuntu: [libjackson-json-java]
 libjaxp1.3-java:
-  ubuntu: 
+  ubuntu:
     precise: [libjaxp1.3-java]
     trusty: [libjaxp1.3-java]
     vivid: [libjaxp1.3-java]
@@ -1729,7 +1729,7 @@ libjson0-dev:
       packages: [dev-libs/json-c]
   ubuntu: [libjson0-dev]
 libjsoncpp:
-  ubuntu: 
+  ubuntu:
     precise: [libjsoncpp0]
     trusty: [libjsoncpp0]
     vivid: [libjsoncpp0]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1244,6 +1244,10 @@ libbluetooth-dev:
   fedora: [bluez-libs-devel]
   gentoo: [net-wireless/bluez-libs]
   ubuntu: [libbluetooth-dev]
+libboost-random:
+  ubuntu: 
+    precise: [libboost-random1.46]
+    trusty: [libboost-random1.54.0]
 libcairo2-dev:
   arch: [cairo]
   fedora: [cairo-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1715,6 +1715,8 @@ libjsoncpp-dev:
     portage:
       packages: [dev-libs/jsoncpp]
   ubuntu: [libjsoncpp-dev]
+libjsoncpp0:
+  ubuntu: [libjsoncpp0]
 libkdtree++-dev:
   fedora: [libkdtree++-devel]
   ubuntu: [libkdtree++-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3353,7 +3353,7 @@ spacenavd:
 sparsehash:
   ubuntu: [sparsehash]
 speex:
-  ubuntu: 
+  ubuntu:
     precise: [speex]
     trusty: [speex]
     vivid: [speex]
@@ -3485,8 +3485,7 @@ tango-icon-theme:
   rhel: [tango-icon-theme]
   ubuntu: [tango-icon-theme]
 tap-plugins:
-  ubuntu: [tap-plugins]
-  ubuntu: 
+  ubuntu:
     precise: [tap-plugins]
     trusty: [tap-plugins]
     vivid: [tap-plugins]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8,7 +8,12 @@ acpi:
   gentoo: [sys-power/acpi]
   ubuntu: [acpi]
 acpitool:
-  ubuntu: [acpitool]
+  ubuntu: 
+    precise: [acpitool]
+    trusty: [acpitool]
+    vivid: [acpitool]
+    wily: [acpitool]
+    xenial: [acpitool]
 alsa-oss:
   arch: [alsa-oss]
   debian: [alsa-oss]
@@ -304,7 +309,11 @@ bluez:
   rhel: [bluez-libs]
   ubuntu: [bluez]
 bluez-hcidump:
-  ubuntu: [bluez-hcidump]
+  ubuntu: 
+    precise: [bluez-hcidump]
+    trusty: [bluez-hcidump]
+    wily: [bluez-hcidump]
+    xenial: [bluez-hcidump]
 boost:
   arch: [boost]
   cygwin: [libboost-devel, libboost1.40]
@@ -1234,7 +1243,12 @@ libavahi-core-dev:
   fedora: [avahi-devel]
   ubuntu: [libavahi-core-dev]
 libbison-dev:
-  ubuntu: [libbison-dev]
+  ubuntu: 
+    precise: [libbison-dev]
+    trusty: [libbison-dev]
+    vivid: [libbison-dev]
+    wily: [libbison-dev]
+    xenial: [libbison-dev]
 libblas-dev:
   arch: [cblas]
   debian: [libblas-dev]
@@ -1661,7 +1675,12 @@ libjackson-json-java:
       packages: [dev-java/json-simple]
   ubuntu: [libjackson-json-java]
 libjaxp1.3-java:
-  ubuntu: [libjaxp1.3-java]
+  ubuntu: 
+    precise: [libjaxp1.3-java]
+    trusty: [libjaxp1.3-java]
+    vivid: [libjaxp1.3-java]
+    wily: [libjaxp1.3-java]
+    xenial: [libjaxp1.3-java]
 libjpeg:
   arch: [libjpeg-turbo]
   debian:
@@ -1717,8 +1736,21 @@ libjsoncpp-dev:
     portage:
       packages: [dev-libs/jsoncpp]
   ubuntu: [libjsoncpp-dev]
-libjsoncpp0:
-  ubuntu: [libjsoncpp0]
+libjsoncpp:
+  ubuntu: 
+    lucid: 
+    maverick: 
+    natty: 
+    oneiric: 
+    precise: [libjsoncpp0]
+    quantal: 
+    raring: 
+    saucy: 
+    trusty: [libjsoncpp0]
+    utopic: 
+    vivid: [libjsoncpp0]
+    wily: 
+    xenial: [libjsoncpp1]
 libkdtree++-dev:
   fedora: [libkdtree++-devel]
   ubuntu: [libkdtree++-dev]
@@ -3330,7 +3362,12 @@ spacenavd:
 sparsehash:
   ubuntu: [sparsehash]
 speex:
-  ubuntu: [speex]
+  ubuntu: 
+    precise: [speex]
+    trusty: [speex]
+    vivid: [speex]
+    wily: [speex]
+    xenial: [speex]
 sqlite3:
   arch: [sqlite]
   debian: [sqlite3]
@@ -3458,6 +3495,12 @@ tango-icon-theme:
   ubuntu: [tango-icon-theme]
 tap-plugins:
   ubuntu: [tap-plugins]
+  ubuntu: 
+    precise: [tap-plugins]
+    trusty: [tap-plugins]
+    vivid: [tap-plugins]
+    wily: [tap-plugins]
+    xenial: [tap-plugins]
 tar:
   arch: [libtar]
   debian: [libtar-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3325,6 +3325,8 @@ spacenavd:
   ubuntu: [spacenavd]
 sparsehash:
   ubuntu: [sparsehash]
+speex:
+  ubuntu: [speex]
 sqlite3:
   arch: [sqlite]
   debian: [sqlite3]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1244,6 +1244,8 @@ libbluetooth-dev:
   fedora: [bluez-libs-devel]
   gentoo: [net-wireless/bluez-libs]
   ubuntu: [libbluetooth-dev]
+libboost-random-dev:
+  ubuntu: [libboost-random-dev]
 libboost-random:
   ubuntu: 
     precise: [libboost-random1.46]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3460,6 +3460,8 @@ tar:
   opensuse: [libtar-devel]
   rhel: [libtar-devel]
   ubuntu: [libtar-dev]
+tap-plugins:
+  ubuntu: [tap-plugins]
 tbb:
   arch: [intel-tbb]
   debian: [libtbb-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2436,6 +2436,8 @@ libtool:
     vivid: [libtool, libltdl-dev, libtool-bin]
     wily: [libtool, libltdl-dev, libtool-bin]
     xenial: [libtool, libltdl-dev, libtool-bin]
+libttspico:
+  ubuntu: [libttspico-dev, libttspico-data, libttspico-utils, libttspico0]
 libturbojpeg:
   fedora: [turbojpeg-devel]
   ubuntu: [libturbojpeg, libjpeg-turbo8-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -303,6 +303,8 @@ bluez:
   gentoo: [net-wireless/bluez-utils]
   rhel: [bluez-libs]
   ubuntu: [bluez]
+bluez-hcidump:
+  ubuntu: [bluez-hcidump]
 boost:
   arch: [boost]
   cygwin: [libboost-devel, libboost1.40]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1233,6 +1233,8 @@ libavahi-core-dev:
   debian: [libavahi-core-dev]
   fedora: [avahi-devel]
   ubuntu: [libavahi-core-dev]
+libbison-dev:
+  ubuntu: [libbison-dev]
 libblas-dev:
   arch: [cblas]
   debian: [libblas-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1728,6 +1728,12 @@ libjson0-dev:
     portage:
       packages: [dev-libs/json-c]
   ubuntu: [libjson0-dev]
+libjsoncpp:
+  ubuntu: 
+    precise: [libjsoncpp0]
+    trusty: [libjsoncpp0]
+    vivid: [libjsoncpp0]
+    xenial: [libjsoncpp1]
 libjsoncpp-dev:
   arch: [jsoncpp]
   debian: [libjsoncpp-dev]
@@ -1736,21 +1742,6 @@ libjsoncpp-dev:
     portage:
       packages: [dev-libs/jsoncpp]
   ubuntu: [libjsoncpp-dev]
-libjsoncpp:
-  ubuntu: 
-    lucid: 
-    maverick: 
-    natty: 
-    oneiric: 
-    precise: [libjsoncpp0]
-    quantal: 
-    raring: 
-    saucy: 
-    trusty: [libjsoncpp0]
-    utopic: 
-    vivid: [libjsoncpp0]
-    wily: 
-    xenial: [libjsoncpp1]
 libkdtree++-dev:
   fedora: [libkdtree++-devel]
   ubuntu: [libkdtree++-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1247,7 +1247,7 @@ libbluetooth-dev:
   gentoo: [net-wireless/bluez-libs]
   ubuntu: [libbluetooth-dev]
 libboost-random:
-  ubuntu: 
+  ubuntu:
     precise: [libboost-random1.46]
     trusty: [libboost-random1.54.0]
 libboost-random-dev:
@@ -3456,6 +3456,8 @@ tango-icon-theme:
   opensuse: [tango-icon-theme]
   rhel: [tango-icon-theme]
   ubuntu: [tango-icon-theme]
+tap-plugins:
+  ubuntu: [tap-plugins]
 tar:
   arch: [libtar]
   debian: [libtar-dev]
@@ -3466,8 +3468,6 @@ tar:
   opensuse: [libtar-devel]
   rhel: [libtar-devel]
   ubuntu: [libtar-dev]
-tap-plugins:
-  ubuntu: [tap-plugins]
 tbb:
   arch: [intel-tbb]
   debian: [libtbb-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7,6 +7,8 @@ acpi:
   fedora: [acpi]
   gentoo: [sys-power/acpi]
   ubuntu: [acpi]
+acpitool:
+  ubuntu: [acpitool]
 alsa-oss:
   arch: [alsa-oss]
   debian: [alsa-oss]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1246,12 +1246,12 @@ libbluetooth-dev:
   fedora: [bluez-libs-devel]
   gentoo: [net-wireless/bluez-libs]
   ubuntu: [libbluetooth-dev]
-libboost-random-dev:
-  ubuntu: [libboost-random-dev]
 libboost-random:
   ubuntu: 
     precise: [libboost-random1.46]
     trusty: [libboost-random1.54.0]
+libboost-random-dev:
+  ubuntu: [libboost-random-dev]
 libcairo2-dev:
   arch: [cairo]
   fedora: [cairo-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1660,6 +1660,8 @@ libjackson-json-java:
     portage:
       packages: [dev-java/json-simple]
   ubuntu: [libjackson-json-java]
+libjaxp1.3-java:
+  ubuntu: [libjaxp1.3-java]
 libjpeg:
   arch: [libjpeg-turbo]
   debian:


### PR DESCRIPTION
New libraries:
- libjaxp1.3-java
- libjsoncpp0
- speex
- tap-plugins
- libbison-dev
- libboost-random (libboost-random-dev, libboost-random1.X)
- libttspico (libttspico-dev, libttspico-data, libttspico-utils, libttspico0)
- bluez-hcidump
- acpitool
