### PR TITLE
rviz: 1.12.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1107,6 +1107,11 @@ repositories:
       type: git
       url: https://github.com/ros-visualization/rviz.git
       version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/rviz-release.git
+      version: 1.12.0-0
     source:
       test_commits: false
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.12.0-0`:
- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rviz

```
* Qt5 is now the default build option, but Qt4 support is still available (for C++ only).
* Fixed support for PyQt5, but disabled PySide2 until we get it working.
* The default plugin's library was changed to ``rviz_default_plugin``.
* Changed to use CMake's ``file(GENERATE ...)`` macro when exporting the default plugin's library name.
* Changed costmap lethal color to be different from illegal values.
* Cleaned-up and generalized the WrenchVisual display:
  * renamed ``WrenchStampedVisual`` to ``WrenchVisual``
  * cleanup: removed deprecated API
* Updated the marker display and tf plugins to update the map of enabled namespaces and frames whenever those frames are enabled/disabled using the check boxes.
  Also updated the plugins so that the map of enabled namespaces and frames does not get erased whenever the plugin is reset. (#988 <https://github.com/ros-visualization/rviz/issues/988>)
  This allows the currently selected namespaces/frames to remain selected after the Reset button is pressed.
* Contributors: Brett, Robert Haschke, William Woodall
```
