### PR TITLE
parrot_arsdk: 3.10.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3709,7 +3709,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/AutonomyLab/parrot_arsdk-release.git
-      version: 3.9.1-3
+      version: 3.10.1-0
     source:
       type: git
       url: https://github.com/AutonomyLab/parrot_arsdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `parrot_arsdk` to `3.10.1-0`:
- upstream repository: https://github.com/AutonomyLab/parrot_arsdk.git
- release repository: https://github.com/AutonomyLab/parrot_arsdk-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `3.9.1-3`
## parrot_arsdk

```
* Update to SDK 3.10.1 (from 3.9.1) - patch 0
* Changelog for SDK 3.10.1

  Fixed events as list management

  Patched curl to avoid using clock_gettime on iOS

  Renamed internal MD5 symbol

  Fixed documentation generator
* Changelog for SDK 3.10.0

  Disco support

  SkyController 2 support

  Mambo support

  Swing support

  new messages
* Changlog for SDK 3.9.2

  Support of audio stream for Jumping evos

  new messages for Bebop and Bebop 2

  Alchemy updated (python3 needed)
* Contributors: Mani Monajjemi
```
