### PR TITLE
rbcar_common: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8551,7 +8551,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/rbcar_common-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/rbcar_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rbcar_common` to `1.0.2-0`:
- upstream repository: https://github.com/RobotnikAutomation/rbcar_common.git
- release repository: https://github.com/RobotnikAutomation/rbcar_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.1-0`
## rbcar_common
- No changes
## rbcar_description
- No changes
## rbcar_pad

```
* Added dependencies
* Contributors: carlos3dx
```
