### PR TITLE
catkin_pip: 0.1.16-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -393,7 +393,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/catkin_pip-release.git
-      version: 0.1.15-0
+      version: 0.1.16-0
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pip.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pip` to `0.1.16-0`:
- upstream repository: https://github.com/asmodehn/catkin_pip.git
- release repository: https://github.com/asmodehn/catkin_pip-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.1.15-0`
## catkin_pip

```
* now also checking for --system for pip > 6.0.0.
* small improvements for travis checks
* Contributors: AlexV, alexv
```
