### PR TITLE
ar_track_alvar: 0.5.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -66,7 +66,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ar_track_alvar-release.git
-      version: 0.5.3-0
+      version: 0.5.4-0
     source:
       type: git
       url: https://github.com/sniekum/ar_track_alvar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar` to `0.5.4-0`:
- upstream repository: https://github.com/sniekum/ar_track_alvar
- release repository: https://github.com/ros-gbp/ar_track_alvar-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.5.3-0`
## ar_track_alvar

```
* [fix] Shutdown camera info sub after called
  Disable camera info subscription after receiving the info.
  This stops e. g. Asus Xtion from having an active subscription to the RGB image stream and thus saving CPU.
* [capability] add mark_resolution and mark_marge as input option
* [capability] New parameter -array to create an array of markers #83 <https://github.com/sniekum/ar_track_alvar/issues/83>
* [maintenance] Add a maintainer to receive notification from ros buildfarm.
* Contributors: AlexReimann, Isaac I.Y. Saito, Mehdi, Tokyo Opensource Robotics Developer 534
```
