### PR TITLE
grasp-synergy: 0.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2990,7 +2990,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/felixduvallet/grasp-synergy-release.git
-      version: 0.0.1-0
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/felixduvallet/grasp-synergy-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grasp-synergy` to `0.0.1-1`:
- upstream repository: https://github.com/felixduvallet/grasp-synergy.git
- release repository: https://github.com/felixduvallet/grasp-synergy-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.1-0`
