### PR TITLE
pyros_config: 0.1.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8368,7 +8368,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/pyros-config-rosrelease.git
-      version: 0.1.3-0
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/asmodehn/pyros-config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_config` to `0.1.3-1`:
- upstream repository: https://github.com/asmodehn/pyros-config.git
- release repository: https://github.com/asmodehn/pyros-config-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.3-0`
## pyros_config

```
* Improved setup to do releases. removed ros files from master branch.
  [alexv]
* Improve self test. [AlexV]
* Reviewing tox and tests. [AlexV]
* Refining tox test command, importing more from __future__. [AlexV]
* Making check for string work with python3. [AlexV]
* Adding .idea folder to gitignore. [AlexV]
* Removing ROS and not using site-package, this is a pure python
  package. [alexv]
* Revert "improving travis files to test catkin_pip build with
  rosdistros." [alexv]This reverts commit 3c3bdd1d65f28f24bf3891ff1567e084b0dfb6bf.
* Improving travis files to test catkin_pip build with rosdistros.
  [alexv]
```
