### PR TITLE
pepper_dcm_robot: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2976,7 +2976,6 @@ repositories:
     release:
       packages:
       - pepper_dcm_bringup
-      - pepper_dcm_msgs
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_dcm_robot-release.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2968,6 +2968,24 @@ repositories:
       url: https://github.com/wg-perception/people.git
       version: indigo-devel
     status: maintained
+  pepper_dcm_robot:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_dcm_robot.git
+      version: master
+    release:
+      packages:
+      - pepper_dcm_bringup
+      - pepper_dcm_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-naoqi/pepper_dcm_robot-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_dcm_robot.git
+      version: master
+    status: developed
   pepper_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_dcm_robot` to `0.0.1-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_dcm_robot.git
- release repository: https://github.com/ros-naoqi/pepper_dcm_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## pepper_dcm_bringup

```
* fixing the source link
* adding CHANGELOG.rst
* updating config params
* making it working on Pepper with naoqi_dcm_driver
* configuring to use with MoveIt
* initial commit
* Contributors: Karsten Knese, Natalia Lyubova
```
## pepper_dcm_msgs

```
* fixing the source link
* adding CHANGELOG.rst
* initial commit
* Contributors: Karsten Knese, Natalia Lyubova
```
