### PR TITLE
nav_pcontroller: 0.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2962,6 +2962,21 @@ repositories:
       url: https://github.com/ros-naoqi/libqicore-release.git
       version: 2.3.1-1
     status: maintained
+  nav_pcontroller:
+    doc:
+      type: git
+      url: https://github.com/code-iai/nav_pcontroller.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/code-iai-release/nav_pcontroller-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/code-iai/nav_pcontroller.git
+      version: master
+    status: maintained
   navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nav_pcontroller` to `0.1.2-0`:
- upstream repository: https://github.com/code-iai/nav_pcontroller.git
- release repository: https://github.com/code-iai-release/nav_pcontroller-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
