### PR TITLE
summit_x_sim: 1.0.4-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11945,7 +11945,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/summit_x_sim-release.git
-      version: 1.0.3-0
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_x_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_x_sim` to `1.0.4-1`:
- upstream repository: https://github.com/RobotnikAutomation/summit_x_sim.git
- release repository: https://github.com/RobotnikAutomation/summit_x_sim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.3-0`
## summit_x_control

```
* modified dependencies
* Contributors: carlos3dx
```
## summit_x_gazebo
- No changes
## summit_x_robot_control
- No changes
