### PR TITLE
roswww: 0.1.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9636,7 +9636,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/roswww-release.git
-      version: 0.1.8-0
+      version: 0.1.9-0
     source:
       type: git
       url: https://github.com/tork-a/roswww.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roswww` to `0.1.9-0`:
- upstream repository: https://github.com/tork-a/roswww.git
- release repository: https://github.com/tork-a/roswww-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.8-0`
## roswww

```
* Changed the target topic to communicate other samples, Rename from chat.launch to start_bridge.launch (#33 <https://github.com/tork-a/roswww/issues/33>)
* add example for talker and listener (#33 <https://github.com/tork-a/roswww/issues/33>)
* [doc] trying to fix that module api doc is gone inaccessible (#32 <https://github.com/tork-a/roswww/issues/32> )
* Contributors: Isaac I.Y. Saito, Kei Okada, Kenta Yonekura
```
