### PR TITLE
moveit_ikfast: 3.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5714,7 +5714,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_ikfast-release.git
-      version: 3.1.0-0
+      version: 3.1.1-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_ikfast.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ikfast` to `3.1.1-0`:
- upstream repository: https://github.com/ros-planning/moveit_ikfast
- release repository: https://github.com/ros-gbp/moveit_ikfast-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `3.1.0-0`
## moveit_ikfast

```
* [feat] added ik_seed_state argument to the getPositionIK method. added support for redundancy sampling
* [feat] Random Sampling uses the joint discretization to determine how many samples to generate
* [feat] Allow hex version number of ikFast as used since 2014-10-08. the current git version of openRAVE uses hex version number since 2014-10-08 #48 <https://github.com/ros-planning/moveit_ikfast/issues/48>
* [enhance] Kinematics base update #57 <https://github.com/ros-planning/moveit_ikfast/issues/57>
* [enhance] updates the template for generating the ikfast KinematicsBase plugin
* [sys][CI] Update Travis config to run on Ubuntu 14.04. #64 <https://github.com/ros-planning/moveit_ikfast/issues/64>
* [enhance] Reduce INFO output at initialization #44 <https://github.com/ros-planning/moveit_ikfast/issues/44>
* [doc] Updated README
* Contributors: Dave Coleman, G.A. vd. Hoorn, Isaac I.Y. Saito, Martin Guenther, gavanderhoorn, jrgnicho, simonschmeisser
```
