### PR TITLE
mavros: Change branch and status for Indigo and Jade

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5382,7 +5382,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/mavlink/mavros.git
-      version: master
+      version: indigo-devel
     release:
       packages:
       - libmavconn
@@ -5397,8 +5397,8 @@ repositories:
     source:
       type: git
       url: https://github.com/mavlink/mavros.git
-      version: master
-    status: developed
+      version: indigo-devel
+    status: maintained
   maxwell:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2395,7 +2395,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/mavlink/mavros.git
-      version: master
+      version: indigo-devel
     release:
       packages:
       - libmavconn
@@ -2410,8 +2410,8 @@ repositories:
     source:
       type: git
       url: https://github.com/mavlink/mavros.git
-      version: master
-    status: developed
+      version: indigo-devel
+    status: maintained
   md49_base_controller:
     doc:
       type: git


### PR DESCRIPTION
Indigo and Jade version separated to indigo-devel branch.
Further development goes for Kinetic.
