### PR TITLE
grid_map: 1.3.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1296,7 +1296,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ethz-asl/grid_map-release.git
-      version: 1.3.0-0
+      version: 1.3.1-0
     source:
       type: git
       url: https://github.com/ethz-asl/grid_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `1.3.1-0`:
- upstream repository: https://github.com/ethz-asl/grid_map.git
- release repository: https://github.com/ethz-asl/grid_map-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.3.0-0`
## grid_map
- No changes
## grid_map_core

```
* Cleanup up Eigen types as preparation for ROS Kinetic release.
* Contributors: Peter Fankhauser
```
## grid_map_cv
- No changes
## grid_map_demos

```
* Updated grid map loader demo.
* Contributors: Peter Fankhauser
```
## grid_map_filters
- No changes
## grid_map_loader
- No changes
## grid_map_msgs
- No changes
## grid_map_ros
- No changes
## grid_map_visualization
- No changes
