### PR TITLE
rbcar_sim: 1.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2621,6 +2621,18 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/rbcar_sim.git
       version: kinetic-devel
+    release:
+      packages:
+      - rbcar_control
+      - rbcar_gazebo
+      - rbcar_joystick
+      - rbcar_robot_control
+      - rbcar_sim
+      - rbcar_sim_bringup
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotnikAutomation/rbcar_sim-release.git
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/rbcar_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rbcar_sim` to `1.0.4-0`:
- upstream repository: https://github.com/RobotnikAutomation/rbcar_sim.git
- release repository: https://github.com/RobotnikAutomation/rbcar_sim-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rbcar_control

```
* added twist_mux cfg file
* added twist mux to accept different inputs a twist
* Contributors: rguzman1
```
## rbcar_gazebo

```
* added gas station world to do some testing with map based loc and nav
* Contributors: rguzman1
```
## rbcar_joystick
- No changes
## rbcar_robot_control
- No changes
## rbcar_sim
- No changes
## rbcar_sim_bringup

```
* added launch to test in gs world with teb
* Contributors: rguzman1
```
