### PR TITLE
rosbridge_suite: 0.7.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9674,7 +9674,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.7.14-1
+      version: 0.7.15-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.7.15-0`:
- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.7.14-1`
## rosapi
- No changes
## rosbridge_library
- No changes
## rosbridge_server

```
* Track Twisted run_depend
  Fixes #218 <https://github.com/RobotWebTools/rosbridge_suite/issues/218>
* Contributors: Matt Vollrath
```
## rosbridge_suite
- No changes
