### PR TITLE
Adding skeleton_markers to documentation index for Indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11036,6 +11036,16 @@ repositories:
       url: https://github.com/mikeferguson/simple_grasping.git
       version: master
     status: developed
+  skeleton_markers:
+    doc:
+      type: git
+      url: https://github.com/pirobot/skeleton_markers.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/pirobot/skeleton_markers.git
+      version: indigo-devel
+    status: end-of-life
   slam6d_exporter:
     doc:
       type: git


### PR DESCRIPTION
I'd like skeleton_markers to be indexed and documented on ros.org.
