### PR TITLE
actionlib: 1.11.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -90,7 +90,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.11.5-0
+      version: 1.11.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.11.6-0`:
- upstream repository: git@github.com:ros/actionlib.git
- release repository: https://github.com/ros-gbp/actionlib-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.11.5-0`
## actionlib

```
* Python code cleanup (#43 <https://github.com/ros/actionlib/issues/43>)
  * Cleaned up semicolons, indentation, spaces.
  * Removed unused local var after further confirmation of no risk of side effects.
* Contributors: Andrew Blakey
```
