### PR TITLE
astra_launch: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -406,6 +406,21 @@ repositories:
       url: https://github.com/tfoote/ros_astra_camera.git
       version: master
     status: developed
+  astra_launch:
+    doc:
+      type: git
+      url: https://github.com/tfoote/ros_astra_launch.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/astra_launch-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/tfoote/ros_astra_launch.git
+      version: master
+    status: developed
   async_web_server_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `astra_launch` to `0.1.0-0`:
- upstream repository: https://github.com/tfoote/ros_astra_launch.git
- release repository: https://github.com/ros-drivers-gbp/astra_launch-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## astra_launch

```
* initial commit
* Contributors: Len Zhong
```
