### PR TITLE
Removed source entries from vigir_footstep_planning stack

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13533,17 +13533,9 @@ repositories:
       type: git
       url: https://github.com/team-vigir/vigir_footstep_planning_basics.git
       version: master
-    source:
-      type: git
-      url: https://github.com/team-vigir/vigir_footstep_planning_basics.git
-      version: master
     status: maintained
   vigir_footstep_planning_core:
     doc:
-      type: git
-      url: https://github.com/team-vigir/vigir_footstep_planning_core.git
-      version: master
-    source:
       type: git
       url: https://github.com/team-vigir/vigir_footstep_planning_core.git
       version: master
@@ -13553,17 +13545,9 @@ repositories:
       type: git
       url: https://github.com/team-vigir/vigir_footstep_planning_msgs.git
       version: master
-    source:
-      type: git
-      url: https://github.com/team-vigir/vigir_footstep_planning_msgs.git
-      version: master
     status: maintained
   vigir_generic_params:
     doc:
-      type: git
-      url: https://github.com/team-vigir/vigir_generic_params.git
-      version: master
-    source:
       type: git
       url: https://github.com/team-vigir/vigir_generic_params.git
       version: master
@@ -13573,17 +13557,9 @@ repositories:
       type: git
       url: https://github.com/team-vigir/vigir_pluginlib.git
       version: master
-    source:
-      type: git
-      url: https://github.com/team-vigir/vigir_pluginlib.git
-      version: master
     status: maintained
   vigir_step_control:
     doc:
-      type: git
-      url: https://github.com/team-vigir/vigir_step_control.git
-      version: master
-    source:
       type: git
       url: https://github.com/team-vigir/vigir_step_control.git
       version: master


### PR DESCRIPTION
Removed source entries from vigir_footstep_planning stack due to Jenkins build errors and we need only documentation to be generated.
