### PR TITLE
thormang3_ppc: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4364,6 +4364,26 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-msgs.git
       version: kinetic-devel
     status: maintained
+  thormang3_ppc:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-PPC.git
+      version: kinetic-devel
+    release:
+      packages:
+      - thormang3_manipulation_demo
+      - thormang3_ppc
+      - thormang3_sensors
+      - thormang3_walking_demo
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-PPC-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-PPC.git
+      version: kinetic-devel
+    status: maintained
   tiny_slam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_ppc` to `0.1.0-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-PPC.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-PPC-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## thormang3_manipulation_demo

```
* ready for first release
* thormang3_manipulation_demo : applying coding style
* thormang3_manipulation_demo/CMakeLists.txt : remove include dir
* Contributors: Jay Song, SCH, Zerom, Pyo
```
## thormang3_ppc

```
* ready for first release
* Contributors: Jay Song, SCH, Zerom, Kayman, Pyo
```
## thormang3_sensors

```
* ready for first release
* add description in thormang3_sensors/package.xml
* thormang3_sensors : applying coding style
* Contributors: Jay Song, SCH, Zerom, Kayman, Pyo
```
## thormang3_walking_demo

```
* ready for first release
* modified thormang3_walking_demo/package.xml
* ROS C++ coding style is applied.
* modified include
* modified Code
  ROS C++ coding style is applied.
  running checking code is inserted
* Contributors: Jay-Song, SCH, Zerom, Pyo
```
