### PR TITLE
Add python-skimage-pip entry to 'rosdep/python.yaml'

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1983,15 +1983,22 @@ python-six:
     xenial: [python-six]
     xenial: [python-six]
 python-skimage:
+  debian: [python-skimage]
+  fedora: [python-scikit-image]
+  osx:
+    pip:
+      packages: [scikit-image]
+  ubuntu:
+    trusty: [python-skimage]
+    wily: [python-skimage]
+    xenial: [python-skimage]
+python-skimage-pip:
   osx:
     pip:
       packages: [scikit-image]
   ubuntu:
     pip:
       packages: [scikit-image]
-python-skimage-apt:
-  ubuntu:
-    trusty: [python-skimage]
 python-sklearn:
   fedora: [python-scikit-learn]
   osx:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1989,6 +1989,9 @@ python-skimage:
   ubuntu:
     pip:
       packages: [scikit-image]
+python-skimage-apt:
+  ubuntu:
+    trusty: [python-skimage]
 python-sklearn:
   fedora: [python-scikit-learn]
   osx:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2014,12 +2014,8 @@ python-skimage:
       pip:
         packages: [scikit-image]
     trusty: [python-skimage]
-    utopic:
-      pip:
-        packages: [scikit-image]
-    vivid:
-      pip:
-        packages: [scikit-image]
+    utopic: [python-skimage]
+    vivid: [python-skimage]
     wily: [python-skimage]
     xenial: [python-skimage]
 python-skimage-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2014,6 +2014,12 @@ python-skimage:
       pip:
         packages: [scikit-image]
     trusty: [python-skimage]
+    utopic:
+      pip:
+        packages: [scikit-image]
+    vivid:
+      pip:
+        packages: [scikit-image]
     wily: [python-skimage]
     xenial: [python-skimage]
 python-skimage-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2004,15 +2004,9 @@ python-skimage:
     precise:
       pip:
         packages: [scikit-image]
-    quantal:
-      pip:
-        packages: [scikit-image]
-    raring:
-      pip:
-        packages: [scikit-image]
-    saucy:
-      pip:
-        packages: [scikit-image]
+    quantal: [python-skimage]
+    raring: [python-skimage]
+    saucy: [python-skimage]
     trusty: [python-skimage]
     utopic: [python-skimage]
     vivid: [python-skimage]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1989,6 +1989,30 @@ python-skimage:
     pip:
       packages: [scikit-image]
   ubuntu:
+    lucid:
+      pip:
+        packages: [scikit-image]
+    maverick:
+      pip:
+        packages: [scikit-image]
+    natty:
+      pip:
+        packages: [scikit-image]
+    oneiric:
+      pip:
+        packages: [scikit-image]
+    precise:
+      pip:
+        packages: [scikit-image]
+    quantal:
+      pip:
+        packages: [scikit-image]
+    raring:
+      pip:
+        packages: [scikit-image]
+    saucy:
+      pip:
+        packages: [scikit-image]
     trusty: [python-skimage]
     wily: [python-skimage]
     xenial: [python-skimage]


### PR DESCRIPTION
There is already pip: [scikit-image] entry for ubuntu.
So maybe it is better to remain the current installation target.
