### PR TITLE
depthimage_to_laserscan: 1.0.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -359,6 +359,21 @@ repositories:
       url: https://github.com/rst-tu-dortmund/costmap_converter.git
       version: master
     status: developed
+  depthimage_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/depthimage_to_laserscan.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/depthimage_to_laserscan-release.git
+      version: 1.0.7-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/depthimage_to_laserscan.git
+      version: indigo-devel
+    status: maintained
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthimage_to_laserscan` to `1.0.7-0`:
- upstream repository: https://github.com/ros-perception/depthimage_to_laserscan.git
- release repository: https://github.com/ros-gbp/depthimage_to_laserscan-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## depthimage_to_laserscan

```
* Merge pull request #11 <https://github.com/ros-perception/depthimage_to_laserscan/issues/11> from ros-perception/hydro-devel
  Update indigo devel with angle fix
* Merge pull request #8 <https://github.com/ros-perception/depthimage_to_laserscan/issues/8> from vliedel/hydro-devel
  fixed angle_increment
* fixed angle_increment
* Merge pull request #7 <https://github.com/ros-perception/depthimage_to_laserscan/issues/7> from bulwahn/hydro-devel
  check for CATKIN_ENABLE_TESTING
* check for CATKIN_ENABLE_TESTING
* Added ARCHIVE DESTINATION
* Contributors: Chad Rockey, Lukas Bulwahn, vliedel
```
