### PR TITLE
add pyper-pip to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -48,6 +48,10 @@ paramiko:
     vivid: [python-paramiko]
     wily: [python-paramiko]
     xenial: [python-paramiko]
+pyper-pip:
+  ubuntu:
+    pip:
+      packages: [pyper]
 pyros-setup-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
This Pull Request adds `pyper` provided in `PyPI` to `rosdep/python.yaml`.

`pyper` is a library for python which provides an interface between python and R language.
