### PR TITLE
rplidar_ros: 1.5.2-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4711,6 +4711,21 @@ repositories:
       url: https://github.com/tork-a/roswww.git
       version: develop
     status: maintained
+  rplidar_ros:
+    doc:
+      type: git
+      url: https://github.com/robopeak/rplidar_ros.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/robopeak/rplidar_ros-release.git
+      version: 1.5.2-1
+    source:
+      type: git
+      url: https://github.com/robopeak/rplidar_ros.git
+      version: master
+    status: maintained
   rqt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `1.5.2-1`:
- upstream repository: https://github.com/robopeak/rplidar_ros.git
- release repository: https://github.com/robopeak/rplidar_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rplidar_ros

```
1.5.1 (2016-04-12)
* Release 1.5.1.
* Add the deiver support rplidar A2.
* Contributors: yhZhao, RoboPeak Public Repos
```
