### PR TITLE
manipulation_msgs: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1691,6 +1691,21 @@ repositories:
       url: https://bitbucket.org/AndyZe/lyap_control.git
       version: master
     status: maintained
+  manipulation_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-interactive-manipulation/manipulation_msgs.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/manipulation_msgs-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/ros-interactive-manipulation/manipulation_msgs.git
+      version: hydro-devel
+    status: maintained
   mapviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `manipulation_msgs` to `0.2.1-0`:
- upstream repository: https://github.com/ros-interactive-manipulation/manipulation_msgs.git
- release repository: https://github.com/ros-gbp/manipulation_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## manipulation_msgs

```
* Add maintainer (to receive ROS buildfarm error).
* Contributors: Dave Coleman, Isaac I.Y. Saito
```
