### PR TITLE
naoqi_bridge: 0.5.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2912,7 +2912,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_bridge-release.git
-      version: 0.5.3-0
+      version: 0.5.5-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge` to `0.5.5-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_bridge.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.5.3-0`
## naoqi_apps

```
* set Surya as the maintainer
* Contributors: Vincent Rabaud
```
## naoqi_bridge

```
* set Surya as the maintainer
* Contributors: Vincent Rabaud
```
## naoqi_driver_py

```
* add doc to args
* disable odom with param and get arg from launch file
* set Surya as the maintainer
* cmd_vel and move_base_simple/goal topic names renamed without '/' at first
* parametrize topic names
* Contributors: Igor Rodriguez, Kei Okada, Naoki-Kameyama, Vincent Rabaud
```
## naoqi_pose
- No changes
## naoqi_sensors_py

```
* set Surya as the maintainer
* Contributors: Vincent Rabaud
```
## naoqi_tools

```
* cleanup, approching pep8 pep257 compliance (#56 <https://github.com/ros-naoqi/naoqi_bridge/issues/56>)
  * cleanup, approching pep8 pep257 compliance
  * fix typo
  * include Transmission and Gazebo for all robots
* Contributors: Mikael Arguedas
```
