### PR TITLE
realsense_camera: 1.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2828,7 +2828,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/intel-ros/realsense-release.git
-      version: 1.2.1-0
+      version: 1.3.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_camera` to `1.3.0-0`:
- upstream repository: https://github.com/intel-ros/realsense.git
- release repository: https://github.com/intel-ros/realsense-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.2.1-0`
## realsense_camera

```
* Fix the Install for Includes
* Move header files
* Updated README for F200 cameras
* Added initial support for F200 cameras
* Refactored code for new cameras
* Contributors: Mark D Horn, Reagan Lopez, Yuki Furuta
```
