### PR TITLE
robot_controllers: 0.5.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8981,7 +8981,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
-      version: 0.5.0-0
+      version: 0.5.1-0
     source:
       type: git
       url: https://github.com/fetchrobotics/robot_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_controllers` to `0.5.1-0`:
- upstream repository: https://github.com/fetchrobotics/robot_controllers.git
- release repository: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.5.0-0`
## robot_controllers

```
* base_controller: only update odometry if inputs are finite (prevents NANs to TF)
* base_controller: add velocity limiting
* pid: fix error in derivative error calculation
* allow velocity limiting code be reused for forward simulation #18 <https://github.com/fetchrobotics/robot_controllers/issues/18>
* Contributors: Cappy Pitts, Derek King, Michael Ferguson
```
## robot_controllers_interface

```
* Dynamically load controllers (#23 <https://github.com/fetchrobotics/robot_controllers/issues/23>)
  * When requested controller not in default list, check parameter server for controller
  * Controller loader catches pluginlib exception when trying to load bad controller
* Return controller states even if update fails
* Contributors: Michael Ferguson, Sarah Elliott
```
## robot_controllers_msgs

```
* Add DiffDriveLimiterParams message
* Contributors: Derek King
```
