### PR TITLE
stdr_simulator: 0.3.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5623,6 +5623,31 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  stdr_simulator:
+    doc:
+      type: git
+      url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator.git
+      version: indigo-devel
+    release:
+      packages:
+      - stdr_gui
+      - stdr_launchers
+      - stdr_msgs
+      - stdr_parser
+      - stdr_resources
+      - stdr_robot
+      - stdr_samples
+      - stdr_server
+      - stdr_simulator
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator.git
+      version: indigo-devel
+    status: developed
   stereo_slam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stdr_simulator` to `0.3.0-0`:
- upstream repository: https://github.com/stdr-simulator-ros-pkg/stdr_simulator.git
- release repository: https://github.com/stdr-simulator-ros-pkg/stdr_simulator-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## stdr_gui

```
* Migrate to package format 2, fix dependency issues
* Refactoring in sources classes, using better astraction
* Support for omni motion controller in robot creator
* Kinematic model appears in info panel
```
## stdr_launchers

```
* Migrate to package format 2, fix dependency issues
```
## stdr_msgs

```
* Migrate to package format 2
* Added kinematic model noise parameters support
```
## stdr_parser

```
* Migrate to package format 2
* Refactoring on parser node destruction (#186 <https://github.com/stdr-simulator-ros-pkg/stdr_simulator/pull/186>)
* Allow loading local/custom resource files (#178 <https://github.com/stdr-simulator-ros-pkg/stdr_simulator/issues/178>)
* Fix bug on footprint loading (#171 <https://github.com/stdr-simulator-ros-pkg/stdr_simulator/issues/171>)
* Added kinematic model noise parameters support
```
## stdr_resources

```
* Migrate to package format 2
* Added new map
* Added omni robot examples
* Added kinematic_model xml specifications
```
## stdr_robot

```
* Migrate to package format 2
* Angles laser beams evenly (#182 <https://github.com/stdr-simulator-ros-pkg/stdr_simulator/pull/182>)
* Fix laser scans off map bug (#174 <https://github.com/stdr-simulator-ros-pkg/stdr_simulator/issues/174>)
* Add support for kinematic model noise parameters
* Add support for omni directional motion model
* Fix segfault on robot_manager due to uninitialized pointer (#159 <https://github.com/stdr-simulator-ros-pkg/stdr_simulator/issues/159>)
```
## stdr_samples

```
* Migrate to package format 2
```
## stdr_server

```
* Add an interfaces test, as a functional test using rostest
* Fix synchronization bug on new robot registration
* Migrate to package format 2
* Visualization for custom sources using Marker messages (#184 <https://github.com/stdr-simulator-ros-pkg/stdr_simulator/pull/184>)
* Remove unnecessary image_loader library in cmake
* Add forgotten run dependency to map_server (#172 <https://github.com/stdr-simulator-ros-pkg/stdr_simulator/issues/172>)
* Remove leading slash from frame_id
```
## stdr_simulator

```
* Migrate to package format 2
```
