### PR TITLE
moveit_robots: 1.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5529,7 +5529,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/moveit_robots-release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_robots` to `1.0.6-0`:
- upstream repository: https://github.com/ros-planning/moveit_robots.git
- release repository: https://github.com/tork-a/moveit_robots-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.5-0`
## atlas_moveit_config
- No changes
## atlas_v3_moveit_config
- No changes
## baxter_ikfast_left_arm_plugin
- No changes
## baxter_ikfast_right_arm_plugin
- No changes
## baxter_moveit_config

```
* [fix] both_arm move group stopped functioning (ref <https://groups.google.com/a/rethinkrobotics.com/forum/#!topic/brr-users/59kLdsAfR-g>)
* Contributors: Ian McMahon
```
## clam_moveit_config
- No changes
## iri_wam_moveit_config
- No changes
## moveit_robots

```
* [fix] both_arm move group stopped functioning (ref <https://groups.google.com/a/rethinkrobotics.com/forum/#!topic/brr-users/59kLdsAfR-g>)
* Contributors: Ian McMahon
```
## r2_moveit_generated
- No changes
