### PR TITLE
trac_ik: 1.4.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11906,10 +11906,21 @@ repositories:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git
       version: master
+    release:
+      packages:
+      - trac_ik
+      - trac_ik_examples
+      - trac_ik_kinematics_plugin
+      - trac_ik_lib
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/traclabs/trac_ik-release.git
+      version: 1.4.2-0
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git
       version: master
+    status: developed
   tum_ardrone:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `trac_ik` to `1.4.2-0`:
- upstream repository: https://bitbucket.org/traclabs/trac_ik.git
- release repository: https://github.com/traclabs/trac_ik-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## trac_ik

```
* New revision for ROS Package release.  Thanks to Gijs van der Hoorn
```
