### PR TITLE
remove obsolete Indigo multi_level_map repository

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6130,26 +6130,6 @@ repositories:
       url: https://github.com/lukscasanova/mtig_driver.git
       version: master
     status: developed
-  multi_level_map:
-    doc:
-      type: git
-      url: https://github.com/utexas-bwi/multi_level_map.git
-      version: master
-    release:
-      packages:
-      - multi_level_map
-      - multi_level_map_msgs
-      - multi_level_map_server
-      - multi_level_map_utils
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/utexas-bwi-gbp/multi_level_map-release.git
-      version: 0.1.2-0
-    source:
-      type: git
-      url: https://github.com/utexas-bwi/multi_level_map.git
-      version: master
-    status: developed
   multimaster_fkie:
     doc:
       type: git


### PR DESCRIPTION
These packages have been moved to bwi_common, which will be released after this is merged.
