### PR TITLE
schunk_canopen_driver: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10303,6 +10303,21 @@ repositories:
       url: https://github.com/ccny-ros-pkg/scan_tools.git
       version: indigo
     status: maintained
+  schunk_canopen_driver:
+    doc:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver.git
+      version: master
+    status: maintained
   schunk_grippers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_canopen_driver` to `1.0.2-0`:
- upstream repository: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## schunk_canopen_driver

```
* remove icl_hardware_canopen from dependencies as it is provided by this
  package
* Contributors: Felix Mauch
```
