### PR TITLE
rviz_visual_tools: 2.2.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5053,7 +5053,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/davetcoleman/rviz_visual_tools-release.git
-      version: 2.1.0-0
+      version: 2.2.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/rviz_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `2.2.0-0`:
- upstream repository: https://github.com/davetcoleman/rviz_visual_tools.git
- release repository: https://github.com/davetcoleman/rviz_visual_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.1.0-0`
## rviz_visual_tools

```
* Created much better demo, added new screenshot
* Numbered colors so that they can be matched in OMPL
* New publishLine() function variants
* Psychedelic mode
* Prevent publishing empty marker arrays
* Improved warning and error correction
* New publishSphere function
* Ability to set marker topic after constructor
* Ability to force waiting for topic to connect
* Added new posesEqual() function
* Updated publishArrow() function
* New publishPath function
* New publishLine function
* New publishCylinder that accepts two points
* New publishText function
* Removed redundant namespace names
* New convertPointToPose function
* Reduced output
* Renamed line_marker_ to line_strip_marker_
* Faster method for waiting for subscriber thread
* Untested publishPath() modification
* Fix to correctly use optional alpha color property
* Change getColorScale to work from 0->1 instead of 0->100
* Additional parameters to publishCuboid()
* New color scale function for generated interpolated colors from RED->GREEN (1->100)
* Contributors: Dave Coleman
```
