### PR TITLE
softkinetic: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11370,6 +11370,14 @@ repositories:
       type: git
       url: https://github.com/ipa320/softkinetic.git
       version: indigo_release_candidate
+    release:
+      packages:
+      - softkinetic
+      - softkinetic_camera
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/softkinetic-release.git
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ipa320/softkinetic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `softkinetic` to `0.6.2-0`:
- upstream repository: https://github.com/ipa320/softkinetic.git
- release repository: https://github.com/ipa320/softkinetic-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## softkinetic

```
* Update CHANGELOG.rst
* Contributors: Nadia Hammoudeh García
```
## softkinetic_camera
- No changes
