### PR TITLE
manipulator_h: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1943,7 +1943,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-MANIPULATOR-H-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-MANIPULATOR-H.git


### PR DESCRIPTION
Increasing version of package(s) in repository `manipulator_h` to `0.2.1-0`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-MANIPULATOR-H.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-MANIPULATOR-H-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.2.0-0`
## manipulator_h

```
* manipulator_h_gui: package.xml cmake_modules dependency added
* manipulator_h_description: for indigo option
* Contributors: SCH
```
## manipulator_h_base_module

```
* manipulator_h_gui: package.xml cmake_modules dependency added
* manipulator_h_description: for indigo option
* Contributors: SCH
```
## manipulator_h_base_module_msgs

```
* manipulator_h_gui: package.xml cmake_modules dependency added
* manipulator_h_description: for indigo option
* Contributors: SCH
```
## manipulator_h_bringup

```
* manipulator_h_gui: package.xml cmake_modules dependency added
* manipulator_h_description: for indigo option
* Contributors: SCH
```
## manipulator_h_description

```
* manipulator_h_gui: package.xml cmake_modules dependency added
* manipulator_h_description: for indigo option
* Contributors: SCH
```
## manipulator_h_gazebo

```
* manipulator_h_gui: package.xml cmake_modules dependency added
* manipulator_h_description: for indigo option
* Contributors: SCH
```
## manipulator_h_gui

```
* manipulator_h_gui: package.xml cmake_modules dependency added
* manipulator_h_description: for indigo option
* Contributors: SCH
```
## manipulator_h_kinematics_dynamics

```
* manipulator_h_gui: package.xml cmake_modules dependency added
* manipulator_h_description: for indigo option
* Contributors: SCH
```
## manipulator_h_manager

```
* manipulator_h_gui: package.xml cmake_modules dependency added
* manipulator_h_description: for indigo option
* Contributors: SCH
```
