### PR TITLE
stream_manipulator_3d: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11978,7 +11978,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/3DVision-Stack/stream-manipulator-3D-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     status: developed
   summit_x_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `stream_manipulator_3d` to `0.1.4-0`:
- upstream repository: https://github.com/3DVision-Stack/stream-manipulator-3D.git
- release repository: https://github.com/3DVision-Stack/stream-manipulator-3D-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.3-0`
## rqt_stream_manipulator_3d

```
* Fix build errors
  Add proper catkin dependencies
* Contributors: Federico Spinelli
```
## stream_manipulator_3d

```
* Fix build errors
  Add proper catkin dependencies
* Contributors: Federico Spinelli
```
