### PR TITLE
pr2_common: 1.12.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1097,6 +1097,27 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: indigo-devel
     status: maintained
+  pr2_common:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_common.git
+      version: kinetic-devel
+    release:
+      packages:
+      - pr2_common
+      - pr2_dashboard_aggregator
+      - pr2_description
+      - pr2_machine
+      - pr2_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_common-release.git
+      version: 1.12.0-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_common.git
+      version: kinetic-devel
+    status: maintained
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common` to `1.12.0-0`:
- upstream repository: https://github.com/pr2/pr2_common.git
- release repository: https://github.com/pr2-gbp/pr2_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
