### PR TITLE
more kinetic rosdep keys for OS X

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -402,12 +402,12 @@ libvtk:
     homebrew:
       options: [--with-qt]
       packages: [vtk]
-libvtk-qt:
-    osx:
-    homebrew:
-      depends: [libvtk]
 libvtk-java:
   osx:
+    homebrew:
+      depends: [libvtk]
+libvtk-qt:
+    osx:
     homebrew:
       depends: [libvtk]
 libx11:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -111,6 +111,10 @@ gazebo5:
   osx:
     homebrew:
       packages: [osrf/simulation/gazebo5]
+gazebo7:
+  osx:
+    homebrew:
+      depends: [gazebo7]
 gccxml:
   osx:
     homebrew:
@@ -313,6 +317,10 @@ libqt4-opengl-dev:
   osx:
     homebrew:
       packages: [qt]
+libqt5-core:
+  osx:
+    homebrew:
+      packages: [qt5]
 libqt5-gui:
   osx:
     homebrew:
@@ -394,10 +402,14 @@ libvtk:
     homebrew:
       options: [--with-qt]
       packages: [vtk]
+libvtk-qt:
+    osx:
+    homebrew:
+      depends: [libvtk]
 libvtk-java:
   osx:
     homebrew:
-      packages: []
+      depends: [libvtk]
 libx11:
   osx:
     homebrew:
@@ -657,6 +669,10 @@ qt4-qmake:
   osx:
     homebrew:
       packages: [qt]
+qt5-qmake:
+  osx:
+    homebrew:
+      packages: [qt5]
 qtbase5-dev:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -407,7 +407,7 @@ libvtk-java:
     homebrew:
       depends: [libvtk]
 libvtk-qt:
-    osx:
+  osx:
     homebrew:
       depends: [libvtk]
 libx11:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -627,6 +627,10 @@ python-qt5-bindings:
   osx:
     homebrew:
       packages: [pyqt5, sip]
+python-qt5-bindings-gl:
+  osx:
+    homebrew:
+      packages: [pyqt5, sip]
 python-rospkg:
   osx:
     pip:


### PR DESCRIPTION
still need to do `python-qt5-bindings-gl`
