### PR TITLE
octomap_ros: 0.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -865,6 +865,21 @@ repositories:
       url: https://github.com/OctoMap/octomap_msgs.git
       version: indigo-devel
     status: maintained
+  octomap_ros:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_ros.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_ros-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_ros.git
+      version: indigo-devel
+    status: maintained
   opencv3:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_ros` to `0.4.0-0`:
- upstream repository: https://github.com/OctoMap/octomap_ros.git
- release repository: https://github.com/ros-gbp/octomap_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## octomap_ros

```
* Dropped PCL support in favor of sensor_msgs::PointCloud2.
```
