### PR TITLE
Adding bta_tof_driver to documentation for indigo, jade and kinetic. …

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -700,6 +700,14 @@ repositories:
       type: git
       url: https://github.com/voxel-dot-at/bta_ros.git
       version: master
+    status: end-of-life
+    status_description: Moved to bta_tof_driver
+  bta_tof_driver:
+    doc:
+      type: git
+      url: https://github.com/voxel-dot-at/bta_tof_driver.git
+      version: master
+    status: maintained
   bus_server:
     release:
       tags:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -281,6 +281,14 @@ repositories:
       type: git
       url: https://github.com/voxel-dot-at/bta_ros.git
       version: master
+    status: end-of-life
+    status_description: Moved to bta_tof_driver
+  bta_tof_driver:
+    doc:
+      type: git
+      url: https://github.com/voxel-dot-at/bta_tof_driver.git
+      version: master
+    status: maintained
   calibration:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -151,6 +151,12 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: master
     status: maintained
+  bta_tof_driver:
+    doc:
+      type: git
+      url: https://github.com/voxel-dot-at/bta_tof_driver.git
+      version: master
+    status: maintained
   calibration:
     doc:
       type: git


### PR DESCRIPTION
Adding bta_tof_driver to documentation for indigo, jade and kinetic. Set previous bta_ros to end-of-life.

It is the same package but we changed the name as suggested in https://github.com/ros/rosdistro/pull/8685
