### PR TITLE
rbcar_sim: 1.0.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3227,7 +3227,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotnikAutomation/rbcar_sim-release.git
-      version: 1.0.4-0
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/RobotnikAutomation/rbcar_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rbcar_sim` to `1.0.4-1`:
- upstream repository: https://github.com/RobotnikAutomation/rbcar_sim.git
- release repository: https://github.com/RobotnikAutomation/rbcar_sim-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.0.4-0`
## rbcar_control

```
* added twist_mux cfg file
* added twist mux to accept different inputs a twist
* Contributors: rguzman1
```
## rbcar_gazebo

```
* added gas station world to do some testing with map based loc and nav
* Contributors: rguzman1
```
## rbcar_joystick
- No changes
## rbcar_robot_control
- No changes
## rbcar_sim
- No changes
## rbcar_sim_bringup

```
* added launch to test in gs world with teb
* Contributors: rguzman1
```
