### PR TITLE
Update of mrpt-ros-pkg-release indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6123,7 +6123,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 0.1.9-0
+      version: 0.1.10-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
For some reason, there was a problem with the bloom pull-request and indigo was left behind when, a few days ago, I released 0.1.10 for indigo, jade and kinetic, so I'm updating the version number MANUALLY.

Edit: The previous PR #12282 had a conflict, this one will solve it.
