### PR TITLE
astra_camera: 0.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -391,6 +391,21 @@ repositories:
       type: git
       url: https://github.com/ethz-asl/asctec_mav_framework.git
       version: master
+  astra_camera:
+    doc:
+      type: git
+      url: https://github.com/tfoote/ros_astra_camera.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/astra_camera-release.git
+      version: 0.1.5-0
+    source:
+      type: git
+      url: https://github.com/tfoote/ros_astra_camera.git
+      version: master
+    status: developed
   async_web_server_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `astra_camera` to `0.1.5-0`:
- upstream repository: https://github.com/tfoote/ros_astra_camera.git
- release repository: https://github.com/ros-drivers-gbp/astra_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## astra_camera

```
* add dependency on generated messages to avoid race condition at build time
* switching to libusb-1.0
* Contributors: Tully Foote
```
