### PR TITLE
multimaster_fkie: 0.5.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6293,7 +6293,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.5.6-0
+      version: 0.5.8-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.5.8-0`:
- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.5.6-0`
## default_cfg_fkie
- No changes
## master_discovery_fkie

```
* fix for #46 <https://github.com/fkie/multimaster_fkie/issues/46>: bouncing offline/online
  reduced discovery heartbeats, especially if one of the masters is not reachable anymore.
* Contributors: Alexander Tiderko
```
## master_sync_fkie
- No changes
## multimaster_fkie

```
* master_discovery_fkie: fix for #46 <https://github.com/fkie/multimaster_fkie/issues/46>: bouncing offline/online
  reduced discovery heartbeats, especially if one of the masters is not reachable anymore.
* node_manager_fkie: fixed the error occurs while open configuration for a selected node
* Contributors: Alexander Tiderko
```
## multimaster_msgs_fkie
- No changes
## node_manager_fkie

```
* node_manager_fkie: fixed the error occurs while open configuration for a selected node
* Contributors: Alexander Tiderko
```
