### PR TITLE
Add libopencv-nonfree-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2026,6 +2026,8 @@ libopencv-dev:
     vivid: [libopencv-dev]
     wily: [libopencv-dev]
     xenial: [libopencv-dev]
+libopencv-nonfree-dev:
+  ubuntu: [libopencv-nonfree-dev]    
 libopenni-dev:
   arch: [openni]
   debian: [libopenni-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2027,7 +2027,7 @@ libopencv-dev:
     wily: [libopencv-dev]
     xenial: [libopencv-dev]
 libopencv-nonfree-dev:
-  ubuntu: [libopencv-nonfree-dev]    
+  ubuntu: [libopencv-nonfree-dev]
 libopenni-dev:
   arch: [openni]
   debian: [libopenni-dev]


### PR DESCRIPTION
This library is needed for packages using nonfree features like SIFT, SURF.

These features are used for non-commercial purposes in the following tutorials:

https://github.com/pal-robotics/tiago_tutorials/tree/master/opencv_tut
