### PR TITLE
bwi_common: 0.3.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -840,7 +840,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/bwi_common-release.git
-      version: 0.3.11-0
+      version: 0.3.12-0
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bwi_common` to `0.3.12-0`:
- upstream repository: https://github.com/utexas-bwi/bwi_common.git
- release repository: https://github.com/utexas-bwi-gbp/bwi_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.3.11-0`
## bwi_common

```
* add missing metapackage dependencies (#74 <https://github.com/utexas-bwi/bwi_common/issues/74>)
```
## bwi_gazebo_entities
- No changes
## bwi_interruptable_action_server
- No changes
## bwi_joystick_teleop
- No changes
## bwi_kr_execution
- No changes
## bwi_logging
- No changes
## bwi_mapper
- No changes
## bwi_msgs
- No changes
## bwi_planning_common
- No changes
## bwi_rqt_plugins
- No changes
## bwi_scavenger
- No changes
## bwi_services
- No changes
## bwi_tasks
- No changes
## bwi_tools
- No changes
## bwi_virtour

```
* set execute permissions when installing scripts (utexas-bwi/bwi#46 <https://github.com/utexas-bwi/bwi/issues/46>)
* document link to web page (#78 <https://github.com/utexas-bwi/bwi_common/issues/78>)
* add roslaunch check (#73 <https://github.com/utexas-bwi/bwi_common/issues/73>)
* Contributors: Jack O'Quin
```
## multi_level_map_msgs
- No changes
## multi_level_map_server
- No changes
## multi_level_map_utils
- No changes
## stop_base
- No changes
## utexas_gdc
- No changes
