### PR TITLE
naoqi_dcm_driver: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6559,7 +6559,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_dcm_driver-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_dcm_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_dcm_driver` to `0.0.2-0`:
- upstream repository: https://github.com/ros-naoqi/naoqi_dcm_driver.git
- release repository: https://github.com/ros-naoqi/naoqi_dcm_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.0.1-0`
## naoqi_dcm_driver

```
* fixed Autonomous Life call
* wakeup the robot during initialization
* Contributors: nlyubova
```
