### PR TITLE
Adding humanoid_navigation to documentation index and pre-release

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3643,6 +3643,16 @@ repositories:
       url: https://github.com/ahornung/humanoid_msgs.git
       version: devel
     status: maintained
+  humanoid_navigation:
+    doc:
+      type: git
+      url: https://github.com/AravindaDP/humanoid_navigation.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/AravindaDP/humanoid_navigation.git
+      version: indigo-devel
+    status: developed
   husky:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3647,7 +3647,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/AravindaDP/humanoid_navigation.git
-      version: master
+      version: indigo-devel
     source:
       type: git
       url: https://github.com/AravindaDP/humanoid_navigation.git


### PR DESCRIPTION
I'd like humanoid_navigation to be indexed and documented for indigo on ros.org for documentation and on prerelease.ros.org for pre-release.
