### PR TITLE
twist_mux: 3.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3809,6 +3809,12 @@ repositories:
       url: https://github.com/tuw-robotics/tuw_uvc.git
       version: kinetic
     status: developed
+  twist_mux:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/twist_mux-release.git
+      version: 3.0.0-0
   twist_mux_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux` to `3.0.0-0`:
- upstream repository: https://github.com/ros-teleop/twist_mux.git
- release repository: https://github.com/ros-gbp/twist_mux-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## twist_mux

```
* Merge pull request #8 <https://github.com/ros-teleop/twist_mux/issues/8> from ros-teleop/update_jade_from_indigo_devel
  fix queue_size SyntaxWarning
* fix queue_size SyntaxWarning
* Update README.md
  Add documentation link and build status.
* Contributors: Enrique Fernández Perdomo, Jeremie Deray
```
