### PR TITLE
urdf_tools: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12183,7 +12183,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/JenniferBuehler/urdf-tools-pkgs-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/JenniferBuehler/urdf-tools-pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tools` to `0.0.4-0`:
- upstream repository: https://github.com/JenniferBuehler/urdf-tools-pkgs.git
- release repository: https://github.com/JenniferBuehler/urdf-tools-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.3-0`
## urdf2inventor

```
* Fixed export depending system libs in cmakelists
* Contributors: Jennifer Buehler
```
## urdf_tools
- No changes
## urdf_transform
- No changes
## urdf_traverser
- No changes
## urdf_viewer

```
* Fixed export depending system libs in cmakelists
* Contributors: Jennifer Buehler
```
