### PR TITLE
rtabmap, rtabmap_ros 0.11.8 in '[indigo|jade|kinetic]/distribution.yaml'

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10628,7 +10628,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.11.7-1
+      version: 0.11.8-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -10643,7 +10643,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.11.7-2
+      version: 0.11.8-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5211,7 +5211,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.11.7-0
+      version: 0.11.8-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -5226,7 +5226,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.11.7-1
+      version: 0.11.8-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3540,7 +3540,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.11.7-0
+      version: 0.11.8-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -3555,7 +3555,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.11.7-1
+      version: 0.11.8-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package in repositories rtabmap and rtabmap_ros to 0.11.8-0:

upstream repository: https://github.com/introlab/rtabmap.git https://github.com/introlab/rtabmap_ros.git
release repository: https://github.com/introlab/rtabmap-release.git https://github.com/introlab/rtabmap_ros-release.git
distro file: indigo/distribution.yaml, jade/distribution.yaml, kinetic/distribution.yaml
bloom version: 0.5.21
previous version for package: 0.11.7
