### PR TITLE
manipulator_h: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1863,12 +1863,13 @@ repositories:
       - manipulator_h_bringup
       - manipulator_h_description
       - manipulator_h_gazebo
+      - manipulator_h_gui
       - manipulator_h_kinematics_dynamics
       - manipulator_h_manager
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-MANIPULATOR-H-release.git
-      version: 0.1.1-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-MANIPULATOR-H.git


### PR DESCRIPTION
Increasing version of package(s) in repository `manipulator_h` to `0.2.0-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-MANIPULATOR-H.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-MANIPULATOR-H-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.1-0`
## manipulator_h

```
* added manipulator_h_gui package that GUI tool to control ROBOTIS MANIPULATOR-H
```
## manipulator_h_base_module

```
* added manipulator_h_gui package that GUI tool to control ROBOTIS MANIPULATOR-H
```
## manipulator_h_base_module_msgs

```
* added manipulator_h_gui package that GUI tool to control ROBOTIS MANIPULATOR-H
```
## manipulator_h_bringup

```
* added manipulator_h_gui package that GUI tool to control ROBOTIS MANIPULATOR-H
```
## manipulator_h_description

```
* added manipulator_h_gui package that GUI tool to control ROBOTIS MANIPULATOR-H
```
## manipulator_h_gazebo

```
* added manipulator_h_gui package that GUI tool to control ROBOTIS MANIPULATOR-H
```
## manipulator_h_gui

```
* added manipulator_h_gui package that GUI tool to control ROBOTIS MANIPULATOR-H
* Contributors: s-changhyun, pyo
```
## manipulator_h_kinematics_dynamics

```
* added manipulator_h_gui package that GUI tool to control ROBOTIS MANIPULATOR-H
```
## manipulator_h_manager

```
* added manipulator_h_gui package that GUI tool to control ROBOTIS MANIPULATOR-H
```
