### PR TITLE
common_msgs: 1.12.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -451,7 +451,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.12.4-0
+      version: 1.12.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.12.5-0`:
- upstream repository: git@github.com:ros/common_msgs.git
- release repository: https://github.com/ros-gbp/common_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.12.4-0`
## actionlib_msgs

```
* Fix spelling mistakes
* Contributors: trorornmn
```
## common_msgs
- No changes
## diagnostic_msgs
- No changes
## geometry_msgs

```
* Fix spelling mistakes
* Contributors: trorornmn
```
## nav_msgs
- No changes
## sensor_msgs

```
* Deal with abstract image encodings
* Fix spelling mistakes
* Fix year
* Contributors: Jochen Sprickerhof, Kentaro Wada, trorornmn
```
## shape_msgs
- No changes
## stereo_msgs

```
* Fix spelling mistakes
* Contributors: trorornmn
```
## trajectory_msgs

```
* Fix spelling mistakes
* Contributors: trorornmn
```
## visualization_msgs

```
* Fix spelling mistakes
* Contributors: trorornmn
```
