### PR TITLE
smarthome_network_wakeonlan: 0.1.66-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10930,6 +10930,21 @@ repositories:
       url: https://github.com/rosalfred/smarthome_media_msgs_java.git
       version: master
     status: developed
+  smarthome_network_wakeonlan:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/smarthome_network_wakeonlan.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/smarthome_network_wakeonlan-release.git
+      version: 0.1.66-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/smarthome_network_wakeonlan.git
+      version: master
+    status: developed
   soem:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `smarthome_network_wakeonlan` to `0.1.66-0`:
- upstream repository: https://github.com/rosalfred/smarthome_network_wakeonlan.git
- release repository: https://github.com/rosalfred-release/smarthome_network_wakeonlan-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## smarthome_network_wakeonlan

```
* Rename package to smarthome_network_wakeonlan
* Contributors: Erwan Le Huitouze, Mickael Gaillard
```
