### PR TITLE
wts_driver: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13545,6 +13545,17 @@ repositories:
       url: https://github.com/RIVeR-Lab/wpi_jaco.git
       version: develop
     status: maintained
+  wts_driver:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ksatyaki/wts_driver-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/ksatyaki/wts_driver.git
+      version: 1.0.1
+    status: developed
   wu_ros_tools:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13554,7 +13554,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ksatyaki/wts_driver.git
-      version: 1.0.1
+      version: master
     status: developed
   wu_ros_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `wts_driver` to `1.0.1-0`:
- upstream repository: https://github.com/ksatyaki/wts_driver.git
- release repository: https://github.com/ksatyaki/wts_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## wts_driver

```
* First version
* Contributors: Chittaranjan Srinivas Swaminathan, Chittaranjan Swaminathan Srinivas
```
