### PR TITLE
summit_xl_common: 1.0.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12222,7 +12222,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/summit_xl_common-release.git
-      version: 1.0.9-0
+      version: 1.0.10-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_xl_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_xl_common` to `1.0.10-0`:
- upstream repository: https://github.com/RobotnikAutomation/summit_xl_common.git
- release repository: https://github.com/RobotnikAutomation/summit_xl_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.0.9-0`
## summit_xl_common

```
* 1.0.9
* updated changelog
* Contributors: carlos3dx
```
## summit_xl_description

```
* Changed xacro.py to xacro, added --inorder option and modified xmlns:xacro
* summit_xl_description: updated xacro to match jade tag syntax
* summit_xl_description: changed gazebo imu plugin to hector
* 1.0.9
* updated changelog
* Contributors: Marc Bosch-Jorge, carlos3dx
```
## summit_xl_localization

```
* summit_xl_localization: commented robot_localization launch files
* summit_xl_localization: updated robot_localization launch files
* summit_xl_localization: added navsat_transform_new to CMakeLists.txt
* 1.0.9
* updated changelog
* Contributors: Marc Bosch-Jorge, carlos3dx
```
## summit_xl_navigation

```
* 1.0.9
* updated changelog
* Contributors: carlos3dx
```
## summit_xl_pad

```
* 1.0.9
* updated changelog
* Contributors: carlos3dx
```
