### PR TITLE
libftdipp-dev support for ubuntu xenial

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1545,9 +1545,13 @@ libftdi-dev:
       packages: [dev-embedded/libftdi]
   ubuntu: [libftdi-dev]
 libftdipp-dev:
+  debian:
+    jessie: [libftdipp-dev]
+    stretch: [libftdipp1-dev]
   fedora: [libftdi-c++-devel]
   ubuntu:
     precise: [libftdipp-dev]
+    saucy: [libftdipp-dev]
     trusty: [libftdipp-dev]
     vivid: [libftdipp-dev]
     wily: [libftdipp-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1546,7 +1546,12 @@ libftdi-dev:
   ubuntu: [libftdi-dev]
 libftdipp-dev:
   fedora: [libftdi-c++-devel]
-  ubuntu: [libftdipp-dev]
+  ubuntu: 
+    precise: [libftdipp-dev]
+    trusty: [libftdipp-dev]
+    vivid: [libftdipp-dev]
+    wily: [libftdipp-dev]
+    xenial: [libftdipp1-dev]
 libftgl-dev:
   arch: [ftgl]
   debian: [libftgl-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1546,7 +1546,7 @@ libftdi-dev:
   ubuntu: [libftdi-dev]
 libftdipp-dev:
   fedora: [libftdi-c++-devel]
-  ubuntu: 
+  ubuntu:
     precise: [libftdipp-dev]
     trusty: [libftdipp-dev]
     vivid: [libftdipp-dev]


### PR DESCRIPTION
Should fix issue #11626. 

I tested it by temporary updating `/etc/ros/rosdep/sources.list.d/20-default.list` to swap the default base.yaml for mine, which worked great:

```
#yaml https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml
yaml https://raw.githubusercontent.com/koenlek/rosdistro/feature/libftdipp_for_xenial/rosdep/base.yaml
```
