### PR TITLE
pyros: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8411,6 +8411,21 @@ repositories:
       url: https://github.com/clearpathrobotics/puma_motor_driver.git
       version: master
     status: maintained
+  pyros:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/pyros.git
+      version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/pyros-rosrelease.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/asmodehn/pyros.git
+      version: indigo
+    status: developed
   pyros_config:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros` to `0.2.0-0`:
- upstream repository: https://github.com/asmodehn/pyros.git
- release repository: https://github.com/asmodehn/pyros-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## pyros

```
* Preparing release flow. cosmetics. [alexv]
* Now fails with explanation if ConnectionCacheProxy not available in
  rocon_python_comms. [alexv]
* Moving on with step by step rostesting and partial python testing,
  because of process conflicts. [alexv]
* Making travis nose tests more verbose. [alexv]
* Increased dependent version of pyros_setup. attempt fixing travis.
  [alexv]
* Changed config behavior. now using pyros-setup default config. getting
  rid of complex default+override behavior for import config. improved
  logger. improved setup.py commands. [alexv]
* Importing pyros_setup only when imports from ros_interface failed.
  [alexv]
* Created deprecated decorator as util in pyros until we find better
  solution. [alexv]
* Fixing dependency on pyzmp with strict version. removed useless env
  values for travis. [alexv]
* Improved main init to import dependencies from python or from ROS
  packages. fixed check for unicode strings. started implementing
  CATKIN_PIP_NO_DEPS for testing. reviewing dependencies version.
  [alexv]
* Improved travis test scripts from pyros-setup scripts. improved
  setup.py with publish method fixed python3 issues on pyros_client.
  [alexv]
* Moved some dependencies out of pyros_setup, to not require pyros_setup
  if using ROS environment as usual. [alexv]
* Describing improved repository structure. [alexv]
* Improving release script. [AlexV]
```
