### PR TITLE
sophus_ros_toolkit: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4330,7 +4330,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/sophus_ros_toolkit-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/stonier/sophus_ros_toolkit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus_ros_toolkit` to `0.1.3-0`:
- upstream repository: https://github.com/stonier/sophus_ros_toolkit.git
- release repository: https://github.com/yujinrobot-release/sophus_ros_toolkit-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.2-0`
