### PR TITLE
waypoint: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5237,6 +5237,25 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros.git
       version: jade-devel
     status: maintained
+  waypoint:
+    doc:
+      type: git
+      url: https://github.com/jihoonl/waypoint.git
+      version: master
+    release:
+      packages:
+      - waypoint_generator
+      - waypoint_meta
+      - waypoint_touring
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/jihoonl/waypoint-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/jihoonl/waypoint.git
+      version: master
+    status: developed
   wireless:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `waypoint` to `0.0.1-0`:
- upstream repository: https://github.com/jihoonl/waypoint.git
- release repository: https://github.com/jihoonl/waypoint-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## waypoint_generator

```
* updating package info for releasE
* Contributors: Jihoon Lee
```
## waypoint_meta

```
* updating package info for releasE
* Contributors: Jihoon Lee
```
## waypoint_touring

```
* updating package info for releasE
* Contributors: Jihoon Lee
```
