### PR TITLE
rtabmap and rtabmap_ros: 0.11.5-0 in 'jade/distribution.yaml'

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4946,7 +4946,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.10.10-4
+      version: 0.11.5-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -4961,7 +4961,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.10.10-1
+      version: 0.11.5-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repositories `rtabmap` and `rtabmap_ros` to `0.11.5-0`:
- upstream repository: https://github.com/introlab/rtabmap[_ros].git
- release repository: https://github.com/introlab/rtabmap[_ros]-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.10.10-1` and `0.10.10-2`
