### PR TITLE
rb1_base_common: 1.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9114,7 +9114,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/rb1_base_common-release.git
-      version: 1.0.3-0
+      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/rb1_base_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rb1_base_common` to `1.0.6-0`:
- upstream repository: https://github.com/RobotnikAutomation/rb1_base_common.git
- release repository: https://github.com/RobotnikAutomation/rb1_base_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.0.3-0`
## rb1_base_common
- No changes
## rb1_base_description

```
* rb1_base_description: added contact link
* Contributors: Marc Bosch
```
## rb1_base_pad

```
* rb1_base_pad: adds missing install rule
* Contributors: Jorge Arino
```
