### PR TITLE
pyros_config: 0.1.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3985,7 +3985,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/pyros-config-rosrelease.git
-      version: 0.1.3-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/asmodehn/pyros-config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_config` to `0.1.5-0`:
- upstream repository: https://github.com/asmodehn/pyros-config.git
- release repository: https://github.com/asmodehn/pyros-config-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.3-0`
## pyros_config

```
* Fixed regression about accepting dict and object when configuring.
  [alexv]
* Improved logging. cosmetics. [alexv]
```
