### PR TITLE
ompl: 1.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1996,7 +1996,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ompl-release.git
-      version: 1.1.3535-0
+      version: 1.2.0-0
     status: maintained
   opencv3:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.2.0-0`:
- upstream repository: https://bitbucket.org/ompl/ompl
- release repository: https://github.com/ros-gbp/ompl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.1.3535-0`
