### PR TITLE
sick_tim: 0.0.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4310,7 +4310,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/sick_tim-release.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/uos/sick_tim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_tim` to `0.0.9-0`:
- upstream repository: https://github.com/uos/sick_tim
- release repository: https://github.com/uos-gbp/sick_tim-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.0.8-0`
## sick_tim

```
* timestamp diagnostics must take into account time_offset (#41 <https://github.com/uos/sick_tim/issues/41>)
* Choose one of multiple connected scanners
* Contributors: Christian Reinhard, procopiostein
```
