### PR TITLE
jsk_common_msgs: 4.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1934,7 +1934,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_common_msgs-release.git
-      version: 3.0.0-0
+      version: 4.0.0-0
     status: developed
   jsk_model_tools:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common_msgs` to `4.0.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common_msgs
- release repository: https://github.com/tork-a/jsk_common_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `3.0.0-0`
## jsk_common_msgs
- No changes
## jsk_footstep_msgs

```
* [jsk_foostep_msgs] add documentation to Footstep.msg
* [jsk_foostep_msgs] add offset parameter to Footstep.msg
* Contributors: Yohei Kakiuchi
```
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## posedetection_msgs
- No changes
## speech_recognition_msgs
- No changes
