### PR TITLE
thormang3_common: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4555,7 +4555,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Common-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_common` to `0.1.1-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Common.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.0-0`
## thormang3_common

```
* modified rviz config file
* Contributors: Kayman
```
## thormang3_description

```
* modified rviz config file
* Contributors: Kayman
```
## thormang3_gazebo

```
* none
```
