### PR TITLE
openni2_camera: 0.2.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6939,7 +6939,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 0.2.6-0
+      version: 0.2.7-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `0.2.7-0`:
- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros-gbp/openni2_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.6-0`
## openni2_camera

```
* Merge pull request #44 <https://github.com/ros-drivers/openni2_camera/issues/44> from jacquelinekay/fix_kinetic_build
  fix compile on kinetic
* Contributors: Jackie Kay, Michael Ferguson
```
