### PR TITLE
image_pipeline: 1.12.17-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1265,7 +1265,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/image_pipeline-release.git
-      version: 1.12.16-0
+      version: 1.12.17-0
     source:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `1.12.17-0`:
- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros-gbp/image_pipeline-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.12.16-0`
## camera_calibration

```
* fix typo np -> numpy
* fix failing tests
* Contributors: Shingo Kitagawa, Vincent Rabaud
```
## depth_image_proc
- No changes
## image_pipeline
- No changes
## image_proc
- No changes
## image_rotate
- No changes
## image_view

```
* Fix timestamp to get correct fps in video_recorder
* Get correct fps in video_recorder.cpp
* Do dynamic scaling for float images
* Contributors: Kentaro Wada
```
## stereo_image_proc
- No changes
