### PR TITLE
stdr_simulator: 0.3.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5642,7 +5642,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `stdr_simulator` to `0.3.1-0`:
- upstream repository: https://github.com/stdr-simulator-ros-pkg/stdr_simulator.git
- release repository: https://github.com/stdr-simulator-ros-pkg/stdr_simulator-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.0-0`
## stdr_gui
- No changes
## stdr_launchers
- No changes
## stdr_msgs
- No changes
## stdr_parser
- No changes
## stdr_resources
- No changes
## stdr_robot
- No changes
## stdr_samples
- No changes
## stdr_server

```
* Add forgotten dependency on visualization_msgs
```
## stdr_simulator
- No changes
