### PR TITLE
Adding rcll_ros and sub-packages to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9132,6 +9132,36 @@ repositories:
       url: https://bitbucket.org/rbdl/rbdl
       version: default
     status: developed
+  rcll_refbox_peer:
+    doc:
+      type: git
+      url: https://github.com/timn/ros-rcll_refbox_peer.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/timn/ros-rcll_refbox_peer.git
+      version: master
+    status: developed
+  rcll_ros:
+    doc:
+      type: git
+      url: https://github.com/timn/ros-rcll_ros.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/timn/ros-rcll_ros.git
+      version: master
+    status: developed
+  rcll_ros_msgs:
+    doc:
+      type: git
+      url: https://github.com/timn/ros-rcll_ros_msgs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/timn/ros-rcll_ros_msgs.git
+      version: master
+    status: developed
   realsense_camera:
     doc:
       type: git


### PR DESCRIPTION
This adds packages related to the RoboCup Logistics League to the documentation index for ROS indigo.
