### PR TITLE
grid_map: 1.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3197,11 +3197,12 @@ repositories:
       - grid_map_loader
       - grid_map_msgs
       - grid_map_ros
+      - grid_map_rviz_plugin
       - grid_map_visualization
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-asl/grid_map-release.git
-      version: 1.3.1-0
+      version: 1.4.0-0
     source:
       type: git
       url: https://github.com/ethz-asl/grid_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `1.4.0-0`:
- upstream repository: https://github.com/ethz-asl/grid_map.git
- release repository: https://github.com/ethz-asl/grid_map-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.3.1-0`
## grid_map

```
* Added new package grid_map_rviz_plugin.
* Contributors: Peter Fankhauser
```
## grid_map_core

```
* Added convenience function to convert a grid map to form with circular buffer at (0,0).
* Contributors: Peter Fankhauser
```
## grid_map_cv
- No changes
## grid_map_demos

```
* Added Grid Map RViz plugin to RViz configuration.
* Contributors: Peter Fankhauser
```
## grid_map_filters
- No changes
## grid_map_loader
- No changes
## grid_map_msgs
- No changes
## grid_map_ros
- No changes
## grid_map_rviz_plugin

```
* Added new package grid_map_rviz_plugin to visualize grid map layers as 3d surfaces.
* Updated documentation.
* Contributors: Péter Fankhauser, Philipp Kruesi
```
## grid_map_visualization
- No changes
