### PR TITLE
interactive_markers: 1.11.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1793,7 +1793,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/interactive_markers-release.git
-      version: 1.11.1-0
+      version: 1.11.3-0
     source:
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `1.11.3-0`:
- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros-gbp/interactive_markers-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.11.1-0`
## interactive_markers

```
* The ``processFeedback`` function of the menu handler no longer catches the ``KeyErrors`` of the feedback_cb.
  See: #29 <https://github.com/ros-visualization/interactive_markers/issues/29>
* Added the ``empty()`` and ``size()`` members to ``InteractiveMarkerServer`` interface.
  See: #30 <https://github.com/ros-visualization/interactive_markers/issues/30>
* Contributors: Blake Anderson, Guglielmo Gemignani
```
