### PR TITLE
Add OSX pip packages for python-dateutil, requests, and responses

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1717,6 +1717,9 @@ python-requests:
     xenial: [python-requests]
     xenial_python3: [python3-requests]
 python-responses-pip:
+  osx:
+    pip:
+      packages: [responses]
   ubuntu:
     pip:
       packages: [responses]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -477,6 +477,9 @@ python-cwiid:
   ubuntu: [python-cwiid]
 python-dateutil:
   fedora: [python-dateutil]
+  osx:
+    pip:
+      packages: [python-dateutil]
   ubuntu:
     lucid: [python-dateutil]
     maverick: [python-dateutil]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1700,6 +1700,9 @@ python-redis-pip:
 python-requests:
   debian: [python-requests]
   fedora: [python-requests]
+  osx:
+    pip:
+      packages: [requests]
   ubuntu:
     lucid: [python-requests]
     maverick: [python-requests]


### PR DESCRIPTION
| Key | URL |
| --- | --- |
| `python-dateutil` | https://pypi.python.org/pypi/python-dateutil |
| `python-requests` | https://pypi.python.org/pypi/requests |
| `python-responses-pip` | https://pypi.python.org/pypi/responses |
