### PR TITLE
geometric_shapes: 0.5.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1013,7 +1013,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.4.4-0
+      version: 0.5.0-0
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.5.0-0`:
- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.4.4-0`
## geometric_shapes

```
* [fix] append cmake module path instead of prepending (#22 <https://github.com/ros-planning/geometric_shapes/issues/22>)
* [fix] FindQhull with non-debian systems (#30 <https://github.com/ros-planning/geometric_shapes/issues/30>). See https://github.com/PointCloudLibrary/pcl/pull/852
* [sys] Use std::shared_ptr for compatibility with FCL 0.5. #47 <https://github.com/ros-planning/geometric_shapes/issues/47>
* [sys] Switch to eigen 3 (#46 <https://github.com/ros-planning/geometric_shapes/issues/46>)
* [sys] Switched to C++11 #44 <https://github.com/ros-planning/geometric_shapes/issues/44>
* [sys] add notice that project will be built in Release mode
* [sys] Remove link_directories, deprecated assimp code
* Contributors: Dave Coleman, Ioan A Sucan, Jochen Sprickerhof, Maarten de Vries, Michael Goerner
```
