### PR TITLE
hector_localization: 0.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1072,6 +1072,22 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
       version: 0.5.0-0
     status: maintained
+  hector_localization:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_localization.git
+      version: catkin
+    release:
+      packages:
+      - hector_localization
+      - hector_pose_estimation
+      - hector_pose_estimation_core
+      - message_to_tf
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
+      version: 0.2.2-0
+    status: maintained
   hector_models:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_localization` to `0.2.2-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_localization.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## hector_localization
- No changes
## hector_pose_estimation

```
* hector_pose_estimation: cleaned up example launch file and add install rule for launch/ and rviz_cfg/
* update rviz file
* add .rviz config file for hector pose estimation
* add launch file for hector_pose_estimation
* Contributors: Johannes Meyer, libing64
```
## hector_pose_estimation_core
- No changes
## message_to_tf
- No changes
