### PR TITLE
grasp-synergy: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2979,6 +2979,15 @@ repositories:
       url: https://github.com/davetcoleman/graph_msgs.git
       version: indigo-devel
     status: maintained
+  grasp-synergy:
+    release:
+      packages:
+      - grasp_synergy
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/felixduvallet/grasp-synergy-release.git
+      version: 0.0.1-0
+    status: developed
   grasping_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grasp-synergy` to `0.0.1-0`:
- upstream repository: https://github.com/felixduvallet/grasp-synergy.git
- release repository: https://github.com/felixduvallet/grasp-synergy-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
