### PR TITLE
turtlebot_msgs: 2.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2870,6 +2870,21 @@ repositories:
       url: https://github.com/turtlebot/turtlebot_create.git
       version: indigo
     status: maintained
+  turtlebot_msgs:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_msgs.git
+      version: indigo
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/turtlebot-release/turtlebot_msgs-release.git
+      version: 2.2.1-0
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_msgs.git
+      version: indigo
+    status: maintained
   uavc_v4lctl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_msgs` to `2.2.1-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_msgs.git
- release repository: https://github.com/turtlebot-release/turtlebot_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## turtlebot_msgs

```
* remove laptop charge status message #2 <https://github.com/turtlebot/turtlebot_msgs/issues/2>
* LaptopChargeStatus moved here from turtlebot stack.
* Contributors: Daniel Stonier, Jihoon Lee
```
