### PR TITLE
Adding python-openssl

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1185,6 +1185,9 @@ python-opengl:
     vivid: [python-opengl]
     wily: [python-opengl]
     xenial: [python-opengl]
+python-openssl:
+  debian: [python-openssl]
+  ubuntu: [python-openssl]
 python-pandas:
   arch: [python2-pandas]
   debian: [python-pandas]


### PR DESCRIPTION
Forgot to also add python-openssl with previous PR #12314

https://packages.debian.org/jessie/python-openssl
http://packages.ubuntu.com/xenial/python-openssl

Agian, not sure what to do for fedora:
https://ask.fedoraproject.org/en/question/27845/how-to-install-python-openssl/
