### PR TITLE
openrtm_aist: 1.1.0-2 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3382,7 +3382,8 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/openrtm_aist-release.git
-      version: 1.1.0-1
+      version: 1.1.0-2
+    status: developed
   openrtm_aist_python:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist` to `1.1.0-2`:
- upstream repository: http://svn.openrtm.org/OpenRTM-aist/tags/RELEASE_1_1_0/OpenRTM-aist/
- release repository: https://github.com/tork-a/openrtm_aist-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.1.0-1`
