### PR TITLE
[rosdep/python] Add easygui

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -561,16 +561,8 @@ python-docx:
     pip: [python-docx]
 python-easygui:
   debian: [python-easygui]
-  ubuntu:
-    precise: [python-easygui]
-    quantal: [python-easygui]
-    raring: [python-easygui]
-    saucy: [python-easygui]
-    trusty: [python-easygui]
-    utopic: [python-easygui]
-    vivid: [python-easygui]
-    wily: [python-easygui]
-    xenial: [python-easygui]
+  fedora: [python-easygui]
+  ubuntu: [python-easygui]
 python-empy:
   arch: [python2-empy]
   debian: [python-empy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -559,6 +559,18 @@ python-docx:
   fedora: [python-docx]
   ubuntu:
     pip: [python-docx]
+python-easygui:
+  debian: [python-easygui]
+  ubuntu:
+    precise: [python-easygui]
+    quantal: [python-easygui]
+    raring: [python-easygui]
+    saucy: [python-easygui]
+    trusty: [python-easygui]
+    utopic: [python-easygui]
+    vivid: [python-easygui]
+    wily: [python-easygui]
+    xenial: [python-easygui]
 python-empy:
   arch: [python2-empy]
   debian: [python-empy]


### PR DESCRIPTION
Added easygui python module. This is a simple standalone python gui module that allows textentry, dialog boxes, etc.

This is useful for fetching user preferences for loading/saving files within RViz when used in coordination with the interactive_markers menu interface.
