### PR TITLE
vision_visp: 0.9.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1524,6 +1524,28 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: kinetic
     status: maintained
+  vision_visp:
+    doc:
+      type: git
+      url: https://github.com/lagadic/vision_visp.git
+      version: kinetic
+    release:
+      packages:
+      - vision_visp
+      - visp_auto_tracker
+      - visp_bridge
+      - visp_camera_calibration
+      - visp_hand2eye_calibration
+      - visp_tracker
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lagadic/vision_visp-release.git
+      version: 0.9.1-0
+    source:
+      type: git
+      url: https://github.com/lagadic/vision_visp.git
+      version: kinetic-devel
+    status: maintained
   visp:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.9.1-0`:
- upstream repository: https://github.com/lagadic/vision_visp.git
- release repository: https://github.com/lagadic/vision_visp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## vision_visp

```
* jade-0.9.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_auto_tracker

```
* Revert build_depend visp removal that is mandatory.
* jade-0.9.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_bridge

```
* Revert build_depend visp removal that is mandatory.
* jade-0.9.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_camera_calibration

```
* Revert build_depend visp removal that is mandatory.
* jade-0.9.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_hand2eye_calibration

```
* Revert build_depend visp removal that is mandatory.
* jade-0.9.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_tracker

```
* Revert build_depend visp removal that is mandatory.
* jade-0.9.0
* Prepare changelogs
* Contributors: Fabien Spindler
```
