### PR TITLE
cob_substitute: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1425,11 +1425,10 @@ repositories:
       - frida_driver
       - prace_common
       - prace_gripper_driver
-      - rplidar_ros
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_substitute-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/ipa320/cob_substitute.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_substitute` to `0.6.4-0`:
- upstream repository: https://github.com/ipa320/cob_substitute.git
- release repository: https://github.com/ipa320/cob_substitute-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.3-0`
## cob_lbr

```
* 0.6.3
* update changelog
* 0.6.2
* update changelog
* migration to package format 2
* remove obsolete autogenerated mainpage.dox files
* cleanup
* Contributors: ipa-fxm
```
## cob_safety_controller

```
* 0.6.3
* update changelog
* 0.6.2
* update changelog
* migration to package format 2
* remove trailing whitespaces
* cleanup
* Contributors: ipa-fxm
```
## cob_substitute

```
* remove rplidar_ros
* 0.6.3
* update changelog
* 0.6.2
* update changelog
* migration to package format 2
* new substitue package rplidar_ros
* Contributors: ipa-fxm, ipa-mig
```
## frida_driver

```
* 0.6.3
* update changelog
* 0.6.2
* update changelog
* migration to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* cleanup
* Contributors: ipa-fxm
```
## prace_common

```
* 0.6.3
* update changelog
* 0.6.2
* update changelog
* migration to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* cleanup
* Contributors: ipa-fxm
```
## prace_gripper_driver

```
* 0.6.3
* update changelog
* 0.6.2
* update changelog
* migration to package format 2
* remove obsolete autogenerated mainpage.dox files
* cleanup
* Contributors: ipa-fxm
```
