### PR TITLE
thormang3_msgs: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4609,7 +4609,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-msgs-release.git
-      version: 0.1.0-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_msgs` to `0.2.0-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.0-0`
## thormang3_action_module_msgs

```
* modified other packages in thormang3_msgs metapackage
```
## thormang3_feet_ft_module_msgs

```
* modified other packages in thormang3_msgs metapackage
```
## thormang3_gripper_module_msgs

```
* modified other packages in thormang3_msgs metapackage
```
## thormang3_manipulation_module_msgs

```
* modified other packages in thormang3_msgs metapackage
```
## thormang3_msgs

```
* wholebody msgs updated
```
## thormang3_offset_tuner_msgs

```
* modified other packages in thormang3_msgs metapackage
```
## thormang3_walking_module_msgs

```
* modify some typing errors
* Contributors: Jay Song
```
## thormang3_wholebody_module_msgs

```
* wholebody msgs updated
* Contributors: SCH
```
