### PR TITLE
pepper_virtual: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3021,6 +3021,24 @@ repositories:
       url: https://github.com/ros-naoqi/pepper_robot.git
       version: master
     status: maintained
+  pepper_virtual:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_virtual.git
+      version: master
+    release:
+      packages:
+      - pepper_control
+      - pepper_gazebo_plugin
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-naoqi/pepper_virtual-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_virtual.git
+      version: master
+    status: developed
   pepperl_fuchs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_virtual` to `0.0.3-0`:
- upstream repository: https://github.com/ros-naoqi/pepper_virtual.git
- release repository: https://github.com/ros-naoqi/pepper_virtual-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## pepper_control

```
* changes in the launch file
* Contributors: nlyubova
```
## pepper_gazebo_plugin

```
* Update README.rst
* Update package.xml
* [doc] Add note for the dependency that needs manually added.
* Contributors: Isaac I.Y. Saito, Natalia Lyubova
```
