### PR TITLE
adding python-certifi

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -341,7 +341,7 @@ python-celery:
   ubuntu: [python-celery]
 python-certifi:
   fedora: [python-certifi]
-  ubuntu: 
+  ubuntu:
     xenial: [python-certifi]
     yakkety: [python-certifi]
 python-chainer:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -340,6 +340,8 @@ python-celery:
   fedora: [python-celery]
   ubuntu: [python-celery]
 python-certifi:
+  debian:
+    stretch: [python-certifi]
   fedora: [python-certifi]
   ubuntu:
     xenial: [python-certifi]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -339,6 +339,11 @@ python-catkin-tools:
 python-celery:
   fedora: [python-celery]
   ubuntu: [python-celery]
+python-certifi:
+  fedora: [python-certifi]
+  ubuntu: 
+    xenial: [python-certifi]
+    yakkety: [python-certifi]
 python-chainer:
   osx:
     pip:


### PR DESCRIPTION
similar to click package : python-certifi is available in ubuntu since xenial.
I am also building third party release for indigo ( and up ...).
