### PR TITLE
nao_moveit_config: 0.0.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2874,7 +2874,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/nao_moveit_config-release.git
-      version: 0.0.9-0
+      version: 0.0.10-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_moveit_config` to `0.0.10-0`:
- upstream repository: https://github.com/ros-nao/nao_moveit_config.git
- release repository: https://github.com/ros-naoqi/nao_moveit_config-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.0.9-0`
## nao_moveit_config

```
* Update README.rst
* adding RRT as default planner
* remove vrabaud as a maintainer
* Merge pull request #12 <https://github.com/ros-naoqi/nao_moveit_config/issues/12> from ros-naoqi/update_dead_links
  update dead links
* update dead links
* updating the README
* Contributors: Mikael Arguedas, Natalia Lyubova, Vincent Rabaud
```
