### PR TITLE
marti_common: 0.0.10-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5132,9 +5132,12 @@ repositories:
       - swri_geometry_util
       - swri_image_util
       - swri_math_util
+      - swri_nodelet
       - swri_opencv_util
       - swri_prefix_tools
       - swri_roscpp
+      - swri_rospy
+      - swri_route_util
       - swri_serial_util
       - swri_string_util
       - swri_system_util
@@ -5143,7 +5146,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 0.0.9-1
+      version: 0.0.10-3
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.0.10-3`:
- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.9-1`
## marti_data_structures
- No changes
## swri_console_util
- No changes
## swri_geometry_util

```
* Fixed compile error when ros-indigo-opencv3 is installed (#307 <https://github.com/evenator/marti_common/issues/307>)
  * Fixed compile error when package ros-indigo-opencv3 is installed.
  swri_geometry_util uses wrong version of OpenCV when the package
  ros-indigo-opencv3 is installed. This patch fixes the issue.
  * Updated all CMakeFiles.txt to specify OpenCV version 2
  The find_package for OpenCV is now:
  ./swri_opencv_util/CMakeLists.txt:find_package(OpenCV 2 REQUIRED)
  ./swri_geometry_util/CMakeLists.txt:find_package(OpenCV 2 REQUIRED)
  ./swri_image_util/CMakeLists.txt:find_package(OpenCV 2)
  ./swri_transform_util/CMakeLists.txt:find_package(OpenCV 2 REQUIRED)
* Contributors: Kim Mathiassen
```
## swri_image_util

```
* Update contrast stretch nodelet to automatically scale image mask to correct size.
* Fixed compile error when ros-indigo-opencv3 is installed (#307 <https://github.com/evenator/marti_common/issues/307>)
  * Fixed compile error when package ros-indigo-opencv3 is installed.
  swri_geometry_util uses wrong version of OpenCV when the package
  ros-indigo-opencv3 is installed. This patch fixes the issue.
  * Updated all CMakeFiles.txt to specify OpenCV version 2
  The find_package for OpenCV is now:
  ./swri_opencv_util/CMakeLists.txt:find_package(OpenCV 2 REQUIRED)
  ./swri_geometry_util/CMakeLists.txt:find_package(OpenCV 2 REQUIRED)
  ./swri_image_util/CMakeLists.txt:find_package(OpenCV 2)
  ./swri_transform_util/CMakeLists.txt:find_package(OpenCV 2 REQUIRED)
* Contributors: Kim Mathiassen, Marc Alban
```
## swri_math_util
- No changes
## swri_nodelet

```
* Update version numbers for new packages.
* Version 0.0.10 changelogs.
* Add swri_nodelet package.
  This package simplifies launch files that can easily change between
  running nodelets in a shared manager or as standalone processes.
* Contributors: Edward Venator, Elliot Johnson
* Add swri_nodelet package.
  This package simplifies launch files that can easily change between
  running nodelets in a shared manager or as standalone processes.
* Contributors: Elliot Johnson
```
## swri_opencv_util

```
* Fixed compile error when ros-indigo-opencv3 is installed (#307 <https://github.com/evenator/marti_common/issues/307>)
  * Fixed compile error when package ros-indigo-opencv3 is installed.
  swri_geometry_util uses wrong version of OpenCV when the package
  ros-indigo-opencv3 is installed. This patch fixes the issue.
  * Updated all CMakeFiles.txt to specify OpenCV version 2
  The find_package for OpenCV is now:
  ./swri_opencv_util/CMakeLists.txt:find_package(OpenCV 2 REQUIRED)
  ./swri_geometry_util/CMakeLists.txt:find_package(OpenCV 2 REQUIRED)
  ./swri_image_util/CMakeLists.txt:find_package(OpenCV 2)
  ./swri_transform_util/CMakeLists.txt:find_package(OpenCV 2 REQUIRED)
* Contributors: Kim Mathiassen
```
## swri_prefix_tools

```
* Adds missing dependency for swri_prefix_tools
* Contributors: Edward Venator
```
## swri_roscpp

