### PR TITLE
ecl_lite: 0.61.4-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -419,7 +419,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_lite-release.git
-      version: 0.61.4-1
+      version: 0.61.4-2
     source:
       type: git
       url: https://github.com/stonier/ecl_lite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_lite` to `0.61.4-2`:
- upstream repository: https://github.com/stonier/ecl_lite.git
- release repository: https://github.com/yujinrobot-release/ecl_lite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.61.4-1`
## ecl_config

```
* macro for use with checking for CXX11
```
## ecl_console

```
* namespaced to within the ecl
* imported from termcolor <https://github.com/ikalnitsky/termcolor> for our low-level cross-compiled embedded projects
```
