### PR TITLE
pyros_config: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8007,7 +8007,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/pyros-config-rosrelease.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/asmodehn/pyros-config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_config` to `0.1.1-0`:
- upstream repository: https://github.com/asmodehn/pyros-config.git
- release repository: https://github.com/asmodehn/pyros-config-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.0-0`
## pyros_config

```
* fixing repo links in package.xml
* using renamed dependency catkin_pip
* small cleanup.
  removing mention of ros.
  now printing sys.path in case import fails.
  added gitignore.
* Contributors: alexv
```
