### PR TITLE
Adding ekf_localization to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2204,6 +2204,12 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/eigen_stl_containers-release.git
       version: 0.1.4-0
+  ekf_localization:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/vislab-tecnico-lisboa/ekf_localization.git
+      version: 1.0.0-0
   eml:
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2210,6 +2210,7 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/vislab-tecnico-lisboa/ekf_localization.git
       version: 1.0.0-0
+    status: maintained
   eml:
     release:
       tags:


### PR DESCRIPTION
I would like to add ekf_localization to be indexed and documented in ros.org.
