### PR TITLE
moveit_setup_assistant: 0.7.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5875,7 +5875,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
-      version: 0.7.0-0
+      version: 0.7.2-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_setup_assistant.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_setup_assistant` to `0.7.2-0`:
- upstream repository: https://github.com/ros-planning/moveit_setup_assistant.git
- release repository: https://github.com/ros-gbp/moveit_setup_assistant-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.7.0-0`
## moveit_setup_assistant

```
* [sys] Qt adjustment.
  * relax Qt-version requirement.  Minor Qt version updates are ABI-compatible with each other:  https://wiki.qt.io/Qt-Version-Compatibility
  * auto-select Qt version matching the one from rviz #114 <https://github.com/ros-planning/moveit_setup_assistant/issues/114>
  * Allow to conditionally compile against Qt5 by setting -DUseQt5=On
* [sys] Add line for supporting CMake 2.8.11 as required for Indigo
* [sys][travis] Update CI conf for ROS Jade (and optionally added Kinetic) #116 <https://github.com/ros-planning/moveit_setup_assistant/issues/116>
* [feat] add ApplyPlanningScene capability to template
* Contributors: Dave Coleman, Isaac I.Y. Saito, Robert Haschke, Simon Schmeisser (isys vision), v4hn
```
