### PR TITLE
hey5_description: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3573,6 +3573,17 @@ repositories:
       url: https://github.com/heron/heron.git
       version: indigo-devel
     status: developed
+  hey5_description:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pal-gbp/hey5_description-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/pal-robotics/hey5_description.git
+      version: master
+    status: maintained
   hokuyo3d:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hey5_description` to `1.0.1-0`:
- upstream repository: https://github.com/pal-robotics/hey5_description.git
- release repository: https://github.com/pal-gbp/hey5_description-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
