### PR TITLE
naoqi_dcm_driver: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2384,6 +2384,21 @@ repositories:
       url: https://github.com/ros-naoqi/naoqi_bridge_msgs-release.git
       version: 0.0.5-3
     status: maintained
+  naoqi_dcm_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_dcm_driver.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-naoqi/naoqi_dcm_driver-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_dcm_driver.git
+      version: master
+    status: maintained
   naoqi_driver:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_dcm_driver` to `0.0.1-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_dcm_driver.git
- release repository: https://github.com/ros-naoqi/naoqi_dcm_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## naoqi_dcm_driver

```
* refactoring
* adding a wrapper for Memory Proxy
* updating the README
* exit Touch service
* adding the diagnostics class
* adding tools for AnyValue conversion
* fixing velocity control
* initial commit
* Contributors: Natalia Lyubova
```
