### PR TITLE
openni_launch: 1.9.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6822,7 +6822,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/openni_launch-release.git
-      version: 1.9.7-0
+      version: 1.9.8-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_launch` to `1.9.8-0`:
- upstream repository: https://github.com/ros-drivers/openni_launch.git
- release repository: https://github.com/ros-gbp/openni_launch-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.9.7-0`
## openni_launch

```
* [feat] adding depth_registered_filtered injection #26 <https://github.com/ros-drivers/openni_launch/issues/26>
* [sys][Travis CI] Update config to using industrial_ci with Prerelease Test. #28 <https://github.com/ros-drivers/openni_launch/issues/28>
* Contributors: Jonathan Bohren, Isaac I.Y. Saito
```
