### PR TITLE
husky_robot: 0.2.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3817,7 +3817,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_robot-release.git
-      version: 0.2.5-0
+      version: 0.2.6-0
     source:
       type: git
       url: https://github.com/husky/husky_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_robot` to `0.2.6-0`:
- upstream repository: https://github.com/husky/husky_robot.git
- release repository: https://github.com/clearpath-gbp/husky_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.5-0`
## husky_base

```
* Adding support for the UM7 IMU.
* Contributors: Tony Baltovski
```
## husky_bringup

```
* Adding support for the UM7 IMU.
* Added new ur_modern_driver
* Added param for laser frame_id.
* Contributors: TheDash, Tony Baltovski
```
## husky_robot

```
* Adding support for the UM7 IMU.
* Contributors: Tony Baltovski
```
