### PR TITLE
[jade][moveit] Add source section to some packages that missed it. Correct version.

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2405,12 +2405,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git
-      version: indigo-devel
+      version: jade-devel
     release:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/moveit_msgs-release.git
       version: 0.6.1-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_msgs.git
+      version: jade-devel
     status: developed
   moveit_planners:
     doc:
@@ -2434,7 +2438,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-planning/moveit_plugins.git
-      version: indigo-devel
+      version: jade-devel
     release:
       packages:
       - moveit_fake_controller_manager
@@ -2447,7 +2451,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-planning/moveit_plugins.git
-      version: indigo-devel
+      version: jade-devel
     status: maintained
   moveit_python:
     doc:
@@ -2471,7 +2475,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-planning/moveit_ros.git
-      version: indigo-devel
+      version: jade-devel
     release:
       packages:
       - moveit_ros
@@ -2489,6 +2493,10 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ros-release.git
       version: 0.6.5-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_ros.git
+      version: jade-devel
     status: developed
   moveit_sim_controller:
     doc:


### PR DESCRIPTION
I just noticed that missing `source` section disables `prerelease` testing using `devel`.
