### PR TITLE
add libopenni2-dev for jessie also in stretch

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1990,6 +1990,7 @@ libopenni-sensor-primesense-dev:
   ubuntu: [libopenni-sensor-primesense-dev]
 libopenni2-dev:
   arch: [openni2]
+  debian: [libopenni2-dev]
   fedora: [openni-devel]
   ubuntu: [libopenni2-dev]
 libopenscenegraph:


### PR DESCRIPTION
Referencing new openni packages backported on jessie: https://github.com/ros-infrastructure/reprepro-updater/commit/63237cd1b5639a51980ce1244a304b74c4220737

https://packages.debian.org/source/stretch/openni2
