### PR TITLE
velodyne_simulator: 1.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4528,6 +4528,25 @@ repositories:
       url: https://github.com/ethz-asl/variant.git
       version: master
     status: developed
+  velodyne_simulator:
+    doc:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
+      version: master
+    release:
+      packages:
+      - velodyne_description
+      - velodyne_gazebo_plugins
+      - velodyne_simulator
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
+      version: master
+    status: maintained
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_simulator` to `1.0.3-0`:
- upstream repository: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
- release repository: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## velodyne_description

```
* Contributors: Kevin Hallenbeck
```
## velodyne_gazebo_plugins

```
* Gazebo7 integration
* Contributors: Kevin Hallenbeck, Konstantin Sorokin
```
## velodyne_simulator

```
* Contributors: Kevin Hallenbeck
```
