### PR TITLE
world_canvas_msgs: 0.2.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3633,6 +3633,17 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros.git
       version: jade-devel
     status: maintained
+  world_canvas_msgs:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/world_canvas_msgs-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/yujinrobot/world_canvas_msgs.git
+      version: kinetic
+    status: maintained
   xacro:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `world_canvas_msgs` to `0.2.0-1`:
- upstream repository: https://github.com/yujinrobot/world_canvas_msgs
- release repository: https://github.com/yujinrobot-release/world_canvas_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
