### PR TITLE
control_msgs: 1.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -219,6 +219,11 @@ repositories:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
       version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/control_msgs-release.git
+      version: 1.4.0-0
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `1.4.0-0`:
- upstream repository: git://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros-gbp/control_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## control_msgs

```
* Add antiwindup to JointControllerState message definition
* Add PidState message
* Contributors: Paul Bovbel
```
