### PR TITLE
mavros: 0.18.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1739,7 +1739,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.18.2-0
+      version: 0.18.3-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.18.3-1`:
- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.18.2-0`
## libmavconn

```
* libmavconn: Enable autoquad dialect. It fixed in mavlink 2016.7.7
* Contributors: Vladimir Ermakov
```
## mavros

```
* plugin:param: Use mavlink::set_string() helper
* Update README.md
* Update README.md
  Fix very confusing instructions mixing steps.
* Update README.md
* Update README.md
* python #569 <https://github.com/mavlink/mavros/issues/569>: convert_to_rosmsg() support for 2.0. NO SIGNING.
* python #569 <https://github.com/mavlink/mavros/issues/569>: Update mavlink.convert_to_bytes()
* Contributors: Lorenz Meier, Vladimir Ermakov
```
## mavros_extras
- No changes
## mavros_msgs
- No changes
## test_mavros
- No changes
