### PR TITLE
camera_pose_calibration: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -833,6 +833,12 @@ repositories:
       url: https://github.com/ros-perception/camera_info_manager_py.git
       version: master
     status: maintained
+  camera_pose_calibration:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/delftrobotics/camera_pose_calibration-release.git
+      version: 0.1.1-0
   camera_umd:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_pose_calibration` to `0.1.1-0`:
- upstream repository: https://github.com/delftrobotics/camera_pose_calibration.git
- release repository: https://github.com/delftrobotics/camera_pose_calibration-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## camera_pose_calibration

```
First public release
```
