### PR TITLE
Adding uavc_v4lctl to documentation index for distro jade (2)

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5388,6 +5388,21 @@ repositories:
       url: https://github.com/ros-teleop/twist_mux_msgs.git
       version: jade-devel
     status: maintained
+  uavc_v4lctl:
+    doc:
+      type: git
+      url: https://github.com/meuchel/uavc_v4lctl.git
+      version: 1.0.3
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/meuchel/uavc_v4lctl-release.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/meuchel/uavc_v4lctl.git
+      version: master
+    status: maintained
   ublox:
     doc:
       type: git


### PR DESCRIPTION
Second try request adding uavc_v4lctl to documentation index for distro jade
