### PR TITLE
naoqi_driver: 0.5.8-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1353,6 +1353,13 @@ repositories:
       url: https://github.com/ros-naoqi/naoqi_bridge_msgs-release.git
       version: 0.0.5-3
     status: maintained
+  naoqi_driver:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-naoqi/naoqi_driver-release.git
+      version: 0.5.8-1
+    status: maintained
   naoqi_libqi:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_driver` to `0.5.8-1`:
- upstream repository: https://github.com/ros-naoqi/alrosbridge.git
- release repository: https://github.com/ros-naoqi/naoqi_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## naoqi_driver

```
* Update maintainership
* Fix broken compilation with libqi-2.5 (#67 <https://github.com/ros-naoqi/naoqi_driver/issues/67>)
  -std=gnu++11 is not mandatory as this flag will be added when importing libqi
  (https://github.com/ros-naoqi/libqi-release/commit/c26f57e25326c9d3447ae7113818a474994e5544).
  naoqi_driver should now work with libqi2.3 and 2.5
* Contributors: Surya Ambrose
```
