### PR TITLE
smarthome_msgs: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11282,7 +11282,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rosalfred-release/smarthome_msgs-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/rosalfred/smarthome_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `smarthome_msgs` to `0.1.3-0`:
- upstream repository: https://github.com/rosalfred/smarthome_msgs.git
- release repository: https://github.com/rosalfred-release/smarthome_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.2-0`
## smarthome_msgs

```
* Update Readme
* Merge branch 'master' of github.com:rosalfred/smarthome_msgs
* Update eclipse project.
* Contributors: Mickael Gaillard
```
