### PR TITLE
jsk_common_msgs: 3.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4304,7 +4304,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common_msgs-release.git
-      version: 2.0.1-0
+      version: 3.0.0-0
     status: developed
   jsk_control:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common_msgs` to `3.0.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common_msgs
- release repository: https://github.com/tork-a/jsk_common_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.0.1-0`
## jsk_common_msgs
- No changes
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs

```
* Add YesNo.srv
* Contributors: Kentaro Wada
```
## jsk_hark_msgs
- No changes
## posedetection_msgs
- No changes
## speech_recognition_msgs
- No changes
