### PR TITLE
rocon_multimaster: 0.8.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2423,6 +2423,30 @@ repositories:
       url: https://github.com/robotics-in-concert/rocon_msgs.git
       version: kinetic
     status: developed
+  rocon_multimaster:
+    doc:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_multimaster.git
+      version: kinetic
+    release:
+      packages:
+      - rocon_gateway
+      - rocon_gateway_tests
+      - rocon_gateway_utils
+      - rocon_hub
+      - rocon_hub_client
+      - rocon_multimaster
+      - rocon_test
+      - rocon_unreliable_experiments
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/rocon_multimaster-release.git
+      version: 0.8.1-0
+    source:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_multimaster.git
+      version: kinetic
+    status: developed
   rocon_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_multimaster` to `0.8.1-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_multimaster.git
- release repository: https://github.com/yujinrobot-release/rocon_multimaster-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rocon_gateway

```
* handle flip problems when connections go down
```
