### PR TITLE
rplidar_ros: 1.5.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9743,7 +9743,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/robopeak/rplidar_ros-release.git
-      version: 1.5.3-0
+      version: 1.5.2-0
     source:
       type: git
       url: https://github.com/robopeak/rplidar_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `1.5.2-0`:
- upstream repository: https://github.com/robopeak/rplidar_ros.git
- release repository: https://github.com/robopeak/rplidar_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.5.3-0`
## rplidar_ros

```
1.5.1 (2016-04-12)
* Release 1.5.1.
* Add the deiver support rplidar A2.
* Contributors: yhZhao, RoboPeak Public Repos
```
