### PR TITLE
Revert "librealsense: 0.9.3-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1802,7 +1802,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/intel-ros/librealsense-release.git
-      version: 0.9.3-0
+      version: 0.9.2-3
     source:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git


### PR DESCRIPTION
FYI @reaganlo 

Reverts ros/rosdistro#12468

This release produces debs that are uninstallable. It is breaking the downstream realsense_camera build. Same as https://github.com/ros/rosdistro/pull/12492
