### PR TITLE
genpy: 0.6.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1095,7 +1095,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.6.1-0`:
- upstream repository: git@github.com:ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.6.0-0`
## genpy

```
* lazy init struct (#65 <https://github.com/ros/genpy/issues/65>)
* fix default value of lists to not expand to N items in the generated code (#64 <https://github.com/ros/genpy/issues/64>)
* simpler and more canonical hash (#55 <https://github.com/ros/genpy/pull/55>)
* various improvements to the time and duration classes (#63 <https://github.com/ros/genpy/issues/63>)
```
