### PR TITLE
moveit_ros: 0.7.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5550,7 +5550,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.7.0-0
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ros` to `0.7.1-0`:
- upstream repository: https://github.com/ros-planning/moveit_ros.git
- release repository: https://github.com/ros-gbp/moveit_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.7.0-0`
## moveit_ros

```
* [feat] Adding acceleration scaling factor
* [fix] widget naming issues
* [fix] conflict issues
* [fix] Remove OpenMP parallelization (fixes #563 <https://github.com/ros-planning/moveit_ros/issues/563>)
* [sys] explicitly link rviz' default_plugin library. The library is not exported anymore and now is provided separately from rviz_LIBRARIES. See https://github.com/ros-visualization/rviz/pull/979 for details.
* [doc] [move_group.cpp] Print the name of the move group action server that failed to be connected (#640 <https://github.com/ros-planning/moveit_ros/issues/640>)
* Contributors: Stefan Kohlbrecher, v4hn, Dave Coleman, Isaac I.Y. Saito, hemes
```
## moveit_ros_benchmarks
- No changes
## moveit_ros_benchmarks_gui

```
* explicitly link rviz' default_plugin library
  The library is not exported anymore and now is provided separately from rviz_LIBRARIES.
  See https://github.com/ros-visualization/rviz/pull/979 for details.
* Contributors: v4hn
```
## moveit_ros_manipulation
- No changes
## moveit_ros_move_group
- No changes
## moveit_ros_perception

```
* [fix] Remove OpenMP parallelization (fixes #563 <https://github.com/ros-planning/moveit_ros/issues/563>)
* Contributors: Stefan Kohlbrecher
```
## moveit_ros_planning

```
* Adding acceleration scaling factor
* Contributors: hemes
```
## moveit_ros_planning_interface

```
* [feat] Adding acceleration scaling factor
* [fix] conflict issues
* [doc] [move_group.cpp] Print the name of the move group action server that failed to be connected (#640 <https://github.com/ros-planning/moveit_ros/issues/640>)
* Contributors: Dave Coleman, Isaac I.Y. Saito, hemes
```
## moveit_ros_robot_interaction
- No changes
## moveit_ros_visualization

```
* [feat] Adding acceleration scaling factor
* [fix] widget naming issues
* [sys] explicitly link rviz' default_plugin library. The library is not exported anymore and now is provided separately from rviz_LIBRARIES. See https://github.com/ros-visualization/rviz/pull/979 for details.
* Contributors: hemes, v4hn
```
## moveit_ros_warehouse
- No changes
