### PR TITLE
update turtlebot to use the kinetic development branch

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4496,7 +4496,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/turtlebot/turtlebot.git
-      version: indigo
+      version: kinetic
     release:
       packages:
       - turtlebot
@@ -4512,7 +4512,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/turtlebot/turtlebot.git
-      version: indigo
+      version: kinetic
     status: maintained
   turtlebot_apps:
     doc:


### PR DESCRIPTION
This will retarget the pr builds to support this: https://github.com/turtlebot/turtlebot/pull/230 and retargeting this https://github.com/turtlebot/turtlebot/pull/226 
