### PR TITLE
sick_tim: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10436,7 +10436,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uos-gbp/sick_tim-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/uos/sick_tim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_tim` to `0.0.7-0`:
- upstream repository: https://github.com/uos/sick_tim
- release repository: https://github.com/uos-gbp/sick_tim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.6-0`
## sick_tim

```
* Check for firmware versions without range output
  Closes #36 <https://github.com/uos/sick_tim/issues/36> .
* Use intensity param in TiM 551/571 parser
  Also print a warning when the intensity param is set, but RSSI is not
  enabled on the scanner. See #32 <https://github.com/uos/sick_tim/issues/32>.
* Other minor changes
* Contributors: Martin Günther
```
