### PR TITLE
katana_driver: 1.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4271,7 +4271,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uos-gbp/katana_driver-release.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/uos/katana_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `katana_driver` to `1.0.5-0`:
- upstream repository: https://github.com/uos/katana_driver.git
- release repository: https://github.com/uos-gbp/katana_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.4-0`
## katana
- No changes
## katana_arm_gazebo
- No changes
## katana_description
- No changes
## katana_driver
- No changes
## katana_gazebo_plugins

```
* Fix katana_gazebo_plugins compilation on Saucy
* Contributors: Martin Günther
```
## katana_moveit_ikfast_plugin
- No changes
## katana_msgs
- No changes
## katana_teleop
- No changes
## katana_tutorials
- No changes
## kni
- No changes
