### PR TITLE
hokuyo3d: 0.1.1-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1567,6 +1567,21 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
       version: 0.3.3-0
     status: maintained
+  hokuyo3d:
+    doc:
+      type: git
+      url: https://github.com/at-wat/hokuyo3d.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/at-wat/hokuyo3d-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/at-wat/hokuyo3d.git
+      version: indigo-devel
+    status: developed
   hokuyo_node:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `hokuyo3d` to `0.1.1-1`:
- upstream repository: https://github.com/at-wat/hokuyo3d.git
- release repository: https://github.com/at-wat/hokuyo3d-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## hokuyo3d

```
* updates e-mail address of the author
* adds error-message packet handling
* Merge branch 'lgerardSRI-master'
* Install the hokuyo3d executable
* Contributors: Atsushi Watanabe, Leonard Gerard
```
