### PR TITLE
sophus_ros_toolkit: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4284,6 +4284,23 @@ repositories:
       url: https://github.com/stonier/sophus.git
       version: indigo
     status: maintained
+  sophus_ros_toolkit:
+    doc:
+      type: git
+      url: https://github.com/stonier/sophus_ros_toolkit.git
+      version: release/0.1-indigo-kinetic
+    release:
+      packages:
+      - sophus_ros_conversions
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/sophus_ros_toolkit-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/stonier/sophus_ros_toolkit.git
+      version: devel
+    status: developed
   sparse_bundle_adjustment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus_ros_toolkit` to `0.1.2-0`:
- upstream repository: https://github.com/stonier/sophus_ros_toolkit.git
- release repository: https://github.com/yujinrobot-release/sophus_ros_toolkit-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## sophus_ros_conversions

```
* tf::Transform -> sophus conversion
```
