### PR TITLE
robot_model: 1.12.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2257,7 +2257,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.12.2-0
+      version: 1.12.3-0
     source:
       type: git
       url: https://github.com/ros/robot_model.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.12.3-0`:
- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.12.2-0`
## collada_parser
- No changes
## collada_urdf
- No changes
## joint_state_publisher

```
* Fix circular logic in joint state publisher events (#140 <https://github.com/ros/robot_model/issues/140>)
* Use signal and sys.exit to fix shutdown in joint_state_publisher (#139 <https://github.com/ros/robot_model/issues/139>)
* joint_state_publisher: Change slider update method (#135 <https://github.com/ros/robot_model/issues/135>)
* Contributors: Jackie Kay, vincentrou
```
## kdl_parser
- No changes
## kdl_parser_py
- No changes
## robot_model
- No changes
## urdf
- No changes
## urdf_parser_plugin
- No changes
