### PR TITLE
thormang3_msgs: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4641,7 +4641,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-msgs-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_msgs` to `0.2.1-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.2.0-0`
## thormang3_action_module_msgs

```
* modified other packages in thormang3_msgs metapackage
```
## thormang3_feet_ft_module_msgs

```
* modified other packages in thormang3_msgs metapackage
```
## thormang3_gripper_module_msgs

```
* modified other packages in thormang3_msgs metapackage
```
## thormang3_manipulation_module_msgs

```
* modified other packages in thormang3_msgs metapackage
```
## thormang3_msgs

```
* modified other packages in thormang3_msgs metapackage
```
## thormang3_offset_tuner_msgs

```
* modified other packages in thormang3_msgs metapackage
```
## thormang3_walking_module_msgs

```
* changed some variable name in StepPositionData.msg
* modified StepPositionData.msg
* Contributors: Jay Song
```
## thormang3_wholebody_module_msgs

```
* modified wholebody msgs
* Contributors: Jay Song
```
