### PR TITLE
turtlebot_apps: 2.3.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3455,6 +3455,28 @@ repositories:
       url: https://github.com/turtlebot/turtlebot.git
       version: indigo
     status: maintained
+  turtlebot_apps:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_apps.git
+      version: indigo
+    release:
+      packages:
+      - turtlebot_actions
+      - turtlebot_apps
+      - turtlebot_calibration
+      - turtlebot_follower
+      - turtlebot_navigation
+      - turtlebot_rapps
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/turtlebot-release/turtlebot_apps-release.git
+      version: 2.3.5-0
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_apps.git
+      version: indigo
+    status: maintained
   turtlebot_create:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_apps` to `2.3.5-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_apps.git
- release repository: https://github.com/turtlebot-release/turtlebot_apps-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## turtlebot_actions
- No changes
## turtlebot_apps

```
* removing unnecessary dependencies
* Contributors: Tully Foote
```
## turtlebot_calibration
- No changes
## turtlebot_follower
- No changes
## turtlebot_navigation
- No changes
## turtlebot_rapps
- No changes
