### PR TITLE
romeo_virtual: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9456,6 +9456,7 @@ repositories:
       url: https://github.com/ros-aldebaran/romeo_virtual-release.git
       version: 0.2.2-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-aldebaran/romeo_virtual.git
       version: master

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9442,6 +9442,24 @@ repositories:
       url: https://github.com/ros-aldebaran/romeo_robot.git
       version: master
     status: maintained
+  romeo_virtual:
+    doc:
+      type: git
+      url: https://github.com/ros-aldebaran/romeo_virtual.git
+      version: master
+    release:
+      packages:
+      - romeo_control
+      - romeo_gazebo_plugin
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-aldebaran/romeo_virtual-release.git
+      version: 0.2.2-0
+    source:
+      type: git
+      url: https://github.com/ros-aldebaran/romeo_virtual.git
+      version: master
+    status: maintained
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_virtual` to `0.2.2-0`:
- upstream repository: https://github.com/ros-aldebaran/romeo_virtual.git
- release repository: https://github.com/ros-aldebaran/romeo_virtual-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## romeo_control

```
* Delete .romeo_trajectory_control_full.launch.swp
* Contributors: Mikael Arguedas
```
## romeo_gazebo_plugin

```
* removing an unused launch file
* Contributors: Natalia Lyubova
```
