### PR TITLE
robotnik_msgs: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2733,6 +2733,11 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/robotnik_msgs.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotnikAutomation/robotnik_msgs-release.git
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/robotnik_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotnik_msgs` to `0.2.1-0`:
- upstream repository: https://github.com/RobotnikAutomation/robotnik_msgs.git
- release repository: https://github.com/RobotnikAutomation/robotnik_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## robotnik_msgs

```
* added MotorsStatusDifferential.msg
* added BatteryStatus msg
* Contributors: rguzman
```
