### PR TITLE
ueye: 0.0.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3808,7 +3808,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/kmhallen/ueye-release.git
-      version: 0.0.9-0
+      version: 0.0.10-0
     source:
       type: hg
       url: https://bitbucket.org/kmhallen/ueye


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye` to `0.0.10-0`:
- upstream repository: https://bitbucket.org/kmhallen/ueye
- release repository: https://github.com/kmhallen/ueye-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.9-0`
## ueye

```
* Updated dependencies
* Contributors: Kevin Hallenbeck
```
