### PR TITLE
summit_xl_sim: 1.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11757,7 +11757,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/summit_xl_sim-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_xl_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_xl_sim` to `1.0.4-0`:
- upstream repository: https://github.com/RobotnikAutomation/summit_xl_sim.git
- release repository: https://github.com/RobotnikAutomation/summit_xl_sim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.3-0`
## summit_xl_control
- No changes
## summit_xl_gazebo

```
* modified dependencies
* Contributors: carlos3dx
```
## summit_xl_robot_control
- No changes
## summit_xl_sim
- No changes
## summit_xl_sim_bringup
- No changes
