### PR TITLE
moveit_msgs: 0.8.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2621,7 +2621,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/moveit_msgs-release.git
-      version: 0.8.2-0
+      version: 0.8.3-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `0.8.3-0`:
- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/ros-gbp/moveit_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.8.2-0`
## moveit_msgs

```
* [fix] broken maintainer tags (#28 <https://github.com/ros-planning/moveit_msgs/issues/28>)
* Contributors: Michael Goerner
```
