### PR TITLE
phoxi_camera: 1.1.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3056,6 +3056,13 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: kinetic-devel
     status: maintained
+  phoxi_camera:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/photoneo/phoxi_camera-release.git
+      version: 1.1.3-1
+    status: developed
   pid:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phoxi_camera` to `1.1.3-1`:
- upstream repository: https://github.com/photoneo/phoxi_camera.git
- release repository: https://github.com/photoneo/phoxi_camera-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## phoxi_camera
- No changes
