### PR TITLE
designator_integration: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -1815,7 +1815,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/code-iai-release/designator_integration-release.git
-      version: 0.0.3-0
+      version: 0.0.5-0
     status: developed
   destruction_scenarios:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `designator_integration` to `0.0.5-0`:
- upstream repository: https://github.com/code-iai/designator_integration.git
- release repository: https://github.com/code-iai-release/designator_integration-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.3-0`
## designator_integration
- No changes
## designator_integration_cpp
- No changes
## designator_integration_lisp
- No changes
