### PR TITLE
moveit_python: 0.2.17-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2134,6 +2134,17 @@ repositories:
       url: https://github.com/ros-planning/moveit_msgs.git
       version: jade-devel
     status: maintained
+  moveit_python:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/moveit_python.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/mikeferguson/moveit_python-release.git
+      version: 0.2.17-0
+    status: developed
   mrpt_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_python` to `0.2.17-0`:
- upstream repository: https://github.com/mikeferguson/moveit_python.git
- release repository: https://github.com/mikeferguson/moveit_python-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## moveit_python

```
* Merge pull request #9 <https://github.com/mikeferguson/moveit_python/issues/9> from mikeferguson/pyassimp_fix
  pyassimp is broken in 16.04, temporary work around so we can release
* Contributors: Michael Ferguson
```
