### PR TITLE
mavros: 0.18.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1547,7 +1547,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.17.3-0
+      version: 0.18.0-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.18.0-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.17.3-0`
## libmavconn

```
* libmavconn: Fix _KiB literal
* readme #544 <https://github.com/mavlink/mavros/issues/544>: add udp-b://@ URL
* libmavconn fix #544 <https://github.com/mavlink/mavros/issues/544>: New URL for UDP Broadcast (for GCS discovery)
  Broadcast v4 address used until GCS respond.
  udp-b://[bind_host][:bind_port]@[:remote_port]
* libmavconn: fix context.py.in
* libmavconn: Add protocol version selection helpers
* libmavconn: Use monotonic id for logging. Looks better than this ptr.
* node: Update plugin loading and message routing
* node: Rename plugib base class - API incompatible to old class
* labmavconn: remove set_thread_name(), add utils::format()
* libmavconn: APM dialect should be second
* libmavconn fix #522 <https://github.com/mavlink/mavros/issues/522>: place generated files in source tree.
* libmavconn: Use EmPy to generate dialect-enabling files
* libmavconn: update copyright year
* libmavconn: update unit test
* libmavconn: Replace sig-slot with simple std::function() callbacks
* libmavconn: Limit send_message() queue maximum size.
* libmavconn:udp: try to make STL container handle allocations
* libmavconn: Use std::call_once() for init
* libmavconn: Leak in send_message() when it called from self IO thread (such as message_received event)
* libmavconn: update unit test
* libmavconn: support C++ serialization. Warn: RX leaks somewhere.
* libmavconn: Use MAVLink2 C++11
* labmavconn: trying to merge all dialects
* libmavconn: std::thread are invalidated before set_thread_name() called. Result is SIGSEGV
* labmavconn: finding sigsegv
* libmavconn: uncrustify
* libmavconn #543 <https://github.com/mavlink/mavros/issues/543>: remove boost::signals2 (TCP)
* libmavconn #543 <https://github.com/mavlink/mavros/issues/543>: remove boost::signals2 (UDP)
* libmavconn #543 <https://github.com/mavlink/mavros/issues/543>: remove boost.signals2 (serial)
* libmavconn: uncrustify all
* mavconn: Import Simple Signal library (with some minor modifications).
  Source file can be found here:
  https://testbit.eu/cpp11-signal-system-performance/
* Contributors: Vladimir Ermakov
```
## mavros

```
* lib #439 <https://github.com/mavlink/mavros/issues/439>: MAV_CMD to_string is not required.
* plugin:sys_status #458 <https://github.com/mavlink/mavros/issues/458>: Hanlde BATTERY_STATUS (PX4)
* plugin:sys_status fix #458 <https://github.com/mavlink/mavros/issues/458>: Use sensor_msgs/BatteryState message.
  Minimal data, for all other need to handle BATTERY_STATUS.
* plugin:command fix #561 <https://github.com/mavlink/mavros/issues/561>: PX4 now sends COMMAND_ACK.
  And like APM do not check confirmation field. :)
* readme #544 <https://github.com/mavlink/mavros/issues/544>: add udp-b://@ URL
* plugin:hil_controls: Update plugin API
* Merge branch 'feature/hil_controls_plugin' of https://github.com/pvechersky/mavros into pvechersky-feature/hil_controls_plugin
  * 'feature/hil_controls_plugin' of https://github.com/pvechersky/mavros:
  Adding anchor to the HIL_CONTROLS message reference link
  Ran uncrustify on hil_controls plugin
  Utilizing synchronise_stamp and adding reference to MAVLINK msg documentation
  Added a plugin that publishes HIL_CONTROLS as ROS messages
* node: fix subscription message type checks
* plugin: use mavlink::to_string() for std::array<char, N>
* readme: update CI, no more MAVLINK_DIALECT
* plugin:waypoint: Fix target id's on MISSION_ITEM
* node: Add ~fcu_protocol parameter
* Ran uncrustify on hil_controls plugin
* Utilizing synchronise_stamp and adding reference to MAVLINK msg documentation
* node: set gcs_url on internal GCS bridge diag hardware Id
* plugins: Use UAS::msg_set_target()
* Added a plugin that publishes HIL_CONTROLS as ROS messages
* lib: PX4 add AUTO.FOLLOW_TARGET
* mavros: Update tests
* extras: Update UAS
* UAS: Update plugins for FTF module
* UAS: move enum stringify functions
* lib: Generate MAV_SENSOR_ORIENTATION
* UAS: move MAV_SENSOR_ORIENTATION out
* UAS: Move transformation utilities to ftf module
* plugin:rc_io: Fix log printf-format warning
* make GCC 4.8 happy. (travis)
* gcs_bridge: done
* param:ftp: Update API
* plugin:param: Works. Tested on APM
* plugin:param: Update, almost work
* plugin:waypoint: Fix Item - ROS binding
* Message type mismatch code do not work
* plugin:waypoint: Update API
* plugin:sys_time: Update API
* plugin:sys_status: Update API
* plugin:setpoint_raw: Update API
* plugin:setpoint_attitude: Update API
* plugin:setpoint_accel: Update API
* plugin:setpoint_velocity: Update API
* plugin:setpoint_position: Update API
* plugin:vfr_hud: Update API
* plugin:safety_area: Update API
* plugin:rc_io: Update API
* plugin:manual_control: Update API, fix uas init
* plugin:local_position: Update API
* plugin:imu_pub: Update API
* plugin:global_position: Update API
* mavros: make_handle() this shouldn't be const
* plugin:common: Update API
* plugin:altitude: uncrustify
* plugins: Rutine sed + fix misprint
* plugin:altitude: Update API
* plugins: Automatic replacement of routine API changes (sed)
* plugin:actuator_control: Update API
* plugin:3dr_radio: Update API
* node: Update plugin loading and message routing
* node: type_info -> SIGSEGV
* node: prepare new plugin loading
* node: Rename plugib base class - API incompatible to old class
* labmavconn: finding sigsegv
* Contributors: Pavel, Vladimir Ermakov
```
## mavros_extras

```
* extras #560 <https://github.com/mavlink/mavros/issues/560>: remove cv_bridge and image_transport deps
* extras: Update UAS
* extras:vision_speed_estimate: Update API
* extras:vision_pose_estimate: Update API
* extras:px4flow: Update API
* extras:mocap_pose_estimate: Update API
* extras:distance_sensor: Update API
* extras:cam_imu_sync: Update API
* extras: Automatic update by sed
* extras: prepare to update
* extras #560 <https://github.com/mavlink/mavros/issues/560>: Remove image streaming over mavlink support.
  Use external RTP streamer, e.g. https://github.com/ProjectArtemis/gst_video_server
* Contributors: Vladimir Ermakov
```
## mavros_msgs

```
* Adding anchor to the HIL_CONTROLS message reference link
* Utilizing synchronise_stamp and adding reference to MAVLINK msg documentation
* Added a plugin that publishes HIL_CONTROLS as ROS messages
* node: Rename plugib base class - API incompatible to old class
* msgs #543 <https://github.com/mavlink/mavros/issues/543>: Update for MAVLink 2.0
* Contributors: Pavel, Vladimir Ermakov
```
## test_mavros

```
* Test_mavros : fix compilation on gcc6.1
* Contributors: khancyr
```
