### PR TITLE
mrp2_common: 0.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6071,7 +6071,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/milvusrobotics/mrp2_common-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/milvusrobotics/mrp2_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrp2_common` to `0.2.3-0`:
- upstream repository: https://github.com/milvusrobotics/mrp2_common.git
- release repository: https://github.com/milvusrobotics/mrp2_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.2-0`
## mrp2_analyzer
- No changes
## mrp2_common
- No changes
## mrp2_control

```
* Enabled robot_localization
* Updated navigation
* Contributors: Akif
```
## mrp2_description

```
* Updated description sizes
* Contributors: Akif
```
## mrp2_navigation

```
* Enabled robot_localization
* Updated navigation
* Updated nav params & files
* Contributors: Akif
```
