### PR TITLE
rtsprofile: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1499,6 +1499,13 @@ repositories:
       url: https://github.com/tork-a/rtctree-release.git
       version: 3.0.1-0
     status: developed
+  rtsprofile:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/rtsprofile-release.git
+      version: 2.0.0-0
+    status: developed
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtsprofile` to `2.0.0-0`:
- upstream repository: https://github.com/gbiggs/rtsprofile.git
- release repository: https://github.com/tork-a/rtsprofile-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
