### PR TITLE
grid_map: 1.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -862,6 +862,31 @@ repositories:
       url: https://github.com/ros-visualization/gl_dependency.git
       version: kinetic-devel
     status: maintained
+  grid_map:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/grid_map.git
+      version: master
+    release:
+      packages:
+      - grid_map
+      - grid_map_core
+      - grid_map_cv
+      - grid_map_demos
+      - grid_map_filters
+      - grid_map_loader
+      - grid_map_msgs
+      - grid_map_ros
+      - grid_map_visualization
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ethz-asl/grid_map-release.git
+      version: 1.3.1-0
+    source:
+      type: git
+      url: https://github.com/ethz-asl/grid_map.git
+      version: master
+    status: developed
   humanoid_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `1.3.1-0`:
- upstream repository: https://github.com/ethz-asl/grid_map.git
- release repository: https://github.com/ethz-asl/grid_map-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## grid_map
- No changes
## grid_map_core

```
* Cleanup up Eigen types as preparation for ROS Kinetic release.
* Contributors: Peter Fankhauser
```
## grid_map_cv
- No changes
## grid_map_demos

```
* Updated grid map loader demo.
* Contributors: Peter Fankhauser
```
## grid_map_filters
- No changes
## grid_map_loader
- No changes
## grid_map_msgs
- No changes
## grid_map_ros
- No changes
## grid_map_visualization
- No changes
