### PR TITLE
rosdep: updated rosdep key libgsl for newer Debian and Ubuntu distros

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1656,13 +1656,25 @@ libgps:
   ubuntu: [libgps-dev]
 libgsl:
   arch: [gsl]
-  debian: [libgsl0-dev]
+  debian:
+    jessie: [libgsl0-dev]
+    stretch: [libgsl-dev]
+    wheezy: [libgsl0-dev]
   fedora: [gsl]
   gentoo:
     portage:
       packages: [sci-libs/gsl]
   macports: [gsl]
-  ubuntu: [libgsl0-dev]
+  ubuntu:
+    precise: [libgsl0-dev]
+    raring: [libgsl0-dev]
+    saucy: [libgsl0-dev]
+    trusty: [libgsl0-dev]
+    utopic: [libgsl0-dev]
+    vivid: [libgsl0-dev]
+    wily: [libgsl0-dev]
+    xenial: [libgsl-dev]
+    yakkety: [libgsl-dev]
 libgstreamer-plugins-base0.10-0:
   arch: [gstreamer0.10-base-plugins]
   debian: [libgstreamer-plugins-base0.10-0]


### PR DESCRIPTION
The library `libgsl` has been updated to version 2 and renamed from `libgsl0-dev` to `libgsl-dev` in newer Debian and Ubuntu releases:
- Debian: https://packages.debian.org/source/gsl
- Ubuntu: http://packages.ubuntu.com/source/gsl
