### PR TITLE
openni2_launch: 0.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1755,6 +1755,21 @@ repositories:
       url: https://github.com/ros-drivers/openni2_camera.git
       version: indigo-devel
     status: maintained
+  openni2_launch:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni2_launch.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/openni2_launch.git
+      version: 0.2.2-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni2_launch.git
+      version: indigo-devel
+    status: maintained
   openni_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_launch` to `0.2.2-0`:
- upstream repository: https://github.com/ros-drivers/openni2_launch.git
- release repository: https://github.com/ros-gbp/openni2_launch.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## openni2_launch

```
* add tf_prefix version, as per #16 <https://github.com/ros-drivers/openni2_launch/issues/16>
* fix #19 <https://github.com/ros-drivers/openni2_launch/issues/19>, reverts #16 <https://github.com/ros-drivers/openni2_launch/issues/16>
* Contributors: Michael Ferguson
```
