### PR TITLE
realsense_camera: 1.2.0-8 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8722,7 +8722,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/intel-ros/realsense-release.git
-      version: 1.2.0-0
+      version: 1.2.0-8
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_camera` to `1.2.0-8`:
- upstream repository: https://github.com/intel-ros/realsense.git
- release repository: https://github.com/intel-ros/realsense-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.2.0-0`
## realsense_camera

```
* Update for ROS librealsense Package Release
* Added navigation package changes related to camera package refactor
* Updated artifacts to disable native pointcloud by default
* Refactored R200 code into derived class
* Added polling for camera
* Refactored launch and test files
* Contributors: Mark D Horn, Matthew Hansen, Reagan Lopez, Rajvi Jingar
```
