### PR TITLE
rocon_app_platform: 0.8.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2395,6 +2395,26 @@ repositories:
       url: https://github.com/ros/robot_state_publisher.git
       version: kinetic-devel
     status: maintained
+  rocon_app_platform:
+    doc:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_app_platform.git
+      version: kinetic
+    release:
+      packages:
+      - rocon_app_manager
+      - rocon_app_platform
+      - rocon_app_utilities
+      - rocon_apps
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/rocon_app_platform-release.git
+      version: 0.8.0-0
+    source:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_app_platform.git
+      version: kinetic
+    status: developed
   rocon_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_app_platform` to `0.8.0-0`:
- upstream repository: http://github.com/robotics-in-concert/rocon_app_platform
- release repository: https://github.com/yujinrobot-release/rocon_app_platform-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rocon_app_manager

```
* provide args to the user so they can prepare for unique namespacing if necessary
* move rapp launching into the root namespace and let the user decide where handles should go
* advertise the rapp manager handles on the gateway by default for concert clients
* simplified launchers into standalone and concert client
* split standalone and concert classes rather than trying to mash them as one
```
## rocon_app_platform

```
* rapps now launching in the root namespace, let the user decide
```
