### PR TITLE
rosauth: 0.1.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2736,6 +2736,21 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: kinetic-devel
     status: maintained
+  rosauth:
+    doc:
+      type: git
+      url: https://github.com/GT-RAIL/rosauth.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/gt-rail-release/rosauth-release.git
+      version: 0.1.7-0
+    source:
+      type: git
+      url: https://github.com/GT-RAIL/rosauth.git
+      version: develop
+    status: maintained
   rosbag_migration_rule:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosauth` to `0.1.7-0`:
- upstream repository: https://github.com/GT-RAIL/rosauth.git
- release repository: https://github.com/gt-rail-release/rosauth-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rosauth

```
* Merge pull request #8 from ckrooss/develop
  Added gencpp-dependency for test target
* Added gencpp-dependency for test target
* Contributors: Russell Toris, ckrooss
```
