### PR TITLE
pepper_moveit_config: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7664,7 +7664,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_moveit_config-release.git
-      version: 0.0.4-1
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_moveit_config` to `0.0.6-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_moveit_config.git
- release repository: https://github.com/ros-naoqi/pepper_moveit_config-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.0.4-1`
## pepper_moveit_config

```
* updating Octomap config to make compatible with pepper_sensors_py
* Update README.rst
* Merge pull request #6 <https://github.com/ros-naoqi/pepper_moveit_config/issues/6> from 130s/impr/default_safe_planner
  Use RRT as default.
* Use RRT as default.
* Contributors: Isaac I.Y. Saito, Natalia Lyubova
```
