### PR TITLE
pepper_robot: 0.1.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1813,6 +1813,26 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: indigo-devel
     status: maintained
+  pepper_robot:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_robot.git
+      version: master
+    release:
+      packages:
+      - pepper_bringup
+      - pepper_description
+      - pepper_robot
+      - pepper_sensors_py
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-naoqi/pepper_robot-release.git
+      version: 0.1.8-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_robot.git
+      version: master
+    status: maintained
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_robot` to `0.1.8-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_robot.git
- release repository: https://github.com/ros-naoqi/pepper_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## pepper_bringup

```
* [pepper_bringup/package.xml] add naoqi_pose, naoqi_driver_py to run_depend
  [pepper_bringup/CMakeLists.txt] add test for launch file validation
* Contributors: Yuki Furuta
```
## pepper_description
- No changes
## pepper_robot
- No changes
## pepper_sensors_py
- No changes
