### PR TITLE
jsk_recognition: 0.3.22-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4571,7 +4571,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.21-0
+      version: 0.3.22-0
     status: developed
   jsk_robot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.22-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.3.21-0`
## checkerboard_detector
- No changes
## imagesift

```
* remove imagesift/CATKIN_IGNORE which is wrongly commited on #1628
* Compile jsk_data from source in released testing
* Compile jsk_data from source in released testing
* jsk_tools/test_topic_published.py won't work on hydro
* Add test for imagesift
* Make imagesift stop depending on jsk_perception
* Install imagesift executable correctly (#1621)
* Contributors: Kei Okada, Kentaro Wada
```
## jsk_pcl_ros

```
* added cfg and launch files
* nodelet for tracking and updating object changes
* increase time-limit
* ColorBasedRegionGrowingSegmentation.cfg remove groovy code
* add test_color_based_region_growing_segmentation.test
* remove passthrough and fix type of kdtree
* fix description of BSD license and remove passthroughfilter
* add cfg of color_based_region_growing
* add dynamic reconfigure of color_based_region_growing
* Revert "Remove dependency on jsk_perception for separated build"
* Merge pull request #1820 from wkentaro/dep-pcl-perception
  Remove dependency on jsk_perception for separated build
* Missing installation of executables
* Fix missing dependency declaration of jsk_pcl_ros
* Fix order of components in find_package of jsk_pcl_ros
* Remove dependency on jsk_perception for separated build
* [jsk_pcl_ros/icp_registration] Fix error in case of input point cloud… (#1795)
  * [jsk_pcl_ros/icp_registration] Fix error in case of input point cloud size is 0
  * [jsk_pcl_ros/icp_registration] Publish empty topics
  * [jsk_pcl_ros/icp_registration] Add test
* Add missing build_depend on jsk_data (#1852)
  This is necessary to run install script on CMakeLists.txt.
* [jsk_pcl_ros] Preserve transform at subscribed timestamp for prev pointcloud in heightmap time accumulation (#1850)
* Install missing dirs for jsk_pcl_ros (#1847)
  The missing dirs are: config, launch, sample.
* Fix missing computation of point cloud center without box alignment (#1844)
* Fix missing dependency on jsk_data
* [jsk_pcl_ros/launch/openni2_remote.launch] relay camera_info for depth_registered.
* [jsk_pcl_ros/src/edge_depth_refinement_nodelet.cpp] fix duplication check. treat edges which have no duplication correctly.
* [jsk_pcl_ros/src/edge_depth_refinement_nodelet.cpp] remove unused local variable.
* [jsk_pcl_ros/src/parallel_edge_finder_nodelet.cpp] use advertise function defined in ConnectionBasedNodelet class.
* Compute point cloud centroid after transformed
* Extract indices correctly with empty cloud
* [jsk_pcl_ros/EdgeDepthRefinement] Add rostest for edge_depth_refinement
* [jsk_pcl_ros] Fixed mistake of condition in edge_depth_refinment
* [jsk_pcl_ros/line_segment_detector] Add test code
* [jsk_pcl_ros/line_segment_detector] Fixed avoiding boost::lock_error
* [jsk_pcl_ros/line_segment_detector] Modified line_segment_detector limitating length
* Publish correct size cloud even with empty indices for ExtractIndices
* [jsk_pcl_ros/people_tracking] Add test
* [jsk_pcl_ros/people_tracking] Add traindata
* [jsk_pcl_ros/people_tracking] Add people tracking nodelet
* Convert point cloud to point indices
* [jsk_pcl_ros] Add rearranged_bounding_box
* [jsk_pcl_ros/hsi_color_filter] Add gui program
* [jsk_pcl_ros] Add test for hsi_color_filter
* [jsk_pcl_ros/hsi_color_filter] Add option keep_organized: ture
* [jsk_pcl_ros] Add option keep_organized for color_filter
* Merge pull request #1758 from knorth55/fix-convex
  fix ConvexConnectedVoxels subscribers and publisher
* Align bounding boxes with target frame in ClusterPointIndicesDecomposer
* Add test for ClusterPointIndicesDecomposer
* Add sample for ClusterPointIndicesDecomposer
* [jsk_pcl_ros] add test for ConvexConnectedVoxels
* [jsk_pcl_ros] fix ConvexConnectedVoxels subscribers and publisher
* allow parent frame not set
* Refactor deprecated node compilation moved to jsk_pcl_ros_utils
  This is from same motivation as https://github.com/jsk-ros-pkg/jsk_recognition/pull/1726.
* [Normal Estimation OMP] add parameter for setting number of threads
* [jsk_pcl_ros] Fixed initialization of pnh in organized_edge_detector
* [jsk_pcl_ros] add test and sample launch for pointcloud database server
* fix parameter name in hsi_color_filter_sample.launch
* [jsk_pcl_ros] Use jsk_data download_data func for test_data
* [jsk_pcl_ros] fix and improve for frame_id
* [jsk_pcl_ros] add stl file load func to PointcloudDatabaseServer
* Stable ros version check by STRGREATER
* [jsk_pcl_ros] add dynamic_reconfigure in pointcloud_database_server (#1632)
* [jsk_pcl_ros] Support pcl 1.8 in 'jsk_pcl_ros' (#1609)
  * Support pcl 1.8 in 'jsk_pcl_ros'
  * Test building with PCL 1.8
  Modified:
  - .travis.yml
  Added:
  - .travis_before_script_pcl1.8.bash
* Build particle_filter_tracking only with OpenMP (#1607)
* Stop passing -z flag to ld with clang (#1606)
* Add boost namespace as boost::tie (#1608)
* Contributors: Iori Kumagai, Kei Okada, Kentaro Wada, Masaki Murooka, Satoshi Otsubo, Shingo Kitagawa, Yohei Kakiuchi, Yu Ohara, Hitoshi Kamada, Krishneel Chaudhary, Iori Yanokura, Yusuke Oshiro
```
## jsk_pcl_ros_utils

```
* [jsk_pcl_ros_utils/delay_point_cloud] Modified using message_filter for delay message
* [jsk_pcl_ros_utils/delay_point_cloud] Modified delay_point's time stampe
* [jsk_pcl_ros_utils/delay_point_cloud] Modified delay_time as dynamic parameter
* [jsk_pcl_ros_utils/delay_point_cloud] Refactor sleep_time -> delay_time
* [jsk_pcl_ros_utils] add test for polygon_array_unwrapper nodelet
* [jsk_pcl_ros_utils] add ~use_likelihood to polygon_array_unwrapper
* Retry at most three times point_indices_to_mask_image.test (#1848)
  To fix error sometimes on Travis.
* Convert cluster indices to point indices with index in rosparam (#1794)
  * Convert cluster indices to point indices with dynamic reconfigure
  * Test ClusterPointIndicesToPointIndices
  * Doc for ClusterPointIndicesToPointIndices
  * Not build cluster_point_indices_to_point_indices on hydro
* Add description about naming rule
* Fix test names in favor to {NODE_NAME}.test
* Negative index is skipped in conversion
* Add test for bounding_box_array_to_bounding_box
* Add sample for bounding_box_array_to_bounding_box
* Convert bounding box array to bounding box
* Fix typo in label_to_cluster_point_indices.h
* Convert point cloud to point indices
* Convert point cloud to mask image in a node
* Convert point indices to mask w/o sync if it's static
* Convert point indices to cluster point indices
  ex)
  - Input Indices: [0, 10, 20]
  - Output Cluster Indices: [[0, 10, 20]]
* [jsk_pcl_ros_utils/PointCloudToPCD] add test and sample launch
* [jsk_pcl_ros_utils/PointCloudToPCD] license modified to JSK
* [jsk_pcl_ros_utils] modify PointCloudToPCD to nodelet and add dynamic_reconfigure
* Stop passing -z flag to ld with clang (#1610)
* Contributors: Kentaro Wada, Shingo Kitagawa, Yuki Furuta, Iori Yanokura
```
## jsk_perception

```
* Basically, if the angle is less than 0, just add 180. Likewise if the angle is greater than 180, just subtract by 180. https://github.com/jsk-ros-pkg/jsk_recognition/pull/1593/files#r77976906
* Sobel operator with higher kernel can give better response https://github.com/jsk-ros-pkg/jsk_recognition/pull/1593#discussion_r77976333
* [jsk_perception] slic as submodule
* sparse_image_encoder.cpp: need to escape %
* remove orientationistogram is not used
* set defiend values to protected member variables
* add doc for image_time_diff.py
* [jsk_perception] Remain executable API for nodes which is moved to opencv_apps
  Delete deprecated API's cfg and src files.
* Declare jsk_add_rostest in all distros
* Add jsk_ prefix for local macros
* Refactor: jsk_perception_add_rostest -> _add_rostest
* Refactor: jsk_perception -> ${PROJECT_NAME}
* Refactor: jsk_perception_nodelet -> _add_nodelet
* Sort service files
* Fix if block syntax
  - Use endif()
  - Use quote "" for VERSION_GREATER
* Fix missing CATKIN_DEPENDS of posedetection_msgs
* Fix node executables installation by introducing macro
* Organize cmake setup order
  1. Initialization
  2. Download
  3. Catkin setup
  4. Build
  5. Install
  6. Test
* Add sample/test for blob_detector (#1849)
  * Add sample/test for blob_detector
  * Rename mask image file for understandable name
* Fix special character for double to print (#1836)
  * Fix special character for double to print
  * Add unit for percentage in sparse_image_encoder info printing
* Add sample & test for color_histogram node
* Fix image dimension robustness in ExtractImageChannel
* [jsk_perception/src/polygon_to_mask_image.cpp] add warning message when no camera info is available.
* Add test for extract_image_channel.py
* Add sample for extract_image_channel.py
* Extract image channel for channel value in rosparam
* disable global set ssl verification  to fase
* Add test for RectArrayToDensityImage
* Add sample for RectArrayToDensityImage
* Add sample for selective_search.py
* Convert rect array to density image
* Publish probability image in fcn_object_segmentation.py
* Publish whole black mask if no contour is found
* Use matplotlib.use('Agg') to make it work on server (without window)
* Update sample/test for drawn label names in label_image_decomposer
* Decompose labels with their names listed as legend
* Test LabelToMaskImage
* Add sample for LabelToMaskImage
* Node to convert label to mask image
* Use std::vector instead of cv::vector for OpenCV3
* Get bounding object mask image from noisy mask image
* replace cv::vector to std::vector
* enable to use cv::vector in opencv-3.x
* Merge pull request #1740 from wkentaro/fcn
  Fully Convolutional Networks for Object Segmentation
* [jsk_perception/src/virtual_camera_mono.cpp] process only when subscribed
* [jsk_perception/fast_rcnn] Modified avoiding size of rects is 0 case
* Catch error which unexpected size of mask
* Use larger buff_size to process input message with queue_size=1
* Use mask image to enhance the object recognition result
* Use timer and load img file when reconfigured in image_publisher
* Add python-fcn-pip in package.xml
* Add fcn_object_segmentation.launch
* Large size buff_size is required for taking time callback
* Test fcn_object_segmentation.py
* Sample for fcn_object_segmentation.py
* Fully Convolutional Networks for Object Segmentation
* Use small sized image for stable testing
* Make test for sklearn_classifier stable
* Make test for label_image_decomposer stable
* Add sample for slic_super_pixels
* Download trained_data in multiprocess
* Stop drawing boundary on label_image_decomposer
  - Not so pretty
  - Maybe Takes time
* Skip when no contours in BoundingRectMaskImage
* Test RectArrayActualSizeFilter
* Add sample for RectArrayActualSizeFilter
* Fix RectArrayActualSizeFilter in terms of size filtering
* Merge pull request #1731 from wkentaro/warn-no-test
  Warnings for without test node/nodelets
* Merge pull request #1732 from wkentaro/test-with-bof
  Add test for bof_histogram_extractor.py and sklearn_classifier.py
* jsk_perception/CMakeList.sxt: eigen_INCLUDE_DIRS must be located after catkin_INCLUDE_DIRS
* [jsk_perception] fix bug in solidity_rag_merge
* [polygon_array_color_histogram, polygon_array_color_likelihood] add queue size for message filter
* Warnings for without test node/nodelets
* Add test for bof_histogram_extractor.py and sklearn_classifier.py
* [polygon_array_color_likelihood] add code for reading yaml with latest yaml-cpp
* [jsk_pcl_ros] Fix mistake of rect_array_actual_size_filter
* Add sample for label_image_decomposer and use it in testing
* Add test, sample, and documentation for OverlayImageColorOnMono
* Add dynamic reconfigure for OverlayImageColorOnMono
* Implement OverlayImageColorOnMono
* Merge pull request #1697 from wkentaro/rectify-mask-image
  Implement ConvexHullMaskImage
* Add sample for mask_image_to_label.py
* Rename publish_fixed_images.launch -> sample_image_publisher.launch
* Use natural name of rqt_gui perspective for bof_object_recognition sample
* Add sample & test for BoundingRectMaskImage
* Implement BoundingRectMaskImage
* Add sample & test for ConvexHullMaskImage
* Implement ConvexHullMaskImage
* Add sample & test for BoundingRectMaskImage
* Implement BoundingRectMaskImage
* Add sample & test for MultiplyMaskImage
* Add sample & test for AddMaskImage
* Fix wrong mask size generated by MaskImageGenerator
  Fix #1701
* Add sample & test for MaskImageGenerator
* Add sample for apply_mask_image
* Install trained_data all time with dependency on ALL
* Merge pull request #1658 from wkentaro/color_pyx
  [jsk_recognition_utils] Add label color utility function
* Add test for 'rect_array_to_image_marker.py'
* Use labelcolormap in 'rect_array_to_image_marker.py'
* Use labelcolormap in 'draw_rect_array.py'
* Rename download_trained_data -> install_trained_data.py
  To follow install_test_data.py.
* Comment out test for vgg16_object_recognition does not work in Jenkins
* Install h5py via rosdep and apt
* Install vgg16 trained model
* Recognize object with VGG16 net
* Rename vgg16 -> vgg16_fast_rcnn
* Fix typo in bof_histogram_extractor.py
* Implement drawing node of classification result
* Rename fast_rcnn_caffenet -> fast_rcnn
* Remove dependency on rbgirshick/fast-rcnn
* CMakeLists.txt:  on Hydro  contains /opt/ros/hydro/include so we need to add after catkin_INCLUDE_DIRS
* Merge pull request #1627 from wkentaro/use-jsk_data
  [jsk_perception] Use jsk_data download_data function for test_data
* Merge pull request #1628 from wkentaro/download-jsk_data-trained-data
  [jsk_perception] Download trained_data with jsk_data function
* Use jsk_data download_data function for test_data
* Download trained_data with jsk_data function
* Add roslaunch_add_file_check with add_rostest
* Comment out bof_object_recognition.test because of no resolved imagesift depends
* Support latest sklearn in BoF feature extraction
* Make jsk_perception depend on imagesift for BoF
* Migrate completely jsk_perception/image_utils.h to jsk_recognition_utils/cv_utils.h
* Stable ros version check by STRGREATER
* Deprecated create_feature0d_dataset.[py,launch]
  Please use create_sift_dataset.py.
* Make it stable image_cluster_indices_decomposer.test
* Make selective_search.test be stable
* Make slic_super_pixels.test be stable
* Make colorize_float_image.test be stable
* Make colorize_labels test stable
* Make apply_mask_image.test be stable
* Make bof_object_recognition.test stable
* Make kmeans.test be stable
* Make bing.test be stable
* Make jsk_perception depend on image_view2 for ImageMaker2 message
* Fix opencv version condition for bing.test (#1638)
* [jsk_perception] Test tile_image.py (#1635)
  * Follow name convention sample_tile_image.launch
  * Test tile_image.py
* Test colorize_float_image (#1636)
* Test mask_image_to_label.py (#1634)
* [jsk_perception] Add test for BoF object recognition sample (#1626)
  * Refactor: BoF object recognition sample filname
  * Add test for BoF object recognition sample
* Test apply mask image (#1615)
  Modified:
  - jsk_perception/CMakeLists.txt
  Added:
  - jsk_perception/test/apply_mask_image.test
* Add rqt_gui perspective file for BoF sample (#1622)
* Test colorize labels (#1614)
  Modified:
  - jsk_perception/CMakeLists.txt
  Added:
  - jsk_perception/test/colorize_labels.test
* Condition to find OpenCV 3 (> 2.9.9) (#1603)
* Test KMeans (#1612)
  Modified:
  - jsk_perception/CMakeLists.txt
  Added:
  - jsk_perception/test/kmeans.test
* Compile some nodes only when OpenMP found (#1604)
* Stop passing -z flag to ld with clang (#1602)
* [jsk_perception] Find OpenMP as an optional module (#1600)
  * Find OpenMP as an optional module
  * Fix indent of cmake
* Refactoring: Rename test file for consistency (#1611)
* [jsk_perception] Test image_publisher.py (#1613)
  * Refactoring: remap ~output/camera_info to ~camera_info
  This is a natural output topic design especially for image_pipeline package.
  * Test image_publisher.py
  Added:
  - jsk_perception/test/image_publisher.test
* [jsk_perception] BING: Binarized Normed Gradients for Objectness Estimation at 300fps (#1598)
  * Add trained_data/
  * Add bing
  * Download trained_data for bing
  * Documentation about bing
  * Add test and sample for bing
  * Download trained_data for bing automatically
* Add trained_data/ (#1597)
* clf save directory fixed (#1539)
* [jsk_perception/image_cluster_indices_decomposer] fix typo (#1592)
* Contributors: Kei Okada, Kentaro Wada, Kim Heecheol, Masaki Murooka, Ryohei Ueda, Shingo Kitagawa, Shintaro Hori, Yohei Kakiuchi, Yuki Furuta, Iori Yanokura, Hiroto Mizohana
```
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## jsk_recognition_utils

```
* Merge pull request #1826 from mmurooka/polyarr-to-poly2
  [jsk_recognition_utils/node_scripts] add polygon_array_to_polygon.py
* [jsk_recognition_utils/node_scripts] add polygon_array_to_polygon.py
* Skip rostest on hydro because of unreleased test tools
* Add test for bounding_box_array_publisher.py
* Add sample for bounding_box_array_publisher.py
* Node to publish bounding box array
* Skip rostest on hydro because of unreleased test tools
* Add test for bounding_box_array_publisher.py
* Add sample for bounding_box_array_publisher.py
* Node to publish bounding box array
* Merge pull request #1809 from wkentaro/feature/pose-array-to-pose
  Convert PoseArray to PoseStamped with a specified index
* Convert PoseArray to PoseStamped with a specified index
* Rename test files in favor to {NODE_NAME}.test
* Add util to convert image 16uc1 to 32fc1
* Merge pull request #1694 from wkentaro/get-numpy-include-dirs
  [jsk_recognition_utils] Set Numpy include directories in cmake to fix error on OS X
* Set Numpy include directories in cmake to fix error on OS X
* Remove color_gategoryXX (use labelcolormap)
* Add label color utility function
* Remove nms.py that is moved to nms.pyx
* Recognize object with VGG16 net
* Rename vgg16 -> vgg16_fast_rcnn
* Cythonize Non-maximum Supression baseline
* Remove dependency on rbgirshick/fast-rcnn
* Support old scipy which does not have face()
* Add static virtual camera
* Copy jsk_perception/image_utils.h to jsk_recognition_utils/cv_utils.h
* Stop passing -z flag to ld with Clang (#1601)
* Contributors: Kei Okada, Kentaro Wada, Masaki Murooka
```
## resized_image_transport

```
* .travis.yml: add test to check if this works with release repository (#1595)
  * .travis.yml: add test to check if this works with release repository
  * update jsk_travis to 0.4.1
  * resized_image_transport: fix to work with jsk_topic_tools < 2.0.10
  * update jsk_travis 0.4.2
* Add onInitPostProcess for image_resizer (#1590)
  Modified:
  - resized_image_transport/src/image_resizer_nodelet.cpp
* [resized_image_transport] Add test for image_resizer (#1589)
  * Fix deprecated error about advertiseCamera
  Modified:
  - resized_image_transport/src/image_processing_nodelet.cpp
  * Test if image_resizer's output topic is published
  Modified:
  - resized_image_transport/CMakeLists.txt
  Added:
  - resized_image_transport/test/image_resizer.test
* Contributors: Kei Okada, Kentaro Wada
```
