### PR TITLE
rgbd_launch: 2.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9163,7 +9163,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rgbd_launch-release.git
-      version: 2.1.2-0
+      version: 2.1.3-0
     source:
       type: git
       url: https://github.com/ros-drivers/rgbd_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rgbd_launch` to `2.1.3-0`:
- upstream repository: https://github.com/ros-drivers/rgbd_launch.git
- release repository: https://github.com/ros-gbp/rgbd_launch-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `2.1.2-0`
## rgbd_launch

```
* [feat] add prefix to nodelet name #28 <https://github.com/ros-drivers/rgbd_launch/issues/28>
* [maintenance] Enable rostest #29 <https://github.com/ros-drivers/rgbd_launch/issues/29>, #31 <https://github.com/ros-drivers/rgbd_launch/issues/31>
* Contributors: Isaac I.Y. Saito, Kentaro Wada, Yuki Furuta
```
