### PR TITLE
rqt_ez_publisher: 0.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9854,7 +9854,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/OTL/rqt_ez_publisher-release.git
-      version: 0.3.1-1
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/OTL/rqt_ez_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_ez_publisher` to `0.3.2-0`:
- upstream repository: https://github.com/OTL/rqt_ez_publisher.git
- release repository: https://github.com/OTL/rqt_ez_publisher-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.1-1`
## rqt_ez_publisher

```
* Fix JointTrajectory issue #22
* Apply pep8
* Merge pull request #21 from felixduvallet/travis_ci
  It seems nice!
* Merge pull request #20 from felixduvallet/load_from_file_fix
  fix problem with loading yaml slider config file
* Add travis CI for package.
* fix problem with loading yaml slider config file.
* remove trailing whitespace.
* Contributors: Felix Duvallet, Takashi Ogura
```
