### PR TITLE
pyros_utils: 0.1.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3028,6 +3028,21 @@ repositories:
       url: https://github.com/asmodehn/pyros-test.git
       version: devel
     status: developed
+  pyros_utils:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/pyros-utils.git
+      version: devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/asmodehn/pyros-utils-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/asmodehn/pyros-utils.git
+      version: devel
+    status: developed
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_utils` to `0.1.2-1`:
- upstream repository: https://github.com/asmodehn/pyros-utils.git
- release repository: https://github.com/asmodehn/pyros-utils-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## pyros_utils

```
* fixing travis file to check multiple distros.
* fixing python package version not matching catkin package version.
* Contributors: alexv
```
