### PR TITLE
summit_x_sim: 1.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4333,7 +4333,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotnikAutomation/summit_x_sim-release.git
-      version: 1.1.0-0
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_x_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_x_sim` to `1.1.1-0`:
- upstream repository: https://github.com/RobotnikAutomation/summit_x_sim.git
- release repository: https://github.com/RobotnikAutomation/summit_x_sim-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.1.0-0`
## summit_x_control
- No changes
## summit_x_gazebo
- No changes
## summit_x_robot_control
- No changes
## summit_x_sim
- No changes
## summit_x_sim_bringup

```
* summit_xl_sim_bringup: removing build dependencies
* Contributors: Jorge Arino
```
