### PR TITLE
s3000_laser: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10969,6 +10969,11 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/s3000_laser.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotnikAutomation/s3000_laser-release.git
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/s3000_laser.git


### PR DESCRIPTION
Increasing version of package(s) in repository `s3000_laser` to `0.1.1-0`:
- upstream repository: https://github.com/RobotnikAutomation/s3000_laser.git
- release repository: https://github.com/RobotnikAutomation/s3000_laser-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## s3000_laser

```
* Added package to indigo
* fixed array types
* cleanup
* code cleanup
* sicks3000 class cleanup
* minor cleanup
* Merge pull request #4 <https://github.com/RobotnikAutomation/s3000_laser/issues/4> from RobotnikAutomation/serial-device-code-cleanup
  Serial device code cleanup
* close port in destructor
* cleanup serial device class interface
* remove all unused code for clarity
  cleanup class interface
* Merge pull request #3 <https://github.com/RobotnikAutomation/s3000_laser/issues/3> from chataign/parse-reflector-data
  Parse reflector data and new parameters
* set queue size to 1
  clean laser scan at each iteration
* allow configuration of the laser scan from ROS params
* parse reflector data
* moved DTOR to header to allow use from other files
* parse reflector data
* make baud rate and topic name configurable. support for 0.5deg resolution
* S30b support added. Minor fixes
* Adding Changelog file
* Adding packages dependencies and removing unused includes
* Modifying package description for Hydro branch
* Adding files for Hydro
* Initial commit
* Contributors: AliquesTomas, Dani Carbonell, Francois Chataigner, RobotnikRoman, Roman Navarro Garcia, francois
```
