### PR TITLE
pyzmp: 0.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8409,6 +8409,21 @@ repositories:
       url: https://github.com/MurpheyLab/trep-release.git
       version: 1.0.2-0
     status: developed
+  pyzmp:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/pyzmp.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/pyzmp-rosrelease.git
+      version: 0.0.12-0
+    source:
+      type: git
+      url: https://github.com/asmodehn/pyzmp.git
+      version: master
+    status: developed
   qglv_toolkit:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyzmp` to `0.0.12-0`:
- upstream repository: https://github.com/asmodehn/pyzmp.git
- release repository: https://github.com/asmodehn/pyzmp-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
