### PR TITLE
nerian_sp1: 1.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1309,6 +1309,21 @@ repositories:
       url: https://github.com/ros-gbp/navigation_msgs-release.git
       version: 1.13.0-0
     status: maintained
+  nerian_sp1:
+    doc:
+      type: git
+      url: https://github.com/nerian-vision/nerian_sp1.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/nerian-vision/nerian_sp1-release.git
+      version: 1.3.2-0
+    source:
+      type: git
+      url: https://github.com/nerian-vision/nerian_sp1.git
+      version: master
+    status: developed
   nodelet_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_sp1` to `1.3.2-0`:
- upstream repository: https://github.com/nerian-vision/nerian_sp1.git
- release repository: https://github.com/nerian-vision/nerian_sp1-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## nerian_sp1

```
* Build fix for ROS kinetic
* Contributors: Konstantin Schauwecker
```
