### PR TITLE
ecto_pcl: 0.4.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -466,6 +466,17 @@ repositories:
       url: https://github.com/plasmodic/ecto_opencv.git
       version: master
     status: maintained
+  ecto_pcl:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/ecto_pcl-release.git
+      version: 0.4.4-0
+    source:
+      type: git
+      url: https://github.com/plasmodic/ecto_pcl.git
+      version: master
+    status: maintained
   ecto_ros:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto_pcl` to `0.4.4-0`:
- upstream repository: https://github.com/plasmodic/ecto_pcl.git
- release repository: https://github.com/ros-gbp/ecto_pcl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## ecto_pcl

```
* compile on Xenial
* fix running examples for doc
* Contributors: Vincent Rabaud
```
