### PR TITLE
pepper_virtual: 0.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3817,6 +3817,24 @@ repositories:
       url: https://github.com/ros-naoqi/pepper_robot.git
       version: master
     status: maintained
+  pepper_virtual:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_virtual.git
+      version: master
+    release:
+      packages:
+      - pepper_control
+      - pepper_gazebo_plugin
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-naoqi/pepper_virtual-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_virtual.git
+      version: master
+    status: maintained
   pepperl_fuchs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_virtual` to `0.0.2-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_virtual
- release repository: https://github.com/ros-naoqi/pepper_virtual-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## pepper_control
- No changes
## pepper_gazebo_plugin

```
* fixing install in CMakeLists
* updating README
* Contributors: nlyubova
```
