### PR TITLE
ekf_localization: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2213,6 +2213,21 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/eigen_stl_containers-release.git
       version: 0.1.4-0
+  ekf_localization:
+    doc:
+      type: git
+      url: https://github.com/vislab-tecnico-lisboa/ekf_localization.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/vislab-tecnico-lisboa/ekf_localization-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/vislab-tecnico-lisboa/ekf_localization.git
+      version: indigo-devel
+    status: developed
   eml:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ekf_localization` to `0.0.2-0`:
- upstream repository: https://github.com/vislab-tecnico-lisboa/ekf_localization.git
- release repository: https://github.com/vislab-tecnico-lisboa/ekf_localization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
