### PR TITLE
pepper_virtual: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7727,7 +7727,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_virtual-release.git
-      version: 0.0.2-3
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_virtual.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_virtual` to `0.0.3-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_virtual
- release repository: https://github.com/ros-naoqi/pepper_virtual-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.0.2-3`
## pepper_control

```
* changes in the launch file
* Contributors: nlyubova
```
## pepper_gazebo_plugin

```
* Update README.rst
* Update package.xml
* [doc] Add note for the dependency that needs manually added.
* Contributors: Isaac I.Y. Saito, Natalia Lyubova
```
