### PR TITLE
fzi_icl_core: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2630,6 +2630,21 @@ repositories:
       url: https://github.com/DaikiMaekawa/fulanghua_navigation.git
       version: indigo-devel
     status: developed
+  fzi_icl_core:
+    doc:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core.git
+      version: master
+    status: maintained
   gazebo2rviz:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fzi_icl_core` to `1.0.1-0`:
- upstream repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core
- release repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## fzi_icl_core

```
* Added initital release version of fzi_icl_core for release in the ROS Ecosystem
* Contributors: Georg Heppner, Klaus Uhl, Lars Pfotzer, Jan Oberländer, Kay-Ulrich Scholl
```
