### PR TITLE
rtabmap_ros: 0.11.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2242,6 +2242,21 @@ repositories:
       url: https://github.com/introlab/rtabmap.git
       version: kinetic-devel
     status: maintained
+  rtabmap_ros:
+    doc:
+      type: git
+      url: https://github.com/introlab/rtabmap_ros.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/introlab/rtabmap_ros-release.git
+      version: 0.11.4-1
+    source:
+      type: git
+      url: https://github.com/introlab/rtabmap_ros.git
+      version: kinetic-devel
+    status: maintained
   rtctree:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.11.4-1`:
- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
