### PR TITLE
robotnik_sensors: 1.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2748,6 +2748,11 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/robotnik_sensors.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotnikAutomation/robotnik_sensors-release.git
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/robotnik_sensors.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotnik_sensors` to `1.0.2-0`:
- upstream repository: https://github.com/RobotnikAutomation/robotnik_sensors.git
- release repository: https://github.com/RobotnikAutomation/robotnik_sensors-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## robotnik_sensors

```
* Setting TIM571 params
* Added Sick Tim571 sensor
* New collision model for s3000
* Merge branch 'indigo-devel' of https://github.com/RobotnikAutomation/robotnik_sensors into indigo-devel
* adding the rplidar sensor
* sick_s300: changed collision model
* kinectv2: added model with no base and corrected bounding box of collision
* Merge remote-tracking branch 'origin/indigo-devel' into indigo-devel
* asus_xtrion_pro: corrected typo
* orbbec_astra: now calls the correct gazebo sensor
* Contributors: Jose Rapado, Marc Bosch-Jorge, RomanRobotnik
```
