### PR TITLE
realsense_camera: 1.5.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9182,7 +9182,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/intel-ros/realsense-release.git
-      version: 1.4.0-0
+      version: 1.5.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_camera` to `1.5.0-0`:
- upstream repository: https://github.com/intel-ros/realsense.git
- release repository: https://github.com/intel-ros/realsense-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.4.0-0`
## realsense_camera

```
* Remove obsolete realsense_navigation files.
* Add depth control preset option (#106)
* Modify launch files for topic remapping.
* Use node handles to enable easier remapping
* Remove invalid SR300 Camera option
* Added multiple cameras support for camera power services
* Added services to start and stop the camera (#85)
* Added a RGBD launch file for SR300
* Clean-up CMakeLists.txt for librealsense
* Contributors: Amber Elliot, Kevin C Wells, Mark D Horn, Séverin Lemaignan, Tully Foote, Rajvi Jingar
```
