### PR TITLE
smarthome_media_msgs_java: 0.1.82-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11024,7 +11024,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rosalfred-release/smarthome_media_msgs_java-release.git
-      version: 0.1.81-0
+      version: 0.1.82-0
     source:
       type: git
       url: https://github.com/rosalfred/smarthome_media_msgs_java.git


### PR DESCRIPTION
Increasing version of package(s) in repository `smarthome_media_msgs_java` to `0.1.82-0`:
- upstream repository: https://github.com/rosalfred/smarthome_media_msgs_java.git
- release repository: https://github.com/rosalfred-release/smarthome_media_msgs_java-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.81-0`
## smarthome_media_msgs_java

```
* Add roslib to packages dependencies
* Add rosjava_messages to packages dependencies
* Fix rosdistro dependency (needed by genjava)
* Contributors: Erwan Le Huitouze, Mickael Gaillard
```
