### PR TITLE
xacro: 1.10.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6147,7 +6147,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.10.6-0
+      version: 1.10.7-0
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.10.7-0`:
- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.10.6-0`
## xacro

```
* workaround for xml.dom.minidom issue
* ensure non-empty error string
* added short option -i as alternative to --inorder
* refactored main(), fix #122
* added xacro indicator to error message, fix #123
* moved banner generation to process_file()
* removed special (but obsolete) output handling for just_includes mode
* fixed unrelated typo
* moved core processing pipeline into function process_file()
* improved documentation: added more comments,input_file -> input_file_name
* fix #120: handle non-space whitespace characters in params string
* extended tests to handle non-space whitespace characters in params string
* always store macros with xacro: prefix in front for #118
* fix #115: enforce xacro namespace usage with --xacro-ns option
* apply correct checking for include tags too
* extended the testcase to include
* allow (one-level) nested expression/extension evaluation
* Contributors: Robert Haschke, Morgan Quigley
```
