### PR TITLE
turtlebot_create: 2.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2272,6 +2272,26 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  turtlebot_create:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_create.git
+      version: indigo
+    release:
+      packages:
+      - create_description
+      - create_driver
+      - create_node
+      - turtlebot_create
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/turtlebot-release/turtlebot_create-release.git
+      version: 2.3.0-0
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_create.git
+      version: indigo
+    status: maintained
   uavc_v4lctl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_create` to `2.3.0-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_create.git
- release repository: https://github.com/turtlebot-release/turtlebot_create-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## create_description

```
* -Fix extreme slipping of create base in gazebo by using same parameters that kobuki uses
* Contributors: Stefan Kohlbrecher
```
## create_driver
- No changes
## create_node

```
* Set queue size
* Actually use provided configuration
* Contributors: Kenneth Bogert, trainman419
```
## turtlebot_create
- No changes
