### PR TITLE
Add dependencies useful for tracing program execution and kernel info

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1799,6 +1799,10 @@ libleptonica-dev:
 liblinear-dev:
   fedora: [liblinear-devel]
   ubuntu: [liblinear-dev]
+liblttng-ust-dev:
+  debian: [liblttng-ust-dev]
+  ubuntu: [liblttng-ust-dev]
+  arch: [lttng-ust]
 libmagick:
   arch: [imagemagick]
   debian: [libmagick++-dev]
@@ -2835,6 +2839,14 @@ log4cxx:
   opensuse: [liblog4cxx-devel]
   rhel: [log4cxx-devel]
   ubuntu: [liblog4cxx10-dev]
+lttng-modules:
+  debian: [lttng-modules-dkms]
+  ubuntu: [lttng-modules-dkms]
+  fedora: [lttng-devel]
+  arch: [lttng-modules]
+lttng-tools:
+  ubuntu: [lttng-tools]
+  arch: [lttng-tools]
 lua-dev:
   arch: [lua]
   debian: [liblua5.1-0-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -262,6 +262,9 @@ avrdude:
     portage:
       packages: [dev-embedded/avrdude]
   ubuntu: [avrdude]
+babeltrace:
+  debian: [babeltrace]
+  ubuntu: [babeltrace]
 bazaar:
   arch: [bzr]
   debian: [bzr]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -264,6 +264,7 @@ avrdude:
   ubuntu: [avrdude]
 babeltrace:
   debian: [babeltrace]
+  fedora: [babeltrace]
   ubuntu: [babeltrace]
 bazaar:
   arch: [bzr]
@@ -1823,6 +1824,7 @@ liblinear-dev:
 liblttng-ust-dev:
   arch: [lttng-ust]
   debian: [liblttng-ust-dev]
+  fedora: [lttng-ust]
   ubuntu: [liblttng-ust-dev]
 libmagick:
   arch: [imagemagick]
@@ -2906,10 +2908,10 @@ log4cxx:
 lttng-modules:
   arch: [lttng-modules]
   debian: [lttng-modules-dkms]
-  fedora: [lttng-devel]
   ubuntu: [lttng-modules-dkms]
 lttng-tools:
   arch: [lttng-tools]
+  fedora: [lttng-tools]
   ubuntu: [lttng-tools]
 lua-dev:
   arch: [lua]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1821,9 +1821,9 @@ liblinear-dev:
   fedora: [liblinear-devel]
   ubuntu: [liblinear-dev]
 liblttng-ust-dev:
+  arch: [lttng-ust]
   debian: [liblttng-ust-dev]
   ubuntu: [liblttng-ust-dev]
-  arch: [lttng-ust]
 libmagick:
   arch: [imagemagick]
   debian: [libmagick++-dev]
@@ -2904,13 +2904,13 @@ log4cxx:
   rhel: [log4cxx-devel]
   ubuntu: [liblog4cxx10-dev]
 lttng-modules:
-  debian: [lttng-modules-dkms]
-  ubuntu: [lttng-modules-dkms]
-  fedora: [lttng-devel]
   arch: [lttng-modules]
+  debian: [lttng-modules-dkms]
+  fedora: [lttng-devel]
+  ubuntu: [lttng-modules-dkms]
 lttng-tools:
-  ubuntu: [lttng-tools]
   arch: [lttng-tools]
+  ubuntu: [lttng-tools]
 lua-dev:
   arch: [lua]
   debian: [liblua5.1-0-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2911,6 +2911,7 @@ lttng-modules:
   ubuntu: [lttng-modules-dkms]
 lttng-tools:
   arch: [lttng-tools]
+  debian: [lttng-tools]
   fedora: [lttng-tools]
   ubuntu: [lttng-tools]
 lua-dev:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -214,6 +214,8 @@ python-babel:
     vivid: [python-babel]
     wily: [python-babel]
     xenial: [python-babel]
+python3-babeltrace:
+  ubuntu: [python3-babeltrace]
 python-beautifulsoup:
   arch: [python2-beautifulsoup3]
   debian: [python-beautifulsoup]
@@ -865,6 +867,11 @@ python-libpgm-pip:
   ubuntu:
     pip:
       packages: [libpgm]
+python2-lttngust:
+  arch: [python2-lttngust]
+python3-lttngust:
+  debian: [python3-lttngust]
+  ubuntu: [python3-lttngust]
 python-lxml:
   debian: [python-lxml]
   fedora: [python-lxml]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -218,14 +218,6 @@ python-babel:
     vivid: [python-babel]
     wily: [python-babel]
     xenial: [python-babel]
-python-babeltrace:
-  debian:
-    jessie_python3: [python3-babeltrace]
-    stretch_python3: [python3-babeltrace]
-    sid_python3: [python3-babeltrace]
-  ubuntu:
-    wily_python3: [python3-babeltrace]
-    xenial_python3: [python3-babeltrace]
 python-beautifulsoup:
   arch: [python2-beautifulsoup3]
   debian: [python-beautifulsoup]
@@ -2542,6 +2534,14 @@ python-zmq:
     trusty: [python-zmq]
     trusty_python3: [python3-zmq]
     vivid: [python-zmq]
+python3-babeltrace:
+  debian:
+    jessie: [python3-babeltrace]
+    sid: [python3-babeltrace]
+    stretch: [python3-babeltrace]
+  ubuntu:
+    wily: [python3-babeltrace]
+    xenial: [python3-babeltrace]
 xdot:
   debian: [xdot]
   fedora: [python-xdot]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -220,8 +220,8 @@ python-babel:
     xenial: [python-babel]
 python-babeltrace:
   debian:
-   jessie_python3: [python3-babeltrace]
-  ubuntu: 
+    jessie_python3: [python3-babeltrace]
+  ubuntu:
     wily_python3: [python3-babeltrace]
     xenial_python3: [python3-babeltrace]
 python-beautifulsoup:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -218,8 +218,6 @@ python-babel:
     vivid: [python-babel]
     wily: [python-babel]
     xenial: [python-babel]
-python3-babeltrace:
-  ubuntu: [python3-babeltrace]
 python-beautifulsoup:
   arch: [python2-beautifulsoup3]
   debian: [python-beautifulsoup]
@@ -894,11 +892,13 @@ python-libpgm-pip:
   ubuntu:
     pip:
       packages: [libpgm]
-python2-lttngust:
-  arch: [python2-lttngust]
-python3-lttngust:
-  debian: [python3-lttngust]
-  ubuntu: [python3-lttngust]
+python-lttngust:
+  debian: 
+    pip:
+      packages: [python-lttngust]}
+  ubuntu: 
+    pip:
+      packages: [python-lttngust]
 python-lxml:
   debian: [python-lxml]
   fedora: [python-lxml]
@@ -2534,6 +2534,8 @@ python-zmq:
     trusty: [python-zmq]
     trusty_python3: [python3-zmq]
     vivid: [python-zmq]
+python3-babeltrace:
+  ubuntu: [python3-babeltrace]
 xdot:
   debian: [xdot]
   fedora: [python-xdot]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -218,6 +218,12 @@ python-babel:
     vivid: [python-babel]
     wily: [python-babel]
     xenial: [python-babel]
+python-babeltrace:
+  debian:
+   jessie_python3: [python3-babeltrace]
+  ubuntu: 
+    wily_python3: [python3-babeltrace]
+    xenial_python3: [python3-babeltrace]
 python-beautifulsoup:
   arch: [python2-beautifulsoup3]
   debian: [python-beautifulsoup]
@@ -2534,8 +2540,6 @@ python-zmq:
     trusty: [python-zmq]
     trusty_python3: [python3-zmq]
     vivid: [python-zmq]
-python3-babeltrace:
-  ubuntu: [python3-babeltrace]
 xdot:
   debian: [xdot]
   fedora: [python-xdot]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -893,10 +893,10 @@ python-libpgm-pip:
     pip:
       packages: [libpgm]
 python-lttngust:
-  debian: 
+  debian:
     pip:
-      packages: [python-lttngust]}
-  ubuntu: 
+      packages: [python-lttngust]
+  ubuntu:
     pip:
       packages: [python-lttngust]
 python-lxml:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -221,6 +221,8 @@ python-babel:
 python-babeltrace:
   debian:
     jessie_python3: [python3-babeltrace]
+    stretch_python3: [python3-babeltrace]
+    sid_python3: [python3-babeltrace]
   ubuntu:
     wily_python3: [python3-babeltrace]
     xenial_python3: [python3-babeltrace]


### PR DESCRIPTION
This pull request adds dependencies for using the Linux Trace Toolkit next generation (LTTng) for both C++ and Python processes. LTTng enables very low-overhead run-time data gathering.

FYI: We (Bosch) have a ROS package in the process of open source release which uses these.
