### PR TITLE
marti_messages: 0.0.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2311,7 +2311,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_messages-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `0.0.4-0`:
- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.3-0`
## marti_can_msgs
- No changes
## marti_common_msgs

```
* Adding KeyValueArray message.
  This message is meant to be useful when you just need to publish a
  list of KeyValue pairs directly instead of including a list in another
  message.
* Contributors: Elliot Johnson
```
## marti_nav_msgs

```
* Build PlanRoute service.
* Add marti_nav_msgs/RouteSpeedArray message.
* Adding a service for planning routes
  Resolves #61 <https://github.com/swri-robotics/marti_messages/issues/61>
* Adding a service to set the currently active route
* Add services for getting routes.
* Add service definition for saving a recorded route.
* Contributors: Elliot Johnson, Marc Alban, P. J. Reed
```
## marti_perception_msgs
- No changes
## marti_sensor_msgs
- No changes
## marti_visualization_msgs
- No changes
