### PR TITLE
rbcar_common: 1.0.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2602,6 +2602,15 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/rbcar_common.git
       version: kinetic-devel
+    release:
+      packages:
+      - rbcar_common
+      - rbcar_description
+      - rbcar_pad
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotnikAutomation/rbcar_common-release.git
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/rbcar_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rbcar_common` to `1.0.5-0`:
- upstream repository: https://github.com/RobotnikAutomation/rbcar_common.git
- release repository: https://github.com/RobotnikAutomation/rbcar_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rbcar_common
- No changes
## rbcar_description
- No changes
## rbcar_pad
- No changes
