### PR TITLE
add libqwt-qt5-dev for ubuntu xenial

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2346,6 +2346,9 @@ libqwt6:
     raring: [libqwt-dev]
     saucy: [libqwt-dev]
     trusty: [libqwt-dev]
+    utopic: [libqwt-dev]
+    vivid: [libqwt-dev]
+    wily: [libqwt-qt5-dev]
     xenial: [libqwt-qt5-dev]
 libqwtplot3d-qt4-dev:
   arch: [qwtplot3d]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2346,6 +2346,7 @@ libqwt6:
     raring: [libqwt-dev]
     saucy: [libqwt-dev]
     trusty: [libqwt-dev]
+    xenial: [libqwt-qt5-dev]
 libqwtplot3d-qt4-dev:
   arch: [qwtplot3d]
   debian:


### PR DESCRIPTION
Rqt in Kinetic is based on QT5, this means rqt plugins using QWT must use the QT5 version of `libqwt` which is `libqwt-qt5`. Otherwise, a `Segmentation fault (core dumped)` occurs at the start of the rqt plugin.

gdb output:

``` bash
Thread 1 "python" received signal SIGSEGV, Segmentation fault.
0x00007fffadb565a4 in ?? () from /usr/lib/x86_64-linux-gnu/libQtGui.so.4
```
