### PR TITLE
robotis_utility: 0.1.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3595,7 +3595,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Utility-release.git
-      version: 0.1.0-0
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Utility.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_utility` to `0.1.1-2`:
- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Utility.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Utility-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.1.0-0`
## robotis_utility

```
* modified install rule
```
## ros_mpg321_player

```
* modified install rule
```
