### PR TITLE
camera_info_manager_py: 0.2.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -119,6 +119,21 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: master
     status: maintained
+  camera_info_manager_py:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/camera_info_manager_py.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/camera_info_manager_py-release.git
+      version: 0.2.3-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/camera_info_manager_py.git
+      version: master
+    status: maintained
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_info_manager_py` to `0.2.3-0`:
- upstream repository: https://github.com/ros-perception/camera_info_manager_py.git
- release repository: https://github.com/ros-gbp/camera_info_manager_py-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## camera_info_manager_py
- No changes
