### PR TITLE
rosparam_shortcuts: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4201,7 +4201,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/davetcoleman/rosparam_shortcuts-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_shortcuts` to `0.2.1-0`:
- upstream repository: https://github.com/davetcoleman/rosparam_shortcuts.git
- release repository: https://github.com/davetcoleman/rosparam_shortcuts-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.2.0-0`
## rosparam_shortcuts

```
* Fix Eigen3 include
* Fix C++11 compiling method
* Update Travis for Kinetic
* Updated README
* Contributors: Dave Coleman
```
