### PR TITLE
marti_common: 0.0.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5146,7 +5146,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 0.0.10-3
+      version: 0.0.11-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.0.11-0`:
- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.10-3`
## marti_data_structures
- No changes
## swri_console_util
- No changes
## swri_geometry_util

```
* Adds explicit dependency on pkg-config
* Contributors: P. J. Reed
```
## swri_image_util

```
* Adds explicit dependency on pkg-config
* Contributors: P. J. Reed
```
## swri_math_util
- No changes
## swri_nodelet
- No changes
## swri_opencv_util
- No changes
## swri_prefix_tools
- No changes
## swri_roscpp
- No changes
## swri_rospy
- No changes
## swri_route_util
- No changes
## swri_serial_util
- No changes
## swri_string_util
- No changes
## swri_system_util
- No changes
## swri_transform_util
- No changes
## swri_yaml_util

```
* Adding an explicit dependency on pkg-config
* Contributors: P. J. Reed
```
