### PR TITLE
genlisp: 0.4.16-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1049,7 +1049,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/genlisp-release.git
-      version: 0.4.15-0
+      version: 0.4.16-0
     source:
       type: git
       url: https://github.com/ros/genlisp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genlisp` to `0.4.16-0`:
- upstream repository: git@github.com:ros/genlisp.git
- release repository: https://github.com/ros-gbp/genlisp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.4.15-0`
