### PR TITLE
pepper_virual: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7444,7 +7444,7 @@ repositories:
   pepper_virual:
     doc:
       type: git
-      url: https://github.com/ros-naoqi/pepper_virtual
+      url: https://github.com/ros-naoqi/pepper_virtual.git
       version: master
     release:
       packages:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7441,6 +7441,24 @@ repositories:
       url: https://github.com/ros-naoqi/pepper_robot.git
       version: master
     status: maintained
+  pepper_virual:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_virtual
+      version: master
+    release:
+      packages:
+      - pepper_control
+      - pepper_gazebo_plugin
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-naoqi/pepper_virtual-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_virtual.git
+      version: master
+    status: developed
   pepperl_fuchs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_virual` to `0.0.1-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_virtual
- release repository: https://github.com/ros-naoqi/pepper_virtual-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## pepper_control

```
* adding pepper_control package
* Contributors: nlyubova
```
## pepper_gazebo_plugin

```
* moving pepper_gazebo_plugin to pepper_virtual
* updating the dependency on pepper_dcm_control
* updating README
* updating the dependency on pepper_dcm_control package
* removing unused launch file
* initial commit
* Contributors: nlyubova
```
