### PR TITLE
jsk_common_msgs: 4.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1586,7 +1586,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_common_msgs-release.git
-      version: 3.0.0-0
+      version: 4.0.0-0
     status: developed
   jskeus:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common_msgs` to `4.0.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common_msgs
- release repository: https://github.com/tork-a/jsk_common_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `3.0.0-0`
## jsk_common_msgs
- No changes
## jsk_footstep_msgs

```
* [jsk_foostep_msgs] add documentation to Footstep.msg
* [jsk_foostep_msgs] add offset parameter to Footstep.msg
* Contributors: Yohei Kakiuchi
```
## jsk_gui_msgs
- No changes
## jsk_hark_msgs
- No changes
## posedetection_msgs
- No changes
## speech_recognition_msgs
- No changes
