### PR TITLE
rtshell: 3.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2792,6 +2792,13 @@ repositories:
       url: https://github.com/tork-a/rtctree-release.git
       version: 3.0.1-0
     status: developed
+  rtshell:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/rtshell-release.git
+      version: 3.0.1-1
+    status: developed
   rtsprofile:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell` to `3.0.1-1`:
- upstream repository: https://github.com/gbiggs/rtshell.git
- release repository: https://github.com/tork-a/rtshell-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
