### PR TITLE
transforms3d: 0.3.0-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4524,6 +4524,13 @@ repositories:
       url: https://bitbucket.org/traclabs/trac_ik.git
       version: no_moveit_plugin-kinetic
     status: developed
+  transforms3d:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/dronecrew/transforms3d-release.git
+      version: 0.3.0-3
+    status: developed
   turtlebot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `transforms3d` to `0.3.0-3`:
- upstream repository: https://github.com/matthew-brett/transforms3d
- release repository: https://github.com/dronecrew/transforms3d-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
