### PR TITLE
robotnik_sensors: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9316,7 +9316,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/robotnik_sensors-release.git
-      version: 1.0.1-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/robotnik_sensors.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotnik_sensors` to `1.0.3-0`:
- upstream repository: https://github.com/RobotnikAutomation/robotnik_sensors.git
- release repository: https://github.com/RobotnikAutomation/robotnik_sensors-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.0.1-0`
## robotnik_sensors

```
* modified xmls:xacro
* Merge branch 'indigo-devel' of https://github.com/RobotnikAutomation/robotnik_sensors into indigo-devel
* Modified .xacro files
* corrected name of orientation parameters
* updated gps and imu_hector parameters
* resolved conflict
* added ueye camera
* Added rplidar to all_sensors
* Contributors: Marc Bosch-Jorge, carlos3dx, summit
```
