### PR TITLE
Adding trac_ik to documentation index for jade/karmic

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5631,6 +5631,16 @@ repositories:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/topic_proxy.git
       version: master
+  trac_ik:
+    doc:
+      type: git
+      url: https://bitbucket.org/traclabs/trac_ik.git
+      version: master
+    source:
+      type: git
+      url: https://bitbucket.org/traclabs/trac_ik.git
+      version: master
+    status: developed
   tuw_visual_marker:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3053,6 +3053,16 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  trac_ik:
+    doc:
+      type: git
+      url: https://bitbucket.org/traclabs/trac_ik.git
+      version: master
+    source:
+      type: git
+      url: https://bitbucket.org/traclabs/trac_ik.git
+      version: master
+    status: developed
   turtlebot_create:
     doc:
       type: git


### PR DESCRIPTION
Already added indigo, jade/karmic should also work with source.
