### PR TITLE
agvs_common: 0.1.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -43,6 +43,25 @@ repositories:
       url: https://github.com/ros/actionlib.git
       version: indigo-devel
     status: maintained
+  agvs_common:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/agvs_common.git
+      version: kinetic-devel
+    release:
+      packages:
+      - agvs_common
+      - agvs_description
+      - agvs_pad
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotnikAutomation/agvs_common-release.git
+      version: 0.1.3-1
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/agvs_common.git
+      version: kinetic-devel
+    status: maintained
   angles:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `agvs_common` to `0.1.3-1`:
- upstream repository: https://github.com/RobotnikAutomation/agvs_common.git
- release repository: https://github.com/RobotnikAutomation/agvs_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## agvs_common
- No changes
## agvs_description
- No changes
## agvs_pad
- No changes
