### PR TITLE
srdfdom: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3751,6 +3751,21 @@ repositories:
       url: https://github.com/stonier/sophus.git
       version: indigo
     status: maintained
+  srdfdom:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/srdfdom-release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: indigo-devel
+    status: maintained
   stage:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `0.3.1-0`:
- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/ros-gbp/srdfdom-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## srdfdom

```
* Change logError to Warn if collision link missing #10 <https://github.com/ros-planning/srdfdom/issues/10> Since MoveIt continues to load anyway, it makes sense to change the unknown collision link pairs ROS Error to a ROS Warning. Everything continues to work if a specified set of collision-link pairs is missing.
* Contributors: Dave Coleman, Ian McMahon
```