```
* Deprecate LatchedSubscriber.
  This commit adds an alternative to LatchedSubscriber and deprecates
  the LatchedSubscriber interface.  LatchedSubscriber should be replaced
  with a swri::Subscriber that is initialized with the address of a
  location to store messages.  For example, instead of:
  swri::LatchedSubscriber<my_package::MyMessage> msg_;
  ...
  msg_.initialize(nh_, "topic_name");
  ...
  ROS_INFO("msg->field = %f", msg->field);
  this becomes:
  swri::Subscriber sub_;
  my_package::MyMessageConstPtr msg_;
  ...
  sub_ = swri::SubscribeR(nh_, "topic_name", &msg_);
  ...
  ROS_INFO("msg->field = %f", msg->field).
  This change makes for a simpler and more consistent interface, and
  avoids the confusion that comes from overloading the -> operator.
* Add timeoutParam() method to swri::Subscriber.
  This commit adds a new convenience method, timeoutParam, to
  swri::Subscriber that reads a specified parameter directly from the
  parameter server and sets it as the subscriber's timeout value.  This
  is to simplify setup code that currently has to define a temporary
  variable, read the parameter in the temp, and then set the timeout.
* Contributors: Elliot Johnson
```
## swri_rospy

```
* Adds swri_rospy subclasses for Subscriber, Service, and Timer
  These classes are drop-in replacements for their rospy counterparts,
  except that their constructor has an additional parameter
  asynchronous, which defaults to False. If asynchronous is false, the
  callback is wrapped with the single_threaded decorator. (This means
  that all of these classes use the single-thread callback queue by
  default.)
  Also, swri_rospy.spin is now injected into the rospy namespace to
  override rospy.spin. This is done to prevent users from accidentally
  using rospy.spin, which does not process the callback queue.
* Adds deadlock protection to single_threaded decorator.
  Decorating a function with single_threaded more than once would cause the
  callback queue to deadlock. This prevents recursive decoration.
* Adds exception handling to single_threaded decorator.
* Makes single_threaded decorator work for arbitrary ags
* Adds service_wrapper decorator.
  Also fixes line endings.
* Updates swri_rospy single_threaded example.
  Also fixes line-endings.
* Creates a new package swri_rospy.
  swri_rospy adds a new callback-based subscription, timer, and service
  capability to rospy.
* Contributors: Ed Venator, Edward Venator
* Adds swri_rospy subclasses for Subscriber, Service, and Timer
  These classes are drop-in replacements for their rospy counterparts,
  except that their constructor has an additional parameter
  asynchronous, which defaults to False. If asynchronous is false, the
  callback is wrapped with the single_threaded decorator. (This means
  that all of these classes use the single-thread callback queue by
  default.)
  Also, swri_rospy.spin is now injected into the rospy namespace to
  override rospy.spin. This is done to prevent users from accidentally
  using rospy.spin, which does not process the callback queue.
* Adds deadlock protection to single_threaded decorator.
  Decorating a function with single_threaded more than once would cause the
  callback queue to deadlock. This prevents recursive decoration.
* Adds exception handling to single_threaded decorator.
* Makes single_threaded decorator work for arbitrary ags
* Adds service_wrapper decorator.
  Also fixes line endings.
* Updates swri_rospy single_threaded example.
  Also fixes line-endings.
* Creates a new package swri_rospy.
  swri_rospy adds a new callback-based subscription, timer, and service
  capability to rospy.
* Contributors: Ed Venator
```
## swri_route_util

