### PR TITLE
mrpt_navigation: 0.1.14-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2215,7 +2215,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 0.1.13-0
+      version: 0.1.14-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `0.1.14-0`:
- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.1.13-0`
## mrpt_bridge

```
* fix build against mrpt < 1.5.0
* Contributors: Jose-Luis Blanco-Claraco
```
## mrpt_local_obstacles
- No changes
## mrpt_localization
- No changes
## mrpt_map
- No changes
## mrpt_msgs
- No changes
## mrpt_navigation
- No changes
## mrpt_rawlog
- No changes
## mrpt_reactivenav2d
- No changes
## mrpt_tutorials
- No changes
