### PR TITLE
pepperl_fuchs: 0.1.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3769,6 +3769,23 @@ repositories:
       url: https://github.com/ros-naoqi/pepper_robot.git
       version: master
     status: maintained
+  pepperl_fuchs:
+    doc:
+      type: git
+      url: https://github.com/dillenberger/pepperl_fuchs.git
+      version: master
+    release:
+      packages:
+      - pepperl_fuchs_r2000
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/dillenberger/pepperl_fuchs-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/dillenberger/pepperl_fuchs.git
+      version: master
+    status: maintained
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepperl_fuchs` to `0.1.3-0`:
- upstream repository: https://github.com/dillenberger/pepperl_fuchs.git
- release repository: https://github.com/dillenberger/pepperl_fuchs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## pepperl_fuchs_r2000

```
* Initial release
* Contributors: Denis Dillenberger, Kevin Hallenbeck
```
