### PR TITLE
roslisp: 1.9.20-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4538,7 +4538,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/roslisp-release.git
-      version: 1.9.19-0
+      version: 1.9.20-0
     source:
       type: git
       url: https://github.com/ros/roslisp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp` to `1.9.20-0`:
- upstream repository: git://github.com/ros/roslisp.git
- release repository: https://github.com/ros-gbp/roslisp-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.9.19-0`
## roslisp

```
* Merge pull request #28 <https://github.com/ros/roslisp/issues/28> from gaya-/master
  In ADD_LISP_EXECUTABLE added a check for slashes in first argument
* in cmake script minor nicification
* [cmake] in ADD_LISP_EXECUTABLE added a check for slashes in first argument
* Contributors: Gayane Kazhoyan, Georg Bartels
```
