### PR TITLE
catkin_pip: 0.1.9-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -397,7 +397,7 @@ repositories:
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pip.git
-      version: jade
+      version: jade-devel
     status: developed
   class_loader:
     doc:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -393,7 +393,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/catkin_pip-release.git
-      version: 0.1.8-0
+      version: 0.1.9-0
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pip.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pip` to `0.1.9-0`:
- upstream repository: https://github.com/asmodehn/catkin_pip.git
- release repository: https://github.com/asmodehn/catkin_pip-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.8-0`
## catkin_pip

```
* fixed site_packages env-hook.
  bash script seems to work fine after all, the problem was somewhere else.
  simplified the envhook flow between catkin, package, overlay.
* changed site-packages env-hook to have .sh extension.
  moving prepend function into catkin-pip package itself.
* Contributors: alexv
```
