### PR TITLE
openrave_planning: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6867,6 +6867,18 @@ repositories:
       url: https://github.com/ros-drivers/openni_launch.git
       version: indigo-devel
     status: maintained
+  openrave_planning:
+    release:
+      packages:
+      - arm_navigation_msgs
+      - collada_robots
+      - openrave
+      - openrave_planning
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/openrave_planning-release.git
+      version: 0.0.1-0
+    status: developed
   openreroc_motion_sensor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openrave_planning` to `0.0.1-0`:
- upstream repository: https://github.com/jsk-ros-pkg/openrave_planning.git
- release repository: https://github.com/tork-a/openrave_planning-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## arm_navigation_msgs

```
* add arm_navigation_msgs
* Contributors: Kei Okada
```
## collada_robots

```
* update openrave/collada_robots package to catkin
* Contributors: Kei Okada
```
## openrave

```
* add 99.openrave.sh
* update openrave/collada_robots package to catkin
* Contributors: Kei Okada
```
## openrave_planning

```
* update openrave/collada_robots package to catkin
* Contributors: Kei Okada
```
