### PR TITLE
qt_gui_core: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1046,7 +1046,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.3.1-0`:
- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.0-0`
## qt_dotgraph

```
* fix imports with Qt 5
```
## qt_gui

```
* workaround bug (QTBUG-52582) in QMenu with Qt 5 (ros-visualization/python_qt_binding#33 <https://github.com/ros-visualization/python_qt_binding/issues/33>)
```
## qt_gui_app
- No changes
## qt_gui_cpp

```
* more fixes for shiboken 2
* add missing Qt include directories
```
## qt_gui_py_common
- No changes
