### PR TITLE
rosdoc_lite: 0.2.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9281,7 +9281,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rosdoc_lite-release.git
-      version: 0.2.5-0
+      version: 0.2.6-0
     source:
       type: git
       url: https://github.com/ros-infrastructure/rosdoc_lite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosdoc_lite` to `0.2.6-0`:
- upstream repository: https://github.com/ros-infrastructure/rosdoc_lite.git
- release repository: https://github.com/ros-gbp/rosdoc_lite-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.5-0`
## rosdoc_lite

```
* Support SEARCHENGINE option for doxygen
  Closes #56 <https://github.com/ros-infrastructure/rosdoc_lite/issues/56>
* Contributors: Jack O'Quin, Kentaro Wada
```
