### PR TITLE
navigation: 1.14.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1379,6 +1379,33 @@ repositories:
       version: 2.3.1-1
     status: maintained
   navigation:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation.git
+      version: kinetic-devel
+    release:
+      packages:
+      - amcl
+      - base_local_planner
+      - carrot_planner
+      - clear_costmap_recovery
+      - costmap_2d
+      - dwa_local_planner
+      - fake_localization
+      - global_planner
+      - map_server
+      - move_base
+      - move_slow_and_clear
+      - nav_core
+      - navfn
+      - navigation
+      - robot_pose_ekf
+      - rotate_recovery
+      - voxel_grid
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/navigation-release.git
+      version: 1.14.0-0
     source:
       type: git
       url: https://github.com/ros-planning/navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.14.0-0`:
- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## amcl

```
* Allow AMCL to run from bag file to allow very fast testing.
* Fixes interpretation of a delayed initialpose message (see #424 <https://github.com/ros-planning/navigation/issues/424>).
  The tf lookup as it was before this change was very likely to fail as
  ros::Time::now() was used to look up a tf without waiting on the tf's
  availability. Additionally, the computation of the "new pose" by
  multiplying the delta that the robot moved from the initialpose's
  timestamp to ros::Time::now() was wrong. That delta has to by multiplied
  from the right to the "old pose".
  This commit also changes the reference frame to look up this delta to be
  the odom frame as this one is supposed to be smooth and therefore the
  best reference to get relative robot motion in the robot (base link) frame.
* New unit test for proper interpretation of a delayed initialpose message.
  Modifies the set_pose.py script to be able to send an initial pose with
  a user defined time stamp at a user defined time. Adds a rostest to
  exercise this new option.
  This reveals the issues mentioned in #424 <https://github.com/ros-planning/navigation/issues/424> (the new test fails).
* Contributors: Derek King, Stephan Wirth
```
## base_local_planner
- No changes
## carrot_planner
- No changes
## clear_costmap_recovery
- No changes
## costmap_2d

```
* Reordered initializer list to match order of declarations.
  This avoids compiler warning with some compilers.
* Made update map threadsafe
  This is necessary for some plugins (e.g. VoxelLayer) that implement a
  thread unsafe updateBounds() function.
* Fix bug with resetting static layer
  If we don't have a new topic, consider our old data as if it were new.
* fix resource locations to fix tests
* Increase time-limit on failing test
* Merge pull request #388 <https://github.com/ros-planning/navigation/issues/388> from yujinrobot/jade_inflation_ghost_fix
  No more ghosts in the inflation layer
* Fixes the dynamic reconfigure segfault
  Doing a dynamic reconfigure of the inflation radius recreates
  the cached cost values without first locking a mutex, which causes
  a segfault. This breaks the reconfigure of inflation parameters into
  a separate function and adds a mutex lock.
* Merge pull request #415 <https://github.com/ros-planning/navigation/issues/415> from alexhenning/jade-fix-multiple-static-layers
  Fixes an issue with having multiple static layers
* Fixes an issue with having multiple static layers
  If you have a static layer in both the local and global costmaps that
  use the same map topic, there is a race condition that can cause the
  static layer to get stuck after printing Requesting map..... This race
  condition seems to be due to the call to shutdown in deactivate and how
  the NodeHandle handles multiple subscribers under the hood.
  This issue appears to happen about 1 in 1000 times in the setup I was
  testing. This fix has never failed in over 1000000 tests. Instead of
  calling activate and deactivate, the publisher is only recreated if the
  topic has changed. Otherwise, it reuses the old setup.
* fix related to issue #408 <https://github.com/ros-planning/navigation/issues/408> - With Rolling Window on, costmap_2d not properly updating bounds and costs in the static layer
* No more ghosts in the inflation layer
  Previous bounds would fit the sensor measurements, and the inflation layer would clear
  out to these, but leave 'ghosts' behind. These ghosts are from two sources - 1) the
  inflation radius and 2) whole obstacles left behind as the robot has moved from the last point.
  The modifications here remember the last bounds and set the new bounds so that a box at least
  large enough to incorporate the old bounds plus the inflation radius is generated.
* Contributors: Alex Henning, Daniel Stonier, Levon Avagyan, Michael Ferguson, palmieri
```
## dwa_local_planner
- No changes
## fake_localization
- No changes
## global_planner
- No changes
## map_server

```
* Corrections to alpha channel detection and usage.
  Changing to actually detect whether the image has an alpha channel instead of
  inferring based on the number of channels.
  Also reverting to legacy behavior of trinary mode overriding alpha removal.
  This will cause the alpha channel to be averaged in with the others in trinary
  mode, which is the current behavior before this PR.
* Removing some trailing whitespace.
* Use enum to control map interpretation
* Contributors: Aaron Hoy, David Lu
```
## move_base
- No changes
## move_slow_and_clear
- No changes
## nav_core
- No changes
## navfn

```
* navfn: make independent on costmap implementation
  navfn::NavfnROS:
  * remove direct dependency on costmap_2d::Costmap2DROS
  * add constructor for barebone costmap_2d::Costmap2D (user must provide also global_frame)
  * NavfnROS::initialize() follows constructor semantics
  nav_core::BaseGlobalPlanner interface unchanged
* Contributors: Jiri Horner
```
## navigation
- No changes
## robot_pose_ekf

```
* add to install script/ directory
* add execute bit to scripts/wtf.py
* robot_pose_ekf/src/odom_estimation_node.cpp: add to print gps sensor and used/not used in getStatus
* Contributors: Kei Okada
```
## rotate_recovery
- No changes
## voxel_grid
- No changes
