### PR TITLE
Revert "summit_xl_sim: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11711,17 +11711,6 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/summit_xl_sim.git
       version: indigo-devel
-    release:
-      packages:
-      - summit_xl_control
-      - summit_xl_gazebo
-      - summit_xl_robot_control
-      - summit_xl_sim
-      - summit_xl_sim_bringup
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/RobotnikAutomation/summit_xl_sim-release.git
-      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_xl_sim.git


### PR DESCRIPTION
Reverts ros/rosdistro#11955

The release repo is missing most of the required tags: 
This is failing the sourcedebs. 

![image](https://cloud.githubusercontent.com/assets/447804/16373268/40e1435c-3c06-11e6-93ba-77f72aea8649.png)
