### PR TITLE
rtmros_gazebo: 0.1.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10839,7 +10839,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_gazebo-release.git
-      version: 0.1.10-0
+      version: 0.1.11-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_gazebo` to `0.1.11-0`:
- upstream repository: https://github.com/start-jsk/rtmros_gazebo.git
- release repository: https://github.com/tork-a/rtmros_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.1.10-0`
## eusgazebo
- No changes
## hrpsys_gazebo_general

```
* [hrpsys_gazebo_general/CMakeLists.txt, hrpsys_gazebo_general/cmake/compile_robot_model_for_gazebo.cmake] install whole robot_models directory.
* Modified package.xml to fix dependency
* Merge pull request #224 <https://github.com/start-jsk/rtmros_gazebo/issues/224> from mmurooka/add-LIP-plugin
  [hrpsys_gazebo_general, hrpsys_gazebo_msgs] Add plugin for Linear Inverted Pendulum
* [hrpsys_gazebo_general/src/LIPPlugin.cpp] add LIPPlugin, which controls Linear Inverted Pendulum.
* [hrpsys_gazebo_general/package.xml] set gazebo_model_path in package.xml
* Contributors: Masaki Murooka, Shunichi Nozawa, Iori Yanokura
```
## hrpsys_gazebo_msgs

```
* [hrpsys_gazebo_msgs] add message and service for LIPPlugin.
* Contributors: Masaki Murooka
```
## staro_moveit_config
- No changes
