### PR TITLE
Adding pioneer_bringup & pioneer_teleop to documentation index

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7648,6 +7648,16 @@ repositories:
   pioneer_bringup:
     doc:
       type: git
+      url: https://github.com/amineHorseman/pioneer_bringup.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/amineHorseman/pioneer_bringup.git
+      version: master
+    status: maintained
+  pioneer_teleop:
+    doc:
+      type: git
       url: https://github.com/amineHorseman/pioneer_teleop.git
       version: master
     source:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7645,6 +7645,16 @@ repositories:
       url: https://bitbucket.org/AndyZe/pid.git
       version: master
     status: developed
+  pioneer_bringup:
+    doc:
+      type: git
+      url: https://github.com/amineHorseman/pioneer_teleop.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/amineHorseman/pioneer_teleop.git
+      version: master
+    status: maintained
   play_motion:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3823,6 +3823,26 @@ repositories:
       url: https://bitbucket.org/AndyZe/pid.git
       version: master
     status: maintained
+  pioneer_bringup:
+    doc:
+      type: git
+      url: https://github.com/amineHorseman/pioneer_bringup.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/amineHorseman/pioneer_bringup.git
+      version: master
+    status: maintained
+  pioneer_teleop:
+    doc:
+      type: git
+      url: https://github.com/amineHorseman/pioneer_teleop.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/amineHorseman/pioneer_teleop.git
+      version: master
+    status: maintained
   pluginlib:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2691,6 +2691,26 @@ repositories:
       url: https://bitbucket.org/AndyZe/pid.git
       version: master
     status: maintained
+  pioneer_bringup:
+    doc:
+      type: git
+      url: https://github.com/amineHorseman/pioneer_bringup.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/amineHorseman/pioneer_bringup.git
+      version: master
+    status: maintained
+  pioneer_teleop:
+    doc:
+      type: git
+      url: https://github.com/amineHorseman/pioneer_teleop.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/amineHorseman/pioneer_teleop.git
+      version: master
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
I'd like pioneer_bringup and pioneer_teleop to be indexed and documented on org.org.
