### PR TITLE
robot_model: 1.12.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -958,7 +958,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.12.1-3
+      version: 1.12.2-0
     source:
       type: git
       url: https://github.com/ros/robot_model.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.12.2-0`:
- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.12.1-3`
## collada_parser
- No changes
## collada_urdf
- No changes
## joint_state_publisher

```
* Migrate qt (#128 <https://github.com/ros/robot_model/issues/128>)
  * Migrate JointStatePublisher from wxPython to qt5
* Contributors: Jackie Kay
```
## kdl_parser
- No changes
## kdl_parser_py
- No changes
## robot_model
- No changes
## urdf
- No changes
## urdf_parser_plugin
- No changes
