### PR TITLE
schunk_canopen_driver: 1.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2428,6 +2428,21 @@ repositories:
       url: https://github.com/ros-visualization/rviz.git
       version: kinetic-devel
     status: maintained
+  schunk_canopen_driver:
+    doc:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver-release.git
+      version: 1.0.6-0
+    source:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver.git
+      version: master
+    status: maintained
   serial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_canopen_driver` to `1.0.6-0`:
- upstream repository: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## schunk_canopen_driver

```
* made xacro usage conform to current standards from jade and kinetic
* implement prepareSwitch instead of canSwitch
* fix: do not start boost thread explicitly
* Contributors: Felix Mauch
```
