### PR TITLE
fanuc: 0.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2505,7 +2505,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/fanuc-release.git
-      version: 0.4.0-1
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/ros-industrial/fanuc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fanuc` to `0.4.1-0`:
- upstream repository: https://github.com/ros-industrial/fanuc.git
- release repository: https://github.com/ros-industrial-release/fanuc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.4.0-1`
## fanuc

```
* no changes.
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_driver

```
* minor: sort install targets in build scripts.
* remove roslaunch test dependencies (#185 <https://github.com/ros-industrial/fanuc/issues/185>).
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_lrmate200ic5h_moveit_config

```
* make RRTConnect the default planner (#179 <https://github.com/ros-industrial/fanuc/issues/179>).
* update package manifests with missing dependencies (found with roslaunch tests).
* add basic roslaunch tests (#104 <https://github.com/ros-industrial/fanuc/issues/104>).
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_lrmate200ic5l_moveit_config

```
* make RRTConnect the default planner (#179 <https://github.com/ros-industrial/fanuc/issues/179>).
* update package manifests with missing dependencies (found with roslaunch tests).
* add basic roslaunch tests (#104 <https://github.com/ros-industrial/fanuc/issues/104>).
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_lrmate200ic_moveit_config

```
* make RRTConnect the default planner (#179 <https://github.com/ros-industrial/fanuc/issues/179>).
* update package manifests with missing dependencies (found with roslaunch tests).
* add basic roslaunch tests (#104 <https://github.com/ros-industrial/fanuc/issues/104>).
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_lrmate200ic_moveit_plugins

```
* no changes.
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_lrmate200ic_support

```
* use ``xacro`` instead of ``xacro.py`` (#195 <https://github.com/ros-industrial/fanuc/issues/195>).
* remove roslaunch test dependencies (#185 <https://github.com/ros-industrial/fanuc/issues/185>).
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_m10ia_moveit_config

```
* make RRTConnect the default planner (#179 <https://github.com/ros-industrial/fanuc/issues/179>).
* update package manifests with missing dependencies (found with roslaunch tests).
* add basic roslaunch tests (#104 <https://github.com/ros-industrial/fanuc/issues/104>).
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_m10ia_moveit_plugins

```
* no changes.
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_m10ia_support

```
* use ``xacro`` instead of ``xacro.py`` (#195 <https://github.com/ros-industrial/fanuc/issues/195>).
* remove roslaunch test dependencies (#185 <https://github.com/ros-industrial/fanuc/issues/185>).
* add support for the M-10iA/7L variant (contributors: Jeremy Zoss (SwRI))
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_m16ib20_moveit_config

```
* make RRTConnect the default planner (#179 <https://github.com/ros-industrial/fanuc/issues/179>).
* update package manifests with missing dependencies (found with roslaunch tests).
* add basic roslaunch tests (#104 <https://github.com/ros-industrial/fanuc/issues/104>).
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_m16ib_moveit_plugins

```
* no changes.
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_m16ib_support

```
* use ``xacro`` instead of ``xacro.py`` (#195 <https://github.com/ros-industrial/fanuc/issues/195>).
* remove roslaunch test dependencies (#185 <https://github.com/ros-industrial/fanuc/issues/185>).
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_m20ia10l_moveit_config

```
* make RRTConnect the default planner (#179 <https://github.com/ros-industrial/fanuc/issues/179>).
* update package manifests with missing dependencies (found with roslaunch tests).
* add basic roslaunch tests (#104 <https://github.com/ros-industrial/fanuc/issues/104>).
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_m20ia_moveit_config

```
* make RRTConnect the default planner (#179 <https://github.com/ros-industrial/fanuc/issues/179>).
* update package manifests with missing dependencies (found with roslaunch tests).
* add basic roslaunch tests (#104 <https://github.com/ros-industrial/fanuc/issues/104>).
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_m20ia_moveit_plugins

```
* no changes.
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_m20ia_support

```
* use ``xacro`` instead of ``xacro.py`` (#195 <https://github.com/ros-industrial/fanuc/issues/195>).
* remove roslaunch test dependencies (#185 <https://github.com/ros-industrial/fanuc/issues/185>).
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_m430ia2f_moveit_config

```
* make RRTConnect the default planner (#179 <https://github.com/ros-industrial/fanuc/issues/179>).
* update package manifests with missing dependencies (found with roslaunch tests).
* add basic roslaunch tests (#104 <https://github.com/ros-industrial/fanuc/issues/104>).
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_m430ia2p_moveit_config

```
* make RRTConnect the default planner (#179 <https://github.com/ros-industrial/fanuc/issues/179>).
* update package manifests with missing dependencies (found with roslaunch tests).
* add basic roslaunch tests (#104 <https://github.com/ros-industrial/fanuc/issues/104>).
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_m430ia_moveit_plugins

```
* no changes.
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_m430ia_support

```
* use ``xacro`` instead of ``xacro.py`` (#195 <https://github.com/ros-industrial/fanuc/issues/195>).
* remove roslaunch test dependencies (#185 <https://github.com/ros-industrial/fanuc/issues/185>).
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
## fanuc_resources

```
* add approximation of Fanuc green (colour for collaborative robot series).
* for a complete list of changes see the commit log for 0.4.1 <https://github.com/ros-industrial/fanuc/compare/0.4.0...0.4.1>.
```
