### PR TITLE
jsk_visualization: 1.0.34-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4668,7 +4668,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.33-0
+      version: 1.0.34-0
     status: developed
   jskeus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `1.0.34-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.0.33-0`
## jsk_interactive
- No changes
## jsk_interactive_marker
- No changes
## jsk_interactive_test
- No changes
## jsk_rqt_plugins
- No changes
## jsk_rviz_plugins

```
* Fix for Ogre >= 1.9, which build fail on Jade on 14.10/15.04
* [jsk_rviz_plugins] add offset to footstep_display.h
* [jsk_rviz_plugin] Add rviz button interface for yes/no service request
* Contributors: Kei Okada, Kentaro Wada, Yohei Kakiuchi
```
## jsk_visualization
- No changes
