### PR TITLE
yocs_msgs: 0.6.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2483,5 +2483,20 @@ repositories:
       url: https://github.com/ros/xacro.git
       version: kinetic-devel
     status: developed
+  yocs_msgs:
+    doc:
+      type: git
+      url: https://github.com/yujinrobot/yocs_msgs.git
+      version: kinetic
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/yocs_msgs-release.git
+      version: 0.6.3-0
+    source:
+      type: git
+      url: https://github.com/yujinrobot/yocs_msgs.git
+      version: kinetic
+    status: developed
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `yocs_msgs` to `0.6.3-0`:
- upstream repository: https://github.com/yujinrobot/yocs_msgs.git
- release repository: https://github.com/yujinrobot-release/yocs_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## yocs_msgs

```
* Merge branch 'indigo' into update
* add distortion
* add more commands
* Contributors: Jihoon Lee
```
