### PR TITLE
schunk_canopen_driver: 1.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10339,7 +10339,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver-release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_canopen_driver` to `1.0.6-0`:
- upstream repository: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.5-0`
## schunk_canopen_driver

```
* made xacro usage conform to current standards from jade and kinetic
* implement prepareSwitch instead of canSwitch
* fix: do not start boost thread explicitly
* Contributors: Felix Mauch
```
