### PR TITLE
dynpick_driver: 0.0.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -739,7 +739,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/dynpick_driver-release.git
-      version: 0.0.9-0
+      version: 0.0.10-0
     source:
       type: git
       url: https://github.com/tork-a/dynpick_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynpick_driver` to `0.0.10-0`:
- upstream repository: https://github.com/tork-a/dynpick_driver.git
- release repository: https://github.com/tork-a/dynpick_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.9-0`
## dynpick_driver

```
* [feat] Add test binary for measuring device throughput on Ubuntu (tested against QNX). #25 <https://github.com/tork-a/dynpick_driver/issues/25>
* [doc] Add a tested product ID. #26 <https://github.com/tork-a/dynpick_driver/issues/26>
* Contributors: Isaac I.Y. Saito
```
