### PR TITLE
aubo-robot: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -466,6 +466,31 @@ repositories:
       url: https://github.com/GT-RAIL/async_web_server_cpp.git
       version: develop
     status: maintained
+  aubo-robot:
+    doc:
+      type: git
+      url: https://github.com/auboliuxin/aubo_robot.git
+      version: 0.1.0
+    release:
+      packages:
+      - aubo_control
+      - aubo_description
+      - aubo_driver
+      - aubo_gazebo
+      - aubo_i5_moveit_config
+      - aubo_kinematics
+      - aubo_msgs
+      - aubo_robot
+      - aubo_trajectory
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/auboliuxin/rosdistro.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/auboliuxin/aubo_robot.git
+      version: 0.1.0
+    status: developed
   audio_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aubo-robot` to `0.1.0-0`:
- upstream repository: https://github.com/auboliuxin/aubo_robot.git
- release repository: https://github.com/auboliuxin/rosdistro.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## aubo_control

```
* add CHANGELOG.rst
* update version 0.0.1
* update README
* Aubo robotics ROS version 1.0
* Contributors: robot
```
## aubo_description

```
* add CHANGELOG.rst
* update version 0.0.1
* update README
* Aubo robotics ROS version 1.0
* Contributors: robot
```
## aubo_driver

```
* add CHANGELOG.rst
* update version 0.0.1
* update README
* Aubo robotics ROS version 1.0
* Contributors: robot
```
## aubo_gazebo

```
* add CHANGELOG.rst
* update version 0.0.1
* update README
* Aubo robotics ROS version 1.0
* Contributors: robot
```
## aubo_i5_moveit_config

```
* add CHANGELOG.rst
* Aubo robotics ROS version 1.0
* Contributors: robot
```
## aubo_kinematics

```
* add CHANGELOG.rst
* update version 0.0.1
* update README
* Aubo robotics ROS version 1.0
* Contributors: robot
```
## aubo_msgs

```
* add CHANGELOG.rst
* update version 0.0.1
* update README
* Aubo robotics ROS version 1.0
* Contributors: robot
```
## aubo_robot

```
* add CHANGELOG.rst
* update version 0.0.1
* update README
* Aubo robotics ROS version 1.0
* Contributors: robot
```
## aubo_trajectory

```
* add CHANGELOG.rst
* update version 0.0.1
* update README
* Aubo robotics ROS version 1.0
* Contributors: robot
```
