### PR TITLE
astra_camera: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -98,7 +98,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/astra_camera-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/tfoote/ros_astra_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `astra_camera` to `0.1.3-0`:
- upstream repository: https://github.com/tfoote/ros_astra_camera.git
- release repository: https://github.com/ros-drivers-gbp/astra_camera-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.2-0`
## astra_camera

```
* Adding build dependency on libudev-dev
* Contributors: Tully Foote
```
