### PR TITLE
humanoid_msgs: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -506,6 +506,24 @@ repositories:
       url: https://github.com/ros/geometry_tutorials.git
       version: indigo-devel
     status: maintained
+  humanoid_msgs:
+    doc:
+      type: git
+      url: https://github.com/ahornung/humanoid_msgs.git
+      version: master
+    release:
+      packages:
+      - humanoid_msgs
+      - humanoid_nav_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/humanoid_msgs-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/ahornung/humanoid_msgs.git
+      version: devel
+    status: maintained
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `humanoid_msgs` to `0.3.0-0`:
- upstream repository: https://github.com/ahornung/humanoid_msgs
- release repository: https://github.com/ros-gbp/humanoid_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## humanoid_msgs
- No changes
## humanoid_nav_msgs

```
* Add service to (re)plan between feet as start and goal.
* Contributors: Armin Hornung
```
