### PR TITLE
diagnostics: 1.8.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -449,7 +449,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/diagnostics-release.git
-      version: 1.8.9-0
+      version: 1.8.10-0
     source:
       type: git
       url: https://github.com/ros/diagnostics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `1.8.10-0`:
- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros-gbp/diagnostics-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.8.9-0`
## diagnostic_aggregator

```
* Start bond after add_diagnostics service is available
* Contributors: Mustafa Safri
```
## diagnostic_analysis
- No changes
## diagnostic_common_diagnostics
- No changes
## diagnostic_updater
- No changes
## diagnostics
- No changes
## self_test
- No changes
## test_diagnostic_aggregator
- No changes
