### PR TITLE
tiny_slam: 0.1.2-2 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5829,11 +5829,12 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/OSLL/tiny-slam-ros-release.git
-      version: 0.1.2-1
+      version: 0.1.2-2
     source:
       type: git
       url: https://github.com/OSLL/tiny-slam-ros-cpp.git
       version: devel
+    status: developed
   topic_proxy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiny_slam` to `0.1.2-2`:
- upstream repository: https://github.com/OSLL/tiny-slam-ros-cpp.git
- release repository: https://github.com/OSLL/tiny-slam-ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.2-1`
