### PR TITLE
rqt_wrapper: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10755,6 +10755,17 @@ repositories:
       url: https://github.com/ros-visualization/rqt_robot_plugins.git
       version: master
     status: developed
+  rqt_wrapper:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yujinrobot-release/rqt_wrapper-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/stonier/rqt_wrapper.git
+      version: devel
+    status: developed
   rtabmap:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_wrapper` to `0.1.3-0`:
- upstream repository: https://github.com/stonier/rqt_wrapper.git
- release repository: https://github.com/yujinrobot-release/rqt_wrapper-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
