### PR TITLE
remove libgstreamer-plugins-ugly1.0

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1013,9 +1013,9 @@ gstreamer1.0-plugins-good:
   fedora: [gstreamer1-plugins-good]
   ubuntu: [gstreamer1.0-plugins-good, libgstreamer-plugins-good1.0-0]
 gstreamer1.0-plugins-ugly:
-  debian: [gstreamer1.0-plugins-ugly, libgstreamer-plugins-ugly1.0-0]
+  debian: [gstreamer1.0-plugins-ugly]
   fedora: [gstreamer1-plugins-ugly]
-  ubuntu: [gstreamer1.0-plugins-ugly, libgstreamer-plugins-ugly1.0-0]
+  ubuntu: [gstreamer1.0-plugins-ugly]
 gstreamer1.0-tools:
   debian: [gstreamer1.0-tools]
   fedora: [gstreamer1]


### PR DESCRIPTION
It doesn't actually exist in Ubuntu Trusty or Xenial: http://packages.ubuntu.com/source/xenial/gst-plugins-ugly1.0
