### PR TITLE
ros_numpy: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9055,11 +9055,12 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/eric-wieser/ros_numpy-release.git
-      version: 0.0.1-1
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/eric-wieser/ros_numpy.git
       version: master
+    status: developed
   ros_openlighting:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_numpy` to `0.0.2-0`:
- upstream repository: https://github.com/eric-wieser/ros_numpy.git
- release repository: https://github.com/eric-wieser/ros_numpy-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.1-1`
