### PR TITLE
update python-pep8 to install Python2 version in xenial

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1214,7 +1214,17 @@ python-pep8:
   osx:
     pip:
       packages: [pep8]
-  ubuntu: [pep8]
+  ubuntu:
+    precise: [pep8]
+    quantal: [pep8]
+    raring: [pep8]
+    saucy: [pep8]
+    trusty: [pep8]
+    utopic: [pep8]
+    vivid: [pep8]
+    wily: [pep8]
+    xenial: [python-pep8]
+    xenial_python3: [python3-pep8]
 python-percol:
   debian:
     pip:


### PR DESCRIPTION
See: http://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=python-pep8&searchon=names
