### PR TITLE
add python-pyqt5.qtsvg for jessie and ubuntu

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1638,11 +1638,11 @@ python-qt4-gl:
       packages: [python-qt4-gl]
 python-qt5-bindings:
   debian:
-    jessie: [pyqt5-dev, python-pyqt5, python-sip-dev, qtbase5-dev]
+    jessie: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
   fedora: [python-qt5, sip]
   ubuntu:
-    wily: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyside2, python-sip-dev, shiboken2]
-    xenial: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyside2, python-sip-dev, shiboken2]
+    wily: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
+    xenial: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
 python-qt5-bindings-gl:
   debian:
     jessie: [python-pyqt5.qtopengl]


### PR DESCRIPTION
Re: https://github.com/ros-visualization/rqt_common_plugins/issues/373
