### PR TITLE
micros_cv_detection: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5730,6 +5730,23 @@ repositories:
       url: https://github.com/orocos-gbp/metaruby-release.git
       version: 1.0.0-3
     status: maintained
+  micros_cv_detection:
+    doc:
+      type: git
+      url: https://github.com/micros-uav/micros_cv_detection.git
+      version: master
+    release:
+      packages:
+      - cv_detection
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/micros-uav/micros_cv_detection-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/micros-uav/micros_cv_detection.git
+      version: master
+    status: developed
   micros_dynamic_objects_filter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `micros_cv_detection` to `0.0.2-0`:
- upstream repository: https://github.com/micros-uav/micros_cv_detection.git
- release repository: https://github.com/micros-uav/micros_cv_detection-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## cv_detection

```
* version 0.0.1
* Contributors: micros-uav
```
