### PR TITLE
hector_slam: 0.3.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3415,7 +3415,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
-      version: 0.3.4-0
+      version: 0.3.5-0
     status: maintained
   hector_vision:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_slam` to `0.3.5-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.4-0`
## hector_compressed_map_transport

```
* Use the FindEigen3.cmake module provided by Eigen
* Contributors: Johannes Meyer
```
## hector_geotiff

```
* Use the FindEigen3.cmake module provided by Eigen
* hector_geotiff/hector_geotiff_plugins: added possibility to specify Color of robot path in the geotiff file in order to allow multiple color robot paths
* Contributors: Dorothea Koert, Johannes Meyer
```
## hector_geotiff_plugins

```
* hector_geotiff/hector_geotiff_plugins: added possibility to specify Color of robot path in the geotiff file in order to allow multiple color robot paths
* Contributors: Dorothea Koert
```
## hector_imu_attitude_to_tf
- No changes
## hector_imu_tools
- No changes
## hector_map_server
- No changes
## hector_map_tools
- No changes
## hector_mapping

```
* Use the FindEigen3.cmake module provided by Eigen
* Contributors: Johannes Meyer
```
## hector_marker_drawing

```
* Use the FindEigen3.cmake module provided by Eigen
* Contributors: Johannes Meyer
```
## hector_nav_msgs
- No changes
## hector_slam
- No changes
## hector_slam_launch
- No changes
## hector_trajectory_server

```
* Changed from ros::WallTime to ros::Time in trajectory server
* hector_trajectory_server: removed bug leading to potential infinite loop
* Contributors: Andreas Lindahl Flåten, Paul Manns
```
