### PR TITLE
turtlebot_simulator: 2.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4411,6 +4411,26 @@ repositories:
       url: https://github.com/turtlebot/turtlebot_msgs.git
       version: indigo
     status: maintained
+  turtlebot_simulator:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_simulator.git
+      version: indigo
+    release:
+      packages:
+      - turtlebot_gazebo
+      - turtlebot_simulator
+      - turtlebot_stage
+      - turtlebot_stdr
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/turtlebot-release/turtlebot_simulator-release.git
+      version: 2.2.2-0
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot_simulator.git
+      version: indigo
+    status: maintained
   tuw_geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_simulator` to `2.2.2-0`:
- upstream repository: https://github.com/turtlebot/turtlebot_simulator.git
- release repository: https://github.com/turtlebot-release/turtlebot_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## turtlebot_gazebo
- No changes
## turtlebot_simulator
- No changes
## turtlebot_stage

```
* view frame is now base_link closes #51 <https://github.com/turtlebot/turtlebot_simulator/issues/51>
* Contributors: Jihoon Lee
```
## turtlebot_stdr
- No changes
