### PR TITLE
roslisp_common: 0.2.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9471,13 +9471,15 @@ repositories:
       - cl_tf
       - cl_tf2
       - cl_transforms
+      - cl_transforms_stamped
+      - cl_urdf
       - cl_utils
       - roslisp_common
       - roslisp_utilities
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/roslisp_common-release.git
-      version: 0.2.3-0
+      version: 0.2.6-0
     source:
       type: git
       url: https://github.com/ros/roslisp_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp_common` to `0.2.6-0`:
- upstream repository: https://github.com/ros/roslisp_common.git
- release repository: https://github.com/ros-gbp/roslisp_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.3-0`
