### PR TITLE
eigen_stl_containers: 0.1.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2367,11 +2367,20 @@ repositories:
       version: master
     status: maintained
   eigen_stl_containers:
+    doc:
+      type: git
+      url: https://github.com/ros/eigen_stl_containers.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/eigen_stl_containers-release.git
-      version: 0.1.4-0
+      version: 0.1.6-0
+    source:
+      type: git
+      url: https://github.com/ros/eigen_stl_containers.git
+      version: master
+    status: maintained
   ekf_localization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigen_stl_containers` to `0.1.6-0`:
- upstream repository: https://github.com/ros/eigen_stl_containers
- release repository: https://github.com/ros-gbp/eigen_stl_containers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.1.4-0`
## eigen_stl_containers

```
* Fixed exporting of eigen3 depends (#6 <https://github.com/ros/eigen_stl_containers/issues/6>)
* Contributors: Kei Okada
```
