### PR TITLE
nao_meshes: 0.1.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1383,6 +1383,21 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: kinetic-devel
     status: maintained
+  nao_meshes:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/nao_meshes.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-naoqi/nao_meshes-release.git
+      version: 0.1.11-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/nao_meshes.git
+      version: master
+    status: maintained
   naoqi_bridge:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_meshes` to `0.1.11-0`:
- upstream repository: https://github.com/ros-nao/nao_meshes.git
- release repository: https://github.com/ros-naoqi/nao_meshes-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## nao_meshes

```
* fixed folder path + added install rule for texture folder
* Update package.xml
  added myself as a maintainer as requested by vrabaud
* Contributors: Arguedas Mikael, Mikael Arguedas
```
