### PR TITLE
uavc_v4lctl: 1.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1499,6 +1499,21 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  uavc_v4lctl:
+    doc:
+      type: git
+      url: https://github.com/meuchel/uavc_v4lctl.git
+      version: 1.0.3
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/meuchel/uavc_v4lctl-release.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/meuchel/uavc_v4lctl.git
+      version: master
+    status: maintained
   ueye:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `uavc_v4lctl` to `1.0.3-0`:
- upstream repository: https://github.com/meuchel/uavc_v4lctl.git
- release repository: https://github.com/meuchel/uavc_v4lctl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## uavc_v4lctl

```
* minor fixes
* Contributors: uavc
```
