### PR TITLE
Update audio_common development branch

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -495,7 +495,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/audio_common.git
-      version: hydro-devel
+      version: indigo-devel
     release:
       packages:
       - audio_capture
@@ -510,7 +510,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git
-      version: hydro-devel
+      version: indigo-devel
     status: maintained
   auv_msgs:
     doc:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -177,7 +177,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/audio_common.git
-      version: hydro-devel
+      version: indigo-devel
     release:
       packages:
       - audio_capture
@@ -192,7 +192,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git
-      version: hydro-devel
+      version: indigo-devel
     status: maintained
   auv_msgs:
     doc:


### PR DESCRIPTION
Last few releases have been from the indigo-devel branch. Update the docs to match.
