### PR TITLE
ros_numpy: 0.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4729,6 +4729,21 @@ repositories:
       url: https://github.com/GT-RAIL/ros_ethernet_rmp.git
       version: develop
     status: maintained
+  ros_numpy:
+    doc:
+      type: git
+      url: https://github.com/eric-wieser/ros_numpy.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/eric-wieser/ros_numpy-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/eric-wieser/ros_numpy.git
+      version: master
+    status: developed
   ros_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_numpy` to `0.0.2-0`:
- upstream repository: https://github.com/eric-wieser/ros_numpy.git
- release repository: https://github.com/eric-wieser/ros_numpy-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
