### PR TITLE
Change version of protobuf in jessie and sid

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3030,7 +3030,10 @@ proj:
   ubuntu: [libproj-dev]
 protobuf:
   arch: [protobuf]
-  debian: [libprotobuf7]
+  debian:
+    jessie: [libprotobuf9]
+    sid: [libprotobuf9]
+    wheezy: [libprotobuf7]
   fedora: [protobuf]
   macports: [protobuf-cpp]
   ubuntu:


### PR DESCRIPTION
I discussed some of the failing vision_opencv packages on Debian with @vrabaud and this appears to be the solution. libprotobuf7 is not available in Jessie or Sid, the default is libprotobuf9 in both.

https://packages.debian.org/jessie/libprotobuf9
https://packages.debian.org/sid/libprotobuf9
https://packages.debian.org/wheezy/libprotobuf7
