### PR TITLE
rosserial: 0.7.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4985,15 +4985,17 @@ repositories:
       - rosserial_arduino
       - rosserial_client
       - rosserial_embeddedlinux
+      - rosserial_mbed
       - rosserial_msgs
       - rosserial_python
       - rosserial_server
+      - rosserial_tivac
       - rosserial_windows
       - rosserial_xbee
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rosserial-release.git
-      version: 0.7.1-0
+      version: 0.7.2-0
     source:
       type: git
       url: https://github.com/ros-drivers/rosserial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial` to `0.7.2-0`:
- upstream repository: https://github.com/ros-drivers/rosserial.git
- release repository: https://github.com/ros-gbp/rosserial-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.7.1-0`
## rosserial
- No changes
## rosserial_arduino

```
* Add ros.h include to transform_broadcaster
* Add environment variable for arduino location
* Add support for HW Serial ports on the Teensy
* Contributors: David Lavoie-Boutin, Gary Servin
```
## rosserial_client

```
* Add ros.h include to transform_broadcaster
* Add environment variable for arduino location
* Supported 32bit array lengths in python make_libraries script
* Contributors: Alan Meekins, David Lavoie-Boutin
```
## rosserial_embeddedlinux
- No changes
## rosserial_mbed

```
* Add initial rosserial_mbed package.
* Contributors: Gary Servin, Romain Reignier
```
## rosserial_msgs
- No changes
## rosserial_python
- No changes
## rosserial_server

```
* Implementation of native UDP rosserial server. (#231 <https://github.com/ros-drivers/rosserial/issues/231>)
* Explicit session lifecycle for the serial server. (#228 <https://github.com/ros-drivers/rosserial/issues/228>)
  This is a long overdue change which will resolve some crashes when
  USB serial devices return error states in the face of noise or other
  interruptions.
* Support for VER1 protocol has been dropped.
* Handle log messages in rosserial_server
* Contributors: Mike Purvis, mkrauter
```
## rosserial_tivac

```
* rosserial package for TivaC Launchpad boards.
* Contributors: Vitor Matos
```
## rosserial_windows
- No changes
## rosserial_xbee

```
* Adding inWaiting method to FakeSerial class. Fixing issue #179 <https://github.com/ros-drivers/rosserial/issues/179>
* Contributors: Lucas
```
