### PR TITLE
openni2_camera: 0.2.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3352,7 +3352,11 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 0.2.5-0
+      version: 0.2.6-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: indigo-devel
     status: maintained
   openni2_launch:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `0.2.6-0`:
- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros-gbp/openni2_camera-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.5-0`
## openni2_camera

```
* [fix] Compile for OSX #30 <https://github.com/ros-drivers/openni2_camera/issues/30>
* [fix] Crash on OSX and warning fixes.
* Contributors: Hans Gaiser, Isaac I.Y. Saito, Michael Ferguson
```
