### PR TITLE
catkin: 0.7.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -407,7 +407,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.1-0
+      version: 0.7.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.2-0`:
- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.7.1-0`
## catkin

```
* change warning to status when nosetests was not found (#823 <https://github.com/ros/catkin/issues/823>)
* maintain file context when invoking Python scripts through relay (#820 <https://github.com/ros/catkin/issues/820>)
* fix rollback logic for more than one value per environment variable and workspace (#819 <https://github.com/ros/catkin/issues/819>)
* add option to use NMake instead of Make (#816 <https://github.com/ros/catkin/pull/816>)
* fix check if DEPENDS was found (#813 <https://github.com/ros/catkin/issues/813>)
* fix quoting of paths to handle spaces (#808 <https://github.com/ros/catkin/issues/808>)
* update doc of catkin_package to clarify importance of case for variable names
* improve doc about catkin_package(CFG_EXTRAS) (#805 <https://github.com/ros/catkin/issues/805>)
* doc: fix format 2 howto to suggest to declare a build export dependency on "message_runtime"
```
