### PR TITLE
qt_gui_core: 0.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1085,7 +1085,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.3.0-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.3.2-0`:
- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.0-0`
## qt_dotgraph
- No changes
## qt_gui

```
* only restore state on toolbars which have an object name (#65 <https://github.com/ros-visualization/qt_gui_core/pull/65>)
```
## qt_gui_app
- No changes
## qt_gui_cpp
- No changes
## qt_gui_py_common

```
* fix another import to work with Qt 5 (#65 <https://github.com/ros-visualization/qt_gui_core/pull/65>)
```
