### PR TITLE
ros_comm: 1.12.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2387,7 +2387,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.12.0-0
+      version: 1.12.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.12.2-0`:
- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.12.0-0`
## message_filters

```
* allow saving timestamp-less messages to Cache, add getLast method (#806 <https://github.com/ros/ros_comm/pull/806>)
```
## ros_comm
- No changes
## rosbag
- No changes
## rosbag_storage
- No changes
## rosconsole
- No changes
## roscpp

```
* improve stacktrace for exceptions thrown in callbacks (#811 <https://github.com/ros/ros_comm/pull/811>)
* fix segfault if creating outgoing UDP transport fails (#807 <https://github.com/ros/ros_comm/pull/807>)
```
## rosgraph

```
* avoid creating a latest symlink for the root of the log dir (#795 <https://github.com/ros/ros_comm/pull/795>)
```
## roslaunch

```
* support registering the same test multiple times with different arguments (#814 <https://github.com/ros/ros_comm/pull/814>)
* fix passing multiple args to roslaunch_add_file_check (#814 <https://github.com/ros/ros_comm/pull/814>)
```
## roslz4
- No changes
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode

```
* add --quiet option (#809 <https://github.com/ros/ros_comm/pull/809>)
```
## rosout
- No changes
## rosparam
- No changes
## rospy

```
* add logXXX_throttle functions (#812 <https://github.com/ros/ros_comm/pull/812>)
```
## rosservice
- No changes
## rostest
- No changes
## rostopic
- No changes
## roswtf
- No changes
## topic_tools
- No changes
## xmlrpcpp
- No changes
