### PR TITLE
rgbd_launch: 2.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8284,7 +8284,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rgbd_launch-release.git
-      version: 2.1.1-0
+      version: 2.1.2-0
     source:
       type: git
       url: https://github.com/ros-drivers/rgbd_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rgbd_launch` to `2.1.2-0`:
- upstream repository: https://github.com/ros-drivers/rgbd_launch.git
- release repository: https://github.com/ros-gbp/rgbd_launch-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.1.1-0`
## rgbd_launch

```
* [feat] depth_registered_filtered injection #25 <https://github.com/ros-drivers/rgbd_launch/issues/25>
* [sys] [Travis CI] Update config to using industrial_ci with Prerelease Test. #23 <https://github.com/ros-drivers/rgbd_launch/issues/23>
* Contributors: Jonathan Bohren, Isaac I.Y. Saito
```
