### PR TITLE
teb_local_planner_tutorials: 0.0.1-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10886,6 +10886,21 @@ repositories:
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git
       version: master
     status: developed
+  teb_local_planner_tutorials:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials-release.git
+      version: 0.0.1-2
+    source:
+      type: git
+      url: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials.git
+      version: master
+    status: maintained
   teleop_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner_tutorials` to `0.0.1-2`:
- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## teb_local_planner_tutorials

```
* Initial release with two stage simulation examples (diffdrive and carlike robots) and all tutorial scripts.
```
