### PR TITLE
yujin_ocs: 0.8.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3320,6 +3320,41 @@ repositories:
       url: https://github.com/yujinrobot/yocs_msgs.git
       version: kinetic
     status: developed
+  yujin_ocs:
+    doc:
+      type: git
+      url: https://github.com/yujinrobot/yujin_ocs.git
+      version: kinetic
+    release:
+      packages:
+      - yocs_ar_marker_tracking
+      - yocs_ar_pair_approach
+      - yocs_ar_pair_tracking
+      - yocs_cmd_vel_mux
+      - yocs_controllers
+      - yocs_diff_drive_pose_controller
+      - yocs_joyop
+      - yocs_keyop
+      - yocs_localization_manager
+      - yocs_math_toolkit
+      - yocs_navi_toolkit
+      - yocs_navigator
+      - yocs_rapps
+      - yocs_safety_controller
+      - yocs_velocity_smoother
+      - yocs_virtual_sensor
+      - yocs_waypoint_provider
+      - yocs_waypoints_navi
+      - yujin_ocs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/yujin_ocs-release.git
+      version: 0.8.1-0
+    source:
+      type: git
+      url: https://github.com/yujinrobot/yujin_ocs.git
+      version: kinetic
+    status: developed
   zeroconf_avahi_suite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yujin_ocs` to `0.8.1-0`:
- upstream repository: https://github.com/yujinrobot/yujin_ocs.git
- release repository: https://github.com/yujinrobot-release/yujin_ocs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
