### PR TITLE
squirrel_common: 0.0.18-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 141: http://ros.org/reps/rep-0141.html
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   fedora:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -10789,6 +10789,30 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/sql_database-release.git
       version: 0.4.9-0
+  squirrel_common:
+    release:
+      packages:
+      - robotino_msgs
+      - squirrel_3d_mapping_msgs
+      - squirrel_common
+      - squirrel_hri_msgs
+      - squirrel_kclhand_msgs
+      - squirrel_localizer_msgs
+      - squirrel_manipulation_msgs
+      - squirrel_mhand_msgs
+      - squirrel_navigation_msgs
+      - squirrel_object_perception_msgs
+      - squirrel_person_tracker_msgs
+      - squirrel_planning_knowledge_msgs
+      - squirrel_prediction_msgs
+      - squirrel_rgbd_mapping_msgs
+      - squirrel_sketch_interface_msgs
+      - squirrel_speech_msgs
+      - squirrel_waypoint_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/squirrel-project/squirrel_common-release.git
+      version: 0.0.18-0
   sr_config:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `squirrel_common` to `0.0.18-0`:
- upstream repository: https://github.com/squirrel-project/squirrel_common.git
- release repository: https://github.com/squirrel-project/squirrel_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## robotino_msgs
- No changes
## squirrel_3d_mapping_msgs
- No changes
## squirrel_common
- No changes
## squirrel_hri_msgs
- No changes
## squirrel_kclhand_msgs
- No changes
## squirrel_localizer_msgs
- No changes
## squirrel_manipulation_msgs
- No changes
## squirrel_mhand_msgs
- No changes
## squirrel_navigation_msgs
- No changes
## squirrel_object_perception_msgs
- No changes
## squirrel_person_tracker_msgs

```
* add skeleton msgs
* Contributors: Peter Regier
```
## squirrel_planning_knowledge_msgs
- No changes
## squirrel_prediction_msgs
- No changes
## squirrel_rgbd_mapping_msgs
- No changes
## squirrel_sketch_interface_msgs
- No changes
## squirrel_speech_msgs
- No changes
## squirrel_waypoint_msgs
- No changes
