### PR TITLE
thormang3_opc: 0.2.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4404,6 +4404,26 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-msgs.git
       version: kinetic-devel
     status: maintained
+  thormang3_opc:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-OPC.git
+      version: kinetic-devel
+    release:
+      packages:
+      - thormang3_action_script_player
+      - thormang3_foot_step_generator
+      - thormang3_offset_tuner_client
+      - thormang3_opc
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-OPC-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-OPC.git
+      version: kinetic-devel
+    status: maintained
   thormang3_ppc:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_opc` to `0.2.0-1`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-OPC.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-OPC-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## thormang3_action_script_player

```
* added thormang3_offset_tuner_client package
```
## thormang3_foot_step_generator

```
* added thormang3_offset_tuner_client package
```
## thormang3_offset_tuner_client

```
* added thormang3_offset_tuner_client package
```
## thormang3_opc

```
* added thormang3_offset_tuner_client package
```
