### PR TITLE
pointgrey_camera_driver: 0.12.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3182,6 +3182,27 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: indigo-devel
     status: maintained
+  pointgrey_camera_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/pointgrey_camera_driver.git
+      version: master
+    release:
+      packages:
+      - image_exposure_msgs
+      - pointgrey_camera_description
+      - pointgrey_camera_driver
+      - statistics_msgs
+      - wfov_camera_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
+      version: 0.12.2-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/pointgrey_camera_driver.git
+      version: master
+    status: maintained
   pr2_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointgrey_camera_driver` to `0.12.2-0`:
- upstream repository: https://github.com/ros-drivers/pointgrey_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## image_exposure_msgs
- No changes
## pointgrey_camera_description
- No changes
## pointgrey_camera_driver

```
* Reconnect on error (#79 <https://github.com/ros-drivers/pointgrey_camera_driver/issues/79>)
* Update to FlyCapture v2.9.3.43 (#65 <https://github.com/ros-drivers/pointgrey_camera_driver/issues/65>)
* Contributors: Anass Al, Enrique Fernández Perdomo, Konrad Banachowicz
```
## statistics_msgs
- No changes
## wfov_camera_msgs
- No changes
