### PR TITLE
ueye_cam: 1.0.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12859,7 +12859,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/anqixu/ueye_cam-release.git
-      version: 1.0.14-1
+      version: 1.0.15-0
     source:
       type: git
       url: https://github.com/anqixu/ueye_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `1.0.15-0`:
- upstream repository: https://github.com/anqixu/ueye_cam.git
- release repository: https://github.com/anqixu/ueye_cam-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.14-1`
## ueye_cam

```
* recover + update from failure in setColorMode
* extended color modes (10, 12, 16 bit per channel)
* added timeout topic for better debugging of frame timeouts
* Contributors: Anqi Xu, Dominik Klein
```
