### PR TITLE
image_transport_plugins: 1.9.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1520,7 +1520,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/image_transport_plugins-release.git
-      version: 1.9.4-0
+      version: 1.9.5-0
     source:
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `1.9.5-0`:
- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros-gbp/image_transport_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.9.4-0`
## compressed_depth_image_transport

```
* disable -Werr
* Contributors: Vincent Rabaud
```
## compressed_image_transport
- No changes
## image_transport_plugins
- No changes
## theora_image_transport
- No changes
