### PR TITLE
marti_common: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1464,6 +1464,37 @@ repositories:
       url: https://bitbucket.org/AndyZe/lyap_control.git
       version: master
     status: maintained
+  marti_common:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: kinetic-devel
+    release:
+      packages:
+      - marti_data_structures
+      - swri_console_util
+      - swri_geometry_util
+      - swri_image_util
+      - swri_math_util
+      - swri_nodelet
+      - swri_opencv_util
+      - swri_prefix_tools
+      - swri_roscpp
+      - swri_route_util
+      - swri_serial_util
+      - swri_string_util
+      - swri_system_util
+      - swri_transform_util
+      - swri_yaml_util
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_common-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: kinetic-devel
+    status: developed
   marti_messages:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.2.0-0`:
- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## marti_data_structures
- No changes
## swri_console_util
- No changes
## swri_geometry_util

```
* Update FindGEOS to generate linker flags correctly in Ubuntu 16.04 (#348 <https://github.com/swri-robotics/marti_common/issues/348>).
  The regexes to find the link directory and library name from the
  output of geos-config were too liberal, so the library name
  regex would match on the -linux portion of the link directory,
  resulting in broken linker flags. This tightens up those regexes
  a bit to yield the correct library directory and name.
* Fix a typedef conflict in Ubuntu 16.04 (#347 <https://github.com/swri-robotics/marti_common/issues/347>)
  Wrapping geos includes in #define statements forces geos to typedef
  int64 to int64_t so that it matches opencv's typedef.
* Add cubic spline interface for tf::Vector3 type.
* Contributors: Ed Venator, Marc Alban
```
## swri_image_util

```
* Replace legacy OpenCV BruteForceMatcher with new cv::BFMatcher.
* Upgrade Qt to version 5.
* Contributors: Ed Venator
```
## swri_math_util
- No changes
## swri_nodelet
- No changes
## swri_opencv_util
- No changes
## swri_prefix_tools
- No changes
## swri_roscpp
- No changes
## swri_route_util

```
* Add error message for non-unique route point IDs.
  This release adds an error check when a sru::Route rebuilds its point
  index.  If the point IDs are not unique, the route will output an
  error message that should make tracking down problems easier.  This
  check is extremely lightweight and should not have a performance
  impact.
* Contributors: Elliot Johnson
```
## swri_serial_util
- No changes
## swri_string_util
- No changes
## swri_system_util
- No changes
## swri_transform_util
- No changes
## swri_yaml_util
- No changes
