### PR TITLE
smarthome_common_driver: 0.1.60-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10870,6 +10870,21 @@ repositories:
       url: https://github.com/rosalfred/smarthome_comm_msgs_java.git
       version: master
     status: developed
+  smarthome_common_driver:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/smarthome_common_driver.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/smarthome_common_driver-release.git
+      version: 0.1.60-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/smarthome_common_driver.git
+      version: master
+    status: developed
   smarthome_heater_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `smarthome_common_driver` to `0.1.60-0`:
- upstream repository: https://github.com/rosalfred/smarthome_common_driver.git
- release repository: https://github.com/rosalfred-release/smarthome_common_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## smarthome_common_driver

```
* Rename package to smarthome_common_driver
* Update catkin dependencies
* Update building imports
* Merge branch 'master' of ssh://git.tactfactory.com:2222/projetx/media-driver
* Update package description & license
* 0.1.59
* 0.1.58
* Contributors: Alfred Team, Erwan Le Huitouze
```
