### PR TITLE
catkin_pure_python: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1031,7 +1031,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/catkin_pure_python-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pure_python.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pure_python` to `0.0.6-0`:
- upstream repository: https://github.com/asmodehn/catkin_pure_python.git
- release repository: https://github.com/asmodehn/catkin_pure_python-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.5-0`
## catkin_pure_python

```
* adding --ignore-installed to avoid pip picking up local editable package when installing.
* informative comments
* better fix for catkin-pip requirements not found in workspace path
* fixing travis to run tests for catkin-pip
* Contributors: alexv
```
