### PR TITLE
uavc_v4lctl: 1.0.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11352,7 +11352,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/meuchel/uavc_v4lctl-release.git
-      version: 1.0.2-0
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/meuchel/uavc_v4lctl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `uavc_v4lctl` to `1.0.2-1`:
- upstream repository: https://github.com/meuchel/uavc_v4lctl.git
- release repository: https://github.com/meuchel/uavc_v4lctl-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.2-0`
## uavc_v4lctl

```
* minor fixes
* Contributors: uavc
```
