### PR TITLE
rqt_launchtree: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9861,7 +9861,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pschillinger/rqt_launchtree-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/pschillinger/rqt_launchtree.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_launchtree` to `0.1.2-0`:
- upstream repository: https://github.com/pschillinger/rqt_launchtree.git
- release repository: https://github.com/pschillinger/rqt_launchtree-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.1-0`
## rqt_launchtree

```
* Changed maintainer email to avoid wrong impression about company involvement
* Contributors: Philipp Schillinger
```
