### PR TITLE
jsk_apc: 0.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4015,7 +4015,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_apc-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/start-jsk/jsk_apc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_apc` to `0.2.4-0`:
- upstream repository: https://github.com/start-jsk/jsk_apc.git
- release repository: https://github.com/tork-a/jsk_apc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.3-0`
## jsk_2015_05_baxter_apc

```
* Add visualization tool to visualize ik to bin
* Update rosinstall
* Contributors: Kentaro Wada
```
## jsk_2016_01_baxter_apc

```
* Rename launch file
* Fix typo left_vacuum_gripper.xacro
* Add softkinetic xacro
* Clean up setup_creative.launch
* Fix name right/left
* Rename camera to left_camera
* Rename setup_baxter_gazebo -> initialize_baxter
* Initialize docs for 'jsk_2016_01_baxter_apc'
* Get organized point cloud from softkinetic camera
* Chang file name
* Add urdf model of Baxter with creative on right hand
* Change baudrate to 115200
* Change jsk_2015_05_baxter_apc/urdf/ -> jsk_2015_05_baxter_apc/robots/
* Add baxter.launch and new arduino node
* Chang topic name
* Add servo state controller in arduino firmware
* Enable to control servo with ros
* Add arduino nano firmware
* Contributors: Kentaro Wada, Shingo Kitagawa, Yusuke Niitani, Masahiro Bando, Shun Hasegawa
```
## jsk_apc
- No changes
## jsk_apc2015_common

```
* Add roslint as test_depend
* Contributors: Kentaro Wada
```
## jsk_apc2016_common
- No changes
