### PR TITLE
vision_opencv: 1.12.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5431,7 +5431,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.12.1-0
+      version: 1.12.2-0
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.12.2-0`:
- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.12.1-0`
## cv_bridge

```
* Specify background label when colorizing label image
* Adjust to arbitrary image channels like 32FC40
  Proper fix for #141 <https://github.com/ros-perception/vision_opencv/issues/141>
* Remove unexpectedly included print statement
* Contributors: Kentaro Wada, Vincent Rabaud
```
## image_geometry

```
* Fix "stdlib.h: No such file or directory" errors in GCC-6
  Including '-isystem /usr/include' breaks building with GCC-6.
  See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129
* Merge pull request #142 <https://github.com/ros-perception/vision_opencv/issues/142> from YuOhara/remap_with_nan_border_value
  remap with nan border if mat value is float or double
* remap with nan border if mat value is float or double
* Contributors: Hodorgasm, Vincent Rabaud, YuOhara
```
## vision_opencv
- No changes
