### PR TITLE
rplidar_ros: 1.5.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9781,7 +9781,8 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/robopeak/rplidar_ros-release.git
+      url: https://github.com/ros-gbp/rplidar_ros-release.git
+      version: 1.5.2-1
     source:
       type: git
       url: https://github.com/robopeak/rplidar_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `1.5.2-1`:
- upstream repository: https://github.com/robopeak/rplidar_ros.git
- release repository: https://github.com/ros-gbp/rplidar_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rplidar_ros

```
* Release 1.5.2.
* Update RPLIDAR SDK to 1.5.2
* Support RPLIDAR A2
* Contributors: kint
```
