### PR TITLE
world_canvas_libs: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3633,6 +3633,22 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros.git
       version: jade-devel
     status: maintained
+  world_canvas_libs:
+    release:
+      packages:
+      - world_canvas_client_cpp
+      - world_canvas_client_examples
+      - world_canvas_client_py
+      - world_canvas_utils
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/world_canvas_libs-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/yujinrobot/world_canvas_libs.git
+      version: kinetic
+    status: maintained
   world_canvas_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `world_canvas_libs` to `0.2.0-0`:
- upstream repository: https://github.com/yujinrobot/world_canvas_libs.git
- release repository: https://github.com/yujinrobot-release/world_canvas_libs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
