### PR TITLE
ueye: 0.0.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1179,6 +1179,21 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  ueye:
+    doc:
+      type: hg
+      url: https://bitbucket.org/kmhallen/ueye
+      version: default
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/kmhallen/ueye-release.git
+      version: 0.0.9-0
+    source:
+      type: hg
+      url: https://bitbucket.org/kmhallen/ueye
+      version: default
+    status: maintained
   unique_identifier:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye` to `0.0.9-0`:
- upstream repository: https://bitbucket.org/kmhallen/ueye
- release repository: https://github.com/kmhallen/ueye-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## ueye

```
* Allow zoom up to 16x
* Contributors: Kevin Hallenbeck
```
