### PR TITLE
ecto_openni: 0.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -477,6 +477,17 @@ repositories:
       url: https://github.com/plasmodic/ecto_opencv.git
       version: master
     status: maintained
+  ecto_openni:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/ecto_openni-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/plasmodic/ecto_openni.git
+      version: master
+    status: maintained
   ecto_pcl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto_openni` to `0.4.0-0`:
- upstream repository: https://github.com/plasmodic/ecto_openni.git
- release repository: https://github.com/ros-gbp/ecto_openni-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## ecto_openni

```
* remove stack.xml now that Fuerte is dropped
* use floats for internals
* remove Fuerte support
* Merge pull request #6 <https://github.com/plasmodic/ecto_openni/issues/6> from zittix/patch-1
  Fixes OpenNI detection under Mac OS X when installed with Homebrew
* Fixed OpenNI detection under Mac OS X when installed with Homebrew
* update url
* update the maintainer's email address
* Contributors: Mathieu Monney, Vincent Rabaud
```
