### PR TITLE
cob_common: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1344,7 +1344,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.6.5-0
+      version: 0.6.6-0
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.6.6-0`:
- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.6.5-0`
## cob_common

```
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* migrate to package format 2
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_description

```
* review velocity axis limit
* new torso and sensorring configurations
* the realsense publishes already the frames, it is a bug
* added realsense torso description
* realsense camera description
* adapt head urdf to hardware kinematics
* check head urdf model
* Update softkinetic.urdf.xacro
* updated softkinetic urdf
* add geometry macros with meshes
* 0.6.5
* update changelog
* fix cob3_tray_3dof meshes
* harmonize simulated cam3d topic namespaces
* restructure simulated lasers and laser topic names
* remove obsolete sensors
* Missed $ key
* added asus sensorring description
* Updated topic name
* added sick sensorring description
* fix joint origins for torsos
* Merge branch 'indigo_dev' into fix_torso_urdf
* 0.6.4
* update changelog
* remove obsolete autogenerated mainpage.dox files
* add explicit exec_depend to xacro
* fix catkin_minimum_required version
* fix torso joint orientation in urdf
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: Nadia Hammoudeh García, fmw-hb, ipa-cob4-2, ipa-cob4-5, ipa-fxm, ipa-fxm-cm, ipa-nhg
```
## cob_msgs

```
* 0.6.5
* update changelog
* Update package.xml
* cleanup dashboard message
* rework messages
* remove unused messages
* 0.6.4
* update changelog
* remove trailing whitespaces
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: Florian Weisshardt, ipa-fmw, ipa-fxm
```
## cob_srvs

```
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* Contributors: ipa-fxm
```
## raw_description

```
* fixed inertia and mass for raw3 base long
* 0.6.5
* update changelog
* restructure simulated lasers and laser topic names
* fixed copy paste error for base_short laser mounting position
* 0.6.4
* update changelog
* fix typo in collision mesh file name
* add explicit exec_depend to xacro
* fix catkin_minimum_required version
* remove trailing whitespaces
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: Benjamin Maidel, ipa-fxm
```
