### PR TITLE
wts_driver: 1.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13625,7 +13625,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ksatyaki/wts_driver-release.git
-      version: 1.0.2-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/ksatyaki/wts_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wts_driver` to `1.0.4-0`:
- upstream repository: https://github.com/ksatyaki/wts_driver.git
- release repository: https://github.com/ksatyaki/wts_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.2-0`
## wts_driver

```
* Update install targets. Correct errors.
* Contributors: Chittaranjan Swaminathan Srinivas
```
