### PR TITLE
rbcar_sim: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8615,6 +8615,18 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/rbcar_sim.git
       version: indigo-devel
+    release:
+      packages:
+      - rbcar_control
+      - rbcar_gazebo
+      - rbcar_joystick
+      - rbcar_robot_control
+      - rbcar_sim
+      - rbcar_sim_bringup
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotnikAutomation/rbcar_sim-release.git
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/rbcar_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rbcar_sim` to `1.0.2-0`:
- upstream repository: https://github.com/RobotnikAutomation/rbcar_sim.git
- release repository: https://github.com/RobotnikAutomation/rbcar_sim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rbcar_control

```
* Modified authors and maintainers
* modified CMakeLists y Package files
* Contributors: carlos3dx
```
## rbcar_gazebo

```
* Modified authors and maintainers
* modified CMakeLists y Package files
* Contributors: carlos3dx
```
## rbcar_joystick

```
* Modified authors and maintainers
* modified CMakeLists y Package files
* Contributors: carlos3dx
```
## rbcar_robot_control

```
* Modified authors and maintainers
* modified CMakeLists y Package files
* Contributors: carlos3dx
```
## rbcar_sim

```
* Modified authors and maintainers
* Contributors: carlos3dx
```
## rbcar_sim_bringup

```
* Modified authors and maintainers
* modified CMakeLists y Package files
* Contributors: carlos3dx
```
