### PR TITLE
marker_msgs: 0.0.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2017,7 +2017,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tuw-robotics/marker_msgs-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/tuw-robotics/marker_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marker_msgs` to `0.0.5-0`:
- upstream repository: https://github.com/tuw-robotics/marker_msgs.git
- release repository: https://github.com/tuw-robotics/marker_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.4-0`
## marker_msgs

```
* new msgs
* Removed MarkerCandidate messages. Use Fiducial.msg and FiducialDetection.msg instead.
* Changed MarkerCandidate* to Fiducial*
* Fiducial msg added
* Fiducial msg added
* gitignore added
* Merge branch 'master' into devel
* header to msg/MarkerCandidate.msg added
* merge
* Added MarkerCandidate/Array messages.
* marker_msg type added
* Contributors: Markus Bader, Markus Bader @ munin, doctorseus
```
