### PR TITLE
mrpt_slam: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2303,7 +2303,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_slam` to `0.1.3-0`:
- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_slam.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.1.2-0`
## mrpt_ekf_slam_2d

```
* Avoid gcc warnings with MRPT < 2.0.0
* fix build against mrpt < 1.5.0
* Contributors: Jose-Luis Blanco-Claraco
```
## mrpt_ekf_slam_3d

```
* Avoid gcc warnings with MRPT < 2.0.0
* fix build against mrpt < 1.5.0
* Contributors: Jose-Luis Blanco-Claraco
```
## mrpt_icp_slam_2d
- No changes
## mrpt_rbpf_slam
- No changes
## mrpt_slam
- No changes
