### PR TITLE
summit_x_sim: 1.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12174,7 +12174,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/summit_x_sim-release.git
-      version: 1.0.7-0
+      version: 1.0.8-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_x_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_x_sim` to `1.0.8-0`:
- upstream repository: https://github.com/RobotnikAutomation/summit_x_sim.git
- release repository: https://github.com/RobotnikAutomation/summit_x_sim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.7-0`
## summit_x_control

```
* 1.0.7
* updated changelog
* updated changelog
* Contributors: carlos3dx
```
## summit_x_gazebo

```
* 1.0.7
* updated changelog
* updated changelog
* Contributors: carlos3dx
```
## summit_x_robot_control

```
* 1.0.7
* updated changelog
* updated changelog
* Contributors: carlos3dx
```
## summit_x_sim

```
* 1.0.7
* updated changelog
* updated changelog
* Contributors: carlos3dx
```
## summit_x_sim_bringup

```
* summit_xl_sim_bringup: removing build dependencies
* 1.0.7
* updated changelog
* modified version number
* updated changelog
* Contributors: Jorge Arino, carlos3dx
```
