### PR TITLE
stream_manipulator_3d: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11970,6 +11970,16 @@ repositories:
       type: git
       url: https://github.com/PeterMitrano/straf_recovery.git
       version: master
+  stream_manipulator_3d:
+    release:
+      packages:
+      - rqt_stream_manipulator_3d
+      - stream_manipulator_3d
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/3DVision-Stack/stream-manipulator-3D-release.git
+      version: 0.1.3-0
+    status: developed
   summit_x_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stream_manipulator_3d` to `0.1.3-0`:
- upstream repository: https://github.com/3DVision-Stack/stream-manipulator-3D.git
- release repository: https://github.com/3DVision-Stack/stream-manipulator-3D-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
