### PR TITLE
jsk_common: 2.0.17-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4336,7 +4336,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.0.16-1
+      version: 2.0.17-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.0.17-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.0.16-1`
## dynamic_tf_publisher
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_data

```
* Validate rosparams of data_collection_server.py
* Fix bug for new savetype YAML in data_collection_server.py
* Add YAML savetype to data_collection_server
* Add sample for data_collection_server in jsk_data
* Return saved message as TriggerResponse in data_collection_server
* Make params as optional for data_collection_server
* Change dynamically save_dir parameter in data_collection_server
* Contributors: Kentaro Wada
```
## jsk_network_tools
- No changes
## jsk_tilt_laser
- No changes
## jsk_tools

```
* Remove dependency on python-termcolor
  Fix #413 <https://github.com/jsk-ros-pkg/jsk_common/issues/413>
* Contributors: Kentaro Wada
```
## jsk_topic_tools

```
* Add JSK_ROS_XXX_THROTTLE, JSK_ROS_XXX_STREAM_THROTTLE
* Contributors: Kentaro Wada
```
## multi_map_server
- No changes
## virtual_force_publisher
- No changes
