### PR TITLE
rviz_visual_tools: 3.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3344,7 +3344,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/davetcoleman/rviz_visual_tools-release.git
-      version: 3.0.0-0
+      version: 3.1.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `3.1.0-0`:
- upstream repository: https://github.com/davetcoleman/rviz_visual_tools.git
- release repository: https://github.com/davetcoleman/rviz_visual_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `3.0.0-0`
## rviz_visual_tools

```
* Switched publishPath() to use cylinders
* Added new publishLineStrip() function
* Added new publishPath() functions
* Added new publishAxis() functions
* Update screenshot
* Broke publishPath() API for recent addition - incorrect Eigen vector used
* New publishPath() function for Affine3d
* New publishAxis() functions that use scale
* New publishAxisInternal() function for more efficient publishing
* New publishAxisPath() function for showing a series of coordinate axis
* Added warning for batch publishing when not enabled
* Bug fix in publishLines() for id incrementing
* New scaleToString() function
* Bug fix for scaling in coordinate axis
* Improved demo to have multiple scales visualized
* Revert "Remove graph msgs"
* Contributors: Dave Coleman
```
