### PR TITLE
qt_gui_core: 0.3.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3199,7 +3199,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.3.2-0
+      version: 0.3.3-0
     source:
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.3.3-0`:
- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.3.2-0`
## qt_dotgraph

```
* work with newer pydot versions (#70 <https://github.com/ros-visualization/qt_gui_core/pull/70>)
* make penwidth attribute optional
```
## qt_gui

```
* remove attribute AA_X11InitThreads which is obsolete in Qt 5
```
## qt_gui_app
- No changes
## qt_gui_cpp
- No changes
## qt_gui_py_common
- No changes
