### PR TITLE
reapp_ros: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9204,6 +9204,16 @@ repositories:
       url: https://github.com/ros-controls/realtime_tools.git
       version: indigo-devel
     status: maintained
+  reapp_ros:
+    release:
+      packages:
+      - reapp_description
+      - reapp_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/reapp-project/reapp_ros-release.git
+      version: 0.1.1-0
+    status: developed
   receive_ublox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `reapp_ros` to `0.1.1-0`:
- upstream repository: https://github.com/reapp-project/reapp_ros.git
- release repository: https://github.com/reapp-project/reapp_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## reapp_description

```
* added reapp_description
* Contributors: Mathias Lüdtke
```
## reapp_msgs

```
* added reapp_msgs
* Contributors: Mathias Lüdtke
```
