### PR TITLE
realsense_camera: 1.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3097,7 +3097,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/intel-ros/realsense-release.git
-      version: 1.3.0-0
+      version: 1.4.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_camera` to `1.4.0-0`:
- upstream repository: https://github.com/intel-ros/realsense.git
- release repository: https://github.com/intel-ros/realsense-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.3.0-0`
## realsense_camera

```
* Updated Install Instructions for ROS Packages
* Added Errata for F200/SR300 Camera Types
* Make librealsense pkg required
* Added code to read depth scale from camera (intel-ros/realsense#46)
* Fix SR300 Max Z + Type casting
* Updated default values for SR300 camera options
* Updated documentation with SR300 camera details
* Updated tests to include SR300 distortion parameters
* Added fix to remove blurriness from SR300 IR stream
* Added initial support for SR300 cameras (#6)
* Change to Static Transforms for camera (#84)
* Contributors: Mark D Horn, Reagan Lopez, Salah-Eddine Missri, Lincoln Lorenz
```
