### PR TITLE
jb_common_libs: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4052,6 +4052,27 @@ repositories:
       url: https://github.com/GT-RAIL/jaco_gazebo.git
       version: develop
     status: maintained
+  jb_common_libs:
+    doc:
+      type: git
+      url: https://github.com/JenniferBuehler/convenience-pkgs.git
+      version: master
+    release:
+      packages:
+      - arm_components_name_manager
+      - baselib_binding
+      - convenience_math_functions
+      - convenience_ros_functions
+      - logger_binding
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/JenniferBuehler/convenience-pkgs-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/JenniferBuehler/convenience-pkgs.git
+      version: master
+    status: maintained
   joystick_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jb_common_libs` to `0.0.1-0`:
- upstream repository: https://github.com/JenniferBuehler/convenience-pkgs.git
- release repository: https://github.com/JenniferBuehler/convenience-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## arm_components_name_manager

```
* Released initial version on ROS.
* Contributors: Jennifer Buehler
```
## baselib_binding

```
* Released initial version on ROS.
* Contributors: Jennifer Buehler
```
## convenience_math_functions

```
* Released initial version on ROS.
* Contributors: Jennifer Buehler
```
## convenience_ros_functions

```
* Released initial version on ROS.
* Contributors: Jennifer Buehler
```
## logger_binding

```
* Released initial version on ROS.
* Contributors: Jennifer Buehler
```
