### PR TITLE
wjwwood_rplidar_ros: 1.5.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5879,6 +5879,14 @@ repositories:
       url: https://github.com/RobotWebTools/web_video_server.git
       version: develop
     status: maintained
+  wjwwood_rplidar_ros:
+    release:
+      packages:
+      - rplidar_ros
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wjwwood/rplidar_ros-release.git
+      version: 1.5.2-0
   wu_ros_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wjwwood_rplidar_ros` to `1.5.2-0`:
- upstream repository: https://github.com/wjwwood/rplidar_ros.git
- release repository: https://github.com/wjwwood/rplidar_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rplidar_ros

```
1.5.1 (2016-04-12)
* Release 1.5.1.
* Add the deiver support rplidar A2.
* Contributors: yhZhao, RoboPeak Public Repos
```
