### PR TITLE
moveit_helpers: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5627,6 +5627,25 @@ repositories:
       url: https://github.com/ros-planning/moveit_core.git
       version: indigo-devel
     status: maintained
+  moveit_helpers:
+    doc:
+      type: git
+      url: https://github.com/JenniferBuehler/moveit-pkgs.git
+      version: master
+    release:
+      packages:
+      - moveit_controller_multidof
+      - moveit_object_handling
+      - moveit_planning_helper
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/JenniferBuehler/moveit-pkgs-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/JenniferBuehler/moveit-pkgs.git
+      version: master
+    status: maintained
   moveit_ikfast:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_helpers` to `1.0.0-0`:
- upstream repository: https://github.com/JenniferBuehler/moveit-pkgs.git
- release repository: https://github.com/JenniferBuehler/moveit-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## moveit_controller_multidof

```
* Initial release
* Contributors: Jennifer Buehler
```
## moveit_object_handling

```
* Initial release
* Contributors: Jennifer Buehler
```
## moveit_planning_helper

```
* Initial release
* Contributors: Jennifer Buehler
```
