### PR TITLE
moveit_commander: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5409,7 +5409,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_commander-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_commander.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_commander` to `0.6.1-0`:
- upstream repository: https://github.com/ros-planning/moveit_commander.git
- release repository: https://github.com/ros-gbp/moveit_commander-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.0-0`
## moveit_commander

```
* [feat] Add the possibility to choose description file #43 <https://github.com/ros-planning/moveit_commander/issues/43>
* [improve] support pyassimp 3.2. Looks like they changed their import path. robot_description should not be hardcoded to allow changing the name of the description file. This is usefull when working with several robots that do not share the same description file. #45 <https://github.com/ros-planning/moveit_commander/issues/45>
* [improve] add queue_size option in planning_scene_interface.py #41 <https://github.com/ros-planning/moveit_commander/issues/41>
* Contributors: Dave Coleman, Isaac I.Y. Saito, Kei Okada, Michael Görner, buschbapti
```
