### PR TITLE
joystick_drivers: 1.10.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -981,6 +981,27 @@ repositories:
       url: https://github.com/ros/ivcon.git
       version: kinetic-devel
     status: maintained
+  joystick_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: indigo-devel
+    release:
+      packages:
+      - joy
+      - joystick_drivers
+      - ps3joy
+      - spacenav_node
+      - wiimote
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/joystick_drivers-release.git
+      version: 1.10.1-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: indigo-devel
+    status: maintained
   jsk_common_msgs:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `1.10.1-0`:
- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros-gbp/joystick_drivers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## joy

```
* Remove stray architechture_independent flags
* Contributors: Jonathan Bohren, Scott K Logan
```
## joystick_drivers
- No changes
## ps3joy

```
* Remove stray architechture_independent flags
* Contributors: Jonathan Bohren, Scott K Logan
```
## spacenav_node

```
* Add full_scale parameter and apply to offset
* Remove stray architechture_independent flags
* Contributors: Gaël Ecorchard, Jonathan Bohren, Scott K Logan
```
## wiimote
- No changes
