### PR TITLE
tesis: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3513,6 +3513,22 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  tesis:
+    doc:
+      type: git
+      url: https://github.com/davidrotor/tesis.git
+      version: branch
+    release:
+      packages:
+      - control
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/davidrotor/tesis.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/davidrotor/tesis.git
+      version: master
   topic_proxy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tesis` to `0.0.1-0`:
- upstream repository: https://github.com/davidrotor/tesis.git
- release repository: https://github.com/davidrotor/tesis.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## control

```
* Merge branch 'master' of https://github.com/davidrotor/tesis
* Initial commit
* 0.1
* Contributors: davidrotor
```
