### PR TITLE
rtshell: 3.0.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2811,7 +2811,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/rtshell-release.git
-      version: 3.0.1-1
+      version: 3.0.1-2
     status: developed
   rtsprofile:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell` to `3.0.1-2`:
- upstream repository: https://github.com/gbiggs/rtshell.git
- release repository: https://github.com/tork-a/rtshell-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `3.0.1-1`
