### PR TITLE
cob_driver: 0.6.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1397,6 +1397,8 @@ repositories:
       - cob_head_axis
       - cob_light
       - cob_mimic
+      - cob_phidget_em_state
+      - cob_phidget_power_state
       - cob_phidgets
       - cob_relayboard
       - cob_scan_unifier
@@ -1409,7 +1411,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.6.7-0
+      version: 0.6.8-0
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.6.8-0`:
- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.6.7-0`
## cob_base_drive_chain

```
* introduced param to set homing velocity
* 0.6.7
* update changelog
* 0.6.6
* update changelog
* changed drive_chains diag name from //base_controller to /base_controller/base_drive_chain_node
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* install tags for libraries
* do not install headers in executable-only packages
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: Benjamin Maidel, bnm, ipa-fxm
```
## cob_bms_driver

```
* restart CAN on failure
* move power_state_phidget node to new package
* invert current + round values
* fix typo
* corrected namespace
* added node to calculate powerstate from phidget board
* 0.6.7
* update changelog
* add missing dependencies
* 0.6.6
* update changelog
* dependency and package cleanup
* remove config and launch as it is added to cob_robots
* adjust version
* move cob_bms_driver to cob_driver
* Contributors: Benjamin Maidel, Mathias Lüdtke, bnm, ipa-fxm
```
## cob_camera_sensors

```
* 0.6.7
* update changelog
* 0.6.6
* update changelog
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* boost revision
* explicit dependency to boost
* more cleanup
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_canopen_motor

```
* 0.6.7
* update changelog
* 0.6.6
* update changelog
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_driver

```
* 0.6.7
* update changelog
* 0.6.6
* update changelog
* add to meta-package
* added cob_elmo_homing to meta package
* added scan unifier to metapackage
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: Benjamin Maidel, Florian Weisshardt, ipa-fxm
```
## cob_elmo_homing

```
* 0.6.7
* update changelog
* 0.6.6
* update changelog
* added cob_elmo_homing
* Contributors: Mathias Lüdtke, ipa-fxm
```
## cob_generic_can

```
* 0.6.7
* update changelog
* 0.6.6
* update changelog
* Update accorting to comments from ipa-fxm
* Correction of include and name
* Correct interface.
* compiles...
* Starting with SocketCAN
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: Denis Štogl, ipa-fxm
```
## cob_head_axis

```
* 0.6.7
* update changelog
* 0.6.6
* update changelog
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* rising no longer supported
* boost revision
* do not install headers in executable-only packages
* explicit dependency to boost
* more cleanup
* remove obsolete autogenerated mainpage.dox files
* catkin_package according to install tags
* remove trailing whitespaces
* add_dependencies EXPORTED_TARGETS
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm, ipa-nhg
```
## cob_light

```
* return true for stop mode service to avoid ugly error messages on client side
* fix tab vs spaces
* at static mode send color to driver on begin of update cylce
* set freq to default 1.0 if not set by requested mode
* 0.6.7
* update changelog
* 0.6.6
* update changelog
* keep static mode running so they can be stopped, paused and resumed
* fixes
* comments
* param tuning
* implemented new mode glow
* implemented feature to resume modes if modes with higher prio ends + refactored code
* considered #241 <https://github.com/ipa320/cob_driver/issues/241> PR comments
* high distances visualized with a lighter green
* moved light dist approx function to cob_light driver
* wip light_approximation
* Merge branch 'feature/led_offset' into feature/light_approximation
* fix
* added node for scan approxiamtion led visualization
* added param to define led mounting offset
* fixed ms35 controller bug
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* Merge branch 'indigo_dev' of github.com:ipa320/cob_driver into indigo_dev
  Conflicts:
  cob_light/CMakeLists.txt
* added headers to add_executable makro for qt_creator visiblity
* boost revision
* do not install headers in executable-only packages
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: Benjamin Maidel, bnm, ipa-fmw, ipa-fxm, msh
```
## cob_mimic

```
* vlc 2.2 version use by default the wrong video output
* 0.6.7
* update changelog
* 0.6.6
* update changelog
* re-add copying mimic files
* fix action name in test node
* fix mimic shutdown and cleanup
* Update CMakeLists.txt
* add rospy again
* merge
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* cleanup
* fixing dependencies
* remove trailing whitespaces
* migrate to package format 2
* missed dependencies
* sort dependencies
* critically review dependencies
* Contributors: Florian Weisshardt, ipa-cob4-5, ipa-fmw, ipa-fxm, ipa-nhg
```
## cob_phidget_em_state

```
* fix
* use values from message
* fixed syntax error
* fixed conditions
* new package to calculate em state from phidgets digital input
* Contributors: Benjamin Maidel
```
## cob_phidget_power_state

