### PR TITLE
mrpt_slam: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6171,6 +6171,17 @@ repositories:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
       version: master
+    release:
+      packages:
+      - mrpt_ekf_slam_2d
+      - mrpt_ekf_slam_3d
+      - mrpt_icp_slam_2d
+      - mrpt_rbpf_slam
+      - mrpt_slam
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_slam` to `0.1.1-0`:
- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_slam.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## mrpt_ekf_slam_2d

```
* First public version, as a result of Vladislav Tananaev's GSoC2016 work.
* Contributors: Jose Luis Blanco, Logrus
```
## mrpt_ekf_slam_3d

```
* First public version, as a result of Vladislav Tananaev's GSoC2016 work.
* Skip mrpt_ekf_slam_3d if version of MRPT is lower than 1.5.0.
* Contributors: Jose Luis Blanco, Logrus
```
## mrpt_icp_slam_2d

```
* First public version, as a result of Vladislav Tananaev's GSoC2016 work.
* Contributors: Jose Luis Blanco, Logrus, Raphael Zack
```
## mrpt_rbpf_slam

```
* First public version, as a result of Vladislav Tananaev's GSoC2016 work.
* Contributors: Jose Luis Blanco, Logrus
```
## mrpt_slam

```
* First public version, as a result of Vladislav Tananaev's GSoC2016 work.
* Contributors: Jose Luis Blanco, Jose Luis Blanco-Claraco, Logrus
```
