### PR TITLE
robotis_controller_msgs: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3049,6 +3049,21 @@ repositories:
       url: https://github.com/ros/robot_state_publisher.git
       version: kinetic-devel
     status: maintained
+  robotis_controller_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework-msgs.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-msgs-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework-msgs.git
+      version: kinetic-devel
+    status: maintained
   robotnik_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_controller_msgs` to `0.1.0-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework-msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## robotis_controller_msgs

```
* first public release for Kinetic
* modified the package information
* added robotis_controller_msgs
* Contributors: ROBOTIS-zerom, pyo
```
