### PR TITLE
hrpsys: 315.9.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1043,6 +1043,13 @@ repositories:
       url: https://github.com/ethz-asl/grid_map.git
       version: master
     status: developed
+  hrpsys:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/hrpsys-release.git
+      version: 315.9.0-0
+    status: developed
   humanoid_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys` to `315.9.0-0`:
- upstream repository: https://github.com/fkanehiro/hrpsys-base.git
- release repository: https://github.com/tork-a/hrpsys-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## hrpsys
- No changes
