### PR TITLE
summit_x_common: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3617,6 +3617,14 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/summit_x_common.git
       version: kinetic-devel
+    release:
+      packages:
+      - summit_x_common
+      - summit_x_description
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotnikAutomation/summit_x_common-release.git
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_x_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_x_common` to `0.0.2-0`:
- upstream repository: https://github.com/RobotnikAutomation/summit_x_common.git
- release repository: https://github.com/RobotnikAutomation/summit_x_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## summit_x_common
- No changes
## summit_x_description
- No changes
