### PR TITLE
rb1_base_common: 1.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2687,6 +2687,15 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/rb1_base_common.git
       version: kinetic-devel
+    release:
+      packages:
+      - rb1_base_common
+      - rb1_base_description
+      - rb1_base_pad
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotnikAutomation/rb1_base_common-release.git
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/rb1_base_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rb1_base_common` to `1.0.4-0`:
- upstream repository: https://github.com/RobotnikAutomation/rb1_base_common.git
- release repository: https://github.com/RobotnikAutomation/rb1_base_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rb1_base_common
- No changes
## rb1_base_description

```
* rb1_base_common package added to kinetic
* Contributors: AliquesTomas
* rb1_base_common package added to kinetic
* Contributors: AliquesTomas
```
## rb1_base_pad
- No changes
