### PR TITLE
ros_control: 0.10.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1482,6 +1482,21 @@ repositories:
       type: git
       url: https://github.com/ros-controls/ros_control.git
       version: kinetic-devel
+    release:
+      packages:
+      - controller_interface
+      - controller_manager
+      - controller_manager_msgs
+      - controller_manager_tests
+      - hardware_interface
+      - joint_limits_interface
+      - ros_control
+      - rqt_controller_manager
+      - transmission_interface
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_control-release.git
+      version: 0.10.1-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.10.1-0`:
- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## controller_interface
- No changes
## controller_manager
- No changes
## controller_manager_msgs
- No changes
## controller_manager_tests

```
* Add missing test dependency on rosservice
* Remove control_toolbox dependency. Fix thread linking error coming from removal of dependency.
* Contributors: Bence Magyar
```
## hardware_interface

```
* Fix rosconsole errors from test build
* Contributors: Bence Magyar
```
## joint_limits_interface

```
* Fix catkin_package
  * Don't export local include dirs.
  * Fix dependency on urdfdom (Thanks to Mathias Lüdtke).
* Contributors: Jochen Sprickerhof
```
## ros_control

```
* Remove control_toolbox dependency. Fix thread linking error coming from removal of dependency.
* Contributors: Bence Magyar
```
## rqt_controller_manager
- No changes
## transmission_interface

```
* Remove control_toolbox dependency. Fix thread linking error coming from removal of dependency.
* Contributors: Bence Magyar
```
