### PR TITLE
jsk_recognition: 0.3.23-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4571,7 +4571,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.22-0
+      version: 0.3.23-0
     status: developed
   jsk_robot:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.23-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.3.22-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros
- No changes
## jsk_pcl_ros_utils
- No changes
## jsk_perception

```
* euslisp/eusmodel_template_gen_utils.l: create directory if tepmlate path is not found
* CMakeLists.txt : Makefile.slic is no longer used
* Contributors: Kei Okada
```
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## jsk_recognition_utils
- No changes
## resized_image_transport
- No changes
