### PR TITLE
widowx_arm: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13324,10 +13324,20 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/widowx_arm.git
       version: master
+    release:
+      packages:
+      - widowx_arm
+      - widowx_arm_controller
+      - widowx_arm_description
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotnikAutomation/widowx_arm-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/widowx_arm.git
       version: master
+    status: maintained
   wifi_ddwrt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `widowx_arm` to `0.0.1-0`:
- upstream repository: https://github.com/RobotnikAutomation/widowx_arm.git
- release repository: https://github.com/RobotnikAutomation/widowx_arm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## widowx_arm

```
* Modified package.xml
* Modified package.xml files
* Fist commit
* Contributors: RomanRobotnik, carlos3dx
```
## widowx_arm_controller

```
* Modified package.xml files
* minor changes
* Create README.md
* Fist commit
* Contributors: Jose Rapado, Roman Navarro Garcia, RomanRobotnik, carlos3dx
```
## widowx_arm_description

```
* Modified package.xml
* Modified package.xml files
* minor changes
* Adding move to gripper joint
* Adding widowx_arm_description
* Contributors: Jose Rapado, carlos3dx
```
