### PR TITLE
mavros: 0.17.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2316,7 +2316,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.17.1-0
+      version: 0.17.2-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.17.2-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.17.1-0`
## libmavconn
- No changes
## mavros

```
* Update README.md
* Update README.md
  Updated / completed examples.
* Update README.md
* Fix for kinetic std::isnan.
* Contributors: James Goppert, Lorenz Meier
```
## mavros_extras
- No changes
## mavros_msgs
- No changes
## test_mavros
- No changes
