### PR TITLE
roscpp_core: 0.6.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3865,7 +3865,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.6.1-0`:
- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.6.0-0`
## cpp_common
- No changes
## roscpp_serialization

```
* fix warning about unused parameter (#51 <https://github.com/ros/roscpp_core/pull/51>)
```
## roscpp_traits
- No changes
## rostime

```
* fix rounding errors leading to invalid stored data in ros::TimeBase (#48 <https://github.com/ros/roscpp_core/issues/48>)
```
