### PR TITLE
rqt_launchtree: 0.1.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5022,6 +5022,21 @@ repositories:
       url: https://github.com/OTL/rqt_ez_publisher.git
       version: jade-devel
     status: developed
+  rqt_launchtree:
+    doc:
+      type: git
+      url: https://github.com/pschillinger/rqt_launchtree.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/pschillinger/rqt_launchtree-release.git
+      version: 0.1.4-0
+    source:
+      type: git
+      url: https://github.com/pschillinger/rqt_launchtree.git
+      version: master
+    status: maintained
   rqt_robot_plugins:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_launchtree` to `0.1.4-0`:
- upstream repository: https://github.com/pschillinger/rqt_launchtree.git
- release repository: https://github.com/pschillinger/rqt_launchtree-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rqt_launchtree

```
* Hide or display machine entries according to nodes (fix #2 <https://github.com/pschillinger/rqt_launchtree/issues/2>)
* Account for different entries with same name (fix #1 <https://github.com/pschillinger/rqt_launchtree/issues/1>)
* Contributors: Philipp Schillinger
```
