### PR TITLE
hector_gazebo: 0.5.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1055,6 +1055,23 @@ repositories:
       url: https://github.com/ethz-asl/grid_map.git
       version: master
     status: developed
+  hector_gazebo:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
+      version: kinetic-devel
+    release:
+      packages:
+      - hector_gazebo
+      - hector_gazebo_plugins
+      - hector_gazebo_thermal_camera
+      - hector_gazebo_worlds
+      - hector_sensors_gazebo
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
+      version: 0.5.0-0
+    status: maintained
   hector_models:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_gazebo` to `0.5.0-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## hector_gazebo
- No changes
## hector_gazebo_plugins

```
* Updated gazebo dependencies to version 7 for kinetic release
* Contributors: Johannes Meyer
```
## hector_gazebo_thermal_camera

```
* Updated gazebo dependencies to version 7 for kinetic release
* hector_gazebo_thermal_camera: get rid of unused dependencies nodelet, dynamic_reconfigure, driver_base and image_transport
* Contributors: Johannes Meyer
```
## hector_gazebo_worlds
- No changes
## hector_sensors_gazebo
- No changes
