### PR TITLE
moveit_ros: 0.7.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5860,7 +5860,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.7.1-0
+      version: 0.7.2-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ros` to `0.7.2-0`:
- upstream repository: https://github.com/ros-planning/moveit_ros.git
- release repository: https://github.com/ros-gbp/moveit_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.7.1-0`
## moveit_ros
- No changes
## moveit_ros_benchmarks
- No changes
## moveit_ros_benchmarks_gui
- No changes
## moveit_ros_manipulation
- No changes
## moveit_ros_move_group

```
* apply planning scene: use newly exposed success value of newPlanningSceneMessage
* add apply_planning_scene capability
  This new capability allows to apply changes to a monitored planning
  scene and *blocks* until the changes are applied. This is meant to
  replace the quasi-standard pattern:
```

  planning_scene_interface.addCollisionObjects(...)
  sleep(2.0)
  group.pick("object")

```
  by
```

  ros::ServiceClient client = n.serviceClient<moveit_msgs::ApplyPlanningScene>("apply_planning_scene");
  client.call(...)
  group.pick("object")

```
  This makes it much more convenient to add&interact with objects
  without useless and arbitrarily long sleeps to ensure planning scene
  updates succeeded.
* clear_octomap_service: fix runtime name (#685 <https://github.com/ros-planning/moveit_ros/issues/685>)
  Looks like the author copy&pasted from a different capability
  and forgot to change the name.
* Contributors: v4hn
```
## moveit_ros_perception

```
* set empty display function for glut window
  With freeglut 3.0 moveit aborts over here, printing
  > ERROR: No display callback registered for window 1
  According to https://sourceforge.net/p/freeglut/bugs/229/
  and https://www.opengl.org/resources/libraries/glut/spec3/node46.html
  a callback *must* be registered for each window.
  With this patch moveit starts up as expected.
* Contributors: v4hn
```
## moveit_ros_planning

```
* apply planning scene: use newly exposed success value of newPlanningSceneMessage
* simplify newPlanningSceneMessage
* monitor: make newPlanningSceneMessage public
  This is required for capabilities to update the planning scene.
  ABI-compatible.
* Add library moveit_collision_plugin_loader as an exported catkin library (#677 <https://github.com/ros-planning/moveit_ros/issues/677>)
* Contributors: Levi Armstrong, v4hn
```
## moveit_ros_planning_interface

```
* Issue #630 <https://github.com/ros-planning/moveit_ros/issues/630>: remove color information from addCollisionObjects method
* attachment to the commit: fab50d487d86aa4011fb05e41e694b837eca92df
  For more information see the specified commit.
* planning_interface: Set is_diff true for empty start state
  Executing a motion without setting the start state of the robot like
  this:
```

  group_arm.setNamedTarget("start_grab_pose");
  success = group_arm.move();

```
  throws the error: Execution of motions should always start at the robot's
  current state. Ignoring the state supplied as start state in the motion
  planning request.
  The problem is, when considered_start_state_ is null, every data field of the start_state
  in the submitted MotionPlanRequest is 0 or false. But we need is_diff to be
  true, because otherwise move_group will not consider its current state as
  actual start state without complaining.
* Implement issue #630 <https://github.com/ros-planning/moveit_ros/issues/630>
* Contributors: Yannick Jonetzko, corot
```
## moveit_ros_robot_interaction

```
* cherry-pick 04e158aca from jade-devel
  - use getModelFrame() as reference frame for markers
  - always (re)create collision object marker
  (other properties than pose (such as name of the marker) need to be adapted too)
* publish markers relative to robot's root frame
  In addition to #669 <https://github.com/ros-planning/moveit_ros/issues/669>, interactive markers need to be place relative to the
  robot's root frame. If nothing is specified (as before), rviz' fixed frame
  is used, leading to offsets when both frames are not identical.
* Contributors: Robert Haschke
```
## moveit_ros_visualization

```
* [fix][joy.py] Installed python file might not be executable. (#691 <https://github.com/ros-planning/moveit_ros/issues/691>)
* [fix] rostest dependency (#680 <https://github.com/ros-planning/moveit_ros/issues/680>), fixes c6d0ede (#639 <https://github.com/ros-planning/moveit_ros/issues/639>)
* [fix] always (re)create collision object marker
  (other properties than pose (such as name of the marker) need to be adapted too)
* [fix] correctly update planning_scene_node on changes of model-frame w.r.t. fixed frame
* [fix] Traj Rviz Plugin to properly change robot description parameter
* [feat] display planned path in correct rviz context
* [feat] leave frame transforms to rviz
* [enhance] use getModelFrame() as reference frame for markers
* Contributors: Ammar Najjar, Dave Coleman, Isaac I.Y. Saito, Robert Haschke, Michael G«Órner
```
## moveit_ros_warehouse
- No changes
