### PR TITLE
ar_track_alvar: 0.6.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -68,7 +68,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ar_track_alvar-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/sniekum/ar_track_alvar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar` to `0.6.1-0`:
- upstream repository: https://github.com/sniekum/ar_track_alvar
- release repository: https://github.com/ros-gbp/ar_track_alvar-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.0-0`
## ar_track_alvar

```
* New parameter -array to create an array of markers #85 <https://github.com/sniekum/ar_track_alvar/issues/85> from 130s/kinetic/add_60
* Fix build for Kinetic by adding missing dependencies on gencfg #84 <https://github.com/sniekum/ar_track_alvar/issues/84> from 130s/kinetic/fix_buildfarm
* [sys] Add a maintainer to receive notification from ros buildfarm.
* Contributors: Jackie Kay, Mehdi, Isaac I.Y. Saito
```
