### PR TITLE
jb_common_libs: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4097,7 +4097,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/JenniferBuehler/convenience-pkgs-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/JenniferBuehler/convenience-pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jb_common_libs` to `0.0.4-0`:
- upstream repository: https://github.com/JenniferBuehler/convenience-pkgs.git
- release repository: https://github.com/JenniferBuehler/convenience-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.3-0`
