### PR TITLE
imu_tools: 1.0.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -491,6 +491,26 @@ repositories:
       url: https://github.com/ros-perception/image_pipeline.git
       version: indigo
     status: maintained
+  imu_tools:
+    doc:
+      type: git
+      url: https://github.com/ccny-ros-pkg/imu_tools.git
+      version: kinetic
+    release:
+      packages:
+      - imu_complementary_filter
+      - imu_filter_madgwick
+      - imu_tools
+      - rviz_imu_plugin
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/uos-gbp/imu_tools-release.git
+      version: 1.0.9-0
+    source:
+      type: git
+      url: https://github.com/ccny-ros-pkg/imu_tools.git
+      version: kinetic
+    status: developed
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.0.9-0`:
- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## imu_complementary_filter

```
* complementary: Add Eigen dependency
  Fixes #54 <https://github.com/ccny-ros-pkg/imu_tools/issues/54>.
* Contributors: Martin Günther
```
## imu_filter_madgwick
- No changes
## imu_tools
- No changes
## rviz_imu_plugin
- No changes
