### PR TITLE
demo1_create_package: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1730,6 +1730,13 @@ repositories:
       type: git
       url: https://github.com/HumaRobotics/darwin_gazebo.git
       version: master
+  demo1_create_package:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tbfungeek/repo_for_ros_release.git
+      version: 0.0.3-0
+    status: developed
   demo_pioneer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demo1_create_package` to `0.0.3-0`:
- upstream repository: https://github.com/tbfungeek/release_ros_package.git
- release repository: https://github.com/tbfungeek/repo_for_ros_release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## demo1_create_package
- No changes
