### PR TITLE
Add python-googleapi to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -666,6 +666,17 @@ python-gdown:
 python-gi:
   debian: [python-gi]
   ubuntu: [python-gi]
+python-googleapi:
+  debian: [python-googleapi]
+  fedora: [google-api-python-client]
+  ubuntu:
+    trusty: [python-googleapi]
+    utopic: [python-googleapi]
+    vivid: [python-googleapi]
+    wily: [python-googleapi]
+    wily_python3: [python3-googleapi]
+    xenial: [python-googleapi]
+    xenial_python3: [python3-googleapi]
 python-gridfs:
   debian: [python-gridfs]
   fedora: [python-pymongo-gridfs]


### PR DESCRIPTION
This add support for apiclient and can be used instead of python-oauth2client for oauth2client.

Ran the unittests as well.
