### PR TITLE
wireless: 0.0.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4709,6 +4709,24 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros.git
       version: jade-devel
     status: maintained
+  wireless:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/wireless.git
+      version: master
+    release:
+      packages:
+      - wireless_msgs
+      - wireless_watcher
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/wireless-release.git
+      version: 0.0.7-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/wireless.git
+      version: master
+    status: maintained
   world_canvas:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless` to `0.0.7-0`:
- upstream repository: https://github.com/clearpathrobotics/wireless.git
- release repository: https://github.com/clearpath-gbp/wireless-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## wireless_msgs

```
* Added frequency to watcher node
* Contributors: Alex Bencz
```
## wireless_watcher

```
* Added frequency to watcher node
* Contributors: Alex Bencz
```
