### PR TITLE
summit_x_common: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12153,7 +12153,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/summit_x_common-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_x_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_x_common` to `0.0.4-0`:
- upstream repository: https://github.com/RobotnikAutomation/summit_x_common.git
- release repository: https://github.com/RobotnikAutomation/summit_x_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.3-0`
## summit_x_common
- No changes
## summit_x_description

```
* Fixed hardware interface
* Contributors: Jorge Arino
```
