### PR TITLE
imagezero_transport: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3979,6 +3979,16 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: indigo-devel
     status: maintained
+  imagezero_transport:
+    release:
+      packages:
+      - imagezero
+      - imagezero_image_transport
+      - imagezero_ros
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
+      version: 0.2.0-0
   imu_compass:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imagezero_transport` to `0.2.0-0`:
- upstream repository: https://github.com/swri-robotics/imagezero_transport.git
- release repository: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## imagezero_image_transport

```
* Pulled ROS methods out into a separate library.
* Contributors: P. J. Reed
```
## imagezero_ros

```
* Initial version
* Contributors: P. J. Reed
```
