### PR TITLE
aubo_robot: 0.1.1-6 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -485,7 +485,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/auboliuxin/aubo_robot-release.git
-      version: 0.1.1-5
+      version: 0.1.1-6
     source:
       type: git
       url: https://github.com/auboliuxin/aubo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aubo_robot` to `0.1.1-6`:
- upstream repository: https://github.com/auboliuxin/aubo_robot.git
- release repository: https://github.com/auboliuxin/aubo_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.1.1-5`
## aubo_control

```
* update CHANGELOG.rst
* Contributors: robot
```
## aubo_description

```
* update CHANGELOG.rst
* Contributors: robot
```
## aubo_driver

```
* update CHANGELOG.rst
* Contributors: robot
```
## aubo_gazebo

```
* update CHANGELOG.rst
* Contributors: robot
```
## aubo_i5_moveit_config

```
* update CHANGELOG.rst
* Contributors: robot
```
## aubo_kinematics

```
* update CHANGELOG.rst
* Contributors: robot
```
## aubo_msgs

```
* update CHANGELOG.rst
* Contributors: robot
```
## aubo_robot

```
* update CHANGELOG.rst
* Contributors: robot
```
## aubo_trajectory

```
* update CHANGELOG.rst
* Contributors: robot
```
