### PR TITLE
bond_core: 1.7.17-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -277,7 +277,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/bond_core-release.git
-      version: 1.7.16-0
+      version: 1.7.17-0
     source:
       type: git
       url: https://github.com/ros/bond_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.7.17-0`:
- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.7.16-0`
## bond

```
* update maintainer
* Contributors: Mikael Arguedas
```
## bond_core

```
* update maintainer
* Contributors: Mikael Arguedas
```
## bondcpp

```
* update maintainer
* Contributors: Mikael Arguedas
```
## bondpy

```
* Queue size for a publisher #10 <https://github.com/ros/bond_core/issues/10>
  Squash the warning.
* update maintainer
* Made code a bit more readable #12 <https://github.com/ros/bond_core/pull/12>
* made local timer a member so we can cancel it during shutdown #11 <https://github.com/ros/bond_core/pull/11>
* Contributors: Daniel Stonier, Esteve Fernandez, Hugo Boyer, Mikael Arguedas
```
## smclib

```
* update maintainer
* Contributors: Mikael Arguedas
```
