### PR TITLE
pepper_moveit_config: 0.0.4-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7664,7 +7664,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_moveit_config-release.git
-      version: 0.0.4-1
+      version: 0.0.4-2
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_moveit_config.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7664,7 +7664,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_moveit_config-release.git
-      version: 0.0.4-2
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_moveit_config` to `0.0.4-2`:
- upstream repository: https://github.com/nlyubova/pepper_moveit_config.git
- release repository: https://github.com/ros-naoqi/pepper_moveit_config-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.0.4-1`
## pepper_moveit_config

```
* remove pepper_meshes from dependency because license not displayed on buildfarm
* Contributors: Mikael Arguedas
```
