### PR TITLE
moveit_msgs: 0.8.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2613,7 +2613,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/moveit_msgs-release.git
-      version: 0.8.1-0
+      version: 0.8.2-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `0.8.2-0`:
- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/ros-gbp/moveit_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.8.1-0`
## moveit_msgs

```
* Add ExecuteTrajectory.action for execution trajectory in a ROS action (#24 <https://github.com/ros-planning/moveit_msgs/issues/24>), (#27 <https://github.com/ros-planning/moveit_msgs/issues/27>)
* [fix] Update maintainers. Bad encoding. #26 <https://github.com/ros-planning/moveit_msgs/issues/26>
* Contributors: Kentaro Wada, Isaac I.Y. Saito
```
