### PR TITLE
aubo_robot: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -466,6 +466,31 @@ repositories:
       url: https://github.com/GT-RAIL/async_web_server_cpp.git
       version: develop
     status: maintained
+  aubo_robot:
+    doc:
+      type: git
+      url: https://github.com/auboliuxin/aubo_robot.git
+      version: master
+    release:
+      packages:
+      - aubo_control
+      - aubo_description
+      - aubo_driver
+      - aubo_gazebo
+      - aubo_i5_moveit_config
+      - aubo_kinematics
+      - aubo_msgs
+      - aubo_robot
+      - aubo_trajectory
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/auboliuxin/aubo_robot-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/auboliuxin/aubo_robot.git
+      version: master
+    status: developed
   audio_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aubo_robot` to `0.1.1-0`:
- upstream repository: https://github.com/auboliuxin/aubo_robot.git
- release repository: https://github.com/auboliuxin/aubo_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## aubo_control

```
* update CHANGELOG.rst
* Contributors: robot
```
## aubo_description

```
* update CHANGELOG.rst
* Contributors: robot
```
## aubo_driver

```
* update CHANGELOG.rst
* Contributors: robot
```
## aubo_gazebo

```
* update CHANGELOG.rst
* Contributors: robot
```
## aubo_i5_moveit_config

```
* update CHANGELOG.rst
* Contributors: robot
```
## aubo_kinematics

```
* update CHANGELOG.rst
* Contributors: robot
```
## aubo_msgs

```
* update CHANGELOG.rst
* Contributors: robot
```
## aubo_robot

```
* update CHANGELOG.rst
* Contributors: robot
```
## aubo_trajectory

```
* update CHANGELOG.rst
* Contributors: robot
```
