### PR TITLE
robotis_math: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3165,6 +3165,21 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git
       version: kinetic-devel
     status: maintained
+  robotis_math:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-Math.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Math-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-Math.git
+      version: kinetic-devel
+    status: maintained
   robotnik_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_math` to `0.1.0-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Math.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Math-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## robotis_math

```
* first public release for Kinetic
* modified the package information files
* Add robotis_math, robotis_math is moved from ROBOTIS-Framework repository.
* Contributors: Jay-Song, pyo
```
