### PR TITLE
pal_msgs: 0.11.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7615,6 +7615,39 @@ repositories:
       url: https://github.com/pal-robotics/pal_hardware_gazebo.git
       version: indigo-devel
     status: maintained
+  pal_msgs:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_msgs.git
+      version: indigo-devel
+    release:
+      packages:
+      - pal_behaviour_msgs
+      - pal_common_msgs
+      - pal_control_msgs
+      - pal_detection_msgs
+      - pal_device_msgs
+      - pal_interaction_msgs
+      - pal_motion_model_msgs
+      - pal_msgs
+      - pal_multirobot_msgs
+      - pal_navigation_msgs
+      - pal_tablet_msgs
+      - pal_video_recording_msgs
+      - pal_vision_msgs
+      - pal_visual_localization_msgs
+      - pal_walking_msgs
+      - pal_web_msgs
+      - pal_wifi_localization_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pal-gbp/pal_msgs-release.git
+      version: 0.11.3-0
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_msgs.git
+      version: indigo-devel
+    status: maintained
   parrot_arsdk:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_msgs` to `0.11.3-0`:
- upstream repository: https://github.com/pal-robotics/pal_msgs.git
- release repository: https://github.com/pal-gbp/pal_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
