### PR TITLE
vision_visp: 0.9.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2739,7 +2739,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.9.1-0
+      version: 0.9.2-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.9.2-0`:
- upstream repository: https://github.com/lagadic/vision_visp.git
- release repository: https://github.com/lagadic/vision_visp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.9.1-0`
