### PR TITLE
message_generation: 0.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1081,7 +1081,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/message_generation-release.git
-      version: 0.3.0-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/ros/message_generation.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1076,7 +1076,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/message_generation.git
-      version: jade-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -1085,7 +1085,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/message_generation.git
-      version: jade-devel
+      version: kinetic-devel
     status: maintained
   message_runtime:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `message_generation` to `0.4.0-0`:
- upstream repository: https://github.com/ros/message_generation.git
- release repository: https://github.com/ros-gbp/message_generation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.0-0`
