### PR TITLE
pepper_virual: 0.0.2-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7471,7 +7471,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_virtual-release.git
-      version: 0.0.1-0
+      version: 0.0.2-3
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_virtual.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_virual` to `0.0.2-3`:
- upstream repository: https://github.com/ros-naoqi/pepper_virtual
- release repository: https://github.com/ros-naoqi/pepper_virtual-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.1-0`
## pepper_control
- No changes
## pepper_gazebo_plugin

```
* fixing install in CMakeLists
* updating README
* Contributors: nlyubova
```
