### PR TITLE
ueye_cam: 1.0.15-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4868,7 +4868,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/anqixu/ueye_cam-release.git
-      version: 1.0.14-0
+      version: 1.0.15-0
     source:
       type: git
       url: https://github.com/anqixu/ueye_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `1.0.15-0`:
- upstream repository: https://github.com/anqixu/ueye_cam.git
- release repository: https://github.com/anqixu/ueye_cam-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.14-0`
## ueye_cam

```
* recover + update from failure in setColorMode
* extended color modes (10, 12, 16 bit per channel)
* added timeout topic for better debugging of frame timeouts
* Contributors: Anqi Xu, Dominik Klein
```
