### PR TITLE
teleop_tools: 0.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12123,7 +12123,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/teleop_tools-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `0.2.3-0`:
- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros-gbp/teleop_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.2-0`
## joy_teleop

```
* Add hello publish to example
* Rename to fix example launch file
* Added example of feature to config file
* Added message_value parameter to specify message content on topics
* PEP8 style stuff
* Fixes bug when keep asking for increments
  would make the goal position grow infinitely instead of be of maximum 'current joint position' + 'increment quantity'
* Contributors: Bence Magyar, Sam Pfeiffer, SomeshDaga
```
## key_teleop
- No changes
## mouse_teleop
- No changes
## teleop_tools
- No changes
## teleop_tools_msgs
- No changes
