### PR TITLE
ecto_opencv: 0.7.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -455,6 +455,17 @@ repositories:
       url: https://github.com/plasmodic/ecto.git
       version: master
     status: maintained
+  ecto_opencv:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/ecto_opencv-release.git
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/plasmodic/ecto_opencv.git
+      version: master
+    status: maintained
   eigen_stl_containers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto_opencv` to `0.7.0-0`:
- upstream repository: https://github.com/plasmodic/ecto_opencv.git
- release repository: https://github.com/ros-gbp/ecto_opencv-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## ecto_opencv

```
* make master Kinetic and above only
  This is because OpenCV3 is the default and cv_backports is now
  useless.
* Contributors: Vincent Rabaud
```
