### PR TITLE
genjs: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -423,6 +423,17 @@ repositories:
       url: https://github.com/jsk-ros-pkg/geneus.git
       version: master
     status: developed
+  genjs:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RethinkRobotics-release/genjs-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/RethinkRobotics-opensource/genjs.git
+      version: kinetic-devel
+    status: developed
   genlisp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genjs` to `1.0.0-0`:
- upstream repository: https://github.com/RethinkRobotics-opensource/genjs.git
- release repository: https://github.com/RethinkRobotics-release/genjs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## genjs

```
* Initial Release
* ROS JS Message Generation
* Builds automatically with catkin
* Include support for ROS Services
* Constants, Msg instances
  -generated msgs are now classes
  -msgs have constants included
* Contributors: Chris Smith, Ian McMahon
```
