### PR TITLE
micros_swarm_framework: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5372,6 +5372,21 @@ repositories:
       url: https://github.com/sukha-cn/micros_rtt.git
       version: master
     status: developed
+  micros_swarm_framework:
+    doc:
+      type: git
+      url: https://github.com/xuefengchang/micros_swarm_framework-release.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/xuefengchang/micros_swarm_framework-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/xuefengchang/micros_swarm_framework-release.git
+      version: master
+    status: developed
   microstrain_3dmgx2_imu:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `micros_swarm_framework` to `0.0.2-0`:
- upstream repository: https://github.com/xuefengchang/micros_swarm_framework.git
- release repository: https://github.com/xuefengchang/micros_swarm_framework-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## micros_swarm_framework

```
* version 1.0
* Contributors: xuefengchang
```
