### PR TITLE
visp: 3.0.0-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1518,7 +1518,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 3.0.0-2
+      version: 3.0.0-3
     status: maintained
   xacro:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `3.0.0-3`:
- upstream repository: https://github.com/lagadic/visp.git
- release repository: https://github.com/lagadic/visp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `3.0.0-2`
