### PR TITLE
ros_controllers: 0.11.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1818,6 +1818,24 @@ repositories:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git
       version: kinetic-devel
+    release:
+      packages:
+      - diff_drive_controller
+      - effort_controllers
+      - force_torque_sensor_controller
+      - forward_command_controller
+      - gripper_action_controller
+      - imu_sensor_controller
+      - joint_state_controller
+      - joint_trajectory_controller
+      - position_controllers
+      - ros_controllers
+      - rqt_joint_trajectory_controller
+      - velocity_controllers
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_controllers-release.git
+      version: 0.11.0-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.11.0-0`:
- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## diff_drive_controller
- No changes
## effort_controllers

```
* Add antinwindup to get and setGains logic for underlying PID controller
* Contributors: Paul Bovbel
```
## force_torque_sensor_controller
- No changes
## forward_command_controller
- No changes
## gripper_action_controller
- No changes
## imu_sensor_controller
- No changes
## joint_state_controller
- No changes
## joint_trajectory_controller
- No changes
## position_controllers
- No changes
## ros_controllers
- No changes
## rqt_joint_trajectory_controller
- No changes
## velocity_controllers

```
* Add antinwindup to get and setGains logic for underlying PID controller
* Contributors: Paul Bovbel
```
