### PR TITLE
qwt_dependency: 1.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3718,6 +3718,21 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: groovy-devel
     status: maintained
+  qwt_dependency:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/qwt_dependency.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/qwt_dependency-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/qwt_dependency.git
+      version: indigo-devel
+    status: maintained
   rail_ceiling:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qwt_dependency` to `1.0.0-0`:
- upstream repository: https://github.com/ros-visualization/qwt_dependency.git
- release repository: https://github.com/ros-gbp/qwt_dependency-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
