### PR TITLE
summit_x_sim: 1.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12170,10 +12170,11 @@ repositories:
       - summit_x_gazebo
       - summit_x_robot_control
       - summit_x_sim
+      - summit_x_sim_bringup
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/summit_x_sim-release.git
-      version: 1.0.5-0
+      version: 1.0.7-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_x_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_x_sim` to `1.0.7-0`:
- upstream repository: https://github.com/RobotnikAutomation/summit_x_sim.git
- release repository: https://github.com/RobotnikAutomation/summit_x_sim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.5-0`
## summit_x_control

```
* updated changelog
* Contributors: carlos3dx
```
## summit_x_gazebo

```
* updated changelog
* Creating package summit_x_sim_bringup
* Adds install rules
* Contributors: Jorge Arino, carlos3dx
* Creating package summit_x_sim_bringup
* Adds install rules
* Contributors: Jorge Arino
```
## summit_x_robot_control

```
* updated changelog
* Adds install rules
* Contributors: Jorge Arino, carlos3dx
* Adds install rules
* Contributors: Jorge Arino
```
## summit_x_sim

```
* updated changelog
* Contributors: carlos3dx
```
## summit_x_sim_bringup

```
* modified version number
* updated changelog
* Creating package summit_x_sim_bringup
* Contributors: Jorge Arino, carlos3dx
* Creating package summit_x_sim_bringup
* Contributors: Jorge Arino
* Creating package summit_x_sim_bringup
* Contributors: Jorge Arino
```
