### PR TITLE
kobuki_desktop: 0.5.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1555,6 +1555,24 @@ repositories:
       url: https://github.com/yujinrobot/kobuki_core.git
       version: kinetic
     status: maintained
+  kobuki_desktop:
+    release:
+      packages:
+      - kobuki_dashboard
+      - kobuki_desktop
+      - kobuki_gazebo
+      - kobuki_gazebo_plugins
+      - kobuki_qtestsuite
+      - kobuki_rviz_launchers
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/kobuki_desktop-release.git
+      version: 0.5.0-0
+    source:
+      type: git
+      url: https://github.com/yujinrobot/kobuki_desktop.git
+      version: kinetic
+    status: maintained
   kobuki_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_desktop` to `0.5.0-0`:
- upstream repository: https://github.com/yujinrobot/kobuki_desktop.git
- release repository: https://github.com/yujinrobot-release/kobuki_desktop-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
