### PR TITLE
fetch_ros: 0.7.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2495,7 +2495,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
-      version: 0.7.4-0
+      version: 0.7.5-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.7.5-0`:
- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.7.4-0`
## fetch_calibration
- No changes
## fetch_depth_layer

```
* Fixed activate and deactivate to avoid errors
* Parameterizing inputs for ObservationBuffer to match parent layers.
* Contributors: Aaron Hoy, Alex Henning, Michael Ferguson
```
## fetch_description
- No changes
## fetch_maps
- No changes
## fetch_moveit_config
- No changes
## fetch_navigation
- No changes
## fetch_teleop

```
* Control gripper via keyboard
* Contributors: Kentaro Wada
```
