### PR TITLE
smarthome_media_model: 0.1.60-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10900,6 +10900,21 @@ repositories:
       url: https://github.com/rosalfred/smarthome_heater_msgs_java.git
       version: master
     status: developed
+  smarthome_media_model:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/smarthome_media_model.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/smarthome_media_model-release.git
+      version: 0.1.60-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/smarthome_media_model.git
+      version: master
+    status: developed
   smarthome_media_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `smarthome_media_model` to `0.1.60-0`:
- upstream repository: https://github.com/rosalfred/smarthome_media_model.git
- release repository: https://github.com/rosalfred-release/smarthome_media_model-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## smarthome_media_model

```
* Rename package to smarthome_media_model
* Add license
* Contributors: Erwan Le Huitouze
```
