### PR TITLE
leap_motion: 0.0.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2128,7 +2128,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/leap_motion-release.git
-      version: 0.0.9-0
+      version: 0.0.10-0
     source:
       type: git
       url: https://github.com/ros-drivers/leap_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leap_motion` to `0.0.10-0`:
- upstream repository: https://github.com/ros-drivers/leap_motion
- release repository: https://github.com/ros-gbp/leap_motion-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.9-0`
## leap_motion

```
* [fix][sys] launch and camera_info directory should be installed
  [fix][sys] a bug of the check method of LEAP_SDK environment value #27 <https://github.com/ros-drivers/leap_motion/issues/28>
* [sys] Add tests #25 <https://github.com/ros-drivers/leap_motion/issues/25>
* Contributors: Kenta Yonekura, Isaac I.Y. Saito
```
