### PR TITLE
repository_name: 0.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4313,6 +4313,15 @@ repositories:
       url: https://github.com/ros-controls/realtime_tools.git
       version: indigo-devel
     status: maintained
+  repository_name:
+    release:
+      packages:
+      - rviz_ortho_view_controller
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ajshort/rviz_ortho_view_controller-release.git
+      version: 0.1.0-0
+    status: maintained
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `repository_name` to `0.1.0-0`:
- upstream repository: https://github.com/ajshort/rviz_ortho_view_controller.git
- release repository: https://github.com/ajshort/rviz_ortho_view_controller-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## rviz_ortho_view_controller

```
* Update catkin_package
* Initial commit
* Contributors: Andrew Short
```
