### PR TITLE
realtime_tools: 1.9.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1999,7 +1999,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/realtime_tools-release.git
-      version: 1.9.1-0
+      version: 1.9.2-0
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `1.9.2-0`:
- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros-gbp/realtime_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.9.1-0`
