### PR TITLE
Rosdep python-networkmanager

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -989,6 +989,8 @@ python-netifaces:
     wily_python3: [python3-netifaces]
     xenial: [python-netifaces]
     xenial_python3: [python3-netifaces]
+python-networkmanager:
+  ubuntu: [python-networkmanager]
 python-networkx:
   arch: [python2-networkx]
   fedora: [python-networkx]


### PR DESCRIPTION
Looks like this is only available on trusty onwards, see [here](http://packages.ubuntu.com/search?keywords=python-networkmanager).

I don't have any packages (nor open source packages) that require this prior to trusty though, so a general key is probably sufficient until individual ones are needed.

If you'd like the distro-specific keys, let me know.
