### PR TITLE
[dep][ubuntu] Add pandoc.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3169,6 +3169,8 @@ osm2pgsql:
 osmium:
   fedora: [libosmium-devel]
   ubuntu: [libosmium-dev]
+pandoc:
+  ubuntu: [pandoc]
 pcre:
   arch: [pcre]
   debian: [libpcre3-dev]


### PR DESCRIPTION
`pandoc` seems to have been consistently called pandoc for at least the last few Ubuntu distros:
- [Trusty](http://packages.ubuntu.com/trusty/text/pandoc)
- [Wily](http://packages.ubuntu.com/wily/pandoc) (EoL but just as fyi)
- [Xenial](http://packages.ubuntu.com/xenial/pandoc)
