### PR TITLE
tiny_slam: 0.1.2-3 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5846,7 +5846,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/OSLL/tiny-slam-ros-release.git
-      version: 0.1.2-2
+      version: 0.1.2-3
     source:
       type: git
       url: https://github.com/OSLL/tiny-slam-ros-cpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiny_slam` to `0.1.2-3`:
- upstream repository: https://github.com/OSLL/tiny-slam-ros-cpp.git
- release repository: https://github.com/OSLL/tiny-slam-ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.2-2`
