### PR TITLE
image_common: 1.11.11-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1670,7 +1670,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/image_common-release.git
-      version: 1.11.10-0
+      version: 1.11.11-0
     source:
       type: git
       url: https://github.com/ros-perception/image_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `1.11.11-0`:
- upstream repository: https://github.com/ros-perception/image_common.git
- release repository: https://github.com/ros-gbp/image_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.11.10-0`
## camera_calibration_parsers
- No changes
## camera_info_manager

```
* Return empty CameraInfo when !ros::ok()
* Contributors: Enrique Fernandez
```
## image_common
- No changes
## image_transport
- No changes
## polled_camera

```
* address gcc6 build error in polled_camera
  With gcc6, compiling fails with stdlib.h: No such file or directory,
  as including '-isystem /usr/include' breaks with gcc6, cf.,
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.
  This commit addresses this issue for this package in the same way
  it was addressed in various other ROS packages. A list of related
  commits and pull requests is at:
  https://github.com/ros/rosdistro/issues/12783
  Signed-off-by: Lukas Bulwahn <mailto:lukas.bulwahn@oss.bmw-carit.de>
* Contributors: Lukas Bulwahn
```
