### PR TITLE
resource_retriever: 1.11.7-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8810,7 +8810,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/resource_retriever-release.git
-      version: 1.11.6-0
+      version: 1.11.7-1
     source:
       type: git
       url: https://github.com/ros/resource_retriever.git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `1.11.7-1`:
- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros-gbp/resource_retriever-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.11.6-0`
