### PR TITLE
ros_controllers: 0.11.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3456,7 +3456,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.11.1-0
+      version: 0.11.2-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.11.2-0`:
- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.11.1-0`
## diff_drive_controller
- No changes
## effort_controllers

```
* Included angles in dependencies
* Contributors: Mr-Yellow
```
## force_torque_sensor_controller
- No changes
## forward_command_controller
- No changes
## gripper_action_controller
- No changes
## imu_sensor_controller
- No changes
## joint_state_controller
- No changes
## joint_trajectory_controller
- No changes
## position_controllers
- No changes
## ros_controllers
- No changes
## rqt_joint_trajectory_controller

```
* Changes in import of Qt modules
* Contributors: Carlos J. Rosales Gallegos
```
## velocity_controllers
- No changes
