### PR TITLE
jsk_common: 2.0.15-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4274,7 +4274,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.0.14-0
+      version: 2.0.15-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.0.15-1`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.0.14-0`
## dynamic_tf_publisher
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_data

```
* Add data_collection_server.py
* Contributors: Kentaro Wada
```
## jsk_network_tools
- No changes
## jsk_tilt_laser
- No changes
## jsk_tools

```
* Install test files that works properly
* Comment out sanity_lib.py testing on hydro
* Simplify to make sanity_lib work on Travis
* Fix style of code 'test_topic_published.py'
* fix test_topic_published.py to sleep in the beginning when rosbag is used
* Contributors: Kentaro Wada, Yusuke Niitani
```
## jsk_topic_tools

```
* add parameter for selecting MultiThread callback or SingleThread callback
* Test LoggingThrottle
* Implement logXXX_throttle
* Support async in is_synchronized
* Install only usable *.test files
* Test and documentize tf_to_pose.py
* Transform tf to pose and publish it
* Contributors: Kentaro Wada, Yohei Kakiuchi
```
## multi_map_server
- No changes
## virtual_force_publisher
- No changes
