### PR TITLE
denso: 1.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1882,7 +1882,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/start-jsk/denso-release.git
-      version: 1.1.6-0
+      version: 1.1.7-0
     source:
       type: git
       url: https://github.com/start-jsk/denso.git


### PR DESCRIPTION
Increasing version of package(s) in repository `denso` to `1.1.7-0`:
- upstream repository: https://github.com/start-jsk/denso.git
- release repository: https://github.com/start-jsk/denso-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.1.6-0`
## denso
- No changes
## denso_controller
- No changes
## denso_launch
- No changes
## vs060

```
* publish_simple_scene.py : quit due to https://github.com/ros-planning/moveit_commander/pull/46/files and wait untel 3 collision object has been published
* Contributors: Kei Okada
```
## vs060_gazebo
- No changes
## vs060_moveit_config
- No changes
