### PR TITLE
Revert "Adding aubo_robot to documentation index for distro"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -466,16 +466,6 @@ repositories:
       url: https://github.com/GT-RAIL/async_web_server_cpp.git
       version: develop
     status: maintained
-  aubo_robot:
-    doc:
-      type: git
-      url: https://github.com/auboliuxin/aubo_robot.git
-      version: master
-    source:
-      type: git
-      url: https://github.com/auboliuxin/aubo_robot.git
-      version: master
-    status: maintained
   audio_common:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#12762

reverting this so I can merge #12763 
