### PR TITLE
Add gazebo and libgazebo7-dev for debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -800,9 +800,9 @@ gawk:
   ubuntu: [gawk]
 gazebo:
   arch: [gazebo]
+  debian: [gazebo7]
   fedora: [gazebo-devel]
   gentoo: [sci-electronics/gazebo]
-  debian: [gazebo7]
   ubuntu:
     precise: [gazebo]
     quantal: [gazebo]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -802,6 +802,7 @@ gazebo:
   arch: [gazebo]
   fedora: [gazebo-devel]
   gentoo: [sci-electronics/gazebo]
+  debian: [gazebo7]
   ubuntu:
     precise: [gazebo]
     quantal: [gazebo]
@@ -1512,6 +1513,7 @@ libgazebo5-dev:
   gentoo: [sci-electronics/gazebo]
   ubuntu: [libgazebo5-dev]
 libgazebo7-dev:
+  debian: [libgazebo7-dev]
   ubuntu: [libgazebo7-dev]
 libgeographiclib-dev:
   fedora: [geographiclib]


### PR DESCRIPTION
Now that @j-rivero has imported Gazebo 7 for Debian Jessie, we can add rosdep keys for Debian.