```
* Fix distances in routeDistances for points before start point.
  There were two bugs in routeDistances that were causing the incorrect
  distance to be calculated for points before the start point.  An error
  in the iteration bounds was causing the distance of the first point to
  be 0.0.  Secondly, the arc length for the other points was just the
  relative distance between two points instead of the cummulative
  distance.
* Merge pull request #330 <https://github.com/evenator/marti_common/issues/330> from elliotjo/sru-add-distance-functions-indigo
  Add util functions to calculate distances between route points. (indigo)
* Remove commented out code in swri_route_util.
* Add util functions to calculate distances between route points.
  This commit adds two utility functions to calculate the distances (in
  terms of arc length) between route points.  One function calculates
  the distance between two points, the other calculates the distance
  between one point and many other points and should provide much better
  performance for that common need.
* Add native-ish ROS serialization support to sru::Route.
  This commit adds native(-ish) ROS serialization support so that
  swri_route_util::Route can be used directly with publishers and
  subscribers. This is purely for convenience rather than performance
  (although you will get improved performance in nodelets that
  publish/subscribe by avoiding serialization).  Under the hood, the
  implementation does serialization with the native type and then
  converts it to/from the swri_route_util::Route type.
  This commit also fixes a missing special case in
  interpolateRouteSegment (0 < distance < 1) and reorganized the if/else
  blocks to be clearer.
* Add swri_route_util package.
  This commit adds a new package called swri_route_util that provides a
  more user-friendly interface to the marti_nav_msgs Route and RoutPoint
  classes, and a set of useful utilities.  At this point, most of the
  code (except the properties) has been well tested on bag files.
* Contributors: Edward Venator, Elliot Johnson, Marc Alban
* Fix distances in routeDistances for points before start point.
  There were two bugs in routeDistances that were causing the incorrect
  distance to be calculated for points before the start point.  An error
  in the iteration bounds was causing the distance of the first point to
  be 0.0.  Secondly, the arc length for the other points was just the
  relative distance between two points instead of the cummulative
  distance.
* Merge pull request #330 <https://github.com/evenator/marti_common/issues/330> from elliotjo/sru-add-distance-functions-indigo
  Add util functions to calculate distances between route points. (indigo)
* Remove commented out code in swri_route_util.
* Add util functions to calculate distances between route points.
  This commit adds two utility functions to calculate the distances (in
  terms of arc length) between route points.  One function calculates
  the distance between two points, the other calculates the distance
  between one point and many other points and should provide much better
  performance for that common need.
* Add native-ish ROS serialization support to sru::Route.
  This commit adds native(-ish) ROS serialization support so that
  swri_route_util::Route can be used directly with publishers and
  subscribers. This is purely for convenience rather than performance
  (although you will get improved performance in nodelets that
  publish/subscribe by avoiding serialization).  Under the hood, the
  implementation does serialization with the native type and then
  converts it to/from the swri_route_util::Route type.
  This commit also fixes a missing special case in
  interpolateRouteSegment (0 < distance < 1) and reorganized the if/else
  blocks to be clearer.
* Add swri_route_util package.
  Adds a new package called swri_route_util that provides a
  more user-friendly interface to the marti_nav_msgs Route and RoutPoint
  classes, and a set of useful utilities.  At this point, most of the
  code (except the properties) has been well tested on bag files.
* Contributors: Elliot Johnson, Marc Alban
```
## swri_serial_util
- No changes
## swri_string_util
- No changes
## swri_system_util

```
* Add helper method to find files within a directory and subdirectories based on regular expression matching for the filename.
* Contributors: Marc Alban
```
## swri_transform_util

```
* Add great circle distance method for tf::Vector3 type.
* Fixed compile error when ros-indigo-opencv3 is installed (#307 <https://github.com/evenator/marti_common/issues/307>)
  * Fixed compile error when package ros-indigo-opencv3 is installed.
  swri_geometry_util uses wrong version of OpenCV when the package
  ros-indigo-opencv3 is installed. This patch fixes the issue.
  * Updated all CMakeFiles.txt to specify OpenCV version 2
  The find_package for OpenCV is now:
  ./swri_opencv_util/CMakeLists.txt:find_package(OpenCV 2 REQUIRED)
  ./swri_geometry_util/CMakeLists.txt:find_package(OpenCV 2 REQUIRED)
  ./swri_image_util/CMakeLists.txt:find_package(OpenCV 2)
  ./swri_transform_util/CMakeLists.txt:find_package(OpenCV 2 REQUIRED)
* Contributors: Kim Mathiassen, Marc Alban
```
## swri_yaml_util

```
* Add support to load YAML from string and dictionary.
* Fix linking with yaml-cpp.
* Contributors: Elliot Johnson, Marc Alban
```
