### PR TITLE
rgbd_launch: 2.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1772,6 +1772,21 @@ repositories:
       type: git
       url: https://github.com/ros/resource_retriever.git
       version: kinetic-devel
+  rgbd_launch:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/rgbd_launch.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/rgbd_launch-release.git
+      version: 2.2.1-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/rgbd_launch.git
+      version: jade-devel
+    status: maintained
   robot_localization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rgbd_launch` to `2.2.1-0`:
- upstream repository: https://github.com/ros-drivers/rgbd_launch.git
- release repository: https://github.com/ros-gbp/rgbd_launch-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rgbd_launch

```
* [feat] Depth registered filtered #26 <https://github.com/ros-drivers/rgbd_launch/issues/26>
* [sys] Update config to using industrial_ci with Prerelease Test. #24 <https://github.com/ros-drivers/rgbd_launch/issues/24>
* Contributors: Jonathan Bohren, Isaac I.Y. Saito
```
