### PR TITLE
hakuto: 0.1.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1317,7 +1317,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/hakuto-release.git
-      version: 0.1.6-0
+      version: 0.1.7-0
     status: developed
   head_pose_estimation:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hakuto` to `0.1.7-0`:
- upstream repository: https://github.com/tork-a/hakuto.git
- release repository: https://github.com/tork-a/hakuto-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.6-0`
## hakuto
- No changes
## tetris_description
- No changes
## tetris_gazebo
- No changes
## tetris_launch

```
* set ROSLIB pport to 127.0.0.1:9090
* Contributors: Kei Okada
```
