### PR TITLE
tiny_slam: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12383,6 +12383,21 @@ repositories:
       url: https://github.com/gus484/ros.git
       version: master
     status: developed
+  tiny_slam:
+    doc:
+      type: git
+      url: https://github.com/OSLL/tiny-slam-ros-cpp.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/OSLL/tiny-slam-ros-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/OSLL/tiny-slam-ros-cpp.git
+      version: master
+    status: developed
   topic_proxy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiny_slam` to `0.1.2-0`:
- upstream repository: https://github.com/OSLL/tiny-slam-ros-cpp.git
- release repository: https://github.com/OSLL/tiny-slam-ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
