### PR TITLE
pid: 0.0.15-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2098,6 +2098,21 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: kinetic-devel
     status: maintained
+  pid:
+    doc:
+      type: git
+      url: https://bitbucket.org/AndyZe/pid.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/AndyZelenak/pid-release.git
+      version: 0.0.15-0
+    source:
+      type: git
+      url: https://bitbucket.org/AndyZe/pid.git
+      version: master
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pid` to `0.0.15-0`:
- upstream repository: https://bitbucket.org/AndyZe/pid
- release repository: https://github.com/AndyZelenak/pid-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## pid

```
* Fixing header "include" error, possible dynamic_reconfigure errors.
* Contributors: Andy Zelenak
```
