### PR TITLE
rtmros_hironx: 1.1.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10688,7 +10688,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.15-0
+      version: 1.1.16-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.16-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.1.15-0`
## hironx_calibration
- No changes
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* [fix] Use existing running hrtpsy components when available (fix to tork-a/rtmros_nextage/#248 <https://github.com/tork-a/rtmros_nextage/issues/248>)
* [fix][hironx.py] Remove an arg that was merged by mistake.
* Contributors: Isaac I.Y. Saito, Kei Okada
```
## rtmros_hironx

```
* [fix] Use existing running hrtpsy components when available (fix to tork-a/rtmros_nextage/#248 <https://github.com/tork-a/rtmros_nextage/issues/248>)
* [fix][hironx.py] Remove an arg that was merged by mistake.
* Contributors: Isaac I.Y. Saito, Kei Okada
```
