### PR TITLE
ur_modern_driver: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11719,6 +11719,17 @@ repositories:
       type: git
       url: https://github.com/uos/uos_tools.git
       version: indigo
+  ur_modern_driver:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/ur_modern_driver-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/TheDash/ur_modern_driver.git
+      version: indigo-devel
+    status: maintained
   urdf_tutorial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_modern_driver` to `0.0.3-0`:
- upstream repository: https://github.com/TheDash/ur_modern_driver
- release repository: https://github.com/clearpath-gbp/ur_modern_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
