### PR TITLE
ocl: 2.8.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3300,7 +3300,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/orocos-gbp/ocl-release.git
-      version: 2.8.1-0
+      version: 2.8.2-0
     source:
       type: git
       url: https://github.com/orocos-toolchain/ocl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ocl` to `2.8.2-0`:
- upstream repository: https://github.com/orocos-toolchain/ocl.git
- release repository: https://github.com/orocos-gbp/ocl-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.8.1-0`
