### PR TITLE
astra_launch: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -104,6 +104,21 @@ repositories:
       url: https://github.com/tfoote/ros_astra_camera.git
       version: master
     status: developed
+  astra_launch:
+    doc:
+      type: git
+      url: https://github.com/tfoote/ros_astra_launch.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/astra_launch-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/tfoote/ros_astra_launch.git
+      version: master
+    status: developed
   auv_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `astra_launch` to `0.1.0-0`:
- upstream repository: https://github.com/tfoote/ros_astra_launch.git
- release repository: https://github.com/ros-drivers-gbp/astra_launch-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## astra_launch

```
* initial commit
* Contributors: Len Zhong
```
