### PR TITLE
pyros_config: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8007,7 +8007,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/pyros-config-rosrelease.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/asmodehn/pyros-config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_config` to `0.1.2-0`:
- upstream repository: https://github.com/asmodehn/pyros-config.git
- release repository: https://github.com/asmodehn/pyros-config-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.1-0`
## pyros_config

```
* Merge pull request #1 <https://github.com/asmodehn/pyros-config/issues/1> from asmodehn/tox_pytest
  Tox pytest
* adding one fake test to succeed tox.
* changing tox command to call py.test directly
* now using pytest form catkin-pip
* now using pytest from __main__
* Merge branch 'master' of https://github.com/asmodehn/pyros-config into tox_pytest
* now using setup.py test command from tox
* first version, adding tox and py.test. removing dependency on importlib, not needed since py2.7 ?
* Contributors: AlexV, alexv
```
