### PR TITLE
visualization_rwt: 0.0.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13767,6 +13767,18 @@ repositories:
       type: git
       url: https://github.com/tork-a/visualization_rwt.git
       version: hydro-devel
+    release:
+      packages:
+      - rwt_image_view
+      - rwt_moveit
+      - rwt_plot
+      - rwt_speech_recognition
+      - rwt_utils_3rdparty
+      - visualization_rwt
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/visualization_rwt-release.git
+      version: 0.0.3-1
     status: developed
   visualization_tutorials:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_rwt` to `0.0.3-1`:
- upstream repository: https://github.com/tork-a/visualization_rwt.git
- release repository: https://github.com/tork-a/visualization_rwt-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## rwt_image_view
- No changes
## rwt_moveit
- No changes
## rwt_plot
- No changes
## rwt_speech_recognition
- No changes
## rwt_utils_3rdparty
- No changes
## visualization_rwt

```
* rwt_robot_monitor depends on roslibjs_experimental whcih is not releaed yet
* Contributors: Tokyo Opensource Robotics Developer 534
```
