### PR TITLE
grid_map: 1.3.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -881,7 +881,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ethz-asl/grid_map-release.git
-      version: 1.3.1-0
+      version: 1.3.3-0
     source:
       type: git
       url: https://github.com/ethz-asl/grid_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `1.3.3-0`:
- upstream repository: https://github.com/ethz-asl/grid_map.git
- release repository: https://github.com/ethz-asl/grid_map-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.3.1-0`
## grid_map

```
* Release for ROS Kinetic.
* Contributors: Peter Fankhauser
```
## grid_map_core

```
* Release for ROS Kinetic.
* Contributors: Peter Fankhauser
```
## grid_map_cv

```
* Release for ROS Kinetic.
* Contributors: Peter Fankhauser
```
## grid_map_demos

```
* Release for ROS Kinetic.
* Contributors: Peter Fankhauser
```
## grid_map_filters

```
* Release for ROS Kinetic.
* Contributors: Peter Fankhauser
```
## grid_map_loader

```
* Release for ROS Kinetic.
* Contributors: Peter Fankhauser
```
## grid_map_msgs

```
* Release for ROS Kinetic.
* Contributors: Peter Fankhauser
```
## grid_map_ros

```
* Release for ROS Kinetic.
* Contributors: Peter Fankhauser
```
## grid_map_visualization

```
* Release for ROS Kinetic.
* Contributors: Peter Fankhauser
```
