### PR TITLE
phantomx_reactor_arm: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7708,7 +7708,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/phantomx_reactor_arm-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/phantomx_reactor_arm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `phantomx_reactor_arm` to `0.1.4-0`:
- upstream repository: https://github.com/RobotnikAutomation/phantomx_reactor_arm.git
- release repository: https://github.com/RobotnikAutomation/phantomx_reactor_arm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.1.3-0`
## phantomx_reactor_arm
- No changes
## phantomx_reactor_arm_controller

```
* modified 4dof launch file
* Contributors: carlos3dx
```
## phantomx_reactor_arm_description
- No changes
