### PR TITLE
p2os: 2.0.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1904,7 +1904,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
-      version: 2.0.4-0
+      version: 2.0.5-0
+    source:
+      type: git
+      url: https://github.com/allenh1/p2os.git
+      version: master
+    status: maintained
   pcl_conversions:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `2.0.5-0`:
- upstream repository: https://github.com/allenh1/p2os
- release repository: https://github.com/allenh1/p2os-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.0.4-0`
## p2os_doc
- No changes
## p2os_driver

```
* Added missing dependencies.
* Contributors: Hunter L. Allen
```
## p2os_launch
- No changes
## p2os_msgs
- No changes
## p2os_teleop
- No changes
## p2os_urdf

```
* Added missing dep.
* Contributors: Hunter L. Allen
```
