### PR TITLE
rocon_tools: 0.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1924,6 +1924,36 @@ repositories:
       url: https://github.com/robotics-in-concert/rocon_msgs.git
       version: kinetic
     status: developed
+  rocon_tools:
+    doc:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_tools.git
+      version: kinetic
+    release:
+      packages:
+      - rocon_bubble_icons
+      - rocon_console
+      - rocon_ebnf
+      - rocon_icons
+      - rocon_interactions
+      - rocon_launch
+      - rocon_master_info
+      - rocon_python_comms
+      - rocon_python_redis
+      - rocon_python_utils
+      - rocon_python_wifi
+      - rocon_semantic_version
+      - rocon_tools
+      - rocon_uri
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/rocon_tools-release.git
+      version: 0.3.2-0
+    source:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_tools.git
+      version: kinetic
+    status: developed
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_tools` to `0.3.2-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_tools.git
- release repository: https://github.com/yujinrobot-release/rocon_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rocon_interactions

```
* test case for global executable with args
* longer looping between warning messages when checking for the rapp list
```
## rocon_python_comms

```
* master check via the rosparam server bugfix
* allow named services in batching functions
* drop pyros_test
```
