### PR TITLE
add wily and xenial python-bluez rules

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -272,6 +272,8 @@ python-bluez:
     trusty: [python-bluez]
     utopic: [python-bluez]
     vivid: [python-bluez]
+    wily: [python-bluez]
+    xenial: [python-bluez]   
 python-box2d:
   fedora: [pybox2d]
   ubuntu: [python-box2d]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -273,7 +273,7 @@ python-bluez:
     utopic: [python-bluez]
     vivid: [python-bluez]
     wily: [python-bluez]
-    xenial: [python-bluez]   
+    xenial: [python-bluez]
 python-box2d:
   fedora: [pybox2d]
   ubuntu: [python-box2d]


### PR DESCRIPTION
needed for joystick_drivers release
