### PR TITLE
Adding python-cryptography and python-apparmor

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -118,6 +118,9 @@ python-anyjson:
   debian: [python-anyjson]
   fedora: [python-anyjson]
   ubuntu: [python-anyjson]
+python-apparmor:
+  debian: [python-apparmor]
+  ubuntu: [python-apparmor]
 python-argcomplete:
   fedora: [python-argcomplete]
   ubuntu: [python-argcomplete]
@@ -472,6 +475,9 @@ python-crypto:
     wily_python3: [python3-crypto]
     xenial: [python-crypto]
     xenial_python3: [python3-crypto]
+python-cryptography:
+  debian: [python-cryptography]
+  ubuntu: [python-cryptography]
 python-cwiid:
   arch: [cwiid]
   debian: [python-cwiid]


### PR DESCRIPTION
Adding keys for python packages:
python-cryptography
python-apparmor

Didn't find these packages for fedora though...
