### PR TITLE
pyros_test: 0.0.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3828,6 +3828,21 @@ repositories:
       url: https://github.com/joselusl/pugixml.git
       version: master
     status: developed
+  pyros_test:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/pyros-test.git
+      version: jade
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/asmodehn/pyros-test-release.git
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/asmodehn/pyros-test.git
+      version: jade
+    status: developed
   python_ethernet_rmp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_test` to `0.0.4-0`:
- upstream repository: https://github.com/asmodehn/pyros-test.git
- release repository: https://github.com/asmodehn/pyros-test-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## pyros_test

```
* now travis checking both indigo and jade
* Merge pull request #2 <https://github.com/asmodehn/pyros-test/issues/2> from asmodehn/package_v2
  Package v2
* README fix
* package description fix
* package v2 wiht minimum required version for dependencies
* Contributors: AlexV, alexv
```
