### PR TITLE
phoxi_camera: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7634,7 +7634,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/photoneo/phoxi_camera-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     status: developed
   pi_tracker:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `phoxi_camera` to `0.0.3-0`:
- upstream repository: https://github.com/photoneo/phoxi_camera.git
- release repository: https://github.com/photoneo/phoxi_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.2-0`
## phoxi_camera

```
* fix bug
* Contributors: Matej Sladek
```
