### PR TITLE
naoqi_dcm_driver: 0.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1036,6 +1036,23 @@ repositories:
       url: https://github.com/introlab/find_object_2d-release.git
       version: 0.5.1-0
     status: maintained
+  foo:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_dcm_driver.git
+      version: master
+    release:
+      packages:
+      - naoqi_dcm_driver
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-naoqi/naoqi_dcm_driver-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_dcm_driver.git
+      version: master
+    status: maintained
   force_torque_tools:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1036,23 +1036,6 @@ repositories:
       url: https://github.com/introlab/find_object_2d-release.git
       version: 0.5.1-0
     status: maintained
-  naoqi_dcm_driver:
-    doc:
-      type: git
-      url: https://github.com/ros-naoqi/naoqi_dcm_driver.git
-      version: master
-    release:
-      packages:
-      - naoqi_dcm_driver
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/ros-naoqi/naoqi_dcm_driver-release.git
-      version: 0.0.1-0
-    source:
-      type: git
-      url: https://github.com/ros-naoqi/naoqi_dcm_driver.git
-      version: master
-    status: maintained
   force_torque_tools:
     doc:
       type: git
@@ -2959,6 +2942,23 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_dashboard.git
+      version: master
+    status: maintained
+  naoqi_dcm_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_dcm_driver.git
+      version: master
+    release:
+      packages:
+      - naoqi_dcm_driver
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-naoqi/naoqi_dcm_driver-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_dcm_driver.git
       version: master
     status: maintained
   naoqi_driver:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2950,8 +2950,6 @@ repositories:
       url: https://github.com/ros-naoqi/naoqi_dcm_driver.git
       version: master
     release:
-      packages:
-      - naoqi_dcm_driver
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_dcm_driver-release.git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1036,7 +1036,7 @@ repositories:
       url: https://github.com/introlab/find_object_2d-release.git
       version: 0.5.1-0
     status: maintained
-  foo:
+  naoqi_dcm_driver:
     doc:
       type: git
       url: https://github.com/ros-naoqi/naoqi_dcm_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foo` to `0.0.1-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_dcm_driver.git
- release repository: https://github.com/ros-naoqi/naoqi_dcm_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## naoqi_dcm_driver

```
* refactoring
* adding a wrapper for Memory Proxy
* updating the README
* exit Touch service
* adding the diagnostics class
* adding tools for AnyValue conversion
* fixing velocity control
* initial commit
* Contributors: Natalia Lyubova
```
