### PR TITLE
image_transport_plugins: 1.9.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -643,6 +643,26 @@ repositories:
       url: https://github.com/ros-perception/image_pipeline.git
       version: indigo
     status: maintained
+  image_transport_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: indigo-devel
+    release:
+      packages:
+      - compressed_depth_image_transport
+      - compressed_image_transport
+      - image_transport_plugins
+      - theora_image_transport
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/image_transport_plugins-release.git
+      version: 1.9.3-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: indigo-devel
+    status: maintained
   imu_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `1.9.3-0`:
- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros-gbp/image_transport_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## compressed_depth_image_transport

```
* Refactor the codec into its own .h and .cpp.
* remove useless tf dependencies
* Contributors: Mac Mason, Vincent Rabaud
```
## compressed_image_transport

```
* remove useless tf dependencies
* Using cfg-defined constants
* Changed flag name, and corrected typo in flag use.
* using IMREAD flags.
* Updated for indigo-devel
* Contributors: Cedric Pradalier, Vincent Rabaud
```
## image_transport_plugins
- No changes
## theora_image_transport

```
* remove useless tf dependencies
* Contributors: Vincent Rabaud
```
