### PR TITLE
Removing Moveit! dependent packages for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3063,11 +3063,11 @@ repositories:
     doc:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git
-      version: master
+      version: no_moveit_plugin-kinetic
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git
-      version: master
+      version: no_moveit_plugin-kinetic
     status: developed
   turtlebot_create:
     doc:


### PR DESCRIPTION
Created branch that removes moveit IK plugin, as MoveIt! has not yet been released for kinetic.
