### PR TITLE
message_multiplexing: 0.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5469,7 +5469,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/message_multiplexing-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/stonier/message_multiplexing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_multiplexing` to `0.2.4-0`:
- upstream repository: https://github.com/stonier/message_multiplexing.git
- release repository: https://github.com/yujinrobot-release/message_multiplexing-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.3-0`
## mm_messages

```
* debug macro to enable/disable message registration logs to stdout (default disable)
```
## mm_radio

```
* bugfix for socket closing - was leaving sockets with id=0 hanging.
```
