### PR TITLE
mapviz: 0.1.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2258,7 +2258,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `0.1.3-0`:
- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.2-0`
## mapviz

```
* Implement mapviz plug-in for calling the marti_nav_msgs::PlanRoute service.
* Adding an explicit dependency on pkg-config to package.xml (#355 <https://github.com/swri-robotics/mapviz/issues/355>)
* Add _gencpp dependency to mapviz targets.
  This commit adds the _gencpp target to mapviz targets to ensure that
  the AddMapvizDisplay service is built before the targets.
* Make compiler flags specific to each target.
* Implement service for adding and modifying mapviz displays.
* Fix for #339 <https://github.com/swri-robotics/mapviz/issues/339>; explicitly depending on OpenCV 2
* Fix for #336 <https://github.com/swri-robotics/mapviz/issues/336>; Qt event handler exceptions shouldn't crash Mapviz
* Fixing blending for GL drawing
  The call to QGLWidget::beginNativePainting has a side effect of clearing
  GL settings related to blending and depth testing, and that was causing
  alpha transparency to not work right for plugins.  I fixed it by manually
  re-enabling those settings every time beginNativePainting is called.
* Fix for #319 <https://github.com/swri-robotics/mapviz/issues/319>
  Previously, the MapCanvas::MapGlCoordToFixedFrame function relied on
  the transform_ member variable being set, but it is not set if the
  target frame is <none>.  Instead it will now use the qtransform_
  variable, which is always initialized for the purpose of QPainters.
* Saving & restoring all matrices and attribs
* Moving QPainter drawing back to being after GL
  I had switched the order while debugging things and forgot to set it
  back to the way it originally was.
* Removing a leftover debug print
* Fixing #317 <https://github.com/swri-robotics/mapviz/issues/317>
  First, the model view matrix needs to be saved and restored around
  QPainter operations because Qt clears several GL variables.  Also, the
  image plugin needed to explicitly call glMatrixMode(GL_PROJECTION);
  it does a few operations on the projection matrix and was just assuming
  that was the current matrix mode.  Also, I added a function that plugins
  need to override if they want to do QPainter operations; this will
  eliminate unnecessary overhead for plugins that do not.
* Removing extraneous calls to MapCanvas::update()
  Now that update() is being called automatically at a rate of 50 Hz,
  the explicit calls in many locations are unnecessary.  It was also
  possible for it to be called in some of these locations from a
  non-main thread, which is invalid and could cause crashes.
* Adding the ability to toggle anti-aliasing
  Now there's a checkbox under the "View" menu that will toggle whether
  anti-aliasing is applied to the canvas.  In some situations this will
  make the display look much prettier at a slight performance cost.
* Cleaning up documentation.
* Merging QPainter/anti-aliasing fixes into jade-devel
  This is the same as the old version of this change, except updated
  to the most recent version of Mapviz.
* Fixing a compile error
* Fix for #298 <https://github.com/swri-robotics/mapviz/issues/298>; right-click + drag will now zoom
* Update map canvas at a fixed rate.
  This update adds a timer to the map canvas to repaint at a fixed rate.
  The default rate is 50 Hz, but there is a method to change it (not
  exposed to the UI at the moment).  50Hz was chosen because it is fast
  enough to give smooth animations and we almost always are running
  mapviz with at least one plugin triggering updates from a 50Hz topic.
* Update mapviz.launch file to also launch anonymously.
* Initialize mapviz as an anonymous node.
* This commit adds a class called SelectFrameDialog that plugins can use
  to present the user with a dialog to choose a TF frame. The dialog
  sorts the frames by name and provides an edit box that the user can
  use to filter the frames to a specific substring.
* Fixing an issue that could cause the click publisher plugin's publisher to not be initialized after it's first added.
* Adding a plugin that, when a user clicks on a point, will publish that point's coordinates to a topic.
* Adding color button widget and updating plugins.
  This commit adds a subclass of QPushButton called ColorButton that
  implements a widget for displaying and selecting colors.  We've been
  doing this manually everywhere with duplicated code.  This is a simple
  abstraction but allows us to elminate a lot of duplication, especially
  in plugins that have multiple color selections.
* Remove debugging messages from SelectFrameDialog.
  These were accidentally left in during initial development.
* Add documentation for the SelectTopicDialog.
* Adds SelecTopicDialog to mapviz.
  This commit adds the SelectTopicDialog that can be used in plugins to
  provide the user with a dialog to select topics.  Typically we have
  done this with a lot of duplicated code across all the plugins.  This
  commit also updates the plugins in mapviz_plugins to use the new
  dialog.
  The new dialog provides several benefits:
  - Reduced code duplication
  - Simplifies writing new plugins
  - Common behavior between all plugins
  - Topics sorted by name
  - User can filter topics by substring
  - Continuously checks the master for new topics while the dialog is open.
* Contributors: Elliot Johnson, Marc Alban, P. J. Reed
```
## mapviz_plugins

```
* Implement mapviz plug-in for calling the marti_nav_msgs::PlanRoute service.
* Migrate route plugin to use swri_route_util
  This change migrates the mapviz route plugin to use swri_route_util to
  get consistent behavior with route transforms and route position
  interpolation.  As part of this change, the route is now transformed
  with each draw so that it will correctly move around if the transform
  between the fixed frame and the route frame is not constant.
* Add support for mono8 textured markers.
* Implement service for adding and modifying mapviz displays.
* Adding attitude indicator plugin.
* Changing some "unsigned long"s to "size_t"s.
* Storing source frames individually for plugins w/ buffers
* Fix for #265 <https://github.com/swri-robotics/mapviz/issues/265>; message source frames don't update
  Several plugins were storing the source frames of messages received when
  they first received a message but never updating them, so subsequent
  messages in different frames would be rendered incorrectly.
* Fix for #339 <https://github.com/swri-robotics/mapviz/issues/339>; explicitly depending on OpenCV 2
* Fix route position search
  The route position search would ignore a matching point unless it is
  already transformed, which means that only points that have already been
  searched and missed would be transformed.
  The new logic looks first for the match, then transforms as necessary.
  Unmatched points are ignored.
* Guard against repeated transforms
  A point should only be transformed once, because the mapviz transforms
  are set outside the plugins; TransformPoint will now only transform
  un-transformed points.
* Remove unused variable
  prev_position_ is set, but never actually used.
* Adds route plugin with routeposition marker attachment.
* Also updating the disparity plugin
* Fixing #317 <https://github.com/swri-robotics/mapviz/issues/317>
  First, the model view matrix needs to be saved and restored around
  QPainter operations because Qt clears several GL variables.  Also, the
  image plugin needed to explicitly call glMatrixMode(GL_PROJECTION);
  it does a few operations on the projection matrix and was just assuming
  that was the current matrix mode.  Also, I added a function that plugins
  need to override if they want to do QPainter operations; this will
  eliminate unnecessary overhead for plugins that do not.
* Declaring types for Qt signal/slot use properly
* Fixing some typos
* Doing GL drawing on the main thread for #313 <https://github.com/swri-robotics/mapviz/issues/313>
* GPS plugin snuck back into CMakeLists.txt
* A plugin for displaying std_msgs/Strings
* Marker plugin will use a QPainter to draw text
  I modified the Marker plugin so that it will use a QPainter to draw
  text labels rather than OpenGL commands.  This doesn't really add any
  functional benefit; it's meant to serve as an example of how to use
  the QPainter.
* Fixing warnings and cleaning up formatting
* updated mapviz_plugins.xml
* add pointcloud2 plugin
* Update map canvas at a fixed rate.
  This update adds a timer to the map canvas to repaint at a fixed rate.
  The default rate is 50 Hz, but there is a method to change it (not
  exposed to the UI at the moment).  50Hz was chosen because it is fast
  enough to give smooth animations and we almost always are running
  mapviz with at least one plugin triggering updates from a 50Hz topic.
* Making the Image plugin use image_transport.
  The image_transport package provides support for transparently
  subscribing and publishing to topics using low-bandwidth compressed
  formats; if the publisher supports it, this will cause the Image
  plugin to consume far less bandwidth than before.
* Handle cases where marker topic changes message types.
  This commit makes a better effort to properly support cases where a
  marker topic changes between Marker and MarkerArray during runtime.
* Use ROS' shapeshifter to handle marker/marker arrays.
* This commit adds a class called SelectFrameDialog that plugins can use
  to present the user with a dialog to choose a TF frame. The dialog
  sorts the frames by name and provides an edit box that the user can
  use to filter the frames to a specific substring.
* Indigo compatibility.
  Fixing swri_transform_util and swri_yaml_util API changes from
  Hydro to Indigo.
* Also filtering out clicks that are held for too long.
* Adding a check to prevent the click event from firing if the user is dragging the mouse.
* Fixing an issue that could cause the click publisher plugin's publisher to not be initialized after it's first added.
* Removing some code I had added for debugging.
* Adding a plugin that, when a user clicks on a point, will publish that point's coordinates to a topic.
* Adding color button widget and updating plugins.
  This commit adds a subclass of QPushButton called ColorButton that
  implements a widget for displaying and selecting colors.  We've been
  doing this manually everywhere with duplicated code.  This is a simple
  abstraction but allows us to elminate a lot of duplication, especially
  in plugins that have multiple color selections.
* Adds SelectTopicDialog to mapviz.
  This commit adds the SelectTopicDialog that can be used in plugins to
  provide the user with a dialog to select topics.  Typically we have
  done this with a lot of duplicated code across all the plugins.  This
  commit also updates the plugins in mapviz_plugins to use the new
  dialog.
  The new dialog provides several benefits:
  - Reduced code duplication
  - Simplifies writing new plugins
  - Common behavior between all plugins
  - Topics sorted by name
  - User can filter topics by substring
  - Continuously checks the master for new topics while the dialog is open.
* Contributors: Elliot Johnson, Jerry Towler, Marc Alban, Nicholas Alton, P. J. Reed
```
## multires_image

```
* Implement service for adding and modifying mapviz displays.
* Fix for #339 <https://github.com/swri-robotics/mapviz/issues/339>; explicitly depending on OpenCV 2
* Contributors: Marc Alban, P. J. Reed
```
## tile_map

```
* Fix typo in tile map view size comparison.
* Contributors: Marc Alban
```
