### PR TITLE
Adding ucl_drone to documentation index for Indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12303,6 +12303,11 @@ repositories:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/ublox.git
       version: catkin
+  ucl_drone:
+    doc:
+      type: git
+      url: https://github.com/Felicien93/ucl_drone.git
+      version: indigo-devel
   ueye:
     doc:
       type: hg

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12307,7 +12307,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/Felicien93/ucl_drone.git
-      version: indigo-devel
+      version: master
   ueye:
     doc:
       type: hg


### PR DESCRIPTION
Hello,

We would like our package ucl_drone to be indexed and documented on ros.org.

It implements ARdrones 2.0 in order to make them search a place and follow a moving target.
