### PR TITLE
pal_hardware_gazebo: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7574,6 +7574,21 @@ repositories:
       url: https://github.com/allenh1/p2os.git
       version: master
     status: developed
+  pal_hardware_gazebo:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_hardware_gazebo.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pal-gbp/pal_hardware_gazebo-release.git
+      version: 0.0.6-0
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_hardware_gazebo.git
+      version: indigo-devel
+    status: maintained
   parrot_arsdk:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_hardware_gazebo` to `0.0.6-0`:
- upstream repository: https://github.com/pal-robotics/pal_hardware_gazebo.git
- release repository: https://github.com/pal-gbp/pal_hardware_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## pal_hardware_gazebo

```
* first public release
* Contributor: Jordi Pages
```
