### PR TITLE
object_recognition_core: 0.6.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1077,6 +1077,17 @@ repositories:
       url: https://github.com/vooon/ntpd_driver.git
       version: master
     status: maintained
+  object_recognition_core:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_core-release.git
+      version: 0.6.6-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/object_recognition_core.git
+      version: master
+    status: maintained
   object_recognition_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_core` to `0.6.6-0`:
- upstream repository: https://github.com/wg-perception/object_recognition_core.git
- release repository: https://github.com/ros-gbp/object_recognition_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## object_recognition_core

```
* add missing dependencies
* fix doc according to https://github.com/wg-perception/reconstruction/issues/6
* simplify OpenCV3 compatibility
* add citation info in the docs
  fixes #34 <https://github.com/wg-perception/object_recognition_core/issues/34>
* Contributors: Vincent Rabaud
```
