### PR TITLE
stage_ros: 1.7.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1638,6 +1638,21 @@ repositories:
       url: https://github.com/ros-gbp/stage-release.git
       version: release/kinetic/stage
     status: maintained
+  stage_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-simulation/stage_ros.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/stage_ros-release.git
+      version: 1.7.5-0
+    source:
+      type: git
+      url: https://github.com/ros-simulation/stage_ros.git
+      version: master
+    status: maintained
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stage_ros` to `1.7.5-0`:
- upstream repository: https://github.com/ros-simulation/stage_ros.git
- release repository: https://github.com/ros-gbp/stage_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## stage_ros

```
* Removed all references to FLTK/Fluid and use the upstream CMake config file instead.
* Added ``reset_positions`` service to stage (adds dependency on ``std_srvs``).
* Contributors: Aurélien Ballier, Daniel Claes, Scott K Logan, William Woodall
```
