### PR TITLE
schunk_canopen_driver: 1.0.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5190,6 +5190,21 @@ repositories:
       url: https://github.com/ccny-ros-pkg/scan_tools.git
       version: indigo
     status: maintained
+  schunk_canopen_driver:
+    doc:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver-release.git
+      version: 1.0.6-0
+    source:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver.git
+      version: master
+    status: maintained
   schunk_grippers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_canopen_driver` to `1.0.6-0`:
- upstream repository: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/schunk_canopen_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## schunk_canopen_driver

```
* made xacro usage conform to current standards from jade and kinetic
* implement prepareSwitch instead of canSwitch
* fix: do not start boost thread explicitly
* Contributors: Felix Mauch
```
