### PR TITLE
waypoint: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13658,6 +13658,25 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros.git
       version: indigo-devel
     status: maintained
+  waypoint:
+    doc:
+      type: git
+      url: https://github.com/jihoonl/waypoint.git
+      version: master
+    release:
+      packages:
+      - waypoint_generator
+      - waypoint_meta
+      - waypoint_touring
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/jihoonl/waypoint-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/jihoonl/waypoint.git
+      version: master
+    status: developed
   web_video_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `waypoint` to `0.0.1-0`:
- upstream repository: https://github.com/jihoonl/waypoint.git
- release repository: https://github.com/jihoonl/waypoint-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## waypoint_generator

```
* updating package info for releasE
* Contributors: Jihoon Lee
```
## waypoint_meta

```
* updating package info for releasE
* Contributors: Jihoon Lee
```
## waypoint_touring

```
* updating package info for releasE
* Contributors: Jihoon Lee
```
