### PR TITLE
octomap_msgs: 0.3.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3330,7 +3330,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/octomap_msgs-release.git
-      version: 0.3.2-0
+      version: 0.3.3-0
     source:
       type: git
       url: https://github.com/OctoMap/octomap_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_msgs` to `0.3.3-0`:
- upstream repository: https://github.com/OctoMap/octomap_msgs.git
- release repository: https://github.com/ros-gbp/octomap_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.2-0`
## octomap_msgs

```
* Fix for binary ColorOcTrees messages
* Removed check for "OcTree" id in binary deserialization, see Issue #4 <https://github.com/OctoMap/octomap_msgs/issues/4> and #5 <https://github.com/OctoMap/octomap_msgs/issues/5>
* Contributors: Armin Hornung, Felix Endres
```
