### PR TITLE
iai_common_msgs: 0.0.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   debian:
@@ -599,6 +599,36 @@ repositories:
       url: https://github.com/ahornung/humanoid_msgs.git
       version: devel
     status: maintained
+  iai_common_msgs:
+    doc:
+      type: git
+      url: https://github.com/code-iai/iai_common_msgs.git
+      version: master
+    release:
+      packages:
+      - attache_msgs
+      - data_vis_msgs
+      - designator_integration_msgs
+      - dna_extraction_msgs
+      - grasp_stability_msgs
+      - iai_common_msgs
+      - iai_content_msgs
+      - iai_control_msgs
+      - iai_kinematics_msgs
+      - iai_robosherlock_actions
+      - iai_urdf_msgs
+      - iai_wsg_50_msgs
+      - json_prolog_msgs
+      - mln_robosherlock_msgs
+      - person_msgs
+      - planning_msgs
+      - saphari_msgs
+      - scanning_table_msgs
+      - sherlock_sim_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/code-iai-release/iai_common_msgs-release.git
+      version: 0.0.6-1
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iai_common_msgs` to `0.0.6-1`:
- upstream repository: https://github.com/code-iai/iai_common_msgs.git
- release repository: https://github.com/code-iai-release/iai_common_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## attache_msgs

```
* Added attache messages
* Contributors: Jan Winkler
```
## data_vis_msgs

```
* Changelog files for release
* Added label to ValueList entry
  This is needed for generating a legend for multiple data rows, for instance multiple timelines
* Contributors: Jan Winkler, Moritz Tenorth
* Added label to ValueList entry
  This is needed for generating a legend for multiple data rows, for instance multiple timelines
* Contributors: Moritz Tenorth
```
## designator_integration_msgs

```
* Changelog files for release
* Contributors: Jan Winkler
```
## dna_extraction_msgs

```
* Changelog files for release
* Contributors: Jan Winkler
```
## grasp_stability_msgs

```
* Changelog files for release
* Contributors: Jan Winkler
```
## iai_common_msgs

```
* Added attache messages
* Changelog files for release
* Reordered deps in metapackage, and added missing deps iai_control_msgs, iai_urdf_msgs, grasp_stability_msgs.
* Added planning request/response service messages
* Contributors: Georg Bartels, Jan Winkler
* Reordered deps in metapackage, and added missing deps iai_control_msgs, iai_urdf_msgs, grasp_stability_msgs.
* Added planning request/response service messages
* Contributors: Georg Bartels, Jan Winkler
```
## iai_content_msgs

```
* Changelog files for release
* Contributors: Jan Winkler
```
## iai_control_msgs

```
* Changelog files for release
* Add a jointlimits message
* arm_ik_controller: report seconds since the goal started
* Add a State message for the Cartesian Controller
* Added a action message for the PTU
* added goal for the arms
* Contributors: Alexis Maldonado, Jan Winkler
* Add a jointlimits message
* arm_ik_controller: report seconds since the goal started
* Add a State message for the Cartesian Controller
* Added a action message for the PTU
* added goal for the arms
* Contributors: Alexis Maldonado
```
## iai_kinematics_msgs

```
* Changelog files for release
* Contributors: Jan Winkler
```
## iai_robosherlock_actions

```
* Changelog files for release
* added a new message type for perceived objects
* Contributors: Ferenc Balint-Benczedi, Jan Winkler
* added a new message type for perceived objects
* Contributors: Ferenc Balint-Benczedi
```
## iai_urdf_msgs

```
* Changelog files for release
* Contributors: Jan Winkler
```
## iai_wsg_50_msgs

```
* added header to wsg status msg
* Changelog files for release
* Contributors: Jan Winkler, ichumuh
```
## json_prolog_msgs

```
* Changelog files for release
* Contributors: Jan Winkler
```
## mln_robosherlock_msgs

```
* Changelog files for release
* Contributors: Jan Winkler
```
## person_msgs

```
* Changelog files for release
* Contributors: Jan Winkler
```
## planning_msgs

```
* Fixed version number in planning_msgs
* Added duration field in planning messages steps and plans
* Per-step scoring
* Scoring methods in planning request
* Added extra call pattern field for plan steps
* Added structure supporting attributes to planning messages
* Added field for unused bindings
* Changed the nature of planning request and response messages again a bit
* Updated planning messages
* Added score and extra Step msg type
* Added planning request/response service messages
* Contributors: Jan Winkler
* Fixed version number in planning_msgs
* Added new CHANGELOG.rst file to planning_msgs
* Added duration field in planning messages steps and plans
* Per-step scoring
* Scoring methods in planning request
* Added extra call pattern field for plan steps
* Added structure supporting attributes to planning messages
* Added field for unused bindings
* Changed the nature of planning request and response messages again a bit
* Updated planning messages
* Added score and extra Step msg type
* Added planning request/response service messages
* Contributors: Jan Winkler
* Added duration field in planning messages steps and plans
* Per-step scoring
* Scoring methods in planning request
* Added extra call pattern field for plan steps
* Added structure supporting attributes to planning messages
* Added field for unused bindings
* Changed the nature of planning request and response messages again a bit
* Updated planning messages
* Added score and extra Step msg type
* Added planning request/response service messages
* Contributors: Jan Winkler
```
## saphari_msgs

```
* Changelog files for release
* new message saphari_msgs/GestureData required for saphari final review.
* Correct BodyPart.msg: FOREARM->LEFTFOREARM.
* adjust CMakefile to build with renamed HumansState.msg (new Humans.msg)
* rename HumansState to Humans
* add HumansState
  - HumansState has observed_user_ids for fast access to the actual observed users without looping the hole list of humans
* Contributors: Georg Bartels, Jan Winkler, beld_rc
* new message saphari_msgs/GestureData required for saphari final review.
* Correct BodyPart.msg: FOREARM->LEFTFOREARM.
* adjust CMakefile to build with renamed HumansState.msg (new Humans.msg)
* rename HumansState to Humans
* add HumansState
  - HumansState has observed_user_ids for fast access to the actual observed users without looping the hole list of humans
* Contributors: Georg Bartels, beld_rc
```
## scanning_table_msgs

```
* Changelog files for release
* Contributors: Jan Winkler
```
## sherlock_sim_msgs

```
* Changelog files for release
* Contributors: Jan Winkler
```
