### PR TITLE
robotis_utility: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3204,6 +3204,24 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Math.git
       version: kinetic-devel
     status: maintained
+  robotis_utility:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-Utility.git
+      version: kinetic-devel
+    release:
+      packages:
+      - robotis_utility
+      - ros_mpg321_player
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Utility-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-Utility.git
+      version: kinetic-devel
+    status: maintained
   robotnik_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_utility` to `0.1.0-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Utility.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Utility-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
