### PR TITLE
object_recognition_capture: 0.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1088,6 +1088,17 @@ repositories:
       url: https://github.com/vooon/ntpd_driver.git
       version: master
     status: maintained
+  object_recognition_capture:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_capture-release.git
+      version: 0.3.2-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/capture.git
+      version: master
+    status: maintained
   object_recognition_core:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_capture` to `0.3.2-0`:
- upstream repository: https://github.com/wg-perception/capture.git
- release repository: https://github.com/ros-gbp/object_recognition_capture-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## object_recognition_capture

```
* compile with OpenCV3
* Contributors: Vincent Rabaud
```
