### PR TITLE
rosserial: 0.7.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5192,7 +5192,6 @@ repositories:
       - rosserial_msgs
       - rosserial_python
       - rosserial_server
-      - rosserial_test
       - rosserial_tivac
       - rosserial_windows
       - rosserial_xbee

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5192,13 +5192,14 @@ repositories:
       - rosserial_msgs
       - rosserial_python
       - rosserial_server
+      - rosserial_test
       - rosserial_tivac
       - rosserial_windows
       - rosserial_xbee
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rosserial-release.git
-      version: 0.7.3-0
+      version: 0.7.4-0
     source:
       type: git
       url: https://github.com/ros-drivers/rosserial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial` to `0.7.4-0`:
- upstream repository: https://github.com/ros-drivers/rosserial.git
- release repository: https://github.com/ros-gbp/rosserial-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.7.3-0`
## rosserial
- No changes
## rosserial_arduino
- No changes
## rosserial_client

```
* Integration tests for rosserial (#243 <https://github.com/ros-drivers/rosserial/issues/243>)
* Support member functions as subscriber callbacks.
* Contributors: Mike O'Driscoll, Mike Purvis
```
## rosserial_embeddedlinux
- No changes
## rosserial_mbed
- No changes
## rosserial_msgs
- No changes
## rosserial_python

```
* Try to read more serial bytes in a loop (#248 <https://github.com/ros-drivers/rosserial/issues/248>)
* Add missing "import errno" to rosserial_python
* Integration tests for rosserial (#243 <https://github.com/ros-drivers/rosserial/issues/243>)
* rosserial_python tcp server allowing socket address reuse (#242 <https://github.com/ros-drivers/rosserial/issues/242>)
* Contributors: Mike Purvis, Vitor Matos, davidshin172
```
## rosserial_server

```
* Use catkin_EXPORTED_TARGETS to avoid CMake warning (#246 <https://github.com/ros-drivers/rosserial/issues/246>)
* Fix AsyncReadBuffer for UDP socket case. (#245 <https://github.com/ros-drivers/rosserial/issues/245>)
* Contributors: Mike Purvis
```
## rosserial_test

```
* Integration tests for rosserial (#243 <https://github.com/ros-drivers/rosserial/issues/243>)
* Contributors: Mike Purvis
```
## rosserial_tivac
- No changes
## rosserial_windows
- No changes
## rosserial_xbee
- No changes
