### PR TITLE
jb_general_msgs: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4118,6 +4118,25 @@ repositories:
       url: https://github.com/JenniferBuehler/convenience-pkgs.git
       version: master
     status: maintained
+  jb_general_msgs:
+    doc:
+      type: git
+      url: https://github.com/JenniferBuehler/general-message-pkgs.git
+      version: master
+    release:
+      packages:
+      - object_msgs
+      - object_msgs_tools
+      - path_navigation_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/JenniferBuehler/general-message-pkgs-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/JenniferBuehler/general-message-pkgs.git
+      version: master
+    status: maintained
   joystick_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jb_general_msgs` to `1.0.0-0`:
- upstream repository: https://github.com/JenniferBuehler/general-message-pkgs.git
- release repository: https://github.com/JenniferBuehler/general-message-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## object_msgs

```
* Initial release
* Contributors: Jennifer Buehler
```
## object_msgs_tools

```
* Initial release
* Contributors: Jennifer Buehler
```
## path_navigation_msgs

```
* Initial release
* Contributors: Jennifer Buehler
```
