### PR TITLE
sick_visionary_t_driver: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11851,7 +11851,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/SICKAG/sick_visionary_t.git
-      version: indigo_release_candiate
+      version: indigo_release_candidate
     release:
       tags:
         release: release/indigo/{package}/{version}

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11832,23 +11832,6 @@ repositories:
       url: https://github.com/wcaarls/shared_serial.git
       version: master
     status: maintained
-  sick_3vistort:
-    doc:
-      type: git
-      url: https://github.com/sickag/sick_3vistort.git
-      version: indigo_release_candidate
-    release:
-      packages:
-      - sick_3vistort_driver
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/sickag/sick_3vistort-release.git
-      version: 0.0.1-0
-    source:
-      type: git
-      url: https://github.com/sickag/sick_3vistort.git
-      version: indigo-devel
-    status: developed
   sick_tim:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11864,6 +11864,21 @@ repositories:
       url: https://github.com/uos/sick_tim.git
       version: indigo
     status: developed
+  sick_visionary_t_driver:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_visionary_t.git
+      version: indigo_release_candiate
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/SICKAG/sick_visionary_t-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_visionary_t.git
+      version: indigo-devel
+    status: developed
   sicktoolbox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_visionary_t_driver` to `0.0.2-0`:
- upstream repository: https://github.com/SICKAG/sick_visionary_t.git
- release repository: https://github.com/SICKAG/sick_visionary_t-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## sick_visionary_t_driver

```
* rename to visionary_t
* Contributors: Florian Weisshardt
```
