### PR TITLE
rqt_common_plugins: 0.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1843,6 +1843,44 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: kinetic-devel
     status: maintained
+  rqt_common_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_common_plugins.git
+      version: master
+    release:
+      packages:
+      - rqt_action
+      - rqt_bag
+      - rqt_bag_plugins
+      - rqt_common_plugins
+      - rqt_console
+      - rqt_dep
+      - rqt_graph
+      - rqt_image_view
+      - rqt_launch
+      - rqt_logger_level
+      - rqt_msg
+      - rqt_plot
+      - rqt_publisher
+      - rqt_py_common
+      - rqt_py_console
+      - rqt_reconfigure
+      - rqt_service_caller
+      - rqt_shell
+      - rqt_srv
+      - rqt_top
+      - rqt_topic
+      - rqt_web
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_common_plugins-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_common_plugins.git
+      version: master
+    status: maintained
   rtctree:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `0.4.0-0`:
- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/ros-gbp/rqt_common_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rqt_action
- No changes
## rqt_bag

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
* fix publishing wrong topic after scrolling (#362 <https://github.com/ros-visualization/rqt_common_plugins/pull/362>)
```
## rqt_bag_plugins

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
```
## rqt_common_plugins
- No changes
## rqt_console

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
```
## rqt_dep

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
```
## rqt_graph

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
```
## rqt_image_view

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
```
## rqt_launch

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
```
## rqt_logger_level

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
```
## rqt_msg

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
```
## rqt_plot

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
* support matplotplot 1.5 (#358 <https://github.com/ros-visualization/rqt_common_plugins/pull/358>)
```
## rqt_publisher

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
```
## rqt_py_common

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
```
## rqt_py_console

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
```
## rqt_reconfigure

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
```
## rqt_service_caller

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
```
## rqt_shell

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
```
## rqt_srv
- No changes
## rqt_top

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
```
## rqt_topic

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
```
## rqt_web

```
* Support Qt 5 (in Kinetic and higher) as well as Qt 4 (in Jade and earlier) (#359 <https://github.com/ros-visualization/rqt_common_plugins/pull/359>)
```
