### PR TITLE
object_recognition_transparent_objects: 0.4.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1280,7 +1280,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_transparent_objects-release.git
-      version: 0.4.1-0
+      version: 0.4.2-0
     source:
       type: git
       url: https://github.com/wg-perception/transparent_objects.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_transparent_objects` to `0.4.2-0`:
- upstream repository: https://github.com/wg-perception/transparent_objects.git
- release repository: https://github.com/ros-gbp/object_recognition_transparent_objects-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.4.1-0`
## object_recognition_transparent_objects

```
* add proj as a dependency
* Contributors: Vincent Rabaud
```
