### PR TITLE
world_canvas: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3654,6 +3654,19 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros.git
       version: jade-devel
     status: maintained
+  world_canvas:
+    release:
+      packages:
+      - world_canvas_server
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/world_canvas-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/yujinrobot/world_canvas.git
+      version: kinetic
+    status: maintained
   world_canvas_libs:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `world_canvas` to `0.2.0-0`:
- upstream repository: https://github.com/yujinrobot/world_canvas.git
- release repository: https://github.com/yujinrobot-release/world_canvas-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
