### PR TITLE
alfred_bot: 0.1.121-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -152,6 +152,21 @@ repositories:
       url: https://github.com/RobotnikAutomation/agvs_sim.git
       version: indigo-devel
     status: maintained
+  alfred_bot:
+    doc:
+      type: git
+      url: https://github.com/rosalfred/alfred_bot.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rosalfred-release/alfred_bot-release.git
+      version: 0.1.121-0
+    source:
+      type: git
+      url: https://github.com/rosalfred/alfred_bot.git
+      version: master
+    status: developed
   alfred_sr_linux:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `alfred_bot` to `0.1.121-0`:
- upstream repository: https://github.com/rosalfred/alfred_bot.git
- release repository: https://github.com/rosalfred-release/alfred_bot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## alfred_bot

```
* Update eclipse project.
* Update package dependencies
  Update messages packages names
* Contributors: Erwan Le Huitouze, Mickael Gaillard
```
