### PR TITLE
rosserial_leonardo_cmake: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10249,6 +10249,21 @@ repositories:
       url: https://github.com/ros-drivers/rosserial.git
       version: indigo-devel
     status: maintained
+  rosserial_leonardo_cmake:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/rosserial_leonardo_cmake.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/rosserial_leonardo_cmake-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/rosserial_leonardo_cmake.git
+      version: hydro-devel
+    status: maintained
   rosshell:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial_leonardo_cmake` to `0.1.3-0`:
- upstream repository: https://github.com/clearpathrobotics/rosserial_leonardo_cmake.git
- release repository: https://github.com/clearpath-gbp/rosserial_leonardo_cmake-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rosserial_leonardo_cmake

```
* Remove old build deps from lists file as well.
* Contributors: Mike Purvis
```
