### PR TITLE
ddynamic_reconfigure_python: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1872,6 +1872,21 @@ repositories:
       type: git
       url: https://github.com/HumaRobotics/darwin_gazebo.git
       version: master
+  ddynamic_reconfigure_python:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/ddynamic_reconfigure_python.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pal-gbp/ddynamic_reconfigure_python-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/pal-robotics/ddynamic_reconfigure_python.git
+      version: master
+    status: maintained
   declination:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ddynamic_reconfigure_python` to `0.0.1-0`:
- upstream repository: https://github.com/pal-robotics/ddynamic_reconfigure_python.git
- release repository: https://github.com/pal-gbp/ddynamic_reconfigure_python-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## ddynamic_reconfigure_python

```
* Add namespace to reconfigure server
* Added examples, making the api easier to use
* Initial commit
* Contributors: Sam Pfeiffer
```
