### PR TITLE
rtmros_hironx: 1.1.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10074,7 +10074,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.13-1
+      version: 1.1.14-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.14-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.1.13-1`
## hironx_calibration
- No changes
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* [fix] remove duplicate functions, put them in upstream
* [enhance][hironx.py] easier default model file location when operating the real robot.
* Contributors: Kei Okada, Isaac I.Y. Saito
```
## rtmros_hironx

```
* [fix] remove duplicate functions, put them in upstream
* [enhance][hironx.py] easier default model file location when operating the real robot.
* Contributors: Kei Okada, Isaac I.Y. Saito
```
