### PR TITLE
ompl: 1.1.3535-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1882,6 +1882,13 @@ repositories:
       url: https://github.com/OctoMap/octomap_ros.git
       version: indigo-devel
     status: maintained
+  ompl:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/ompl-release.git
+      version: 1.1.3535-0
+    status: maintained
   opencv3:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.1.3535-0`:
- upstream repository: https://bitbucket.org/ompl/ompl
- release repository: https://github.com/ros-gbp/ompl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
