### PR TITLE
nodelet_core: 1.9.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2531,7 +2531,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.9.4-0
+      version: 1.9.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.6-0`:
- upstream repository: https://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.9.4-0`
## nodelet
- No changes
## nodelet_core
- No changes
## nodelet_topic_tools

```
* Add NodeletLazy abstract class for lazy transport (#45 <https://github.com/ros/nodelet_core/issues/45>)
  * Add NodeletLazy abstract class for lazy transport
  * Add test for NodeletLazy with checking its lazy-ness
  * Fix ROS logging format supporting ros/ros_comm#875 <https://github.com/ros/ros_comm/issues/875>
  * Fix ever_subscribed_ flag setting location
  * Clearfy the comment describing advertise method
  * Parameterize the duration to warn the no connection
  User can disable this feature by setting -1 to the param.
* Contributors: Kentaro Wada
```
