### PR TITLE
teb_local_planner_tutorials: 0.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5239,6 +5239,21 @@ repositories:
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git
       version: master
     status: developed
+  teb_local_planner_tutorials:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials.git
+      version: master
+    status: maintained
   teleop_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner_tutorials` to `0.0.1-0`:
- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## teb_local_planner_tutorials

```
* Initial release with two stage simulation examples (diffdrive and carlike robots) and all tutorial scripts.
```
