### PR TITLE
urdf_tools: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12203,7 +12203,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/JenniferBuehler/urdf-tools-pkgs-release.git
-      version: 0.0.4-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/JenniferBuehler/urdf-tools-pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tools` to `1.0.0-0`:
- upstream repository: https://github.com/JenniferBuehler/urdf-tools-pkgs.git
- release repository: https://github.com/JenniferBuehler/urdf-tools-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.4-0`
## urdf2inventor

```
* Added missing installation of hpp files
* Added installation of launch files
* Contributors: Jennifer Buehler
```
## urdf_tools
- No changes
## urdf_transform
- No changes
## urdf_traverser
- No changes
## urdf_viewer

```
* Added installation of launch files
* Contributors: Jennifer Buehler
```
