### PR TITLE
webtest: 2.0.18-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13471,6 +13471,17 @@ repositories:
       url: https://github.com/RobotWebTools/web_video_server.git
       version: develop
     status: maintained
+  webtest:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/webtest-rosrelease.git
+      version: release/indigo/webtest
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/webtest-rosrelease.git
+      version: 2.0.18-0
+    status: maintained
   wge100_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webtest` to `2.0.18-0`:
- upstream repository: https://github.com/Pylons/webtest.git
- release repository: https://github.com/asmodehn/webtest-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## webtest

```
* Avoid deprecation warning with py3.4
```
