### PR TITLE
removing rplidar release version since it's continuously failing

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9767,7 +9767,6 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/robopeak/rplidar_ros-release.git
-      version: 1.5.2-0
     source:
       type: git
       url: https://github.com/robopeak/rplidar_ros.git


### PR DESCRIPTION
This will stop the repeated build failures until it's rereleased.

@kintzhao FYI
