### PR TITLE
wu_ros_tools: 0.2.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4334,6 +4334,27 @@ repositories:
       url: https://github.com/yujinrobot/world_canvas_msgs.git
       version: kinetic
     status: maintained
+  wu_ros_tools:
+    doc:
+      type: git
+      url: https://github.com/DLu/wu_ros_tools.git
+      version: hydro
+    release:
+      packages:
+      - easy_markers
+      - joy_listener
+      - kalman_filter
+      - rosbaglive
+      - wu_ros_tools
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/wu-robotics/wu_ros_tools.git
+      version: 0.2.4-0
+    source:
+      type: git
+      url: https://github.com/DLu/wu_ros_tools.git
+      version: kinetic
+    status: maintained
   xacro:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wu_ros_tools` to `0.2.4-0`:
- upstream repository: https://github.com/DLu/wu_ros_tools
- release repository: https://github.com/wu-robotics/wu_ros_tools.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
