### PR TITLE
object_recognition_ros: 0.3.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2459,7 +2459,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_ros-release.git
-      version: 0.3.5-0
+      version: 0.3.6-0
     source:
       type: git
       url: https://github.com/wg-perception/object_recognition_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_ros` to `0.3.6-0`:
- upstream repository: https://github.com/wg-perception/object_recognition_ros.git
- release repository: https://github.com/ros-gbp/object_recognition_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.3.5-0`
## object_recognition_ros

```
* do not risk anything bellow kinetic
* build on Kinetic
* dox fix (fixes #18 <https://github.com/wg-perception/object_recognition_ros/issues/18>)
* try a longer wait to get the buildfarm working
* convert tests into proper rostests
* clean extensions
* Contributors: Vincent Rabaud
```
