### PR TITLE
openrtm_aist: 1.1.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1473,7 +1473,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/openrtm_aist-release.git
-      version: 1.1.0-1
+      version: 1.1.0-2
     status: developed
   openslam_gmapping:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist` to `1.1.0-2`:
- upstream repository: http://svn.openrtm.org/OpenRTM-aist/tags/RELEASE_1_1_0/OpenRTM-aist/
- release repository: https://github.com/tork-a/openrtm_aist-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.1.0-1`
