### PR TITLE
tiny_slam: 0.1.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4023,7 +4023,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/OSLL/tiny-slam-ros-release.git
-      version: 0.1.2-0
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/OSLL/tiny-slam-ros-cpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiny_slam` to `0.1.2-1`:
- upstream repository: https://github.com/OSLL/tiny-slam-ros-cpp.git
- release repository: https://github.com/OSLL/tiny-slam-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.2-0`
