### PR TITLE
fetch_pbd: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2623,7 +2623,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics/fetch_pbd-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_pbd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_pbd` to `0.0.3-0`:
- upstream repository: https://github.com/fetchrobotics/fetch_pbd.git
- release repository: https://github.com/fetchrobotics/fetch_pbd-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.2-0`
## fetch_arm_control

```
* More dependency fixing
* Contributors: Sarah Elliott
```
## fetch_pbd_interaction
- No changes
## fetch_social_gaze
- No changes
