### PR TITLE
class_loader: 0.3.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1151,7 +1151,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/class_loader-release.git
-      version: 0.3.3-1
+      version: 0.3.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `0.3.4-0`:
- upstream repository: https://github.com/ros/class_loader
- release repository: https://github.com/ros-gbp/class_loader-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.3-1`
## class_loader

```
* cleanup: don't use active_class_loaders_[library_path] for existence test (#35 <https://github.com/ros/class_loader/issues/35>)
  * cleanup: don't use active_class_loaders_[library_path] for existence test
  - this accumulates map entries with NULL pointer
  - fixing it, allows some cleanup
  * list headers in CodeBlocks / QtCreator
  * explicitly list all headers
* Merge pull request #34 <https://github.com/ros/class_loader/issues/34> from rhaschke/fix-on-demand-unloading
  fix on demand unloading
* Merge pull request #32 <https://github.com/ros/class_loader/issues/32> from saarnold/fixed_unset_variable_evaluation
  fixed evaluation of undefined variable
* fixed evaluation of undefined variable
* not unloading the ClassLoaders (to avoid the SEVERE WARNING) doesn't work either
* bugfix: enable on-demand loading/unloading with MultiClassLoader
  - enforce loading of library in loadLibrary(), otherwise we cannot know
  - don't unload libraries in destructor when on-demand-unloading is enabled
* extra utest: MultiClassLoaderTest.lazyLoad succeeds two times in a row?
* added MultiLibraryClassLoader unittest
* Contributors: Mikael Arguedas, Robert Haschke, Sascha Arnold
```
