### PR TITLE
sparse_bundle_adjustment: 0.3.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5624,6 +5624,17 @@ repositories:
       url: https://github.com/stonier/sophus.git
       version: jade
     status: maintained
+  sparse_bundle_adjustment:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/sparse_bundle_adjustment.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
+      version: 0.3.2-0
+    status: maintained
   spatial_temporal_learning:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sparse_bundle_adjustment` to `0.3.2-0`:
- upstream repository: https://github.com/ros-perception/sparse_bundle_adjustment.git
- release repository: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## sparse_bundle_adjustment

```
* major build/install fixes for the farm
* Contributors: Michael Ferguson
```
