### PR TITLE
rqt_paramedit: 1.0.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9767,6 +9767,24 @@ repositories:
       url: https://github.com/osrf/rqt_graphprofiler.git
       version: master
     status: developed
+  rqt_paramedit:
+    doc:
+      type: git
+      url: https://github.com/dornhege/rqt_paramedit.git
+      version: indigo-devel
+    release:
+      packages:
+      - qt_paramedit
+      - rqt_paramedit
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/dornhege/rqt_paramedit-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/dornhege/rqt_paramedit.git
+      version: indigo-devel
+    status: maintained
   rqt_pr2_dashboard:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_paramedit` to `1.0.0-2`:
- upstream repository: https://github.com/dornhege/rqt_paramedit.git
- release repository: https://github.com/dornhege/rqt_paramedit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
