### PR TITLE
catkin_pip: 0.1.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1130,7 +1130,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/catkin_pip-release.git
-      version: 0.1.9-0
+      version: 0.1.10-0
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pip.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pip` to `0.1.10-0`:
- upstream repository: https://github.com/asmodehn/catkin_pip.git
- release repository: https://github.com/asmodehn/catkin_pip-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.9-0`
## catkin_pip

```
* added rospack dependency
* (Re)adding site-packages folder creation in devel workspace.
* setup of catkin_pip environment also adds the workspace site-packages to the python path to get it ready for use, even if envhook was not used before.
* Merge pull request #28 <https://github.com/asmodehn/catkin_pip/issues/28> from asmodehn/separate_catkin_pip_env
  separating catkin_pip environment with workspace environment.
* making sure env-hooks have all variables setup before adding.
* separating catkin_pip environment with workspace environment.
  added envhook for loading caktin_pip env on installspace.
  removing install script for python on windows for now (outdated).
* Contributors: AlexV, alexv
```
