### PR TITLE
p2os: 2.0.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3520,10 +3520,11 @@ repositories:
       - p2os_launch
       - p2os_msgs
       - p2os_teleop
+      - p2os_urdf
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
-      version: 2.0.3-0
+      version: 2.0.4-0
     source:
       type: git
       url: https://github.com/allenh1/p2os.git


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `2.0.4-0`:
- upstream repository: https://github.com/allenh1/p2os
- release repository: https://github.com/allenh1/p2os-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.0.3-0`
## p2os_doc
- No changes
## p2os_driver

```
* Cleaned up driver source.
* Contributors: Hunter L. Allen
```
## p2os_launch
- No changes
## p2os_msgs
- No changes
## p2os_teleop
- No changes
## p2os_urdf
- No changes
