### PR TITLE
navigation: 1.12.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6317,7 +6317,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.12.10-0
+      version: 1.12.11-0
     source:
       test_commits: false
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.12.11-0`:
- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.12.10-0`
## amcl
- No changes
## base_local_planner
- No changes
## carrot_planner
- No changes
## clear_costmap_recovery
- No changes
## costmap_2d

```
* Fixed bug with inflation layer that caused underinflation
  When marking before adding to the priority queue, it was possible to
  underestimate the cost of a cell. This is both dangerous and can lead to
  unintended side-effects with navigation.
* Fixed bug with artifacts when not current
  This is due to not getting clearing observations if the marking
  observations aren't current.
* Fix bug with inflation artifacts being left behind
* Contributors: Alex Henning
```
## dwa_local_planner
- No changes
## fake_localization
- No changes
## global_planner

```
* [Fix] Illegal vector visit when no path planned
* Contributors: gjc13
```
## map_server
- No changes
## move_base

```
* [Fix] Illegal vector visit when no path planned
* Contributors: gjc13
```
## move_base_msgs
- No changes
## move_slow_and_clear
- No changes
## nav_core
- No changes
## navfn
- No changes
## navigation
- No changes
## robot_pose_ekf
- No changes
## rotate_recovery
- No changes
## voxel_grid
- No changes
