### PR TITLE
rqt_robot_plugins: 0.5.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2331,7 +2331,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-      version: 0.5.2-1
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins` to `0.5.3-0`:
- upstream repository: https://github.com/ros-visualization/rqt_robot_plugins.git
- release repository: https://github.com/ros-gbp/rqt_robot_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.5.2-1`
## rqt_moveit
- No changes
## rqt_nav_view

```
* fix mouse wheel delta in Qt 5 (#105 <https://github.com/ros-visualization/rqt_robot_plugins/pull/105>)
```
## rqt_pose_view

```
* fix mouse wheel delta in Qt 5 (#105 <https://github.com/ros-visualization/rqt_robot_plugins/pull/105>)
```
## rqt_robot_dashboard
- No changes
## rqt_robot_monitor
- No changes
## rqt_robot_plugins
- No changes
## rqt_robot_steering
- No changes
## rqt_runtime_monitor

```
* fix Qt5 compatibility (#104 <https://github.com/ros-visualization/rqt_robot_plugins/pull/104>)
```
## rqt_rviz
- No changes
## rqt_tf_tree
- No changes
