### PR TITLE
pyros_test: 0.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3008,6 +3008,21 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: kinetic-devel
     status: maintained
+  pyros_test:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/pyros-test.git
+      version: devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/asmodehn/pyros-test-release.git
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/asmodehn/pyros-test.git
+      version: devel
+    status: developed
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_test` to `0.0.4-0`:
- upstream repository: https://github.com/asmodehn/pyros-test.git
- release repository: https://github.com/asmodehn/pyros-test-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## pyros_test

```
* now travis checking both indigo and jade
* Merge pull request #2 <https://github.com/asmodehn/pyros-test/issues/2> from asmodehn/package_v2
  Package v2
* README fix
* package description fix
* package v2 wiht minimum required version for dependencies
* Contributors: AlexV, alexv
```
