### PR TITLE
moveit_core: 0.7.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5665,7 +5665,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_core-release.git
-      version: 0.7.1-0
+      version: 0.7.2-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_core` to `0.7.2-0`:
- upstream repository: https://github.com/ros-planning/moveit_core.git
- release repository: https://github.com/ros-gbp/moveit_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.7.1-0`
