### PR TITLE
rviz_visual_tools: 3.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3262,6 +3262,21 @@ repositories:
       url: https://github.com/ros-visualization/rviz.git
       version: kinetic-devel
     status: maintained
+  rviz_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/rviz_visual_tools.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/davetcoleman/rviz_visual_tools-release.git
+      version: 3.0.0-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/rviz_visual_tools.git
+      version: kinetic-devel
+    status: developed
   schunk_canopen_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `3.0.0-0`:
- upstream repository: https://github.com/davetcoleman/rviz_visual_tools.git
- release repository: https://github.com/davetcoleman/rviz_visual_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rviz_visual_tools

```
* Improve Travis script
* Upgrade to Eigen3 per ROS Kinetic requirements
* New screenshot
* Refactored entire scaling method - all sizes of shapes have been affected
* Renamed scales
* Removed const reference for primitive types in function headers
* Cleaned up getScale() function
* New publishSpheres function
* Two new tests & screenshot
* Deprecated size REGULAR
* Number scale sizes
* New intToRvizScale() function
* New publishSpheres() functions for showing list of lines AND colors
* New publishLines() functions for using LINE_LIST
* New publishCylinder() function that uses scales
* Bug fix for getVectorBetweenPoints() when vector is all zeros
* New printTranslation() function
* added intToRvizColor() for interfaces that do not directly depend on Rviz Visual Tools, such as OMPL
* publishPath with vector of colors
* Update demo
* New variant of publishPath with vector of colors
* New publishSphere() helper
* Add eigen_stl_containers
* Add missing breaks in switch statement
* Add namespace to ease debugging ROS messages
* Do not pass Eigen structures by value
* Fix all vector<Eigen> to EigenSTL::vector_Vector3d as recommended by @VictorLamoine
* Hide upstream package cast warning
* Overload new operator for Eigen structures
* Changing the angles will change the opening angle of the cone
* Better way to turn on C++11, maybe?
* Removed deprecated code for Kinetic
* Began converting to C++11
* Fix dead link to the documentation
* New waitForMarkerPub() function
* Fix bug in waitForSubscriber() introduced in previous commit
* Added blocking constraint option in function waitForSubscriber
* New publishLine() variant
* ID for publishing rectangles
* Optimize clearing and resizing vectors
* Increase random color sampling attempts
* Move variable declaration
* Latched publisher
* publishAxisLabeled arguments
* Include path, boost typedef and class name are now up to date with the code.
* New publishLine() variant
* Optional latched publisher
* ID for publishing rectangles
* Optimize clearing and resizing vectors
* Increase random color sampling attempts
* Move variable declaration
* publishAxisLabeled arguments order
* Adds Publish Labeled Axis
* Contributors: Abhijit Makhal, Dave Coleman, Naveed Usmani, Sow Papa Libasse, Victor Lamoine
```
