### PR TITLE
naoqi_bridge_msgs: 0.0.5-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1351,7 +1351,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_bridge_msgs-release.git
-      version: 0.0.5-2
+      version: 0.0.5-3
     status: maintained
   naoqi_libqi:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge_msgs` to `0.0.5-3`:
- upstream repository: https://github.com/ros-naoqi/naoqi_bridge_msgs.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.5-2`
## naoqi_bridge_msgs

```
* add orthogonal / tangential security distance service files
* change constants with capital letters
* increase touched hand directions and move it in msg folder correctly
* add back bumper value for Pepper
* Contributors: Kanae Kochigami, Vincent Rabaud
```
