### PR TITLE
mapviz: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1464,6 +1464,26 @@ repositories:
       url: https://bitbucket.org/AndyZe/lyap_control.git
       version: master
     status: maintained
+  mapviz:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/mapviz.git
+      version: kinetic-devel
+    release:
+      packages:
+      - mapviz
+      - mapviz_plugins
+      - multires_image
+      - tile_map
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/mapviz-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/mapviz.git
+      version: kinetic-devel
+    status: developed
   marti_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `0.2.0-0`:
- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## mapviz

```
* Update mapviz to qt5
* Adding a Q_OBJECT declaration to MapvizPlugin
* Adding signals for various plugin events
  The MapvizPlugin class will now emit signals when any of the following settings change:
  - Draw Order
  - Target Frame
  - Use Latest Transforms
  - Visibility
  Note that the signals will only be emitted if the setting actually *changes*, not
  if it is somehow set to the same value that it was previously.
* Contributors: Ed Venator, P. J. Reed
```
## mapviz_plugins

```
* Update Qt to version 5
* Fixing a crash in the PointCloud2 plugin
  Also sneaking in a few more changes:
  - Caching transformed clouds to improve performance
  - Properly saving the value of the "Color Transformer" combo box
* Returning "false" if no other code handles the mouse event
  Fixes #360 <https://github.com/swri-robotics/mapviz/issues/360>
* Contributors: Ed Venator, P. J. Reed
```
## multires_image

```
* Update Qt to version 5
* Contributors: Ed Venator
```
## tile_map

```
* Update tile_map to Qt5.
* Contributors: Ed Venator
```
