### PR TITLE
naoqi_libqicore: 2.3.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1353,6 +1353,13 @@ repositories:
       url: https://github.com/ros-naoqi/libqi-release.git
       version: 2.5.0-2
     status: maintained
+  naoqi_libqicore:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-naoqi/libqicore-release.git
+      version: 2.3.1-1
+    status: maintained
   navigation:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqicore` to `2.3.1-1`:
- upstream repository: https://github.com/aldebaran/libqicore.git
- release repository: https://github.com/ros-naoqi/libqicore-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
