### PR TITLE
smarthome_heater_msgs: 0.1.21-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10870,6 +10870,21 @@ repositories:
       url: https://github.com/rosalfred/smarthome_comm_msgs_java.git
       version: master
     status: developed
+  smarthome_heater_msgs:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/smarthome_heater_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/smarthome_heater_msgs-release.git
+      version: 0.1.21-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/smarthome_heater_msgs.git
+      version: master
+    status: developed
   smarthome_media_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `smarthome_heater_msgs` to `0.1.21-0`:
- upstream repository: https://github.com/rosalfred/smarthome_heater_msgs.git
- release repository: https://github.com/rosalfred-release/smarthome_heater_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## smarthome_heater_msgs

```
* Update script
* Contributors: Erwan Le Huitouze
```
