### PR TITLE
rplidar_ros: 1.5.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7610,8 +7610,8 @@ repositories:
     release:
       tags:
         release: release/hydro/{package}/{version}
-      url: https://github.com/robopeak/rplidar_ros-release.git
-      version: 1.0.1-0
+      url: https://github.com/kintzhao/rplidar_ros-release.git
+      version: 1.5.2-0
     source:
       type: git
       url: https://github.com/robopeak/rplidar_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `1.5.2-0`:
- upstream repository: https://github.com/robopeak/rplidar_ros.git
- release repository: https://github.com/kintzhao/rplidar_ros-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.1-0`
## rplidar_ros

```
* Release 1.5.2.
* Update RPLIDAR SDK to 1.5.2
* Support RPLIDAR A2
* Contributors: kint
```
