### PR TITLE
romeo_moveit_config: 0.2.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4459,7 +4459,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-aldebaran/romeo_moveit_config-release.git
-      version: 0.2.6-0
+      version: 0.2.7-0
     source:
       type: git
       url: https://github.com/ros-aldebaran/romeo_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_moveit_config` to `0.2.7-0`:
- upstream repository: https://github.com/ros-aldebaran/romeo_moveit_config.git
- release repository: https://github.com/ros-aldebaran/romeo_moveit_config-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.6-0`
## romeo_moveit_config

```
* Update package.xml
  removing the dependence on moveit_ros_visualization
* Update package.xml
  changing the maintainer
* Update ompl_planning.yaml
  fixing arm groups
* Merge pull request #5 <https://github.com/ros-aldebaran/romeo_moveit_config/issues/5> from nlyubova/master
  cleaning the launch file and readme
* updating the tutorial
* renaming demo_real.launch to moveit_planner.launch to keep the naming convention as fro Nao
* using xacro command instead of the URDF file
* Contributors: Natalia Lyubova, nlyubova
```
