### PR TITLE
summit_xl_common: 1.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12194,7 +12194,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/summit_xl_common-release.git
-      version: 1.0.5-0
+      version: 1.0.9-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_xl_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_xl_common` to `1.0.9-0`:
- upstream repository: https://github.com/RobotnikAutomation/summit_xl_common.git
- release repository: https://github.com/RobotnikAutomation/summit_xl_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.5-0`
## summit_xl_common
- No changes
## summit_xl_description

```
* description: added orbbec camera to the frontal robot area
* Contributors: RomanRobotnik
```
## summit_xl_localization

```
* Adding install rules
* Deleting unused files
* Added rl_utils.launch
* Contributors: Jorge Arino, summit
```
## summit_xl_navigation

```
* Deleting unused files
* Contributors: Jorge Arino
```
## summit_xl_pad

```
* Adding install rules
* Contributors: Jorge Arino
```
