### PR TITLE
kobuki: 0.7.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1238,6 +1238,34 @@ repositories:
       url: https://github.com/tork-a/jskeus-release.git
       version: 1.0.12-0
     status: developed
+  kobuki:
+    doc:
+      type: git
+      url: https://github.com/yujinrobot/kobuki.git
+      version: kinetic
+    release:
+      packages:
+      - kobuki
+      - kobuki_auto_docking
+      - kobuki_bumper2pc
+      - kobuki_capabilities
+      - kobuki_controller_tutorial
+      - kobuki_description
+      - kobuki_keyop
+      - kobuki_node
+      - kobuki_random_walker
+      - kobuki_rapps
+      - kobuki_safety_controller
+      - kobuki_testsuite
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/kobuki-release.git
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/yujinrobot/kobuki.git
+      version: kinetic
+    status: maintained
   kobuki_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki` to `0.7.0-0`:
- upstream repository: https://github.com/yujinrobot/kobuki.git
- release repository: https://github.com/yujinrobot-release/kobuki-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
