### PR TITLE
rtmros_hironx: 1.1.13-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10057,7 +10057,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.12-0
+      version: 1.1.13-1
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.13-1`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.1.12-0`
## hironx_calibration
- No changes
## hironx_moveit_config

```
* [sys] Add test for eef geometry.
* Contributors: Isaac I.Y. Saito
```
## hironx_ros_bridge

```
* [fix] Correct collada file location for real robot.
* [sys] Add better test for ros_client
* Contributors: Kei Okada, Isaac I.Y. Saito
```
## rtmros_hironx

```
* [fix] Correct collada file location for real robot.
* [sys] Add better test for ros_client
  * Contributors: Kei Okada, Isaac I.Y. Saito
```
