### PR TITLE
ubiquity_motor: 0.5.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5016,6 +5016,13 @@ repositories:
       url: https://github.com/meuchel/uavc_v4lctl.git
       version: master
     status: maintained
+  ubiquity_motor:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
+      version: 0.5.0-0
+    status: developed
   ublox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ubiquity_motor` to `0.5.0-0`:
- upstream repository: https://github.com/UbiquityRobotics/ubiquity_motor.git
- release repository: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## ubiquity_motor

```
* **NOTE:** This version drops support for firmware versions before 24
* Use new 8-byte serial protocol
* Add support for using dynamic_reconfigure to change PID parameters
* Add support for setting the deadman timer via a parameter
* Add support for debug registers, do enable better firmware diagnostics
* Add support for limit reached warnings from firmware
* Improved testing, more coverage and cleaner tests
* Have motor_node explicitly return an exit code
* Reduce memory allocations caused by resizing vectors
* Use size_t instead of int for iterating
* Contributors: Rohan Agrawal, Jim Vaughan
```
