### PR TITLE
on debian libtool-bin is required for both jessie and sid, as ubuntu need them since utopic

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2516,9 +2516,9 @@ libtiff4-dev:
 libtool:
   arch: [libtool]
   debian:
-    jessie: [libtool, libltdl-dev]
+    jessie: [libtool, libltdl-dev, libtool-bin]
     lenny: [libtool, libltdl3-dev]
-    sid: [libtool, libltdl-dev]
+    sid: [libtool, libltdl-dev, libtool-bin]
     squeeze: [libtool, libltdl-dev]
     wheezy: [libtool, libltdl-dev]
   fedora: [libtool, libtool-ltdl-devel]


### PR DESCRIPTION
see https://packages.debian.org/search?keywords=libtool-bin
