### PR TITLE
ecl_tools: 0.61.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -362,6 +362,25 @@ repositories:
       url: https://github.com/ros/dynamic_reconfigure.git
       version: master
     status: maintained
+  ecl_tools:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: indigo-stable
+    release:
+      packages:
+      - ecl_build
+      - ecl_license
+      - ecl_tools
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_tools-release.git
+      version: 0.61.4-0
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: indigo-devel
+    status: developed
   ecto:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_tools` to `0.61.4-0`:
- upstream repository: https://github.com/stonier/ecl_tools.git
- release repository: https://github.com/yujinrobot-release/ecl_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## ecl_build

```
* check, but just quietly avoid including cotire if version check fails.
```
