### PR TITLE
catkin_pure_python: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1040,7 +1040,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/catkin_pure_python-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pure_python.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pure_python` to `0.0.7-0`:
- upstream repository: https://github.com/asmodehn/catkin_pure_python.git
- release repository: https://github.com/asmodehn/catkin_pure_python-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.6-0`
## catkin_pure_python

```
* removing --ignore-installed for editable package, to allow requirements to satisfy setup.py dependencies.
* changing package to format v2
* Contributors: alexv
```
