### PR TITLE
thormang3_common: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4321,6 +4321,25 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  thormang3_common:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Common.git
+      version: kinetic-devel
+    release:
+      packages:
+      - thormang3_common
+      - thormang3_description
+      - thormang3_gazebo
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Common-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Common.git
+      version: kinetic-devel
+    status: maintained
   tiny_slam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_common` to `0.1.0-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Common.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## thormang3_common

```
* first public release for Kinetic
* Contributors: s-changhyun, pyo
```
## thormang3_description

```
* modified gripper pub
* applied ROS C++ Coding Style
* Contributors: ROBOTIS-zerom, s-changhyun, pyo
```
## thormang3_gazebo

```
* modified gripper pub
* changed controller name and topic name
* applied ROS C++ Coding Style
* Contributors: Jay-Song, ROBOTIS-zerom, s-changhyun
```
