### PR TITLE
rosserial: 0.7.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5041,7 +5041,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rosserial-release.git
-      version: 0.7.2-0
+      version: 0.7.3-0
     source:
       type: git
       url: https://github.com/ros-drivers/rosserial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial` to `0.7.3-0`:
- upstream repository: https://github.com/ros-drivers/rosserial.git
- release repository: https://github.com/ros-gbp/rosserial-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.7.2-0`
## rosserial
- No changes
## rosserial_arduino
- No changes
## rosserial_client

```
* Order packages by alpha rather than topologically. (#234 <https://github.com/ros-drivers/rosserial/issues/234>)
* Contributors: Mike Purvis
```
## rosserial_embeddedlinux
- No changes
## rosserial_mbed
- No changes
## rosserial_msgs
- No changes
## rosserial_python
- No changes
## rosserial_server

```
* Avoid runaway async condition when port is bad. (#236 <https://github.com/ros-drivers/rosserial/issues/236>)
* Add missing install rule for udp_socket_node
* Make the ~require param configurable from Session. (#233 <https://github.com/ros-drivers/rosserial/issues/233>)
* Contributors: Mike Purvis
```
## rosserial_tivac
- No changes
## rosserial_windows
- No changes
## rosserial_xbee
- No changes
