### PR TITLE
perception_pcl: 1.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1115,7 +1115,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/perception_pcl.git
-      version: jade-devel
+      version: kinetic-devel
     release:
       packages:
       - pcl_ros

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1111,6 +1111,24 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: indigo-devel
     status: maintained
+  perception_pcl:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: jade-devel
+    release:
+      packages:
+      - pcl_ros
+      - perception_pcl
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/perception_pcl-release.git
+      version: 1.4.0-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: kinetic-devel
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.4.0-0`:
- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## pcl_ros

```
* Fixup libproj-dev rosdep
* Add build depend on libproj, since it's not provided by vtk right now
* manually remove dependency on vtkproj from PCL_LIBRARIES
* Remove python-vtk for kinetic-devel, see issue #44 <https://github.com/ros-perception/perception_pcl/issues/44>
* Contributors: Jackie Kay, Paul Bovbel
```
## perception_pcl
- No changes
