### PR TITLE
gennodejs: 1.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -756,7 +756,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RethinkRobotics-release/gennodejs-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/RethinkRobotics-opensource/gennodejs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gennodejs` to `1.0.3-0`:
- upstream repository: https://github.com/RethinkRobotics-opensource/gennodejs.git
- release repository: https://github.com/RethinkRobotics-release/gennodejs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.2-0`
## gennodejs

```
* Removed extraneous base file installs
* Revert install space fix that re-used base js files per package
* Added install space fix that copies base js files per package
* Contributors: Ian McMahon, Rob Linsalata
```
