### PR TITLE
gazebo_ros_pkgs: 2.5.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -563,6 +563,20 @@ repositories:
       version: hydro-devel
     status: maintained
   gazebo_ros_pkgs:
+    doc:
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+      version: kinetic-devel
+    release:
+      packages:
+      - gazebo_msgs
+      - gazebo_plugins
+      - gazebo_ros
+      - gazebo_ros_pkgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
+      version: 2.5.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.5.4-0`:
- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## gazebo_msgs

```
* merge indigo, jade to kinetic-devel
* Update maintainer for Kinetic release
* Contributors: Jose Luis Rivero, Steven Peters
```
## gazebo_plugins

```
* merge indigo, jade to kinetic-devel
* Accept /world for the frameName parameter in gazebo_ros_p3d
* Upgrade to gazebo 7 and remove deprecated driver_base dependency
  * Upgrade to gazebo 7 and remove deprecated driver_base dependency
  * disable gazebo_ros_control until dependencies are met
  * Remove stray backslash
* Update maintainer for Kinetic release
* use HasElement in if condition
* Contributors: Hugo Boyer, Jackie Kay, Jose Luis Rivero, Steven Peters, William Woodall, Yuki Furuta
```
## gazebo_ros

```
* merge indigo, jade to kinetic-devel
* Upgrade to gazebo 7 and remove deprecated driver_base dependency
  * Upgrade to gazebo 7 and remove deprecated driver_base dependency
  * disable gazebo_ros_control until dependencies are met
  * Remove stray backslash
* spawn_model: adding -b option to bond to the model and delete it on sigint
* Update maintainer for Kinetic release
* Allow respawning gazebo node.
* Contributors: Hugo Boyer, Isaac IY Saito, Jackie Kay, Jonathan Bohren, Jose Luis Rivero, Steven Peters
```
## gazebo_ros_pkgs

```
* merge indigo, jade to kinetic-devel
* Update maintainer for Kinetic release
* Contributors: Jose Luis Rivero, Steven Peters
```
