### PR TITLE
fetch_ros: 0.7.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2581,7 +2581,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
-      version: 0.7.6-0
+      version: 0.7.7-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.7.7-0`:
- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.7.6-0`
## fetch_calibration
- No changes
## fetch_depth_layer
- No changes
## fetch_description

```
* add base camera links to freight URDF
* Contributors: Michael Ferguson
```
## fetch_maps
- No changes
## fetch_moveit_config
- No changes
## fetch_navigation

```
* remove run_depend on metapackage
* Contributors: Michael Ferguson
```
## fetch_teleop
- No changes
