### PR TITLE
rtmros_hironx: 1.1.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10258,7 +10258,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.14-0
+      version: 1.1.15-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.15-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.1.14-0`
## hironx_calibration
- No changes
## hironx_moveit_config

```
* Workaround MoveIt! RRT issue (see https://github.com/tork-a/rtmros_nextage/issues/170).
* Contributors: Isaac I.Y. Saito
```
## hironx_ros_bridge
- No changes
## rtmros_hironx

```
* Workaround MoveIt! RRT issue (see https://github.com/tork-a/rtmros_nextage/issues/170).
* Contributors: Isaac I.Y. Saito
```
