### PR TITLE
axcli: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -532,6 +532,13 @@ repositories:
       url: https://github.com/wjwwood/ax2550.git
       version: master
     status: maintained
+  axcli:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/po1/axcli-release.git
+      version: 0.1.0-0
+    status: maintained
   axis_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `axcli` to `0.1.0-0`:
- upstream repository: https://github.com/po1/axcli.git
- release repository: https://github.com/po1/axcli-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## axcli

```
* Initial release, with colorized output, tab completion and fire&forget option
* Contributors: Adolfo Rodriguez Tsouroukdissian, Paul Mathieu
```
