### PR TITLE
resource_retriever: 1.12.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2205,7 +2205,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/resource_retriever-release.git
-      version: 1.12.1-0
+      version: 1.12.2-0
     source:
       type: git
       url: https://github.com/ros/resource_retriever.git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `1.12.2-0`:
- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros-gbp/resource_retriever-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.12.1-0`
## resource_retriever

```
* fix failing build due to cmake error (#6 <https://github.com/ros/resource_retriever/issues/6>)
* Contributors: Jackie Kay
```
