### PR TITLE
ros_control: 0.11.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3479,7 +3479,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.11.0-0
+      version: 0.11.1-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.11.1-0`:
- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.11.0-0`
## combined_robot_hw
- No changes
## combined_robot_hw_tests
- No changes
## controller_interface

```
* Fix the example in the comments in multi_interface_controller.h.
* Contributors: Miguel Prada
```
## controller_manager
- No changes
## controller_manager_msgs
- No changes
## controller_manager_tests
- No changes
## hardware_interface
- No changes
## joint_limits_interface
- No changes
## ros_control
- No changes
## rqt_controller_manager

```
* Qt5 migration
* Contributors: Bence Magyar
```
## transmission_interface
- No changes
