### PR TITLE
imagezero_transport: 0.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1535,7 +1535,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
   imu_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imagezero_transport` to `0.2.2-0`:
- upstream repository: https://github.com/swri-robotics/imagezero_transport.git
- release repository: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.2.1-0`
## imagezero

```
* Don't use Intel-specific GCC flags on non-Intel platforms
* Contributors: P. J. Reed
```
## imagezero_image_transport
- No changes
## imagezero_ros
- No changes
