### PR TITLE
jsk_robot: 1.0.6-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4440,7 +4440,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_robot-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     status: developed
   jsk_roseus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `1.0.6-1`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.5-1`
## baxtereus

```
* [baxtereus] make ik-bin test faster (#604 <https://github.com/jsk-ros-pkg/jsk_robot/issues/604>)
  * [baxtereus] ik-bin test fix coords pos
  * [baxtereus] make ik-bin test faster
* [baxtereus] Compute IK from prepared poses (using :ik-prepared-poses methods) (#602 <https://github.com/jsk-ros-pkg/jsk_robot/issues/602>)
  * Refactor: Remove no need variable
  * Compute IK from prepared poses (using :ik-prepared-poses methods)
  * Documentation for :inverse-kinematics in baxter-util.l
* add ik-bin-test for apc
* Contributors: Kentaro Wada, Shingo Kitagawa
```
## fetcheus

```
* feteus-interface.l : always use moveit within :angle-vector (#620 <https://github.com/jsk-ros-pkg/jsk_robot/issues/620>)
  * fetcheus: fetch-interface.l : always use moveit within :angle-vector
  * fetcheus : add test for fetch-moveit-interface
  * feetcheus : fix typo in fetcheus.test
* Contributors: Kei Okada
```
## jsk_201504_miraikan
- No changes
## jsk_baxter_desktop
- No changes
## jsk_baxter_startup
- No changes
## jsk_baxter_web
- No changes
## jsk_fetch_startup
- No changes
## jsk_nao_startup
- No changes
## jsk_pepper_startup

```
* change from naoqi_msgs to naoqi_bridge_msgs (#614 <https://github.com/jsk-ros-pkg/jsk_robot/issues/614>)
* Contributors: Kanae Kochigami
```
## jsk_pr2_calibration
- No changes
## jsk_pr2_startup

```
* fix too long file name in deb build (#618 <https://github.com/jsk-ros-pkg/jsk_robot/issues/618>)
  * fix too long file name in deb build
  * update maintainer names
* Contributors: Kei Okada
```
## jsk_robot
- No changes
## jsk_robot_startup

```
* [jsk_robot_startup] Define publisher before callback definition (#615 <https://github.com/jsk-ros-pkg/jsk_robot/issues/615>)
* Combine EKF and GPF for more constant odometry output (#617 <https://github.com/jsk-ros-pkg/jsk_robot/issues/617>)
  * [jsk_robot_startup] Add script for odometry calculation with combination of EKF and GPF
  * [jsk_robot_startup] Fix some misses
  * [jsk_robot_startup] Use ekf+gpf odometry instead of particle odometry and thus iir filter is no longer used
  * [jsk_robot_startup] Tune jaxon_red odometry param
* [jsk_robot_startup] add multisense_local.launch
* Use only important partilces when estimating output distribution of particle odom  (#601 <https://github.com/jsk-ros-pkg/jsk_robot/issues/601>)
  * [jsk_robot_startup] Use only important particles to guess output distribution
  * [jsk_robot_startup] Rename parameter name for valid particles
  * [jsk_robot_startup] Use 1/3 particles for estimate normal distribution and make initial distribution narrower
  * [jsk_robot_startup] Rename value name to match with rosparam name
  * [jsk_robot_startup] Add comments
* activate_user.l : fix for non pr2 robot, see #589 <https://github.com/jsk-ros-pkg/jsk_robot/issues/589> (#590 <https://github.com/jsk-ros-pkg/jsk_robot/issues/590>)
* [jsk_robot_startup] Add jsk_recognition_msgs to dependency because of histgram msgs
* [jsk_robot_startup] Fix typo
* [jsk_robot_startup] Add publish_histogram option to visualize particles
* [jsk_robot_startup] Use parameter_yaml arg instead of ROBOT environmental value for odometry params
* [jsk_robot_startup] Tune z direction parameter for JAXON_RED odometry
* Contributors: Iori Kumagai, Kei Okada, Yohei Kakiuchi
```
## jsk_robot_utils
- No changes
## naoeus
- No changes
## naoqieus
- No changes
## peppereus
- No changes
## pr2_base_trajectory_action
- No changes
## roseus_remote
- No changes
