### PR TITLE
moveit_ros: 0.6.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2627,7 +2627,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.6.5-0
+      version: 0.6.6-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ros` to `0.6.6-0`:
- upstream repository: https://github.com/ros-planning/moveit_ros.git
- release repository: https://github.com/ros-gbp/moveit_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.6.5-0`
## moveit_ros

```
* Removed trailing whitespace from entire repository
* Contributors: Dave Coleman
```
## moveit_ros_benchmarks

```
* Removed trailing whitespace from entire repository
* Adding tf dep fixes #572 <https://github.com/ros-planning/moveit_ros/issues/572>
* Contributors: Dave Coleman, Mr-Yellow
```
## moveit_ros_benchmarks_gui

```
* relax Qt-version requirement
  Minor Qt version updates are ABI-compatible with each other:
  https://wiki.qt.io/Qt-Version-Compatibility
* replaced cmake_modules dependency with eigen
* [jade] eigen3 adjustment
* benchmark_gui: Fix conversion of shared_ptr to bool for C++11
* unify Qt4 / Qt5 usage across cmake files
  - fetch Qt version from rviz
  - define variables/macros commonly used for Qt4 and Qt5
  - QT_LIBRARIES
  - qt_wrap_ui()
* Enable optional build against Qt5, use -DUseQt5=On to enable it
* explicitly link rviz' default_plugin library
  The library is not exported anymore and now is provided separately from rviz_LIBRARIES.
  See https://github.com/ros-visualization/rviz/pull/979 for details.
* Removed trailing whitespace from entire repository
* Contributors: Dave Coleman, Isaac I.Y. Saito, Maarten de Vries, Robert Haschke, Simon Schmeisser (isys vision), v4hn
```
## moveit_ros_manipulation

```
* replaced cmake_modules dependency with eigen
* [jade] eigen3 adjustment
* Removed trailing whitespace from entire repository
* Contributors: Dave Coleman, Isaac I.Y. Saito, Robert Haschke
```
## moveit_ros_move_group

```
* added missing validity check
  iterator found with configs.find() needs to be validated before use...
* Removed trailing whitespace from entire repository
* moved planner params services into existing capability QueryPlannerInterfaces
* capability plugin MoveGroupPlannerParamsService to get/set planner params
* Fixed bug(?) in move_group::MoveGroupKinematicsService::computeIK link name selection.
* Contributors: Dave Coleman, Mihai Pomarlan, Robert Haschke
```
## moveit_ros_perception

```
* replaced cmake_modules dependency with eigen
* [jade] eigen3 adjustment
* remove unknown dependency sensor_msgs_generate_cpp
  dependencies are pulled in via ${catkin_LIBRARIES}
* Find X11 for build on OS X 10.11
* set empty display function for glut window
  With freeglut 3.0 moveit aborts over here, printing
  > ERROR: No display callback registered for window 1
  According to https://sourceforge.net/p/freeglut/bugs/229/
  and https://www.opengl.org/resources/libraries/glut/spec3/node46.html
  a callback *must* be registered for each window.
  With this patch moveit starts up as expected.
* Remove OpenMP parallelization, fixes #563 <https://github.com/ros-planning/moveit_ros/issues/563>
* Removed trailing whitespace from entire repository
* last comment
* Added missing dependency on moveit_msgs package
* Contributors: Andriy Petlovanyy, Dave Coleman, Isaac I.Y. Saito, Kentaro Wada, Robert Haschke, Stefan Kohlbrecher, dg, v4hn
```
## moveit_ros_planning

```
* Add library moveit_collision_plugin_loader as an exported catkin library (#678 <https://github.com/ros-planning/moveit_ros/issues/678>)
* replaced cmake_modules dependency with eigen
* [jade] eigen3 adjustment
* Fix compilation with C++11.
* Enable optional build against Qt5, use -DUseQt5=On to enable it
* merge indigo-devel changes (PR #633 <https://github.com/ros-planning/moveit_ros/issues/633> trailing whitespace) into jade-devel
* Removed trailing whitespace from entire repository
* Optional ability to copy velocity and effort to RobotState
* cherry-picked PR #614 <https://github.com/ros-planning/moveit_ros/issues/614>
  fixed segfault on shutdown
* fixed segfault on shutdown
  use of pluginlib's createUnmanagedInstance() is strongly discouraged:
  http://wiki.ros.org/class_loader#Understanding_Loading_and_Unloading
  here, the kinematics plugin libs were unloaded before destruction of corresponding pointers
* Deprecate shape_tools
* CurrentStateMonitor no longer requires hearing mimic joint state values.
* Fix crash due to robot state not getting updated (moveit_ros #559 <https://github.com/ros-planning/moveit_ros/issues/559>)
* Contributors: Dave Coleman, Dave Hershberger, Isaac I.Y. Saito, Levi Armstrong, Maarten de Vries, Robert Haschke, Simon Schmeisser (isys vision), kohlbrecher
```
## moveit_ros_planning_interface

