### PR TITLE
Consolidate gstreamer 1.0 rosdeps

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -888,12 +888,6 @@ gimp:
   fedora: [gimp]
   gentoo: [media-gfx/gimp]
   ubuntu: [gimp]
-gir1.2-gst-plugins-base-1.0:
-  debian: [gir1.2-gst-plugins-base-1.0]
-  ubuntu: [gir1.2-gst-plugins-base-1.0]
-gir1.2-gstreamer-1.0:
-  debian: [gir1.2-gstreamer-1.0]
-  ubuntu: [gir1.2-gstreamer-1.0]
 git:
   arch: [git]
   debian: [git-core]
@@ -998,6 +992,10 @@ gstreamer0.10-plugins-ugly:
 gstreamer0.10-pocketsphinx:
   fedora: [pocketsphinx-plugin]
   ubuntu: [gstreamer0.10-pocketsphinx]
+gstreamer1.0:
+  debian: [gstreamer1.0-tools, libgstreamer1.0-0, gir1.2-gstreamer-1.0]
+  fedora: [gstreamer1]
+  ubuntu: [gstreamer1.0-tools, libgstreamer1.0-0, gir1.2-gstreamer-1.0]
 gstreamer1.0-libav:
   debian: [gstreamer1.0-libav]
   fedora: [gstreamer1-libav]
@@ -1007,17 +1005,17 @@ gstreamer1.0-plugins-bad:
   fedora: [gstreamer1-plugins-bad-free]
   ubuntu: [gstreamer1.0-plugins-bad]
 gstreamer1.0-plugins-base:
-  debian: [gstreamer1.0-plugins-base]
+  debian: [gstreamer1.0-plugins-base, libgstreamer-plugins-base1.0-0, gir1.2-gst-plugins-base-1.0]
   fedora: [gstreamer1-plugins-base]
-  ubuntu: [gstreamer1.0-plugins-base]
+  ubuntu: [gstreamer1.0-plugins-base, libgstreamer-plugins-base1.0-0, gir1.2-gst-plugins-base-1.0]
 gstreamer1.0-plugins-good:
-  debian: [gstreamer1.0-plugins-good]
+  debian: [gstreamer1.0-plugins-good, libgstreamer-plugins-good1.0-0]
   fedora: [gstreamer1-plugins-good]
-  ubuntu: [gstreamer1.0-plugins-good]
+  ubuntu: [gstreamer1.0-plugins-good, libgstreamer-plugins-good1.0-0]
 gstreamer1.0-plugins-ugly:
-  debian: [gstreamer1.0-plugins-ugly]
+  debian: [gstreamer1.0-plugins-ugly, libgstreamer-plugins-ugly1.0-0]
   fedora: [gstreamer1-plugins-ugly]
-  ubuntu: [gstreamer1.0-plugins-ugly]
+  ubuntu: [gstreamer1.0-plugins-ugly, libgstreamer-plugins-ugly1.0-0]
 gstreamer1.0-tools:
   debian: [gstreamer1.0-tools]
   fedora: [gstreamer1]
@@ -1663,10 +1661,6 @@ libgstreamer-plugins-base0.10-dev:
   debian: [libgstreamer-plugins-base0.10-dev]
   fedora: [gstreamer-plugins-base-devel]
   ubuntu: [libgstreamer-plugins-base0.10-dev]
-libgstreamer-plugins-base1.0-0:
-  debian: [libgstreamer-plugins-base1.0-0]
-  fedora: [gstreamer1-plugins-base]
-  ubuntu: [libgstreamer-plugins-base1.0-0]
 libgstreamer-plugins-base1.0-dev:
   debian: [libgstreamer-plugins-base1.0-dev]
   fedora: [gstreamer1-plugins-base-devel]
@@ -1681,10 +1675,6 @@ libgstreamer0.10-dev:
   debian: [libgstreamer0.10-dev]
   fedora: [gstreamer-devel]
   ubuntu: [libgstreamer0.10-dev]
-libgstreamer1.0-0:
-  debian: [libgstreamer1.0-0]
-  fedora: [gstreamer1]
-  ubuntu: [libgstreamer1.0-0]
 libgstreamer1.0-dev:
   debian: [libgstreamer1.0-dev]
   fedora: [gstreamer1-devel]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -691,8 +691,8 @@ python-gevent:
   ubuntu: [python-gevent]
 python-gi:
   debian: [python-gi]
-  ubuntu: [python-gi]
   fedora: [pygobject3]
+  ubuntu: [python-gi]
 python-googleapi:
   debian: [python-googleapi]
   fedora: [google-api-python-client]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -692,6 +692,7 @@ python-gevent:
 python-gi:
   debian: [python-gi]
   ubuntu: [python-gi]
+  fedora: [pygobject3]
 python-googleapi:
   debian: [python-googleapi]
   fedora: [google-api-python-client]


### PR DESCRIPTION
I'm cleaning up the rosdeps for gstreamer 1.0 in preparation for Kinetic
release of audio_common.

Ubuntu and Fedora package gstreamer 1.0 quite differently, and my goal here is to provide a common set of rosdeps that work across platforms. Fedora packages the plugins, libraries and gobject introspection data into a single package, while Ubuntu packages these as three separate packages. Since most users will want all of these, and it aligns with the Fedora packaging strategy, I've combined all three under the same rosdep key.

I've also created a gstreamer1.0 package which is an umbrella for the tools and gobject introspection data that should come with gstreamer.

I've removed the libgstreamer-**1.0 packages, because they don't exist on Fedora and they're depended on by the more generic gstreamer packages on Ubuntu. I've added them to the package lists for the relevant Ubuntu packages so that it's clear to future rosdep maintainers that there are
already rosdep keys for these packages.

@BennyRe , @mvollrath and @cottsay: since you're contributed to these rosdep keys, I would appreciate your feedback on these changes.
