### PR TITLE
Roll back to vtk5 to match pcl on wily and jessie

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2634,8 +2634,9 @@ libvpx-dev:
 libvtk:
   arch: [vtk]
   debian:
-    jessie: [libvtk6-dev]
+    jessie: [libvtk5-dev]
     sid: [libvtk6-dev]
+    stretch: [libvtk6-dev]
     wheezy: [libvtk5-dev]
   fedora: [vtk-devel]
   gentoo: [sci-libs/vtk]
@@ -2653,7 +2654,7 @@ libvtk:
     trusty: [libvtk5-dev]
     utopic: [libvtk5-dev]
     vivid: [libvtk5-dev]
-    wily: [libvtk6-dev]
+    wily: [libvtk5-dev]
     xenial: [libvtk6-dev]
 libvtk-java:
   arch: [vtk]


### PR DESCRIPTION
We picked our version of vtk to match the version packaged wit pcl however we missed the transition vtk6 is available in Wily and Jessie, however pcl still uses vtk5 on those platforms. If we want to leverage pcl we need to match their dependencies. 

Right now on Jessie rosdep fights itself installing libpcl-dev with vtk5 and uninstalling ros packages using vtk6, then it installs other ros packages with vtk6 and uninstalls libpcl-dev with vtk5. 

PCL using vtk5 on jessie and wily: 
http://packages.ubuntu.com/wily/libpcl-dev
https://packages.debian.org/jessie/libpcl-dev

PCL using vtk6 starting with stretch and xenial
https://packages.debian.org/stretch/libpcl-dev
http://packages.ubuntu.com/xenial/libpcl-dev

Related discussions #11095 #11097
