### PR TITLE
kvh_drivers: 1.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1706,7 +1706,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/kvh_drivers-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/ros-drivers/kvh_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kvh_drivers` to `1.0.2-0`:
- upstream repository: https://github.com/ros-drivers/kvh_drivers.git
- release repository: https://github.com/ros-drivers-gbp/kvh_drivers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.0.1-0`
## kvh

```
* relaxed errors as warnings
* Contributors: Geoff Viola
```
