### PR TITLE
libfreenect: 0.5.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1204,6 +1204,17 @@ repositories:
       url: https://github.com/ros-perception/laser_pipeline.git
       version: hydro-devel
     status: maintained
+  libfreenect:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/libfreenect.git
+      version: ros-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/libfreenect-ros-release.git
+      version: 0.5.1-0
+    status: maintained
   libg2o:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libfreenect` to `0.5.1-0`:
- upstream repository: https://github.com/ros-drivers/libfreenect.git
- release repository: https://github.com/ros-drivers-gbp/libfreenect-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
