### PR TITLE
gazebo_ros_pkgs: 2.5.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1018,11 +1018,12 @@ repositories:
       - gazebo_msgs
       - gazebo_plugins
       - gazebo_ros
+      - gazebo_ros_control
       - gazebo_ros_pkgs
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.5.2-0
+      version: 2.5.3-0
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.5.3-0`:
- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.5.2-0`
## gazebo_msgs
- No changes
## gazebo_plugins
- No changes
## gazebo_ros

```
* Include binary in runtime
* Remove ROS remapping arguments from gazebo_ros launch scripts.
* Contributors: Jose Luis Rivero, Martin Pecka
```
## gazebo_ros_control
- No changes
## gazebo_ros_pkgs
- No changes
