### PR TITLE
catkin_pip: 0.1.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -377,6 +377,21 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: indigo-devel
     status: maintained
+  catkin_pip:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/catkin_pip.git
+      version: jade
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/asmodehn/catkin_pip-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/asmodehn/catkin_pip.git
+      version: jade
+    status: developed
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pip` to `0.1.3-0`:
- upstream repository: https://github.com/asmodehn/catkin_pure_python.git
- release repository: https://github.com/asmodehn/catkin_pip-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## catkin_pip

```
* renaming catkin_pure_python to catkin_pip for clarity
* Contributors: alexv
```
