### PR TITLE
hector_worldmodel: 0.3.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1113,6 +1113,22 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
       version: 0.3.5-0
     status: maintained
+  hector_worldmodel:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_worldmodel.git
+      version: catkin
+    release:
+      packages:
+      - hector_object_tracker
+      - hector_worldmodel
+      - hector_worldmodel_geotiff_plugins
+      - hector_worldmodel_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
+      version: 0.3.4-0
+    status: maintained
   hrpsys:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_worldmodel` to `0.3.4-0`:
- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_worldmodel.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## hector_object_tracker

```
* Use the FindEigen3.cmake module provided by Eigen
* Contributors: Johannes Meyer
```
## hector_worldmodel
- No changes
## hector_worldmodel_geotiff_plugins
- No changes
## hector_worldmodel_msgs
- No changes
