### PR TITLE
object_recognition_transparent_objects: 0.4.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1264,6 +1264,17 @@ repositories:
       url: https://github.com/wg-perception/tod.git
       version: master
     status: maintained
+  object_recognition_transparent_objects:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_transparent_objects-release.git
+      version: 0.4.1-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/transparent_objects.git
+      version: master
+    status: maintained
   octomap:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_transparent_objects` to `0.4.1-0`:
- upstream repository: https://github.com/wg-perception/transparent_objects.git
- release repository: https://github.com/ros-gbp/object_recognition_transparent_objects-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## object_recognition_transparent_objects

```
* get code to compile on Xenial
* add explanation for algorithm
* clean extensions
* cleanup CMake a bit
* Contributors: Jordi Pages, Po-Jen Lai, Vincent Rabaud
```
