### PR TITLE
Added python-networkx for Xenial and Debian

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1057,6 +1057,7 @@ python-networkmanager:
   ubuntu: [python-networkmanager]
 python-networkx:
   arch: [python2-networkx]
+  debian: [python-networkx]
   fedora: [python-networkx]
   ubuntu:
     lucid: [python-networkx]
@@ -1069,6 +1070,10 @@ python-networkx:
     saucy: [python-networkx]
     trusty: [python-networkx]
     trusty_python3: [python3-networkx]
+    wily: [python-networkx]
+    wily_python3: [python3-networkx]
+    xenial: [python-networkx]
+    xenial_python3: [python3-networkx]
 python-nose:
   arch: [python2-nose]
   debian: [python-nose]


### PR DESCRIPTION
For your reference:
https://packages.debian.org/jessie/python-networkx
http://packages.ubuntu.com/xenial/python-networkx
http://packages.ubuntu.com/xenial/python3-networkx
