### PR TITLE
lms1xx: 0.1.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1105,6 +1105,21 @@ repositories:
       url: https://github.com/ros-gbp/libg2o-release.git
       version: 2016.4.24-0
     status: maintained
+  lms1xx:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/lms1xx.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/lms1xx-release.git
+      version: 0.1.5-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/lms1xx.git
+      version: master
+    status: maintained
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lms1xx` to `0.1.5-0`:
- upstream repository: https://github.com/clearpathrobotics/LMS1xx.git
- release repository: https://github.com/clearpath-gbp/lms1xx-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## lms1xx

```
* Rework startup/reconnection logic.
* Add roslaunch, roslint checks.
* Other fixes, including a new buffer class with tests.
* Add travis.
* Apply astyle to original package.
* Remove screen attribute from example launcher.
* Contributors: Mike Purvis
```
