### PR TITLE
openni_launch: 1.9.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1539,6 +1539,21 @@ repositories:
       url: https://github.com/ros-drivers/openni_camera.git
       version: indigo-devel
     status: maintained
+  openni_launch:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni_launch.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/openni_launch-release.git
+      version: 1.9.8-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni_launch.git
+      version: indigo-devel
+    status: maintained
   openrtm_aist:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_launch` to `1.9.8-0`:
- upstream repository: https://github.com/ros-drivers/openni_launch.git
- release repository: https://github.com/ros-gbp/openni_launch-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## openni_launch

```
* [feat] adding depth_registered_filtered injection #26 <https://github.com/ros-drivers/openni_launch/issues/26>
* [sys][Travis CI] Update config to using industrial_ci with Prerelease Test. #28 <https://github.com/ros-drivers/openni_launch/issues/28>
* Contributors: Jonathan Bohren, Isaac I.Y. Saito
```
