### PR TITLE
qglv_toolkit: 0.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8269,7 +8269,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/qglv_toolkit-release.git
-      version: 0.1.6-0
+      version: 0.1.7-0
     source:
       type: git
       url: https://github.com/yujinrobot/qglv_toolkit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qglv_toolkit` to `0.1.7-0`:
- upstream repository: https://github.com/yujinrobot/qglv_toolkit.git
- release repository: https://github.com/yujinrobot-release/qglv_toolkit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.6-0`
## qglv_opengl

```
* bugfix small arrows
* use inf as the potential field threshold
```
