### PR TITLE
ueye_cam: 1.0.14-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5631,7 +5631,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/anqixu/ueye_cam-release.git
-      version: 1.0.13-0
+      version: 1.0.14-0
     source:
       type: git
       url: https://github.com/anqixu/ueye_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `1.0.14-0`:
- upstream repository: https://github.com/anqixu/ueye_cam.git
- release repository: https://github.com/anqixu/ueye_cam-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.13-0`
## ueye_cam

```
* now attempting to link against 32-bit ARMHF IDS libs on ARM64 arch
* added capability to detect ARM64 processor (aarch64)
* added separate rates for polling frames vs publishing images
* fixed buffersize for subsampling and increased maximum image size availible via rqt
* added Travis CI config
* Contributors: Anqi Xu, Eddy, Isaac I.Y. Saito, francois
```
