### PR TITLE
Fix selected python rosdep keys for Xenial.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -197,18 +197,7 @@ python-avahi:
   arch: [avahi]
   debian: [python-avahi]
   fedora: [avahi-ui-tools]
-  ubuntu:
-    lucid: [python-avahi]
-    maverick: [python-avahi]
-    natty: [python-avahi]
-    oneiric: [python-avahi]
-    precise: [python-avahi]
-    quantal: [python-avahi]
-    raring: [python-avahi]
-    saucy: [python-avahi]
-    trusty: [python-avahi]
-    utopic: [python-avahi]
-    vivid: [python-avahi]
+  ubuntu: [python-avahi]
 python-babel:
   fedora: [python-babel]
   ubuntu:
@@ -582,12 +571,7 @@ python-empy:
     xenial: [python-empy]
 python-enum:
   fedora: [python-enum]
-  ubuntu:
-    precise: [python-enum]
-    quantal: [python-enum]
-    raring: [python-enum]
-    saucy: [python-enum]
-    trusty: [python-enum]
+  ubuntu: [python-enum]
 python-enum34:
   fedora: [python-enum34]
   ubuntu: [python-enum34]
@@ -1186,16 +1170,7 @@ python-pandas:
   arch: [python2-pandas]
   debian: [python-pandas]
   fedora: [python-pandas]
-  ubuntu:
-    lucid: [python-pandas]
-    maverick: [python-pandas]
-    natty: [python-pandas]
-    oneiric: [python-pandas]
-    precise: [python-pandas]
-    quantal: [python-pandas]
-    raring: [python-pandas]
-    saucy: [python-pandas]
-    trusty: [python-pandas]
+  ubuntu: [python-pandas]
 python-paramiko:
   arch: [python2-paramiko]
   debian: [python-paramiko]
@@ -1352,6 +1327,8 @@ python-psycopg2:
     saucy: [python-psycopg2]
     trusty: [python-psycopg2]
     trusty_python3: [python3-psycopg2]
+    xenial: [python-psycopg2]
+    xenial_python3: [python3-psycopg2]
 python-pyassimp:
   arch: [python2-pyassimp]
   debian:
@@ -2155,6 +2132,8 @@ python-sqlalchemy:
     saucy: [python-sqlalchemy]
     trusty: [python-sqlalchemy]
     trusty_python3: [python3-sqlalchemy]
+    xenial: [python-sqlalchemy]
+    xenial_python3: [python3-sqlalchemy]
 python-support:
   debian: [python-support]
   fedora: [python]
@@ -2203,34 +2182,12 @@ python-termcolor:
     pip:
       packages: [termcolor]
   ubuntu:
-    lucid:
-      pip:
-        packages: [termcolor]
-    maverick:
-      pip:
-        packages: [termcolor]
-    natty:
-      pip:
-        packages: [termcolor]
-    oneiric:
-      pip:
-        packages: [termcolor]
-    precise:
-      pip:
-        packages: [termcolor]
-    quantal:
-      pip:
-        packages: [termcolor]
-    raring:
-      pip:
-        packages: [termcolor]
-    saucy:
-      pip:
-        packages: [termcolor]
     trusty: [python-termcolor]
     trusty_python3: [python3-termcolor]
     utopic: [python-termcolor]
     vivid: [python-termcolor]
+    xenial: [python-termcolor]
+    xenial_python3: [python3-termcolor]
 python-texttable:
   fedora: [python-texttable]
   osx:
@@ -2441,7 +2398,12 @@ python-vtk:
   arch: [vtk]
   debian: [python-vtk]
   fedora: [vtk-python]
-  ubuntu: [python-vtk]
+  ubuntu:
+    trusty: [python-vtk]
+    utopic: [python-vtk]
+    vivid: [python-vtk]
+    wily: [python-vtk]
+    xenial: [python-vtk6]
 python-walrus-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1327,6 +1327,9 @@ python-psycopg2:
     saucy: [python-psycopg2]
     trusty: [python-psycopg2]
     trusty_python3: [python3-psycopg2]
+    utopic: [python-psycopg2]
+    vivid: [python-psycopg2]
+    wily: [python-psycopg2]
     xenial: [python-psycopg2]
     xenial_python3: [python3-psycopg2]
 python-pyassimp:
@@ -2132,6 +2135,9 @@ python-sqlalchemy:
     saucy: [python-sqlalchemy]
     trusty: [python-sqlalchemy]
     trusty_python3: [python3-sqlalchemy]
+    utopic: [python-sqlalchemy]
+    vivid: [python-sqlalchemy]
+    wily: [python-sqlalchemy]
     xenial: [python-sqlalchemy]
     xenial_python3: [python3-sqlalchemy]
 python-support:
@@ -2186,6 +2192,7 @@ python-termcolor:
     trusty_python3: [python3-termcolor]
     utopic: [python-termcolor]
     vivid: [python-termcolor]
+    wily: [python-termcolor]
     xenial: [python-termcolor]
     xenial_python3: [python3-termcolor]
 python-texttable:


### PR DESCRIPTION
Affected: python-termcolor, python-enum, python-pandas, python-psycopg2, python-avahi, python-sqlalchemy
