### PR TITLE
webtest: 2.0.18-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6365,6 +6365,17 @@ repositories:
       url: https://github.com/RobotWebTools/web_video_server.git
       version: develop
     status: maintained
+  webtest:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/webtest-rosrelease.git
+      version: release/indigo/webtest
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/asmodehn/webtest-rosrelease.git
+      version: 2.0.18-0
+    status: maintained
   wireless:
     release:
       packages:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6369,7 +6369,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/asmodehn/webtest-rosrelease.git
-      version: release/indigo/webtest
+      version: release/jade/webtest
     release:
       tags:
         release: release/jade/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `webtest` to `2.0.18-0`:
- upstream repository: https://github.com/Pylons/webtest.git
- release repository: https://github.com/asmodehn/webtest-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## webtest

```
* Avoid deprecation warning with py3.4
```
