### PR TITLE
network_zeroconf: 0.1.64-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6334,6 +6334,21 @@ repositories:
       url: https://github.com/nerian-vision/nerian_sp1.git
       version: master
     status: developed
+  network_zeroconf:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/network_zeroconf.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/network_zeroconf-release.git
+      version: 0.1.64-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/network_zeroconf.git
+      version: master
+    status: developed
   nmea_comms:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `network_zeroconf` to `0.1.64-0`:
- upstream repository: https://github.com/rosalfred/network_zeroconf.git
- release repository: https://github.com/rosalfred-release/network_zeroconf-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
