### PR TITLE
add protobuf for Wily/Xenial

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3058,6 +3058,8 @@ protobuf:
     trusty: [libprotobuf8]
     utopic: [libprotobuf8]
     vivid: [libprotobuf9]
+    wily: [libprotobuf9v5]
+    xenial: [libprotobuf9v5]
 protobuf-dev:
   arch: [protobuf]
   debian: [libprotobuf-dev, protobuf-compiler, libprotoc-dev]


### PR DESCRIPTION
Source: http://packages.ubuntu.com/wily/libprotobuf9v5