```
* fix current sign
* fix current sign
* remove print
* fix namespace and syntax for phidget power state
* Merge branch 'indigo_dev' into feature/phidget_power_state_params
  Conflicts:
  cob_phidget_power_state/scripts/power_state_phidget.py
* read power state params from param server
* increase voltage limit for empty battery
* cut percentage between 0 and 100
* updates for changed hardware
* fixed typo
* remove find_package entries as this package only as python nodes
* Update package.xml
* updated license and version
* move power_state_phidget node to new package
* Contributors: Benjamin Maidel, Florian Weisshardt, msh
```
## cob_phidgets

```
* 0.6.7
* update changelog
* 0.6.6
* update changelog
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* do not install headers in executable-only packages
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* add_dependencies EXPORTED_TARGETS
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_relayboard

```
* 0.6.7
* update changelog
* 0.6.6
* update changelog
* use aggregated power state message
* tabs vs. spaces
* harmonize publisher queue sizes
* relaynode delete slashes topics
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* add_dependencies EXPORTED_TARGETS
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: Felix Gruber, ipa-fmw, ipa-fxm
```
## cob_scan_unifier

```
* 0.6.7
* update changelog
* 0.6.6
* fix version
* update changelog
* changed scan_unifier maintainer
* filtered out scan unifier and moved to new directory
* Contributors: Benjamin Maidel, ipa-fxm
```
## cob_sick_lms1xx

```
* cob_sick_lms1xx: add range configuration
* 0.6.7
* update changelog
* add missing dependencies
* 0.6.6
* update changelog
* Sick LMS1xx node now uses global NodeHandle
* Resolved problem with tabs and spaces.
* Clean trailing spaces. Convert default frame name to tf2 format (remove "/")
* Revert indentation style as it was
* Correction.
* Corrected revert.
* Revert indentation style as it was
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* install tags for libraries
* boost revision
* do not install headers in executable-only packages
* explicit dependency to boost
* catkin_package according to install tags
* remove trailing whitespaces
* add_dependencies EXPORTED_TARGETS
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Node rewritten and publishing on diagnostics topic added.
* Contributors: Denis Štogl, Shin, ipa-fxm
```
## cob_sick_s300

```
* 0.6.7
* update changelog
* 0.6.6
* update changelog
* replace spaces by tab
* add try/catch to handle XmlRpc exceptions
* add time stamp to sick s300 diagnostic messages
* adjust filter topics
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* do not install headers in executable-only packages
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* catkin_package according to install tags
* remove trailing whitespaces
* add_dependencies EXPORTED_TARGETS
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: Frederik Hegger, ipa-fxm
```
## cob_sound

```
* fade volume on play and between tracks
* fix sound action namespaces
* unify namespaces with cob_light
* use private namespace for cob_sound parameters
* consistently fill result for say and play
* 0.6.7
* update changelog
* 0.6.6
* update changelog
* fix sound dependencies
* considered pr comments
* removed debug logging
* start feedback timer only if action is active
* start action server after complete init
* use libvlc for sound play
* merge
* support for other cepstral voices (e.g. german Matthias)
* 0.6.5
* update changelog
* fix dependencies
* 0.6.4
* update changelog
* boost revision
* do not install headers in executable-only packages
* explicit dependency to boost
* alsa-oss dependency
* fixing dependencies
* remove obsolete autogenerated mainpage.dox files
* sound error with Cepstral,use alsa oss
* remove trailing whitespaces
* add_dependencies EXPORTED_TARGETS
* migrate to package format 2
* missed dependencies
* merge
* deleted name argument and added a comment
* update cob_sound
* sort dependencies
* critically review dependencies
* play sound
* Contributors: Benjamin Maidel, cob4-2, ipa-cob4-2, ipa-fmw, ipa-fxm, ipa-nhg, msh
```
## cob_undercarriage_ctrl

```
* 0.6.7
* update changelog
* 0.6.6
* update changelog
* fix frame id for odometry
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* install tags for libraries
* do not install headers in executable-only packages
* explicit dependency to boost
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* add_dependencies EXPORTED_TARGETS
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-cob4-2, ipa-fxm
```
## cob_utilities

```
* 0.6.7
* update changelog
* 0.6.6
* update changelog
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```
## cob_voltage_control

```
* 0.6.7
* update changelog
* 0.6.6
* update changelog
* beautify
* Merge branch 'aggregated_power_message' into feature/raw_batterie_state
  Conflicts:
  cob_voltage_control/common/src/cob_voltage_control_common.cpp
  cob_voltage_control/ros/src/cob_voltage_control_ros.cpp
* voltage and current measurements for raw3-3
* use aggregated power state message
* changed name relayboard to powerboard
* removed debug outputs
* fixed topic names
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* explicit dependency to boost
* remove trailing whitespaces
* add_dependencies EXPORTED_TARGETS
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: Benjamin Maidel, ipa-bnm, ipa-fmw, ipa-fxm
```
