### PR TITLE
hokuyo3d: 0.1.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3557,7 +3557,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/at-wat/hokuyo3d-release.git
-      version: 0.1.0-0
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/at-wat/hokuyo3d.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hokuyo3d` to `0.1.1-1`:
- upstream repository: https://github.com/at-wat/hokuyo3d.git
- release repository: https://github.com/at-wat/hokuyo3d-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.1.0-0`
## hokuyo3d

```
* updates e-mail address of the author
* adds error-message packet handling
* Merge branch 'lgerardSRI-master'
* Install the hokuyo3d executable
* Contributors: Atsushi Watanabe, Leonard Gerard
```
