### PR TITLE
object_recognition_reconstruction: 0.3.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3127,7 +3127,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_reconstruction-release.git
-      version: 0.3.5-0
+      version: 0.3.6-0
     source:
       type: git
       url: https://github.com/wg-perception/reconstruction.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_reconstruction` to `0.3.6-0`:
- upstream repository: https://github.com/wg-perception/reconstruction.git
- release repository: https://github.com/ros-gbp/object_recognition_reconstruction-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.5-0`
## object_recognition_reconstruction

```
* fix PCL compilation
* Fix poisson script. Enhance ball pivoting script
* Contributors: JimmyDaSilva, Vincent Rabaud
```
