### PR TITLE
Add nodejs-legacy package to nodejs dep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3057,6 +3057,10 @@ nodejs:
   debian: [nodejs]
   fedora: [nodejs]
   ubuntu: [nodejs]
+nodejs-legacy:
+  debian: [nodejs-legacy]
+  fedora: [nodejs]
+  ubuntu: [nodejs-legacy]
 npm:
   debian: [npm]
   fedora: [npm]


### PR DESCRIPTION
Debian and Ubuntu versions after Precise renamed node binary to
nodejs, and provided the node symlink as a separate package. This fixes
many node packages that rely on the node binary, and makes it compatible
with Fedora
