### PR TITLE
mrpt_navigation: 0.1.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2141,7 +2141,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 0.1.10-0
+      version: 0.1.11-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `0.1.11-0`:
- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.10-0`
## mrpt_bridge

```
* fix unit test error due to uninitialized tf::Pose
* fix deprecated PCL header
* Add landmark to bridge.
* Contributors: Jose-Luis Blanco-Claraco, Logrus
```
## mrpt_local_obstacles
- No changes
## mrpt_localization
- No changes
## mrpt_map
- No changes
## mrpt_msgs

```
* Add landmark to bridge.
* Contributors: Logrus
```
## mrpt_navigation
- No changes
## mrpt_rawlog

```
* fix missing #include
* Add wheeled robot example and 2d ekf.
* Add landmark to bridge.
* Contributors: Jose Luis Blanco, Logrus
```
## mrpt_reactivenav2d
- No changes
## mrpt_tutorials
- No changes
