### PR TITLE
rqt_common_plugins: 0.4.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4215,7 +4215,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.4.1-0
+      version: 0.4.2-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `0.4.2-0`:
- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/ros-gbp/rqt_common_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.4.1-0`
## rqt_action
- No changes
## rqt_bag

```
* add "From nodes" button to record mode (#348 <https://github.com/ros-visualization/rqt_common_plugins/issues/348>)
* show file size of bag file in the status bar (#347 <https://github.com/ros-visualization/rqt_common_plugins/pull/347>)
```
## rqt_bag_plugins

```
* fix crash when toggling thumbnail (#380 <https://github.com/ros-visualization/rqt_common_plugins/issues/380>)
* lock bag when reading for plotting (#382 <https://github.com/ros-visualization/rqt_common_plugins/pull/382>)
```
## rqt_common_plugins
- No changes
## rqt_console

```
* make message column stretch (#398 <https://github.com/ros-visualization/rqt_common_plugins/issues/398>)
```
## rqt_dep

```
* fix newer mock version (#397 <https://github.com/ros-visualization/rqt_common_plugins/issues/397>)
```
## rqt_graph
- No changes
## rqt_image_view

```
* select existing topic (#391 <https://github.com/ros-visualization/rqt_common_plugins/pull/391>)
```
## rqt_launch
- No changes
## rqt_logger_level
- No changes
## rqt_msg

```
* add remove action to context menu in message type browser (#400 <https://github.com/ros-visualization/rqt_common_plugins/pull/400>)
```
## rqt_plot

```
* add keyword arg to make sort optional (#360 <https://github.com/ros-visualization/rqt_common_plugins/pull/360>)
* disable PyQtGraph backend when Qt 5 is being used (#399 <https://github.com/ros-visualization/rqt_common_plugins/pull/399>)
* add missing dependency on numpy (#396 <https://github.com/ros-visualization/rqt_common_plugins/issues/396>)
```
## rqt_publisher

```
* use checkbox for boolean types (#372 <https://github.com/ros-visualization/rqt_common_plugins/issues/372>)
```
## rqt_py_common
- No changes
## rqt_py_console
- No changes
## rqt_reconfigure
- No changes
## rqt_service_caller
- No changes
## rqt_shell
- No changes
## rqt_srv
- No changes
## rqt_top
- No changes
## rqt_topic
- No changes
## rqt_web
- No changes
