### PR TITLE
teb_local_planner: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10800,7 +10800,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
-      version: 0.2.3-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner` to `0.3.0-0`:
- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.3-0`
## teb_local_planner

```
* Different/custom robot footprints are now supported and subject to optimization (refer to the new tutorial!).
* The new robot footprint is also visualized using the common marker topic.
* The strategy of taking occupied costmap cells behind the robot into account has been improved.
  These changes significantly improve navigation close to walls.
* Parameter 'max_global_plan_lookahead_dist' added.
  Previously, the complete subset of the global plan contained in the local costmap
  was taken into account for choosing the current intermediate goal point. With this parameter, the maximum
  length of the reference global plan can be limited. The actual global plan subset
  is now computed using the logical conjunction of both local costmap size and 'max_global_plan_lookahead_dist'.
* Bug fixes:
  * Fixed a compilation issue on ARM architectures
  * If custom obstacles are used, the container with old obstacles is now cleared properly.
* Parameter cleanup:
  * "weight_X_obstacle" parameters combined to single parameter "weight_obstacle".
  * "X_obstacle_poses_affected" parameters combined to single parameter "obstacle_poses_affected".
  * Deprecated parameter 'costmap_emergency_stop_dist' removed.
* Code cleanup
```
