### PR TITLE
rb1_base_sim: 1.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2711,6 +2711,17 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/rb1_base_sim.git
       version: kinetic-devel
+    release:
+      packages:
+      - rb1_base_2dnav
+      - rb1_base_control
+      - rb1_base_gazebo
+      - rb1_base_purepursuit
+      - rb1_base_sim
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotnikAutomation/rb1_base_sim-release.git
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/rb1_base_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rb1_base_sim` to `1.0.2-0`:
- upstream repository: https://github.com/RobotnikAutomation/rb1_base_sim.git
- release repository: https://github.com/RobotnikAutomation/rb1_base_sim-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rb1_base_2dnav
- No changes
## rb1_base_control
- No changes
## rb1_base_gazebo
- No changes
## rb1_base_purepursuit
- No changes
## rb1_base_sim
- No changes
