### PR TITLE
qwt_dependency: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8170,7 +8170,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/qwt_dependency-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/ros-visualization/qwt_dependency.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qwt_dependency` to `1.0.1-0`:
- upstream repository: https://github.com/ros-visualization/qwt_dependency.git
- release repository: https://github.com/ros-gbp/qwt_dependency-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.0-0`
