### PR TITLE
smarthome_media_kodi_driver: 0.1.57-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10985,6 +10985,21 @@ repositories:
       url: https://github.com/rosalfred/smarthome_heater_msgs_java.git
       version: master
     status: developed
+  smarthome_media_kodi_driver:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/smarthome_media_kodi_driver.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/smarthome_media_kodi_driver-release.git
+      version: 0.1.57-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/smarthome_media_kodi_driver.git
+      version: master
+    status: developed
   smarthome_media_model:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `smarthome_media_kodi_driver` to `0.1.57-0`:
- upstream repository: https://github.com/rosalfred/smarthome_media_kodi_driver.git
- release repository: https://github.com/rosalfred-release/smarthome_media_kodi_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## smarthome_media_kodi_driver

```
* Clean package info
* Update package dependencies
  Update messages packages names
* Rename package name to smarthome_media_kodi_driver
* Remove building dependency
* Update package description & license
* Contributors: Alfred Team, Erwan Le Huitouze
```
