### PR TITLE
mavros: 0.17.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5241,7 +5241,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.17.2-0
+      version: 0.17.3-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.17.3-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.17.2-0`
## libmavconn

```
* libmavconn #543 <https://github.com/mavlink/mavros/issues/543>: support build with mavlink 2.0 capable mavgen
* Contributors: Vladimir Ermakov
```
## mavros

```
* libmavconn #543 <https://github.com/mavlink/mavros/issues/543>: support build with mavlink 2.0 capable mavgen
* node: Remove warning about MAVLINK_VERSION redefine
* Fix bug with orientation in setpoint_raw plugin
  Fixes a bug where the ned_desired_orientation was not actually passed into set_attitude_target. Instead, the desired_orientation (wrong frame) was passed.
* Contributors: Justin Thomas, Vladimir Ermakov
```
## mavros_extras
- No changes
## mavros_msgs
- No changes
## test_mavros

```
* test #546 <https://github.com/mavlink/mavros/issues/546>: Added check of control_toolbox version (1.14.0)
  In Kinetic control_toolbox changed API of Pid::initPid().
* Contributors: Vladimir Ermakov
```
