### PR TITLE
Avoid demanding PCL head.

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -265,26 +265,8 @@ libpcl-all:
       depends: [libpcl-all-dev]
 libpcl-all-dev:
   osx:
-    "el capitan":
-      homebrew:
-        install_flags: [--HEAD]
-        packages: [homebrew/science/pcl]
-    leopard:
-      homebrew: [homebrew/science/pcl]
-    lion:
-      homebrew: [homebrew/science/pcl]
-    mavericks:
-      homebrew:
-        install_flags: [--HEAD]
-        packages: [homebrew/science/pcl]
-    "mountain lion":
-      homebrew: [homebrew/science/pcl]
-    snow:
-      homebrew: [homebrew/science/pcl]
-    yosemite:
-      homebrew:
-        install_flags: [--HEAD]
-        packages: [homebrew/science/pcl]
+    homebrew:
+      packages: [homebrew/science/pcl]
 libpgm:
   osx:
     homebrew:
@@ -404,7 +386,6 @@ libv4l-dev:
 libvtk:
   osx:
     homebrew:
-      options: [--with-qt]
       packages: [vtk]
 libvtk-java:
   osx:


### PR DESCRIPTION
Now that PCL 1.8.0 is released, we can simply use the bottle of it and avoid having to build it locally everywhere.

Must merge after this: https://github.com/Homebrew/homebrew-science/pull/3752
