### PR TITLE
roslisp_common: 0.2.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1173,6 +1173,31 @@ repositories:
       url: https://github.com/ros/roslisp.git
       version: master
     status: maintained
+  roslisp_common:
+    doc:
+      type: git
+      url: https://github.com/ros/roslisp_common.git
+      version: master
+    release:
+      packages:
+      - actionlib_lisp
+      - cl_tf
+      - cl_tf2
+      - cl_transforms
+      - cl_transforms_stamped
+      - cl_urdf
+      - cl_utils
+      - roslisp_common
+      - roslisp_utilities
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/roslisp_common-release.git
+      version: 0.2.6-1
+    source:
+      type: git
+      url: https://github.com/ros/roslisp_common.git
+      version: master
+    status: developed
   rospack:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp_common` to `0.2.6-1`:
- upstream repository: https://github.com/ros/roslisp_common.git
- release repository: https://github.com/ros-gbp/roslisp_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
