### PR TITLE
variant: 0.1.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6071,6 +6071,26 @@ repositories:
       url: https://github.com/uji-ros-pkg/uwsim_osgworks-release.git
       version: 3.0.3-2
     status: maintained
+  variant:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/variant.git
+      version: master
+    release:
+      packages:
+      - variant
+      - variant_msgs
+      - variant_topic_test
+      - variant_topic_tools
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ethz-asl/variant-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/ethz-asl/variant.git
+      version: master
+    status: developed
   velodyne_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `variant` to `0.1.3-0`:
- upstream repository: https://github.com/ethz-asl/variant.git
- release repository: https://github.com/ethz-asl/variant-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## variant
- No changes
## variant_msgs
- No changes
## variant_topic_test

```
* fix missing file extension
* Contributors: Samuel Bachmann
```
## variant_topic_tools

```
* add executables to install
* add install commands
* Contributors: Samuel Bachmann
```
