### PR TITLE
visualization_tutorials: 0.10.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1669,7 +1669,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/visualization_tutorials-release.git
-      version: 0.10.0-0
+      version: 0.10.1-0
     source:
       type: git
       url: https://github.com/ros-visualization/visualization_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_tutorials` to `0.10.1-0`:
- upstream repository: https://github.com/ros-visualization/visualization_tutorials.git
- release repository: https://github.com/ros-gbp/visualization_tutorials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.10.0-0`
## interactive_marker_tutorials
- No changes
## librviz_tutorial

```
* Added qt5 dependencies to the package.xml.
* Contributors: William Woodall
```
## rviz_plugin_tutorials

```
* Added qt5 dependencies to the package.xml.
* Contributors: William Woodall
```
## rviz_python_tutorial
- No changes
## visualization_marker_tutorials
- No changes
## visualization_tutorials
- No changes
