### PR TITLE
moveit_commander: 0.6.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2422,6 +2422,21 @@ repositories:
       url: https://github.com/strands-project/mongodb_store.git
       version: hydro-devel
     status: developed
+  moveit_commander:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_commander.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_commander-release.git
+      version: 0.6.1-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_commander.git
+      version: indigo-devel
+    status: maintained
   moveit_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_commander` to `0.6.1-0`:
- upstream repository: https://github.com/ros-planning/moveit_commander.git
- release repository: https://github.com/ros-gbp/moveit_commander-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## moveit_commander

```
* [feat] Add the possibility to choose description file #43 <https://github.com/ros-planning/moveit_commander/issues/43>
* [improve] support pyassimp 3.2. Looks like they changed their import path. robot_description should not be hardcoded to allow changing the name of the description file. This is usefull when working with several robots that do not share the same description file. #45 <https://github.com/ros-planning/moveit_commander/issues/45>
* [improve] add queue_size option in planning_scene_interface.py #41 <https://github.com/ros-planning/moveit_commander/issues/41>
* Contributors: Dave Coleman, Isaac I.Y. Saito, Kei Okada, Michael Görner, buschbapti
```
