### PR TITLE
add rplidar_ros to documentation index for indigo/jade/kinetic

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9673,6 +9673,21 @@ repositories:
       url: https://github.com/ethz-asl/rotors_simulator.git
       version: master
     status: developed
+  rplidar_ros:
+    doc:
+      type: git
+      url: https://github.com/robopeak/rplidar_ros.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/robopeak/rplidar_ros-release.git
+      version: 1.5.1
+    source:
+      type: git
+      url: https://github.com/robopeak/rplidar_ros.git
+      version: master
+    status: maintained
   rqt:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4711,6 +4711,21 @@ repositories:
       url: https://github.com/tork-a/roswww.git
       version: develop
     status: maintained
+  rplidar_ros:
+    doc:
+      type: git
+      url: https://github.com/robopeak/rplidar_ros.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/robopeak/rplidar_ros-release.git
+      version: 1.5.1
+    source:
+      type: git
+      url: https://github.com/robopeak/rplidar_ros.git
+      version: master
+    status: maintained
   rqt:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1397,21 +1397,6 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: jade-devel
     status: maintained
-  rplidar_ros:
-    doc:
-      type: git
-      url: https://github.com/robopeak/rplidar_ros.git
-      version: master
-    release:
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/robopeak/rplidar_ros-release.git
-      version: 1.5.1
-    source:
-      type: git
-      url: https://github.com/robopeak/rplidar_ros.git
-      version: master
-    status: maintained
   rqt:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1397,6 +1397,21 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: jade-devel
     status: maintained
+  rplidar_ros:
+    doc:
+      type: git
+      url: https://github.com/robopeak/rplidar_ros.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/robopeak/rplidar_ros-release.git
+      version: 1.5.1
+    source:
+      type: git
+      url: https://github.com/robopeak/rplidar_ros.git
+      version: master
+    status: maintained
   rqt:
     doc:
       type: git


### PR DESCRIPTION
I'd like rplidar_ros to be indexed and documented on ros.org.  Because the github addres of rplidar_ros package in the version of indigo have been change by a mistake .  
