### PR TITLE
mavros: 0.18.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1583,7 +1583,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.18.0-0
+      version: 0.18.1-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.18.1-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.18.0-0`
## libmavconn
- No changes
## mavros

```
* lib: Fix base mode flag check
* plugins: Move pluginlib macros.h to tail
* plugin:param fix #559 <https://github.com/mavlink/mavros/issues/559>: Ignore PX4 _HASH_CHECK param
* Contributors: Vladimir Ermakov
```
## mavros_extras
- No changes
## mavros_msgs
- No changes
## test_mavros
- No changes
