### PR TITLE
gazebo_ros_pkgs: 2.6.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1106,7 +1106,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.5.5-0
+      version: 2.6.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.6.0-0`:
- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.5.5-0`
## gazebo_msgs
- No changes
## gazebo_plugins

```
* Use NOT VERSION_LESS to simplify cmake logic
* Added an interface to gazebo's harness plugin
* removed extra includes
* Fix gazebo7 deprecation warnings
* bugfix: duplicated tf prefix resolution
* Contributors: Steven Peters, Yuki Furuta, nate koenig
```
## gazebo_ros

```
* Honor GAZEBO_MASTER_URI for gzserver and gzclient.
* Contributors: Martin Pecka
```
## gazebo_ros_control
- No changes
## gazebo_ros_pkgs
- No changes
