### PR TITLE
smarthome_common_driver: 0.1.61-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10964,7 +10964,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rosalfred-release/smarthome_common_driver-release.git
-      version: 0.1.60-0
+      version: 0.1.61-0
     source:
       type: git
       url: https://github.com/rosalfred/smarthome_common_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `smarthome_common_driver` to `0.1.61-0`:
- upstream repository: https://github.com/rosalfred/smarthome_common_driver.git
- release repository: https://github.com/rosalfred-release/smarthome_common_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.60-0`
## smarthome_common_driver

```
* Add rosjava_messages dependency
* Contributors: Erwan Le Huitouze
```
