### PR TITLE
librealsense: 0.9.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5052,6 +5052,21 @@ repositories:
       url: https://github.com/ethz-asl/libpointmatcher.git
       version: master
     status: developed
+  librealsense:
+    doc:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/intel-ros/realsense.git
+      version: 0.9.2-0
+    source:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: master
+    status: maintained
   librms:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense` to `0.9.2-0`:
- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/intel-ros/realsense.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
