### PR TITLE
gazebo_ros_pkgs: 2.4.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2833,7 +2833,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.4.10-0
+      version: 2.4.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.4.11-0`:
- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.4.10-0`
## gazebo_msgs

```
* [gazebo_msgs] fix wrong dependencies
* Contributors: Yuki Furuta
```
## gazebo_plugins

```
* Use NOT VERSION_LESS to simplify cmake logic
* Added an interface to gazebo's harness plugin
* Merge pull request #460 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/460> from furushchev/fix-camera-util
  [gazebo_plugins] bugfix: duplicated tf prefix resolution in gazebo_ros_camera plugin
* removed extra includes
* Fix gazebo7 deprecation warnings
* [gazebo_plugins] bugfix: duplicated tf prefix resolution
* Revert change. AdvertiseOption API is nothing related to latched mode
* Fix issue of passing a member class to Advertise instead of a boolean
* Fix gazebo_ros_joint_trajectory, whitespace
  Duplicate of #405 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/405> targeted to indigo-devel
* gazebo_packges/gazebo_ros_joint_pose_trajectory.cpp BUG that caused simulated trajectories to run fast
  The points in the class.points_ member never had their time_from_start set.
  This caused all the time_from_starts to be set to 0. This in turn caused all
  the trajectory points to be played instantly one after the other in Gazebo.
* use HasElement in if condition
* Set GAZEBO_PLUGIN_PATH for test
* Add rostest to accompany range plugin world
* Follow ROS documentation and depend on catkin_EXPORTED_TARGETS
* Remove all references to gazebo_msgs_gencpp (ghost)
* Fix row_step of openni_kinect plugin
* Publish organized point cloud from openni_kinect plugin
* missing link_directories()
* imu supports frameName
* Also accept "/world" as frameName parameter in gazebo_ros_p3d plugin
* Contributors: Bence Magyar, Benjamin Blumer, Jan Skoda, Jan Škoda, Johannes Meyer, John Hsu, Jose Luis Rivero, Kentaro Wada, Steven Peters, Yuki Furuta, nate koenig
```
## gazebo_ros

```
* GAZEBO_MASTER_URI is loaded from setup.sh if empty in environment.
* Honor GAZEBO_MASTER_URI for gzserver.
* Honor GAZEBO_MASTER_URI for gzclient.
* Fix string replacement to look for mesh filename surrounded by single or double quotes. Also do not replace unless there are two slashes after package
* Merge pull request #423 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/423> from furushchev/fix-include
  [gazebo_ros] fix include path
* Include {PROJECT_NAME}_EXPORTED_TARGETS into dependencies for dynamic reconfiguration
* [gazebo_ros] put header file to standard catkin include path
* Add rostest to accompany range plugin world
* Follow ROS documentation and depend on catkin_EXPORTED_TARGETS
* Remove all references to gazebo_msgs_gencpp (ghost)
* missing link_directories()
* add option to change package:// to model:// when loading urdf file
* Contributors: Bence Magyar, John Hsu, Jose Luis Rivero, Kei Okada, Martin Pecka, Steven Peters, Yuki Furuta
```
## gazebo_ros_control

```
* missing link_directories()
* Contributors: John Hsu, Jose Luis Rivero
```
## gazebo_ros_pkgs
- No changes
