### PR TITLE
catkin_pip: 0.1.11-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -393,7 +393,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/catkin_pip-release.git
-      version: 0.1.9-0
+      version: 0.1.11-0
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pip.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pip` to `0.1.11-0`:
- upstream repository: https://github.com/asmodehn/catkin_pip.git
- release repository: https://github.com/asmodehn/catkin_pip-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.9-0`
## catkin_pip

```
* added description of the catkin_pip build flow
* we might not need the install envhook after all.
  correct setuptools is found via path in install script.
  correct tools for test or other should be found via path in generated scripts, and used via catkin/make commands.
* added warning in pycharm setup doc.
* added first draft of pycharm setup doc
* improved workflow doc with pointer to example package repos.
* adding documentation for 3 ros-python workflows enabled by catkin_pip
* improving documentation
* disabling tests check from travis on install since mypippkg doesnt have any yet.
* fixing travis_checks to run our pytest version from catkin_pip_env
* cleaning up doc, installing ros-base in travis install step.
* adding specific script for travis checks.
  added basic doc structure.
* new travis build flow to split devel and install flow and avoid one unwanted interferences.
* Contributors: alexv
```
