### PR TITLE
repository_name: 0.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8711,7 +8711,7 @@ repositories:
       url: https://github.com/So-Cool/report_card.git
       version: master
     status: maintained
-  repository_name:
+  hansagv_description:
     release:
       packages:
       - hansagv_description

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3303,6 +3303,12 @@ repositories:
       url: https://github.com/atenpas/handle_detector.git
       version: indigo
     status: maintained
+  hansagv_description:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/hans-x-lab/hansagv_description.git
+      version: 0.0.1-1  
   head_action:
     doc:
       type: git
@@ -8711,14 +8717,6 @@ repositories:
       url: https://github.com/So-Cool/report_card.git
       version: master
     status: maintained
-  hansagv_rviz:
-    release:
-      packages:
-      - hansagv_description    
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/hans-x-lab/hansagv_description.git
-      version: 0.0.1-1
   resource_retriever:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8711,10 +8711,8 @@ repositories:
       url: https://github.com/So-Cool/report_card.git
       version: master
     status: maintained
-  repository_name:
+  hansagv_description:
     release:
-      packages:
-      - hansagv_description
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/hans-x-lab/hansagv_description.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8711,6 +8711,14 @@ repositories:
       url: https://github.com/So-Cool/report_card.git
       version: master
     status: maintained
+  repository_name:
+    release:
+      packages:
+      - hansagv_description
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/hans-x-lab/hansagv_description.git
+      version: 0.0.1-1
   resource_retriever:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8711,8 +8711,10 @@ repositories:
       url: https://github.com/So-Cool/report_card.git
       version: master
     status: maintained
-  hansagv_description:
+  hansagv_rviz:
     release:
+      packages:
+      - hansagv_description    
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/hans-x-lab/hansagv_description.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8711,7 +8711,7 @@ repositories:
       url: https://github.com/So-Cool/report_card.git
       version: master
     status: maintained
-  hansagv_description:
+  repository_name:
     release:
       packages:
       - hansagv_description


### PR DESCRIPTION
Increasing version of package(s) in repository `repository_name` to `0.0.1-1`:
- upstream repository: ~/github/src/hansagv_description
- release repository: https://github.com/hans-x-lab/hansagv_description.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## hansagv_description

```
* version 1.0
* Contributors: Cong Liu
```
