### PR TITLE
librealsense: 1.11.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1893,7 +1893,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/intel-ros/librealsense-release.git
-      version: 0.9.2-3
+      version: 1.11.0-0
     source:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense` to `1.11.0-0`:
- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/intel-ros/librealsense-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.9.2-3`
