### PR TITLE
smarthome_msgs: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11192,7 +11192,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rosalfred-release/smarthome_msgs-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/rosalfred/smarthome_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `smarthome_msgs` to `0.1.2-0`:
- upstream repository: https://github.com/rosalfred/smarthome_msgs.git
- release repository: https://github.com/rosalfred-release/smarthome_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.1-0`
## smarthome_msgs

```
* Rename Info message
* Contributors: Erwan Le Huitouze
```
