### PR TITLE
slam_gmapping: 1.3.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1720,6 +1720,24 @@ repositories:
       url: https://github.com/wjwwood/serial.git
       version: master
     status: maintained
+  slam_gmapping:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/slam_gmapping.git
+      version: hydro-devel
+    release:
+      packages:
+      - gmapping
+      - slam_gmapping
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/slam_gmapping-release.git
+      version: 1.3.8-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/slam_gmapping.git
+      version: hydro-devel
+    status: maintained
   sophus:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_gmapping` to `1.3.8-0`:
- upstream repository: https://github.com/ros-perception/slam_gmapping
- release repository: https://github.com/ros-gbp/slam_gmapping-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## gmapping

```
* fix a test that would take too long sometimes
* better verbosity
* add a test for upside down lasers
* add a test for symmetry
* make sure the laser sent to gmapping is always centered
* do not display warning message if scan is processed at some point
* Contributors: Vincent Rabaud
```
## slam_gmapping
- No changes
