### PR TITLE
teb_local_planner: 0.4.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12255,7 +12255,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
-      version: 0.4.2-0
+      version: 0.4.3-0
     source:
       type: git
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner` to `0.4.3-0`:
- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.4.2-0`
## teb_local_planner

```
* Changed the f0 function for calculating the H-Signature.
  The new one seems to be more robust for a much larger number of obstacles
  after some testing.
* HomotopyClassPlanner: vertex collision check removed since collisions will be determined in the edge collision check again
* Fixed distance calculation polygon-to-polygon-obstacle
* Enlarged upper bounds on goal position and orientation tolerances in *dynamic_reconfigure*. Fixes #13.
```
