### PR TITLE
control_toolbox: 1.14.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -307,6 +307,11 @@ repositories:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
       version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/control_toolbox-release.git
+      version: 1.14.0-0
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `1.14.0-0`:
- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros-gbp/control_toolbox-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## control_toolbox

```
* Fix negative gains issue and add tests; update gains setting through DynamicReconfig
* Add antiwindup and tests to PID controller; rename old behaviour 'clamping'
* Move message to control_toolbox
* Add optional state publishing to PID controller, for logging/debugging/etc
* Fix some typos in comments
* changed the range of dynamic reconfigure to allow negative ones
* Address -Wunused-parameter warnings
* Factor out updatePid as negative calls to computeCommand
* Increasing covergae of PID class test suite.
* Chain calls of computeCommand and updatePid for code reuse
* Contributors: Adolfo Rodriguez Tsouroukdissian, Bence Magyar, Carlos Rosales, Guillaume Walck, Paul Bovbel, VahidAminZ
```
