### PR TITLE
Fix collada rosdep key for Xenial

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -494,7 +494,7 @@ collada-dom:
     utopic: [collada-dom-dev]
     vivid: [collada-dom-dev]
     wily: [collada-dom-dev]
-    xenial: [libcollada-dom2.4-dep-dev]
+    xenial: [libcollada-dom2.4-dp-dev]
 comedi:
   fedora: [comedilib-devel]
   ubuntu: [libcomedi-dev]


### PR DESCRIPTION
robot_model is currently failing for Kinetic on the buildfarm:

http://build.ros.org/job/Kdev__robot_model__ubuntu_xenial_amd64/1/console#console-section-9

```
00:09:53 Traceback (most recent call last):
00:09:53   File "/usr/lib/python3/dist-packages/apt/cache.py", line 194, in __getitem__
00:09:53     return self._weakref[key]
00:09:53   File "/usr/lib/python3.5/weakref.py", line 131, in __getitem__
00:09:53     o = self.data[key]()
00:09:53 KeyError: 'libcollada-dom2.4-dep-dev'
```

It turns out that the package is named `libcollada-dom2.4-dp-dev` in Xenial:

http://packages.ubuntu.com/xenial/libdevel/libcollada-dom2.4-dp-dev
