### PR TITLE
robot_pose_publisher: 0.2.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2438,6 +2438,21 @@ repositories:
       url: https://github.com/ros/robot_model.git
       version: kinetic-devel
     status: maintained
+  robot_pose_publisher:
+    doc:
+      type: git
+      url: https://github.com/GT-RAIL/robot_pose_publisher.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/gt-rail-release/robot_pose_publisher-release.git
+      version: 0.2.4-0
+    source:
+      type: git
+      url: https://github.com/GT-RAIL/robot_pose_publisher.git
+      version: develop
+    status: maintained
   robot_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_pose_publisher` to `0.2.4-0`:
- upstream repository: https://github.com/WPI-RAIL/robot_pose_publisher.git
- release repository: https://github.com/gt-rail-release/robot_pose_publisher-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## robot_pose_publisher

```
* Update README.md
* Update package.xml
* fixed dox file
* fixed readme
* travis edit
* Contributors: David Kent, Russell Toris
```
