### PR TITLE
visualization_tutorials: 0.10.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1653,6 +1653,28 @@ repositories:
       url: https://github.com/lagadic/visp-release.git
       version: 3.0.0-3
     status: maintained
+  visualization_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/visualization_tutorials.git
+      version: kinetic-devel
+    release:
+      packages:
+      - interactive_marker_tutorials
+      - librviz_tutorial
+      - rviz_plugin_tutorials
+      - rviz_python_tutorial
+      - visualization_marker_tutorials
+      - visualization_tutorials
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/visualization_tutorials-release.git
+      version: 0.10.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/visualization_tutorials.git
+      version: kinetic-devel
+    status: maintained
   xacro:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_tutorials` to `0.10.0-0`:
- upstream repository: https://github.com/ros-visualization/visualization_tutorials.git
- release repository: https://github.com/ros-gbp/visualization_tutorials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## interactive_marker_tutorials

```
* Added support Qt5 in Kinetic.
* Contributors: William Woodall
```
## librviz_tutorial

```
* Added support Qt5 in Kinetic.
* Contributors: William Woodall
```
## rviz_plugin_tutorials

```
* Added support Qt5 in Kinetic.
* Contributors: William Woodall
```
## rviz_python_tutorial
- No changes
## visualization_marker_tutorials
- No changes
## visualization_tutorials
- No changes
