### PR TITLE
mavros: 0.17.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2406,7 +2406,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.17.3-0
+      version: 0.17.4-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.17.4-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.17.3-0`
## libmavconn
- No changes
## mavros

```
* Ran uncrustify on hil_controls plugin
* Utilizing synchronise_stamp and adding reference to MAVLINK msg documentation
* Added a plugin that publishes HIL_CONTROLS as ROS messages
* Revert "readme: update CI, no more MAVLINK_DIALECT"
  This reverts commit 1510deb2c5db12441cf9e44175fdb8a8889a8af6.
* readme: update CI, no more MAVLINK_DIALECT
* Contributors: Pavel, Vladimir Ermakov
```
## mavros_extras
- No changes
## mavros_msgs

```
* Adding anchor to the HIL_CONTROLS message reference link
* Utilizing synchronise_stamp and adding reference to MAVLINK msg documentation
* Added a plugin that publishes HIL_CONTROLS as ROS messages
* Contributors: Pavel
```
## test_mavros

```
* Test_mavros : fix compilation on gcc6.1
* Contributors: khancyr
```
