### PR TITLE
pcl_msgs: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1081,6 +1081,21 @@ repositories:
       url: https://bitbucket.org/DataspeedInc/oxford_gps_eth
       version: default
     status: maintained
+  pcl_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/pcl_msgs.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/pcl_msgs-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/pcl_msgs.git
+      version: indigo-devel
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_msgs` to `0.2.0-0`:
- upstream repository: https://github.com/ros-perception/pcl_msgs.git
- release repository: https://github.com/ros-gbp/pcl_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## pcl_msgs

```
* clean up package.xml
* update maintainer info
* remove eigen dependency
* Merge pull request #1 <https://github.com/ros-perception/pcl_msgs/issues/1> from bulwahn/patch-1
* Contributors: Lukas Bulwahn, Paul Bovbel
```
