### PR TITLE
gennodejs: 1.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -756,7 +756,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RethinkRobotics-release/gennodejs-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/RethinkRobotics-opensource/gennodejs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gennodejs` to `1.0.2-0`:
- upstream repository: https://github.com/RethinkRobotics-opensource/gennodejs.git
- release repository: https://github.com/RethinkRobotics-release/gennodejs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.1-0`
## gennodejs

```
* Fixed gennodejs file deployment in install space
* Fixed a python3 incompatibility in generate.py
* Contributors: Chris Smith, Ian McMahon, Maarten de Vries
```
