### PR TITLE
visvualization_rwt: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13790,6 +13790,20 @@ repositories:
       url: https://github.com/ros-visualization/visualization_tutorials.git
       version: indigo-devel
     status: maintained
+  visvualization_rwt:
+    release:
+      packages:
+      - rwt_image_view
+      - rwt_moveit
+      - rwt_plot
+      - rwt_speech_recognition
+      - rwt_utils_3rdparty
+      - visualization_rwt
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/visualization_rwt-release.git
+      version: 0.0.3-0
+    status: developed
   volksbot_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visvualization_rwt` to `0.0.3-0`:
- upstream repository: https://github.com/tork-a/visualization_rwt.git
- release repository: https://github.com/tork-a/visualization_rwt-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## rwt_image_view
- No changes
## rwt_moveit
- No changes
## rwt_plot
- No changes
## rwt_speech_recognition
- No changes
## rwt_utils_3rdparty
- No changes
## visualization_rwt

```
* rwt_robot_monitor depends on roslibjs_experimental whcih is not releaed yet
* Contributors: Tokyo Opensource Robotics Developer 534
```
