### PR TITLE
Revert "pyros_setup: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7880,19 +7880,11 @@ repositories:
       version: master
     status: maintained
   pyros_setup:
-    doc:
-      type: git
-      url: https://github.com/asmodehn/pyros-setup.git
-      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/asmodehn/pyros-setup-rosrelease.git
-      version: 0.1.0-0
-    source:
-      type: git
-      url: https://github.com/asmodehn/pyros-setup.git
-      version: master
+      url: https://github.com/asmodehn/pyros-setup-release.git
+      version: 0.0.8-0
     status: developed
   pyros_test:
     doc:


### PR DESCRIPTION
pyros_setup 0.1.0 not building on jenkins yet.
https://github.com/asmodehn/pyros-setup/issues/21
Reverting for now.
