### PR TITLE
fzi_icl_core: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2668,7 +2668,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fzi_icl_core` to `1.0.2-0`:
- upstream repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core
- release repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.1-0`
## fzi_icl_core

```
* declared package as plain cmake package
* Disabled crypt library test for now due to strange build farm fail.
* Added Boost as build dependency
* Contributors: Felix Mauch, Georg Heppner
```
