### PR TITLE
moveit_msgs: 0.7.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2423,7 +2423,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/moveit_msgs-release.git
-      version: 0.6.1-0
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `0.7.1-0`:
- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/ros-gbp/moveit_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.1-0`
## moveit_msgs

```
* Adding acceleration scaling factor #17 <https://github.com/ros-planning/moveit_msgs/issues/17>
* Contributors: Dave Coleman, hemes
```
