### PR TITLE
segbot: 0.3.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11256,7 +11256,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/segbot-release.git
-      version: 0.3.4-0
+      version: 0.3.5-0
     source:
       type: git
       url: https://github.com/utexas-bwi/segbot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `segbot` to `0.3.5-0`:
- upstream repository: https://github.com/utexas-bwi/segbot.git
- release repository: https://github.com/utexas-bwi-gbp/segbot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.3.4-0`
## segbot
- No changes
## segbot_bringup

```
* Added xtion and led strip to segbot_v3 launch file in segbot_bringup
  (#75 <https://github.com/utexas-bwi/segbot/issues/75>)
* Contributors: Rolando Fernandez
```
## segbot_description
- No changes
## segbot_firmware
- No changes
## segbot_gazebo
- No changes
## segbot_gui
- No changes
## segbot_led

```
* Added need assistance animation and made circular 4-set animation default turn animation
* Added additonal circular variations to turn signals
* Updated led segments and blocked animation.  (#73 <https://github.com/utexas-bwi/segbot/issues/73>)
* Added install target for launch directory.
* Contributors: FernandezR, Rolando Fernandez
```
## segbot_logical_translator
- No changes
## segbot_navigation
- No changes
## segbot_sensors
- No changes
## segbot_simulation_apps
- No changes
