### PR TITLE
sophus: 0.9.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1647,7 +1647,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/sophus-release.git
-      version: 0.9.0-0
+      version: 0.9.0-1
     source:
       type: git
       url: https://github.com/stonier/sophus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `0.9.0-1`:
- upstream repository: https://github.com/stonier/sophus.git
- release repository: https://github.com/yujinrobot-release/sophus-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.9.0-0`
