### PR TITLE
gazebo_ros_pkgs: 2.5.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -799,11 +799,12 @@ repositories:
       - gazebo_msgs
       - gazebo_plugins
       - gazebo_ros
+      - gazebo_ros_control
       - gazebo_ros_pkgs
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.5.6-2
+      version: 2.5.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.5.7-0`:
- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.5.6-2`
## gazebo_msgs
- No changes
## gazebo_plugins
- No changes
## gazebo_ros
- No changes
## gazebo_ros_control

```
* delete CATKIN_IGNORE in gazebo_ros_control (#456 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/456>)
* Contributors: Jackie Kay, Jose Luis Rivero
```
## gazebo_ros_pkgs
- No changes
