### PR TITLE
added dxfgrabber python package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -593,6 +593,9 @@ python-docx:
   fedora: [python-docx]
   ubuntu:
     pip: [python-docx]
+python-dxfgrabber:
+  ubuntu:
+    pip: [dxfgrabber]
 python-easygui:
   debian: [python-easygui]
   fedora: [python-easygui]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -593,7 +593,7 @@ python-docx:
   fedora: [python-docx]
   ubuntu:
     pip: [python-docx]
-python-dxfgrabber:
+python-dxfgrabber-pip:
   ubuntu:
     pip: [dxfgrabber]
 python-easygui:


### PR DESCRIPTION
A Python library to grab information from DXF drawings - all DXF versions supported.
https://pypi.python.org/pypi/dxfgrabber/0.8.1

Intended use: Generate (feature)maps from DXF drawings.
