### PR TITLE
object_recognition_tod: 0.5.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1145,6 +1145,15 @@ repositories:
     source:
       type: git
       url: https://github.com/wg-perception/object_recognition_ros_visualization.git
+  object_recognition_tod:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_tod-release.git
+      version: 0.5.6-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/tod.git
       version: master
     status: maintained
   octomap:


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_tod` to `0.5.6-0`:
- upstream repository: https://github.com/wg-perception/tod.git
- release repository: https://github.com/ros-gbp/object_recognition_tod-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## object_recognition_tod

```
* fix OpenCV3 compilation
* Contributors: Vincent Rabaud
```
