### PR TITLE
gazebo_ros_pkgs: 2.5.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -576,7 +576,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.5.6-0
+      version: 2.5.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.5.6-1`:
- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.5.6-0`
## gazebo_msgs
- No changes
## gazebo_plugins

```
* fix gazebo7 deprecation warnings on kinetic
* Contributors: Steven Peters
```
## gazebo_ros

```
* Remove deprecated spawn_gazebo_model service
* Contributors: Steven Peters
```
## gazebo_ros_pkgs
- No changes
