### PR TITLE
summit_xl_common: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11715,7 +11715,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/summit_xl_common-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_xl_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_xl_common` to `1.0.3-0`:
- upstream repository: https://github.com/RobotnikAutomation/summit_xl_common.git
- release repository: https://github.com/RobotnikAutomation/summit_xl_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.2-0`
## summit_xl_common
- No changes
## summit_xl_description
- No changes
## summit_xl_localization
- No changes
## summit_xl_navigation
- No changes
## summit_xl_pad

```
* Deleted nav_msgs dependency
* Contributors: carlos3dx
```
