### PR TITLE
gl_dependency: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2893,6 +2893,21 @@ repositories:
       url: https://github.com/ros/geometry_tutorials.git
       version: hydro-devel
     status: maintained
+  gl_dependency:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/gl_dependency.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/gl_dependency-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/gl_dependency.git
+      version: indigo-devel
+    status: maintained
   gperftools_21:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `gl_dependency` to `1.0.0-0`:
- upstream repository: https://github.com/ros-visualization/gl_dependency.git
- release repository: https://github.com/ros-gbp/gl_dependency-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
