### PR TITLE
imu_tools: 1.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1500,7 +1500,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.1.0-0
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/imu_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.1.2-0`:
- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.1.0-0`
## imu_complementary_filter
- No changes
## imu_filter_madgwick

```
* Add missing dependency on tf2_geometry_msgs
* Contributors: Martin Guenther
```
## imu_tools
- No changes
## rviz_imu_plugin
- No changes
