### PR TITLE
Adding pi_tracker to documentation index for Indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7455,6 +7455,17 @@ repositories:
       url: https://github.com/ccny-ros-pkg/phidgets_drivers.git
       version: indigo
     status: maintained
+  pi_tracker:
+    doc:
+      type: git
+      url: https://github.com/pirobot/pi_tracker.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/pirobot/pi_tracker.git
+      version: indigo-devel
+    status: end-of-life
+    status_description: No longer developed or maintained.
   pi_trees:
     doc:
       type: git


### PR DESCRIPTION
I'd like pi_tracker to be indexed and documented on ros.org.
