### PR TITLE
zeroconf_avahi_suite: 0.2.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2546,6 +2546,25 @@ repositories:
       url: https://github.com/yujinrobot/yocs_msgs.git
       version: kinetic
     status: developed
+  zeroconf_avahi_suite:
+    doc:
+      type: git
+      url: https://github.com/stonier/zeroconf_avahi_suite.git
+      version: indigo
+    release:
+      packages:
+      - zeroconf_avahi
+      - zeroconf_avahi_demos
+      - zeroconf_avahi_suite
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/zeroconf_avahi_suite-release.git
+      version: 0.2.3-0
+    source:
+      type: git
+      url: https://github.com/stonier/zeroconf_avahi_suite.git
+      version: indigo
+    status: maintained
   zeroconf_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `zeroconf_avahi_suite` to `0.2.3-0`:
- upstream repository: https://github.com/stonier/zeroconf_avahi_suite.git
- release repository: https://github.com/yujinrobot-release/zeroconf_avahi_suite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
