### PR TITLE
uavc_v4lctl: 1.0.3-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5395,6 +5395,21 @@ repositories:
       url: https://github.com/ros-teleop/twist_mux_msgs.git
       version: jade-devel
     status: maintained
+  uavc_v4lctl:
+    doc:
+      type: git
+      url: https://github.com/meuchel/uavc_v4lctl.git
+      version: 1.0.3
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/meuchel/uavc_v4lctl-release.git
+      version: 1.0.3-1
+    source:
+      type: git
+      url: https://github.com/meuchel/uavc_v4lctl.git
+      version: master
+    status: maintained
   ublox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uavc_v4lctl` to `1.0.3-1`:
- upstream repository: https://github.com/meuchel/uavc_v4lctl.git
- release repository: https://github.com/meuchel/uavc_v4lctl-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## uavc_v4lctl

```
* minor fixes
* Contributors: uavc
```
