### PR TITLE
rqt_launchtree: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9920,7 +9920,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pschillinger/rqt_launchtree-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/pschillinger/rqt_launchtree.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_launchtree` to `0.1.4-0`:
- upstream repository: https://github.com/pschillinger/rqt_launchtree.git
- release repository: https://github.com/pschillinger/rqt_launchtree-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.3-0`
## rqt_launchtree

```
* Hide or display machine entries according to nodes (fix #2 <https://github.com/pschillinger/rqt_launchtree/issues/2>)
* Account for different entries with same name (fix #1 <https://github.com/pschillinger/rqt_launchtree/issues/1>)
* Contributors: Philipp Schillinger
```
