### PR TITLE
catkin_pure_python: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1084,10 +1084,12 @@ repositories:
       url: https://github.com/asmodehn/catkin_pure_python.git
       version: indigo
     release:
+      packages:
+      - catkin_pip
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/catkin_pure_python-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pure_python.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1078,21 +1078,19 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: indigo-devel
     status: maintained
-  catkin_pure_python:
+  catkin_pip:
     doc:
       type: git
-      url: https://github.com/asmodehn/catkin_pure_python.git
+      url: https://github.com/asmodehn/catkin_pip.git
       version: indigo
     release:
-      packages:
-      - catkin_pip
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/asmodehn/catkin_pure_python-release.git
+      url: https://github.com/asmodehn/catkin_pip-release.git
       version: 0.1.3-0
     source:
       type: git
-      url: https://github.com/asmodehn/catkin_pure_python.git
+      url: https://github.com/asmodehn/catkin_pip.git
       version: indigo
     status: developed
   cit_adis_imu:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pure_python` to `0.1.3-0`:
- upstream repository: https://github.com/asmodehn/catkin_pure_python.git
- release repository: https://github.com/asmodehn/catkin_pure_python-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.2-0`
## catkin_pip

```
* renaming catkin_pure_python to catkin_pip for clarity
* Contributors: alexv
```
