### PR TITLE
dynpick_driver: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -681,7 +681,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/dynpick_driver-release.git
-      version: 0.0.11-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/tork-a/dynpick_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynpick_driver` to `0.1.0-0`:
- upstream repository: https://github.com/tork-a/dynpick_driver.git
- release repository: https://github.com/tork-a/dynpick_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.0.11-0`
## dynpick_driver

```
* ADD urdf model #32 <https://github.com/tork-a/dynpick_driver/issues/32>
  * Changed sample launch to show model instead of static tf-frame
* Add tare service #30 <https://github.com/tork-a/dynpick_driver/issues/30>
  * uses std::srvs::Trigger
  * ordered dependencies alphabetically
  * Need to send offset_reset command several times (3 at my tests) to work
* Contributors: Lorenz Halt
```
