### PR TITLE
moveit_msgs: 0.8.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2558,7 +2558,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/moveit_msgs-release.git
-      version: 0.8.0-0
+      version: 0.8.1-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `0.8.1-0`:
- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/ros-gbp/moveit_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.8.0-0`
## moveit_msgs

```
* [feat] add new srv ApplyPlanningScene #21 <https://github.com/ros-planning/moveit_msgs/issues/21>
  This service takes a PlanningScene message and applies it to the monitored scene. Ideally it should include a bool success field, but it is not possible to apply the scene and check for success without ABI changes, so leave it out for now. To get this change pushed to indigo.
* [feat] apply_planning_scene: add a success field in response
  This will be set to true in indigo, but might return false in kinetic and upcoming after we broke the underlying API to get that information.
* Contributors: Dave Coleman, Michael G«Órner
```
