### PR TITLE
Revert "rplidar_ros: 1.5.2-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9781,8 +9781,7 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/rplidar_ros-release.git
-      version: 1.5.2-0
+      url: https://github.com/robopeak/rplidar_ros-release.git
     source:
       type: git
       url: https://github.com/robopeak/rplidar_ros.git


### PR DESCRIPTION
Reverts ros/rosdistro#11469

This is failing to build sourcedebs: http://build.ros.org:8080/view/Queue/job/Isrc_uS__rplidar_ros__ubuntu_saucy__source/
