### PR TITLE
ros_controllers: 0.11.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2298,7 +2298,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.11.0-0
+      version: 0.11.1-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.11.1-0`:
- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.11.0-0`
## diff_drive_controller
- No changes
## effort_controllers
- No changes
## force_torque_sensor_controller
- No changes
## forward_command_controller
- No changes
## gripper_action_controller
- No changes
## imu_sensor_controller
- No changes
## joint_state_controller
- No changes
## joint_trajectory_controller

```
* Write feedback for the RealtimeServerGoalHandle to publish on the non-realtime thread.
* Contributors: Miguel Prada
```
## position_controllers
- No changes
## ros_controllers
- No changes
## rqt_joint_trajectory_controller
- No changes
## velocity_controllers
- No changes
