### PR TITLE
rqt_multiplot_plugin: 0.0.5-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5176,7 +5176,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ethz-asl/rqt_multiplot_plugin-release.git
-      version: 0.0.5-0
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/ethz-asl/rqt_multiplot_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_multiplot_plugin` to `0.0.5-1`:
- upstream repository: https://github.com/ethz-asl/rqt_multiplot_plugin.git
- release repository: https://github.com/ethz-asl/rqt_multiplot_plugin-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.5-0`
## rqt_multiplot

```
* fixes #2 <https://github.com/ethz-asl/rqt_multiplot_plugin/issues/2> a QT API change
* rename two tooltips (copy and past curve) in PlotConfigWidget
* qt5 ready
* Contributors: Samuel Bachmann
```
