### PR TITLE
Adding a netft_utils package for indigo/jade/kinetic

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6728,6 +6728,16 @@ repositories:
       url: https://github.com/nerian-vision/nerian_sp1.git
       version: master
     status: developed
+  netft_utils:
+    doc:
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/netft_utils.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/netft_utils.git
+      version: master
+    status: maintained
   nmea_comms:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3102,6 +3102,16 @@ repositories:
       url: https://github.com/nerian-vision/nerian_sp1.git
       version: master
     status: developed
+  netft_utils:
+    doc:
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/netft_utils.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/netft_utils.git
+      version: master
+    status: maintained
   nmea_comms:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2456,6 +2456,16 @@ repositories:
       url: https://github.com/nerian-vision/nerian_sp1.git
       version: master
     status: developed
+  netft_utils:
+    doc:
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/netft_utils.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/netft_utils.git
+      version: master
+    status: maintained
   nodelet_core:
     doc:
       type: git


### PR DESCRIPTION
It provides a C++ interface and a ROS node for an ATI force/torque sensor that's connected to an ATI Netbox. There are also some handy features like being able to specify the rate of data acquistion, the World tf frame, and the sensor tf frame. It builds on the original netft_rdt_driver package by Derek King, written in 2008 but not updated since ROS groovy.
