### PR TITLE
Added pytz and tzlocal python packages to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1553,6 +1553,10 @@ python-pytest:
   debian: [python-pytest]
   fedora: [python-pytest]
   ubuntu: [python-pytest]
+python-pytz-pip:
+  ubuntu:
+    pip:
+      packages: [pytz]
 python-pyudev:
   debian: [python-pyudev]
   fedora: [python-pyudev]
@@ -2289,6 +2293,10 @@ python-twitter:
     raring: [python-twitter]
     saucy: [python-twitter]
     trusty: [python-twitter]
+python-tzlocal-pip:
+  ubuntu:
+    pip:
+      packages: [tzlocal]
 python-ujson:
   debian:
     pip:


### PR DESCRIPTION
This adds two python packages for dealing with time conversion between time zones.
