### PR TITLE
rosparam_shortcuts: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3067,6 +3067,21 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: jade-devel
     status: maintained
+  rosparam_shortcuts:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/rosparam_shortcuts.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/davetcoleman/rosparam_shortcuts-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/rosparam_shortcuts.git
+      version: kinetic-devel
+    status: maintained
   rospy_message_converter:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_shortcuts` to `0.2.0-0`:
- upstream repository: https://github.com/davetcoleman/rosparam_shortcuts.git
- release repository: https://github.com/davetcoleman/rosparam_shortcuts-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rosparam_shortcuts

```
* Upgrade to Eigen3 per ROS Kinetic requirements
* Converted to C++11 for ROS Kinetic
* Removed deprecated functions
* Improve documentation
* fix typo
* Added loading a vector to example
* Contributors: Dave Coleman, Sammy Pfeiffer
```
