### PR TITLE
jsk_common: 2.1.2-4 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4443,7 +4443,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.1.2-2
+      version: 2.1.2-4
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.1.2-4`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `2.1.2-2`
## dynamic_tf_publisher
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_data

```
* src/jsk_data/download_data.py : create path direcotory before download data and return if permission denied, catch resourceNotFound
* Contributors: Kei Okada
```
## jsk_network_tools
- No changes
## jsk_tilt_laser
- No changes
## jsk_tools
- No changes
## jsk_topic_tools
- No changes
## multi_map_server
- No changes
## virtual_force_publisher
- No changes
