### PR TITLE
bowpmap_ros-release: 0.1.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -780,6 +780,18 @@ repositories:
       url: https://github.com/kejriwalnishant1990/bowpmap_ros.git
       version: master
     status: maintained
+  bowpmap_ros-release:
+    release:
+      packages:
+      - bowpmap_ros
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/kejriwalnishant1990/bowpmap_ros-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/kejriwalnishant1990/bowpmap_ros.git
+      version: 0.1.2
   brics_actuator:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `bowpmap_ros-release` to `0.1.2-1`:
- upstream repository: https://github.com/kejriwalnishant1990/bowpmap_ros.git
- release repository: https://github.com/kejriwalnishant1990/bowpmap_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
