### PR TITLE
hrpsys: 315.10.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1610,7 +1610,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/hrpsys-release.git
-      version: 315.10.0-0
+      version: 315.10.1-0
     status: developed
   humanoid_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys` to `315.10.1-0`:
- upstream repository: https://github.com/fkanehiro/hrpsys-base.git
- release repository: https://github.com/tork-a/hrpsys-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `315.10.0-0`
## hrpsys
- No changes
