### PR TITLE
thormang3_tools: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4423,6 +4423,24 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-PPC.git
       version: kinetic-devel
     status: maintained
+  thormang3_tools:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Tools.git
+      version: kinetic-devel
+    release:
+      packages:
+      - thormang3_offset_tuner_server
+      - thormang3_tools
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Tools-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Tools.git
+      version: kinetic-devel
+    status: maintained
   tiny_slam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_tools` to `0.1.0-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Tools.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## thormang3_offset_tuner_server

```
* first public release for Kinetic
* modified thormang3_offset_tuner_server/CMakeLists.txt (.cpp file name)
* ROS C++ Coding Style is applied.
* modified thormang3_offset_tuner_server.launch
* modified CMakelist.txt / change executable name
* launch param name changed.
* Contributors: Jay Song, Zerom, Pyo
```
## thormang3_tools

```
* first public release for Kinetic
```
