### PR TITLE
imu_tools: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -830,7 +830,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.0.11-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/imu_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.1.0-0`:
- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.11-0`
## imu_complementary_filter
- No changes
## imu_filter_madgwick
- No changes
## imu_tools
- No changes
## rviz_imu_plugin

```
* Add qt5 dependencies to rviz_imu_plugin package.xml
  This fixes the compilation errors on Kinetic for Debian Jessie.
* Contributors: Martin Guenther
```
