### PR TITLE
rtabmap/rtabmap_ros: 0.11.7-0 in '[indigo|jade|kinetic]/distribution.yaml'

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10174,7 +10174,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.11.5-0
+      version: 0.11.7-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -10189,7 +10189,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.11.5-0
+      version: 0.11.7-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4985,7 +4985,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.11.5-0
+      version: 0.11.7-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -5000,7 +5000,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.11.5-0
+      version: 0.11.7-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2697,7 +2697,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.11.5-0
+      version: 0.11.7-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -2712,7 +2712,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.11.5-0
+      version: 0.11.7-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repositories rtabmap and rtabmap_ros to 0.11.7-0:

upstream repository: https://github.com/introlab/rtabmap[_ros].git
release repository: https://github.com/introlab/rtabmap[_ros]-release.git
distro file: [indigo|jade|kinetic]/distribution.yaml
bloom version: 0.5.21
previous version for package: 0.11.5-0
