### PR TITLE
dynamixel_sdk: 3.4.0-6 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -612,11 +612,19 @@ repositories:
       version: master
     status: maintained
   dynamixel_sdk:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
-      version: 3.4.0-4
+      version: 3.4.0-6
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
+      version: kinetic-devel
     status: maintained
   dynpick_driver:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.4.0-6`:
- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `3.4.0-4`
## dynamixel_sdk

```
* first public release for Kinetic
* added package information for wrapping version for ROS
* added ROS catkin package files.
* linux build file for SBC
* License marks for example codes
* Resource Files comments Korean -> English
* Update Makefile
* Update Makefile
* comments modified & aligned
* Release folders in c++ example removed & dxl_monitor.cpp Capital function name modified as ROS c++ code style & included file paths of packet/port handler in dynamixel_sdk.h removed and added parent header file
* Update dxl_monitor.cpp
* file opened
* folder name modification error solved
* License specified
* Code Style modified into ROS C++ coding style
  Function & File Names changed into underscored
* Group Bulk/Sync class ClearParam() function changed.
* dll file name changed
* dll file name changed
* Comment modified
* [Protocol1PacketHandler]
  RxPacket packet length re-calculate bug fixed.
* [Protocol2PacketHandler]
  RxPacket packet length re-calculate bug fixed.
* Makefile updated
  Source reorganization
* Windows version updated
  Makefile modified
  Source reorganization
* GroupBulkRead : GetData function bug fixed.
* [GroupBulkRead / GroupSyncRead]
  added IsAvailable() function
  modified GetData() function
* GetData() function changed.
* reducing the count of calling MakeParam function
* added rxpacket error check
* ReadTxRx function modified. (to use TxRxPacket function)
* DXL Monitor program arguments added.
* if the last bulk_read / sync_read result is failure -> GetData return false
* communication result & rx packet error print function modified.
* first release
* Contributors: Leon, ROBOTIS, ROBOTIS-zerom, leon, pyo, sadtale
```
