### PR TITLE
jsk_visualization: 1.0.33-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4642,7 +4642,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.32-0
+      version: 1.0.33-0
     status: developed
   jskeus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.33-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.0.32-0`
## jsk_interactive
- No changes
## jsk_interactive_marker

```
* Show description of only object which is selected #633 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/633>
* [jsk_interactive_marker] Mode to display interactive manipultor only when selected #626 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/626>

    * Refactor: remove variable which is not used
    * Add doc symlink for jsk_interactive_marker
    * Menu to enable/disable interactive manipulator
    * Mode to display interactive manipultor only when selected

* Validate object name is not empty to insert #621 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/621>
* Set marker pose periodically for re-enabling on rviz #618 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/618>
* Contributors: Kentaro Wada
```
## jsk_interactive_test
- No changes
## jsk_rqt_plugins
- No changes
## jsk_rviz_plugins

```
* [doc/jsk_rviz_plugins/plugins/pie_chart.md, plotter_2d.md] add doc to how to change caption of overray text (Fix https://github.com/jsk-ros-pkg/jsk_visualization/issues/634)
* [jsk_rviz_plugins/CMakeLists.txt] Install samples dir that was missing for jsk_rviz_plugins (https://github.com/jsk-ros-pkg/jsk_visualization/issues/632)
* [jsk_rviz_plugins/samples/overlay_sample.py] Add queue_size arg for deprecated warning in overlay_sample.py (https://github.com/jsk-ros-pkg/jsk_visualization/issues/631)
* [jsk_rviz_plugins/src/overlay_text_display.cpp] Show available fonts using enum property (https://github.com/jsk-ros-pkg/jsk_visualization/issues/630)
* [jsk_rviz_plugins/src/overlay_picker_tool.cpp] handleDisplayClick was not going past first group  as after processing a group with no overlay item, it was still  returning true by default. It needed to return false to continue the
  seach (https://github.com/jsk-ros-pkg/jsk_visualization/issues/627)
* New rviz plugin to visualize jsk_recognition_msgs::BoundingBox (https://github.com/jsk-ros-pkg/jsk_visualization/issues/616)

    * [jsk_rviz_plugins/src/bounding_box_array_display.cpp] Show valid boxes even if invalid box is included

* Contributors: Jit Ray Chowdhury, Kei Okada, Kentaro Wada
```
## jsk_visualization
- No changes
