### PR TITLE
rqt_robot_plugins: 0.5.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4258,7 +4258,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-      version: 0.5.3-0
+      version: 0.5.4-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins` to `0.5.4-0`:
- upstream repository: https://github.com/ros-visualization/rqt_robot_plugins.git
- release repository: https://github.com/ros-gbp/rqt_robot_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.5.3-0`
## rqt_moveit
- No changes
## rqt_nav_view
- No changes
## rqt_pose_view
- No changes
## rqt_robot_dashboard

```
* fix Qt 5 compatibility (#106 <https://github.com/ros-visualization/rqt_robot_plugins/issues/106>)
```
## rqt_robot_monitor
- No changes
## rqt_robot_plugins
- No changes
## rqt_robot_steering
- No changes
## rqt_runtime_monitor
- No changes
## rqt_rviz

```
* mark rviz plugin as experimental since it has severe issues for while
```
## rqt_tf_tree
- No changes
