### PR TITLE
Revert "jsk_apc: 0.8.0-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4146,7 +4146,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_apc-release.git
-      version: 0.8.0-0
+      version: 0.2.4-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#11680

All sourcedebs are not building due to missing branches in the release repository. 
