### PR TITLE
naoqi_bridge_msgs: 0.0.5-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1346,6 +1346,13 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: kinetic-devel
     status: maintained
+  naoqi_bridge_msgs:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-naoqi/naoqi_bridge_msgs-release.git
+      version: 0.0.5-2
+    status: maintained
   naoqi_libqi:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge_msgs` to `0.0.5-2`:
- upstream repository: https://github.com/ros-naoqi/naoqi_bridge_msgs.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## naoqi_bridge_msgs

```
* add orthogonal / tangential security distance service files
* change constants with capital letters
* increase touched hand directions and move it in msg folder correctly
* add back bumper value for Pepper
* Contributors: Kanae Kochigami, Vincent Rabaud
```
