### PR TITLE
pyros_utils: 0.1.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3858,6 +3858,21 @@ repositories:
       url: https://github.com/asmodehn/pyros-test.git
       version: jade
     status: developed
+  pyros_utils:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/pyros-utils.git
+      version: jade
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/asmodehn/pyros-utils-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/asmodehn/pyros-utils.git
+      version: jade
+    status: developed
   python_ethernet_rmp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_utils` to `0.1.1-0`:
- upstream repository: https://github.com/asmodehn/pyros-utils.git
- release repository: https://github.com/asmodehn/pyros-utils-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## pyros_utils

```
* using renamed dependency catkin_pip
* Contributors: alexv
```
