### PR TITLE
add archlinux to kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11,6 +11,8 @@ release_platforms:
   ubuntu:
   - wily
   - xenial
+  arch:
+  - latest
 repositories:
   ackermann_msgs:
     doc:


### PR DESCRIPTION
This allows bloom to identify archlinux as supported distribution, as per https://github.com/bchretien/arch-ros-stacks/issues/50
In that issue the changes required to support archlinux are being discussed. Currently, a modified bloom version which allows to generate the required build files was proposed and successfully tested. This addition to rosdistro will allow the modified bloom to be proposed as a PR and tested by others. Since the buildfarm does not yet have support for archlinux, this addition to the distributions file should be inoccuous.
