### PR TITLE
jsk_common: 2.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4041,7 +4041,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.0.11-0
+      version: 2.0.12-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.0.12-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.0.11-0`
## dynamic_tf_publisher
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_data

```
* Omitted name of filename for gdrive go cli
* Contributors: Kentaro Wada
```
## jsk_network_tools
- No changes
## jsk_tilt_laser
- No changes
## jsk_tools

```
* Test tool with shell command with catkin
  Modified:
  - jsk_tools/CMakeLists.txt
  Added:
  - jsk_tools/cmake/run_shell_test.py
  - jsk_tools/cmake/shell_test.cmake.em
* Handle shell and dotfiles for shared computers
  Modified:
  - jsk_tools/CMakeLists.txt
  Added:
  - jsk_tools/env-hooks/99.dotfile.bash
  - jsk_tools/env-hooks/99.dotfile.zsh
  - doc/jsk_tools/cltools/dotfile.rst
* Reuse roscat in rosview shell function
  Modified:
  - jsk_tools/env-hooks/99.jsk_tools.bash
  - jsk_tools/env-hooks/99.jsk_tools.zsh
* Contributors: Kentaro Wada
```
## jsk_topic_tools

```
* Set flag of subscribed even when always_subscribe
  Modified:
  - jsk_topic_tools/src/connection_based_nodelet.cpp
* Show test condition for 'scripts/is_synchronized'
* Support timeout and exit fastly
* Add method of wait_for_sync in 'scripts/is_synchronized'
* Set queue_size as 100
* Fix unregistering of the subscribers
* Exit with exit code to represent the synchronization
* Use rostime to check synchronization
* Contributors: Kentaro Wada
```
## multi_map_server
- No changes
## virtual_force_publisher
- No changes
