### PR TITLE
navigation_2d: 0.3.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2834,7 +2834,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/skasperski/navigation_2d-release.git
-      version: 0.1.4-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/skasperski/navigation_2d.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_2d` to `0.3.0-0`:
- upstream repository: https://github.com/skasperski/navigation_2d.git
- release repository: https://github.com/skasperski/navigation_2d-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.4-0`
