### PR TITLE
mavros: 0.17.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1038,6 +1038,26 @@ repositories:
       url: https://github.com/mavlink/mavlink-gbp-release.git
       version: 2016.4.4-0
     status: maintained
+  mavros:
+    doc:
+      type: git
+      url: https://github.com/mavlink/mavros.git
+      version: master
+    release:
+      packages:
+      - libmavconn
+      - mavros
+      - mavros_extras
+      - mavros_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/mavlink/mavros-release.git
+      version: 0.17.2-0
+    source:
+      type: git
+      url: https://github.com/mavlink/mavros.git
+      version: master
+    status: developed
   md49_base_controller:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.17.2-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## libmavconn
- No changes
## mavros

```
* Update README.md
* Update README.md
  Updated / completed examples.
* Update README.md
* Fix for kinetic std::isnan.
* Contributors: James Goppert, Lorenz Meier
```
## mavros_extras
- No changes
## mavros_msgs
- No changes
