### PR TITLE
imu_tools: 1.1.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1718,7 +1718,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.1.0-0
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/imu_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.1.1-0`:
- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.1.0-0`
## imu_complementary_filter
- No changes
## imu_filter_madgwick

```
* Add parameter "world_frame": optionally use ENU or NED instead of NWU
  convention (from #60 <https://github.com/ccny-ros-pkg/imu_tools/issues/60>;
  closes #36 <https://github.com/ccny-ros-pkg/imu_tools/issues/36>)
* Add parameter "stateless" for debugging purposes: don't do any stateful
  filtering, but instead publish the orientation directly computed from the
  latest accelerometer (+ optionally magnetometer) readings alone
* Replace the (buggy) Euler-angle-based initialization routine
  (ImuFilterRos::computeRPY) by a correct transformation
  matrix based one (StatelessOrientation::computeOrientation) and make it
  available as a library function
* Refactor madgwickAHRSupdate() (pull out some functions, remove micro
  optimizations to improve readability)
* Add unit tests
* Contributors: Martin Guenther, Michael Stoll
```
## imu_tools
- No changes
## rviz_imu_plugin
- No changes
