### PR TITLE
smarthome_media_msgs: 0.1.59-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10840,6 +10840,21 @@ repositories:
       url: https://github.com/ros-drivers/smart_battery_msgs.git
       version: master
     status: maintained
+  smarthome_media_msgs:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/smarthome_media_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/smarthome_media_msgs-release.git
+      version: 0.1.59-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/smarthome_media_msgs.git
+      version: master
+    status: developed
   soem:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `smarthome_media_msgs` to `0.1.59-0`:
- upstream repository: https://github.com/rosalfred/smarthome_media_msgs.git
- release repository: https://github.com/rosalfred-release/smarthome_media_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
