### PR TITLE
lyap_control: 0.0.13-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1395,6 +1395,21 @@ repositories:
       url: https://github.com/clearpathrobotics/lms1xx.git
       version: master
     status: maintained
+  lyap_control:
+    doc:
+      type: git
+      url: https://bitbucket.org/AndyZe/lyap_control.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/AndyZelenak/lyap_control-release.git
+      version: 0.0.13-0
+    source:
+      type: git
+      url: https://bitbucket.org/AndyZe/lyap_control.git
+      version: master
+    status: maintained
   marti_messages:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lyap_control` to `0.0.13-0`:
- upstream repository: https://bitbucket.org/AndyZe/lyap_control.git
- release repository: https://github.com/AndyZelenak/lyap_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
