### PR TITLE
graspit_tools: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3106,7 +3106,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/JenniferBuehler/graspit-pkgs-release.git
-      version: 0.1.5-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/JenniferBuehler/graspit-pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graspit_tools` to `1.0.0-0`:
- upstream repository: https://github.com/JenniferBuehler/graspit-pkgs.git
- release repository: https://github.com/JenniferBuehler/graspit-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.5-0`
## grasp_planning_graspit

```
* Removed direct Qt dependencies from urdf2graspit, as this is now in urdf2inventor
* Now compiles with new graspit and new urdf2inventor
* Contributors: Jennifer Buehler
```
## grasp_planning_graspit_msgs
- No changes
## grasp_planning_graspit_ros

```
* Now compiles with new graspit and new urdf2inventor
* Contributors: Jennifer Buehler
```
## graspit_tools
- No changes
## jaco_graspit_sample
- No changes
## urdf2graspit

```
* Removed direct Qt dependencies from urdf2graspit, as this is now in urdf2inventor
* Now working with new urdf2inventor, tested on jaco
* Fixed some bugs in DH parameter computation
* Can now be used to display local coordinate axes of DH parameters, useful for debugging
* Allows to save the contacts file as different filename
* Contact selection is now done in separate postprocessing step
* Contacts can now be generated in a post-processing step.
* Contacts can now be generated in a post-processing step. This commit includes the old code within ifndef 0 directives
* urdf2graspit now depends on urdf2inventor
* Contributors: Jennifer Buehler
```
