### PR TITLE
smarthome_msgs_java: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11198,6 +11198,21 @@ repositories:
       url: https://github.com/rosalfred/smarthome_msgs.git
       version: master
     status: developed
+  smarthome_msgs_java:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/smarthome_msgs_java.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/smarthome_msgs_java-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/smarthome_msgs_java.git
+      version: master
+    status: developed
   smarthome_network_wakeonlan:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `smarthome_msgs_java` to `0.1.1-0`:
- upstream repository: https://github.com/rosalfred/smarthome_msgs_java.git
- release repository: https://github.com/rosalfred-release/smarthome_msgs_java-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## smarthome_msgs_java

```
* Initial Commit.
* Contributors: Mickael Gaillard
```
