### PR TITLE
robot_model: 1.11.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8715,7 +8715,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.11.10-0
+      version: 1.11.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.11.11-0`:
- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.11.10-0`
## collada_parser
- No changes
## collada_urdf
- No changes
## joint_state_publisher

```
* scroll joint_state_publisher if there are too many joints (#137 <https://github.com/ros/robot_model//issues/137>)
* Contributors: v4hn
```
## kdl_parser
- No changes
## kdl_parser_py
- No changes
## robot_model
- No changes
## urdf
- No changes
## urdf_parser_plugin
- No changes
