### PR TITLE
cob_extern: 0.6.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1441,13 +1441,16 @@ repositories:
     release:
       packages:
       - cob_extern
+      - libconcorde_tsp_solver
+      - libdlib
       - libntcan
+      - libopengm
       - libpcan
       - libphidgets
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_extern-release.git
-      version: 0.6.4-0
+      version: 0.6.5-0
     source:
       type: git
       url: https://github.com/ipa320/cob_extern.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_extern` to `0.6.5-0`:
- upstream repository: https://github.com/ipa320/cob_extern.git
- release repository: https://github.com/ipa320/cob_extern-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.6.4-0`
## libconcorde_tsp_solver

```
* fixed bug in install directives
* fixed package.xmls
* removed unnecessary autogenerated files
* added 3 libs: concorde_tsp_solver, dlib, and opengm
* Contributors: Richard Bormann
```
## libdlib

```
* fixed package.xmls
* added 3 libs: concorde_tsp_solver, dlib, and opengm
* Contributors: Richard Bormann
```
## libopengm

```
* fixed bug in install directives
* fixed package.xmls
* added 3 libs: concorde_tsp_solver, dlib, and opengm
* Contributors: Richard Bormann
```
