### PR TITLE
rb1_base_common: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8620,7 +8620,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/rb1_base_common-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/rb1_base_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rb1_base_common` to `1.0.3-0`:
- upstream repository: https://github.com/RobotnikAutomation/rb1_base_common.git
- release repository: https://github.com/RobotnikAutomation/rb1_base_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.2-0`
## rb1_base_common
- No changes
## rb1_base_description
- No changes
## rb1_base_pad

```
* Modified Cmake.lists rb1_base_pad
* Contributors: AliquesTomas
```
