### PR TITLE
rviz_visual_tools: 3.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4445,7 +4445,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/davetcoleman/rviz_visual_tools-release.git
-      version: 3.2.0-0
+      version: 3.3.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `3.3.0-0`:
- upstream repository: https://github.com/davetcoleman/rviz_visual_tools.git
- release repository: https://github.com/davetcoleman/rviz_visual_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `3.2.0-0`
## rviz_visual_tools

```
* BREAKING CHANGE: Make batch publishing enabled by default
* Removed enableInternalBatchPublishing()
* Removed triggerInternalBatchPublishAndDisable()
* Deprecated triggerBatchPublish() in favor of function name trigger()
* Deprecated triggerBatchPublishAndDisable()
* Ability to trigger every x markers that are in queue, ideal in for loops
* New waitForMarkerPub() function that takes timeout
* Add std::move
* Added Docker for Kinetic
* Added delay to demo to allow rviz to load in Docker
* Change the sphere marker type from SPHERE_LIST to SPHERE - This makes irregularly scaled spheres (i.e. ellipsoids) to be rendered correctly.
* Contributors: Dave Coleman, Miguel Prada
```
