### PR TITLE
opencv_apps: 1.11.13-0 in '{indigo,jade}/distribution.yaml'

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6819,6 +6819,21 @@ repositories:
       url: https://github.com/ros-gbp/opencv3-release.git
       version: 3.1.0-1
     status: maintained
+  opencv_apps:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/opencv_apps.git
+      version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-perception/opencv_apps-release.git
+      version: 1.11.13-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/opencv_apps.git
+      version: indigo
+    status: maintained
   opencv_candidate:
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12290,7 +12290,6 @@ repositories:
       packages:
       - cv_bridge
       - image_geometry
-      - opencv_apps
       - vision_opencv
       tags:
         release: release/indigo/{package}/{version}

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3378,6 +3378,21 @@ repositories:
       url: https://github.com/ros-gbp/opencv3-release.git
       version: 3.1.0-1
     status: maintained
+  opencv_apps:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/opencv_apps.git
+      version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-perception/opencv_apps-release.git
+      version: 1.11.13-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/opencv_apps.git
+      version: indigo
+    status: maintained
   opencv_candidate:
     release:
       tags:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5812,7 +5812,6 @@ repositories:
       packages:
       - cv_bridge
       - image_geometry
-      - opencv_apps
       - vision_opencv
       tags:
         release: release/jade/{package}/{version}


### PR DESCRIPTION
@vrabaud can we remove oepncv_apps from this and re-release from new repo? or should we keep indigo/jade as it is and start from kinetic?
