### PR TITLE
gennodejs: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -641,6 +641,13 @@ repositories:
       url: https://github.com/ros/genmsg.git
       version: indigo-devel
     status: maintained
+  gennodejs:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RethinkRobotics-release/gennodejs-release.git
+      version: 1.0.1-0
+    status: developed
   genpy:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -631,11 +631,19 @@ repositories:
       version: indigo-devel
     status: maintained
   gennodejs:
+    doc:
+      type: git
+      url: https://github.com/RethinkRobotics-opensource/gennodejs.git
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RethinkRobotics-release/gennodejs-release.git
       version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/RethinkRobotics-opensource/gennodejs.git
+      version: kinetic-devel
     status: developed
   genpy:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -599,17 +599,6 @@ repositories:
       url: https://github.com/jsk-ros-pkg/geneus.git
       version: master
     status: developed
-  genjs:
-    release:
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/RethinkRobotics-release/genjs-release.git
-      version: 1.0.0-0
-    source:
-      type: git
-      url: https://github.com/RethinkRobotics-opensource/genjs.git
-      version: kinetic-devel
-    status: developed
   genlisp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gennodejs` to `1.0.1-0`:
- upstream repository: https://github.com/RethinkRobotics-opensource/gennodejs.git
- release repository: https://github.com/RethinkRobotics-release/gennodejs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## gennodejs

```
* Package name-switch from genjs to gennodejs based on feedback
* When deserializing, creates an instance of the message
  rather than using json.
* Update genjs for install
  -No longer includes hardcoded paths in generated message files
  -Actually install stuff
* Contributors: Chris Smith, Ian McMahon, chris-smith
```
