### PR TITLE
geometric_shapes: 0.5.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1094,7 +1094,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.4.4-0
+      version: 0.5.1-0
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.5.1-0`:
- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.4.4-0`
## geometric_shapes

```
* add c++11 safe-guards to the respective headers (#51 <https://github.com/ros-planning/geometric_shapes/issues/51>)
  This is, to be polite and point problems that might arise it out to users.
* Fix incorrect hint always sent to Assimp, improved STL reading (#24 <https://github.com/ros-planning/geometric_shapes/issues/24>)
* Contributors: Dave Coleman, Michael Görner
```
