### PR TITLE
hokuyo3d: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1381,6 +1381,21 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
       version: 0.3.4-0
     status: maintained
+  hokuyo3d:
+    doc:
+      type: git
+      url: https://github.com/at-wat/hokuyo3d.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/at-wat/hokuyo3d-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/at-wat/hokuyo3d.git
+      version: indigo-devel
+    status: developed
   household_objects_database_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hokuyo3d` to `0.1.1-0`:
- upstream repository: https://github.com/at-wat/hokuyo3d.git
- release repository: https://github.com/at-wat/hokuyo3d-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## hokuyo3d

```
* updates e-mail address of the author
* adds error-message packet handling
* Merge branch 'lgerardSRI-master'
* Install the hokuyo3d executable
* Contributors: Atsushi Watanabe, Leonard Gerard
```
