### PR TITLE
variant: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4287,6 +4287,26 @@ repositories:
       url: https://github.com/ros/urdf_parser_py.git
       version: indigo-devel
     status: maintained
+  variant:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/variant.git
+      version: master
+    release:
+      packages:
+      - variant
+      - variant_msgs
+      - variant_topic_test
+      - variant_topic_tools
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ethz-asl/variant-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/ethz-asl/variant.git
+      version: master
+    status: developed
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `variant` to `0.1.3-0`:
- upstream repository: https://github.com/ethz-asl/variant.git
- release repository: https://github.com/ethz-asl/variant-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## variant
- No changes
## variant_msgs
- No changes
## variant_topic_test

```
* fix missing file extension
* Contributors: Samuel Bachmann
```
## variant_topic_tools

```
* add executables to install
* add install commands
* Contributors: Samuel Bachmann
```
