### PR TITLE
robotis_framework: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3359,7 +3359,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
-      version: 0.1.1-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_framework` to `0.2.0-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.1-0`
## robotis_controller

```
* bug fixed (position pid gain & velocity pid gain sync write).
* added velocity_to_value_ratio to DXL Pro-H series.
* changed some debug messages.
* added velocity p/i/d gain and position i/d gain sync_write code.
* SyncWriteItem bug fixed.
* add function / modified the code simple (using auto / range based for loop)
* added XM-430-W210 / XM-430-W350 device file.
* rename ControlMode(CurrentControl -> TorqueControl)
* rename (port_to_sync_write_torque_ -> port_to_sync_write_current_)
* rename (present_current_ -> present_torque_)
* modified torque control code
* fixed typos / changed ROS_INFO -> fprintf (for processing speed)
* startTimer() : after bulkread txpacket(), need some sleep()
* changed the order of processing in the Process() function.
* added missing mutex for gazebo
* fixed crash when running in gazebo simulation
* sync write bug fix.
* added position_p_gain sync write
* MotionModule/SensorModule member variable access changed (public -> protected).
* Contributors: Jay Song, Zerom, Pyo, SCH
```
## robotis_device

```
* bug fixed (position pid gain & velocity pid gain sync write).
* added velocity_to_value_ratio to DXL Pro-H series.
* added velocity p/i/d gain and position i/d gain sync_write code.
* fixed robotis_device build_depend.
* added XM-430-W210 / XM-430-W350 device file.
* rename (present_current_ -> present_torque_)
* modified torque control code
* added device file for MX-64 / MX-106
* adjusted position min/max value. (MX-28, XM-430)
* Contributors: Zerom, Pyo
```
## robotis_framework

```
* updated CHANGLOG.rst for minor release
```
## robotis_framework_common

```
* updated CHANGLOG.rst for minor release
* rename ControlMode(CurrentControl -> TorqueControl)
* rename (port_to_sync_write_torque_ -> port_to_sync_write_current_)
* Contributors: Zerom, Pyo
```
