### PR TITLE
marshmallow: 2.9.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1978,6 +1978,13 @@ repositories:
       url: https://github.com/tuw-robotics/marker_rviz_plugin.git
       version: master
     status: maintained
+  marshmallow:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/asmodehn/marshmallow-rosrelease.git
+      version: 2.9.1-0
+    status: maintained
   marti_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marshmallow` to `2.9.1-0`:
- upstream repository: https://github.com/marshmallow-code/marshmallow.git
- release repository: https://github.com/asmodehn/marshmallow-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## marshmallow

```
Bug fixes:
* Fix serialization of ``datetime.time`` objects with microseconds (:issue:`464`). Thanks :user:`Tim-Erwin` for reporting and thanks :user:`vuonghv` for the fix.
* Make ``@validates`` consistent with field validator behavior: if validation fails, the field will not be included in the deserialized output (:issue:`391`). Thanks :user:`martinstein` for reporting and thanks :user:`@vuonghv` for the fix.
```
