### PR TITLE
axcli: 0.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -209,6 +209,13 @@ repositories:
       url: https://github.com/oceansystemslab/auv_msgs.git
       version: master
     status: developed
+  axcli:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/po1/axcli-release.git
+      version: 0.1.0-0
+    status: maintained
   battery_monitor_rmp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `axcli` to `0.1.0-0`:
- upstream repository: https://github.com/po1/axcli.git
- release repository: https://github.com/po1/axcli-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## axcli

```
* Initial release, with colorized output, tab completion and fire&forget option
* Contributors: Adolfo Rodriguez Tsouroukdissian, Paul Mathieu
```
