### PR TITLE
jsk_planning: 0.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4243,7 +4243,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_planning-release.git
-      version: 0.1.6-0
+      version: 0.1.7-0
     status: developed
   jsk_pr2eus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_planning` to `0.1.7-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_planning
- release repository: https://github.com/tork-a/jsk_planning-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.6-0`
## jsk_planning
- No changes
## pddl_msgs
- No changes
## pddl_planner

```
* [pddl_planner/demos/2013_fridge_demo/solve-bring-can.l] comment in recovery motion ( #43 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/43> )
* [pddl_planner/README] fix typo  ( #42 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/42> )
* [pddl_planner/README] Update README.md, Add search option and plan file path to bare downward example ( #38 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/38> )
* Contributors: Grollo, Kamada Hitoshi, Yuki Furuta
```
## pddl_planner_viewer
- No changes
## task_compiler

```
* [task_compiler/euslisp/execute-pddl-core.l] add hook function call on execution ( #44 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/44> )
* Contributors: Yuki Furuta
```
