### PR TITLE
mapviz: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5383,7 +5383,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `0.0.6-0`:
- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.5-0`
## mapviz

```
* Fixes several reorder and signed comparison warnings in the mapviz
  package.
* Adds a dialog for selecting services by type
  This dialog is similar to the ones for listing topics or TF frames, but it is
  a little different under the hood.  Notably:

    * It relies on the rosapi node in order to be able to search for services
    * Since searching is done via a service call, ROS communication is handled
      on a separate thread that will not block the GUI
    * Unlike topics, only searching for a single service type is supported

* Adds a way for plugin config widgets to resize and modifies the PCL2 plugin
  as an example of this behavior.
  Fixes #393 <https://github.com/swri-robotics/mapviz/issues/393>
* Adds  an icon on the right side of Mapviz's status bar tthat will reset
  the view to the default zoom level and center it on the origin of the target
  frame.
  Resolves #371 <https://github.com/swri-robotics/mapviz/issues/371>
* The MapvizPlugin class now emits signals when any of the following settings change:

    * Draw Order
    * Target Frame
    * Use Latest Transforms
    * Visibility
  Note that the signals will only be emitted if the setting actually *changes*, not
  if it is somehow set to the same value that it was previously.
* Contributors: Ed Venator, Edward Venator, Marc Alban, P. J. Reed
```
## mapviz_plugins

```
* Fixes signed comparison warnings in mapviz_plugins
* Adds a way for plugin config widgets to resize

    * Adding an event plugins can emit to indicate their geometry has changed
    * Modifying the PCL2 plugin to use it as an example
  Fixes #393 <https://github.com/swri-robotics/mapviz/issues/393>
* Sets default values for uninitialized variables
  Resolves #372 <https://github.com/swri-robotics/mapviz/issues/372>
* Creates and implements an abstract class for drawing point paths
  Updates gps, navsat, odometry, path, and tf_frame plugins to use the
  abstract point drawing class.
* Adds the draw laps functionality, which allows the user to change the color
  of the path as it passes a base point for ease of visibility. This option
  is implemented for the gps and odometry plugins.
* Implements support for the ARROW marker type
  Resolves #365 <https://github.com/swri-robotics/mapviz/issues/365>
* Ensures that Mapviz won't subscribe to empty topic names. This involved
  cleaning up the code for handling subscriptions for all topics. The behavior
  is now:

    * All input is trimmed before processing
    * If a topic name is empty, the old subscriber will be shut down and will not subscribe to the empty topic
  Resolves #327 <https://github.com/swri-robotics/mapviz/issues/327>
* Fixes a crash in the PointCloud2 plugin
* Caches transformed pointclouds to improve performance
* PointCloud2 plugin "Color Transformer" combo box now properly saves its value
* Return "false" if no other code handles the mouse event
  Fixes #360 <https://github.com/swri-robotics/mapviz/issues/360>
* Contributors: Ed Venator, Marc Alban, P. J. Reed
```
## multires_image
- No changes
## tile_map

```
* Adds support for Bing Maps (#407 <https://github.com/swri-robotics/mapviz/issues/407>)
  This makes a number of changes in the tile_map plugin in order to support
  different types of tile servers, including Bing Maps.  Notable changes include:

    * TileSource is now an abstract class
    * WMTS server-specific behavior has been moved into a new WmtsSource class
    * BingSource provides support for obtaining tiles from Bing Maps
    * The UI for specifying server URLs has changed
    * Prefix and coordinate order are no longer separate fields
    * In URLs for WMTS sources, the variables {level}, {x}, and {y} will be substituted with appropriate values when tiles are requested
    * Rather than generating hashes for image tiles based on their URLs, hashes are now generated by the TileSource implementations in order to support sources that can pull tiles from multiple servers
    * Idle performance has been improved by removing redundant recalculations of the map view
    * Added a dependency on libjsoncpp
  Resolves #227 <https://github.com/swri-robotics/mapviz/issues/227>
* Overhauls tile_map interface and removes Mapquest.
  MapQuest has turned off their public API for map tiles, so this plugin needed some work.

    * Removed the MapQuest sources
    * Made the interface for adding new sources more powerful
    * Overhauled how sources are saved and loaded under the hood
    * Added a button to reset the current tile cache
  Resolves #402 <https://github.com/swri-robotics/mapviz/issues/402>
* Contributors: P. J. Reed
```
