### PR TITLE
robot_state_publisher: 1.12.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4196,7 +4196,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/robot_state_publisher-release.git
-      version: 1.12.1-0
+      version: 1.12.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `1.12.2-0`:
- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros-gbp/robot_state_publisher-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.12.1-0`
## robot_state_publisher

```
* Add back future dating for robot_state_publisher (#49 <https://github.com/ros/robot_state_publisher/issues/49>)
* Restore default argument of tf_static
* Contributors: Jackie Kay
```
