### PR TITLE
Add python-pynfft to rosdep.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1613,6 +1613,9 @@ python-pymouse:
   ubuntu:
     pip:
       packages: [pymouse]
+python-pynfft:
+  debian: [python-pynfft]
+  ubuntu: [python-pynfft]
 python-pynmea2:
   ubuntu:
     pip:


### PR DESCRIPTION
The pynfft package allows non-uniform fourier analysis of signals. The
package is available at https://pypi.python.org/pypi/pynfftls, but is installed
through apt so as to satisfy underlying dependencies such as libfftw and libnfft3.
