### PR TITLE
summit_xl_sim: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11695,6 +11695,17 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/summit_xl_sim.git
       version: indigo-devel
+    release:
+      packages:
+      - summit_xl_control
+      - summit_xl_gazebo
+      - summit_xl_robot_control
+      - summit_xl_sim
+      - summit_xl_sim_bringup
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotnikAutomation/summit_xl_sim-release.git
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_xl_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_xl_sim` to `1.0.0-0`:
- upstream repository: https://github.com/RobotnikAutomation/summit_xl_sim.git
- release repository: https://github.com/RobotnikAutomation/summit_xl_sim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
