### PR TITLE
graspit_tools: 1.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3163,7 +3163,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/JenniferBuehler/graspit-pkgs-release.git
-      version: 1.0.0-0
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/JenniferBuehler/graspit-pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graspit_tools` to `1.1.2-0`:
- upstream repository: https://github.com/JenniferBuehler/graspit-pkgs.git
- release repository: https://github.com/JenniferBuehler/graspit-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.0-0`
