### PR TITLE
astra_camera: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -89,6 +89,21 @@ repositories:
       url: https://github.com/AutonomyLab/ardrone_autonomy.git
       version: indigo-devel
     status: developed
+  astra_camera:
+    doc:
+      type: git
+      url: https://github.com/tfoote/ros_astra_camera.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/astra_camera-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/tfoote/ros_astra_camera.git
+      version: master
+    status: developed
   auv_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `astra_camera` to `0.1.1-0`:
- upstream repository: https://github.com/tfoote/ros_astra_camera.git
- release repository: https://github.com/ros-drivers-gbp/astra_camera-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## astra_camera

```
* removing dependency which was internalilzed
* Contributors: Tully Foote
```
