### PR TITLE
ar_track_alvar: 0.6.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -59,6 +59,21 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  ar_track_alvar:
+    doc:
+      type: git
+      url: https://github.com/sniekum/ar_track_alvar.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/ar_track_alvar-release.git
+      version: 0.6.0-0
+    source:
+      type: git
+      url: https://github.com/sniekum/ar_track_alvar.git
+      version: kinetic-devel
+    status: maintained
   ar_track_alvar_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar` to `0.6.0-0`:
- upstream repository: https://github.com/sniekum/ar_track_alvar
- release repository: https://github.com/ros-gbp/ar_track_alvar-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## ar_track_alvar

```
* Made compatible to ROS-Kinetic-Kame #80 <https://github.com/sniekum/ar_track_alvar/issues/80>
* [Travis CI] Add ROS Kinetic support. Add Prerelease Test on Travis #79 <https://github.com/sniekum/ar_track_alvar/issues/79>
* Contributors: Sepehr MohaimenianPour, Isaac I.Y. Saito
```
