### PR TITLE
cob_substitute: 0.6.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1605,7 +1605,9 @@ repositories:
       version: indigo_release_candidate
     release:
       packages:
+      - cob_docker_control
       - cob_lbr
+      - cob_reflector_referencing
       - cob_safety_controller
       - cob_substitute
       - frida_driver
@@ -1614,7 +1616,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_substitute-release.git
-      version: 0.6.4-0
+      version: 0.6.5-0
     source:
       type: git
       url: https://github.com/ipa320/cob_substitute.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_substitute` to `0.6.5-0`:
- upstream repository: https://github.com/ipa320/cob_substitute.git
- release repository: https://github.com/ipa320/cob_substitute-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.6.4-0`
## cob_docker_control

```
* add substitution packages for docking
* Contributors: Florian Weisshardt
* add substitution packages for docking
* Contributors: Florian Weisshardt
```
## cob_lbr
- No changes
## cob_reflector_referencing

```
* add substitution packages for docking
* Contributors: Florian Weisshardt
* add substitution packages for docking
* Contributors: Florian Weisshardt
```
## cob_safety_controller
- No changes
## cob_substitute
- No changes
## frida_driver
- No changes
## prace_common
- No changes
## prace_gripper_driver
- No changes
