### PR TITLE
navigation: 1.12.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6498,7 +6498,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.12.12-0
+      version: 1.12.13-0
     source:
       test_commits: false
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.12.13-0`:
- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.12.12-0`
## amcl
- No changes
## base_local_planner
- No changes
## carrot_planner
- No changes
## clear_costmap_recovery
- No changes
## costmap_2d

```
* Fixed race condition with costmaps
  Modifying minx_, miny_,, maxx_, and maxy_ without locking the mutex is
  unsafe and is a race condition if updateMap is called from multiple
  threads.
* Contributors: Alex Henning
```
## dwa_local_planner
- No changes
## fake_localization
- No changes
## global_planner
- No changes
## map_server
- No changes
## move_base

```
* Merge pull request #495 <https://github.com/ros-planning/navigation/issues/495> from corot/patch-3
  Fix #494 <https://github.com/ros-planning/navigation/issues/494>: prevent zero-velocity commands during recovery behaviors
* move_base: Add move_base_msgs to find_package.
* Issue #496 <https://github.com/ros-planning/navigation/issues/496>: add a max_planning_retries parameter as an alternative to planner_patience to limit the failed calls to global planner
* Fix #494 <https://github.com/ros-planning/navigation/issues/494>: prevent zero-velocity commands during recovery behaviors
  Partially reverts 0a686c90c6f188a2731f6f88c2c08610f0ec907e
* Contributors: Jorge Santos, Jorge Santos Simón, Maarten de Vries, Michael Ferguson
```
## move_base_msgs
- No changes
## move_slow_and_clear
- No changes
## nav_core
- No changes
## navfn
- No changes
## navigation
- No changes
## robot_pose_ekf
- No changes
## rotate_recovery
- No changes
## voxel_grid
- No changes
