### PR TITLE
warehouse_ros: 0.9.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6075,7 +6075,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/warehouse_ros-release.git
-      version: 0.8.8-0
+      version: 0.9.0-0
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `0.9.0-0`:
- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/ros-gbp/warehouse_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.8.8-0`
## warehouse_ros

```
* [fix] Omit dependency on mongo (and replace with pluginlib) #32 <https://github.com/ros-planning/warehouse_ros/issues/22>
* [fix] Specifically including a header that seems to be required from Ubuntu Xenial.
* [sys] Ensure headers and libraries are present for downstream pkgs #17 <https://github.com/ros-planning/warehouse_ros/issues/17>
* [sys] Update CI config to test Jade and Kinetic #30 <https://github.com/ros-planning/warehouse_ros/issues/30>
* [sys] Add rostest file and configs.
* Contributors: Connor Brew, Dave Coleman, Ioan A Sucan, Isaac I.Y. Saito, Michael Ferguson, Scott K Logan
```
