### PR TITLE
summit_x_sim: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11937,6 +11937,15 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/summit_x_sim.git
       version: indigo-devel
+    release:
+      packages:
+      - summit_x_control
+      - summit_x_gazebo
+      - summit_x_robot_control
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotnikAutomation/summit_x_sim-release.git
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_x_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_x_sim` to `1.0.1-0`:
- upstream repository: https://github.com/RobotnikAutomation/summit_x_sim.git
- release repository: https://github.com/RobotnikAutomation/summit_x_sim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## summit_x_control

```
* creating summit_x_sim metapackage
* Contributors: Jorge Arino
```
## summit_x_gazebo

```
* Modified dependencies
* Modified CmakeLists and Package.xml files
* creating summit_x_sim metapackage
* Contributors: Jorge Arino, carlos3dx
```
## summit_x_robot_control

```
* Modified CmakeLists and Package.xml files
* creating summit_x_sim metapackage
* Contributors: Jorge Arino, carlos3dx
```
