### PR TITLE
moveit_resources: 0.6.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2160,6 +2160,21 @@ repositories:
       url: https://github.com/mikeferguson/moveit_python-release.git
       version: 0.2.17-0
     status: developed
+  moveit_resources:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_resources.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_resources-release.git
+      version: 0.6.1-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_resources.git
+      version: master
+    status: developed
   mrpt_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `0.6.1-0`:
- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros-gbp/moveit_resources-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## moveit_resources

```
* [sys] Added Fanuc robot model (m10ia) for system testing. Improve README (#7 <https://github.com/ros-planning/moveit_resources/issues/7>, #8 <https://github.com/ros-planning/moveit_resources/issues/8>)
* Contributors: Dave Coleman, Robert Haschke
```
