### PR TITLE
resource_retriever: 1.12.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2204,11 +2204,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/resource_retriever-release.git
-      version: 1.12.0-0
+      version: 1.12.1-0
     source:
       type: git
       url: https://github.com/ros/resource_retriever.git
       version: kinetic-devel
+    status: maintained
   rgbd_launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `1.12.1-0`:
- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros-gbp/resource_retriever-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.12.0-0`
## resource_retriever

```
* Fix warnings in test (#5 <https://github.com/ros/resource_retriever/issues/5>)
  add spaces around ROS_PACKAGE_NAME
* Merge pull request #4 <https://github.com/ros/resource_retriever/issues/4> from DLu/kinetic-devel
  Add c++11 flag
* Contributors: David V. Lu!!, Jackie Kay, Steven Peters
```
