### PR TITLE
remove uavc_v4lctl from Kinetic for now

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1541,7 +1541,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/meuchel/uavc_v4lctl-release.git
-      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/meuchel/uavc_v4lctl.git


### PR DESCRIPTION
As discussed in meuchel/uavc_v4lctl#1. The package provided by this repo fails to build on all platforms right now for Kinetic, so I am removing the release entry.
