### PR TITLE
Adding rsync_ros to documentation index for jade

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5081,6 +5081,16 @@ repositories:
       url: https://github.com/robosavvy/rsv_balance_simulator.git
       version: master
     status: maintained
+  rsync_ros:
+    doc:
+      type: git
+      url: https://github.com/clungzta/rsync_ros.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/clungzta/rsync_ros.git
+      version: master
+    status: maintained
   rtabmap:
     doc:
       type: git


### PR DESCRIPTION
Hi,

I'd like rsync_ros to be indexed and documented on ros.org
