### PR TITLE
trac_ik: 1.4.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5636,6 +5636,16 @@ repositories:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git
       version: master
+    release:
+      packages:
+      - trac_ik
+      - trac_ik_examples
+      - trac_ik_kinematics_plugin
+      - trac_ik_lib
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/traclabs/trac_ik-release.git
+      version: 1.4.3-0
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `trac_ik` to `1.4.3-0`:
- upstream repository: https://bitbucket.org/traclabs/trac_ik.git
- release repository: https://github.com/traclabs/trac_ik-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## trac_ik

```
* trac_ik_kinematics_plugin and trac_ik_examples needed build depends on libnlopt-dev
```
