### PR TITLE
smarthome_media_onkyo_driver: 0.1.64-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11147,7 +11147,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rosalfred-release/smarthome_media_onkyo_driver-release.git
-      version: 0.1.64-0
+      version: 0.1.64-1
     source:
       type: git
       url: https://github.com/rosalfred/smarthome_media_onkyo_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `smarthome_media_onkyo_driver` to `0.1.64-1`:
- upstream repository: https://github.com/rosalfred/smarthome_media_onkyo_driver.git
- release repository: https://github.com/rosalfred-release/smarthome_media_onkyo_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.64-0`
## smarthome_media_onkyo_driver

```
* Add jeiscp library
* Remove submodule
* Contributors: Erwan Le Huitouze
```
