### PR TITLE
declination: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1829,6 +1829,20 @@ repositories:
       type: git
       url: https://github.com/HumaRobotics/darwin_gazebo.git
       version: master
+  declination:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/declination.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/declination-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/declination.git
+      version: master
   demo_pioneer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `declination` to `0.0.2-0`:
- upstream repository: https://github.com/clearpathrobotics/declination
- release repository: https://github.com/clearpath-gbp/declination-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## declination

```
* Fix executable name.
```
