### PR TITLE
ubiquity_motor: 0.5.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13061,7 +13061,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
-      version: 0.4.1-0
+      version: 0.5.0-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/ubiquity_motor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ubiquity_motor` to `0.5.0-0`:
- upstream repository: https://github.com/UbiquityRobotics/ubiquity_motor.git
- release repository: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.4.1-0`
## ubiquity_motor

```
* **NOTE:** This version drops support for firmware versions before 24
* Use new 8-byte serial protocol
* Add support for using dynamic_reconfigure to change PID parameters
* Add support for setting the deadman timer via a parameter
* Add support for debug registers, do enable better firmware diagnostics
* Add support for limit reached warnings from firmware
* Improved testing, more coverage and cleaner tests
* Have motor_node explicitly return an exit code
* Reduce memory allocations caused by resizing vectors
* Use size_t instead of int for iterating
* Contributors: Rohan Agrawal, Jim Vaughan
```
