### PR TITLE
convex_decomposition: 0.1.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -281,6 +281,17 @@ repositories:
       url: https://github.com/ros-controls/control_toolbox.git
       version: kinetic-devel
     status: maintained
+  convex_decomposition:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/convex_decomposition-release.git
+      version: 0.1.11-0
+    source:
+      type: git
+      url: https://github.com/ros/convex_decomposition.git
+      version: kinetic-devel
+    status: maintained
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `convex_decomposition` to `0.1.11-0`:
- upstream repository: https://github.com/ros/convex_decomposition.git
- release repository: https://github.com/ros-gbp/convex_decomposition-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
