### PR TITLE
jsk_robot: 1.0.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4194,6 +4194,7 @@ repositories:
       - jsk_pepper_startup
       - jsk_pr2_calibration
       - jsk_pr2_startup
+      - jsk_robot
       - jsk_robot_startup
       - jsk_robot_utils
       - naoeus
@@ -4204,7 +4205,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_robot-release.git
-      version: 1.0.4-0
+      version: 1.0.5-1
     status: developed
   jsk_roseus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `1.0.5-1`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.4-0`
## baxtereus
- No changes
## fetcheus

```
* Control gripper from robot interface
* Fix arm end coords of 'fetch.l'
  Modified:
  - jsk_fetch_robot/fetcheus/fetch.yaml
* Contributors: Kentaro Wada
```
## jsk_201504_miraikan
- No changes
## jsk_baxter_desktop
- No changes
## jsk_baxter_startup

```
* Install jsk_baxter_tools
* Add document for 'xdisplay_image_topic.py'
* Convert to BGR image
  to handle mono and rgba images
* Contributors: Kentaro Wada
```
## jsk_baxter_web
- No changes
## jsk_fetch_startup
- No changes
## jsk_nao_startup

```
* add params for new naoqi_driver.launch
* Contributors: Kanae Kochigami
```
## jsk_pepper_startup
- No changes
## jsk_pr2_calibration
- No changes
## jsk_pr2_startup

```
* [jsk_pr2_startup/CMakeLists.txt] install launch files related gazebo
* Merge pull request #577 <https://github.com/jsk-ros-pkg/jsk_robot/issues/577> from mmurooka/add-run-dependency
  [jsk_pr2_startup/package.xml] add run_dependency.
* [jsk_pr2_startup/package.xml] add run_dependency.
* [jsk_pr2_startup/jsk_pr2.rosinstall] update jsk_robot to 1.0.2
  for applying the fix in #539 <https://github.com/jsk-ros-pkg/jsk_robot/issues/539>
* Contributors: Yuki Furuta, Kei Okada, Masaki Murooka
```
## jsk_robot_startup

```
* [jsk_robot_startup] Use robot_center_pointcloud_bbox_clipped as input for octomap server
* Contributors: leus
```
## jsk_robot_utils
- No changes
## naoeus

```
* move send-stiffness-controller, servo-on, servo-off methods to naoqi-interface
* Contributors: Kanae Kochigami
```
## naoqieus

```
* fixed program when the order of two optional params is upside down
* move send-stiffness-controller, servo-on, servo-off methods to naoqi-interface
* Contributors: Kanae Kochigami
```
## peppereus

```
* move send-stiffness-controller, servo-on, servo-off methods to naoqi-interface
* Contributors: Kanae Kochigami
```
## pr2_base_trajectory_action
- No changes
## roseus_remote
- No changes
