### PR TITLE
sophus: 0.9.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1623,6 +1623,17 @@ repositories:
       url: https://github.com/wjwwood/serial.git
       version: master
     status: maintained
+  sophus:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/sophus-release.git
+      version: 0.9.0-0
+    source:
+      type: git
+      url: https://github.com/stonier/sophus.git
+      version: indigo
+    status: maintained
   stage:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `0.9.0-0`:
- upstream repository: https://github.com/stonier/sophus.git
- release repository: https://github.com/yujinrobot-release/sophus-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
