### PR TITLE
rbcar_common: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8543,6 +8543,15 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/rbcar_common.git
       version: indigo-devel
+    release:
+      packages:
+      - rbcar_common
+      - rbcar_description
+      - rbcar_pad
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotnikAutomation/rbcar_common-release.git
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/rbcar_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rbcar_common` to `1.0.1-0`:
- upstream repository: https://github.com/RobotnikAutomation/rbcar_common.git
- release repository: https://github.com/RobotnikAutomation/rbcar_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rbcar_common

```
* Added website
* Modified dependencies
* minor change
* added common mtpkg folder
* Contributors: carlos3dx, rguzman
```
## rbcar_description

```
* Added website
* Modified dependencies
* changed hw interface to VelocityJointInterface for traction, added damping and friction to axle and suspension
* rbcar_description: changing 3d sensor position to fit with the real model
* added imu, needed for odometry estimation
* updated urdf
* sensors imported from robotnik_sensors package
* deleted sensors - now from robotnik_sensors package
* rbcar_description: adding rviz config file
* corrected ranges of hokuyo3d and added measurement tf
* updated hokuyo3d model
* control period of plugin to 0.001 and updated traction torque
* updated model - 1st working in gazebo
* modified to work in gazebo
* changed 3d laser pos
* added rbcar_description
* Contributors: RomanRobotnik, carlos3dx, rguzman, trurl
```
## rbcar_pad

```
* Added website
* Modified dependencies
* rbcar_description: changing 3d sensor position to fit with the real model
* rbcar_pad: enabling params like max speed and steering angle
* Adding compilation dependencies with robotnik_msgs
* Adding new package rbcar_pad for sim and real robot
* Contributors: RomanRobotnik, Usuario, carlos3dx
```
