### PR TITLE
add iproute2

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1129,6 +1129,13 @@ ipmitool:
     portage:
       packages: [sys-apps/ipmitool]
   ubuntu: [ipmitool]
+iproute2:
+  arch: [iproute2]
+  debian: [iproute2]
+  fedora: [iproute]
+  gentoo: [iproute2]
+  opensuse: [iproute2]
+  ubuntu: [iproute2]
 jack:
   arch: [jack]
   debian: [libjack-jackd2-dev]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -155,6 +155,10 @@ hdf5:
   osx:
     homebrew:
       packages: [hdf5]
+iproute2:
+  osx:
+    homebrew:
+      packages: [iproute2mac]
 jasper:
   osx:
     homebrew:


### PR DESCRIPTION
The package `iproute2` provides `ip` command, which will be standard than `ifconfig`.
