### PR TITLE
catkin_pip: 0.1.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1129,7 +1129,7 @@ repositories:
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pip.git
-      version: indigo
+      version: indigo-devel
     status: developed
   cit_adis_imu:
     release:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1125,7 +1125,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/catkin_pip-release.git
-      version: 0.1.8-0
+      version: 0.1.9-0
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pip.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pip` to `0.1.9-0`:
- upstream repository: https://github.com/asmodehn/catkin_pip.git
- release repository: https://github.com/asmodehn/catkin_pip-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.8-0`
## catkin_pip

```
* fixed site_packages env-hook.
  bash script seems to work fine after all, the problem was somewhere else.
  simplified the envhook flow between catkin, package, overlay.
* changed site-packages env-hook to have .sh extension.
  moving prepend function into catkin-pip package itself.
* Contributors: alexv
```
