### PR TITLE
navigation: 1.12.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6177,7 +6177,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.12.7-0
+      version: 1.12.8-0
     source:
       type: git
       url: https://github.com/ros-planning/navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.12.8-0`:
- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.12.7-0`
## amcl

```
* Allow AMCL to run from bag file to allow very fast testing.
* Fixes interpretation of a delayed initialpose message
* Contributors: Derek King, Michael Ferguson, Stephan Wirth
```
## base_local_planner
- No changes
## carrot_planner
- No changes
## clear_costmap_recovery
- No changes
## costmap_2d

```
* fix resource locations to fix tests
* Fix bug with resetting static layer
* Made update map threadsafe
* Reordered initializer list to match order of declarations.
* Parametrize movementCB timer's period
* No more ghosts in the inflation layer
* Contributors: Alex Henning, Daniel Stonier, Michael Ferguson, Spyros Maniatopoulos
```
## dwa_local_planner
- No changes
## fake_localization
- No changes
## global_planner
- No changes
## map_server

```
* Corrections to alpha channel detection and usage.
* Removing some trailing whitespace.
* Use enum to control map interpretation
* Contributors: Aaron Hoy, David Lu
```
## move_base
- No changes
## move_base_msgs
- No changes
## move_slow_and_clear
- No changes
## nav_core
- No changes
## navfn
- No changes
## navigation
- No changes
## robot_pose_ekf
- No changes
## rotate_recovery
- No changes
## voxel_grid
- No changes
