### PR TITLE
hector_gazebo: 0.4.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1444,7 +1444,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     status: maintained
   hector_localization:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_gazebo` to `0.4.1-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.4.0-0`
## hector_gazebo

```
* Merge branch 'indigo-devel' into jade-devel
  Conflicts:
  hector_gazebo/CHANGELOG.rst
  hector_gazebo/package.xml
  hector_gazebo_plugins/CHANGELOG.rst
  hector_gazebo_plugins/package.xml
  hector_gazebo_thermal_camera/CHANGELOG.rst
  hector_gazebo_thermal_camera/package.xml
  hector_gazebo_worlds/CHANGELOG.rst
  hector_gazebo_worlds/package.xml
  hector_sensors_gazebo/CHANGELOG.rst
  hector_sensors_gazebo/package.xml
* 0.4.0
* Contributors: Johannes Meyer
```
## hector_gazebo_plugins

```
* Merge branch 'indigo-devel' into jade-devel
  Conflicts:
  hector_gazebo/CHANGELOG.rst
  hector_gazebo/package.xml
  hector_gazebo_plugins/CHANGELOG.rst
  hector_gazebo_plugins/package.xml
  hector_gazebo_thermal_camera/CHANGELOG.rst
  hector_gazebo_thermal_camera/package.xml
  hector_gazebo_worlds/CHANGELOG.rst
  hector_gazebo_worlds/package.xml
  hector_sensors_gazebo/CHANGELOG.rst
  hector_sensors_gazebo/package.xml
* Merge branch 'jade-devel' of https://github.com/nicolaerosia/hector_gazebo into nicolaerosia-jade-devel
  Conflicts:
  hector_gazebo_plugins/src/diffdrive_plugin_6w.cpp
  hector_gazebo_plugins/src/diffdrive_plugin_multi_wheel.cpp
  hector_gazebo_plugins/src/gazebo_ros_sonar.cpp
  hector_gazebo_plugins/src/servo_plugin.cpp
* Merge branch 'indigo-devel' into jade-devel
* Fix compilation errors and warnings against Gazebo 7
  Signed-off-by: Nicolae Rosia <mailto:nicolae.rosia@gmail.com>
* Add Cmake flags for C++11
* 0.4.0
* Added proper dependencies for jade and gazebo5. Now compiles and works for gazebo5
* Contributors: Johannes Meyer, L0g1x, Nicolae Rosia, Romain Reignier
```
## hector_gazebo_thermal_camera

```
* Merge branch 'indigo-devel' into jade-devel
  Conflicts:
  hector_gazebo/CHANGELOG.rst
  hector_gazebo/package.xml
  hector_gazebo_plugins/CHANGELOG.rst
  hector_gazebo_plugins/package.xml
  hector_gazebo_thermal_camera/CHANGELOG.rst
  hector_gazebo_thermal_camera/package.xml
  hector_gazebo_worlds/CHANGELOG.rst
  hector_gazebo_worlds/package.xml
  hector_sensors_gazebo/CHANGELOG.rst
  hector_sensors_gazebo/package.xml
* Add Cmake flags for C++11
* 0.4.0
* Added proper dependencies for jade and gazebo5. Now compiles and works for gazebo5
* Contributors: Johannes Meyer, L0g1x, Romain Reignier
```
## hector_gazebo_worlds

```
* Merge branch 'indigo-devel' into jade-devel
  Conflicts:
  hector_gazebo/CHANGELOG.rst
  hector_gazebo/package.xml
  hector_gazebo_plugins/CHANGELOG.rst
  hector_gazebo_plugins/package.xml
  hector_gazebo_thermal_camera/CHANGELOG.rst
  hector_gazebo_thermal_camera/package.xml
  hector_gazebo_worlds/CHANGELOG.rst
  hector_gazebo_worlds/package.xml
  hector_sensors_gazebo/CHANGELOG.rst
  hector_sensors_gazebo/package.xml
* 0.4.0
* Contributors: Johannes Meyer
```
## hector_sensors_gazebo

```
* Merge branch 'indigo-devel' into jade-devel
  Conflicts:
  hector_gazebo/CHANGELOG.rst
  hector_gazebo/package.xml
  hector_gazebo_plugins/CHANGELOG.rst
  hector_gazebo_plugins/package.xml
  hector_gazebo_thermal_camera/CHANGELOG.rst
  hector_gazebo_thermal_camera/package.xml
  hector_gazebo_worlds/CHANGELOG.rst
  hector_gazebo_worlds/package.xml
  hector_sensors_gazebo/CHANGELOG.rst
  hector_sensors_gazebo/package.xml
* 0.4.0
* Contributors: Johannes Meyer
```
