### PR TITLE
summit_x_common: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11919,6 +11919,14 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/summit_x_common.git
       version: indigo-devel
+    release:
+      packages:
+      - summit_x_common
+      - summit_x_description
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotnikAutomation/summit_x_common-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_x_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_x_common` to `0.0.1-0`:
- upstream repository: https://github.com/RobotnikAutomation/summit_x_common.git
- release repository: https://github.com/RobotnikAutomation/summit_x_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## summit_x_common

```
* Changed package.xml files
* summit_x_description: creating package. Migrating urdf descriptions to indigo
* summit_x_common: first commit of metapackage
* Contributors: Jorge Arino, carlos3dx
```
## summit_x_description

```
* Changed package.xml files
* summit_x_description: added correct position for the asus xtion camera
* summit_x_common: fixed link to robotnik_sensors
* summit_x_description: creating package. Migrating urdf descriptions to indigo
* Contributors: Jorge Arino, carlos3dx
```
