### PR TITLE
urdf_tutorial: 0.2.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1991,6 +1991,21 @@ repositories:
       url: https://github.com/ros-geographic-info/unique_identifier.git
       version: master
     status: maintained
+  urdf_tutorial:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_tutorial.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/urdf_tutorial-release.git
+      version: 0.2.4-0
+    source:
+      type: git
+      url: https://github.com/ros/urdf_tutorial.git
+      version: master
+    status: maintained
   urdfdom_py:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tutorial` to `0.2.4-0`:
- upstream repository: https://github.com/ros/urdf_tutorial.git
- release repository: https://github.com/ros-gbp/urdf_tutorial-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## urdf_tutorial

```
* Maintainer list changes
* Add .rviz as an arg
* fix gazebo.launch for indigo, update to new package name
* Add run depends
* Contributors: David V. Lu, Ioan A Sucan, Isaac IY Saito, Kei Okada
```
