### PR TITLE
dr_base: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -433,6 +433,15 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: indigo-devel
     status: maintained
+  dr_base:
+    release:
+      packages:
+      - dr_base
+      - dr_cmake
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/delftrobotics/dr_base-release.git
+      version: 1.0.0-0
   dynamic_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dr_base` to `1.0.0-0`:
- upstream repository: https://github.com/delftrobotics/dr_base.git
- release repository: https://github.com/delftrobotics/dr_base-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
