### PR TITLE
marker_msgs: 0.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1903,7 +1903,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tuw-robotics/marker_msgs-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/tuw-robotics/marker_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marker_msgs` to `0.0.4-0`:
- upstream repository: https://github.com/tuw-robotics/marker_msgs.git
- release repository: https://github.com/tuw-robotics/marker_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.3-0`
## marker_msgs

```
* build system cleanup
* Contributors: Markus Bader
```
