### PR TITLE
tiny_slam: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3997,6 +3997,21 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  tiny_slam:
+    doc:
+      type: git
+      url: https://github.com/OSLL/tiny-slam-ros-cpp.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/OSLL/tiny-slam-ros-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/OSLL/tiny-slam-ros-cpp.git
+      version: devel
+    status: developed
   topic_proxy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiny_slam` to `0.1.2-0`:
- upstream repository: https://github.com/OSLL/tiny-slam-ros-cpp.git
- release repository: https://github.com/OSLL/tiny-slam-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
