### PR TITLE
vision_visp: 0.9.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2746,7 +2746,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.9.2-0
+      version: 0.9.3-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.9.3-0`:
- upstream repository: https://github.com/lagadic/vision_visp.git
- release repository: https://github.com/lagadic/vision_visp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.9.2-0`
## vision_visp

```
* kinetic-0.9.2
* jade-0.9.1
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_auto_tracker

```
* Fix CMAKE_CXX_FLAGS as separated list
* kinetic-0.9.2
* Contributors: Fabien Spindler
```
## visp_bridge

```
* kinetic-0.9.2
* Cleanify code
* jade-0.9.1
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_camera_calibration

```
* kinetic-0.9.2
* Cleanify code
* jade-0.9.1
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_hand2eye_calibration

```
* kinetic-0.9.2
* Cleanify code
* jade-0.9.1
* Prepare changelogs
* Contributors: Fabien Spindler
```
## visp_tracker

```
* kinetic-0.9.2
* Cleanify code
* jade-0.9.1
* Prepare changelogs
* Contributors: Fabien Spindler
```
