### PR TITLE
rplidar_ros: 1.5.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3902,7 +3902,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/kintzhao/rplidar_ros-release.git
-      version: 1.5.4-0
+      version: 1.5.5-0
     source:
       type: git
       url: https://github.com/robopeak/rplidar_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `1.5.5-0`:
- upstream repository: https://github.com/robopeak/rplidar_ros.git
- release repository: https://github.com/kintzhao/rplidar_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.5.4-0`
## rplidar_ros

```
* Release 1.5.5.
* Update RPLIDAR SDK to 1.5.5
* Add RPLIDAR information print, and fix the standard motor speed of RPLIDAR A2.
* Contributors: kint
```
