### PR TITLE
Add python module readchar to ubuntu

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1737,6 +1737,10 @@ python-rdflib:
     raring: [python-rdflib]
     saucy: [python-rdflib]
     trusty: [python-rdflib]
+python-readchar:
+  ubuntu:
+    pip:
+      packages: [readchar]
 python-redis:
   debian: [python-redis]
   fedora: [python-redis]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1737,7 +1737,7 @@ python-rdflib:
     raring: [python-rdflib]
     saucy: [python-rdflib]
     trusty: [python-rdflib]
-python-readchar:
+python-readchar-pip:
   ubuntu:
     pip:
       packages: [readchar]


### PR DESCRIPTION
Adds the ability to get keyboard input without waiting for the enter key being pressed. For details see https://pypi.python.org/pypi/readchar
