### PR TITLE
switch to use custom packaged fcl-0.5-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1438,8 +1438,8 @@ libexpat1-dev:
   ubuntu: [libexpat1-dev]
 libfcl-dev:
   arch: [fcl]
-  debian: [libfcl-dev]
-  ubuntu: [libfcl-dev]
+  debian: [libfcl-0.5-dev]
+  ubuntu: [libfcl-0.5-dev]
 libfftw3:
   arch: [fftw]
   debian: [libfftw3-3, libfftw3-dev]


### PR DESCRIPTION
As discussed and tested in https://github.com/flexible-collision-library/fcl/issues/137

I only updated the general rule for now since fcl-dev has only been packaged upstream since wily: http://packages.ubuntu.com/search?keywords=libfcl-dev
https://packages.debian.org/search?keywords=libfcl-dev

I have added the packages to the ros_bootsrap and imported it into the ROS repos: http://build.ros.org:8080/job/import_upstream/77/consoleFull
