### PR TITLE
make ubuntu rule generic for python-cwiid

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -472,18 +472,7 @@ python-cwiid:
   fedora: [cwiid]
   gentoo: [app-misc/cwiid]
   rhel: [cwiid]
-  ubuntu:
-    lucid: [python-cwiid]
-    maverick: [python-cwiid]
-    natty: [python-cwiid]
-    oneiric: [python-cwiid]
-    precise: [python-cwiid]
-    quantal: [python-cwiid]
-    raring: [python-cwiid]
-    saucy: [python-cwiid]
-    trusty: [python-cwiid]
-    utopic: [python-cwiid]
-    vivid: [python-cwiid]
+  ubuntu: [python-cwiid]
 python-dateutil:
   fedora: [python-dateutil]
   ubuntu:


### PR DESCRIPTION
Needed to release joystick_drivers in Kinetic for xenial and wily rule.
