### PR TITLE
rtmros_common: 1.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9914,7 +9914,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.3.1-0
+      version: 1.3.2-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.3.2-0`:
- upstream repository: https://github.com/start-jsk/rtmros_common.git
- release repository: https://github.com/tork-a/rtmros_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.3.1-0`
## hrpsys_ros_bridge

```
* [fix] getFootStepParam interface according to upstream change. Remove rleg_coords and lleg_coords.
* [fix] HrpsysSeqStateROSBridgeImpl.cpp: sensor->localR is world coords
* [fix] Modified HrpsysSeqStateROSBridgeImpl to enable virtual force
* [fix] [rtm-ros-robot-interface.l] add time constant prameter according to upstream idl update
* [fix] [hrpsys_ros_bridge] Fix genjava problem by adding message_generation as build_depend
* [fix] getFootStepParam interface according to upstream change. Remove rleg_coords and lleg_coords.
* [fix] [hrpsys_ros_bridge]change D if D from hrpsys is empty
* [feat] [hrpsys_ros_bridge/test/test-samplerobot.py] add test programs to check frame_id of off_xxsensor and ref_xxsensor (#940)
* [feat] Set /robot/type param according to lower-case robot name such as samplerobot.
* [feat] [hrpsys_ros_bridge/test/test-samplerobot.*] add a test program for init of hcf
* [feat] fix collision visualization, color of sphere will be purple if collision occur
* [feat] .travis.yml : add test when old hrpsys-ros-bridge exists (#929)
* [feat] [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Add check for param existence for def-set-get-param-method to neglect idl mismatch error. Fix indent. (#933)
* [feat] [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Add reference force updater euslisp methods.
* [feat] [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Add object turnaround detector moment version interface.l
* [feat] Add define controller #887 <https://github.com/start-jsk/rtmros_common/issues/887>
* [feat] Add leg limb controller setting.
* [feat] Add method to define joint trajectory controller by default setting.
* [feat] Add gopos overwrite and graspless manip mode to all demos
* [feat] Add example for graspless manip mode and gopos overwrite.
* [feat] Add euslisp interface for graspless manip mode.
* [feat] add a set-default-step-time-with-the-same-swing-time method
* [feat] add time constant prameter according to upstream idl update
* [feat] Add HrpsysSeqStateROSBridge tf rate test
* [feat] enable virtual force in HrpsysSeqStateROSBridgeImpl
* [feat] Enable to set subscription_type for DataPorts from hrpsys_ros_bridge.launch argument. Use new by default to keep backward compatibility.
* [feat] Add loading of optionalData from seq pattern file.
* [improve] add more mesage to prevent confusion
* [improve] Add setting for ReferenceForceUpdater
* [improve] Reset object turnaround detector's detector total wrench mode as TOTAL_FORCE in force estimation.
* [improve] Enable to set push_policy and push_rate for DataPorts from hrpsys_ros_bridge.launch argument. Use all and 50.0 by default to keep backward compatibility.
* [improve] Rename tf extract script for test and add comments for that
* [improve] add arguments(SIMULATOR_NAME_[ANGLE,VELOCITY,TORQUE]) to hrpsys_ros_bridge.launch, for connecting rtc components other than RobotHardware
* [improve] add time constant prameter according to u… #910 <https://github.com/start-jsk/rtmros_common/issues/910>
* [improve] add argument to set periodic time for object turning detection.
* [improve] define method to set/get emergency-stopper-paramMerge pull request #865 <https://github.com/start-jsk/rtmros_common/issues/865>
* [improve] Suppress /tf publishing rate by tf_rate using Timer callback in ros.
* [improve] Separate updating odometry and imu into functions
* [improve] Update st param #894 <https://github.com/start-jsk/rtmros_common/issues/894>
* [improve] add eefm_swing_rot_spring_gain / eefm_swing_pos_spring_gain as st param
* [improve] Update joint group and add test for limb controller
* [doc] [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] In-code documentation improvement
* [doc] [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Set default documentation string for def-set-get-param-method setter and getter.
* [doc] [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Add argument documentation for :set-xxx methods.
* [doc] [hrpsys_ros_bridge/euslisp/README.md,hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Update readme and euslisp documentation strings
* [doc] default documentation string for def-set-get-param-method setter and getter.
* [doc] In-code documentation improvement
* Contributors: Eisoku Kuroiwa, Kei Okada, Kentaro Wada, Masaki Murooka, Shunichi Nozawa, Yohei Kakiuchi, Yu Ohara, Iori Yanokura
```
## hrpsys_tools

```
* [refactor] remove old rosbuild files
* [hrpsys_tools/launch/hrpsys.launch] add ReferenceForceUpdater
* Contributors: Koyama Ryo, Kei Okada
```
## openrtm_ros_bridge

