### PR TITLE
ridgeback_desktop: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8376,6 +8376,14 @@ repositories:
       type: git
       url: https://github.com/ridgeback/ridgeback_desktop.git
       version: indigo-devel
+    release:
+      packages:
+      - ridgeback_desktop
+      - ridgeback_viz
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback_desktop-release.git
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_desktop` to `0.1.1-0`:
- upstream repository: https://github.com/ridgeback/ridgeback_desktop
- release repository: https://github.com/clearpath-gbp/ridgeback_desktop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## ridgeback_desktop
- No changes
## ridgeback_viz

```
* Updated laser scan topic.
* Contributors: Tony Baltovski
```
