### PR TITLE
jsk_model_tools: 0.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4168,7 +4168,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     status: developed
   jsk_planning:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.2.4-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.3-0`
## eus_assimp
- No changes
## euscollada

```
* Support building on OS X
* Support passing limbs to predefined pose method
  Modified:
  - euscollada/src/collada2eus.cpp
* [euscollada/src/collada2eus_urdfmodel.cpp] Fix location of gl::vertices setting. Move after geom is set.
* Contributors: Kentaro Wada, Shunichi Nozawa
```
## eusurdf

```
* Ignore world files
* Contributors: Kentaro Wada
```
## jsk_model_tools
- No changes
