### PR TITLE
cob_calibration_data: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1300,7 +1300,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_calibration_data-release.git
-      version: 0.6.5-0
+      version: 0.6.6-0
     source:
       type: git
       url: https://github.com/ipa320/cob_calibration_data.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_calibration_data` to `0.6.6-0`:
- upstream repository: https://github.com/ipa320/cob_calibration_data.git
- release repository: https://github.com/ipa320/cob_calibration_data-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.6.5-0`
## cob_calibration_data

```
* Merge pull request #105 <https://github.com/ipa320/cob_calibration_data/issues/105> from ipa-nhg/Feature/headcamURDF
  Added head_cam frame to urdf
* new calibration for cob4-1 head cam
* added head_cam frame to urdf
* head cam calibration
* Merge pull request #104 <https://github.com/ipa320/cob_calibration_data/issues/104> from ipa-bnm/feature/ur10_calibration_offsets
  added ur10 calibration offsets to raw3-6
* added ur10 calibration_offsets to raw3-6
* Merge pull request #103 <https://github.com/ipa320/cob_calibration_data/issues/103> from ipa-fmw/indigo_dev
  remove -j1 from travis script
* remove -j1 from travis script
* Merge pull request #102 <https://github.com/ipa320/cob_calibration_data/issues/102> from ipa-cob4-5/indigo_dev
  add arm and sensorring for cob4-5
* add arm and sensorring for cob4-5
* Merge pull request #101 <https://github.com/ipa320/cob_calibration_data/issues/101> from ipa-cob4-7/indigo_dev
  setup cob4-7
* setup cob4-7
* Merge pull request #100 <https://github.com/ipa320/cob_calibration_data/issues/100> from ipa-cob4-5/indigo_dev
  Setup cob4-5
* setup cob4-5
* Merge pull request #98 <https://github.com/ipa320/cob_calibration_data/issues/98> from ipa320/indigo_release_candidate
  Updates from latest release
* Contributors: Benjamin Maidel, Florian Weisshardt, Matthias Gruhler, ipa-cob4-1, ipa-cob4-5, ipa-nhg, robot
```
