### PR TITLE
micros_mars_task_alloc: 0.0.3-4 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5523,6 +5523,21 @@ repositories:
       url: https://github.com/yincanben/micros_dynamic_objects_filter.git
       version: master
     status: developed
+  micros_mars_task_alloc:
+    doc:
+      type: git
+      url: https://github.com/liminglong/micros_mars_task_alloc.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/liminglong/micros_mars_task_alloc-release.git
+      version: 0.0.3-4
+    source:
+      type: git
+      url: https://github.com/liminglong/micros_mars_task_alloc.git
+      version: master
+    status: developed
   micros_rtt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `micros_mars_task_alloc` to `0.0.3-4`:
- upstream repository: https://github.com/liminglong/micros_mars_task_alloc.git
- release repository: https://github.com/liminglong/micros_mars_task_alloc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## micros_mars_task_alloc

```
* first commit
* Contributors: liminglong
```
