### PR TITLE
hakuto: 0.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3061,7 +3061,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/hakuto-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/tork-a/hakuto.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hakuto` to `0.1.5-0`:
- upstream repository: https://github.com/tork-a/hakuto.git
- release repository: https://github.com/tork-a/hakuto-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.4-0`
## hakuto
- No changes
## tetris_description
- No changes
## tetris_gazebo

```
* *.launch : add INITIAL_POSE_{X,Y,Z} arguments
* remove camera init pose, because gzweb did not handle that
* Contributors: Kei Okada
```
## tetris_launch

```
* add test to install
* add rostest test/tetris.test
* *.launch : add INITIAL_POSE_{X,Y,Z} arguments
* [doc] Some clarifications
* [doc] Seperate gzweb installation
* [doc] Minor formatting
* doc/sysadmin.rst: add how to use supervisor tool, fix sysadmin tools
* set default cmd_vel to 1.0
* add rosbridge_websocket.launch to demo.launch
* Update index.rst
* Contributors: Isaac I.Y. Saito, Kei Okada
```
