### PR TITLE
agvs_sim: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -77,7 +77,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotnikAutomation/agvs_sim-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/agvs_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `agvs_sim` to `0.1.3-0`:
- upstream repository: https://github.com/RobotnikAutomation/agvs_sim.git
- release repository: https://github.com/RobotnikAutomation/agvs_sim-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.2-0`
## agvs_control
- No changes
## agvs_gazebo

```
* fixed gazebo package.xml
* Contributors: carlos3dx
```
## agvs_robot_control
- No changes
## agvs_sim
- No changes
## agvs_sim_bringup
- No changes
