### PR TITLE
ecl_manipulation: 0.60.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -425,6 +425,25 @@ repositories:
       url: https://github.com/stonier/ecl_lite.git
       version: indigo-devel
     status: developed
+  ecl_manipulation:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_manipulation.git
+      version: indigo-stable
+    release:
+      packages:
+      - ecl
+      - ecl_manipulation
+      - ecl_manipulators
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_manipulation-release.git
+      version: 0.60.1-1
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_manipulation.git
+      version: indigo-devel
+    status: developed
   ecl_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_manipulation` to `0.60.1-1`:
- upstream repository: https://github.com/stonier/ecl_manipulation.git
- release repository: https://github.com/yujinrobot-release/ecl_manipulation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