```
* [refactor] remove old rosbuild files
* [openrtm_ros_bridge] Fix genjava problem build_depend message_generation
* Contributors: Kentaro Wada, Kei Okada
```
## openrtm_tools

```
* [fix ] Revert "workaround for ros-groovy-rqt-top installs wrong(?) psutil" (#938)  This reverts commit 94975a81eadbf251a85b2fd3c77137b1f96f248b. This closes #936 <https://github.com/start-jsk/rtmros_common/issues/936>
* [refactor] add more mesage to prevent confusion
* [refactor] remove old rosbuild files
* [feat] Enable to set push_policy and push_rate for DataPorts from hrpsys_ros_bridge.launch argument. Use all and 50.0 by default to keep backward compatibility.
* [feat] Enable to set subscription_type for DataPorts from hrpsys_ros_bridge.launch argument. Use new by default to keep backward compatibility.
* Contributors: Shunichi Nozawa, Kei Okada, Iori Yanokura
```
## rosnode_rtc

```
* [refactor] remove old rosbuild files
* Contributors: Kei Okada
```
## rtmbuild

```
* [refactor] delete depends from AutoBalancerService.hh to StabilizerService.hh (#939)
  * delete depends from AutoBalancerService.hh to StabilizerService.hh
  * CMakeLists.txt: add Loing ... rtmbuild.cmake message
  * CMakeLists.txt: fix syntax warning
  * cmake/rtmbuild.cmake: genrcp may depends on any idl (.hh) file
* [refactor] remove old rosbuild files
* [feat][rtmbuild/scripts/idl2srv.py] Add more CORBA exception information. Add BAD_PARAM, MARSHAL, and OBJECT_NOT_EXIST checking. Add minor code printing and possible case assumption.
* Contributors: Shunichi Nozawa, Kei Okada
```
## rtmros_common

```
* [fix][openrtm_ros_bridge] Fix genjava problem build_depend message_generation
* [fix][hrpsys_ros_bridge] HrpsysSeqStateROSBridgeImpl.cpp: sensor->localR is world coords
* [fix][rtm-ros-robot-interface.l] add time constant prameter according to upstream idl update
* [fix] getFootStepParam interface according to upstream change. Remove rleg_coords and lleg_coords.
* [feat] [hrpsys_ros_bridge/test/test-samplerobot.py] add test programs to check frame_id of off_xxsensor and ref_xxsensor (#940)
* [feat] Set /robot/type param according to lower-case robot name such as samplerobot.
* [feat] [hrpsys_ros_bridge/test/test-samplerobot.*] add a test program for init of hcf
* [feat] fix collision visualization, color of sphere will be purple if collision occur
* [feat] .travis.yml : add test when old hrpsys-ros-bridge exists (#929)
* [feat] [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Add check for param existence for def-set-get-param-method to neglect idl mismatch error. Fix indent. (#933)
* [feat] [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Add reference force updater euslisp methods.
* [feat] [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Add object turnaround detector moment version interface.l
* [feat] Add more CORBA exception information. Add BAD_PARAM, MARSHAL, and OBJECT_NOT_EXIST checking. Add minor code printing and possible case assumption.
* [feat][openrtm_tools] Enable to set push_policy and push_rate for DataPorts from hrpsys_ros_bridge.launch argument. Use all and 50.0 by default to keep backward compatibility.
* [feat][openrtm_tools] Enable to set subscription_type for DataPorts from hrpsys_ros_bridge.launch argument. Use new by default to keep backward compatibility.
* [feat][hrpsys_tools] add ReferenceForceUpdater
* [feat] enable virtual force in HrpsysSeqStateROSBridgeImpl
* [feat] Enable to set subscription_type for DataPorts from hrpsys_ros_bridge.launch argument. Use new by default to keep backward compatibility.
* [feat] Add loading of optionalData from seq pattern file.
* [feat] add time constant prameter according to upstream idl update
* [feat] Add HrpsysSeqStateROSBridge tf rate test
* [feat] Add define controller #887 <https://github.com/start-jsk/rtmros_common/issues/887>
* [feat] Add leg limb controller setting.
* [feat] Add method to define joint trajectory controller by default setting.
* [feat] Add gopos overwrite and graspless manip mode to all demos
* [feat] Add example for graspless manip mode and gopos overwrite.
* [feat] Add euslisp interface for graspless manip mode.
* [feat] add a set-default-step-time-with-the-same-swing-time method
* [doc] default documentation string for def-set-get-param-method setter and getter.
* [doc] In-code documentation improvement
* Contributors: Eisoku Kuroiwa, Kei Okada, Kentaro Wada, Masaki Murooka, Shunichi Nozawa, Koyama Ryo, Yohei Kakiuchi, Yu Ohara, Iori Kuroiwa, Isaac I.Y. Saito
```
