### PR TITLE
turtlebot_apps: 2.3.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3524,7 +3524,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_apps-release.git
-      version: 2.3.5-0
+      version: 2.3.6-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_apps` to `2.3.6-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_apps.git
- release repository: https://github.com/turtlebot-release/turtlebot_apps-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.3.5-0`
## turtlebot_actions
- No changes
## turtlebot_apps
- No changes
## turtlebot_calibration
- No changes
## turtlebot_follower

```
* add dependency on depth_image_proc
* Contributors: Tully Foote
```
## turtlebot_navigation
- No changes
## turtlebot_rapps
- No changes
