### PR TITLE
graph_msgs: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1035,6 +1035,13 @@ repositories:
       url: https://github.com/ros-visualization/gl_dependency.git
       version: kinetic-devel
     status: maintained
+  graph_msgs:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/davetcoleman/graph_msgs-release.git
+      version: 0.1.0-0
+    status: maintained
   grid_map:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `graph_msgs` to `0.1.0-0`:
- upstream repository: https://github.com/davetcoleman/graph_msgs
- release repository: https://github.com/davetcoleman/graph_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## graph_msgs

```
* Added header / timestamp
* Contributors: Dave Coleman
```
