### PR TITLE
ecto_ros: 0.4.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -466,6 +466,17 @@ repositories:
       url: https://github.com/plasmodic/ecto_opencv.git
       version: master
     status: maintained
+  ecto_ros:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/ecto_ros-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/plasmodic/ecto_ros.git
+      version: master
+    status: maintained
   eigen_stl_containers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto_ros` to `0.4.8-0`:
- upstream repository: https://github.com/plasmodic/ecto_ros.git
- release repository: https://github.com/ros-gbp/ecto_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## ecto_ros

```
* reenable some tests
* fix constness
* Expose tcp_nodelay parameter for subscribers.
* cleaner dependency handling
* Contributors: Daniel Stonier, Vincent Rabaud
```
