### PR TITLE
freenect_stack: 0.4.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -684,7 +684,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/freenect_stack-release.git
-      version: 0.4.1-0
+      version: 0.4.2-0
     source:
       type: git
       url: https://github.com/ros-drivers/freenect_stack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `freenect_stack` to `0.4.2-0`:
- upstream repository: https://github.com/ros-drivers/freenect_stack.git
- release repository: https://github.com/ros-drivers-gbp/freenect_stack-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.4.1-0`
## freenect_camera

```
* add include path for dynamic reconfigure
* Fixed cmake dependency issue. #28 <https://github.com/ros-drivers/freenect_stack/issues/28>
* Including log4cxx in CMakefile file. Compilation on OS X fails without this.
* Contributors: Nick Hawes, Piyush Khandelwal, Tully Foote
```
## freenect_launch
- No changes
## freenect_stack
- No changes
