### PR TITLE
euslisp: 9.18.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -272,7 +272,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/euslisp-release.git
-      version: 9.18.0-0
+      version: 9.18.1-0
     status: developed
   filters:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `euslisp` to `9.18.1-0`:
- upstream repository: https://github.com/euslisp/EusLisp
- release repository: https://github.com/tork-a/euslisp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `9.18.0-0`
