### PR TITLE
pyros_utils: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8044,7 +8044,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/pyros-utils-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/asmodehn/pyros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_utils` to `0.1.2-0`:
- upstream repository: https://github.com/asmodehn/pyros-utils.git
- release repository: https://github.com/asmodehn/pyros-utils-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.1-0`
## pyros_utils

```
* fixing travis file to check multiple distros.
* fixing python package version not matching catkin package version.
* Contributors: alexv
```
