### PR TITLE
rplidar_ros: 1.5.2-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4814,7 +4814,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/kintzhao/rplidar_ros-release.git
-      version: 1.5.2-0
+      version: 1.5.2-1
     source:
       type: git
       url: https://github.com/robopeak/rplidar_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `1.5.2-1`:
- upstream repository: https://github.com/robopeak/rplidar_ros.git
- release repository: https://github.com/kintzhao/rplidar_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.5.2-0`
## rplidar_ros

```
* Release 1.5.2.
* Update RPLIDAR SDK to 1.5.2
* Support RPLIDAR A2
* Contributors: kint
```
