### PR TITLE
ueye_cam: 1.0.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11597,7 +11597,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/anqixu/ueye_cam-release.git
-      version: 1.0.12-0
+      version: 1.0.13-0
     source:
       type: git
       url: https://github.com/anqixu/ueye_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `1.0.13-0`:
- upstream repository: https://github.com/anqixu/ueye_cam.git
- release repository: https://github.com/anqixu/ueye_cam-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.12-0`
## ueye_cam

```
* Change timestamp source based on issue https://github.com/anqixu/ueye_cam/issues/37
* changed 'failure to set active-low flash' from error to warning
* Fixed typo in Gain for dynamic reconfigure parameters
* Updated pixel_clock cap in dyncfg settings
* Added check_ueye_api to confirm availability of IDS SDK at runtime
* Contributors: Anqi Xu, Anup, Aris Synodinos, Kei Okada
```
