### PR TITLE
imagezero_transport: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1526,6 +1526,16 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: indigo-devel
     status: maintained
+  imagezero_transport:
+    release:
+      packages:
+      - imagezero
+      - imagezero_image_transport
+      - imagezero_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
+      version: 0.2.1-0
   imu_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imagezero_transport` to `0.2.1-0`:
- upstream repository: https://github.com/swri-robotics/imagezero_transport.git
- release repository: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## imagezero

```
* No changes
```
## imagezero_image_transport

```
* No changes
```
## imagezero_ros

```
* Add build_depend on roscpp
* Contributors: P. J. Reed
```
