### PR TITLE
agvs_common: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -125,7 +125,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/agvs_common-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/agvs_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `agvs_common` to `0.1.2-0`:
- upstream repository: https://github.com/RobotnikAutomation/agvs_common.git
- release repository: https://github.com/RobotnikAutomation/agvs_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.1-0`
