### PR TITLE
romeo_dcm_robot: 0.1.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9392,6 +9392,23 @@ repositories:
       url: https://github.com/robotics-in-concert/rocon_tutorials.git
       version: indigo
     status: developed
+  romeo_dcm_robot:
+    doc:
+      type: git
+      url: https://github.com/ros-aldebaran/romeo_dcm_robot.git
+      version: master
+    release:
+      packages:
+      - romeo_dcm_control
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-aldebaran/romeo_dcm_robot-release.git
+      version: 0.1.5-1
+    source:
+      type: git
+      url: https://github.com/ros-aldebaran/romeo_dcm_robot.git
+      version: master
+    status: developed
   romeo_moveit_actions:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_dcm_robot` to `0.1.5-1`:
- upstream repository: https://github.com/ros-aldebaran/romeo_dcm_robot.git
- release repository: https://github.com/ros-aldebaran/romeo_dcm_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## romeo_dcm_control

```
* adding config for Gazebo: Gazebo xacro files and full list of controllers
* 0.1.4
* update changelog
* 0.1.3
* udpate changelogs
* excluding torso controller for a moment
* 0.1.2
* update changelogs
* 0.1.1
* update changelogs
* adding head and torso controllers
* few changes in arm and hand controllers to make compatible with romeo_moveit_config
* Removing the namespace prefix and fixing the head controllers with correct joint names (the HeadYaw joint does not exist)
* 0.1.0
* update the changelog
* 0.0.13
* update changelogs
* 0.0.12
* update changelogs
* 0.0.11
* update changelogs
* 0.0.10
* update changelog
* 0.0.9
* update changelogs
* 0.0.8
* update changelog
* 0.0.7
* update changelog
* 0.0.6
* update changelog
* 0.0.5
* update changelog
* 0.0.4
* changelog
* 0.0.3
* update changelog for build
* 0.0.2
* updated changelog
* 0.0.1
* update version
* add changelog for release
* added control via DCM proxy
* Contributors: Ha Dang, Mikael ARGUEDAS, Mikael Arguedas, Natalia Lyubova, Vincent Rabaud, margueda, nlyubova
```
