### PR TITLE
realsense_camera: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2295,6 +2295,13 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  realsense_camera:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/intel-ros/realsense-release.git
+      version: 1.1.0-0
+    status: developed
   realtime_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_camera` to `1.1.0-0`:
- upstream repository: https://github.com/intel-ros/realsense.git
- release repository: https://github.com/intel-ros/realsense-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## realsense_camera

```
* Fix white space issues in test files
* Updated docs with Kinetic Kame details and for consistency
* Added usb_port_id for selecting camera
* Updated artifacts to reflect 'stable' tag
* Added code to skip publishing PointCloud frame if Depth and/or Color has duplicate frames
* Added code to skip publishing duplicate frames for native streams
* Added example for launching multiple cameras from a single launch file (#22)
* Fixed transformation origin bug for base frame to depth frame
* Rename package directory (#33)
* Update README to include rosdep install
* Resolved testTransform unit test issue
* Refined the log messages and made them consistent
* Removed extra space before ROS Log function calls
* Added nodelet name to log messages
* Remove hard-coded paths
* Fixed README bug to show correct depth format Z16
* Fixed unit conversion bug in the projection matrix
* Added unit test to check camera_info distortion-parameter
* adding D to camera info
* Contributors: Mark D Horn, Matthew Hansen, Reagan Lopez, Rajvi Jingar, Natalia Lyubova, Michael Gorner
```
