### PR TITLE
pyzmp: 0.0.13-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4073,6 +4073,21 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: groovy-devel
     status: maintained
+  pyzmp:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/pyzmp.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/asmodehn/pyzmp-rosrelease.git
+      version: 0.0.13-0
+    source:
+      type: git
+      url: https://github.com/asmodehn/pyzmp.git
+      version: master
+    status: maintained
   qt_gui_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyzmp` to `0.0.13-0`:
- upstream repository: https://github.com/asmodehn/pyzmp.git
- release repository: https://github.com/asmodehn/pyzmp-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## pyzmp

```
* Retrieving changes from indigo-devel, because it s building now and
  ready to be offloaded to release repo as patches. [alexv]
* Improved setup.py. now relying on twine for release. [alexv]
* Preparing version 0.0.12. [alexv]
```
