### PR TITLE
imagezero_transport: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3988,7 +3988,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
   imu_compass:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imagezero_transport` to `0.2.1-0`:
- upstream repository: https://github.com/swri-robotics/imagezero_transport.git
- release repository: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.2.0-0`
## imagezero

```
* No changes
```
## imagezero_image_transport

```
* No changes
```
## imagezero_ros

```
* Add build_depend on roscpp
* Contributors: P. J. Reed
```
