### PR TITLE
tty0tty: 1.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12825,6 +12825,13 @@ repositories:
       url: https://bitbucket.org/traclabs/trac_ik.git
       version: master
     status: developed
+  tty0tty:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/rohbotics/tty0tty-release.git
+      version: 1.2.0-0
+    status: maintained
   tum_ardrone:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tty0tty` to `1.2.0-0`:
- upstream repository: https://github.com/rohbotics/tty0tty.git
- release repository: https://github.com/rohbotics/tty0tty-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
