### PR TITLE
household_objects_database_msgs: 0.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1582,7 +1582,11 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/household_objects_database_msgs-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/ros-interactive-manipulation/household_objects_database_msgs.git
+      version: hydro-devel
     status: maintained
   hrpsys:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `household_objects_database_msgs` to `0.1.2-0`:
- upstream repository: https://github.com/ros-interactive-manipulation/household_objects_database_msgs.git
- release repository: https://github.com/ros-gbp/household_objects_database_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.1-0`
## household_objects_database_msgs

```
* [feat] added ORK type field in DatabaseModelPose #1 <https://github.com/ros-interactive-manipulation/household_objects_database_msgs/issues/1>
* Updated maintainers
* Contributors: Matei Ciocarlie, Dave Coleman, Isaac I.Y. Saito
```
