### PR TITLE
phoxi_camera: 1.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7671,7 +7671,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/photoneo/phoxi_camera-release.git
-      version: 0.0.2-0
+      version: 1.1.3-0
     status: developed
   pi_tracker:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `phoxi_camera` to `1.1.3-0`:
- upstream repository: https://github.com/photoneo/phoxi_camera.git
- release repository: https://github.com/photoneo/phoxi_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.2-0`
## phoxi_camera
- No changes
