### PR TITLE
jsk_visualization: 1.0.32-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4535,7 +4535,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.31-0
+      version: 1.0.32-0
     status: developed
   jskeus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.32-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.31-0`
## jsk_interactive
- No changes
## jsk_interactive_marker

```
* Fix missing cpp format string
* Contributors: Kentaro Wada
```
## jsk_interactive_test
- No changes
## jsk_rqt_plugins
- No changes
## jsk_rviz_plugins

```
* Show colorized ros logging on rviz overlay text
* Fix style of code of rosconsole_overlay_text.py
* Convert RGB to BGR precisely in video capturing
* Support multi legs in footstep_display
* Use small sized icons for faster adding display properties
  Fix https://github.com/jsk-ros-pkg/jsk_visualization/issues/603
* Cleanup jsk_rviz_plugins package.xml
* Fix moc generation errors with boost >= 1.57 (for OS X currently)
  Please refer to https://github.com/ros-visualization/rviz/pull/826
* Keep aspect ratio with only specified width for OverlayImage
* Contributors: Kentaro Wada, Eisoku Kuroiwa
```
## jsk_visualization
- No changes
