### PR TITLE
teb_local_planner: 0.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11081,7 +11081,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner` to `0.4.1-0`:
- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.4.0-0`
## teb_local_planner

```
* Wrong parameter namespace for *costmap_converter* plugins fixed
* Compiler warnings fixed
* Workaround for compilation issues that are caused by a bug in boost 1.58
  concerning the graph library (missing move constructor/assignment operator
  in boost source).
* Using *tf*-listener from *move_base* instead of an isolated one
* Via-point support improved
```
