### PR TITLE
catkin_pure_python: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1025,7 +1025,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/catkin_pure_python-release.git
-      version: 0.0.2-1
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pure_python.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pure_python` to `0.0.3-0`:
- upstream repository: https://github.com/asmodehn/catkin_pure_python.git
- release repository: https://github.com/asmodehn/catkin_pure_python-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.2-1`
## catkin_pure_python

```
* small refactor to improve cmake messages
* now specifying source director and exists-action backup when installing reuqirements.
  restored previous behavior to check for installed packages before installing current package. this avoid reinstalling dependencies satisfied by requirements.
* always cleaning cache for catkin_pip for safety.
* added --ignore-installed so pip doesnt try to remove old packages from system.
  quick Readme Roadmap
* Contributors: alexv
```
