### PR TITLE
rqt_multiplot_plugin: 0.0.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3567,6 +3567,23 @@ repositories:
       url: https://github.com/ros-visualization/rqt_common_plugins.git
       version: master
     status: maintained
+  rqt_multiplot_plugin:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/rqt_multiplot_plugin.git
+      version: master
+    release:
+      packages:
+      - rqt_multiplot
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ethz-asl/rqt_multiplot_plugin-release.git
+      version: 0.0.5-0
+    source:
+      type: git
+      url: https://github.com/ethz-asl/rqt_multiplot_plugin.git
+      version: master
+    status: developed
   rqt_robot_plugins:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_multiplot_plugin` to `0.0.5-0`:
- upstream repository: https://github.com/ethz-asl/rqt_multiplot_plugin.git
- release repository: https://github.com/ethz-asl/rqt_multiplot_plugin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rqt_multiplot

```
* fixes #2 <https://github.com/ethz-asl/rqt_multiplot_plugin/issues/2> a QT API change
* rename two tooltips (copy and past curve) in PlotConfigWidget
* qt5 ready
* Contributors: Samuel Bachmann
```
