### PR TITLE
Enable Pull Request builds for realsense_camera

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8724,6 +8724,7 @@ repositories:
       url: https://github.com/intel-ros/realsense-release.git
       version: 1.2.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/intel-ros/realsense.git
       version: indigo-devel

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2583,6 +2583,7 @@ repositories:
       url: https://github.com/intel-ros/realsense-release.git
       version: 1.2.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/intel-ros/realsense.git
       version: indigo-devel


### PR DESCRIPTION
Continuous Integration builds for all new Pull Requests
against realsense_camera package.
Trigger builds under both Indigo and Kinetic.
