### PR TITLE
octomap_rviz_plugins: 0.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3403,6 +3403,21 @@ repositories:
       url: https://github.com/OctoMap/octomap_ros.git
       version: indigo-devel
     status: maintained
+  octomap_rviz_plugins:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_rviz_plugins.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_rviz_plugins-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_rviz_plugins.git
+      version: jade-devel
+    status: maintained
   ompl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_rviz_plugins` to `0.1.0-0`:
- upstream repository: https://github.com/OctoMap/octomap_rviz_plugins.git
- release repository: https://github.com/ros-gbp/octomap_rviz_plugins-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## octomap_rviz_plugins

```
* Remove -ldefault_plugin from linker options, fixes #19 <https://github.com/OctoMap/octomap_rviz_plugins/issues/19>
* Support for displaying ColorOcTree and OcTreeStamped, templated rviz plugins
* Trim Z values in the octomap visualization
* Add alpha property to OccupancyGridDisplay
* add fix for qt moc BOOST_JOIN problem for osx yosemite build
* Contributors: Armin Hornung, Felix Endres, Gautham Manoharan, Javier V. Gómez, Oleksandr Lavrushchenko, Ryohei Ueda
```
