### PR TITLE
openni2_camera: 0.2.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1402,6 +1402,21 @@ repositories:
       url: https://github.com/tork-a/openhrp3-release.git
       version: 3.1.8-1
     status: developed
+  openni2_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/openni2_camera-release.git
+      version: 0.2.6-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: indigo-devel
+    status: maintained
   openni_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `0.2.6-0`:
- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros-gbp/openni2_camera-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## openni2_camera

```
* [fix] Compile for OSX #30 <https://github.com/ros-drivers/openni2_camera/issues/30>
* [fix] Crash on OSX and warning fixes.
* Contributors: Hans Gaiser, Isaac I.Y. Saito, Michael Ferguson
```
