### PR TITLE
jsk_pr2eus: 0.3.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1943,7 +1943,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_pr2eus-release.git
-      version: 0.3.4-0
+      version: 0.3.5-0
     status: developed
   jsk_recognition:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.3.5-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_pr2eus
- release repository: https://github.com/tork-a/jsk_pr2eus-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.3.4-0`
## jsk_pr2eus
- No changes
## pr2eus

```
* robot-interface.l

    * fix :wait-intepolation-smooth for SinglePointJointAcionGoal (#245 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/245>)
    * use control_msgs/FollowJointTrajectoryAction for base trajectory action (#237 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/237>)
    * fix: wrong code in  :move-trajectory (#240 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/240>)
    * the implementation of condition to break loop in :wait-until-update-all-joints. (#239 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/239>)
    * :wait-until-update-all-joints need to call :robot-interface-simulation-callback explicitly (#238 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/238>)

* sometines :state .. :wait-unitl-update t did not return (https://github.com/jsk-ros-pkg/jsk_robot/pull/627)

    * add test-state-wait-until-updatee (#238 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/238>)
    * include also redundant links when calculate collision

* speak.l

    * add *speak-timeout* param to wait action server (#246 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/246>)
    * use single speak-action-client (#241 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/241>)

* CMakeLists.txt: remove unused variable from catkin_package (#243 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/243>)
* pr2.l: comment out pr2 function for pr2-robot (#242 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/242>)
* Contributors: Kei Okada, MasakiMurooka, Yuki Furuta, Chi Wun Au
```
## pr2eus_moveit
- No changes
## pr2eus_tutorials
- No changes
