### PR TITLE
moveit_setup_assistant: 0.7.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2655,6 +2655,21 @@ repositories:
       url: https://github.com/ros-planning/moveit_ros.git
       version: jade-devel
     status: maintained
+  moveit_setup_assistant:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_setup_assistant.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
+      version: 0.7.1-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_setup_assistant.git
+      version: jade-devel
+    status: maintained
   moveit_sim_controller:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_setup_assistant` to `0.7.1-0`:
- upstream repository: https://github.com/ros-planning/moveit_setup_assistant.git
- release repository: https://github.com/ros-gbp/moveit_setup_assistant-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## moveit_setup_assistant

```
* [sys] Qt adjustment.
  * relax Qt-version requirement.  Minor Qt version updates are ABI-compatible with each other:  https://wiki.qt.io/Qt-Version-Compatibility
  * auto-select Qt version matching the one from rviz #114 <https://github.com/ros-planning/moveit_setup_assistant/issues/114>
  * Allow to conditionally compile against Qt5 by setting -DUseQt5=On
* [sys] Add line for supporting CMake 2.8.11 as required for Indigo
* [sys][travis] Update CI conf for ROS Jade (and optionally added Kinetic) #116 <https://github.com/ros-planning/moveit_setup_assistant/issues/116>
* [feat] add ApplyPlanningScene capability to template
* Contributors: Dave Coleman, Isaac I.Y. Saito, Robert Haschke, Simon Schmeisser (isys vision), v4hn
```
