### PR TITLE
Revert "geometric_shapes: 0.5.0-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1013,7 +1013,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.5.0-0
+      version: 0.4.4-0
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Reverts ros/rosdistro#12246

It's causing downstream failures: https://github.com/ros/rosdistro/pull/12246#issuecomment-236726117
