### PR TITLE
building_msgs: 0.1.18-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -717,6 +717,21 @@ repositories:
       url: https://github.com/voxel-dot-at/bta_tof_driver.git
       version: master
     status: maintained
+  building_msgs:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/building_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/building_msgs-release.git
+      version: 0.1.18-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/building_msgs.git
+      version: master
+    status: developed
   bus_server:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `building_msgs` to `0.1.18-0`:
- upstream repository: https://github.com/rosalfred/building_msgs.git
- release repository: https://github.com/rosalfred-release/building_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## building_msgs

```
* Add changelog
* Contributors: Mickael Gaillard
```
