### PR TITLE
diagnostics: 1.8.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -672,7 +672,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/diagnostics-release.git
-      version: 1.8.9-1
+      version: 1.8.10-0
     source:
       type: git
       url: https://github.com/ros/diagnostics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `1.8.10-0`:
- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros-gbp/diagnostics-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.8.9-1`
## diagnostic_aggregator

```
* Start bond after add_diagnostics service is available
* Contributors: Mustafa Safri
```
## diagnostic_analysis
- No changes
## diagnostic_common_diagnostics
- No changes
## diagnostic_updater
- No changes
## diagnostics
- No changes
## self_test
- No changes
## test_diagnostic_aggregator
- No changes
