### PR TITLE
dr_base: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1902,6 +1902,15 @@ repositories:
       type: git
       url: https://github.com/ZhuangYanDLUT/dlut_vision.git
       version: indigo-devel
+  dr_base:
+    release:
+      packages:
+      - dr_base
+      - dr_cmake
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/delftrobotics/camera_pose_calibration-release.git
+      version: 1.0.0-0
   drc_hubo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dr_base` to `1.0.0-0`:
- upstream repository: https://github.com/delftrobotics/dr_base.git
- release repository: https://github.com/delftrobotics/camera_pose_calibration-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
