### PR TITLE
urg_c: 1.0.404-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5298,6 +5298,21 @@ repositories:
       url: https://github.com/ros/urdf_parser_py.git
       version: indigo-devel
     status: maintained
+  urg_c:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/urg_c-release.git
+      version: 1.0.404-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: master
+    status: maintained
   variant:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_c` to `1.0.404-0`:
- upstream repository: git://github.com/ros-drivers/urg_c.git
- release repository: https://github.com/ros-gbp/urg_c-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## urg_c

```
* Merge pull request #2 <https://github.com/ros-drivers/urg_c/issues/2> from dawonn/master
  Issue #1 <https://github.com/ros-drivers/urg_c/issues/1> - missing libmath link
* Ubuntu 14.04 Fix - missing libmath link
* Fix build for Android.
* Contributors: Chad Rockey, dawonn
```
