### PR TITLE
mrp2_robot: 0.2.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6109,7 +6109,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/milvusrobotics/mrp2_robot-release.git
-      version: 0.2.4-0
+      version: 0.2.5-0
     source:
       type: git
       url: https://github.com/milvusrobotics/mrp2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrp2_robot` to `0.2.5-0`:
- upstream repository: https://github.com/milvusrobotics/mrp2_robot.git
- release repository: https://github.com/milvusrobotics/mrp2_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.4-0`
## mrp2_bringup

```
* Minor fixes
* Fixed bringup
* Implemented motor controller
* Solved hw problems. Updated parameters.
* Contributors: Akif
```
## mrp2_display

```
* Fixed bringup
* Fixed topic name
* Fixed voltage and added estop button led controller
* Minor fixes
* Solved hw problems. Updated parameters.
* Contributors: Bolkar Altuntas, Akif
```
## mrp2_hardware

```
* Removed redundant topics
* Fixed bringup
* Implemented motor controller
* Minor fixes
* Solved hw problems. Updated parameters.
* Contributors: Akif
```
## mrp2_robot
- No changes
