### PR TITLE
twist_mux_msgs: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3780,6 +3780,12 @@ repositories:
       url: https://github.com/tuw-robotics/tuw_uvc.git
       version: kinetic
     status: developed
+  twist_mux_msgs:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/twist_mux_msgs-release.git
+      version: 2.0.0-0
   uavc_v4lctl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux_msgs` to `2.0.0-0`:
- upstream repository: https://github.com/ros-teleop/twist_mux_msgs.git
- release repository: https://github.com/ros-gbp/twist_mux_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## twist_mux_msgs

```
* Update README.md
  Add documentation link and build status.
* Contributors: Enrique Fernández Perdomo
```
