### PR TITLE
opencv_candidate: 0.2.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1104,6 +1104,17 @@ repositories:
       url: https://github.com/ros-gbp/opencv3-release.git
       version: 3.1.0-12
     status: maintained
+  opencv_candidate:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/opencv_candidate-release.git
+      version: 0.2.5-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/opencv_candidate.git
+      version: master
+    status: maintained
   openhrp3:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `opencv_candidate` to `0.2.5-0`:
- upstream repository: https://github.com/wg-perception/opencv_candidate.git
- release repository: https://github.com/ros-gbp/opencv_candidate-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## opencv_candidate

```
* fixes for Kinetic
* do not compile RGBD for OpenCV3 (as it is in there)
* proper error handling in OpenCV3
  fixes #5 <https://github.com/wg-perception/opencv_candidate/issues/5>
* Contributors: Vincent Rabaud
```
