### PR TITLE
rtt: 2.8.3-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5335,7 +5335,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/orocos-gbp/rtt-release.git
-      version: 2.8.3-0
+      version: 2.8.3-1
     source:
       type: git
       url: https://github.com/orocos-toolchain/rtt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt` to `2.8.3-1`:
- upstream repository: https://github.com/orocos-toolchain/rtt.git
- release repository: https://github.com/orocos-gbp/rtt-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `2.8.3-0`
