### PR TITLE
slam_karto: 0.7.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5598,6 +5598,17 @@ repositories:
       url: https://github.com/ros-perception/slam_gmapping.git
       version: hydro-devel
     status: developed
+  slam_karto:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/slam_karto.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/slam_karto-release.git
+      version: 0.7.3-0
+    status: maintained
   smart_battery_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_karto` to `0.7.3-0`:
- upstream repository: https://github.com/ros-perception/slam_karto.git
- release repository: https://github.com/ros-gbp/slam_karto-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## slam_karto

```
* fixed the upside-down detection
* update maintainer email
* Contributors: Michael Ferguson, mgerdzhev
```
