### PR TITLE
dynamic_reconfigure: 1.5.44-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -478,7 +478,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.5.43-0
+      version: 1.5.44-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.5.44-0`:
- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.5.43-0`
## dynamic_reconfigure

```
* Add server namespaces (#56 <https://github.com/ros/dynamic_reconfigure/issues/56>)
  * Add optional namespace argument to Python Server
  * Add test for server with multiple namespaces
* Merge pull request #61 <https://github.com/ros/dynamic_reconfigure/issues/61> from vagvaz/Issue_51_Unable_to_reload_parameters_from_file
  fix issue #51 <https://github.com/ros/dynamic_reconfigure/issues/51> reloading parameters from dumped file
* Contributors: Evangelos Vazaios, Mikael Arguedas, v-lopez
```
