### PR TITLE
fzi_icl_core: 1.0.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1022,6 +1022,21 @@ repositories:
       url: https://github.com/freefloating-gazebo/freefloating_gazebo.git
       version: jade-devel
     status: maintained
+  fzi_icl_core:
+    doc:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core-release.git
+      version: 1.0.4-0
+    source:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core.git
+      version: master
+    status: maintained
   gazebo_ros_pkgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fzi_icl_core` to `1.0.4-0`:
- upstream repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core
- release repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## fzi_icl_core

```
* use cmake as buildtool_depend and install package.xml
* Add catkin as run_depend
* Contributors: Felix Mauch
```
