### PR TITLE
wts_driver: 1.0.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6379,7 +6379,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ksatyaki/wts_driver-release.git
-      version: 1.0.2-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/ksatyaki/wts_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wts_driver` to `1.0.4-0`:
- upstream repository: https://github.com/ksatyaki/wts_driver.git
- release repository: https://github.com/ksatyaki/wts_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.2-0`
## wts_driver

```
* Update install targets. Correct errors.
* Contributors: Chittaranjan Swaminathan Srinivas
```
