### PR TITLE
cartesian_msgs: 0.0.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -266,6 +266,21 @@ repositories:
       url: https://github.com/osrf/capabilities.git
       version: master
     status: maintained
+  cartesian_msgs:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/cartesian_msgs.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/davetcoleman/cartesian_msgs-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/davetcoleman/cartesian_msgs.git
+      version: jade-devel
+    status: maintained
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartesian_msgs` to `0.0.3-1`:
- upstream repository: https://github.com/davetcoleman/cartesian_msgs.git
- release repository: https://github.com/davetcoleman/cartesian_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## cartesian_msgs

```
* catkin lint cleanup
* Contributors: Dave Coleman
```
