### PR TITLE
fzi_icl_can: 1.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2677,7 +2677,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can-release.git
-      version: 1.0.8-0
+      version: 1.0.9-0
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fzi_icl_can` to `1.0.9-0`:
- upstream repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.8-0`
## fzi_icl_can

```
* reset the project name after including the IcMaker
* Contributors: Felix Mauch
```
