### PR TITLE
smarthome_light_msgs: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11078,6 +11078,21 @@ repositories:
       url: https://github.com/rosalfred/smarthome_heater_msgs_java.git
       version: master
     status: developed
+  smarthome_light_msgs:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/smarthome_light_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/smarthome_light_msgs-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/smarthome_light_msgs.git
+      version: master
+    status: developed
   smarthome_media_kodi_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `smarthome_light_msgs` to `0.1.1-0`:
- upstream repository: https://github.com/rosalfred/smarthome_light_msgs.git
- release repository: https://github.com/rosalfred-release/smarthome_light_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## smarthome_light_msgs

```
* Upgrade dependency
* Rename statedata.
* Fix dependency.
* Enable package.
* Initial commit.
* Contributors: Mickael Gaillard
```
