### PR TITLE
pluginlib: 1.10.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7523,7 +7523,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.10.2-0
+      version: 1.10.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.10.3-0`:
- upstream repository: https://github.com/ros/pluginlib
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.10.2-0`
## pluginlib

```
* Merge pull request #40 <https://github.com/ros/pluginlib/issues/40> from ros/fix_warnings
  fix deprecated warnings in unit tests
* fix deprecated warnings in unit tests
* removed merge messages and redundant commits
* Contributors: Mikael Arguedas
```
