### PR TITLE
naoqi_libqi: 2.5.0-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1365,7 +1365,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-naoqi/libqi-release.git
-      version: 2.5.0-2
+      version: 2.5.0-3
     status: maintained
   naoqi_libqicore:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqi` to `2.5.0-3`:
- upstream repository: https://github.com/aldebaran/libqi.git
- release repository: https://github.com/ros-naoqi/libqi-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.5.0-2`
