### PR TITLE
image_pipeline: 1.12.18-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3802,7 +3802,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/image_pipeline-release.git
-      version: 1.12.16-0
+      version: 1.12.18-0
     source:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `1.12.18-0`:
- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros-gbp/image_pipeline-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.12.16-0`
## camera_calibration
- No changes
## depth_image_proc
- No changes
## image_pipeline
- No changes
## image_proc
- No changes
## image_rotate
- No changes
## image_view

```
* Use image_transport::Subscriber aside from ros::Subscriber
* Refactor: Remove subscription of camera_info in video_recorder
* Add colormap options for displaying image topic
* Use CvtColorForDisplayOptions for cvtColorForDisplay
* Contributors: Kentaro Wada, Vincent Rabaud
```
## stereo_image_proc
- No changes
