### PR TITLE
object_recognition_ros_visualization: 0.3.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6484,7 +6484,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_ros_visualization-release.git
-      version: 0.3.8-0
+      version: 0.3.9-0
     source:
       type: git
       url: https://github.com/wg-perception/object_recognition_ros_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_ros_visualization` to `0.3.9-0`:
- upstream repository: https://github.com/wg-perception/object_recognition_ros_visualization.git
- release repository: https://github.com/ros-gbp/object_recognition_ros_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.8-0`
## object_recognition_ros_visualization

```
* fix compilation with Qt4
  This fixes https://github.com/wg-perception/object_recognition_core/issues/39
* only enable Qt5 for Kinetic
  This fixes #5 <https://github.com/wg-perception/object_recognition_ros_visualization/issues/5>
* Contributors: Vincent Rabaud
```
