### PR TITLE
rospilot: 1.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3854,7 +3854,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rospilot/rospilot-release.git
-      version: 1.3.1-0
+      version: 1.3.2-0
     source:
       type: git
       url: https://github.com/rospilot/rospilot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot` to `1.3.2-0`:
- upstream repository: https://github.com/rospilot/rospilot.git
- release repository: https://github.com/rospilot/rospilot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.3.1-0`
## rospilot

```
* Support building on Debian
* Contributors: Christopher Berner
```
