### PR TITLE
teleop_twist_joy: 0.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5841,7 +5841,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-teleop/teleop_twist_joy-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_twist_joy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `0.1.2-0`:
- upstream repository: https://github.com/ros-teleop/teleop_twist_joy.git
- release repository: https://github.com/ros-teleop/teleop_twist_joy-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.1-0`
## teleop_twist_joy

```
* Fixed incorrect key. (#21 <https://github.com/ros-teleop/teleop_twist_joy/issues/21>)
* Allow custom config file from location outside of this package
* Setting scale_angular_turbo if axis_angular is set so that turning works when turbo is pressed.
* Added turbo scale for angular velocities and accompanying test.
* Add LICENSE.txt.
* Contributors: Daniel Aden, Isaac I.Y. Saito, Mike Purvis, Tony Baltovski
```
