### PR TITLE
srdfdom: 0.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4404,7 +4404,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/srdfdom-release.git
-      version: 0.3.2-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `0.4.0-0`:
- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/ros-gbp/srdfdom-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.3.2-0`
## srdfdom

```
* [fix] Define shared_ptr typedef (adjusting to the recent change in urdfdom) #21 <https://github.com/ros-planning/srdfdom/issues/21>
* Contributors: Dave Coleman, Robert Haschke
```
