### PR TITLE
object_recognition_ros: 0.3.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2459,7 +2459,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_ros-release.git
-      version: 0.3.6-0
+      version: 0.3.7-0
     source:
       type: git
       url: https://github.com/wg-perception/object_recognition_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_ros` to `0.3.7-0`:
- upstream repository: https://github.com/wg-perception/object_recognition_ros.git
- release repository: https://github.com/ros-gbp/object_recognition_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.3.6-0`
## object_recognition_ros

```
* fix compilation on Jessie and Willy
* no C++11 for indigo and jade
* Contributors: Vincent Rabaud
```
