### PR TITLE
executive_smach: 2.0.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -531,6 +531,22 @@ repositories:
       url: https://github.com/tork-a/euslisp-release.git
       version: 9.18.2-0
     status: developed
+  executive_smach:
+    release:
+      packages:
+      - executive_smach
+      - smach
+      - smach_msgs
+      - smach_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/executive_smach-release.git
+      version: 2.0.0-2
+    source:
+      type: git
+      url: https://github.com/ros/executive_smach.git
+      version: indigo-devel
+    status: maintained
   filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `executive_smach` to `2.0.0-2`:
- upstream repository: https://github.com/ros/executive_smach.git
- release repository: https://github.com/ros-gbp/executive_smach-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## executive_smach
- No changes
## smach

```
* Merging changes, resolving conflicts, from strands-project (@cburbridge)
* cleaning up and removing rosbuild support
* merging groovy and hydro
* Fix get_internal_edges returning list of tuples, not list of lists
* Remove old methods set_userdata
* Remove superfluous parent class declaration 'UserData' from 'Remapper'
* Add local error base class 'SmachError', extending Exception
* Fix syntax errors, doc typos and indentations glitches
* Fixed invalid exception type in concurrence.py
* Checking threads have fully terminated before cleanup of outcomes dict
  This commit uses thread.isAlive() on each concurrent state runner to check for termination of all the threads before continuing. This is necessary as only checking that the outcome has been filled in does not mean the thread has completed; if the thread has not completed it may not yet have called the termination callback. If this loop exits before the termination callback of the last thread is called, then the callback will occasionally be sent an empty dictionary (when the main thread has got to line 305).
* cope with missed state termination notifications
  Concurrent states could terminate and notify _ready_event without the concurrence container realising, as it could be busy checking the outcome values. This makes the concurrency container get stuck on line 250. This commit adds a timeout to the wait to safely cope with missing notifications.
* Adding event for thread synchronization in concurrence and using event not condition in monitor state
* Contributors: Felix Kolbe, Jonathan Bohren, Piotr Orzechowski, cburbridge
```
## smach_msgs

```
* cleaning up and removing rosbuild support
* merging groovy and hydro
* Add explanations within message definitions
* Contributors: Felix Kolbe, Jonathan Bohren
```
## smach_ros

```
* smach_ros: Adding rostests to cmakelists
* Merging changes, resolving conflicts, from strands-project (@cburbridge)
* cleaning up and removing rosbuild support
* merging groovy and hydro
* Listing available goal slots in case of specifying wrong ones
* Fix syntax errors, doc typos and indentations glitches
* if monitor state prempted before executing, return.
* Adding event for thread synchronization in concurrence and using event not condition in monitor state
* Listing available goal slots in case of specifying wrong ones
* [MonitorState] Make exception handler more verbose
* edited monitor state to allow input and output keys
* Contributors: Boris Gromov, Bruno Lacerda, Felix Kolbe, Hendrik Wiese, Jonathan Bohren, cburbridge
```
