### PR TITLE
romea_controllers: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9764,7 +9764,8 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/Romea/romea_controllers-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
+    status: developed
   romeo_moveit_actions:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `romea_controllers` to `0.1.2-0`:
- upstream repository: https://github.com/Romea/romea_controllers.git
- release repository: https://github.com/Romea/romea_controllers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.1.1-0`
## ackermann_controller

```
* Install python scripts
* Contributors: Vincent Rousseau
```
