### PR TITLE
fzi_icl_can: 1.0.9-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1022,6 +1022,21 @@ repositories:
       url: https://github.com/freefloating-gazebo/freefloating_gazebo.git
       version: jade-devel
     status: maintained
+  fzi_icl_can:
+    doc:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can-release.git
+      version: 1.0.9-0
+    source:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can.git
+      version: master
+    status: maintained
   fzi_icl_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fzi_icl_can` to `1.0.9-0`:
- upstream repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## fzi_icl_can

```
* reset the project name after including the IcMaker
* Contributors: Felix Mauch
```
