### PR TITLE
multimaster_fkie: 0.5.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2582,7 +2582,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.5.3-0
+      version: 0.5.4-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.5.4-0`:
- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.5.3-0`
## default_cfg_fkie
- No changes
## master_discovery_fkie

```
* multimaster_fkie: added '/do_not_sync' parameter
  this allows to hide some topics/services, topic types, from
  synchronisation. It can be defined as string or as list.
* master_sync_fkie: fixed unnecessary update requests
  wrong timestamps leads to updates
* Contributors: Alexander Tiderko
```
## master_sync_fkie

```
* multimaster_fkie: added '/do_not_sync' parameter
  this allows to hide some topics/services, topic types, from
  synchronisation. It can be defined as string or as list.
* master_sync_fkie: fixed unnecessary update requests
  wrong timestamps leads to updates
* Contributors: Alexander Tiderko
```
## multimaster_fkie

```
* multimaster_fkie: added '/do_not_sync' parameter
  this allows to hide some topics/services, topic types, from
  synchronisation. It can be defined as string or as list.
* master_sync_fkie: fixed unnecessary update requests
  wrong timestamps leads to updates
* node_manager_fkie: added visualisation for not synchronized topics/services
* node_manager_fkie: add parameter to the order of publisher/subscriber in description dock
  new parameter: 'Transpose pub/sub description'
* node_manager_fkie: changed behaviour of description dock while update info
* node_manager_fkie: fixed deselection of text on context menu
* node_manager_fkie: fixed threading problem while searching for sync interfaces
* Contributors: Alexander Tiderko
```
## multimaster_msgs_fkie
- No changes
## node_manager_fkie

```
* node_manager_fkie: added visualisation for not synchronized topics/services
* node_manager_fkie: add parameter to the order of publisher/subscriber in description dock
  new parameter: 'Transpose pub/sub description'
* node_manager_fkie: changed behaviour of description dock while update info
* node_manager_fkie: fixed deselection of text on context menu
* node_manager_fkie: fixed threading problem while searching for sync interfaces
* Contributors: Alexander Tiderko
```
