### PR TITLE
rgbd_launch: 2.2.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4023,7 +4023,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rgbd_launch-release.git
-      version: 2.2.0-0
+      version: 2.2.1-0
     source:
       type: git
       url: https://github.com/ros-drivers/rgbd_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rgbd_launch` to `2.2.1-0`:
- upstream repository: https://github.com/ros-drivers/rgbd_launch.git
- release repository: https://github.com/ros-gbp/rgbd_launch-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.2.0-0`
## rgbd_launch

```
* [feat] Depth registered filtered #26 <https://github.com/ros-drivers/rgbd_launch/issues/26>
* [sys] Update config to using industrial_ci with Prerelease Test. #24 <https://github.com/ros-drivers/rgbd_launch/issues/24>
* Contributors: Jonathan Bohren, Isaac I.Y. Saito
```
