### PR TITLE
rospy_message_converter: 0.4.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2589,6 +2589,12 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: jade-devel
     status: maintained
+  rospy_message_converter:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/baalexander/rospy_message_converter-release.git
+      version: 0.4.0-1
   rplidar_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospy_message_converter` to `0.4.0-1`:
- upstream repository: https://github.com/baalexander/rospy_message_converter.git
- release repository: https://github.com/baalexander/rospy_message_converter-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rospy_message_converter

```
* Adds support for ROS Jade
* Removes support for ROS Groovy and Hydro (EOL)
* Uses single branch for all ROS versions
* Docker support for local development and Travis CI
```
