### PR TITLE
phantomx_reactor_arm: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7575,6 +7575,15 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/phantomx_reactor_arm.git
       version: indigo-devel
+    release:
+      packages:
+      - phantomx_reactor_arm
+      - phantomx_reactor_arm_controller
+      - phantomx_reactor_arm_description
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobotnikAutomation/phantomx_reactor_arm-release.git
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/phantomx_reactor_arm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `phantomx_reactor_arm` to `0.1.2-0`:
- upstream repository: https://github.com/RobotnikAutomation/phantomx_reactor_arm.git
- release repository: https://github.com/RobotnikAutomation/phantomx_reactor_arm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## phantomx_reactor_arm
- No changes
## phantomx_reactor_arm_controller
- No changes
## phantomx_reactor_arm_description
- No changes
