### PR TITLE
rb1_base_sim: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8631,6 +8631,17 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/rb1_base_sim.git
       version: indigo-devel
+    release:
+      packages:
+      - rb1_base_2dnav
+      - rb1_base_control
+      - rb1_base_gazebo
+      - rb1_base_purepursuit
+      - rb1_base_sim
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotnikAutomation/rb1_base_sim-release.git
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/rb1_base_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rb1_base_sim` to `1.0.1-0`:
- upstream repository: https://github.com/RobotnikAutomation/rb1_base_sim.git
- release repository: https://github.com/RobotnikAutomation/rb1_base_sim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rb1_base_2dnav

```
* removing builds from package xml
* Adding 2dnav dependencies
* Adding 2dnav dependencies
* Adding move base dependencies
* Adding std msgs dependencies
* Added message runtime dependencies
* Edited xml packages and Cmake lists
* commented param footprint options
* added teb cfg files and launch
* added packages coming from rb1_sim
* Contributors: AliquesTomas, rguzman
```
## rb1_base_control

```
* Edited xml packages and Cmake lists
* changed control yaml and launch to use the diff_drive_controller - allows diff drive control using ros control and velocity interface
* commented param footprint options
* added packages coming from rb1_sim
* Contributors: AliquesTomas, rguzman, rguzman1
```
## rb1_base_gazebo

```
* removing builds from package xml
* Edited xml packages and Cmake lists
* changed control yaml and launch to use the diff_drive_controller - allows diff drive control using ros control and velocity interface
* corrected pad file
* added packages coming from rb1_sim
* Contributors: AliquesTomas, rguzman, rguzman1
```
## rb1_base_purepursuit

```
* removing robotnik pp planner dependencies
* removing robotnik pp planner dependencies
* Adding robotnik pp planner dependencies
* Adding robotnik pp planner dependencies
* Adding robotnik pp planner dependencies
* Adding robotnik pp planner dependencies
* Edited xml packages and Cmake lists
* added packages coming from rb1_sim
* Contributors: AliquesTomas, rguzman
```
## rb1_base_sim

```
* Edited xml packages and Cmake lists
* added metapackage folder
* Contributors: AliquesTomas, rguzman
```
