### PR TITLE
eigen_stl_containers: 0.1.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -905,11 +905,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/eigen_stl_containers-release.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/ros/eigen_stl_containers.git
       version: master
+    status: maintained
   euslisp:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `eigen_stl_containers` to `0.1.6-0`:
- upstream repository: https://github.com/ros/eigen_stl_containers
- release repository: https://github.com/ros-gbp/eigen_stl_containers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.1.5-0`
## eigen_stl_containers

```
* Fixed exporting of eigen3 depends (#6 <https://github.com/ros/eigen_stl_containers/issues/6>)
* Contributors: Kei Okada
```
