### PR TITLE
kobuki_soft: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1603,6 +1603,25 @@ repositories:
       url: https://github.com/yujinrobot/kobuki_msgs.git
       version: kinetic
     status: maintained
+  kobuki_soft:
+    doc:
+      type: git
+      url: https://github.com/yujinrobot/kobuki_soft.git
+      version: kinetic
+    release:
+      packages:
+      - kobuki_soft
+      - kobuki_softapps
+      - kobuki_softnode
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/kobuki_soft-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/yujinrobot/kobuki_soft.git
+      version: kinetic
+    status: maintained
   korg_nanokontrol:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_soft` to `0.1.3-0`:
- upstream repository: https://github.com/yujinrobot/kobuki_soft
- release repository: https://github.com/yujinrobot-release/kobuki_soft-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## kobuki_soft

```
* remove yujin map dependency. update maintainer
* Contributors: Jihoon Lee
```
## kobuki_softapps

```
* remove yujin map dependency. update maintainer
* Contributors: Jihoon Lee
```
## kobuki_softnode

```
* remove yujin map dependency. update maintainer
* Contributors: Jihoon Lee
```
