### PR TITLE
rtabmap: 0.11.8-4 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4378,7 +4378,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.11.8-3
+      version: 0.11.8-4
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap` to `0.11.8-4`:
- upstream repository: https://github.com/introlab/rtabmap.git
- release repository: https://github.com/introlab/rtabmap-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.11.8-3`
