### PR TITLE
heron: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3471,6 +3471,24 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
       version: 0.3.3-0
     status: maintained
+  heron:
+    doc:
+      type: git
+      url: https://github.com/heron/heron.git
+      version: indigo-devel
+    release:
+      packages:
+      - heron_description
+      - heron_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/heron-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/heron/heron.git
+      version: indigo-devel
+    status: developed
   hokuyo3d:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron` to `0.2.0-0`:
- upstream repository: https://github.com/heron/heron
- release repository: https://github.com/clearpath-gbp/heron-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## heron_description

```
* Updated the UM6 orientation.
* Added SICK lms1xx laser and Axis ptz camera to accessories.
* Added Power message.
* Added optional Novatel Smart6 GPS, updated Gazebo GPS plugin and made default environment variables more specific.
* Fixed IMU angle substitution.
* Updated URDF.
* Heron rename.
* Contributors: Tony Baltovski
```
## heron_msgs

```
* Changed Power message to Status.
* Added Power message.
* Updated URDF.
* Heron rename.
* Contributors: Tony Baltovski
```
