### PR TITLE
pr2_kinematics: 1.0.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3940,6 +3940,20 @@ repositories:
       url: https://github.com/pr2/pr2_controllers.git
       version: indigo-devel
     status: maintained
+  pr2_kinematics:
+    release:
+      packages:
+      - pr2_arm_kinematics
+      - pr2_kinematics
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_kinematics-release.git
+      version: 1.0.8-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_kinematics.git
+      version: hydro-devel
+    status: maintained
   pr2_mechanism:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_kinematics` to `1.0.8-0`:
- upstream repository: https://github.com/PR2/pr2_kinematics.git
- release repository: https://github.com/pr2-gbp/pr2_kinematics-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
