### PR TITLE
screenrun: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10237,6 +10237,21 @@ repositories:
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git
       version: master
     status: maintained
+  screenrun:
+    doc:
+      type: git
+      url: https://github.com/dornhege/screenrun.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/dornhege/screenrun-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/dornhege/screenrun.git
+      version: indigo-devel
+    status: maintained
   segbot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `screenrun` to `1.0.2-0`:
- upstream repository: https://github.com/dornhege/screenrun.git
- release repository: https://github.com/dornhege/screenrun-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
