### PR TITLE
rgbd_launch: 2.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3334,7 +3334,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rgbd_launch-release.git
-      version: 2.2.1-0
+      version: 2.2.2-0
     source:
       type: git
       url: https://github.com/ros-drivers/rgbd_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rgbd_launch` to `2.2.2-0`:
- upstream repository: https://github.com/ros-drivers/rgbd_launch.git
- release repository: https://github.com/ros-gbp/rgbd_launch-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `2.2.1-0`
## rgbd_launch

```
* [capability] add rgb prefix, rectify_ir to node name
* [maintenance] enable rostest upon build.
* [maintenance] Remove Indigo. Enable Kinetic from Travis conf. #32 <https://github.com/ros-drivers/rgbd_launch/issues/32>
* Contributors: Yuki Furuta, Isaac I.Y. Saito
```
