### PR TITLE
marti_messages: 0.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1226,6 +1226,28 @@ repositories:
       url: https://github.com/clearpathrobotics/lms1xx.git
       version: master
     status: maintained
+  marti_messages:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: indigo-devel
+    release:
+      packages:
+      - marti_can_msgs
+      - marti_common_msgs
+      - marti_nav_msgs
+      - marti_perception_msgs
+      - marti_sensor_msgs
+      - marti_visualization_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_messages-release.git
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: indigo-devel
+    status: developed
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `0.0.4-0`:
- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## marti_can_msgs
- No changes
## marti_common_msgs

```
* Adding KeyValueArray message.
  This message is meant to be useful when you just need to publish a
  list of KeyValue pairs directly instead of including a list in another
  message.
* Contributors: Elliot Johnson
```
## marti_nav_msgs

```
* Build PlanRoute service.
* Add marti_nav_msgs/RouteSpeedArray message.
* Adding a service for planning routes
  Resolves #61 <https://github.com/swri-robotics/marti_messages/issues/61>
* Adding a service to set the currently active route
* Add services for getting routes.
* Add service definition for saving a recorded route.
* Contributors: Elliot Johnson, Marc Alban, P. J. Reed
```
## marti_perception_msgs
- No changes
## marti_sensor_msgs
- No changes
## marti_visualization_msgs
- No changes
