### PR TITLE
bus_server: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -705,7 +705,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/bus_server-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     status: developed
   bwi:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `bus_server` to `0.1.1-0`:
- upstream repository: https://github.com/UbiquityRobotics/bus_server.git
- release repository: https://github.com/UbiquityRobotics-release/bus_server-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.0-0`
## bus_server

```
* Added minor travis stuff
* Contributors: Rohan Agrawal
```
