### PR TITLE
Fix mrpt dep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2999,15 +2999,7 @@ mplayer:
 mrpt:
   debian: [libmrpt-dev]
   fedora: [mrpt-devel]
-  ubuntu:
-    oneiric: [libmrpt-dev]
-    precise: [libmrpt-dev]
-    quantal: [libmrpt-dev]
-    raring: [libmrpt-dev, mrpt-apps]
-    saucy: [libmrpt-dev, mrpt-apps]
-    trusty: [libmrpt-dev]
-    utopic: [libmrpt-dev]
-    vivid: [libmrpt-dev]
+  ubuntu: [libmrpt-dev]
 muparser:
   fedora: [muParser-devel]
   ubuntu: [libmuparser-dev]


### PR DESCRIPTION
Deletion of special case in old (now unsupported Ubuntu releases) due to a bug in those packages. 
Now all versions should depend on libmrpt-dev only. Simpler = better.
