### PR TITLE
vision_opencv: 1.11.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13632,7 +13632,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.11.13-0
+      version: 1.11.14-0
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.11.14-0`:
- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.11.13-0`
## cv_bridge

```
* Specify background label when colorizing label image
* Adjust to arbitrary image channels like 32FC40
  Proper fix for #141 <https://github.com/ros-perception/vision_opencv/issues/141>
* Remove unexpectedly included print statement
* Contributors: Kentaro Wada, Vincent Rabaud
```
## image_geometry

```
* Fix "stdlib.h: No such file or directory" errors in GCC-6
  Including '-isystem /usr/include' breaks building with GCC-6.
  See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129
* remap with nan border if mat value is float or double
* remap with nan border if mat value is float or double
* Contributors: Hodorgasm, YuOhara
```
## vision_opencv
- No changes
