### PR TITLE
marker_msgs: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1731,6 +1731,11 @@ repositories:
       type: git
       url: https://github.com/tuw-robotics/marker_msgs.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tuw-robotics/marker_msgs-release.git
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/tuw-robotics/marker_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marker_msgs` to `0.0.2-0`:
- upstream repository: https://github.com/tuw-robotics/marker_msgs.git
- release repository: https://github.com/tuw-robotics/marker_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## marker_msgs

```
* Added missing file msg/MarkerWithCovarianceArray.msg
* Replaced Markers.msg with MarkerWithCovarianceArray.msg
* Added support of multiple ids with confidence
* msgs added
* Initial commit
* Contributors: Markus Bader, mailto:Max@racket, mmacsek
```
