### PR TITLE
pyros_config: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7983,6 +7983,21 @@ repositories:
       url: https://github.com/clearpathrobotics/puma_motor_driver.git
       version: master
     status: maintained
+  pyros_config:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/pyros-config.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/pyros-config-rosrelease.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/asmodehn/pyros-config.git
+      version: master
+    status: developed
   pyros_setup:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_config` to `0.1.0-0`:
- upstream repository: https://github.com/asmodehn/pyros-config.git
- release repository: https://github.com/asmodehn/pyros-config-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## pyros_config

```
* cleaned up README. added .travis.yml
* copying files from pyros-setup
* Contributors: alexv
```
