### PR TITLE
Adding robotcloudserver to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8703,6 +8703,16 @@ repositories:
       url: https://github.com/RobotWebTools/robot_web_tools.git
       version: develop
     status: maintained
+  robotcloudserver:
+    doc:
+      type: git
+      url: https://github.com/mjezersky/robotcloudserver.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/mjezersky/robotcloudserver.git
+      version: master
+    status: maintained
   roboteq:
     doc:
       type: git


### PR DESCRIPTION
I'd like robotcloudserver to be indexed and documented on ros.org.
