### PR TITLE
robotis_framework: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3072,6 +3072,26 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework-msgs.git
       version: kinetic-devel
     status: maintained
+  robotis_framework:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git
+      version: kinetic-devel
+    release:
+      packages:
+      - robotis_controller
+      - robotis_device
+      - robotis_framework
+      - robotis_framework_common
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git
+      version: kinetic-devel
+    status: maintained
   robotnik_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_framework` to `0.1.0-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## robotis_controller

```
* first public release for Kinetic
* modified the package information for release
* develop branch -> master branch
* Merge pull request #4 <https://github.com/ROBOTIS-GIT/ROBOTIS-Framework/issues/4> from ROBOTIS-GIT/add_sensor_device
  Add sensor device
* function name changed : DeviceInit() -> InitDevice()
* Fixed high CPU consumption due to busy waits
* add SensorState
  add Singleton template
* XM-430 / CM-740 device file added.
  Sensor device added.
* added code to support the gazebo simulator
* added first bulk read failure protection code
* renewal
* Contributors: Alexander Stumpf, ROBOTIS, ROBOTIS-zerom, pyo
```
## robotis_device

```
* first public release for Kinetic
* modified the package information for release
* develop branch -> master branch
* Setting the license to BSD.
* add SensorState
  add Singleton template
* XM-430 / CM-740 device file added.
  Sensor device added.
* modified.
* variable name changed.
  ConvertRadian2Value / ConvertValue2Radian function bug fixed.
* added code to support the gazebo simulator
* renewal
* Contributors: ROBOTIS, ROBOTIS-zerom, pyo
```
## robotis_framework

```
* make a meta-package
* Contributors: pyo
```
## robotis_framework_common

```
* modified the package information for release
* develop branch -> master branch
* Setting the license to BSD.
* add SensorState
  add Singleton template
* Contributors: ROBOTIS, ROBOTIS-zerom, pyo
```
