### PR TITLE
class_loader: 0.3.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -408,7 +408,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/class_loader-release.git
-      version: 0.3.4-0
+      version: 0.3.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `0.3.5-0`:
- upstream repository: https://github.com/ros/class_loader
- release repository: https://github.com/ros-gbp/class_loader-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.3.4-0`
## class_loader

```
* Add ClassLoader::createUniqueInstance (#38 <https://github.com/ros/class_loader/issues/38>)
  * Wrap comments on createInstance and friend.
  * Delegate createInstance and createUnmanagedInstance to private impl.
  * Add ClassLoader::createUniqueInstance.
  * MultiLibraryClassLoader: Factor out getClassLoaderForClass.
  * MultiLibraryClassLoader: Add unique_ptr API.
  * Add tests for unique_ptr API.
* Contributors: Maarten de Vries
```
