### PR TITLE
ompl: 1.0.3094-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6876,7 +6876,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ompl-release.git
-      version: 1.0.0003094-0
+      version: 1.0.3094-0
     status: maintained
   ompl_visual_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.0.3094-0`:
- upstream repository: https://bitbucket.org/ompl/ompl
- release repository: https://github.com/ros-gbp/ompl-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.0003094-0`
