### PR TITLE
pyros_utils: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8020,6 +8020,21 @@ repositories:
       url: https://github.com/asmodehn/pyros-test.git
       version: indigo
     status: developed
+  pyros_utils:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/pyros-utils.git
+      version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/pyros-utils-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/asmodehn/pyros-utils.git
+      version: indigo
+    status: developed
   pysdf:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_utils` to `0.1.0-0`:
- upstream repository: https://github.com/asmodehn/pyros-utils.git
- release repository: https://github.com/asmodehn/pyros-utils-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## pyros_utils

```
* now using shadow-fixed ros packages for travis test build
* cleanup.
* fixing tests
* fixing cmakelists and setup.py. removed requirements.txt
* cleaning up README, removed ros_utils since this is a pure ROS package, like pyros-test
* fixing __init__ imports. added travis.yml.
* extracted code from pyros-setup
* Contributors: AlexV, alexv
```
