### PR TITLE
rtctree: 3.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1485,6 +1485,13 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: kinetic-devel
     status: maintained
+  rtctree:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/rtctree-release.git
+      version: 3.0.1-0
+    status: developed
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtctree` to `3.0.1-0`:
- upstream repository: https://github.com/gbiggs/rtctree.git
- release repository: https://github.com/tork-a/rtctree-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
