### PR TITLE
zeroconf_msgs: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2526,5 +2526,20 @@ repositories:
       url: https://github.com/yujinrobot/yocs_msgs.git
       version: kinetic
     status: developed
+  zeroconf_msgs:
+    doc:
+      type: git
+      url: https://github.com/stonier/zeroconf_msgs.git
+      version: indigo
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/zeroconf_msgs-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/stonier/zeroconf_msgs.git
+      version: indigo
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `zeroconf_msgs` to `0.2.1-0`:
- upstream repository: https://github.com/stonier/zeroconf_msgs.git
- release repository: https://github.com/yujinrobot-release/zeroconf_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
