### PR TITLE
certifi: 2015.11.20-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1136,6 +1136,13 @@ repositories:
       url: https://github.com/asmodehn/catkin_pip.git
       version: indigo-devel
     status: developed
+  certifi:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/certifi-rosrelease.git
+      version: 2015.11.20-0
+    status: maintained
   cit_adis_imu:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `certifi` to `2015.11.20-0`:
- upstream repository: https://github.com/certifi/python-certifi.git
- release repository: https://github.com/asmodehn/certifi-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
