### PR TITLE
wts_driver: 1.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5676,6 +5676,17 @@ repositories:
       url: https://github.com/yujinrobot/world_canvas_msgs.git
       version: kinetic
     status: maintained
+  wts_driver:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ksatyaki/wts_driver-release.git
+      version: 1.0.4-0
+    source:
+      type: git
+      url: https://github.com/ksatyaki/wts_driver.git
+      version: master
+    status: maintained
   wu_ros_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wts_driver` to `1.0.4-0`:
- upstream repository: https://github.com/ksatyaki/wts_driver.git
- release repository: https://github.com/ksatyaki/wts_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## wts_driver

```
* Update install targets. Correct errors.
* Contributors: Chittaranjan Swaminathan Srinivas
```
