### PR TITLE
summit_xl_common: 1.0.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3546,6 +3546,17 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/summit_xl_common.git
       version: kinetic-devel
+    release:
+      packages:
+      - summit_xl_common
+      - summit_xl_description
+      - summit_xl_localization
+      - summit_xl_navigation
+      - summit_xl_pad
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotnikAutomation/summit_xl_common-release.git
+      version: 1.0.8-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_xl_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_xl_common` to `1.0.8-0`:
- upstream repository: https://github.com/RobotnikAutomation/summit_xl_common.git
- release repository: https://github.com/RobotnikAutomation/summit_xl_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## summit_xl_common
- No changes
## summit_xl_description
- No changes
## summit_xl_localization
- No changes
## summit_xl_navigation
- No changes
## summit_xl_pad

```
* removed twist_mux dependency
* Contributors: carlos3dx
```
