### PR TITLE
pyros_config: 0.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3843,6 +3843,21 @@ repositories:
       url: https://github.com/joselusl/pugixml.git
       version: master
     status: developed
+  pyros_config:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/pyros-config.git
+      version: jade
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/asmodehn/pyros-config-rosrelease.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/asmodehn/pyros-config.git
+      version: jade
+    status: developed
   pyros_test:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_config` to `0.1.2-0`:
- upstream repository: https://github.com/asmodehn/pyros-config.git
- release repository: https://github.com/asmodehn/pyros-config-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## pyros_config

```
* Merge pull request #1 <https://github.com/asmodehn/pyros-config/issues/1> from asmodehn/tox_pytest
  Tox pytest
* adding one fake test to succeed tox.
* changing tox command to call py.test directly
* now using pytest form catkin-pip
* now using pytest from __main__
* Merge branch 'master' of https://github.com/asmodehn/pyros-config into tox_pytest
* now using setup.py test command from tox
* first version, adding tox and py.test. removing dependency on importlib, not needed since py2.7 ?
* Contributors: AlexV, alexv
```
