### PR TITLE
navigation_layers: 0.3.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2851,6 +2851,25 @@ repositories:
       url: https://github.com/skasperski/navigation_2d.git
       version: jade
     status: maintained
+  navigation_layers:
+    doc:
+      type: git
+      url: https://github.com/DLu/navigation_layers.git
+      version: indigo
+    release:
+      packages:
+      - navigation_layers
+      - range_sensor_layer
+      - social_navigation_layers
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wu-robotics/navigation_layers_release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/DLu/navigation_layers.git
+      version: indigo
+    status: maintained
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_layers` to `0.3.1-0`:
- upstream repository: https://github.com/DLu/navigation_layers.git
- release repository: https://github.com/wu-robotics/navigation_layers_release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
