### PR TITLE
jsk_common: 2.0.16-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1881,7 +1881,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.0.15-0
+      version: 2.0.16-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.0.16-1`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.0.15-0`
## dynamic_tf_publisher
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_data
- No changes
## jsk_network_tools
- No changes
## jsk_tilt_laser
- No changes
## jsk_tools

```
* Fix video recording to avoid the bug in image_view
  https://github.com/ros-perception/image_pipeline/issues/187
* Contributors: Kentaro Wada
```
## jsk_topic_tools

```
* Fix unreasonable test name of test_log_utils.cpp
* Add test for getFunctionName
* Use JSK_NODELET_WARN in connection_based_nodelet
* Show only func name in JSK_XXX log utils
* Contributors: Kentaro Wada
```
## multi_map_server
- No changes
## virtual_force_publisher
- No changes
