### PR TITLE
oxford_gps_eth: 0.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -767,6 +767,21 @@ repositories:
       url: https://github.com/orocos/orocos_kinematics_dynamics.git
       version: master
     status: maintained
+  oxford_gps_eth:
+    doc:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/oxford_gps_eth
+      version: default
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
+      version: 0.0.4-0
+    source:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/oxford_gps_eth
+      version: default
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `oxford_gps_eth` to `0.0.4-0`:
- upstream repository: https://bitbucket.org/DataspeedInc/oxford_gps_eth
- release repository: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## oxford_gps_eth

```
* Updated license year for 2016
* Contributors: Kevin Hallenbeck
```
