### PR TITLE
rqt_common_plugins: 0.4.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2305,7 +2305,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.4.0-1
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `0.4.1-0`:
- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/ros-gbp/rqt_common_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.4.0-1`
## rqt_action
- No changes
## rqt_bag

```
* fix mouse wheel delta in Qt 5 (#376 <https://github.com/ros-visualization/rqt_common_plugins/issues/376>)
```
## rqt_bag_plugins
- No changes
## rqt_common_plugins
- No changes
## rqt_console
- No changes
## rqt_dep
- No changes
## rqt_graph

```
* fix mouse wheel delta in Qt 5 (#376 <https://github.com/ros-visualization/rqt_common_plugins/issues/376>)
```
## rqt_image_view

```
* add the possibility to publish mouse events (#368 <https://github.com/ros-visualization/rqt_common_plugins/issues/368>)
```
## rqt_launch
- No changes
## rqt_logger_level
- No changes
## rqt_msg
- No changes
## rqt_plot

```
* fix mouse wheel delta in Qt 5 (#376 <https://github.com/ros-visualization/rqt_common_plugins/issues/376>)
```
## rqt_publisher
- No changes
## rqt_py_common
- No changes
## rqt_py_console
- No changes
## rqt_reconfigure

```
* fix accessing attribute superseded in Qt5 (#370 <https://github.com/ros-visualization/rqt_common_plugins/issues/370>)
```
## rqt_service_caller
- No changes
## rqt_shell
- No changes
## rqt_srv
- No changes
## rqt_top
- No changes
## rqt_topic
- No changes
## rqt_web
- No changes
