### PR TITLE
[K] doc and source for opencv_apps

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2682,11 +2682,19 @@ repositories:
       version: 3.1.0-16
     status: maintained
   opencv_apps:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/opencv_apps.git
+      version: indigo
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-perception/opencv_apps-release.git
       version: 1.11.13-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/opencv_apps.git
+      version: indigo
     status: developed
   opencv_candidate:
     release:


### PR DESCRIPTION
I think these entries just slipped off when it was released initially into K https://github.com/ros/rosdistro/pull/11777. [I](https://github.com/ros/rosdistro/blob/d0f1b754b8365ea55afb3b02d004a821e9eac87f/indigo/distribution.yaml#L7220) and [J](https://github.com/ros/rosdistro/blob/d0f1b754b8365ea55afb3b02d004a821e9eac87f/jade/distribution.yaml#L3469) already have these.
