### PR TITLE
moveit_resources: 0.6.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5946,11 +5946,19 @@ repositories:
       version: master
     status: developed
   moveit_resources:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_resources.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_resources-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_resources.git
+      version: master
     status: maintained
   moveit_robots:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `0.6.1-0`:
- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros-gbp/moveit_resources-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.6.0-0`
## moveit_resources

```
* [sys] Added Fanuc robot model (m10ia) for system testing. Improve README (#7 <https://github.com/ros-planning/moveit_resources/issues/7>, #8 <https://github.com/ros-planning/moveit_resources/issues/8>)
* Contributors: Dave Coleman, Robert Haschke
```
