### PR TITLE
opencv_apps: 1.11.13-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1853,6 +1853,13 @@ repositories:
       url: https://github.com/ros-gbp/opencv3-release.git
       version: 3.1.0-14
     status: maintained
+  opencv_apps:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-perception/opencv_apps-release.git
+      version: 1.11.13-0
+    status: developed
   opencv_candidate:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `opencv_apps` to `1.11.13-0`:
- upstream repository: https://github.com/ros-perception/opencv_apps.git
- release repository: https://github.com/ros-perception/opencv_apps-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## opencv_apps

```
* Add parameter to people_detector #9 <https://github.com/ros-perception/opencv_apps/issues/9>
* hough_circles: enable to set double value to the HoughCircle params #8 <https://github.com/ros-perception/opencv_apps/issues/8>

    * hough_circle enable to set gaussian_blue_size and kernel sigma from cfg
    * hough_circles: fix default/min/max value of cfg
    * hough_circle: enable to set db to 100
    * circle_hough: dp, accumrate_threshold, canny_threshold is double, not int

* Add parameter to hough_circles_nodelet #7 <https://github.com/ros-perception/opencv_apps/issues/7>
* Add parameter to hough_lines_nodelet #6 <https://github.com/ros-perception/opencv_apps/issues/6>
* Add parameter to edge_detection_nodelet(canny) #5 <https://github.com/ros-perception/opencv_apps/issues/5>
* Simplify source tree by removing duplicated node codes #4 <https://github.com/ros-perception/opencv_apps/issues/4>  Closes #3 <https://github.com/ros-perception/opencv_apps/issues/3>
* fix .travis file
* copy Travis and .gitignore from vision_opencv
* geometry_msgs doesn't get used by opencv_apps, but std_msgs does. (#119 <https://github.com/ros-perception/vision_opencv/pull/119>)
* Contributors: Kei Okada, Kentaro Wada, Lucas Walter, Vincent Rabaud, IorI Yanokura
```
