### PR TITLE
moveit_visual_tools: 3.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2589,7 +2589,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 3.0.5-0
+      version: 3.1.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `3.1.0-0`:
- upstream repository: https://github.com/davetcoleman/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `3.0.5-0`
## moveit_visual_tools

```
* Re-factored and fixed visual tools demo!
* Fixes for catkin lint
* Fixes for roslint
* Removed deprecated function call
* Remove deprecated test
* New root_robot_state utilization
* Ablity to move a RobotState's root frame permenatly around in the scene
* Better publishCollisionWall() function
* Deprecated old publishTrajectoryLine() functions - removed clear_all_markers argument
* New publishTrajectoryPath() variant
* Rename namespace of RobotState
* Made INFO into DEBUG output
* New publishTrajectoryLine function
* Switched publishTrajectoryLine to use cylinders instead of lines
* New showJointLimits() function for console debugging a robot state
* Fix publishTrajectoryPath() bug
* Default blocking time for trajectory if not parameterized
* Publish workspace parameters was incorrectly creating a collision object
* Contributors: Dave Coleman
```
