### PR TITLE
rviz_visual_tools: 3.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3429,7 +3429,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/davetcoleman/rviz_visual_tools-release.git
-      version: 3.1.0-0
+      version: 3.2.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `3.2.0-0`:
- upstream repository: https://github.com/davetcoleman/rviz_visual_tools.git
- release repository: https://github.com/davetcoleman/rviz_visual_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `3.1.0-0`
## rviz_visual_tools

```
* Catkin depend on eigen and tf conversions
* New warning
* Added EulerConvention enum
* Added new convertFromXYZRPY() function
* Added new tests
* Contributors: Dave Coleman, Enrique Fernandez
```
