### PR TITLE
moveit_ikfast: 3.2.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2558,6 +2558,21 @@ repositories:
       url: https://github.com/ros-planning/moveit_core.git
       version: jade-devel
     status: maintained
+  moveit_ikfast:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_ikfast.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_ikfast-release.git
+      version: 3.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_ikfast.git
+      version: jade-devel
+    status: maintained
   moveit_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_ikfast` to `3.2.0-0`:
- upstream repository: https://github.com/ros-planning/moveit_ikfast
- release repository: https://github.com/ros-gbp/moveit_ikfast-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## moveit_ikfast

```
* [feat] added ik_seed_state argument to the getPositionIK method. added support for redundancy sampling
* [feat] Random Sampling uses the joint discretization to determine how many samples to generate
* [feat] Allow hex version number of ikFast as used since 2014-10-08. the current git version of openRAVE uses hex version number since 2014-10-08 #48 <https://github.com/ros-planning/moveit_ikfast/issues/48>
* [enhance] Kinematics base update #57 <https://github.com/ros-planning/moveit_ikfast/issues/57>
* [enhance] updates the template for generating the ikfast KinematicsBase plugin
* [sys][CI] Update Travis config to run on Ubuntu 14.04. #64 <https://github.com/ros-planning/moveit_ikfast/issues/64>
* [enhance] Reduce INFO output at initialization #44 <https://github.com/ros-planning/moveit_ikfast/issues/44>
* [doc] Updated README
* Contributors: Dave Coleman, G.A. vd. Hoorn, Isaac I.Y. Saito, Jonathan Meyer, Martin Guenther, gavanderhoorn, jrgnicho, simonschmeisser
```
