### PR TITLE
catkin_pure_python: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1057,7 +1057,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/catkin_pure_python-release.git
-      version: 0.0.8-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pure_python.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pure_python` to `0.1.0-0`:
- upstream repository: https://github.com/asmodehn/catkin_pure_python.git
- release repository: https://github.com/asmodehn/catkin_pure_python-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.8-0`
## catkin_pure_python

```
* separating catkin_pip_setup and catkin_package macros.
* now ignoring installed pip packaging when fetching requirements for pipproject.
* removing debug output for shell envhook
* fixing install procedure to get same structure as the distutils version.
* now catkin-pip package is using normal catkin_package(), and installs fine, although with setuptools, which might break packaging...
* refactoring cmake include and configure. test project devel space ok. the rest is still broken...
* small improvement to do less configuration
* now using an envhook to modify pythonpath instead of hacking catkin's _setup_util.py
* _setup_util.py hack now done in cmake binary dir instead of final workspace.
* Contributors: AlexV, alexv
```
