### PR TITLE
jsk_common: 2.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4424,7 +4424,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.0.17-0
+      version: 2.1.0-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.1.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.0.17-0`
## dynamic_tf_publisher
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_data

```
* record.launch : add bagfile_prefix arg, add machine argument (https://github.com/jsk-ros-pkg/jsk_common/pull/1437, https://github.com/jsk-ros-pkg/jsk_common/pull/1438)

    * jsk_data/CMakeLists.txt : pr2_record could not run on travis
    * [jsk_data] add machine argument for record.launch
    * [jsk_data] add bagfile_prefix arg for record.launch
    * jsk_data/CMakeLists.txt : check if baxter_description is installed
    * [jsk_data] add pr2_description to run_depend
    * [jsk_data] add xacro to run_depend for testing
    * [jsk_data] add baxter_description to run_depend for testing
    * [jsk_data] add bagfile_prefix arg for record.launch

* hrp2_play.launch use urdf model with hand for robot_description when  playing with hrp2. (#1434 <https://github.com/jsk-ros-pkg/jsk_common/pull/1434>)
* pr2_play.launch: Remap /kinect_head topics to /kinect_head_c2 to play rosbag for pr2. (#1431 <https://github.com/jsk-ros-pkg/jsk_common/pull/1431>)
* download_data.py: Add pkg_name for cache_dir to avoid data filename conflicts (#1442 <https://github.com/jsk-ros-pkg/jsk_common/issues/1442> )

    * Add pkg_name for cache_dir to avoid data filename conflicts
    * Support setting abspath for downloading data

* data_collection_server.py: Another saving type LabelImage of data_collection_server (#1427 <https://github.com/jsk-ros-pkg/jsk_common/issues/1427>)
* camera_coords_change_trigger : Add trigger node for data collection by camera coords change  (#1432 <https://github.com/jsk-ros-pkg/jsk_common/issues/1432>)
  Originally developped in
  https://github.com/furushchev/jsk_semantics_201607/blob/master/jsk_pr2_wandering/node_scripts/camera_coords_change_trigger.py.
* synchronize_republish.py : Synchronize properly with slop for slow topics  (#1428 <https://github.com/jsk-ros-pkg/jsk_common/issues/1428>)
* Move README to sphinx docs for jsk_data package   (#1433 <https://github.com/jsk-ros-pkg/jsk_common/issues/1433>)
* Contributors: Kei Okada, Kentaro Wada, Masaki Murooka, Yuki Furuta
```
## jsk_network_tools

```
* [jsk_network_tools] add wifi_status.py (https://github.com/jsk-ros-pkg/jsk_common/pull/1448)
* Contributors: Yuki Furuta
```
## jsk_tilt_laser
- No changes
## jsk_tools

```
* now wstool info can run from any directory (#1452 <https://github.com/jsk-ros-pkg/jsk_common/issues/1452>)
  Closes (#1317 <https://github.com/jsk-ros-pkg/jsk_common/issues/1318>)
* use ip command for rossetip for better compatibility (#1436 <https://github.com/jsk-ros-pkg/jsk_common/issues/1436>)

    * [jsk_tools] add iproute2 to run_depend
    * [jsk_tools/env-hooks/99.jsk_tools.sh] use ip for rossetip instead of ifconfig

* Stamped filename for recoding video with axis camera (#1424 <https://github.com/jsk-ros-pkg/jsk_common/issues/1424>)
* Contributors: Kei Okada, Kentaro Wada, Yuki Furuta
```
## jsk_topic_tools

```
* [synchronize_republish.py] Republish after approximate synchronization (#1443 <https://github.com/jsk-ros-pkg/jsk_common/issues/1443>)

    * Add sample for synchronize_republish.py
    * Add script to publish statid image for sample/testing
    * Republish after approxiamte synchronization
    * Refactor synchrnoze_republish.py (making it pythonic)

* Refactor CMake files (#1447 <https://github.com/jsk-ros-pkg/jsk_common/issues/1447>)

    * Use project exported library for linking target library
    * Add ::test namespace to avoid conflicts of nodelet class name
    * Rename to have log_utils in the filename
    * Nodelet should be have suffix of _nodelet

* add JSK_NODELET_LOG_THROTTLE (#1446 <https://github.com/jsk-ros-pkg/jsk_common/issues/1446>)

    * [jsk_topic_tools] add test for JSK_NODELET_LOG
    * [jsk_topic_tools/src/log_utils.h] add THROTTLE to JSK_NODELET_LOG

* Contributors: Kei Okada, Kentaro Wada, Yuki Furuta
```
## multi_map_server
- No changes
## virtual_force_publisher
- No changes
