### PR TITLE
realsense_camera: 1.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8754,7 +8754,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/intel-ros/realsense-release.git
-      version: 1.2.1-0
+      version: 1.3.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_camera` to `1.3.0-0`:
- upstream repository: https://github.com/intel-ros/realsense.git
- release repository: https://github.com/intel-ros/realsense-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.2.1-0`
## realsense_camera

```
* Fix the Install for Includes
* Move header files
* Updated README for F200 cameras
* Added initial support for F200 cameras
* Refactored code for new cameras
* Contributors: Mark D Horn, Reagan Lopez, Yuki Furuta
```
