### PR TITLE
moveit_core: 0.8.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2542,7 +2542,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/moveit_core-release.git
-      version: 0.8.1-0
+      version: 0.8.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_core` to `0.8.2-0`:
- upstream repository: https://github.com/ros-planning/moveit_core.git
- release repository: https://github.com/ros-gbp/moveit_core-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.8.1-0`
## moveit_core

```
* [feat] planning_scene updates: expose success state to caller. This is required to get the information back for the ApplyPlanningSceneService. #296 <https://github.com/ros-planning/moveit_core/issues/297>
* [sys] replaced cmake_modules dependency with eigen
* Contributors: Michael Ferguson, Robert Haschke, Michael G«Órner, Isaac I. Y. Saito
```
