### PR TITLE
simple_grasping: 0.2.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5580,6 +5580,17 @@ repositories:
       url: https://github.com/ros-gbp/sicktoolbox_wrapper-release.git
       version: 2.5.3-0
     status: maintained
+  simple_grasping:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/simple_grasping.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/simple_grasping-release.git
+      version: 0.2.2-0
+    status: developed
   slam_gmapping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_grasping` to `0.2.2-0`:
- upstream repository: https://github.com/mikeferguson/simple_grasping.git
- release repository: https://github.com/fetchrobotics-gbp/simple_grasping-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## simple_grasping

```
* parameterize gripper opening tolerance
* Contributors: Michael Ferguson
```
