### PR TITLE
libqt5-opengl-dev for os x

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -329,6 +329,10 @@ libqt5-opengl:
   osx:
     homebrew:
       packages: [qt5]
+libqt5-opengl-dev:
+  osx:
+    homebrew:
+      packages: [qt5]
 libqt5-widgets:
   osx:
     homebrew:


### PR DESCRIPTION
`libqt5-opengl-dev` for OS X.
