### PR TITLE
add rpy2 to rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3330,6 +3330,10 @@ rosemacs-el:
     lucid: [rosemacs-el]
     oneiric: [rosemacs-el]
     precise: [rosemacs-el]
+rpy2:
+  arch: [python-rpy2]
+  debian: [python-rpy2]
+  ubuntu: [python-rpy2]
 ruby:
   arch: [ruby]
   debian: [ruby1.8-dev, libruby1.8, rubygems1.8]


### PR DESCRIPTION
This Pull Request adds `rpy2` to `rosdep/base.yaml`.

`rpy2` is a long-used interface between python and R.
