### PR TITLE
fetch_tools: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2472,7 +2472,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_tools` to `0.1.4-0`:
- upstream repository: https://github.com/fetchrobotics/fetch_tools.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.3-0`
## fetch_tools

```
* Added FETCH_USER to sf/sfr & additional usage notes
* Updated readme to detail robothostname.local usage with fetch_tools and how to set ports with ul
* Contributors: Alex Henning, Eric Relson
```
