### PR TITLE
robotis_math: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3374,7 +3374,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Math-release.git
-      version: 0.1.0-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Math.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_math` to `0.2.0-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Math.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Math-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.0-0`
## robotis_math

```
* merged pull request #4 <https://github.com/ROBOTIS-GIT/ROBOTIS-Math/issues/4> from thor-mang/pr_step_data_to_string
* added string serializer for step data for more convenient debugging options
* minimum jerk with via-points(position) added
* added string serializer for step data for more convenient debugging options
* eigen test
* added trapezoidal profile
* Contributors: Alexander Stumpf, Jay Song, SCH
```
