### PR TITLE
robot_controllers: 0.5.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8982,7 +8982,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
-      version: 0.5.1-0
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/fetchrobotics/robot_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_controllers` to `0.5.2-0`:
- upstream repository: https://github.com/fetchrobotics/robot_controllers.git
- release repository: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.5.1-0`
## robot_controllers

```
* do not export python library for linking
* Contributors: Michael Ferguson
```
## robot_controllers_interface
- No changes
## robot_controllers_msgs
- No changes
