### PR TITLE
opencv3: 3.1.0-12 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1020,7 +1020,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/opencv3-release.git
-      version: 3.1.0-11
+      version: 3.1.0-12
     status: maintained
   openhrp3:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `opencv3` to `3.1.0-12`:
- upstream repository: /home/vrabaud/workspace/ws_opencv3/tmp/opencv.tar.gz
- release repository: https://github.com/ros-gbp/opencv3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `3.1.0-11`
