### PR TITLE
pyros_config: 0.1.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3016,8 +3016,8 @@ repositories:
   pyros_config:
     doc:
       type: git
-      url: https://github.com/asmodehn/pyros-config.git
-      version: master
+      url: https://github.com/asmodehn/pyros-config-rosrelease.git
+      version: release/kinetic/{package}
     release:
       tags:
         release: release/kinetic/{package}/{version}

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3013,6 +3013,17 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: kinetic-devel
     status: maintained
+  pyros_config:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/pyros-config.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/asmodehn/pyros-config-rosrelease.git
+      version: 0.1.5-1
+    status: developed
   pyros_test:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3017,7 +3017,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/asmodehn/pyros-config-rosrelease.git
-      version: release/kinetic/{package}
+      version: release/kinetic/pyros_config
     release:
       tags:
         release: release/kinetic/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_config` to `0.1.5-1`:
- upstream repository: https://github.com/asmodehn/pyros-config.git
- release repository: https://github.com/asmodehn/pyros-config-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## pyros_config

```
* Fixed regression about accepting dict and object when configuring.
  [alexv]
* Improved logging. cosmetics. [alexv]
```
