### PR TITLE
stdr_simulator: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3629,6 +3629,31 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  stdr_simulator:
+    doc:
+      type: git
+      url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator.git
+      version: indigo-devel
+    release:
+      packages:
+      - stdr_gui
+      - stdr_launchers
+      - stdr_msgs
+      - stdr_parser
+      - stdr_resources
+      - stdr_robot
+      - stdr_samples
+      - stdr_server
+      - stdr_simulator
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator-release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator.git
+      version: indigo-devel
+    status: developed
   summit_x_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stdr_simulator` to `0.3.1-0`:
- upstream repository: https://github.com/stdr-simulator-ros-pkg/stdr_simulator.git
- release repository: https://github.com/stdr-simulator-ros-pkg/stdr_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## stdr_gui
- No changes
## stdr_launchers
- No changes
## stdr_msgs
- No changes
## stdr_parser
- No changes
## stdr_resources
- No changes
## stdr_robot
- No changes
## stdr_samples
- No changes
## stdr_server

```
* Add forgotten dependency on visualization_msgs
```
## stdr_simulator
- No changes
