### PR TITLE
turtlebot_create_desktop: 2.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3573,6 +3573,25 @@ repositories:
       url: https://github.com/turtlebot/turtlebot_create.git
       version: indigo
     status: maintained
+  turtlebot_create_desktop:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_create_desktop.git
+      version: indigo
+    release:
+      packages:
+      - create_dashboard
+      - create_gazebo_plugins
+      - turtlebot_create_desktop
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/turtlebot-release/turtlebot_create_desktop-release.git
+      version: 2.3.1-0
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_create_desktop.git
+      version: indigo
+    status: maintained
   turtlebot_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_create_desktop` to `2.3.1-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_create_desktop.git
- release repository: https://github.com/turtlebot-release/turtlebot_create_desktop-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## create_dashboard

```
* create_dashboard: Fix some python syntax errors
  Even if this file isn't used, it will be bytecompiled when packaged for Fedora. This will fail if there are syntax errors in the file, so even if it is not used or has functional errors, it needs to be syntactically correct if it is in the repository.
* Contributors: Scott K Logan
```
## create_gazebo_plugins
- No changes
## turtlebot_create_desktop
- No changes
