### PR TITLE
variant: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11882,7 +11882,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-asl/variant-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/ethz-asl/variant.git


### PR DESCRIPTION
Increasing version of package(s) in repository `variant` to `0.1.3-0`:
- upstream repository: https://github.com/ethz-asl/variant.git
- release repository: https://github.com/ethz-asl/variant-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.2-0`
## variant
- No changes
## variant_msgs
- No changes
## variant_topic_test

```
* fix missing file extension
* Contributors: Samuel Bachmann
```
## variant_topic_tools

```
* add executables to install
* add install commands
* Contributors: Samuel Bachmann
```
