### PR TITLE
rtmros_nextage: 0.7.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10519,7 +10519,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.7.7-0
+      version: 0.7.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.7.8-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.7.7-0`
## nextage_description
- No changes
## nextage_gazebo
- No changes
## nextage_ik_plugin
- No changes
## nextage_moveit_config

```
* [feat] Add joystick launch (https://groups.google.com/d/msg/moveit-users/lbUwNqiMuP8/DZX2Fn0EAQAJ).
* Contributors: Kei Okada, Isaac I.Y. Saito
```
## nextage_ros_bridge
- No changes
## rtmros_nextage

```
* [feat] Add joystick launch (https://groups.google.com/d/msg/moveit-users/lbUwNqiMuP8/DZX2Fn0EAQAJ).
* Contributors: Kei Okada, Isaac I.Y. Saito
```
