### PR TITLE
variant: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8902,6 +8902,26 @@ repositories:
       url: https://github.com/ros/ros.git
       version: indigo-devel
     status: maintained
+  ros-variant:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/ros-variant.git
+      version: master
+    release:
+      packages:
+      - variant
+      - variant_msgs
+      - variant_topic_test
+      - variant_topic_tools
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ethz-asl/ros-variant-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/ethz-asl/ros-variant.git
+      version: master
+    status: developed
   rosR:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8902,26 +8902,6 @@ repositories:
       url: https://github.com/ros/ros.git
       version: indigo-devel
     status: maintained
-  variant:
-    doc:
-      type: git
-      url: https://github.com/ethz-asl/variant.git
-      version: master
-    release:
-      packages:
-      - variant
-      - variant_msgs
-      - variant_topic_test
-      - variant_topic_tools
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ethz-asl/variant-release.git
-      version: 0.1.1-0
-    source:
-      type: git
-      url: https://github.com/ethz-asl/variant.git
-      version: master
-    status: developed
   rosR:
     doc:
       type: git
@@ -11868,6 +11848,26 @@ repositories:
       url: https://github.com/uji-ros-pkg/uwsim_osgworks-release.git
       version: 3.0.3-1
     status: maintained
+  variant:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/variant.git
+      version: master
+    release:
+      packages:
+      - variant
+      - variant_msgs
+      - variant_topic_test
+      - variant_topic_tools
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ethz-asl/variant-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/ethz-asl/variant.git
+      version: master
+    status: developed
   velodyne:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8902,10 +8902,10 @@ repositories:
       url: https://github.com/ros/ros.git
       version: indigo-devel
     status: maintained
-  ros-variant:
+  variant:
     doc:
       type: git
-      url: https://github.com/ethz-asl/ros-variant.git
+      url: https://github.com/ethz-asl/variant.git
       version: master
     release:
       packages:
@@ -8915,11 +8915,11 @@ repositories:
       - variant_topic_tools
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ethz-asl/ros-variant-release.git
+      url: https://github.com/ethz-asl/variant-release.git
       version: 0.1.1-0
     source:
       type: git
-      url: https://github.com/ethz-asl/ros-variant.git
+      url: https://github.com/ethz-asl/variant.git
       version: master
     status: developed
   rosR:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros-variant` to `0.1.1-0`:
- upstream repository: https://github.com/ethz-asl/ros-variant.git
- release repository: https://github.com/ethz-asl/ros-variant-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## variant
- No changes
## variant_msgs

```
* Message variant tests successful
* Refined traits, code cleanups
* 

    * Created test package
    * Moved test binaries to test package

* Contributors: Ralf Kaestner
```
## variant_topic_test

```
* Fixes related to OS X clang compatibility
* Added message data type member access by name
* 

    * Added type name resolution for member definitions neglecting package names
    * Added receipt time to variant subscriber callback

* 

    * Code cleanups
    * Added variant publisher and subscriber
    * Added MD5 sum calculation for variant message types
    * Updated README

* Added convenience serialization methods to message class
* Added method for serializer creation to variants
* Basic serializer testing
* Added numeric value access for built-in types
* Message variant tests successful
* Message data type now separates constant and variable members
* Refined traits, code cleanups
* Removed SharedVariant and friend-relationship between Variant and CollectionVariant
* Renamed some classes, code cleanups
* 

    * Created test package
    * Moved test binaries to test package

* Contributors: Ralf Kaestner
```
## variant_topic_tools

```
* Fixes related to OS X clang compatibility
* Fixed some issues of subscriber
* Fixed bug in MessageDefinition::setMessageType() which was caused by a wrong order of defining the required message types of a message type
* Added message data type member access by name
* 

    * Added type name resolution for member definitions neglecting package names
    * Added receipt time to variant subscriber callback

* 

    * Code cleanups
    * Added variant publisher and subscriber
    * Added MD5 sum calculation for variant message types
    * Updated README

* Added convenience serialization methods to message class
* Added method for serializer creation to variants
* Basic serializer testing
* Added numeric value access for built-in types
* Message variant tests successful
* Message data type now separates constant and variable members
* Reverted templated variant value to represent actual value type
* Refined traits, code cleanups
* Removed SharedVariant and friend-relationship between Variant and CollectionVariant
* Renamed some classes, code cleanups
* 

    * Created test package
    * Moved test binaries to test package

* Contributors: Ralf Kaestner
```
