### PR TITLE
ridgeback_simulator: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8392,6 +8392,26 @@ repositories:
       url: https://github.com/ridgeback/ridgeback_robot.git
       version: indigo-devel
     status: maintained
+  ridgeback_simulator:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_simulator.git
+      version: indigo-devel
+    release:
+      packages:
+      - mecanum_gazebo_plugin
+      - ridgeback_gazebo
+      - ridgeback_gazebo_plugins
+      - ridgeback_simulator
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback_simulator-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_simulator.git
+      version: indigo-devel
+    status: developed
   riskrrt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_simulator` to `0.0.1-0`:
- upstream repository: https://github.com/ridgeback/ridgeback_simulator.git
- release repository: https://github.com/clearpath-gbp/ridgeback_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## mecanum_gazebo_plugin

```
* Rewound version numbers and removed changes logs.
* Disable building plugin (only works on Gazebo 5).
* Remove experimental std::abs call from geometry.
* Parameterize roller friction, add gazebo_ros_control PID gains.
* Add some specific TODO callouts.
* Remove assignment from within if-condition.
* Remove unused header.
* Fix linter warnings.
* Add roslint.
* Use M_PI, remove extra line.
* Fix url in package.xml
* Fix indentation, add license.
* Remove unnecessary build stuff.
* Add roller angle parameter.
* Skeleton of a mecanum gazebo plugin.
* Contributors: Mike Purvis, Tony Baltovski
```
## ridgeback_gazebo

```
* Initial release.
* Contributors: Mike Purvis, Tony Baltovski
```
## ridgeback_gazebo_plugins

```
* Initial release.
* Contributors: Tony Baltovski
```
## ridgeback_simulator

```
* Initial release.
* Contributors: Tony Baltovski
```
