### PR TITLE
remove pal packages which are unstable

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1873,21 +1873,6 @@ repositories:
       type: git
       url: https://github.com/HumaRobotics/darwin_gazebo.git
       version: master
-  ddynamic_reconfigure_python:
-    doc:
-      type: git
-      url: https://github.com/pal-robotics/ddynamic_reconfigure_python.git
-      version: master
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/pal-gbp/ddynamic_reconfigure_python-release.git
-      version: 0.0.1-0
-    source:
-      type: git
-      url: https://github.com/pal-robotics/ddynamic_reconfigure_python.git
-      version: master
-    status: maintained
   declination:
     doc:
       type: git
@@ -3589,17 +3574,6 @@ repositories:
       url: https://github.com/heron/heron.git
       version: indigo-devel
     status: developed
-  hey5_description:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/pal-gbp/hey5_description-release.git
-      version: 1.0.1-0
-    source:
-      type: git
-      url: https://github.com/pal-robotics/hey5_description.git
-      version: master
-    status: maintained
   hokuyo3d:
     doc:
       type: git
@@ -7601,21 +7575,6 @@ repositories:
       url: https://github.com/allenh1/p2os.git
       version: master
     status: developed
-  pal_hardware_gazebo:
-    doc:
-      type: git
-      url: https://github.com/pal-robotics/pal_hardware_gazebo.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/pal-gbp/pal_hardware_gazebo-release.git
-      version: 0.0.6-0
-    source:
-      type: git
-      url: https://github.com/pal-robotics/pal_hardware_gazebo.git
-      version: indigo-devel
-    status: maintained
   pal_msgs:
     doc:
       type: git
@@ -8015,46 +7974,6 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: indigo-devel
     status: maintained
-  pmb2_robot:
-    doc:
-      type: git
-      url: https://github.com/pal-robotics/pmb2_robot.git
-      version: indigo-devel
-    release:
-      packages:
-      - pmb2_bringup
-      - pmb2_controller_configuration
-      - pmb2_description
-      - pmb2_robot
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/pal-gbp/pmb2_robot-release.git
-      version: 0.1.0-0
-    source:
-      type: git
-      url: https://github.com/pal-robotics/pmb2_robot.git
-      version: indigo-devel
-    status: developed
-  pmb2_simulation:
-    doc:
-      type: git
-      url: https://github.com/pal-robotics/pmb2_simulation.git
-      version: indigo-devel
-    release:
-      packages:
-      - pmb2_controller_configuration_gazebo
-      - pmb2_gazebo
-      - pmb2_hardware_gazebo
-      - pmb2_simulation
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/pal-gbp/pmb2_simulation-release.git
-      version: 0.1.0-0
-    source:
-      type: git
-      url: https://github.com/pal-robotics/pmb2_simulation.git
-      version: indigo-devel
-    status: developed
   pocketsphinx:
     doc:
       type: git
@@ -12870,70 +12789,6 @@ repositories:
     source:
       type: git
       url: https://github.com/wcaarls/threemxl.git
-      version: master
-    status: maintained
-  tiago_moveit_config:
-    doc:
-      type: git
-      url: https://github.com/pal-robotics/tiago_moveit_config.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/pal-gbp/tiago_moveit_config-release.git
-      version: 0.0.1-0
-    source:
-      type: git
-      url: https://github.com/pal-robotics/tiago_moveit_config.git
-      version: indigo-devel
-    status: maintained
-  tiago_robot:
-    doc:
-      type: git
-      url: https://github.com/pal-robotics/tiago_robot.git
-      version: indigo-devel
-    release:
-      packages:
-      - tiago_bringup
-      - tiago_controller_configuration
-      - tiago_description
-      - tiago_robot
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/pal-gbp/tiago_robot-release.git
-      version: 0.0.1-0
-    source:
-      type: git
-      url: https://github.com/pal-robotics/tiago_robot.git
-      version: indigo-devel
-    status: maintained
-  tiago_simulation:
-    doc:
-      type: git
-      url: https://github.com/pal-robotics/tiago_simulation.git
-      version: indigo-devel
-    release:
-      packages:
-      - tiago_gazebo
-      - tiago_hardware_gazebo
-      - tiago_simulation
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/pal-gbp/tiago_simulation-release.git
-      version: 0.0.1-0
-    source:
-      type: git
-      url: https://github.com/pal-robotics/tiago_simulation.git
-      version: indigo-devel
-    status: maintained
-  tiago_tutorials:
-    doc:
-      type: git
-      url: https://github.com/pal-robotics/tiago_tutorials.git
-      version: master
-    source:
-      type: git
-      url: https://github.com/pal-robotics/tiago_tutorials.git
       version: master
     status: maintained
   tinkerforge_laser_transform:


### PR DESCRIPTION
These PAL packages are not ready to be build against ROS indigo released packages, so it is better to remove then for the moment.
