### PR TITLE
pyzmp: 0.0.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8427,7 +8427,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/pyzmp-rosrelease.git
-      version: 0.0.12-0
+      version: 0.0.14-0
     source:
       type: git
       url: https://github.com/asmodehn/pyzmp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyzmp` to `0.0.14-0`:
- upstream repository: https://github.com/asmodehn/pyzmp.git
- release repository: https://github.com/asmodehn/pyzmp-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.12-0`
## pyzmp

```
* Removing release shell script. now done from setup.py. [alexv]
* Removing package.xml. doing thirdparty release from release repo now.
  [alexv]
* Moving docs to doc. [alexv]
* Merge branch 'docs' of https://github.com/asmodehn/pyzmp. [alexv]Conflicts:

  CHANGELOG.rst
* Added doc-requirements. [AlexV]
* Added tutorial and example changelog generated with gitchangelog.
  [AlexV]
* More docs about process managers... [AlexV]
* Added very basic rpc tutorial. [AlexV]
* First doc version generated with sphinx-apidoc. added CHANGELOG.
  [AlexV]
```
