### PR TITLE
urlgrabber seems to have an implicit dependency on pycurl

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2303,7 +2303,7 @@ python-urlgrabber:
   fedora: [python-urlgrabber]
   osx:
     pip:
-      packages: [urlgrabber]
+      packages: [pycurl, urlgrabber]
   ubuntu: [python-urlgrabber]
 python-usb:
   debian: [python-usb]


### PR DESCRIPTION
Without this I get:

```
% rosdep install --from-paths src --ignore-src --rosdistro kinetic -y
executing command [sudo -H pip install -U urlgrabber]
Password:
Collecting urlgrabber
  Downloading urlgrabber-3.9.1.tar.gz (72kB)
    100% |████████████████████████████████| 81kB 3.8MB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/tmp/pip-build-FT8P3i/urlgrabber/setup.py", line 3, in <module>
        import urlgrabber as _urlgrabber
      File "urlgrabber/__init__.py", line 54, in <module>
        from grabber import urlgrab, urlopen, urlread
      File "urlgrabber/grabber.py", line 427, in <module>
        import pycurl
    ImportError: No module named pycurl

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/tmp/pip-build-FT8P3i/urlgrabber/
ERROR: the following rosdeps failed to install
  pip: command [sudo -H pip install -U urlgrabber] failed
```

When installing `urlgrabber` from `pip` on OS X.
