### PR TITLE
catkin_pip: 0.1.14-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -393,7 +393,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/catkin_pip-release.git
-      version: 0.1.13-0
+      version: 0.1.14-0
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pip.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pip` to `0.1.14-0`:
- upstream repository: https://github.com/asmodehn/catkin_pip.git
- release repository: https://github.com/asmodehn/catkin_pip-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.13-0`
## catkin_pip

```
* Merge pull request #44 <https://github.com/asmodehn/catkin_pip/issues/44> from asmodehn/pip_system
  Now checking for pip --system option before using.
* Now checking for pip --system option before using.
  cleanup some cmake status messages.
* improving pip detection
* Contributors: AlexV, alexv
```
