### PR TITLE
Added moveit_tutorials to rosdoc job

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6049,6 +6049,11 @@ repositories:
       url: https://github.com/davetcoleman/moveit_simple_grasps.git
       version: indigo-devel
     status: end-of-life
+  moveit_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_tutorials.git
+      version: master
   moveit_visual_tools:
     doc:
       type: git


### PR DESCRIPTION
I hope this is all is needed to generate rosdoc output but not release the package. I might need some help finding the link to where it generates the output

@tfoote this is what we want to run more often than nightly the next 24 hours

For more details: https://github.com/ros-planning/moveit/issues/36#issuecomment-241596120
