### PR TITLE
Add libqt5-network rosdep key for Debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2312,6 +2312,7 @@ libqt5-gui:
   gentoo: [dev-qt/qtgui]
   ubuntu: [libqt5gui5]
 libqt5-network:
+  debian: [libqt5network5]
   fedora: [qt5-qtbase]
   gentoo: [dev-qt/qtnetwork]
   ubuntu: [libqt5network5]


### PR DESCRIPTION
See https://packages.debian.org/jessie/libqt5network5
