### PR TITLE
rtabmap: 0.11.4-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2221,7 +2221,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.11.4-1
+      version: 0.11.4-2
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap` to `0.11.4-2`:
- upstream repository: https://github.com/introlab/rtabmap.git
- release repository: https://github.com/introlab/rtabmap-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.11.4-1`
