### PR TITLE
librealsense: 0.9.2-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5107,7 +5107,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/intel-ros/librealsense-release.git
-      version: 0.9.2-1
+      version: 0.9.2-2
     source:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense` to `0.9.2-2`:
- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/intel-ros/librealsense-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.9.2-1`
