### PR TITLE
summit_x_sim: 1.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3713,6 +3713,16 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/summit_x_sim.git
       version: kinetic-devel
+    release:
+      packages:
+      - summit_x_control
+      - summit_x_gazebo
+      - summit_x_robot_control
+      - summit_x_sim
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotnikAutomation/summit_x_sim-release.git
+      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_x_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_x_sim` to `1.0.6-0`:
- upstream repository: https://github.com/RobotnikAutomation/summit_x_sim.git
- release repository: https://github.com/RobotnikAutomation/summit_x_sim-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## summit_x_control
- No changes
## summit_x_gazebo
- No changes
## summit_x_robot_control
- No changes
## summit_x_sim
- No changes
