### PR TITLE
hector_gazebo: 0.3.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3320,7 +3320,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
-      version: 0.3.7-0
+      version: 0.3.8-0
     status: maintained
   hector_localization:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_gazebo` to `0.3.8-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.7-0`
## hector_gazebo
- No changes
## hector_gazebo_plugins

```
* hector_gazebo_plugins: fixed angular rate output with non-zero rpyOffset parameter (fix #23)
* Fix compilation errors and warnings against Gazebo 7
* Fix
* Compatible with gazebo7
* [hector_gazebo_plugins] fix missing dependencies
* Update odometry with proper covariance data
* Updates to 2d odom
* Basics of 2d odom
* Add gitignore
* Add Cmake flags for C++11
* Make force based p gains parameters
* Contributors: Furushchev, Johannes Meyer, Nate Koenig, Nicolae Rosia, Romain Reignier, Stefan Kohlbrecher
```
## hector_gazebo_thermal_camera

```
* Compatible with gazebo7
* Add Cmake flags for C++11
* Contributors: Nate Koenig, Romain Reignier
```
## hector_gazebo_worlds
- No changes
## hector_sensors_gazebo
- No changes
