### PR TITLE
object_recognition_reconstruction: 0.3.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1232,6 +1232,17 @@ repositories:
       url: https://github.com/wg-perception/object_recognition_msgs.git
       version: master
     status: maintained
+  object_recognition_reconstruction:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_reconstruction-release.git
+      version: 0.3.6-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/reconstruction.git
+      version: master
+    status: maintained
   object_recognition_ros:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_reconstruction` to `0.3.6-0`:
- upstream repository: https://github.com/wg-perception/reconstruction.git
- release repository: https://github.com/ros-gbp/object_recognition_reconstruction-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## object_recognition_reconstruction

```
* fix PCL compilation
* Fix poisson script. Enhance ball pivoting script
* Contributors: JimmyDaSilva, Vincent Rabaud
```
