### PR TITLE
thormang3_opc: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4364,6 +4364,25 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-msgs.git
       version: kinetic-devel
     status: maintained
+  thormang3_opc:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-OPC.git
+      version: kinetic-devel
+    release:
+      packages:
+      - thormang3_action_script_player
+      - thormang3_foot_step_generator
+      - thormang3_opc
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-OPC-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-OPC.git
+      version: kinetic-devel
+    status: maintained
   tiny_slam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_opc` to `0.1.0-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-OPC.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-OPC-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## thormang3_action_script_player

```
* first public release for Kinetic
* modified arg of ros init
* added a fuction - action play for only specified joints
  modified action_script_player.cpp
  modified action_script.yaml
  modified message_callback.cpp for coding style
* modified thormang3_foot_step_generator for realtime control
  modified src in robotis_foot_step_generator.cpp and robotis_foot_step_generator.h
  modified msg file
  applied coding style
* enable stop button : thormang3_demo, walking
* ROS C++ coding style is applied.
* Change name of thormang3_motion_script_player to thormang3_action_script_player.
* Contributors: Jay Song, Kayman, Pyo
```
## thormang3_foot_step_generator

```
* first public release for Kinetic
* applied coding style
  modified thormang3_offset_tuner_client : dynamic UI
* step data can be changed in walking.
* modified thormang3_foot_step_generator for realtime control
* removed balance_param.yaml
* added thormang3_motion_script
  added thormang3_action_msgs
* modified thormang3_walking_module_msgs
  added demo : manipulation, walking
* Contributors: Jay Song, Zerom, Kayman, Pyo
```
## thormang3_opc

```
* first public release for Kinetic
```
