### PR TITLE
sophus_ros_toolkit: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11858,7 +11858,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/sophus_ros_toolkit-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/stonier/sophus_ros_toolkit.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11851,7 +11851,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/stonier/sophus_ros_toolkit.git
-      version: indigo-devel
+      version: release/0.1-indigo-kinetic
     release:
       packages:
       - sophus_ros_conversions
@@ -11862,7 +11862,7 @@ repositories:
     source:
       type: git
       url: https://github.com/stonier/sophus_ros_toolkit.git
-      version: indigo-devel
+      version: devel
     status: developed
   sparse_bundle_adjustment:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus_ros_toolkit` to `0.1.2-0`:
- upstream repository: https://github.com/stonier/sophus_ros_toolkit.git
- release repository: https://github.com/yujinrobot-release/sophus_ros_toolkit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.1-0`
## sophus_ros_conversions

```
* tf::Transform -> sophus conversion
```
