### PR TITLE
rviz: 1.12.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1464,7 +1464,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.12.0-0
+      version: 1.12.1-0
     source:
       test_commits: false
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.12.1-0`:
- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.12.0-0`
## rviz

```
* Updated the ``plugin_description.xml`` to reflect the new default plugin library name, see: #1004 <https://github.com/ros-visualization/rviz/issues/1004>
* Contributors: William Woodall
```
