### PR TITLE
pyros_test: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8029,7 +8029,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/pyros-test-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/asmodehn/pyros-test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_test` to `0.0.4-0`:
- upstream repository: https://github.com/asmodehn/pyros-test.git
- release repository: https://github.com/asmodehn/pyros-test-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.3-0`
## pyros_test

```
* now travis checking both indigo and jade
* Merge pull request #2 <https://github.com/asmodehn/pyros-test/issues/2> from asmodehn/package_v2
  Package v2
* README fix
* package description fix
* package v2 wiht minimum required version for dependencies
* Contributors: AlexV, alexv
```
