### PR TITLE
pointgrey_camera_driver: 0.12.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8072,7 +8072,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
-      version: 0.12.1-1
+      version: 0.12.2-0
     source:
       type: git
       url: https://github.com/ros-drivers/pointgrey_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointgrey_camera_driver` to `0.12.2-0`:
- upstream repository: https://github.com/ros-drivers/pointgrey_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.12.1-1`
## image_exposure_msgs
- No changes
## pointgrey_camera_description
- No changes
## pointgrey_camera_driver

```
* Reconnect on error (#79 <https://github.com/ros-drivers/pointgrey_camera_driver/issues/79>)
* Update to FlyCapture v2.9.3.43 (#65 <https://github.com/ros-drivers/pointgrey_camera_driver/issues/65>)
* Contributors: Anass Al, Enrique Fernández Perdomo, Konrad Banachowicz
```
## statistics_msgs
- No changes
## wfov_camera_msgs
- No changes
