### PR TITLE
smarthome_msgs: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11168,6 +11168,21 @@ repositories:
       url: https://github.com/rosalfred/smarthome_media_samsungtv_driver.git
       version: master
     status: developed
+  smarthome_msgs:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/smarthome_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/smarthome_msgs-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/smarthome_msgs.git
+      version: master
+    status: developed
   smarthome_network_wakeonlan:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `smarthome_msgs` to `0.1.1-0`:
- upstream repository: https://github.com/rosalfred/smarthome_msgs.git
- release repository: https://github.com/rosalfred-release/smarthome_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## smarthome_msgs

```
* Initial commit.
* Contributors: Mickael Gaillard
```
