### PR TITLE
auv_msgs: 0.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -93,6 +93,11 @@ repositories:
       type: git
       url: https://github.com/oceansystemslab/auv_msgs.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/oceansystemslab/auv_msgs-release.git
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/oceansystemslab/auv_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `auv_msgs` to `0.0.1-1`:
- upstream repository: https://github.com/oceansystemslab/auv_msgs.git
- release repository: https://github.com/oceansystemslab/auv_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## auv_msgs

```
* Initial commit
* Contributors: Bence Magyar
```
