### PR TITLE
ecto_image_pipeline: 0.5.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -455,6 +455,17 @@ repositories:
       url: https://github.com/plasmodic/ecto.git
       version: master
     status: maintained
+  ecto_image_pipeline:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/ecto_image_pipeline-release.git
+      version: 0.5.7-0
+    source:
+      type: git
+      url: https://github.com/plasmodic/ecto_image_pipeline.git
+      version: master
+    status: maintained
   ecto_opencv:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto_image_pipeline` to `0.5.7-0`:
- upstream repository: https://github.com/plasmodic/ecto_image_pipeline.git
- release repository: https://github.com/ros-gbp/ecto_image_pipeline-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## ecto_image_pipeline

```
* fix PCL compilation
* fix compilation with OpenCV3
* convert tests to proper nosetests
* move samples to the proper folder
* Contributors: Vincent Rabaud
```
