### PR TITLE
manipulator_h: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1850,6 +1850,30 @@ repositories:
       url: https://github.com/ros-interactive-manipulation/manipulation_msgs.git
       version: hydro-devel
     status: maintained
+  manipulator_h:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-MANIPULATOR-H.git
+      version: kinetic-devel
+    release:
+      packages:
+      - manipulator_h
+      - manipulator_h_base_module
+      - manipulator_h_base_module_msgs
+      - manipulator_h_bringup
+      - manipulator_h_description
+      - manipulator_h_gazebo
+      - manipulator_h_kinematics_dynamics
+      - manipulator_h_manager
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-MANIPULATOR-H-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-MANIPULATOR-H.git
+      version: kinetic-devel
+    status: maintained
   mapviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `manipulator_h` to `0.1.1-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-MANIPULATOR-H.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-MANIPULATOR-H-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## manipulator_h

```
* first public release for Kinetic
* applied the semantic versioning
* add a meta-package
* Contributors: pyo
```
## manipulator_h_base_module

```
* first public release for Kinetic
* Contributors: s-changhyun, pyo
```
## manipulator_h_base_module_msgs

```
* first public release for Kinetic
* Contributors: s-changhyun, pyo
```
## manipulator_h_bringup

```
* first public release for Kinetic
* Contributors: s-changhyun, pyo
```
## manipulator_h_description

```
* first public release for Kinetic
* Contributors: s-changhyun, pyo
```
## manipulator_h_gazebo

```
* first public release for Kinetic
* Contributors: s-changhyun, pyo
```
## manipulator_h_kinematics_dynamics

```
* first public release for Kinetic
* Contributors: s-changhyun, pyo
```
## manipulator_h_manager

```
* first public release for Kinetic
* Contributors: s-changhyun, pyo
```