```
* replaced cmake_modules dependency with eigen
* [jade] eigen3 adjustment
* merge indigo-devel changes (PR #633 <https://github.com/ros-planning/moveit_ros/issues/633> trailing whitespace) into jade-devel
* Removed trailing whitespace from entire repository
* planning_interface::MoveGroup::get/setPlannerParams
* new method MoveGroup::getDefaultPlannerId(const std::string &group)
  ... to retrieve default planner config from param server
  moved corresponding code from rviz plugin to MoveGroup interface
  to facilitate re-use
* fixing conflicts, renaming variable
* Merge pull request #589 <https://github.com/ros-planning/moveit_ros/issues/589> from MichaelStevens/set_num_planning_attempts
  adding set_num_planning_attempts to python interface
* comments addressed
* Added python wrapper for setMaxVelocityScalingFactor
* saves robot name to db from moveit. also robot name accessible through robot interface python wrapper
* adding set_num_planning_attempts to python interface
* Merge pull request #571 <https://github.com/ros-planning/moveit_ros/issues/571> from ymollard/indigo-devel
  Added python wrapper for MoveGroup.asyncExecute()
* Added python wrapper for MoveGroup.asyncExecute()
* Add retime_trajectory to moveit python wrapper
* add getHandle to move_group_interface
* Updated documentation on move() to inform the user that an asynchronus spinner is required. Commonly new users don't do this and move() blocks permanently
* Contributors: Dave Coleman, Dave Hershberger, Isaac I.Y. Saito, Kei Okada, Michael Stevens, Robert Haschke, Sachin Chitta, Scott, Yoan Mollard, dg, ferherranz
```
## moveit_ros_robot_interaction

```
* use getModelFrame() as reference frame for markers
* publish markers relative to robot's root frame
  In addition to #669 <https://github.com/ros-planning/moveit_ros/issues/669>, interactive markers need to be place relative to the
  robot's root frame. If nothing is specified (as before), rviz' fixed frame
  is used, leading to offsets when both frames are not identical.
* merge indigo-devel changes (PR #633 <https://github.com/ros-planning/moveit_ros/issues/633> trailing whitespace) into jade-devel
* Removed trailing whitespace from entire repository
* further adapted marker size computation
  - drop largest extension dimension (-> use cross-section size of elongated link)
  - for an end-effector group, consider the sizes of individual links
  instead of the overall size of all links (which becomes huge very fast)
  - enlarge marker size by factor of 1.5 when there is only a single eef marker
* reworked computeLinkMarkerSize()
  compute size such that the marker sphere will cover
  - a spherical link geometry -> AABB.maxCoeff
  - a cubical link geometry -> AABB.norm
  -> use average of both values
  Virtual links (without any shape) will have a size of AABB of zero dims.
  In this case use the dimensions of the closest parent link instead.
* improved computation of interactive marker size
  - use parent_link if group == parent_group
  - scale smaller than 5cm is clipped to 5cm instead of using default
  - clarified size computation, using diameter of AABB
* fixing error caused by BOOST_STATIC_ASSERT
* Fixed compile error caused by BOOST_STATIC_ASSERT in kinematic_options.cpp
  Added kinematics::DiscretizationMethods::DiscretizationMethod to QO_FIELDS in kinematic_options.cpp.
  At pull request #581 <https://github.com/ros-planning/moveit_ros/issues/581>, type of discretization_method was set to int. Changed it to proper type.
* reinstated changes related to the updates in the  moveit_core::KinematicsBase interface
* Revert "  Kinematics Base changes in moveit_core"
* adds the 'returns_approximate_solution' entry so that it is compatible with the changes in kinematics::KinematicsBase class in the moveit_core repo
* Contributors: Daichi Yoshikawa, Dave Coleman, Robert Haschke, Sachin Chitta, jrgnicho
```
## moveit_ros_visualization

