### PR TITLE
sick_3vistort: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11261,6 +11261,23 @@ repositories:
       url: https://github.com/wcaarls/shared_serial.git
       version: master
     status: maintained
+  sick_3vistort:
+    doc:
+      type: git
+      url: https://github.com/sickag/sick_3vistort.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - sick_3vistort_driver
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/sickag/sick_3vistort-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/sickag/sick_3vistort.git
+      version: indigo-devel
+    status: developed
   sick_tim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_3vistort` to `0.0.1-0`:
- upstream repository: https://github.com/sickag/sick_3vistort.git
- release repository: https://github.com/sickag/sick_3vistort-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## sick_3vistort_driver

```
* fixed warning
* added parameter:prevent_frame_skipping
  f true: prevents skipping of frames and publish everything, otherwise use newest data to publish to ROS world
* using pointer instead of copy constructor (optimization)
* warning instead of debug msg
* fixed receive queue
* added functions to check header + size before parsing
* debug messaging
* check data header
* detach publishing data from network thread
* Renamed launch file to match the driver name
* Updated formatting and adding parameter comment in launch file.
* initial version of sick_3vistort ROS driver
* Contributors: Florian Weisshardt, Joshua Hampp, Marco Dierschke
```
