### PR TITLE
pyros_setup: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7880,11 +7880,19 @@ repositories:
       version: master
     status: maintained
   pyros_setup:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/pyros-setup.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/asmodehn/pyros-setup-release.git
-      version: 0.0.8-0
+      url: https://github.com/asmodehn/pyros-setup-rosrelease.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/asmodehn/pyros-setup.git
+      version: master
     status: developed
   pyros_test:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_setup` to `0.1.0-0`:
- upstream repository: https://github.com/asmodehn/pyros-setup.git
- release repository: https://github.com/asmodehn/pyros-setup-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.8-0`
## pyros_setup

```
* adding missing config package to setup.py
* ros package still depending on catkin afterall
* modifying ros utils script to improve debug for python and pip behavior
* helping debug of rosutils scripts
* rosutils scripts changing to build directory before doing anything else
* now using package v2 format
* fixing rosutils scripts.
* adding package version
* mention shadowrobot buildtools in readme.
* attempting matrix build.
* fixing virtualenvwrapper setup script path on ubuntu.
  removed debian_frontend already setup on travis trusty image.
* fixing virtualenvwrapper setup.
* force yes for python virtualenv install.
* adding shell script to isolate ros setup during travis test.
  improved travis build to test usage from both python venv and ROS.
* now running python test (in venvs) from travis.
* set next version number. cosmetics.
* added a default config file to be used by client programs for default ros configuration.
  now using importlib instead of custom import_string()
  separated packagebound, confighandler, and config import classes
  simplified setup
  fixed tests
* master is now default branch. fixing travis badge url.
* fiddling around with configuration to make it usable from pyros.
* first version after refactor to handle config file. good enough for self tests to use it.
* fixes for latest catkin_pure_python.
  readme improvements
* improving readme
* cleanup doc and comments.
* now depending on catkin_pure_python.
* working pip install requirements in catkin workspace
* added simple method to get ros_home.
* first verison of cmake creating a venv to store packages.
* added comments...
* fixing pip install command
* trying to install pip requirements ni devel space. notworking yet
* comments
* broken cmake stub for catkin-pip
* setting cmake as buildtool
* improved error message when ROs setup fails
* first experiment with using a virtualenv in devel workspace.
* fixed logic for ros_package_path when not a devel workspace.
  cosmetics.
* Contributors: AlexV, alexv
```
