### PR TITLE
romeo_robot: 0.1.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2092,6 +2092,26 @@ repositories:
       url: https://github.com/robotics-in-concert/rocon_tools.git
       version: kinetic
     status: developed
+  romeo_robot:
+    doc:
+      type: git
+      url: https://github.com/ros-aldebaran/romeo_robot.git
+      version: master
+    release:
+      packages:
+      - romeo_bringup
+      - romeo_description
+      - romeo_robot
+      - romeo_sensors_py
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-aldebaran/romeo_robot-release.git
+      version: 0.1.4-0
+    source:
+      type: git
+      url: https://github.com/ros-aldebaran/romeo_robot.git
+      version: master
+    status: maintained
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_robot` to `0.1.4-0`:
- upstream repository: https://github.com/ros-aldebaran/romeo_robot.git
- release repository: https://github.com/ros-aldebaran/romeo_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## romeo_bringup

```
* fixed packages.xml
* Contributors: Mikael Arguedas
```
## romeo_description

```
* fixed packages.xml
* Contributors: Mikael Arguedas
```
## romeo_robot

```
* added missing metapackage dependency
* Contributors: Mikael Arguedas
```
## romeo_sensors_py
- No changes
