### PR TITLE
make rosdistro accept collada-dom from gentoo's portage

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -494,7 +494,7 @@ collada-dom:
   fedora: [collada-dom-devel]
   gentoo:
     portage:
-      packages: [media-libs/collada-dom]
+      packages: [media-libs/collada-dom, dev-libs/collada-dom]
   macports: [collada-dom]
   ubuntu:
     lucid: [collada-dom-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -494,7 +494,7 @@ collada-dom:
   fedora: [collada-dom-devel]
   gentoo:
     portage:
-      packages: [media-libs/collada-dom, dev-libs/collada-dom]
+      packages: [dev-libs/collada-dom]
   macports: [collada-dom]
   ubuntu:
     lucid: [collada-dom-dev]


### PR DESCRIPTION
dev-libs/collada-dom is provided by gentoos package management system portage.
media-libs/collada-dom is provided by ros-overlay [1] which is used in the official (although experimental) install instructions for ROS on gentoo [2].

Allowing ros to install without the over will ease/eable the transition of gentoo's ROS-support from overlay to its native repository, especially since the overlay is suspected to be redundant.

relevant issue:
https://github.com/ros/rosdistro/issues/11687

[1] https://github.com/ros/ros-overlay
[2] http://wiki.ros.org/kinetic/Installation/Gentoo (also for older ROS distros)
