### PR TITLE
gazebo_tools: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2803,7 +2803,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/JenniferBuehler/gazebo-pkgs-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/JenniferBuehler/gazebo-pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_tools` to `1.0.1-0`:
- upstream repository: https://github.com/JenniferBuehler/gazebo-pkgs.git
- release repository: https://github.com/JenniferBuehler/gazebo-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.0-0`
## gazebo_grasp_plugin

```
* Fixed cmake files for jenkins builds
* Contributors: Jennifer Buehler
```
## gazebo_state_plugins

```
* Fixed cmake files for jenkins builds
* Contributors: Jennifer Buehler
```
## gazebo_test_tools

```
* Fixed cmake files for jenkins builds
* Contributors: Jennifer Buehler
```
## gazebo_world_plugin_loader

```
* Fixed cmake files for jenkins builds
* Contributors: Jennifer Buehler
```
