### PR TITLE
view_controller_msgs: 0.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6219,6 +6219,21 @@ repositories:
       url: https://github.com/ros-drivers/video_stream_opencv.git
       version: master
     status: maintained
+  view_controller_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/view_controller_msgs.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/view_controller_msgs-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/view_controller_msgs.git
+      version: hydro-devel
+    status: maintained
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `view_controller_msgs` to `0.1.2-0`:
- upstream repository: https://github.com/ros-visualization/view_controller_msgs.git
- release repository: https://github.com/ros-gbp/view_controller_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## view_controller_msgs

```
* force correct version in package.xml
* rename scripts; install scripts
* fix test scripts
* apply catkin_lint
* catkinizing
* 0.1.1
* more attempts 2
* more attempts 2
* more attempts
* still fixing release build - 3
* still fixing release build - 2
* still fixing release build
* trys to fix msg generation
* fixed stack.xml
* changed parameter name
* moved msgs to own repo
* Initial commit
* Contributors: Adam Leeper, Sachin Chitta
```
