### PR TITLE
octomap_rviz_plugins: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2192,7 +2192,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/octomap_rviz_plugins-release.git
-      version: 0.1.0-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/OctoMap/octomap_rviz_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_rviz_plugins` to `0.2.0-0`:
- upstream repository: https://github.com/OctoMap/octomap_rviz_plugins.git
- release repository: https://github.com/ros-gbp/octomap_rviz_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.0-0`
## octomap_rviz_plugins

```
* Fix: RViz uses Qt5 in kinetic
* Contributors: Armin Hornung
```
