### PR TITLE
rosconsole_bridge: 0.4.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9244,12 +9244,13 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rosconsole_bridge-release.git
-      version: 0.4.2-0
+      version: 0.4.4-0
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/rosconsole_bridge.git
       version: indigo-devel
+    status: maintained
   roscpp_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole_bridge` to `0.4.4-0`:
- upstream repository: https://github.com/ros/rosconsole_bridge.git
- release repository: https://github.com/ros-gbp/rosconsole_bridge-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.4.2-0`
