### PR TITLE
media_msgs_java: 0.1.78-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5318,6 +5318,21 @@ repositories:
       url: https://github.com/rosalfred/media_msgs.git
       version: master
     status: developed
+  media_msgs_java:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/media_msgs_java.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/media_msgs_java-release.git
+      version: 0.1.78-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/media_msgs_java.git
+      version: master
+    status: developed
   message_generation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `media_msgs_java` to `0.1.78-0`:
- upstream repository: https://github.com/rosalfred/media_msgs_java.git
- release repository: https://github.com/rosalfred-release/media_msgs_java-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
