### PR TITLE
rviz_visual_tools: 2.2.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10905,7 +10905,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/davetcoleman/rviz_visual_tools-release.git
-      version: 2.1.0-0
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/davetcoleman/rviz_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `2.2.1-1`:
- upstream repository: https://github.com/davetcoleman/rviz_visual_tools.git
- release repository: https://github.com/davetcoleman/rviz_visual_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.1.0-0`
## rviz_visual_tools

```
* Latched publisher
* publishAxisLabeled arguments
* publishAxisLabeled arguments order
* Remove TODO msg
* Adds Publish Labeled Axis
* Numbered colors so that they can be matched in OMPL
* New publishLine() function variants
* Psychedelic mode
* Prevent publishing empty marker arrays
* Improved warning and error correction
* New publishSphere function
* Hide debug message
* Ability to set marker topic after constructor
* Ability to force waiting for topic to connect
* Added new posesEqual() function
* Updated publishArrow() function
* New publishPath function
* New publishLine function
* New publishCylinder that accepts two points
* New publishText function
* Removed redundant namespace names
* New convertPointToPose function
* README
* Created much better demo, added new screenshot
* Reduced output
* Renamed line_marker_ to line_strip_marker_
* Faster method for waiting for subscriber thread
* Untested publishPath() modification
* Fix to correctly use optional alpha color property
* Change getColorScale to work from 0->1 instead of 0->100
* Additional parameters to publishCuboid()
* New color scale function for generated interpolated colors from RED->GREEN (1->100)
* Contributors: Dave Coleman, Enrique Fernandez, Naveed Usmani
```
