### PR TITLE
jsk_recognition: 0.3.20-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4168,7 +4168,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.19-0
+      version: 0.3.20-0
     status: developed
   jsk_robot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.20-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.19-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros

```
* [jsk_pcl_ros] add jsk_pcl version of tabletop_object_detector launch/config (#1585 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/1585>)
  * [jsk_pcl_ros_utils/jsk_pcl_nodelets.xml] fix: pcl class name typo of CloudOnPlane
  * [jsk_pcl_ros/sample/tabletop_object_detector.launch] add jsk version of tabletop_object_detector
* [jsk_pcl_ros] Support bilateral filtering in HeightmapMorphologicalFiltering (#1564 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/1564>)
* Install python executables
* Contributors: Yuki Furuta, Kentaro Wada, Ryohei Ueda
```
## jsk_pcl_ros_utils

```
* [jsk_pcl_ros] add jsk_pcl version of tabletop_object_detector launch/config (#1585 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/1585>)
  * [jsk_pcl_ros_utils/jsk_pcl_nodelets.xml] fix: pcl class name typo of CloudOnPlane
  * [jsk_pcl_ros/sample/tabletop_object_detector.launch] add jsk version of tabletop_object_detector
* Contributors: Yuki Furuta
```
## jsk_perception

```
* Add sample/test for image_cluster_indices_decomposer.py (#1580 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/1580>)
* Add sample and test for BoundingBoxToRect (#1577 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/1577>)
  * Add sample for BoundingBoxToRect
  Modified:
  - jsk_perception/CMakeLists.txt
  Added:
  - jsk_perception/sample/sample_bounding_box_to_rect.launch
  - jsk_perception/scripts/install_sample_data.py
  - jsk_perception/test_data/.gitignore
  * Add test for BoundingBoxToRect
  * add an example to the documentation
  * modified document
* [jsk_perception/bounding_box_to_rect] add rosparam approximate sync and queue_size (#1583 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/1583>)
  * [jsk_perception/bounding_box_to_rect] add approximate sync and queue_size param
  * [jsk_perception/bounding_box_to_rect] add parameters in doc
* Visualize ClusterPointIndices for image (#1579 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/1579>)
* Install python executables
  * Install python executables
* Refactor: Make test filenames consistent
* Fix typo in 'test/test_split_fore_background.test'
* Merge pull request #1568 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/1568> from wkentaro/draw-rect-array
  [jsk_perception/draw_rect_array.py] Draw rect_array onto a image
* Add test for jsk_perception/draw_rect_array.py
  Modified:
  - jsk_perception/CMakeLists.txt
  Added:
  - jsk_perception/test/draw_rect_array.test
* Documentize draw_rect_array.py
* Draw rect_array onto a image
  Added:
  - jsk_perception/node_scripts/draw_rect_array.py
* Add example for fast_rcnn_caffenet.py
* Subscribe rect_array as object location proposals
* Test jsk_perception/selective_search.py
* Pass RGB image to dlib.find_candidate_object_locations
  Modified:
  - jsk_perception/node_scripts/selective_search.py
* [jsk_perception] include opencv header in rect_array_actual_size_filter.h
* [jsk_perception] Add RectArrayActualSizeFilter
  Filtering array of rectangle regions based on actual size estimated from
  depth image.
* Remove duplicated roslint in test_depend
  Modified:
  - jsk_perception/package.xml
* Contributors: Kei Okada, Kentaro Wada, Ryohei Ueda, Shingo Kitagawa, Yusuke Niitani
```
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## jsk_recognition_utils

```
* [jsk_recognition_utils] Support Affine3d project function in Plane (#1576 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/1576>)
* [jsk_recognition_utils] Add multiple ClusterPointIndices to one (#1581 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/1581>)
  * Add multiple ClusterPointIndices to one
  Added:
  - jsk_recognition_utils/node_scripts/add_cluster_indices.py
  * Document for add_cluster_indices.py
* Visualize ClusterPointIndices for image (#1579 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/1579>)
* Contributors: Iori Kumagai, Kentaro Wada
```
## resized_image_transport
- No changes
