### PR TITLE
moveit_core: 0.8.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2491,7 +2491,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/moveit_core-release.git
-      version: 0.6.15-0
+      version: 0.8.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_core` to `0.8.0-0`:
- upstream repository: https://github.com/ros-planning/moveit_core.git
- release repository: https://github.com/ros-gbp/moveit_core-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.15-0`
## moveit_core

```
* [feat] Added file and trajectory_msg to RobotState conversion functions #267 <https://github.com/ros-planning/moveit_core/issues/267>
* [feat] Added setJointVelocity and setJointEffort functions #261 <https://github.com/ros-planning/moveit_core/issues/261>
* [feat] KinematicsBase changes #248 <https://github.com/ros-planning/moveit_core/issues/248>
* [feat] added an ik_seed_state argument to the new getPositionIK(...) method
* [feat] added new interface method for computing multiple ik solutions for a single pose
* [fix] RevoluteJointModel::computeVariablePositions #282 <https://github.com/ros-planning/moveit_core/issues/282>
* [fix] getStateAtDurationFromStart would never execute as the check for number of waypoints was inverted #289 <https://github.com/ros-planning/moveit_core/issues/289>
* [fix] Revert "Use libfcl-dev rosdep key in kinetic" #287 <https://github.com/ros-planning/moveit_core/issues/287>
* [fix] memory leak in RobotState::attachBody #276 <https://github.com/ros-planning/moveit_core/issues/276>. Fixing #275 <https://github.com/ros-planning/moveit_core/issues/275>
* [fix] New getOnlyOneEndEffectorTip() function #262 <https://github.com/ros-planning/moveit_core/issues/262>
* [fix] issue #258 <https://github.com/ros-planning/moveit_core/issues/258> in jade-devel #266 <https://github.com/ros-planning/moveit_core/issues/266>
* [fix] Segfault in parenthesis operator #254 <https://github.com/ros-planning/moveit_core/issues/254>
* [fix] API Change of shape_tools #242 <https://github.com/ros-planning/moveit_core/issues/242>
* [fix] Fixed bug in KinematicConstraintSet::decide that makes it evaluate only joint_constraints. #250 <https://github.com/ros-planning/moveit_core/issues/250>
* [fix] Prevent divide by zero #246 <https://github.com/ros-planning/moveit_core/issues/246>
* [fix] removed the 'f' float specifiers and corrected misspelled method name
* [fix] typo MULTIPLE_TIPS_NO_SUPPORTED -> MULTIPLE_TIPS_NOT_SUPPORTED
* [sys] Upgrade to Eigen3 as required in Jade #293 <https://github.com/ros-planning/moveit_core/issues/293>
* [sys] [cmake] Tell the compiler about FCL include dirs #263 <https://github.com/ros-planning/moveit_core/issues/263>
* [sys] Install static libs #251 <https://github.com/ros-planning/moveit_core/issues/251>
* [enhance] Allow a RobotTrajectory to be initialized with a pointer joint model group #245 <https://github.com/ros-planning/moveit_core/issues/245>
* [doc] Better documentation and formatting #244 <https://github.com/ros-planning/moveit_core/issues/244>
* Contributors: Alexis Ballier, Bastian Gaspers, Christian Dornhege, Dave Coleman, Gary Servin, Ioan A Sucan, Isaac I.Y. Saito, Jim Mainprice, Levi Armstrong, Michael Ferguson, Mihai Pomarlan, Robert Haschke, Sachin Chitta, Sam Pfeiffer, Steven Peters, Séverin Lemaignan, jrgnicho, ros-devel, simonschmeisser
```
