### PR TITLE
wts_driver: 1.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6374,6 +6374,17 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/clearpath-gbp/wireless-release.git
       version: 0.0.7-0
+  wts_driver:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ksatyaki/wts_driver-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/ksatyaki/wts_driver.git
+      version: master
+    status: developed
   wu_ros_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wts_driver` to `1.0.2-0`:
- upstream repository: https://github.com/ksatyaki/wts_driver.git
- release repository: https://github.com/ksatyaki/wts_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## wts_driver

```
* Fixed some mistakes that made the build to fail
```
