### PR TITLE
barrett_hand_common: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -196,6 +196,24 @@ repositories:
       url: https://github.com/po1/axcli-release.git
       version: 0.1.0-0
     status: maintained
+  barrett_hand_common:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/barrett_hand_common.git
+      version: kinetic-devel
+    release:
+      packages:
+      - barrett_hand_common
+      - barrett_hand_description
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotnikAutomation/barrett_hand_common-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/barrett_hand_common.git
+      version: kinetic-devel
+    status: maintained
   bebop_autonomy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `barrett_hand_common` to `0.1.1-0`:
- upstream repository: https://github.com/RobotnikAutomation/barrett_hand_common.git
- release repository: https://github.com/RobotnikAutomation/barrett_hand_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## barrett_hand_common

```
* Adding Changelog files
* Adding metapackage and setting CMakeLists and package.xml for release
* Contributors: RomanRobotnik
```
## barrett_hand_description

```
* cleaned up bh280 mimic joints
* change bh280 to mimic joints
* updated gazebo elements to support multiples/renaming
  -added ${name} param to mimic joint names to match corresponding urdf
  -moved control plugin to bh_alone.urdf.xacro so multiple hands can be included into other robots without a name collision in gazebo
* Adding Changelog files
* Url fix
* Fixing catkin error
* Adding metapackage and setting CMakeLists and package.xml for release
* Add Barrett Hand description package
* Contributors: Allison Thackston, Elena Gambaro, RomanRobotnik
```
