### PR TITLE
openslam_gmapping: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1133,6 +1133,21 @@ repositories:
       url: https://github.com/tork-a/openrtm_aist-release.git
       version: 1.1.0-0
     status: developed
+  openslam_gmapping:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/openslam_gmapping.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/openslam_gmapping-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/openslam_gmapping.git
+      version: master
+    status: maintained
   orocos_kinematics_dynamics:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `openslam_gmapping` to `0.1.2-0`:
- upstream repository: https://github.com/ros-perception/openslam_gmapping
- release repository: https://github.com/ros-gbp/openslam_gmapping-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## openslam_gmapping

```
* better Windows compilation
  This is taken from #9 <https://github.com/ros-perception/openslam_gmapping/issues/9> which can now be closed.
* fix a few more graphics stuff for Qt5
* get GUI back in shape for those interested
* use srand instead of srand48
  srand48 is non-standard and we are using a seed that is an
  unsigned int so we might as well use srand
* Contributors: Vincent Rabaud
```
