### PR TITLE
robot_model: 1.12.1-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -882,7 +882,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.12.1-1
+      version: 1.12.1-3
     source:
       type: git
       url: https://github.com/ros/robot_model.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.12.1-3`:
- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.12.1-1`
## collada_parser
- No changes
## collada_urdf
- No changes
## joint_state_publisher
- No changes
## kdl_parser
- No changes
## kdl_parser_py

```
* Remove cmake_modules dependency
* Contributors: Jackie Kay
```
## robot_model
- No changes
## urdf
- No changes
## urdf_parser_plugin
- No changes
