### PR TITLE
srdfdom: 0.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4209,7 +4209,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/srdfdom-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `0.3.2-0`:
- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/ros-gbp/srdfdom-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.3.1-0`
## srdfdom

```
* [feat] Move SRDF-specific commands from moveit package #14 <https://github.com/ros-planning/srdfdom/issues/14>
* [sys] remove ROS-dependent logging.
* [sys] Much cleanup in package.xml. #12 <https://github.com/ros-planning/srdfdom/issues/12> pkg-config is no longer used after https://github.com/ros-planning/srdfdom/commit/19b23e5900e9c179089e99caae52023f95d2fec8#diff-af3b638bc2a3e6c650974192a53c7291
* Contributors: Dave Coleman, Sarah Elliott, Robert Haschke, Isaac I.Y. Saito
```
