### PR TITLE
pepperl_fuchs: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7681,6 +7681,13 @@ repositories:
       type: git
       url: https://github.com/dillenberger/pepperl_fuchs.git
       version: master
+    release:
+      packages:
+      - pepperl_fuchs_r2000
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/dillenberger/pepperl_fuchs-release.git
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/dillenberger/pepperl_fuchs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepperl_fuchs` to `0.1.3-0`:
- upstream repository: https://github.com/dillenberger/pepperl_fuchs.git
- release repository: https://github.com/dillenberger/pepperl_fuchs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## pepperl_fuchs_r2000

```
* Initial release
* Contributors: Denis Dillenberger, Kevin Hallenbeck
```
