### PR TITLE
Adding blink1 and sf30 to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -651,6 +651,21 @@ repositories:
       url: https://github.com/ros-gbp/bfl-release.git
       version: 0.7.0-6
     status: maintained
+  blink1:
+    doc:
+      type: git
+      url: https://bitbucket.org/castacks/blink1_node.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://bitbucket.org/castacks/blink1_node.git
+      version: master
+    source:
+      type: git
+      url: https://bitbucket.org/castacks/blink1_node.git
+      version: master 	
+    status: maintained
   bond_core:
     doc:
       type: git
@@ -10552,6 +10567,21 @@ repositories:
       type: git
       url: https://github.com/wjwwood/serial_utils.git
       version: master
+    status: maintained
+  sf30:
+    doc:
+      type: git
+      url: https://bitbucket.org/castacks/sf30_node.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://bitbucket.org/castacks/sf30_node.git
+      version: master
+    source:
+      type: git
+      url: https://bitbucket.org/castacks/sf30_node.git
+      version: master 	
     status: maintained
   shadow_robot:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -664,7 +664,7 @@ repositories:
     source:
       type: git
       url: https://bitbucket.org/castacks/blink1_node.git
-      version: master 	
+      version: master
     status: maintained
   bond_core:
     doc:
@@ -10581,7 +10581,7 @@ repositories:
     source:
       type: git
       url: https://bitbucket.org/castacks/sf30_node.git
-      version: master 	
+      version: master
     status: maintained
   shadow_robot:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -660,7 +660,6 @@ repositories:
       type: git
       url: https://bitbucket.org/castacks/blink1_node.git
       version: master
-    status: maintained
   bond_core:
     doc:
       type: git
@@ -10572,7 +10571,6 @@ repositories:
       type: git
       url: https://bitbucket.org/castacks/sf30_node.git
       version: master
-    status: maintained
   shadow_robot:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -656,11 +656,6 @@ repositories:
       type: git
       url: https://bitbucket.org/castacks/blink1_node.git
       version: master
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://bitbucket.org/castacks/blink1_node.git
-      version: master
     source:
       type: git
       url: https://bitbucket.org/castacks/blink1_node.git
@@ -10571,11 +10566,6 @@ repositories:
   sf30:
     doc:
       type: git
-      url: https://bitbucket.org/castacks/sf30_node.git
-      version: master
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
       url: https://bitbucket.org/castacks/sf30_node.git
       version: master
     source:


### PR DESCRIPTION
These new repositories are drivers for blink(1) LED, very useful for debugging robot controllers and for the single bean laser range finder SF30. Please, consider indexing these repositories in ros.org.  
