### PR TITLE
ros_control: 0.11.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2258,6 +2258,8 @@ repositories:
       version: kinetic-devel
     release:
       packages:
+      - combined_robot_hw
+      - combined_robot_hw_tests
       - controller_interface
       - controller_manager
       - controller_manager_msgs
@@ -2270,7 +2272,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.10.1-0
+      version: 0.11.0-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.11.0-0`:
- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.10.1-0`
## combined_robot_hw

```
* Add packages combined_robot_hw and combined_robot_hw_tests. combined_robot_hw allows to load different RobotHW as plugins and combines them into a single RobotHW. A single controller manager can then access resources from any robot.
* Contributors: Toni Oliver
```
## combined_robot_hw_tests

```
* Add packages combined_robot_hw and combined_robot_hw_tests. combined_robot_hw allows to load different RobotHW as plugins and combines them into a single RobotHW. A single controller manager can then access resources from any robot.
* Contributors: Toni Oliver
```
## controller_interface
- No changes
## controller_manager
- No changes
## controller_manager_msgs
- No changes
## controller_manager_tests
- No changes
## hardware_interface

```
* Allow the InterfaceManager class to register other InterfaceManagers.
  This will make it possible to combine several RobotHW objects into a single one.
* Contributors: Toni Oliver
```
## joint_limits_interface
- No changes
## ros_control
- No changes
## rqt_controller_manager
- No changes
## transmission_interface
- No changes
