### PR TITLE
Kinetic: Add ros_control to source & doc jobs

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1283,6 +1283,16 @@ repositories:
       url: https://github.com/ros/ros_comm_msgs.git
       version: indigo-devel
     status: maintained
+  ros_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros_control.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros_control.git
+      version: kinetic-devel
+    status: maintained
   ros_tutorials:
     doc:
       type: git


### PR DESCRIPTION
*May not turn green until `control_toolbox` is released.

Cordially yours,
Bence
