### PR TITLE
jsk_visualization: 1.0.31-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4334,7 +4334,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.30-0
+      version: 1.0.31-0
     status: developed
   jskeus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.31-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.30-0`
## jsk_interactive
- No changes
## jsk_interactive_marker
- No changes
## jsk_interactive_test
- No changes
## jsk_rqt_plugins

```
* Warn about unsupported topic type
* Check class type of data instead of subscribed topic type in rqt_histgram_plot to support HistgramWithRangeArray
* Contributors: Kentaro Wada, Iori Kumagai
```
## jsk_rviz_plugins

```
* Stop passing -z flag to ld with Clang
* Contributors: Kentaro Wada
```
## jsk_visualization
- No changes
