### PR TITLE
teleop-twist-joy-xbot-release: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 141: http://ros.org/reps/rep-0141.html
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   fedora:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10806,21 +10806,19 @@ repositories:
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git
       version: master
     status: developed
-  teleop-twist-joy-xbot-release:
+  teleop-twist-joy-xbot:
     doc:
       type: git
-      url: https://github.com/giupal/teleop_twist_joy_xbot-release.git
+      url: https://github.com/giupal/teleop_twist_joy_xbot-devel.git
       version: 0.1.2
     release:
-      packages:
-      - teleop_twist_joy_xbot
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/giupal/teleop_twist_joy_xbot-release.git
       version: 0.1.2-0
     source:
       type: git
-      url: https://github.com/giupal/teleop_twist_joy_xbot-release.git
+      url: https://github.com/giupal/teleop_twist_joy_xbot-devel.git
       version: 0.1.2
     status: maintained
   teleop_tools:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -10806,6 +10806,23 @@ repositories:
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git
       version: master
     status: developed
+  teleop-twist-joy-xbot-release:
+    doc:
+      type: git
+      url: https://github.com/giupal/teleop_twist_joy_xbot-release.git
+      version: 0.1.2
+    release:
+      packages:
+      - teleop_twist_joy_xbot
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/giupal/teleop_twist_joy_xbot-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/giupal/teleop_twist_joy_xbot-release.git
+      version: 0.1.2
+    status: maintained
   teleop_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop-twist-joy-xbot-release` to `0.1.2-0`:
- upstream repository: https://github.com/giupal/teleop_twist_joy_xbot-devel.git
- release repository: https://github.com/giupal/teleop_twist_joy_xbot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
