### PR TITLE
rtmros_hironx: 1.1.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10039,7 +10039,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.11-0
+      version: 1.1.12-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.12-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.1.11-0`
## hironx_calibration
- No changes
## hironx_moveit_config

```
* [fix][test_hironx_moveit.py] fix "rospy.init_node() has already been called with different arguments" exception.
* [fix][test_hironx_moveit.py] old file names
* [improve][test-hironx-moveit.test] Relax test duration.
* Contributors: Kei Okada
```
## hironx_ros_bridge

```
* [fix][RTM py] Remove redundant connection for impedance controller RTC.
* [fix][ROS py] fix segfault on ros_client exit.
* [feat] Add QNX driver for Dynpick F/T sensor.
* Contributors: Isaac Kei Okada, I.Y. Saito
```
## rtmros_hironx

```
* [fix][RTM py] Remove redundant connection for impedance controller RTC.
* [fix][ROS py] fix segfault on ros_client exit.
* [feat] Add QNX driver for Dynpick F/T sensor.
* [fix][test_hironx_moveit.py] fix "rospy.init_node() has already been called with different arguments" exception.
* [fix][test_hironx_moveit.py] old file names
* [improve][test-hironx-moveit.test] Relax test duration.
* Contributors: Isaac Kei Okada, I.Y. Saito
```
