### PR TITLE
kobuki_msgs: 0.7.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1043,6 +1043,21 @@ repositories:
       url: https://github.com/yujinrobot/kobuki_core.git
       version: kinetic
     status: maintained
+  kobuki_msgs:
+    doc:
+      type: git
+      url: https://github.com/yujinrobot/kobuki_msgs.git
+      version: kinetic
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/kobuki_msgs-release.git
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/yujinrobot/kobuki_msgs.git
+      version: kinetic
+    status: maintained
   korg_nanokontrol:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_msgs` to `0.7.0-0`:
- upstream repository: https://github.com/yujinrobot/kobuki_msgs.git
- release repository: https://github.com/yujinrobot-release/kobuki_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
