### PR TITLE
micros_swarm_framework: 0.0.12-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5629,7 +5629,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/xuefengchang/micros_swarm_framework-release.git
-      version: 0.0.9-0
+      version: 0.0.12-1
     source:
       type: git
       url: https://github.com/xuefengchang/micros_swarm_framework.git


### PR DESCRIPTION
Increasing version of package(s) in repository `micros_swarm_framework` to `0.0.12-1`:
- upstream repository: https://github.com/xuefengchang/micros_swarm_framework.git
- release repository: https://github.com/xuefengchang/micros_swarm_framework-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.9-0`
## micros_swarm_framework

```
* reconstructe the whole architecture using nodelet to improve performance
* is extensible to Opensplice DDS
* add neighbor communication mechanism
* standard the interface definition
* repair bugs in cmake file
```
