### PR TITLE
pluginlib: 1.10.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2259,7 +2259,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.10.2-0
+      version: 1.10.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.10.3-0`:
- upstream repository: https://github.com/ros/pluginlib
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.10.2-0`
## pluginlib

```
* Merge pull request #40 <https://github.com/ros/pluginlib/issues/40> from ros/fix_warnings
  fix deprecated warnings in unit tests
* fix deprecated warnings in unit tests
* removed merge messages and redundant commits
* Contributors: Mikael Arguedas
```
