### PR TITLE
ecl_tools: 0.61.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2268,7 +2268,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_tools-release.git
-      version: 0.61.4-0
+      version: 0.61.5-0
     source:
       type: git
       url: https://github.com/stonier/ecl_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_tools` to `0.61.5-0`:
- upstream repository: https://github.com/stonier/ecl_tools.git
- release repository: https://github.com/yujinrobot-release/ecl_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.61.4-0`
## ecl_build

```
* avoid re-loading cotire for every project
```
