### PR TITLE
urdf_tools: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12841,14 +12841,14 @@ repositories:
     release:
       packages:
       - urdf2inventor
-      - urdf_tools
+      - urdf_processing_tools
       - urdf_transform
       - urdf_traverser
       - urdf_viewer
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/JenniferBuehler/urdf-tools-pkgs-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/JenniferBuehler/urdf-tools-pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tools` to `1.0.1-0`:
- upstream repository: https://github.com/JenniferBuehler/urdf-tools-pkgs.git
- release repository: https://github.com/JenniferBuehler/urdf-tools-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.0-0`
## urdf2inventor

```
* Changed to BSD 3-clause license
* Fix cylinder and box orientations
* Added function to compute Bounding Box
* Added new transform and cylinder methods to IVHelpers
* Supports Cylinder in urdf2inventor now
* Contributors: Jennifer Buehler
```
## urdf_processing_tools

```
* resolved urdf_tools name clash and renamed to urdf_processing_tools
* Contributors: Jennifer Buehler
```
## urdf_transform

```
* Changed to BSD 3-clause license
* Contributors: Jennifer Buehler
```
## urdf_traverser

```
* Changed to BSD 3-clause license
* Contributors: Jennifer Buehler
```
## urdf_viewer

```
* Changed to BSD 3-clause license
* Fix cylinder and box orientations
* Added function to compute Bounding Box
* Added new transform and cylinder methods to IVHelpers
* Supports Cylinder in urdf2inventor now
* Contributors: Jennifer Buehler
```
