### PR TITLE
pcl_conversions: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1096,6 +1096,21 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: indigo-devel
     status: maintained
+  pcl_conversions:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/pcl_conversions.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/pcl_conversions-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/pcl_conversions.git
+      version: indigo-devel
+    status: maintained
   pluginlib:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1081,21 +1081,6 @@ repositories:
       url: https://bitbucket.org/DataspeedInc/oxford_gps_eth
       version: default
     status: maintained
-  pcl_msgs:
-    doc:
-      type: git
-      url: https://github.com/ros-perception/pcl_msgs.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-gbp/pcl_msgs-release.git
-      version: 0.2.0-0
-    source:
-      type: git
-      url: https://github.com/ros-perception/pcl_msgs.git
-      version: indigo-devel
-    status: maintained
   pcl_conversions:
     doc:
       type: git
@@ -1109,6 +1094,21 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-perception/pcl_conversions.git
+      version: indigo-devel
+    status: maintained
+  pcl_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/pcl_msgs.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/pcl_msgs-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/pcl_msgs.git
       version: indigo-devel
     status: maintained
   pluginlib:


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_conversions` to `0.2.1-0`:
- upstream repository: https://github.com/ros-perception/pcl_conversions.git
- release repository: https://github.com/ros-gbp/pcl_conversions-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## pcl_conversions

```
* Added a test for rounding errors in stamp conversion
  for some values the test fails.
* add pcl::PointCloud to Image msg converter for extracting the rgb component of a cloud
* Contributors: Brice Rebsamen, Lucid One, Michael Ferguson, Paul Bovbel
```
