### PR TITLE
jb_common_libs: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4067,7 +4067,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/JenniferBuehler/convenience-pkgs-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/JenniferBuehler/convenience-pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jb_common_libs` to `0.0.2-0`:
- upstream repository: https://github.com/JenniferBuehler/convenience-pkgs.git
- release repository: https://github.com/JenniferBuehler/convenience-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.1-0`
## arm_components_name_manager

```
* Small adjustments in cmake files
* Contributors: Jennifer Buehler
```
## baselib_binding

```
* Adjusted cmake files for build on jenkins: CFG_EXTRAS cannot have same name as <packagename>Config.cmake
* Contributors: Jennifer Buehler
```
## convenience_math_functions
- No changes
## convenience_ros_functions

```
* Contributors: Jennifer Buehler
```
## logger_binding

```
* Adjusted cmake files for build on jenkins: CFG_EXTRAS cannot have same name as <packagename>Config.cmake
* Contributors: Jennifer Buehler
```
