### PR TITLE
jsk_roseus: 1.5.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1870,7 +1870,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.5.0-0
+      version: 1.5.1-0
     status: developed
   jskeus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.5.1-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.5.0-0`
## jsk_roseus
- No changes
## roseus

```
* Fix generating Euslisp ROS message with catkin_tools 0.4.x
  Modified:
  - roseus/cmake/roseus.cmake
* Contributors: Kentaro Wada
```
## roseus_mongo
- No changes
## roseus_smach

```
* [roseus_smach/README.md] update to use github official image link
* Contributors: Furushchev
```
