### PR TITLE
calibration: 0.10.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -777,7 +777,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/calibration-release.git
-      version: 0.10.13-0
+      version: 0.10.14-0
     source:
       type: git
       url: https://github.com/ros-perception/calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `calibration` to `0.10.14-0`:
- upstream repository: http://github.com/ros-perception/calibration.git
- release repository: https://github.com/ros-gbp/calibration-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.10.13-0`
## calibration
- No changes
## calibration_estimation

```
* remove useless dependency
* fix bad PyKDL usage
  fixes #39 <https://github.com/ros-perception/calibration/issues/39>
* get rid of the tf dependency
* Contributors: Vincent Rabaud
```
## calibration_launch
- No changes
## calibration_msgs
- No changes
## calibration_setup_helper
- No changes
## image_cb_detector

```
* simplify OpenCV3 dependency
* Contributors: Vincent Rabaud
```
## interval_intersection
- No changes
## joint_states_settler
- No changes
## laser_cb_detector
- No changes
## monocam_settler
- No changes
## settlerlib
- No changes
