### PR TITLE
apriltags_ros: 0.1.2-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -244,7 +244,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RIVeR-Lab-release/apriltags_ros-release.git
-      version: 0.1.1-0
+      version: 0.1.2-2
     source:
       type: git
       url: https://github.com/RIVeR-Lab/apriltags_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltags_ros` to `0.1.2-2`:
- upstream repository: https://github.com/RIVeR-Lab/apriltags_ros.git
- release repository: https://github.com/RIVeR-Lab-release/apriltags_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.1-0`
## apriltags
- No changes
## apriltags_ros

```
* Added parameter for selecting tag family
* Update the example launch file
  Added the topics that needs to be remapped to avoid looking up in the code, as well as using a compressed version of the video stream.
* Contributors: Brent Yi, Daniel Angelov
```
