### PR TITLE
jsk_pr2eus: 0.3.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1937,7 +1937,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_pr2eus-release.git
-      version: 0.3.3-0
+      version: 0.3.4-0
     status: developed
   jsk_recognition:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.3.4-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_pr2eus
- release repository: https://github.com/tork-a/jsk_pr2eus-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.3-0`
## jsk_pr2eus
- No changes
## pr2eus

```
* Merge pull request #235 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/235> from k-okada/fix_smooth
  fix :wait-interpolation-smooth for pr2_controllers_msgs/JointTrajectoryActionFeedback
* add code when last-feedback-msgs-stamp is not updated
* robot-interface.l : wait for feedback message is updated
* fix :wait-interpolation-smooth for pr2_controllers_msgs/JointTrajectoryActionFeedback
* Contributors: Kei Okada
```
## pr2eus_moveit
- No changes
## pr2eus_tutorials
- No changes
