### PR TITLE
Revert "twist_mux: 1.0.3-1 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12522,7 +12522,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/twist_mux-release.git
-      version: 1.0.3-1
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/ros-teleop/twist_mux.git


### PR DESCRIPTION
Reverts ros/rosdistro#12140
