### PR TITLE
enu: 1.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2336,6 +2336,20 @@ repositories:
       url: https://github.com/ros-gbp/eml-release.git
       version: 1.8.15-0
     status: maintained
+  enu:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/enu.git
+      version: hydro
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/enu-release.git
+      version: 1.2.2-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/enu.git
+      version: hydro
   epos_hardware:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `enu` to `1.2.2-0`:
- upstream repository: https://github.com/clearpathrobotics/enu.git
- release repository: https://github.com/clearpath-gbp/enu-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## enu

```
* Define _xerbla logging function to fix regression from swiftnav.
* Contributors: Mike Purvis
```
