### PR TITLE
add meshlab for Debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2897,6 +2897,7 @@ mesa-common-dev:
   fedora: [mesa-libGL-devel, libdrm-devel, libX11-devel]
   ubuntu: [mesa-common-dev]
 meshlab:
+  debian: [meshlab]
   fedora: [meshlab]
   ubuntu: [meshlab]
 mongodb:


### PR DESCRIPTION
Link at https://packages.debian.org/jessie/meshlab
