### PR TITLE
added r2 simulation repos to indigo distribution

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8692,11 +8692,11 @@ repositories:
   r2_gazebo:
     doc:
       type: git
-      url: https://gitlab.com/nasa-jsc-robotics/  r2_gazebo.git
+      url: https://gitlab.com/nasa-jsc-robotics/r2_gazebo.git
       version: develop
     source:
       type: git
-      url: https://gitlab.com/nasa-jsc-robotics/  r2_gazebo.git
+      url: https://gitlab.com/nasa-jsc-robotics/r2_gazebo.git
       version: develop
     status: maintained
   r2_gazebo_gripper:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2784,6 +2784,16 @@ repositories:
       url: https://github.com/paulbovbel/frontier_exploration.git
       version: indigo-devel
     status: maintained
+  fsm_utils:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/fsm_utils.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/fsm_utils.git
+      version: develop
+    status: maintained
   fulanghua_navigation:
     release:
       packages:
@@ -3322,6 +3332,16 @@ repositories:
       type: git
       url: https://github.com/atenpas/handle_detector.git
       version: indigo
+    status: maintained
+  hayai:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/hayai.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/hayai.git
+      version: develop
     status: maintained
   head_action:
     doc:
@@ -4153,6 +4173,16 @@ repositories:
       type: git
       url: https://github.com/iralabdisco/ira_photonfocus_driver.git
       version: master
+    status: maintained
+  iss_taskboard_gazebo:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/iss_taskboard_gazebo.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/iss_taskboard_gazebo.git
+      version: develop
     status: maintained
   ivcon:
     release:
@@ -6494,6 +6524,26 @@ repositories:
       url: https://github.com/ros-naoqi/libqicore-release.git
       version: 2.3.1-3
     status: maintained
+  nasa_common_cmake:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/nasa_common_cmake.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/nasa_common_cmake.git
+      version: develop
+    status: maintained
+  nasa_common_logging:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/nasa_common_logging.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/nasa_common_logging.git
+      version: develop
+    status: maintained
   nav2_platform:
     doc:
       type: git
@@ -8629,6 +8679,86 @@ repositories:
       url: https://github.com/ros-visualization/qwt_dependency.git
       version: indigo-devel
     status: maintained
+  r2_description:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/r2_description.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/r2_description.git
+      version: develop
+    status: maintained
+  r2_gazebo:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/  r2_gazebo.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/  r2_gazebo.git
+      version: develop
+    status: maintained
+  r2_gazebo_gripper:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/r2_gazebo_gripper.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/r2_gazebo_gripper.git
+      version: develop
+    status: maintained
+  r2_gazebo_interface:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/r2_gazebo_interface.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/r2_gazebo_interface.git
+      version: develop
+    status: maintained
+  r2_moveit_config:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/r2_moveit_config.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/r2_moveit_config.git
+      version: develop
+    status: maintained
+  r2_msgs:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/r2_msgs.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/r2_msgs.git
+      version: develop
+    status: maintained
+  r2_supervisors_control:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/r2_supervisors_control.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/r2_supervisors_control.git
+      version: develop
+    status: maintained
+  r2_upperbody_moveit_config:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/r2_upperbody_moveit_config.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/r2_upperbody_moveit_config.git
+      version: develop
+    status: maintained
   rail_ceiling:
     doc:
       type: git
@@ -9120,6 +9250,46 @@ repositories:
       type: git
       url: https://github.com/hrnr/robo-rescue.git
       version: master
+  robodyn_controllers:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/robodyn_controllers.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/robodyn_controllers.git
+      version: develop
+    status: maintained
+  robodyn_mechanisms:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/robodyn_mechanisms.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/robodyn_mechanisms.git
+      version: develop
+    status: maintained
+  robodyn_ros:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/robodyn_ros.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/robodyn_ros.git
+      version: develop
+    status: maintained
+  robodyn_utilities:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/robodyn_utilities.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/robodyn_utilities.git
+      version: develop
+    status: maintained
   robot_calibration:
     doc:
       type: git
@@ -9157,6 +9327,16 @@ repositories:
       url: https://github.com/fetchrobotics/robot_controllers.git
       version: indigo-devel
     status: developed
+  robot_instance:
+    doc:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/robot_instance.git
+      version: develop
+    source:
+      type: git
+      url: https://gitlab.com/nasa-jsc-robotics/robot_instance.git
+      version: develop
+    status: maintained
   robot_localization:
     doc:
       type: git


### PR DESCRIPTION
In response to #12528.

Hydro and older are untouched.  Added entries to indigo/distribution.yaml.  I'm wanting new wiki documents, but no packages built.
