### PR TITLE
pepper_meshes: 0.2.3-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2985,6 +2985,13 @@ repositories:
       url: https://github.com/ros-naoqi/pepper_dcm_robot.git
       version: master
     status: developed
+  pepper_meshes:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-naoqi/pepper_meshes-release.git
+      version: 0.2.3-2
+    status: maintained
   pepper_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_meshes` to `0.2.3-2`:
- upstream repository: https://github.com/ros-naoqi/pepper_meshes.git
- release repository: https://github.com/ros-naoqi/pepper_meshes-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## pepper_meshes

```
* fixed install rule and flder path
* Update package.xml
  added myself as a maintainer as requested by vrabaud
* Contributors: Arguedas Mikael, Mikael Arguedas
```
