### PR TITLE
imu_tools: 1.0.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3637,7 +3637,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.0.9-0
+      version: 1.0.10-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/imu_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.0.10-0`:
- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.9-0`
## imu_complementary_filter

```
* Remove Eigen dependency
  Eigen is not actually used anywhere. Thanks @asimay!
* Removed main function from shared library
* Contributors: Martin Guenther, Matthias Nieuwenhuisen
```
## imu_filter_madgwick
- No changes
## imu_tools
- No changes
## rviz_imu_plugin

```
* Support qt4/qt5 using rviz's exported qt version
  Closes #58 <https://github.com/ccny-ros-pkg/imu_tools/issues/58> .
  This fixes the build on Kinetic, where only Qt5 is available, and
  is backwards compatible with Qt4 for Indigo.
* Contributors: Martin Guenther
```
