### PR TITLE
click: 6.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1163,6 +1163,12 @@ repositories:
       url: https://github.com/ros/class_loader.git
       version: indigo-devel
     status: maintained
+  click:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/click-rosrelease.git
+      version: 6.2.0-0
   cmake_modules:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `click` to `6.2.0-0`:
- upstream repository: https://github.com/pallets/click.git
- release repository: https://github.com/asmodehn/click-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
