### PR TITLE
humanoid_navigation: 0.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3668,6 +3668,17 @@ repositories:
       type: git
       url: https://github.com/AravindaDP/humanoid_navigation.git
       version: indigo-devel
+    release:
+      packages:
+      - footstep_planner
+      - gridmap_2d
+      - humanoid_localization
+      - humanoid_navigation
+      - humanoid_planner_2d
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/AravindaDP/humanoid_navigation-release.git
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/AravindaDP/humanoid_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `humanoid_navigation` to `0.4.1-0`:
- upstream repository: https://github.com/AravindaDP/humanoid_navigation.git
- release repository: https://github.com/AravindaDP/humanoid_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## footstep_planner

```
* Added include files for footstep_planner and gridmap_2d for install.
* uses double 2.0 and makes style locally consistent
* catkinize the stack
* Add service to (re)plan between feet as start and goal.
* Requires newest humanoid_msgs.
* Merge plan and replan functions
* RViz launch file / config Groovy
* mark heuristic as expired when map is updated
* removed code in the destructor that gets already cleaned up in the super class
* use pre-increment instead of post-increment (faster + post-increment for iterators not always optimizable)
* fixed sbpl exception catch
* introduced new functionality to totally reset the planning environment
* storing environment params in new struct -- get rid of unnecessary member variables
* more detailed information when sbpl planning was successful but only the old path is returned
* wait 0.5 sec before updating the start (robot) pose
* bug fix in path cost heuristic
* make footsteps smaller; +  std::max
* handle receiving of foot transformations differently
* implemented the polygon-intersection-check for the navigation as well; not used so far due to some usability issues
* bug resolved: free the execution log when planning failed; use ros::Time(0) instead of ros::Time::now() since when using the latter sometimes the tf cannot be received (now sometimes an outdated step is received but this works better anyhow)
* bug resulting in segfaulting thread now (probably) resolved
* replaced old reachable check by a new more smoother grid based approach
* small fix in the replanning logic
* enforce planning from scratch when necessary (e.g. goal changed when using backward planning)
* added assertion to enforce correct heuristic calculation
* applied ROS code style
* reorganized the way FootstepNavigation invokes the planner and starts the execution; changed FootstepPlanner::updateMap
* Contributors: Armin Hornung, Johannes Garimort, Pramuditha Aravinda, Vincent Rabaud, enriquefernandez
```
## gridmap_2d

```
* Added include files for footstep_planner and gridmap_2d for install.
* gridmap_2d : OpenCV migration for indigo.
* gridmap_2d: Adding conversion back to OccupancyGrid msg
* gridmap_2d: adding external access to individual cells, allow recomputation of distance map
* catkinize the stack
* gridmap_2d: Add option to treat unknown as obstacle
* Adding copy c'tor to gridmap_2d, humanoid_planner_2d using local map copy now
* gridmap_2d: Fix map inflation
* Contributors: Armin Hornung, Pramuditha Aravinda, Vincent Rabaud, enriquefernandez
```
## humanoid_localization

```
* catkinize the stack
* get code to compile under Hydro
* removes some trailing blanks and semicolon
* added localization Service to HumanoidLocalization (untested)
* Localization updates are now done based on the distance to the last localized pose (not summed distance)
* Homogeneous subsampling of laser points (PCL voxel grid) instead of angular
* Uniform sampling for depth camera data
* Motion model and noise can now be calibrated with a variance matrix. Some parameters are no longer used, please adjust accordingly:
  motion_noise/x, motion_noise/y, motion_noise/yaw, num_sensor_beams
* Preventing TF_OLD_DATA Warning when init from RVIZ
* refactoring/cleanup
* Added Timer to Localization and timerCallback now republishes latest tf transform
* added parameterization for odometry calibration in MotionModel
* Proper floor offset if z is constrained to supporting surface by kinematics / odometry
* More loops parallelized (motion model)
* fixes:

    * Fixed invalid conversion from 'octomap::AbstractOcTree*' to 'octomap::OcTree*'
    * Add dependency to cmake_modules for FindEigen.cmake
    * Fixed duplicate library export
    * Fixed linking endpointmodel to humanoidlocalization in case dynamicEDT3D is available
    * Fix missing OpenMP compilation flags (from catkinization)
    * Fixing error with constrainMotion flags and optimized-away assertion
    * Fixed point cloud callback crashing when ground filtering and no ground visible
    * Bugfix for OctoMap in Groovy
    * Height lookup for endpoint model fixed
    * Fixed raycasting height integration on non-zero ground and raycast max_range
    * bug fix: removed (unnecessary) feature in HumanoidLocalization
    * Fixed compilation with ROS groovy (tf types)
    * fixed localization for point clouds

* Contributors: Armin Hornung, Daniel Maier, Pramuditha Aravinda, Stefan Osswald, Vincent Rabaud, enriquefernandez
```
## humanoid_navigation

```
* humanoid_navigation : removed hrl_kinematics from runtime dependancy
* catkinize the stack
* humanoid_planner_2d on gridmaps, provides a lightweight wrapper around SBPL
* Contributors: Armin Hornung, Vincent Rabaud, enriquefernandez
```
## humanoid_planner_2d

```
* catkinize the stack
* humanoid_planner_2d on gridmaps, provides a lightweight wrapper around SBPL
* enhancements:

    * check if goal / start reachable before planning
    * adding option to find SBPL overlay, reducing output
    * Getters for robot (inflation) radius, path costs from SBPL
    * Add another planning method (double)

* fixes:

    * Fix map inflation for planning

* Contributors: Armin Hornung, Vincent Rabaud, enriquefernandez
```
