### PR TITLE
alfred_sr_linux: 0.1.20-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -152,6 +152,21 @@ repositories:
       url: https://github.com/RobotnikAutomation/agvs_sim.git
       version: indigo-devel
     status: maintained
+  alfred_sr_linux:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/alfred_sr_linux.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/alfred_sr_linux-release.git
+      version: 0.1.20-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/alfred_sr_linux.git
+      version: master
+    status: developed
   android_apps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `alfred_sr_linux` to `0.1.20-0`:
- upstream repository: https://github.com/rosalfred/alfred_sr_linux.git
- release repository: https://github.com/rosalfred-release/alfred_sr_linux-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## alfred_sr_linux

```
* Update package dependencies
* Update package description & license
* Contributors: Erwan Le Huitouze
```
