### PR TITLE
image_pipeline: 1.12.19-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1324,13 +1324,14 @@ repositories:
       - depth_image_proc
       - image_pipeline
       - image_proc
+      - image_publisher
       - image_rotate
       - image_view
       - stereo_image_proc
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/image_pipeline-release.git
-      version: 1.12.18-0
+      version: 1.12.19-0
     source:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `1.12.19-0`:
- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros-gbp/image_pipeline-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.12.18-0`
## camera_calibration

```
* Fix array check in camerachecky.py
  This closes #205 <https://github.com/ros-perception/image_pipeline/issues/205>
* Contributors: Vincent Rabaud
```
## depth_image_proc
- No changes
## image_pipeline
- No changes
## image_proc
- No changes
## image_publisher

```
* add image_publisher
* Contributors: Kei Okada
* add image_publisher
* Contributors: Kei Okada
```
## image_rotate

```
* Fix frames if it is empty to rotate image
* Contributors: Kentaro Wada
```
## image_view

```
* Add colormap option in video_recorder
* Merge pull request #203 <https://github.com/ros-perception/image_pipeline/issues/203> from wkentaro/video-recorder-timestamp
  [image_view] Stamped video output filename for video recorder
* bump version requirement for cv_bridge dep
  Closes #215 <https://github.com/ros-perception/image_pipeline/issues/215>
* Request for saving image with start/end two triggers
* Stamped video output filename
  - _filename:=output.avi _stamped_filename:=false -> output.avi
  - _filename:=_out.avi _stamped_filename:=true -> 1466299931.584632829_out.avi
  - _filename:=$HOME/.ros/.avi _stamped_filename:=true -> /home/ubuntu/.ros/1466299931.584632829.avi
* Revert max_depth_range to default value for cvtColorForDisplay
* Contributors: Kentaro Wada, Vincent Rabaud
```
## stereo_image_proc
- No changes
