### PR TITLE
rtabmap: 0.11.7-1 rtabmap_ros: 0.11.7-2 in 'indigo/distribution.yaml'

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10351,7 +10351,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.11.7-0
+      version: 0.11.7-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -10366,7 +10366,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.11.7-1
+      version: 0.11.7-2
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package in repository rtabmap to 0.11.7-1 and rtabmap_ros to 0.11.7-2:

upstream repository: https://github.com/introlab/rtabmap.git https://github.com/introlab/rtabmap_ros.git
release repository: https://github.com/introlab/rtabmap-release.git https://github.com/introlab/rtabmap_ros-release.git
distro file: indigo/distribution.yaml
bloom version: 0.5.21
previous version for package: 0.11.7-0 and 0.11.7-1
