### PR TITLE
mavros: 0.18.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1739,7 +1739,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.18.1-0
+      version: 0.18.2-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.18.2-0`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.18.1-0`
## libmavconn

```
* Revert "libmavconn: Update console_bridge macroses."
  This reverts commit 73fd7f755ed919bc3c170574f514ba6525cd31a2.
  It breaks Travis builds for Indigo and Jade.
* libmavconn: Update console_bridge macroses.
  https://github.com/ros/console_bridge/issues/18
* libmavconn: tcp: enable_shared_from_this
* libmavconn: udp: enable_shared_from_this
* libmavconn: serial: enable_shared_from_this
* libmavconn: std::deque automatically free buffers
* libmavconn fix #567 <https://github.com/mavlink/mavros/issues/567>: Fix tcp server stat calculation
* libmavconn: Fix debug log conn_id
* Contributors: Vladimir Ermakov
```
## mavros

```
* plugin:sys_status: Fix STATUSTEXT log prefix
* Contributors: Vladimir Ermakov
```
## mavros_extras
- No changes
## mavros_msgs
- No changes
## test_mavros
- No changes
