### PR TITLE
turtlebot: 2.3.12-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3409,6 +3409,27 @@ repositories:
       url: https://bitbucket.org/traclabs/trac_ik.git
       version: no_moveit_plugin-kinetic
     status: developed
+  turtlebot:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot.git
+      version: indigo
+    release:
+      packages:
+      - turtlebot
+      - turtlebot_bringup
+      - turtlebot_capabilities
+      - turtlebot_description
+      - turtlebot_teleop
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/turtlebot-release/turtlebot-release.git
+      version: 2.3.12-0
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot.git
+      version: indigo
+    status: maintained
   turtlebot_create:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot` to `2.3.12-0`:
- upstream repository: https://github.com/turtlebot/turtlebot.git
- release repository: https://github.com/turtlebot-release/turtlebot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## turtlebot
- No changes
## turtlebot_bringup

```
* update xacro usage for jade deprecations
  comment out unused arguments generating errors
* add support for Orbbec Astra
* add the teleop switch script as a default input to support joystick interactive follower
* use rocon_apps/make_a_map for make a map interaction closes #210 <https://github.com/turtlebot/turtlebot/issues/210>
* Fix icon for interactions.
* Contributors: Jihoon Lee, Tully Foote, commaster90
```
## turtlebot_capabilities

```
* Fix typo.
* Contributors: Patrick Chin
```
## turtlebot_description

```
* update xacro usage for jade deprecations
  comment out unused arguments generating errors
* [turtlebot_description] adds orbbec astra urdfs and mesh
* Contributors: Marcus Liebhardt, Tully Foote
```
## turtlebot_teleop
- No changes
