### PR TITLE
Revert "librealsense: 0.9.3-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5154,7 +5154,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/intel-ros/librealsense-release.git
-      version: 0.9.3-0
+      version: 0.9.2-3
     source:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git


### PR DESCRIPTION
FYI @reaganlo 

Reverts ros/rosdistro#12468

This release produces debs that are uninstallable. It is breaking the downstream realsense_camera build. 

http://build.ros.org/view/Ibin_uT64/job/Ibin_uT64__realsense_camera__ubuntu_trusty_amd64__binary/8/console

```
00:05:38.605 Invoking 'apt-get install -q -y -o Debug::pkgProblemResolver=yes ros-indigo-librealsense'
00:05:40.501 Reading package lists...
00:05:40.776 Building dependency tree...
00:05:40.778 Reading state information...
00:05:40.820 Starting pkgProblemResolver with broken count: 0
00:05:40.845 Starting 2 pkgProblemResolver with broken count: 0
00:05:40.846 Done
00:05:40.874 The following extra packages will be installed:
00:05:40.874   dkms libusb-1.0-0-dev libusb-1.0-doc
00:05:40.876 The following NEW packages will be installed:
00:05:40.876   dkms libusb-1.0-0-dev libusb-1.0-doc ros-indigo-librealsense
00:05:41.274 0 upgraded, 4 newly installed, 0 to remove and 3 not upgraded.
00:05:41.274 Need to get 404 kB of archives.
00:05:41.275 After this operation, 2,520 kB of additional disk space will be used.
00:05:41.275 Get:1 http://archive.ubuntu.com/ubuntu/ trusty-updates/main dkms all 2.2.0.3-1.1ubuntu5.14.04.7 [66.1 kB]
00:05:41.275 Get:2 http://repositories.ros.org/ubuntu/building/ trusty/main ros-indigo-librealsense amd64 0.9.3-0trusty-20160823-153400-0700 [169 kB]
00:05:41.280 Get:3 http://archive.ubuntu.com/ubuntu/ trusty/main libusb-1.0-0-dev amd64 2:1.0.17-1ubuntu2 [54.7 kB]
00:05:41.283 Get:4 http://archive.ubuntu.com/ubuntu/ trusty/main libusb-1.0-doc all 2:1.0.17-1ubuntu2 [115 kB]
00:05:44.504 Fetched 404 kB in 0s (23.1 MB/s)
00:05:44.690 Selecting previously unselected package dkms.
00:05:44.732 (Reading database ... 46071 files and directories currently installed.)
00:05:44.734 Preparing to unpack .../dkms_2.2.0.3-1.1ubuntu5.14.04.7_all.deb ...
00:05:44.742 Unpacking dkms (2.2.0.3-1.1ubuntu5.14.04.7) ...
00:05:44.801 Selecting previously unselected package libusb-1.0-0-dev:amd64.
00:05:44.804 Preparing to unpack .../libusb-1.0-0-dev_2%3a1.0.17-1ubuntu2_amd64.deb ...
00:05:44.818 Unpacking libusb-1.0-0-dev:amd64 (2:1.0.17-1ubuntu2) ...
00:05:44.876 Selecting previously unselected package libusb-1.0-doc.
00:05:44.876 Preparing to unpack .../libusb-1.0-doc_2%3a1.0.17-1ubuntu2_all.deb ...
00:05:44.881 Unpacking libusb-1.0-doc (2:1.0.17-1ubuntu2) ...
00:05:44.967 Selecting previously unselected package ros-indigo-librealsense.
00:05:44.967 Preparing to unpack .../ros-indigo-librealsense_0.9.3-0trusty-20160823-153400-0700_amd64.deb ...
00:05:44.972 Unpacking ros-indigo-librealsense (0.9.3-0trusty-20160823-153400-0700) ...
00:05:45.029 Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
00:05:45.469 Setting up dkms (2.2.0.3-1.1ubuntu5.14.04.7) ...
00:05:45.540 Setting up libusb-1.0-0-dev:amd64 (2:1.0.17-1ubuntu2) ...
00:05:45.550 Setting up libusb-1.0-doc (2:1.0.17-1ubuntu2) ...
00:05:45.562 Setting up ros-indigo-librealsense (0.9.3-0trusty-20160823-153400-0700) ...
00:05:45.865 
00:05:45.865 Creating symlink /var/lib/dkms/uvcvideo/1.1.1-1-realsense/source ->
00:05:45.866                  /usr/src/uvcvideo-1.1.1-1-realsense
00:05:45.868 
00:05:45.869 DKMS: add completed.
00:05:45.986 Error! Your kernel headers for kernel 3.13.0-48-generic cannot be found.
00:05:45.987 Please install the linux-headers-3.13.0-48-generic package,
00:05:45.987 or use the --kernelsourcedir option to tell DKMS where it's located
00:05:45.991 libkmod: ERROR ../libkmod/libkmod.c:556 kmod_search_moddep: could not open moddep file '/lib/modules/3.13.0-48-generic/modules.dep.bin'
00:05:45.992 modinfo: ERROR: Module alias uvcvideo not found.
00:05:45.998 dpkg: error processing package ros-indigo-librealsense (--configure):
00:05:45.998  subprocess installed post-installation script returned error exit status 1
00:05:46.009 Errors were encountered while processing:
```
