### PR TITLE
kobuki: 0.7.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1544,7 +1544,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki-release.git
-      version: 0.7.0-0
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki` to `0.7.1-0`:
- upstream repository: https://github.com/yujinrobot/kobuki.git
- release repository: https://github.com/yujinrobot-release/kobuki-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.7.0-0`
## kobuki_auto_docking

```
* bugfix for racing condition in goal assigning/enabling the docker
```
