### PR TITLE
designator_integration: 0.0.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -620,6 +620,16 @@ repositories:
       url: https://github.com/ros-gbp/depthimage_to_laserscan-release.git
       version: 1.0.7-0
     status: maintained
+  designator_integration:
+    release:
+      packages:
+      - designator_integration
+      - designator_integration_cpp
+      - designator_integration_lisp
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/code-iai-release/designator_integration-release.git
+      version: 0.0.5-0
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `designator_integration` to `0.0.5-0`:
- upstream repository: https://github.com/code-iai/designator_integration.git
- release repository: https://github.com/code-iai-release/designator_integration-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## designator_integration
- No changes
## designator_integration_cpp
- No changes
## designator_integration_lisp
- No changes
