### PR TITLE
ros: 1.13.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3699,7 +3699,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.13.1-0
+      version: 1.13.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.13.3-0`:
- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.13.1-0`
## mk
- No changes
## rosbash

```
* fix spelling of 'rosed' in usage (#118 <https://github.com/ros/ros/pull/118>)
```
## rosboost_cfg
- No changes
## rosbuild
- No changes
## rosclean
- No changes
## roscreate
- No changes
## roslang
- No changes
## roslib

```
* allow expected ROS_DISTRO value to be overridden at compile time (#122 <https://github.com/ros/ros/pull/122>)
```
## rosmake
- No changes
## rosunit

```
* allow custom class_name, testcase_name in test_xx_junit_xml (#119 <https://github.com/ros/ros/issues/119>)
* fix check of test type (#121 <https://github.com/ros/ros/issues/121>)
```
