### PR TITLE
ecto: 0.6.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2138,7 +2138,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ecto-release.git
-      version: 0.6.11-0
+      version: 0.6.12-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto` to `0.6.12-0`:
- upstream repository: https://github.com/plasmodic/ecto.git
- release repository: https://github.com/ros-gbp/ecto-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.11-0`
## ecto

```
* fix tests on Kinetic
* fix PySide dependency
* add missing implementation for executing
  That fixes #233 <https://github.com/plasmodic/ecto/issues/233>
* install the ecto library of test cells for users to utilise in their own tests.
* checking for ecto-test target existence
* Contributors: Daniel Stonier, Vincent Rabaud, edgarriba
```
