### PR TITLE
phoxi_camera: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7615,6 +7615,13 @@ repositories:
       url: https://github.com/ccny-ros-pkg/phidgets_drivers.git
       version: indigo
     status: maintained
+  phoxi_camera:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/photoneo/phoxi_camera-release.git
+      version: 0.0.2-0
+    status: developed
   pi_tracker:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phoxi_camera` to `0.0.2-0`:
- upstream repository: https://github.com/photoneo/phoxi_camera.git
- release repository: https://github.com/photoneo/phoxi_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## phoxi_camera

```
* add gitignore
* Contributors: Matej Sladek
```
