### PR TITLE
nao_robot: 0.5.14-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1383,6 +1383,26 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: kinetic-devel
     status: maintained
+  nao_robot:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/nao_robot.git
+      version: master
+    release:
+      packages:
+      - nao_apps
+      - nao_bringup
+      - nao_description
+      - nao_robot
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-naoqi/nao_robot-release.git
+      version: 0.5.14-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/nao_robot.git
+      version: master
+    status: maintained
   naoqi_bridge:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_robot` to `0.5.14-0`:
- upstream repository: https://github.com/ros-naoqi/nao_robot.git
- release repository: https://github.com/ros-naoqi/nao_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## nao_apps
- No changes
## nao_bringup
- No changes
## nao_description

```
* removed nao_dcm namespace to match changes made to nao_control
* added gui:=true to match pepper_description display.launch
* Contributors: Mikael Arguedas
```
## nao_robot
- No changes
