### PR TITLE
smarthome_media_msgs_java: 0.1.80-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10855,6 +10855,21 @@ repositories:
       url: https://github.com/rosalfred/smarthome_media_msgs.git
       version: master
     status: developed
+  smarthome_media_msgs_java:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/smarthome_media_msgs_java.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/smarthome_media_msgs_java-release.git
+      version: 0.1.80-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/smarthome_media_msgs_java.git
+      version: master
+    status: developed
   soem:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `smarthome_media_msgs_java` to `0.1.80-0`:
- upstream repository: https://github.com/rosalfred/smarthome_media_msgs_java.git
- release repository: https://github.com/rosalfred-release/smarthome_media_msgs_java-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
