### PR TITLE
robot_model: 1.12.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3197,7 +3197,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.12.3-0
+      version: 1.12.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.12.4-0`:
- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.12.3-0`
## collada_parser
- No changes
## collada_urdf

```
* Use the C++11 standard (#145 <https://github.com/ros/robot_model/issues/145>)
* Contributors: William Woodall
```
## joint_state_publisher
- No changes
## kdl_parser
- No changes
## kdl_parser_py
- No changes
## robot_model
- No changes
## urdf
- No changes
## urdf_parser_plugin
- No changes
