### PR TITLE
ros_comm: 1.11.20-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4469,7 +4469,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.19-0
+      version: 1.11.20-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.20-0`:
- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.11.19-0`
## message_filters
- No changes
## ros_comm
- No changes
## rosbag
- No changes
## rosbag_storage
- No changes
## rosconsole
- No changes
## roscpp

```
* fix segfault if connection fails (#807 <https://github.com/ros/ros_comm/pull/807>)
```
## rosgraph

```
* fix symlink of the log dir itself as latest (#795 <https://github.com/ros/ros_comm/pull/795>)
```
## roslaunch

```
* fix roslaunch check for multiple tests with multiple args (#814 <https://github.com/ros/ros_comm/pull/814>)
```
## roslz4
- No changes
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy
- No changes
## rosservice
- No changes
## rostest
- No changes
## rostopic
- No changes
## roswtf
- No changes
## topic_tools
- No changes
## xmlrpcpp
- No changes
