### PR TITLE
hakuto: 0.1.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1307,6 +1307,18 @@ repositories:
       url: https://github.com/g/grizzly.git
       version: indigo-devel
     status: maintained
+  hakuto:
+    release:
+      packages:
+      - hakuto
+      - tetris_description
+      - tetris_gazebo
+      - tetris_launch
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/hakuto-release.git
+      version: 0.1.5-0
+    status: developed
   head_pose_estimation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hakuto` to `0.1.5-0`:
- upstream repository: https://github.com/tork-a/hakuto.git
- release repository: https://github.com/tork-a/hakuto-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## hakuto
- No changes
## tetris_description
- No changes
## tetris_gazebo

```
* *.launch : add INITIAL_POSE_{X,Y,Z} arguments
* remove camera init pose, because gzweb did not handle that
* Contributors: Kei Okada
```
## tetris_launch

```
* add test to install
* add rostest test/tetris.test
* *.launch : add INITIAL_POSE_{X,Y,Z} arguments
* [doc] Some clarifications
* [doc] Seperate gzweb installation
* [doc] Minor formatting
* doc/sysadmin.rst: add how to use supervisor tool, fix sysadmin tools
* set default cmd_vel to 1.0
* add rosbridge_websocket.launch to demo.launch
* Update index.rst
* Contributors: Isaac I.Y. Saito, Kei Okada
```
