### PR TITLE
Adding pi_trees to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7400,6 +7400,16 @@ repositories:
       url: https://github.com/ccny-ros-pkg/phidgets_drivers.git
       version: indigo
     status: maintained
+  pi_trees:
+    doc:
+      type: git
+      url: https://github.com/pirobot/pi_trees.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/pirobot/pi_trees.git
+      version: indigo-devel
+    status: developed
   pid:
     doc:
       type: git


### PR DESCRIPTION
I'd like pi_trees to be indexed and documented on ros.org.
