### PR TITLE
ecl_tools: 0.61.4-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -438,7 +438,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_tools-release.git
-      version: 0.61.4-1
+      version: 0.61.4-2
     source:
       type: git
       url: https://github.com/stonier/ecl_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_tools` to `0.61.4-2`:
- upstream repository: https://github.com/stonier/ecl_tools.git
- release repository: https://github.com/yujinrobot-release/ecl_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.61.4-1`
## ecl_build

```
* check, but just quietly avoid including cotire if version check fails.
```
