### PR TITLE
[jade] Remove some moveit_* packages that are consolidated into a new single repository.

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2552,37 +2552,6 @@ repositories:
       url: https://github.com/strands-project/mongodb_store.git
       version: hydro-devel
     status: developed
-  moveit_commander:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/moveit_commander.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/moveit_commander-release.git
-      version: 0.6.1-0
-    source:
-      type: git
-      url: https://github.com/ros-planning/moveit_commander.git
-      version: indigo-devel
-    status: maintained
-  moveit_core:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/moveit_core.git
-      version: jade-devel
-    release:
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/moveit_core-release.git
-      version: 0.8.2-0
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ros-planning/moveit_core.git
-      version: jade-devel
-    status: maintained
   moveit_experimental:
     doc:
       type: git
@@ -2619,43 +2588,6 @@ repositories:
       url: https://github.com/ros-planning/moveit_msgs.git
       version: jade-devel
     status: developed
-  moveit_planners:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/moveit_planners.git
-      version: indigo-devel
-    release:
-      packages:
-      - moveit_planners
-      - moveit_planners_ompl
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/moveit_planners-release.git
-      version: 0.6.7-0
-    source:
-      type: git
-      url: https://github.com/ros-planning/moveit_planners.git
-      version: indigo-devel
-    status: maintained
-  moveit_plugins:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/moveit_plugins.git
-      version: jade-devel
-    release:
-      packages:
-      - moveit_fake_controller_manager
-      - moveit_plugins
-      - moveit_simple_controller_manager
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/moveit_plugins-release.git
-      version: 0.5.6-0
-    source:
-      type: git
-      url: https://github.com/ros-planning/moveit_plugins.git
-      version: jade-devel
-    status: maintained
   moveit_python:
     doc:
       type: git
@@ -2673,48 +2605,6 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/moveit_resources-release.git
       version: 0.5.0-0
-    status: maintained
-  moveit_ros:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/moveit_ros.git
-      version: jade-devel
-    release:
-      packages:
-      - moveit_ros
-      - moveit_ros_benchmarks
-      - moveit_ros_benchmarks_gui
-      - moveit_ros_manipulation
-      - moveit_ros_move_group
-      - moveit_ros_perception
-      - moveit_ros_planning
-      - moveit_ros_planning_interface
-      - moveit_ros_robot_interaction
-      - moveit_ros_visualization
-      - moveit_ros_warehouse
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.6.6-0
-    source:
-      type: git
-      url: https://github.com/ros-planning/moveit_ros.git
-      version: jade-devel
-    status: maintained
-  moveit_setup_assistant:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/moveit_setup_assistant.git
-      version: jade-devel
-    release:
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
-      version: 0.7.1-0
-    source:
-      type: git
-      url: https://github.com/ros-planning/moveit_setup_assistant.git
-      version: jade-devel
     status: maintained
   moveit_sim_controller:
     doc:


### PR DESCRIPTION
Once this gets merged a new release from https://github.com/ros-planning/moveit.git will be made.
