### PR TITLE
genpy: 0.5.9-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1108,7 +1108,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.5.8-0
+      version: 0.5.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.5.9-0`:
- upstream repository: git@github.com:ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.5.8-0`
## genpy

```
* warn about using floor division of durations (#58 <https://github.com/ros/genpy/issues/58>)
* allow durations to be divided by other durations (#48 <https://github.com/ros/genpy/issues/48>)
* avoid adding newline in msg_generator (#47 <https://github.com/ros/genpy/issues/47>, #51 <https://github.com/ros/genpy/issues/51>)
```
