### PR TITLE
marti_messages: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5437,7 +5437,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_messages-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `0.0.5-0`:
- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.4-0`
## marti_can_msgs
- No changes
## marti_common_msgs
- No changes
## marti_nav_msgs

```
* Adds new services to save a route and to update a route's metadata:

    * SaveRoute

        * Takes a list of route points and saves it
        * If the route's GUID matches an existing route, it will be overwritten

    * UpdateRouteMetadata

        * Modifies an existing route
        * Replaces the properties on specified points with new properties


* Adds Obstacle/ObstacleArray messages to marti_nav_msgs.
* Contributors: Elliot Johnson, P. J. Reed
```
## marti_perception_msgs
- No changes
## marti_sensor_msgs
- No changes
## marti_visualization_msgs
- No changes
