### PR TITLE
mrpt_navigation: 0.1.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2719,7 +2719,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 0.1.6-0
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `0.1.8-0`:
- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.6-0`
## mrpt_bridge
- No changes
## mrpt_local_obstacles
- No changes
## mrpt_localization
- No changes
## mrpt_map
- No changes
## mrpt_msgs
- No changes
## mrpt_navigation
- No changes
## mrpt_rawlog

```
* Fix CMake dependencies (it failed to build in some platforms randomly)
* Contributors: Jose-Luis Blanco-Claraco
```
## mrpt_reactivenav2d

```
* Reactive nav default config file: coarser collision grid for faster initialization
* fix build and sample config file for reactivenav with mrpt>=1.5.0
* Contributors: Jose-Luis Blanco-Claraco
```
## mrpt_tutorials
- No changes
