### PR TITLE
jsk_pr2eus: 0.3.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1898,7 +1898,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_pr2eus-release.git
-      version: 0.3.1-1
+      version: 0.3.2-0
     status: developed
   jsk_recognition:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.3.2-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_pr2eus
- release repository: https://github.com/tork-a/jsk_pr2eus-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.1-1`
## jsk_pr2eus
- No changes
## pr2eus

```
* fix typo topuc -> topic
* robot-interface.l : add option to set queue size for /joint_state subscriber
* robot-interface.l : need a consistency of controller order in the the entry of controller-table fix #227 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/227>
* Contributors: Kei Okada
```
## pr2eus_moveit
- No changes
## pr2eus_tutorials
- No changes
