### PR TITLE
Add pika package

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3817,7 +3817,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_robot-release.git
-      version: 0.2.5-0
+      version: 0.2.6-0
     source:
       type: git
       url: https://github.com/husky/husky_robot.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13889,6 +13889,24 @@ repositories:
       url: https://github.com/warthog-cpr/warthog.git
       version: indigo-devel
     status: developed
+  warthog_desktop:
+    doc:
+      type: git
+      url: https://github.com/warthog-cpr/warthog_desktop.git
+      version: indigo-devel
+    release:
+      packages:
+      - warthog_desktop
+      - warthog_viz
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/warthog_desktop-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/warthog-cpr/warthog_desktop.git
+      version: indigo-devel
+    status: developed
   waypoint:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3988,7 +3988,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
   imu_compass:
     doc:
       type: git

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -48,6 +48,12 @@ paramiko:
     vivid: [python-paramiko]
     wily: [python-paramiko]
     xenial: [python-paramiko]
+pika:
+  macports: [py27-pika]
+  osx:
+    pip:
+      packages: [pika]
+  ubuntu: [python-pika]
 pyper-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -22,6 +22,12 @@ ipython:
     xenial: [ipython]
 libgv-python:
   ubuntu: [libgv-python]
+pika:
+  macports: [py27-pika]
+  osx:
+    pip:
+      packages: [pika]
+  ubuntu: [python-pika]
 paramiko:
   arch: [python2-paramiko]
   debian: [python-paramiko]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -49,6 +49,7 @@ paramiko:
     wily: [python-paramiko]
     xenial: [python-paramiko]
 pika:
+  debian: [python-pika]
   macports: [py27-pika]
   osx:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -22,12 +22,6 @@ ipython:
     xenial: [ipython]
 libgv-python:
   ubuntu: [libgv-python]
-pika:
-  macports: [py27-pika]
-  osx:
-    pip:
-      packages: [pika]
-  ubuntu: [python-pika]
 paramiko:
   arch: [python2-paramiko]
   debian: [python-paramiko]
@@ -54,6 +48,12 @@ paramiko:
     vivid: [python-paramiko]
     wily: [python-paramiko]
     xenial: [python-paramiko]
+pika:
+  macports: [py27-pika]
+  osx:
+    pip:
+      packages: [pika]
+  ubuntu: [python-pika]
 pyper-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
Pika is a pure-Python implementation of the AMQP 0-9-1 protocol that tries to stay fairly independent of the underlying network support library.

PYPI: https://pypi.python.org/pypi/pika/0.10.0
Macports: https://trac.macports.org/browser/trunk/dports/python/py-pika/Portfile
Ubuntu Xenial: http://packages.ubuntu.com/xenial/python-pika
Ubuntu Trusty: http://packages.ubuntu.com/trusty/python-pika
Ubuntu Precise: http://packages.ubuntu.com/precise/python-pika
