### PR TITLE
urdf_tools: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11888,6 +11888,27 @@ repositories:
       url: https://github.com/TheDash/ur_modern_driver.git
       version: indigo-devel
     status: maintained
+  urdf_tools:
+    doc:
+      type: git
+      url: https://github.com/JenniferBuehler/urdf-tools-pkgs.git
+      version: master
+    release:
+      packages:
+      - urdf2inventor
+      - urdf_tools
+      - urdf_transform
+      - urdf_traverser
+      - urdf_viewer
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/JenniferBuehler/urdf-tools-pkgs-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/JenniferBuehler/urdf-tools-pkgs.git
+      version: master
+    status: developed
   urdf_tutorial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tools` to `0.0.2-0`:
- upstream repository: https://github.com/JenniferBuehler/urdf-tools-pkgs.git
- release repository: https://github.com/JenniferBuehler/urdf-tools-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
