### PR TITLE
ecl_navigation: 0.60.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -425,6 +425,24 @@ repositories:
       url: https://github.com/stonier/ecl_lite.git
       version: indigo-devel
     status: developed
+  ecl_navigation:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_navigation.git
+      version: indigo-devel
+    release:
+      packages:
+      - ecl_mobile_robot
+      - ecl_navigation
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_navigation-release.git
+      version: 0.60.1-0
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_navigation.git
+      version: indigo-devel
+    status: developed
   ecl_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_navigation` to `0.60.1-0`:
- upstream repository: https://github.com/stonier/ecl_navigation.git
- release repository: https://github.com/yujinrobot-release/ecl_navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
