### PR TITLE
Update Debian header file package names

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2936,7 +2936,10 @@ libzmqpp3:
   ubuntu: [libzmqpp3]
 linux-headers-generic:
   arch: [linux-headers]
-  debian: [linux-headers-generic]
+  debian:
+    jessie: [linux-headers-3.16.0-4-all]
+    stretch: [linux-headers-4.6.0-1-all]
+    wheezy: [linux-headers-3.2.0-4-all]
   fedora: [kernel-headers]
   ubuntu: [linux-headers-generic]
 log4cxx:


### PR DESCRIPTION
Debian does not have a package named 'linux-headers-generic'
E: Package 'linux-headers-generic' has no installation candidate

Found while testing DKMS functionality as part of ros-<distro>-librealsense package install as dependency of ros-<distro>-realsense-camera in Debian docker images for ARM.
