### PR TITLE
ros_comm: 1.11.19-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4217,7 +4217,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.18-0
+      version: 1.11.19-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.19-0`:
- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.11.18-0`
## message_filters

```
* use directory specific compiler flags (#785 <https://github.com/ros/ros_comm/pull/785>)
```
## ros_comm
- No changes
## rosbag

```
* promote the result of read_messages to a namedtuple (#777 <https://github.com/ros/ros_comm/pull/777>)
* use directory specific compiler flags (#785 <https://github.com/ros/ros_comm/pull/785>)
```
## rosbag_storage

```
* use directory specific compiler flags (#785 <https://github.com/ros/ros_comm/pull/785>)
```
## rosconsole

```
* use directory specific compiler flags (#785 <https://github.com/ros/ros_comm/pull/785>)
```
## roscpp

```
* use directory specific compiler flags (#785 <https://github.com/ros/ros_comm/pull/785>)
```
## rosgraph

```
* fix str conversion in encode_ros_handshake_header (#792 <https://github.com/ros/ros_comm/pull/792>)
```
## roslaunch
- No changes
## roslz4

```
* use directory specific compiler flags (#785 <https://github.com/ros/ros_comm/pull/785>)
```
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode
- No changes
## rosout

```
* use directory specific compiler flags (#785 <https://github.com/ros/ros_comm/pull/785>)
```
## rosparam
- No changes
## rospy
- No changes
## rosservice
- No changes
## rostest

```
* fix passing multiple args to add_rostest (fix #790 <https://github.com/ros/ros_comm/issues/790>)
```
## rostopic
- No changes
## roswtf
- No changes
## topic_tools

```
* use directory specific compiler flags (#785 <https://github.com/ros/ros_comm/pull/785>)
```
## xmlrpcpp

```
* use directory specific compiler flags (#785 <https://github.com/ros/ros_comm/pull/785>)
```
