### PR TITLE
uavc_v4lctl-release: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11328,6 +11328,23 @@ repositories:
       url: https://github.com/orocos-toolchain/typelib.git
       version: toolchain-2.8
     status: maintained
+  uavc_v4lctl-release:
+    doc:
+      type: git
+      url: https://github.com/meuchel/uavc_v4lctl.git
+      version: 1.0.2
+    release:
+      packages:
+      - uavc_v4lctl
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/meuchel/uavc_v4lctl-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/meuchel/uavc_v4lctl.git
+      version: 1.0.2
+    status: maintained
   ubiquity_launches:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uavc_v4lctl-release` to `1.0.2-0`:
- upstream repository: https://github.com/meuchel/uavc_v4lctl.git
- release repository: https://github.com/meuchel/uavc_v4lctl-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## uavc_v4lctl

```
* minor fixes
* Contributors: uavc
```
