### PR TITLE
turtlebot_create: 2.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3423,7 +3423,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_create-release.git
-      version: 2.3.0-0
+      version: 2.3.1-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot_create.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_create` to `2.3.1-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_create.git
- release repository: https://github.com/turtlebot-release/turtlebot_create-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.3.0-0`
## create_description

```
* update xacro:property tag usage to stricter standard
* Fix base geometry collision size
* Contributors: Tully Foote, trainman419
```
## create_driver
- No changes
## create_node
- No changes
## turtlebot_create
- No changes