```
* cleanup cmake tests, fix empty output
* added missing rostest dependency (#680 <https://github.com/ros-planning/moveit_ros/issues/680>), fixes c6d0ede (#639 <https://github.com/ros-planning/moveit_ros/issues/639>)
* [moveit joy] Add friendlier error message
* relax Qt-version requirement
  Minor Qt version updates are ABI-compatible with each other:
  https://wiki.qt.io/Qt-Version-Compatibility
* replaced cmake_modules dependency with eigen
* [jade] eigen3 adjustment
* always (re)create collision object marker
  other properties than pose (such as name of the marker) need to be adapted too
* use getModelFrame() as reference frame for markers
* moved "Publish Scene" button to "Scene Objects" tab
  previous location on "Context" tab was weird
* cherry-pick PR #635 <https://github.com/ros-planning/moveit_ros/issues/635> from indigo-devel
* unify Qt4 / Qt5 usage across cmake files
  - fetch Qt version from rviz
  - define variables/macros commonly used for Qt4 and Qt5
  - QT_LIBRARIES
  - qt_wrap_ui()
* leave frame transforms to rviz
  The old code
  (1.) reimplemented frame transforms in rviz
  although it could simply utilize rviz' FrameManager
  (2.) assumed the transform between the model-frame
  and the fixed_frame was constant and only needed to be updated
  if the frame changes (ever tried to make the endeffector
  your fixed frame?)
  (3.) was broken because on startup calculateOffsetPosition was called
  *before* the robot model is loaded, so the first (and usually only)
  call to calculateOffsetPosition failed.
  Disabling/Enabling the display could be used to work around this...
  This fixes all three issues.
* display planned path in correct rviz context
  This was likely a typo.
* Solved parse error with Boost 1.58. Fixes #653 <https://github.com/ros-planning/moveit_ros/issues/653>
* Enable optional build against Qt5, use -DUseQt5=On to enable it
* explicitly link rviz' default_plugin library
  The library is not exported anymore and now is provided separately from rviz_LIBRARIES.
  See https://github.com/ros-visualization/rviz/pull/979 for details.
* merge indigo-devel changes (PR #633 <https://github.com/ros-planning/moveit_ros/issues/633> trailing whitespace) into jade-devel
* Removed trailing whitespace from entire repository
* correctly handle int and float parameters
  Try to parse parameter as int and float (in that series)
  and use IntProperty or FloatProperty on success to have
  input checking.
  Floats formatted without decimal dot, e.g. "0", will be
  considered as int!
  All other parameters will be handled as string.
* access planner params in rviz' MotionPlanningFrame
* new method MoveGroup::getDefaultPlannerId(const std::string &group)
  ... to retrieve default planner config from param server
  moved corresponding code from rviz plugin to MoveGroup interface
  to facilitate re-use
* correctly initialize scene robot's parameters after initialization
  - loaded parameters were ignored
  - changed default alpha value to 1 to maintain previous behaviour
* load default_planner_config from default location
  instead of loading from /<ns>/default_planner_config, use
  /<ns>/move_group/<group>/default_planner_config, which is the default
  location for planner_configs too
* Merge pull request #610 <https://github.com/ros-planning/moveit_ros/issues/610>: correctly update all markers after robot motion
* fixing conflicts, renaming variable
* Merge pull request #612 <https://github.com/ros-planning/moveit_ros/issues/612> from ubi-agni/interrupt-traj-vis
  interrupt trajectory visualization on arrival of new display trajectory
* cherry-picked PR #611 <https://github.com/ros-planning/moveit_ros/issues/611>
  fix segfault when disabling and re-enabling TrajectoryVisualization
* cherry-picked PR #609 <https://github.com/ros-planning/moveit_ros/issues/609>
  load / save rviz' workspace config
  fixed tab order of rviz plugin widgets
  use move_group/default_workspace_bounds as a fallback for workspace bounds
* fixup! cleanup TrajectoryVisualization::update
  only enter visualization loop when displaying_trajectory_message_ is defined
* added missing initialization
* correctly setAlpha for new trail
* fixed race condition for trajectory-display interruption
  - TrajectoryVisualization::update() switches to new trajectory
  automatically when it has finished displaying the old one
  - TrajectoryVisualization::interruptCurrentDisplay() might interrupt
  this newly started trajectory
  consequences:
  - protect switching of trajectory with mutex
  - interrupt only if trajectory display progressed past first waypoint
  - removed obsolete signal timeToShowNewTrail:
  update() automatically switches and updates trail in sync
* cleanup TrajectoryVisualization::update
  simplified code to switch to new trajectory / start over animation in loop mode
* new GUI property to allow immediate interruption of displayed trajectory
* immediately show trajectory after planning (interrupting current display)
* fix segfault when disabling and re-enabling TrajectoryVisualization
  animating_path_ was still true causing update() to access
  displaying_trajectory_message_, which was reset onDisable().
* update pose of all markers when any marker moved
  Having several end-effector markers attached to a group (e.g. a multi-
  fingered hand having an end-effector per fingertip and an end-effector
  for the hand base), all markers need to update their pose on any motion
  of any marker. In the example: if the hand base is moved, the fingertip
  markers should be moved too.
* use move_group/default_workspace_bounds as a fallback for workspace bounds
* code style cleanup
* fixed tab order of rviz plugin widgets
* load / save rviz' workspace config
* saves robot name to db from moveit. also robot name accessible through robot interface python wrapper
* Added install rule to install moveit_joy.py.
* motion_planning_frame_planning: use /default_planner_config parma to specify default planning algorithm
* Avoid adding a slash if getMoveGroupNS() is empty.
  If the getMoveGroupNS() returns an empty string, ros::names::append() inserts a slash in front of 'right', which changes it to a global name.
  Checking getMoveGroupNS() before calling append removes the issue.
  append() behaviour will not be changed in ros/ros_comm.
* Contributors: Ammar Najjar, Dave Coleman, Isaac I.Y. Saito, Jochen Welle, Kei Okada, Michael Ferguson, Michael Görner, Robert Haschke, Sachin Chitta, Simon Schmeisser (isys vision), TheDash, Thomas Burghout, dg, v4hn
```
## moveit_ros_warehouse

```
* Removed trailing whitespace from entire repository
* comments addressed
* changed to global node handle so warehouse connection params work correctly
* camelCase
* removed extraneous includes
* added delete and rename
* now takes port + host from param server
* removed defunct code
* checks db connection is good
* services advertised
* Contributors: Dave Coleman, dg
```
