### PR TITLE
freenect_stack: 0.4.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -650,6 +650,25 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: kinetic-devel
     status: maintained
+  freenect_stack:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/freenect_stack.git
+      version: master
+    release:
+      packages:
+      - freenect_camera
+      - freenect_launch
+      - freenect_stack
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/freenect_stack-release.git
+      version: 0.4.1-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/freenect_stack.git
+      version: master
+    status: maintained
   fzi_icl_can:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `freenect_stack` to `0.4.1-0`:
- upstream repository: https://github.com/ros-drivers/freenect_stack.git
- release repository: https://github.com/ros-drivers-gbp/freenect_stack-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## freenect_camera
- No changes
## freenect_launch

```
* fix tf_prefix leading slash issue #13 <https://github.com/ros-drivers/freenect_stack/issues/13>
* Contributors: Jihoon Lee, Piyush Khandelwal
```
## freenect_stack
- No changes
