### PR TITLE
Change Collada package name for Debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -475,7 +475,7 @@ coinor-libipopt-dev:
   ubuntu: [coinor-libipopt-dev]
 collada-dom:
   arch: [collada-dom]
-  debian: [collada-dom-dev]
+  debian: [libcollada-dom2.4-dp-dev]
   fedora: [collada-dom-devel]
   gentoo:
     portage:


### PR DESCRIPTION
I'm pretty sure there's no package called `collada-dom-dev` in Debian; perhaps it was renamed since the rosdep key was first added.

https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=collada-dom
