### PR TITLE
fzi_icl_can: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2659,6 +2659,21 @@ repositories:
       url: https://github.com/DaikiMaekawa/fulanghua_navigation.git
       version: indigo-devel
     status: developed
+  fzi_icl_can:
+    doc:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can.git
+      version: master
+    status: maintained
   fzi_icl_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fzi_icl_can` to `1.0.2-0`:
- upstream repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## fzi_icl_can

```
* declared package as plain cmake package
* Contributors: Felix Mauch
```
