### PR TITLE
rbcar_common: 1.0.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3205,7 +3205,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotnikAutomation/rbcar_common-release.git
-      version: 1.0.5-0
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/RobotnikAutomation/rbcar_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rbcar_common` to `1.0.5-1`:
- upstream repository: https://github.com/RobotnikAutomation/rbcar_common.git
- release repository: https://github.com/RobotnikAutomation/rbcar_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.0.5-0`
## rbcar_common
- No changes
## rbcar_description
- No changes
## rbcar_pad
- No changes
