### PR TITLE
Add rosdep definition for libmysqlcppconn-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1865,6 +1865,16 @@ libmysqlclient-dev:
   macports: [mysql5]
   opensuse: [libmysqlclient-devel]
   ubuntu: [libmysqlclient-dev]
+libmysqlcppconn-dev:
+  arch:
+    aur: [mysql-connector-c++]
+  debian: [libmysqlcppconn-dev]
+  fedora: [libmysqlcppconn-devel]
+  gentoo:
+    portage:
+      packages: [dev-db/mysql-connector-c++]
+  opensuse: [libmysqlcppconn-devel]
+  ubuntu: [libmysqlcppconn-dev]
 libncurses-dev:
   arch: [ncurses]
   debian: [libncurses5-dev]


### PR DESCRIPTION
MySQL Connector/C++ is a MySQL database connector for C++ mimicking the JDBC 4.0 API.
