### PR TITLE
add lua 5.2 support

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2942,6 +2942,10 @@ lua-dev:
     spherical: [lua-devel]
   macports: [lua51]
   ubuntu: [liblua5.1-0-dev]
+lua5.2-dev:
+  debian: [liblua5.2-dev]
+  fedora: [lua]
+  ubuntu: [liblua5.2-dev]
 lz4:
   arch: [lz4]
   debian: [liblz4-dev]


### PR DESCRIPTION
It appears to be side by side installable with 5.1 

Debian: https://packages.debian.org/jessie/liblua5.2-dev
Fedora: https://admin.fedoraproject.org/pkgdb/package/rpms/lua/ (appears to be possibly 5.3 now)
Ubuntu: http://packages.ubuntu.com/xenial/liblua5.2-dev

https://admin.fedoraproject.org/pkgdb/package/rpms/lua/
