### PR TITLE
Revert "Adding uavc_v4lctl to documentation index for distro jade"

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5380,21 +5380,6 @@ repositories:
       url: https://github.com/ros-teleop/twist_mux_msgs.git
       version: jade-devel
     status: maintained
-  uavc_v4lctl:
-    doc:
-      type: git
-      url: https://github.com/meuchel/uavc_v4lctl.git
-      version: 1.0.2
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/meuchel/uavc_v4lctl-release.git
-      version: 1.0.2-0
-    source:
-      type: git
-      url: https://github.com/meuchel/uavc_v4lctl.git
-      version: master
-    status: maintained
   ublox:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#11103

See: http://build.ros.org/job/Jsrc_uT__uavc_v4lctl__ubuntu_trusty__source/35/console
