### PR TITLE
robotis_math: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3374,7 +3374,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Math-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Math.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_math` to `0.2.1-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Math.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Math-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.2.0-0`
## robotis_math

```
* bug fix and changed some variable name
* Modify StepData
* Contributors: Jay Song
```
