### PR TITLE
parrot_arsdk: remove the released tag, add the devel job

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7263,6 +7263,10 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/AutonomyLab/parrot_arsdk-release.git
       version: 3.9.1-0
+    source:
+      type: git
+      url: https://github.com/AutonomyLab/parrot_arsdk.git
+      version: indigo-devel
     status: developed
   patrolling_sim:
     doc:


### PR DESCRIPTION
There are some issues regarding the release that I need to fix, so I removed the `release` tag and added the `source` repo. Could you please tell me how I can re-release the same version using `bloom` when  problems are fixed (i.e. `3.9.1-0` to `3-9.1-1`)?
