### PR TITLE
industrial_metapackages: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3927,6 +3927,23 @@ repositories:
       url: https://github.com/ros-industrial/industrial_core.git
       version: indigo
     status: maintained
+  industrial_metapackages:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/industrial_metapackages.git
+      version: indigo
+    release:
+      packages:
+      - industrial_desktop
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-industrial-release/industrial_metapackages-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/ros-industrial/industrial_metapackages.git
+      version: indigo
+    status: developed
   innok_heros_control:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_metapackages` to `0.0.3-0`:
- upstream repository: https://github.com/ros-industrial/industrial_metapackages.git
- release repository: https://github.com/ros-industrial-release/industrial_metapackages-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## industrial_desktop

```
* Updated for Indigo release (same packages)
```
