### PR TITLE
marti_common: 0.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5415,7 +5415,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 0.0.11-0
+      version: 0.0.12-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.0.12-0`:
- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.11-0`
## marti_data_structures
- No changes
## swri_console_util
- No changes
## swri_geometry_util

```
* Adds cubic spline interface for tf::Vector3 type.
* Contributors: Marc Alban
```
## swri_image_util
- No changes
## swri_math_util
- No changes
## swri_nodelet
- No changes
## swri_opencv_util
- No changes
## swri_prefix_tools
- No changes
## swri_roscpp
- No changes
## swri_rospy
- No changes
## swri_route_util

```
* Changes the order of include dirs
  "${catkin_INCLUDE_DIRS}" needs to be listed after "include", otherwise gcc may
  try to compile this component's cpp files using headers from a system-installed
  version of swri_route_util.
* Adds support for stop point metadata.
* Adds sru::projectOntoRouteWindow, a utility function to project a point onto a
  window of the route.
* Fixes projectOntoRoute to return a normalized route coordinate
  when the point is past the end of the route.
* Fixes a major bug in nearestDistanceToLineSegment that was
  affecting projectOntoRoute.  A misnamed variable v_len was actually
  the square of v_len and caused the reported distance along the route
  segment to be the square of the desired answer.  Chanes the code to take the
  appropriate square root and changes the variable name to avoid
  confusion in the future.
* Adds an error check when a sru::Route rebuilds its point
  index.  If the point IDs are not unique, the route will output an
  error message that should make tracking down problems easier.  This
  check is extremely lightweight and should not have a performance
  impact.
* Contributors: Elliot Johnson, P. J. Reed
```
## swri_serial_util
- No changes
## swri_string_util
- No changes
## swri_system_util
- No changes
## swri_transform_util

```
* Add explicit getOrientation function for Utm transformer
* Improve georeferencing warnings.
* Contributors: Jason Gassaway, Marc Alban
```
## swri_yaml_util
- No changes
