### PR TITLE
pepper_moveit_config: 0.0.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3737,7 +3737,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_moveit_config-release.git
-      version: 0.0.4-1
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_moveit_config` to `0.0.5-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_moveit_config.git
- release repository: https://github.com/ros-naoqi/pepper_moveit_config-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.4-1`
## pepper_moveit_config

```
* removing the broken moveit_ros_visualization dependence
* adding disabled self-collisions and cleaning
* Merge pull request #5 <https://github.com/ros-naoqi/pepper_moveit_config/issues/5> from nlyubova/master
  updating the tutorial
* updating the tutorial
* Merge pull request #4 <https://github.com/ros-naoqi/pepper_moveit_config/issues/4> from nlyubova/master
  cleaning and launch file rename
* renaming demo_real.launch to moveit_planner.launch to keep the same naming convention as for Nao
* cleaning
* Contributors: Mikael Arguedas, Natalia Lyubova, nlyubova
```
