### PR TITLE
[rosdep/base] Add dkms

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -601,6 +601,12 @@ disper:
   fedora: [disper]
   gentoo: [x11-apps/disper]
   ubuntu: [disper]
+dkms:
+  arch: [dkms]
+  debian: [dkms]
+  fedora: [dkms]
+  opensuse: [dkms]
+  ubuntu: [dkms]
 dnsmasq:
   fedora: [dnsmasq]
   gentoo: [net-dns/dnsmasq]


### PR DESCRIPTION
Added Dynamic Kernel Module Support Framework (dkms).

Needed to enable automatic kernel module rebuild for librealsense.
