### PR TITLE
micros_swarm_framework: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5433,7 +5433,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/xuefengchang/micros_swarm_framework-release.git
-      version: 0.0.6-2
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/xuefengchang/micros_swarm_framework.git


### PR DESCRIPTION
Increasing version of package(s) in repository `micros_swarm_framework` to `0.0.7-0`:
- upstream repository: https://github.com/xuefengchang/micros_swarm_framework.git
- release repository: https://github.com/xuefengchang/micros_swarm_framework-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.6-2`
## micros_swarm_framework

```
* optimize the installation
```
