### PR TITLE
object_recognition_ros_visualization: 0.3.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1136,6 +1136,17 @@ repositories:
       url: https://github.com/wg-perception/object_recognition_ros.git
       version: master
     status: maintained
+  object_recognition_ros_visualization:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_ros_visualization-release.git
+      version: 0.3.8-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/object_recognition_ros_visualization.git
+      version: master
+    status: maintained
   octomap:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_ros_visualization` to `0.3.8-0`:
- upstream repository: https://github.com/wg-perception/object_recognition_ros_visualization.git
- release repository: https://github.com/ros-gbp/object_recognition_ros_visualization-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## object_recognition_ros_visualization

```
* work with Qt5
* prevent a crash if object not in DB
* Contributors: Vincent Rabaud
```
