### PR TITLE
pepper_dcm_robot: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7627,6 +7627,24 @@ repositories:
       url: https://github.com/wg-perception/people.git
       version: indigo-devel
     status: maintained
+  pepper_dcm_robot:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_dcm_robot.git
+      version: git
+    release:
+      packages:
+      - pepper_dcm_bringup
+      - pepper_dcm_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-naoqi/pepper_dcm_robot-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_dcm_robot.git
+      version: master
+    status: maintained
   pepper_meshes:
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7631,7 +7631,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-naoqi/pepper_dcm_robot.git
-      version: git
+      version: master
     release:
       packages:
       - pepper_dcm_bringup


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_dcm_robot` to `0.0.1-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_dcm_robot.git
- release repository: https://github.com/ros-naoqi/pepper_dcm_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## pepper_dcm_bringup

```
* fixing the source link
* adding CHANGELOG.rst
* updating config params
* making it working on Pepper with naoqi_dcm_driver
* configuring to use with MoveIt
* initial commit
* Contributors: Karsten Knese, Natalia Lyubova
```
## pepper_dcm_msgs

```
* fixing the source link
* adding CHANGELOG.rst
* initial commit
* Contributors: Karsten Knese, Natalia Lyubova
```
