### PR TITLE
catkin_pip: 0.1.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1130,7 +1130,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/catkin_pip-release.git
-      version: 0.1.14-0
+      version: 0.1.15-0
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pip.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pip` to `0.1.15-0`:
- upstream repository: https://github.com/asmodehn/catkin_pip.git
- release repository: https://github.com/asmodehn/catkin_pip-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.1.14-0`
## catkin_pip

```
* now transferring paths from pth in devel site-packages to pythonpath shell env, to handle egg-link and workspace overlaying together...
* adding current devel space dist-packages via envhook to get it even if env not sourced... is it a good idea ?
* officially not supporting broken old pip on EOL saucy.
* Contributors: AlexV, alexv
```
