### PR TITLE
rtmros_nextage: 0.7.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10079,7 +10079,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.7.6-0
+      version: 0.7.7-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.7.7-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.7.6-0`
## nextage_description
- No changes
## nextage_gazebo
- No changes
## nextage_ik_plugin
- No changes
## nextage_moveit_config
- No changes
## nextage_ros_bridge

```
* [fix] Wrong collada file location for real.launch.
* [fix] Use NXO file instead of Hironx as a collision detector input.
* Contributors: Isaac I.Y. Saito
```
## rtmros_nextage

```
* [fix] Wrong collada file location for real.launch.
* [fix] Use NXO file instead of Hironx as a collision detector input.
* Contributors: Isaac I.Y. Saito
```
