### PR TITLE
audio_common: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -174,6 +174,27 @@ repositories:
       url: https://github.com/tfoote/ros_astra_launch.git
       version: master
     status: developed
+  audio_common:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/audio_common.git
+      version: master
+    release:
+      packages:
+      - audio_capture
+      - audio_common
+      - audio_common_msgs
+      - audio_play
+      - sound_play
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/audio_common-release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/audio_common.git
+      version: master
+    status: maintained
   auv_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.1-0`:
- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## audio_capture

```
* Update to new gstreamer rosdeps
* #70 can launch these in different namespaces with different microphones, and both are operating.
* #70 can switch between different microphones, but the first microphone doesn't like the hw:1, it only works with device:="" - so must be doing something wrong still.
* Add changelogs
* [audio_capture] add error handler
* [audio_capture] add option to publish captured audio data as wav format
  Conflicts:
  audio_capture/src/audio_capture.cpp
* Fixed memory leak (see #18).
* Removed trailing whitespace.
* Fixed problem that CMake uses gstreamer-0.1 instead of gstreamer-1.0
* Added gstreamer 1.0 dependecies
* Ported to gstreamer 1.0
  package.xml dependencies still missing
* Update maintainer email
* Contributors: Benny, Felix Duvallet, Furushchev, Lucas Walter, trainman419
```
## audio_common

```
* Add changelogs
* Update maintainer email
* Contributors: trainman419
```
## audio_common_msgs

```
* Add changelogs
* Update maintainer email
* Contributors: trainman419
```
## audio_play

```
* Update to new gstreamer rosdeps
* #70 can launch these in different namespaces with different microphones, and both are operating.
* Add changelogs
* Changed message level to warning
* Fixed problem that CMake uses gstreamer-0.1 instead of gstreamer-1.0
* Fixed underflow.
  Before the sink buffer underflows the pipeline is paused. When data is received again the pipeline is set to playing again.
* Added gstreamer 1.0 dependecies
* Ported to gstreamer 1.0
  package.xml dependencies still missing
* Change audio sink to autoaudiosink
* Update maintainer email
* Contributors: Benny, Hans Gaiser, Lucas Walter, trainman419
```
## sound_play

```
* Update to new gstreamer rosdeps
* Update sound_play to gstreamer 1.0
* remove chance of uninitialised variable being called in a subscriber callback.
* Add changelogs
* Issue: The error checks for missing publisher/action client in sendMsg were inverted.
  The non-blocking brach tested the action client while the blocking branch
  tested the publisher.
  Fix: Inverted the blocking boolean for both branchs.
* sound_play: Fix build with -DCATKIN_ENABLE_TESTING=OFF.
  https://bugs.gentoo.org/show_bug.cgi?id=567466
* [soundplay_node] fix resources not being released on dict cleanup
  This was resulting in the number of sink inputs reaching the maximum threshold,
  (32 on ubuntu 14.04 with pulseaudio 4.0) after which no more sounds could be
  played by the node. It would only happen if the rate of sounds being played was
  slower than the dictionary cleanup.
* depend on actionlib.
* Introduce unit test to ensure soundclient is started correctly.
* Example of using the explicit blocking parameter to override the class setting.
* SoundClient can also explicitly specify whether or not to block while playing the sound.
  Each play/repeat/say/... method can take an option blocking=True|False argument (using **kwargs), which over-rides the class-wide setting.
* Merge pull request #62 from felixduvallet/set_queue_size
  Set queue_size in soundplay_node Publisher
* do both in same script.
* Added script showing the various blocking/non-blocking ways of using SoundClient.
* removed trailing whitespace only
* loginfo -> logdebug.
* Slightly more condensed version of thresholding.
* Enable blocking calls inside libsoundplay's SoundClient.
  This makes use of the actionlib interface provided by soundplay_node, by ensuring SoundClient receives a response before returning.
  Turn this on by: SoundClient(blocking=true).
* Use new-style python classes (inherits from object).
* removed trailing whitespace.
* Set the volume in each of the sound_play actionlib tests.
  This makes the script actually play the sounds it requests.
* Specify queue size explicitly.
  Removed warning message printed each time soundplay_node was started.
* remove trailing whitespace only.
* Change wiki urls
* Fix test target name collision. Fixes #49
* sound_play: cpp header conforms to the style guide
* sound_play: update scripts to allow volume to be set
* sound_play: updated tests to include volume changes
* sound_play: add ability to specify volume at which to play sounds
  Also changed error to warning as per todo
* sound_play: fix indentation and comment inconsistencies
* sound_play: remove some raw prints cluttering output
* sound_play: added queue_size to SoundClient init
  Should prevent warning being displayed whenever the client is created.
  Fixes issue #43
* add simple-actionlib functionality to sound_play
* sound_play: Added functions to play files relative to a package path
* Update maintainer email
* Contributors: Alexis Ballier, Austin, Daniel Stonier, David V. Lu, Felix Duvallet, Matthias Nieuwenhuisen, Michal Staniaszek, Neowizard, aginika, trainman419
```
