### PR TITLE
naoqi_bridge: 0.5.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1350,6 +1350,19 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: kinetic-devel
     status: maintained
+  naoqi_bridge:
+    release:
+      packages:
+      - naoqi_apps
+      - naoqi_bridge
+      - naoqi_driver_py
+      - naoqi_pose
+      - naoqi_sensors_py
+      - naoqi_tools
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-naoqi/naoqi_bridge-release.git
+      version: 0.5.4-0
   naoqi_bridge_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge` to `0.5.4-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_bridge.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## naoqi_apps
- No changes
## naoqi_bridge
- No changes
## naoqi_driver_py

```
* Merge branch 'add_fake_effort' of https://github.com/k-okada/naoqi_bridge into k-okada-add_fake_effort
* Contributors: Vincent Rabaud
```
## naoqi_pose
- No changes
## naoqi_sensors_py

```
* remove the dependency on driver_base
* Contributors: Vincent Rabaud
```
## naoqi_tools
- No changes
