### PR TITLE
Revert "summit_xl_common: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11641,18 +11641,6 @@ repositories:
       type: git
       url: https://github.com/srv/stereo_slam.git
       version: indigo
-  summit_xl_common:
-    release:
-      packages:
-      - summit_xl_common
-      - summit_xl_description
-      - summit_xl_localization
-      - summit_xl_navigation
-      - summit_xl_pad
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/RobotnikAutomation/summit_xl_common-release.git
-      version: 1.0.0-0
   swiftnav:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#11863

http://build.ros.org:8080/job/Isrc_uS__summit_xl_common__ubuntu_saucy__source/

@carlos3dx Reverting these because they are not building. It looks like you did not push the tags to the release repo. 
