### PR TITLE
gl_dependency: 1.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1224,6 +1224,21 @@ repositories:
       url: https://github.com/ros/geometry_tutorials.git
       version: indigo-devel
     status: maintained
+  gl_dependency:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/gl_dependency.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/gl_dependency-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/gl_dependency.git
+      version: indigo-devel
+    status: maintained
   graft:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gl_dependency` to `1.0.0-0`:
- upstream repository: https://github.com/ros-visualization/gl_dependency.git
- release repository: https://github.com/ros-gbp/gl_dependency-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
