### PR TITLE
vision_opencv: 1.11.13-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6021,7 +6021,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.11.12-0
+      version: 1.11.13-0
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.11.13-0`:
- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.11.12-0`
## cv_bridge

```
* split the conversion tests out of enumerants
* support is_bigendian in Python
  Fixes #114 <https://github.com/ros-perception/vision_opencv/issues/114>
  Also fixes mono16 test
* Support compressed Images messages in python for indigo
  - Add cv2_to_comprssed_imgmsg: Convert from cv2 image to compressed image ros msg.
  - Add comprssed_imgmsg_to_cv2:   Convert the compress message to a new image.
  - Add compressed image tests.
  - Add time to msgs (compressed and regular).
  add enumerants test for compressed image.
  merge the compressed tests with the regular ones.
  better comment explanation. I will squash this commit.
  Fix indentation
  fix typo mistage: from .imgmsg_to_compressed_cv2 to .compressed_imgmsg_to_cv2.
  remove cv2.CV_8UC1
  remove rospy and time depndency.
  change from IMREAD_COLOR to IMREAD_ANYCOLOR.
  - make indentaion of 4.
  - remove space trailer.
  - remove space from empty lines.
  - another set of for loops, it will make things easier to track. In that new set,  just have the number of channels in ([],1,3,4) (ignore two for jpg). from: https://github.com/ros-perception/vision_opencv/pull/132#discussion_r66721943
  - keep the OpenCV error message. from: https://github.com/ros-perception/vision_opencv/pull/132#discussion_r66721013
  add debug print for test.
  add case for 4 channels in test.
  remove 4 channels case from compressed test.
  add debug print for test.
  change typo of format.
  fix typo in format. change from dip to dib.
  change to IMREAD_ANYCOLOR as python code. (as it should).
  rename TIFF to tiff
  Sperate the tests one for regular images and one for compressed.
  update comment
* Add CvtColorForDisplayOptions with new colormap param
* fix doc jobs
* Add python binding for cv_bridge::cvtColorForDisplay
* Fix compilation of cv_bridge with opencv3 and python3.
* Don't colorize float image as label image
  This is a bug and image whose encoding is other than 32SC1 should not be
  colorized. (currently, depth images with 32FC1 is also colorized.)
* Contributors: Kentaro Wada, Maarten de Vries, Vincent Rabaud, talregev
```
## image_geometry

```
* Add fullResolution getter to PinholeCameraModel
* add a missing dependency when building the doc
* fix sphinx doc path
* Contributors: Jacob Panikulam, Vincent Rabaud
```
## vision_opencv

```
* move opencv_apps to its own repo
* Contributors: Vincent Rabaud
```
