### PR TITLE
jsk_recognition: 0.3.24-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1964,7 +1964,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.23-0
+      version: 0.3.24-0
     status: developed
   jsk_roseus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.24-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.3.23-0`
## checkerboard_detector
- No changes
## imagesift
- No changes
## jsk_pcl_ros
- No changes
## jsk_pcl_ros_utils
- No changes
## jsk_perception

```
* CMakeLists.txt : jsk_data is required in build time, used in scripts/install_sample_data
* Contributors: Kei Okada
```
## jsk_recognition
- No changes
## jsk_recognition_msgs
- No changes
## jsk_recognition_utils
- No changes
## resized_image_transport
- No changes
