### PR TITLE
rqt_ez_publisher: 0.3.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4873,7 +4873,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/OTL/rqt_ez_publisher-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/OTL/rqt_ez_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_ez_publisher` to `0.3.2-0`:
- upstream repository: https://github.com/OTL/rqt_ez_publisher.git
- release repository: https://github.com/OTL/rqt_ez_publisher-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.1-0`
## rqt_ez_publisher

```
* Fix JointTrajectory issue #22
* Apply pep8
* Merge pull request #21 from felixduvallet/travis_ci
  It seems nice!
* Merge pull request #20 from felixduvallet/load_from_file_fix
  fix problem with loading yaml slider config file
* Add travis CI for package.
* fix problem with loading yaml slider config file.
* remove trailing whitespace.
* Contributors: Felix Duvallet, Takashi Ogura
```
