### PR TITLE
rtt_ros_integration: 2.8.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10834,7 +10834,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_ros_integration-release.git
-      version: 2.8.2-0
+      version: 2.8.3-0
     source:
       type: git
       url: https://github.com/orocos/rtt_ros_integration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_ros_integration` to `2.8.3-0`:
- upstream repository: https://github.com/orocos/rtt_ros_integration.git
- release repository: https://github.com/orocos-gbp/rtt_ros_integration-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.8.2-0`
## rtt_actionlib
- No changes
## rtt_actionlib_msgs
- No changes
## rtt_common_msgs
- No changes
## rtt_diagnostic_msgs
- No changes
## rtt_dynamic_reconfigure

```
* rtt_dynamic_reconfigure: fixed potential deadlock in refresh() for RTT prior to 2.9
* rtt_dynamic_reconfigure: set owner of default updateCallback implementation
* Contributors: Johannes Meyer
```
## rtt_geometry_msgs
- No changes
## rtt_kdl_conversions
- No changes
## rtt_nav_msgs
- No changes
## rtt_ros
- No changes
## rtt_ros_comm
- No changes
## rtt_ros_integration

```
* Please check the changelogs of the individual packages, e.g.:

    * rtt_roscomm <../rtt_roscomm/CHANGELOG.rst>
    * rtt_rosclock <../rtt_rosclock/CHANGELOG.rst>
    * rtt_rosparam <../rtt_rosparam/CHANGELOG.rst>
    * rtt_dynamic_reconfigure <../rtt_dynamic_reconfigure/CHANGELOG.rst>
    * ...

```
## rtt_ros_msgs
- No changes
## rtt_rosclock

```
* fix xenomai rtt_now() fix PR`#41 <https://github.com/orocos/rtt_ros_integration/issues/41>`_
* Contributors: Antoine Hoarau
```
## rtt_roscomm

```
* rtt_roscomm: set minimum ROS subscriber queue_size to 1
* rtt_roscomm: fixed destruction of RosSubChannelElement<T> and ROS subscriber shutdown (fix #61 <https://github.com/orocos/rtt_ros_integration/issues/61>)
* Contributors: Johannes Meyer
```
## rtt_rosdeployment
- No changes
## rtt_rosgraph_msgs
- No changes
## rtt_rosnode

```
* rtt_rosnode: fixed corruption of RTT's argv vector when loading the rosnode plugin (fix #54 <https://github.com/orocos/rtt_ros_integration/issues/54>)
* Contributors: Johannes Meyer
```
## rtt_rospack
- No changes
## rtt_rosparam

```
* cast enum to int to avoid warning
* Contributors: Antoine Hoarau
```
## rtt_sensor_msgs
- No changes
## rtt_shape_msgs
- No changes
## rtt_std_msgs
- No changes
## rtt_std_srvs
- No changes
## rtt_stereo_msgs
- No changes
## rtt_tf
- No changes
## rtt_trajectory_msgs
- No changes
## rtt_visualization_msgs
- No changes
