### PR TITLE
hrpsys: 315.8.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1481,6 +1481,13 @@ repositories:
       url: https://github.com/ros-gbp/household_objects_database_msgs-release.git
       version: 0.1.1-0
     status: maintained
+  hrpsys:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/hrpsys-release.git
+      version: 315.8.0-0
+    status: developed
   humanoid_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys` to `315.8.0-0`:
- upstream repository: https://github.com/fkanehiro/hrpsys-base.git
- release repository: https://github.com/tork-a/hrpsys-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## hrpsys
- No changes
