### PR TITLE
smarthome_comm_msgs: 0.1.19-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10840,6 +10840,21 @@ repositories:
       url: https://github.com/ros-drivers/smart_battery_msgs.git
       version: master
     status: maintained
+  smarthome_comm_msgs:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/smarthome_comm_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/smarthome_comm_msgs-release.git
+      version: 0.1.19-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/smarthome_comm_msgs.git
+      version: master
+    status: developed
   smarthome_media_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `smarthome_comm_msgs` to `0.1.19-0`:
- upstream repository: https://github.com/rosalfred/smarthome_comm_msgs.git
- release repository: https://github.com/rosalfred-release/smarthome_comm_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## smarthome_comm_msgs

```
* Rename package to smarthome_comm_msgs
* Contributors: Erwan Le Huitouze
```
