### PR TITLE
catkin_pip: 0.1.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -386,7 +386,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/catkin_pip-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pip.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pip` to `0.1.4-0`:
- upstream repository: https://github.com/asmodehn/catkin_pure_python.git
- release repository: https://github.com/asmodehn/catkin_pip-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.3-0`
## catkin_pip

```
* adding pytest as a test runner.
  now using our nose in nosetests (instead of sytem one)
  small fixes.
* now travis building on jade as well
* Contributors: AlexV, alexv
```
