### PR TITLE
robot_state_publisher: 1.13.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1954,7 +1954,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/robot_state_publisher-release.git
-      version: 1.13.0-0
+      version: 1.13.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `1.13.1-0`:
- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros-gbp/robot_state_publisher-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.13.0-0`
## robot_state_publisher

```
* Add back future dating for robot_state_publisher (#49 <https://github.com/ros/robot_state_publisher/issues/49>) (#51 <https://github.com/ros/robot_state_publisher/issues/51>)
* Fix subclassing test (#48 <https://github.com/ros/robot_state_publisher/issues/48>)
* Support for subclassing (#45 <https://github.com/ros/robot_state_publisher/issues/45>)
  * Add joint_state_listener as a library
* Contributors: Jackie Kay
```
