### PR TITLE
summit_xl_common: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11685,6 +11685,17 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/summit_xl_common.git
       version: indigo-devel
+    release:
+      packages:
+      - summit_xl_common
+      - summit_xl_description
+      - summit_xl_localization
+      - summit_xl_navigation
+      - summit_xl_pad
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotnikAutomation/summit_xl_common-release.git
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_xl_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_xl_common` to `1.0.0-0`:
- upstream repository: https://github.com/RobotnikAutomation/summit_xl_common.git
- release repository: https://github.com/RobotnikAutomation/summit_xl_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
