### PR TITLE
thormang3_mpc: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4358,7 +4358,6 @@ repositories:
     release:
       packages:
       - ati_ft_sensor
-      - imu_3dm_gx4
       - motion_module_tutorial
       - sensor_module_tutorial
       - thormang3_action_module
@@ -4366,6 +4365,7 @@ repositories:
       - thormang3_base_module
       - thormang3_feet_ft_module
       - thormang3_head_control_module
+      - thormang3_imu_3dm_gx4
       - thormang3_kinematics_dynamics
       - thormang3_manager
       - thormang3_manipulation_module
@@ -4374,7 +4374,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-MPC-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-MPC.git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_mpc` to `0.1.1-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-MPC.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-MPC-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.0-0`
## ati_ft_sensor

```
* none
```
## motion_module_tutorial

```
* none
```
## sensor_module_tutorial

```
* none
```
## thormang3_action_module

```
* none
```
## thormang3_balance_control

```
* none
```
## thormang3_base_module

```
* none
```
## thormang3_feet_ft_module

```
* none
```
## thormang3_head_control_module

```
* none
```
## thormang3_imu_3dm_gx4

```
* bug fix
* package name changed
  imu_3dm_gx4 -> thormang3_imu_3dm_gx4
* Contributors: Jay Song
```
## thormang3_kinematics_dynamics

```
* none
```
## thormang3_manager

```
* package name changed
  imu_3dm_gx4 -> thormang3_imu_3dm_gx4
* Contributors: Jay-Song
```
## thormang3_manipulation_module

```
* none
```
## thormang3_mpc

```
* bug fix
* package name changed
  imu_3dm_gx4 -> thormang3_imu_3dm_gx4
* Contributors: Jay Song
```
## thormang3_walking_module

```
* modify CMakeLists.txt for sync
* file name is changed
* bug fix
* Contributors: Jay Song
```
