### PR TITLE
ros: 1.13.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3601,7 +3601,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.13.1-0
+      version: 1.13.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.13.2-0`:
- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.13.1-0`
## mk
- No changes
## rosbash

```
* add missing verbs to rosservice completion (#117 <https://github.com/ros/ros/pull/117>)
```
## rosboost_cfg
- No changes
## rosbuild
- No changes
## rosclean
- No changes
## roscreate
- No changes
## roslang
- No changes
## roslib

```
* avoid putting the rosbuild stacks dir on RPP if it doesn't exist (#111 <https://github.com/ros/ros/pull/111>)
```
## rosmake
- No changes
## rosunit
- No changes
