### PR TITLE
Revert "softkinetic: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11370,14 +11370,6 @@ repositories:
       type: git
       url: https://github.com/ipa320/softkinetic.git
       version: indigo_release_candidate
-    release:
-      packages:
-      - softkinetic
-      - softkinetic_camera
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ipa320/softkinetic-release.git
-      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/ipa320/softkinetic.git


### PR DESCRIPTION
Reverts ros/rosdistro#11909
@ipa-nhg FYI

This is failing to build the sourcedebs continuously. 

The changes file generated has an invalid character:

http://build.ros.org:8080/job/Irel_import-package/86037/console

```
17:29:14 Unexpected binary character \001 in /var/repos/ubuntu/building/queue/trusty/Isrc_uT__softkinetic__ubuntu_trusty__source__33/ros-indigo-softkinetic_0.6.1-0trusty_source.changes
```
