### PR TITLE
rtabmap_ros: 0.11.7-1 in '[indigo|jade|kinetic]/distribution.yaml'

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10280,7 +10280,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.11.7-0
+      version: 0.11.7-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5077,7 +5077,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.11.7-0
+      version: 0.11.7-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2777,7 +2777,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.11.7-0
+      version: 0.11.7-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package in repository `rtabmap_ros` to `0.11.7-1`:

upstream repository: https://github.com/introlab/rtabmap_ros.git
release repository: https://github.com/introlab/rtabmap_ros-release.git
distro file: [indigo|jade|kinetic]/distribution.yaml
bloom version: `0.5.21`
previous version for package: `0.11.7-0`
