### PR TITLE
ivcon: 0.1.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -526,6 +526,17 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: indigo-devel
     status: maintained
+  ivcon:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/ivcon-release.git
+      version: 0.1.6-0
+    source:
+      type: git
+      url: https://github.com/ros/ivcon.git
+      version: kinetic-devel
+    status: maintained
   jsk_common_msgs:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ivcon` to `0.1.6-0`:
- upstream repository: https://github.com/ros/ivcon.git
- release repository: https://github.com/ros-gbp/ivcon-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
