### PR TITLE
openrtm_aist: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -975,6 +975,13 @@ repositories:
       url: https://github.com/ros-drivers/openni_camera.git
       version: indigo-devel
     status: maintained
+  openrtm_aist:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/openrtm_aist-release.git
+      version: 1.1.0-0
+    status: developed
   orocos_kinematics_dynamics:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist` to `1.1.0-0`:
- upstream repository: http://svn.openrtm.org/OpenRTM-aist/tags/RELEASE_1_1_0/OpenRTM-aist/
- release repository: https://github.com/tork-a/openrtm_aist-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
