### PR TITLE
rosbridge_suite: 0.7.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10001,7 +10001,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.7.15-0
+      version: 0.7.16-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.7.16-0`:
- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.7.15-0`
## rosapi

```
* new srv: topics types and details
* Contributors: Marco Arruda
```
## rosbridge_library

```
* Fixed deprecated code in pillow
* Contributors: vladrotea
```
## rosbridge_server
- No changes
## rosbridge_suite
- No changes
