### PR TITLE
household_objects_database_msgs: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3577,11 +3577,19 @@ repositories:
       version: hydro-devel
     status: maintained
   household_objects_database_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-interactive-manipulation/household_objects_database_msgs.git
+      version: hydro-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/household_objects_database_msgs-release.git
-      version: 0.1.1-2
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/ros-interactive-manipulation/household_objects_database_msgs.git
+      version: hydro-devel
     status: maintained
   hrpsys:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `household_objects_database_msgs` to `0.1.2-0`:
- upstream repository: https://github.com/ros-interactive-manipulation/household_objects_database_msgs.git
- release repository: https://github.com/ros-gbp/household_objects_database_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.1-2`
## household_objects_database_msgs

```
* [feat] added ORK type field in DatabaseModelPose #1 <https://github.com/ros-interactive-manipulation/household_objects_database_msgs/issues/1>
* Updated maintainers
* Contributors: Matei Ciocarlie, Dave Coleman, Isaac I.Y. Saito
```
