### PR TITLE
barrett_hand_common: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -220,6 +220,14 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/barrett_hand_common.git
       version: kinetic-devel
+    release:
+      packages:
+      - barrett_hand_common
+      - barrett_hand_description
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotnikAutomation/barrett_hand_common-release.git
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/barrett_hand_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `barrett_hand_common` to `0.1.2-0`:
- upstream repository: https://github.com/RobotnikAutomation/barrett_hand_common.git
- release repository: https://github.com/RobotnikAutomation/barrett_hand_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## barrett_hand_common
- No changes
## barrett_hand_description
- No changes
