### PR TITLE
add xenial:libglew-dev to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1558,6 +1558,7 @@ libglew-dev:
     trusty: [libglew-dev]
     utopic: [libglew-dev]
     vivid: [libglew-dev]
+    xenial: [libglew-dev]
 libglib-dev:
   arch: [glib2]
   debian: [libglib2.0-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1558,6 +1558,7 @@ libglew-dev:
     trusty: [libglew-dev]
     utopic: [libglew-dev]
     vivid: [libglew-dev]
+    wily: [libglew-dev]
     xenial: [libglew-dev]
 libglib-dev:
   arch: [glib2]


### PR DESCRIPTION
In order to install GLEW library on Ubuntu 16.04 Xenial Xerus with rosdep, the libglew-dev section in https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml should be updated to:

```
libglew-dev:
  arch: [glew]
  debian: [libglew-dev]
  fedora: [glew-devel]
  gentoo:
    portage:
      packages: [media-libs/glew]
  ubuntu:
    oneiric: [libglew1.5-dev]
    precise: [libglew1.6-dev]
    quantal: [libglew-dev]
    raring: [libglew-dev]
    saucy: [libglew-dev]
    trusty: [libglew-dev]
    utopic: [libglew-dev]
    vivid: [libglew-dev]
    xenial: [libglew-dev]
```

reference: https://launchpad.net/ubuntu/xenial/+package/libglew-dev
