### PR TITLE
gazebo_tools: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2789,6 +2789,26 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: indigo-devel
     status: developed
+  gazebo_tools:
+    doc:
+      type: git
+      url: https://github.com/JenniferBuehler/gazebo-pkgs.git
+      version: master
+    release:
+      packages:
+      - gazebo_grasp_plugin
+      - gazebo_state_plugins
+      - gazebo_test_tools
+      - gazebo_world_plugin_loader
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/JenniferBuehler/gazebo-pkgs-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/JenniferBuehler/gazebo-pkgs.git
+      version: master
+    status: developed
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_tools` to `1.0.0-0`:
- upstream repository: https://github.com/JenniferBuehler/gazebo-pkgs.git
- release repository: https://github.com/JenniferBuehler/gazebo-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## gazebo_grasp_plugin

```
* Initial release
* Contributors: Jennifer Buehler
```
## gazebo_state_plugins

```
* Initial release
* Contributors: Jennifer Buehler
```
## gazebo_test_tools

```
* Initial release
* Contributors: Jennifer Buehler
```
## gazebo_world_plugin_loader

```
* Initial release
* Contributors: Jennifer Buehler
```
