### PR TITLE
moveit: 0.8.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2552,6 +2552,44 @@ repositories:
       url: https://github.com/strands-project/mongodb_store.git
       version: hydro-devel
     status: developed
+  moveit:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit.git
+      version: jade-devel
+    release:
+      packages:
+      - moveit
+      - moveit_commander
+      - moveit_controller_manager_example
+      - moveit_core
+      - moveit_fake_controller_manager
+      - moveit_planners
+      - moveit_planners_ompl
+      - moveit_plugins
+      - moveit_ros
+      - moveit_ros_benchmarks
+      - moveit_ros_benchmarks_gui
+      - moveit_ros_control_interface
+      - moveit_ros_manipulation
+      - moveit_ros_move_group
+      - moveit_ros_perception
+      - moveit_ros_planning
+      - moveit_ros_planning_interface
+      - moveit_ros_robot_interaction
+      - moveit_ros_visualization
+      - moveit_ros_warehouse
+      - moveit_setup_assistant
+      - moveit_simple_controller_manager
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/moveit-release.git
+      version: 0.8.3-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit.git
+      version: jade-devel
+    status: developed
   moveit_experimental:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.8.3-0`:
- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## moveit

```
* [Jade] Unify package version numbers (see https://github.com/davetcoleman/moveit_merge/issues/9). (#79 <https://github.com/ros-planning/moveit/issues/79>)
* Add meta package moveit.
* Contributors: Isaac I.Y. Saito
```
## moveit_commander

```
* 1st release after repository consolidation
* [feat] Add retime_trajectory() to MoveGroupCommander #29 <https://github.com/ros-planning/moveit_commander/pull/29>
* [feat] Added set_max_velocity_scaling_factor function to move_group.py
* Contributors: Dave Coleman, Michael Goerner, Robert Haschke
```
## moveit_core

```
* 1st release after repository consolidation
* [fix] Add object types when requesting attached bodies in planning scene msg. pushDiff also pushes attached bodies' types and colors
* [improve] Cache robot FCL objects to avoid fcl::CollisionObject's being created every time a request is made ros-planning/moveit_core#295 <https://github.com/ros-planning/moveit_core/pull/295>
* [feat] Added maximum acceleration scaling factor ros-planning/moveit_core#273 <https://github.com/ros-planning/moveit_core/pull/273>
* Contributors: Levi Armstrong, Dave Coleman, Christian Dornhege, hemes, Michael Goerner, Robert Haschke, Maarten de Vries
```
## moveit_planners

```
* 1st release after repository consolidation
* [feat] Enables setting optimization objectives from ompl_planning.yaml ros-planning/moveit_planners#75 <https://github.com/ros-planning/moveit_planners/pull/75>
* [doc] Short tutorial for using ompl optimization config. ros-planning/moveit_planners#75 <https://github.com/ros-planning/moveit_planners/pull/75>
* Contributors: Ruben Burger, Dave Coleman, Robert Haschke, Maarten de Vries
```
## moveit_plugins

```
* 1st release after repository consolidation
* [fix] FakeController: publish all trajectory points in real time ros-planning/moveit_plugins#21 <https://github.com/ros-planning/moveit_plugins/pull/21>
* [fix] install plugin xml even if it's no functional controller ros-planning/moveit_plugins#19 <https://github.com/ros-planning/moveit_plugins/pull/19>
* [fix] Jade fix ROS Control API changes ros-planning/moveit_plugins#15 <https://github.com/ros-planning/moveit_plugins/pull/15>
* Contributors: Dave Coleman, Robert Haschke, Michael Goener, Maarten de Vries
```
## moveit_ros

```
* 1st release after repository consolidation
* [fix] Properly monitor trajectory execution ros-planning/moveit#72 <https://github.com/ros-planning/moveit/pull/72>
* [fix] trajectory service blocking callback queue ros-planning/moveit_ros#717 <https://github.com/ros-planning/moveit_ros/pull/717>
* [fix] Empty Robot Model ros-planning/moveit#45 <https://github.com/ros-planning/moveit/pull/45>
* [fix] Allow minimum value 0.0 for jump_factor ros-planning/moveit_ros#727 <https://github.com/ros-planning/moveit_ros/pull/727>
* [fix] joy: Clean installation ros-planning/moveit_ros#704 <https://github.com/ros-planning/moveit_ros/pull/704>
* [fix] Re-enable warehouse_ros ros-planning/moveit_ros#699 <https://github.com/ros-planning/moveit_ros/pull/699>
* [fix] MoveGroup class_loader::LibraryUnloadException on destruction ros-planning/moveit_ros#706 <https://github.com/ros-planning/moveit_ros/pull/706>
* [fix] planning_interface: Set is_diff true for empty start state ros-planning/moveit_ros#688 <https://github.com/ros-planning/moveit_ros/pull/688>
* [feat] rviz plugin: stop execution + update of start state to current ros-planning/moveit_ros/713 <https://github.com/ros-planning/moveit_ros/pull/713>
* [feat] add velocity & acceleration values to cartesian trajectory ros-planning/moveit_ros#735 <https://github.com/ros-planning/moveit_ros/pull/735>
* [feat] Added kinematics plugin that uses Levenberg-Marquardt method ros-planning/moveit_ros#740 <https://github.com/ros-planning/moveit_ros/pull/740>
* [feat] Add nodehandle for specific params ros-planning/moveit_ros#707 <https://github.com/ros-planning/moveit_ros/pull/707>
* [feat] Added support for nodes handles with specific callbacks queues ros-planning/moveit_ros#701 <https://github.com/ros-planning/moveit_ros#701>
* [feat] Extended planning_interface::PlanningSceneInterface `ros-planning/moveit_ros/issues/630 https://github.com/ros-planning/moveit_ros/issues/630>`_
* [feat] add ApplyPlanningSceneService capability ros-planning/moveit_ros#686 <https://github.com/ros-planning/moveit_ros/pull/686>
* [improve] Improve fillGrasp method for pick("object_name") interface ros-planning/moveit#31 <https://github.com/ros-planning/moveit/pull/31>
* Contributors: anderwm, chengshy, Dave Coleman, Yannick Jonetzko, Robert Haschke, Michael Goener, Isaac I. Y. Saito, Alain Sanguinetti, Jorge Santos Simon, Maarten de Vries, Kentaro Wada
```
## moveit_setup_assistant

```
* 1st release after repository consolidation
* [fix] msa: push traj exec monitor params down int proper nsroper ns ros-planning/moveit#68 <https://github.com/ros-planning/moveit/pull/68>
* [fix] write float numbers always in POSIX format ros-planning/moveit_setup_assistant#123 <https://github.com/ros-planning/moveit_setup_assistant/pull/123>
* Contributors: G.A. vd. Hoorn
```
