### PR TITLE
bfl: 0.7.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -124,6 +124,7 @@ repositories:
       url: https://github.com/ros-gbp/bfl-release.git
       version: 0.7.0-1
     source:
+      test_commits: false
       type: git
       url: https://github.com/ros-gbp/bfl-release.git
       version: upstream

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -113,6 +113,21 @@ repositories:
       url: https://github.com/AutonomyLab/bebop_autonomy.git
       version: indigo-devel
     status: developed
+  bfl:
+    doc:
+      type: git
+      url: https://github.com/ros-gbp/bfl-release.git
+      version: upstream
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/bfl-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/ros-gbp/bfl-release.git
+      version: upstream
+    status: maintained
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bfl` to `0.7.0-1`:
- upstream repository: http://svn.mech.kuleuven.be/repos/orocos/branches/bfl/branch-0.7/
- release repository: https://github.com/ros-gbp/bfl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
