### PR TITLE
rosjava_dynamic_reconfigure: 0.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9600,6 +9600,21 @@ repositories:
       url: https://github.com/rosjava/rosjava_core.git
       version: indigo
     status: maintained
+  rosjava_dynamic_reconfigure:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/rosjava_dynamic_reconfigure.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/rosjava_dynamic_reconfigure-release.git
+      version: 0.2.4-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/rosjava_dynamic_reconfigure.git
+      version: master
+    status: developed
   rosjava_extras:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_dynamic_reconfigure` to `0.2.4-0`:
- upstream repository: https://github.com/rosalfred/rosjava_dynamic_reconfigure.git
- release repository: https://github.com/rosalfred-release/rosjava_dynamic_reconfigure-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rosjava_dynamic_reconfigure

```
* Clean code
* Update package file description
* Update gradle & dependencies
* Contributors: Erwan Le Huitouze, Mickael Gaillard
```
