### PR TITLE
summit_x_sim: 1.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11970,10 +11970,11 @@ repositories:
       - summit_x_control
       - summit_x_gazebo
       - summit_x_robot_control
+      - summit_x_sim
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/summit_x_sim-release.git
-      version: 1.0.4-1
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_x_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_x_sim` to `1.0.5-0`:
- upstream repository: https://github.com/RobotnikAutomation/summit_x_sim.git
- release repository: https://github.com/RobotnikAutomation/summit_x_sim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.4-1`
## summit_x_control

```
* updated changelog
* Contributors: carlos3dx
```
## summit_x_gazebo

```
* updated changelog
* Contributors: carlos3dx
```
## summit_x_robot_control

```
* updated changelog
* Contributors: carlos3dx
```
## summit_x_sim

```
* 1.0.4
* updated changelog
* updated changelog
* Update package.xml
* deleted catkin_ignore
* modified package.xml
* Contributors: Carlos Villar, carlos3dx
* updated changelog
* Update package.xml
* deleted catkin_ignore
* modified package.xml
* Contributors: Carlos Villar, carlos3dx
* deleted catkin_ignore
* modified package.xml
* Contributors: carlos3dx
```
