### PR TITLE
motoman: 0.3.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5651,6 +5651,23 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/motoman.git
       version: indigo-devel
+    release:
+      packages:
+      - motoman
+      - motoman_driver
+      - motoman_mh5_support
+      - motoman_msgs
+      - motoman_sda10f_moveit_config
+      - motoman_sda10f_support
+      - motoman_sia10d_support
+      - motoman_sia10f_support
+      - motoman_sia20d_moveit_config
+      - motoman_sia20d_support
+      - motoman_sia5d_support
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-industrial-release/motoman-release.git
+      version: 0.3.5-0
     source:
       type: git
       url: https://github.com/ros-industrial/motoman.git


### PR DESCRIPTION
Increasing version of package(s) in repository `motoman` to `0.3.5-0`:
- upstream repository: https://github.com/ros-industrial/motoman.git
- release repository: https://github.com/ros-industrial-release/motoman-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## motoman

```
* No changes
```
## motoman_driver

```
* Cleaned up issues with Changelogs
* Contributors: Shaun Edwards
```
## motoman_mh5_support

```
* No changes
```
## motoman_msgs

```
* No changes
```
## motoman_sda10f_moveit_config

```
* No changes
```
## motoman_sda10f_support

```
* No changes
```
## motoman_sia10d_support

```
* No changes
```
## motoman_sia10f_support

```
* No changes
```
## motoman_sia20d_moveit_config

```
* No changes
```
## motoman_sia20d_support

```
* No changes
```
## motoman_sia5d_support

```
* No changes
```
