### PR TITLE
ecto_pcl: 0.4.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -493,7 +493,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ecto_pcl-release.git
-      version: 0.4.4-0
+      version: 0.4.5-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto_pcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto_pcl` to `0.4.5-0`:
- upstream repository: https://github.com/plasmodic/ecto_pcl.git
- release repository: https://github.com/ros-gbp/ecto_pcl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.4.4-0`
## ecto_pcl

```
* add dependency on proj to fix PCL compilation on kinetic
* remove useless dependency on ecto_ros
* Contributors: Vincent Rabaud
```
