### PR TITLE
xsens_driver: 2.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6431,7 +6431,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ethz-asl/ethzasl_xsens_driver-release.git
-      version: 2.0.0-0
+      version: 2.0.1-0
     source:
       type: git
       url: https://github.com/ethz-asl/ethzasl_xsens_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xsens_driver` to `2.0.1-0`:
- upstream repository: https://github.com/ethz-asl/ethzasl_xsens_driver.git
- release repository: https://github.com/ethz-asl/ethzasl_xsens_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.0.0-0`
## xsens_driver

```
* fix TimeReference member name
* Contributors: Francis Colas
```
