### PR TITLE
ecl_lite: 0.61.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -552,7 +552,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_lite-release.git
-      version: 0.61.4-3
+      version: 0.61.6-0
     source:
       type: git
       url: https://github.com/stonier/ecl_lite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_lite` to `0.61.6-0`:
- upstream repository: https://github.com/stonier/ecl_lite.git
- release repository: https://github.com/yujinrobot-release/ecl_lite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.61.4-3`
## ecl_io

```
* accomodate platforms (e.g. macosx) without SOCK_NONBLOCK
```
