### PR TITLE
grid_map: 1.3.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1271,6 +1271,7 @@ repositories:
       packages:
       - grid_map
       - grid_map_core
+      - grid_map_cv
       - grid_map_demos
       - grid_map_filters
       - grid_map_loader
@@ -1280,7 +1281,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ethz-asl/grid_map-release.git
-      version: 1.2.0-0
+      version: 1.3.0-0
     source:
       type: git
       url: https://github.com/ethz-asl/grid_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `1.3.0-0`:
- upstream repository: https://github.com/ethz-asl/grid_map.git
- release repository: https://github.com/ethz-asl/grid_map-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.2.0-0`
## grid_map

```
* Separated OpenCV to grid map conversions to grid_map_cv package. The new methods
  are more generalized, faster, and can be used without ROS message types.
* Contributors: Peter Fankhauser
```
## grid_map_core

```
* Made the isInside checks const.
* Fixes polygon iterator bug when using moved maps.
* Added unit test for polygon iterator on a moved map.
* Added comment about size of the returning submap.
* Reduced test build warning.
* Contributors: Peter Fankhauser, Martin Wermelinger, Marcus Liebhardt
```
## grid_map_cv

```
* Separated OpenCV to grid map conversions to grid_map_cv package. The new methods
  are more generalized, faster, and can be used without ROS message types.
* Added new convenience function to change the resolution of grid maps with help of the OpenCV interpolation methods.
* Added initializeFromImage() to GridMapCvConverter.
* Added unit tests for grid_map_cv. Updated documentation.
* Resolving build errors for OpenCV.
* Fixed typo and added documentation.
* Contributors: Peter Fankhauser, Dominic Jud,
```
## grid_map_demos

```
* Added new demonstrators for OpenCV based operations.
* Resolving build errors for OpenCV.
* Added comment on iterator performance (#45 <https://github.com/ethz-asl/grid_map/issues/45>).
* Contributors: Peter Fankhauser
```
## grid_map_filters

```
* Contributors: Peter Fankhauser
```
## grid_map_loader

```
* Contributors: Peter Fankhauser
```
## grid_map_msgs

```
* Contributors: Peter Fankhauser
```
## grid_map_ros

```
* Added new convenience function to change the resolution of grid maps with help of OpenCV interpolation methods (#60 <https://github.com/ethz-asl/grid_map/issues/60>).
* Separated OpenCV to grid map conversions to grid_map_cv package (also fixes #56 <https://github.com/ethz-asl/grid_map/issues/56>)
* Improved efficiency and generalized image to grid map conversion.
* Added image conversion for different encodings and depth resolutions.
* Fix scaling of image value to height conversion.
* Improved efficiency of the grid map to point cloud conversion by omitting invalid cells.
* Contributors: Peter Fankhauser, Daniel Stonier, Martin Wermelinger, Dominic Jud
```
## grid_map_visualization

```
* Added new visualizer for flat point clouds and updated documentation and demos.
* Contributors: Peter Fankhauser, Daniel Stonier
```
