### PR TITLE
hector_models: 0.4.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3352,7 +3352,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
-      version: 0.4.1-0
+      version: 0.4.2-0
     status: maintained
   hector_navigation:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_models` to `0.4.2-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_models.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.4.1-0`
## hector_components_description

```
* fixed for checkerboard
* Add checkerboard with associated macro.
* Added calibration and fixed an origin bug at the spinnning joint of the lidar
* Added realistic inertias and masses. Moved RGB-D Cam according to reality
* Contributors: Marius Schnaubelt, Martin Oehler, Stefan Kohlbrecher
```
## hector_models
- No changes
## hector_sensors_description

```
* Update flir a35 camera macro
* Add gazebo material for flir and realsense models
* Add models for flir a35 and realsense r200 cameras
* Formatting of thermaleye_camera macro
* Contributors: Stefan Kohlbrecher, kohlbrecher
```
## hector_xacro_tools

```
* Add joint macros (contains transmission macro for the moment)
* Contributors: Stefan Kohlbrecher
```
