### PR TITLE
marshmallow: 2.9.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5389,6 +5389,13 @@ repositories:
       url: https://github.com/swri-robotics/mapviz.git
       version: indigo-devel
     status: developed
+  marshmallow:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/marshmallow-rosrelease.git
+      version: 2.9.1-0
+    status: maintained
   marti_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marshmallow` to `2.9.1-0`:
- upstream repository: https://github.com/marshmallow-code/marshmallow.git
- release repository: https://github.com/asmodehn/marshmallow-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## marshmallow

```
Bug fixes:
* Fix serialization of ``datetime.time`` objects with microseconds (:issue:`464`). Thanks :user:`Tim-Erwin` for reporting and thanks :user:`vuonghv` for the fix.
* Make ``@validates`` consistent with field validator behavior: if validation fails, the field will not be included in the deserialized output (:issue:`391`). Thanks :user:`martinstein` for reporting and thanks :user:`@vuonghv` for the fix.
```
