### PR TITLE
leap_motion: 0.0.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1343,6 +1343,21 @@ repositories:
       url: https://github.com/ros-perception/laser_pipeline.git
       version: hydro-devel
     status: maintained
+  leap_motion:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/leap_motion.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/leap_motion-release.git
+      version: 0.0.10-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/leap_motion.git
+      version: master
+    status: maintained
   leptrino_force_torque:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `leap_motion` to `0.0.10-0`:
- upstream repository: https://github.com/ros-drivers/leap_motion
- release repository: https://github.com/ros-gbp/leap_motion-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## leap_motion

```
* [fix][sys] launch and camera_info directory should be installed
  [fix][sys] a bug of the check method of LEAP_SDK environment value #27 <https://github.com/ros-drivers/leap_motion/issues/28>
* [sys] Add tests #25 <https://github.com/ros-drivers/leap_motion/issues/25>
* Contributors: Kenta Yonekura, Isaac I.Y. Saito
```
