### PR TITLE
hector_models: 0.4.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1055,6 +1055,22 @@ repositories:
       url: https://github.com/ethz-asl/grid_map.git
       version: master
     status: developed
+  hector_models:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_models.git
+      version: kinetic-devel
+    release:
+      packages:
+      - hector_components_description
+      - hector_models
+      - hector_sensors_description
+      - hector_xacro_tools
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
+      version: 0.4.2-0
+    status: maintained
   hrpsys:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_models` to `0.4.2-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_models.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## hector_components_description

```
* fixed for checkerboard
* Add checkerboard with associated macro.
* Added calibration and fixed an origin bug at the spinnning joint of the lidar
* Added realistic inertias and masses. Moved RGB-D Cam according to reality
* Contributors: Marius Schnaubelt, Martin Oehler, Stefan Kohlbrecher
```
## hector_models
- No changes
## hector_sensors_description

```
* Update flir a35 camera macro
* Add gazebo material for flir and realsense models
* Add models for flir a35 and realsense r200 cameras
* Formatting of thermaleye_camera macro
* Contributors: Stefan Kohlbrecher, kohlbrecher
```
## hector_xacro_tools

```
* Add joint macros (contains transmission macro for the moment)
* Contributors: Stefan Kohlbrecher
```
