### PR TITLE
cob_simulation: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1592,7 +1592,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_simulation-release.git
-      version: 0.6.5-0
+      version: 0.6.6-0
     source:
       type: git
       url: https://github.com/ipa320/cob_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.6.6-0`:
- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.6.5-0`
## cob_bringup_sim

```
* enable tests for ipa-office
* fix roslaunch tests
* fix roslaunch tests
* delete ipa-factory
* support relative defined objects in remove_objects.py and tabs vs spaces
* Added feature of deleting multiple objects included in a group to script remove_object.py
* enable roslaunch checks
* remove prints and rename groups namespace
* Updated structure of spawn_object.py to reduce code redundance
* Added the functionality to spawn sdf's using spawn_object and a check if object is there before deleting it
* Updated spawn objects script so that it takes object groups into account
* generic wait for environment before spawn robot
* spawn_object supports children objects
* added script file to spawn racks and other objects
* 0.6.5
* update changelog
* fix install tags and dependencies
* fix move_object script
* Update move.py
* added people, move.py and changed model names
* added people and the possibility to move objects
* enable other gazebo worlds packages
* remove robot_id
* better default robot_id
* delete two_robots.launch
* Merge pull request #91 <https://github.com/ipa320/cob_simulation/issues/91> from ipa-mig-mc/fix/issue_number_90_missing_import_roslib
  added import roslib to spawn_object.py and did corresponding addition…
* launch file for spawning two robots
* added import roslib to spawn_object.py and did corresponding addition to packages.xml
* space
* nicer structure
* Revert "spawn two robots"
  This reverts commit b66aa13d920824a052d398dd8b49cb52c2c4a155.
* spawn two robots
* 0.6.4
* update changelog
* migration to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* sort dependencies
* review dependencies
* Contributors: Benjamin Maidel, Felix Gruber, Felix Messmer, Florian Weisshardt, hannes, ipa-fmw, ipa-fxm, ipa-mig-mc, ipa-nhg, ipa-srd-rd
```
## cob_gazebo

```
* generic wait for environment before spawn robot
* inserted wait for model, hopefully fixes max range bug
* 0.6.5
* update changelog
* fix dependency
* remove robot_id
* better default robot_id
* new line
* tf_prefix in higher level
* better diff
* nicer structure
* Revert "spawn two robots"
  This reverts commit b66aa13d920824a052d398dd8b49cb52c2c4a155.
* spawn two robots
* 0.6.4
* update changelog
* migration to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* sort dependencies
* review dependencies
* Contributors: Benjamin Maidel, Felix Gruber, Florian Weisshardt, ipa-fxm, ipa-srd
```
## cob_gazebo_objects

```
* Moved ipa-office walls to cob gazebo worlds
* Set correct origin/scale for ipa-office_walls and added walls for stairway
* Updated model of ipa-office_walls
* Added object for ipa-office walls
* Merged branch 'feature/ipa_production_plant_improvement' and updated the structure.
* working on meshes
* Added additional files for outsourced content
* Changes made based on PR review by fxm
* added files to spawn storage racks - note: spawning is not working yet
* 0.6.5
* update changelog
* add launch file
* add urdf and stl
* add ikea kallax mesh
* fix man urdfs
* fix meshes
* old objects deleted
* added people, move.py and changed model names
* added people and the possibility to move objects
* 0.6.4
* update changelog
* migration to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* review dependencies
* Contributors: Florian Weisshardt, hannes, ipa-fxm, ipa-mig-mc, ipa-srd-rd
```
## cob_gazebo_worlds

```
* enable tests for ipa-office
* fix roslaunch tests
* Moved ipa-office walls to cob gazebo worlds
* fix roslaunch tests
* delete ipa-factory
* use empty world from cob_gazebo_world and do not spawn objects by default
* Removed unneeded commented part from ipa-office.launch
* Added urdf.xacro and launch file for ipa-office
* Added transforms for sick lasers in ipa-production-plant again
* enable roslaunch checks
* remove static laser, remove movable object, remove duplicted upload, remove spawn all
* Updated urdf structure of ipa-produtcion-plant and the trajectory of the moving object.
* Merged branch 'feature/ipa_production_plant_improvement' and updated the structure.
* final beautification
* move object_locations.yaml to cob_default_env_config
* fix ipa-production-plant environment
* working on meshes
* Updated some untitled namings
* Removed reflMarker model from another branch
* Added additional files for outsourced content
* Changes made based on PR review by fxm
* Merge of branch feature/ipa_production_plant_simulation with current indigo_dev
* re-structured the floor map and added objects
* Populated environment with objects
* children objects now also spawned
* added more storage racks - note: storage rack objects not getting loaded
* added files to spawn storage racks - note: spawning is not working yet
* initial draft of ipa_production_plant
* 0.6.5
* update changelog
* enable other gazebo worlds packages
* remove robot_id
* changed color of boxes on the belt to grey
* nicer structure
* changed name of the environment to automotive-assembly-line
* added hardwareInterface tag in Joint section of belt_trans transmission description
* 0.6.4
* update changelog
* cleanup
* migration to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* sort dependencies
* review dependencies
* removed unnecessary imports
* added buttons controllers
* use default inertias
* use default inertias
* fix ipa-apartment elevator
* fix ipa-apartment elevetor controllers
* use controller_manager spawn
* minor code cleanup
* added model files which were left out in previous commit
* added objects to the environment
* successful integration of bmw-assembly into cob_simulation
* error state: problem with loading joint controller
* Contributors: Felix Gruber, Florian Weisshardt, ipa-fmw, ipa-fxm, ipa-mig-mc, ipa-nhg, ipa-srd-rd
```
## cob_simulation

```
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* migration to package format 2
* remove trailing whitespaces
* review dependencies
* Contributors: ipa-fxm
```
