### PR TITLE
romeo_virtual: 0.2.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4622,6 +4622,24 @@ repositories:
       url: https://github.com/ros-aldebaran/romeo_robot.git
       version: master
     status: maintained
+  romeo_virtual:
+    doc:
+      type: git
+      url: https://github.com/ros-aldebaran/romeo_virtual.git
+      version: master
+    release:
+      packages:
+      - romeo_control
+      - romeo_gazebo_plugin
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-aldebaran/romeo_virtual-release.git
+      version: 0.2.2-0
+    source:
+      type: git
+      url: https://github.com/ros-aldebaran/romeo_virtual.git
+      version: master
+    status: developed
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_virtual` to `0.2.2-0`:
- upstream repository: https://github.com/ros-aldebaran/romeo_virtual.git
- release repository: https://github.com/ros-aldebaran/romeo_virtual-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## romeo_control

```
* Delete .romeo_trajectory_control_full.launch.swp
* Contributors: Mikael Arguedas
```
## romeo_gazebo_plugin

```
* removing an unused launch file
* Contributors: Natalia Lyubova
```
