### PR TITLE
rosbridge_suite: 0.7.14-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 141: http://ros.org/reps/rep-0141.html
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   fedora:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -9234,7 +9234,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.7.14-0
+      version: 0.7.14-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.7.14-1`:
- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.7.14-0`
## rosapi

```
* Update proxy.py
  Fixes an issue when call the service "/rosapi/service_type"
* Contributors: Robert Codd-Downey
```
## rosbridge_library

```
* Another fix for code
* Replaced += with ''.join() for python code
* Default Protocol delay_between_messages = 0
  This prevents performance problems when multiple clients are subscribing to high frequency topics.
  Fixes #203 <https://github.com/RobotWebTools/rosbridge_suite/issues/203>
* Contributors: Matt Vollrath, kiloreux
```
## rosbridge_server

```
* Abort websocket server listen() retry on shutdown
  This allows the server to shut down via SIGINT or SIGTERM during its listen() retry loop.
* rospy.get_param instead of get_param
* actually use those parameters
* remove reference to retry_startup_delay from rosbridge_udp.launch
* clean up parameters and handling
  * make parameters accessible via parameter server for all three versions
  * remove old advertise_service parameters
  * UDP and TCP can't do SSL
  * TCP can't authenticate yet (because the RosbridgeTcpSocket class is instantiated for each request and hence does not hold state)
  * UDP does not take a hostname or address, but rather an interface
* Allow TCP Server to reuse address after restart
  After killing (Ctrl-C) a rosbridge_tcp server instance which has
  connected clients, starting a new instance (on the same port) can
  fail with the error: '[Errno 98] Address already in use'. Although the
  node retries until the server starts, this can take up to a few minutes.
  Instruct the ThreadingTCPServer to allow the reuse of the same address.
* Adding UDP
* Contributors: Matt Vollrath, Nils Berg, Victor Savu, XuHao, xuhao1
```
## rosbridge_suite
- No changes
