### PR TITLE
aubo_robot: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -485,7 +485,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/auboliuxin/aubo_robot-release.git
-      version: 0.1.1-6
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/auboliuxin/aubo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aubo_robot` to `0.1.2-0`:
- upstream repository: https://github.com/auboliuxin/aubo_robot.git
- release repository: https://github.com/auboliuxin/aubo_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.1.1-6`
## aubo_control

```
* fixed a lib path bug
* Update package.xml
  add aubo_msgs  build_depend
* Update CMakeLists.txt
  add aubo_msgs required.
* Contributors: JerryLiu, robot
```
## aubo_description
- No changes
## aubo_driver

```
* fixed a lib path bug
* Contributors: robot
```
## aubo_gazebo
- No changes
## aubo_i5_moveit_config
- No changes
## aubo_kinematics
- No changes
## aubo_msgs
- No changes
## aubo_robot
- No changes
## aubo_trajectory

```
* fixed a lib path bug
* Update package.xml
  add aubo_msgs to build_depend
* Update CMakeLists.txt
  add aubo_msgs to find_package
* Contributors: JerryLiu, robot
```
