### PR TITLE
Add debian libgflags-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1537,6 +1537,7 @@ libgeos++-dev:
   fedora: [geos-devel]
   ubuntu: [libgeos++-dev]
 libgflags-dev:
+  debian: [libgflags-dev]
   fedora: [gflags-devel]
   gentoo:
     portage:


### PR DESCRIPTION
When blooming a package that required gflags I get:

> Failed to resolve libgflags-dev on debian:jessie with: Error running generator: Failed to resolve rosdep key 'libgflags-dev', aborting.
