### PR TITLE
heater_msgs: 0.1.18-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3216,6 +3216,21 @@ repositories:
       url: https://github.com/OSUrobotics/ros-head-tracking.git
       version: hydro-devel
     status: maintained
+  heater_msgs:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/heater_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/heater_msgs-release.git
+      version: 0.1.18-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/heater_msgs.git
+      version: master
+    status: developed
   hector_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `heater_msgs` to `0.1.18-0`:
- upstream repository: https://github.com/rosalfred/heater_msgs.git
- release repository: https://github.com/rosalfred-release/heater_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
