### PR TITLE
openni_camera: 1.9.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1533,7 +1533,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/openni_camera-release.git
-      version: 1.9.5-0
+      version: 1.9.5-1
     source:
       type: git
       url: https://github.com/ros-drivers/openni_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_camera` to `1.9.5-1`:
- upstream repository: https://github.com/ros-drivers/openni_camera.git
- release repository: https://github.com/ros-gbp/openni_camera-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.9.5-0`
## openni_camera

```
* [feat] Updated max drop rate
* [sys] Added log4cxx missing explicit linkage #44 <https://github.com/ros-drivers/openni_camera/issues/44>
* Contributors: Francois-Michel De Rainville, Isaac IY Saito, Leopold Palomo-Avellaneda, Isaac I.Y. Saito
```
