### PR TITLE
robotis_framework: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3183,7 +3183,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_framework` to `0.1.1-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.0-0`
## robotis_controller

```
* updated the package information
```
## robotis_device

```
* updated the package information
```
## robotis_framework

```
* updated the package information
```
## robotis_framework_common

```
* updated the package information
```
