### PR TITLE
librealsense: 0.9.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5060,7 +5060,7 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/intel-ros/realsense.git
+      url: https://github.com/intel-ros/librealsense-release.git
       version: 0.9.2-0
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense` to `0.9.2-0`:
- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/intel-ros/librealsense-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.9.2-0`
