### PR TITLE
barrett_hand_sim: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -238,6 +238,15 @@ repositories:
       type: git
       url: https://github.com/RobotnikAutomation/barrett_hand_sim.git
       version: kinetic-devel
+    release:
+      packages:
+      - barrett_hand_control
+      - barrett_hand_gazebo
+      - barrett_hand_sim
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotnikAutomation/barrett_hand_sim-release.git
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/barrett_hand_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `barrett_hand_sim` to `0.1.2-0`:
- upstream repository: https://github.com/RobotnikAutomation/barrett_hand_sim.git
- release repository: https://github.com/RobotnikAutomation/barrett_hand_sim-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## barrett_hand_control
- No changes
## barrett_hand_gazebo
- No changes
## barrett_hand_sim
- No changes
