### PR TITLE
m_explore: 1.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2174,6 +2174,18 @@ repositories:
       type: git
       url: https://github.com/hrnr/m-explore.git
       version: master
+    release:
+      packages:
+      - explore_lite
+      - multirobot_map_merge
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/hrnr/m-explore-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/hrnr/m-explore.git
+      version: master
     status: developed
   maggie_devices_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `m_explore` to `1.0.0-0`:
- upstream repository: https://github.com/hrnr/m-explore.git
- release repository: https://github.com/hrnr/m-explore-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
