### PR TITLE
xsens_driver: 2.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6311,6 +6311,21 @@ repositories:
       url: https://github.com/ros/xacro.git
       version: jade-devel
     status: developed
+  xsens_driver:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/ethzasl_xsens_driver.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ethz-asl/ethzasl_xsens_driver-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/ethz-asl/ethzasl_xsens_driver.git
+      version: master
+    status: maintained
   youbot_driver:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `xsens_driver` to `2.0.0-0`:
- upstream repository: https://github.com/ethz-asl/ethzasl_xsens_driver.git
- release repository: https://github.com/ethz-asl/ethzasl_xsens_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## xsens_driver

```
* support of mark iv devices (configuration and ROS node)
* remove gps_common dependency (for jade and kinetic)
* work in 16.04 with pyserial3
* proper message types for temperature, pressure, magnetic field and time
* better timeout management
* various bug fixes
* Contributors: CTU robot, Francis Colas, João Sousa, Konstantinos Chatzilygeroudis, Latitude OBC, Vincent Rousseau, fcolas, jotaemesousa
```
