### PR TITLE
rospilot: 1.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3778,6 +3778,17 @@ repositories:
       url: https://github.com/davetcoleman/rosparam_shortcuts.git
       version: kinetic-devel
     status: maintained
+  rospilot:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/rospilot/rospilot-release.git
+      version: 1.3.0-0
+    source:
+      type: git
+      url: https://github.com/rospilot/rospilot.git
+      version: kinetic
+    status: developed
   rospy_message_converter:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot` to `1.3.0-0`:
- upstream repository: https://github.com/rospilot/rospilot.git
- release repository: https://github.com/rospilot/rospilot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## rospilot

```
* Initialize source frame data structure
* Update init script to Kinetic
* Set CherryPy to production instead of manually configuring it
* Use npm for build
* Use more canonical license string
* Fix scoping in set waypoint callback
* Improve mavlink wait logic to be interruptable
* Fix retry logic for serial mavlink
* Migrate to Angular 2.0
* Add timeout to waypoint fetching
  Previously, if a message was lost waypoints would no longer be fetched
  and new ones could not be set
* Contributors: Christopher Berner
```
