### PR TITLE
rail_segmentation: 0.1.10-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4262,7 +4262,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/gt-rail-release/rail_segmentation.git
-      version: 0.1.9-0
+      version: 0.1.10-1
     source:
       type: git
       url: https://github.com/GT-RAIL/rail_segmentation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_segmentation` to `0.1.10-1`:
- upstream repository: https://github.com/GT-RAIL/rail_segmentation.git
- release repository: https://github.com/gt-rail-release/rail_segmentation.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.1.9-0`
## rail_segmentation

```
* Merge pull request #4 <https://github.com/GT-RAIL/rail_segmentation/issues/4> from velveteenrobot/publish-table
  Now publishes table as SegmentedObject and table marker as Marker
* Now publishes table as SegmentedObject and table marker as Marker
* New travis for indigo and jade
* email update
* Contributors: Russell Toris, Sarah Elliott
```
