### PR TITLE
cob_robots: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1571,7 +1571,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.6.5-0
+      version: 0.6.6-0
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.6.6-0`:
- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.6.5-0`
## cob_bringup

```
* renamed visionary_t sensor by sick
* Update usb_camera_node.launch
* update cob4-2.xml
* hd monitor active
* worker threads for openni2 and calibration for head cam
* corrected ur ip address
* fixed namespaces
* Fix usb_cam warning: set the pixel format to yuyv
* Merge github.com:ipa320/cob_robots into fix/env-loader-script
  Conflicts:
  cob_bringup/robots/raw3-6.launch
  cob_bringup/robots/raw3-6.xml
* expand env argument to all robots
* fixed raw3-4 ur bringup
* added env.sh plath as argument
* fix argument naming
* adapted ur.launch to actual ur package
* removed multiple robot_state_publishers by using own ur launch
* added ur10, phidgets, battery monitor, em monitor to robot bringup for raw3-6
* added configs for bringup
* reduce number of nodelet worker to not overload cpu
* add data skip launch argument for openni2 to limit CPU load
* add diagnostics hz monitor to cob4-1 and cob4-2 for cameras
* add nodelet version of realsense to bringup
* unify docking configuration, now only one station config file per robot
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_robots into indigo_dev
  Conflicts:
  cob_bringup/robots/cob4-1.xml
* Merge branch 'indigo_dev' of github.com:ipa-fmw/cob_robots into indigo_dev
  Conflicts:
  cob_bringup/robots/cob4-1.xml
* add dependency to cob_phidget_em_state
* Merge branch 'feature/em_state_phidget' of github.com:ipa-bnm/cob_robots into indigo_dev
* Merge branch 'feature/power_state' of github.com:ipa-bnm/cob_robots into feature/power_state
* beautify
* tabs vs spaces
* use imageflip with torso_cam3d_down camera
* use docking on cob4-2
* tabs vs spaces
* Merge branch 'feature/power_state' into feature/em_state_phidget
* tabs vs spaces
* Merge pull request #469 <https://github.com/ipa320/cob_robots/issues/469> from ipa-cob4-5/indigo_dev
  Setup cob4-5
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_robots into RemoveDistanceMoveit
  Conflicts:
  cob_bringup/package.xml
  cob_bringup/robots/cob4-1.xml
  cob_bringup/robots/cob4-2.xml
* disable roslaunch check for tools
* fix dependencies
* move hand launch file to bringup
* enable roslaunch tests for robot xmls
* Merge branch 'indigo_dev' of https://github.com/ipa-cob4-5/cob_robots into indigo_dev
* proper remapping
* typo
* bringup emstate from phidget node for raw3-1 raw3-3
* use powerstate from phidget node
* move docking config and launch to cob_hardware_config and cob_bringup
* set check to true for rosserial
* explicit dependency on cob_omni_drive_controller
* Setup cob4-5 : final launch file version
* new schunk_sdhx launch file
* Revert "respawn bms driver"
  This reverts commit a067a923f76fde4264dc42da1d1e987636200f58.
* include/configure stuck detector
* Merge branch 'indigo_dev' of github.com:ipa-cob4-5/cob_robots into indigo_dev
* add cob_hand_bridge to bringup dependencies
* Merge branch 'indigo_dev' of https://github.com/ipa-cob4-5/cob_robots into merge-cob4-5
  Conflicts:
  cob_bringup/package.xml
* added arms, hands and cameras
* harmonize cob4-1.xml and cob4-2.xml
* disable head and sensorring
* reduce framerate of usb camera to lower CPU load
* rename launch arguments
* fix remapping
* publish true with fake collission monitor
* fix diagnostics remapping for sound
* Merge branch 'Feature/SoftkineticParams' of github.com:ipa-nhg/cob_robots into feature/softkinetic
  Conflicts:
  cob_bringup/drivers/softkinetic.launch
  cob_bringup/robots/cob4-1.xml
* add missing dep to usb_cam
* tabs vs spaces
* Merge branch 'indigo_dev' into feature/usb_head_cam
* removed pkg_hardware_cfg from cob4-1.xml
* removed unused line
* cleanup
* tabs vs spaces
* typos
* use camera_name argument as frame_id and camera name
* changed default camera_name to usb_cam
* create softlink instead of copy
* added usb head cam launch file and added it to cob4 bringup
* moved power_state phidget driver to extra package
* removed bms launch + added power_state from phidget launch
* respawn bms driver
* cob4-2 imageflip on same nodeletmanager as cam
* removed data_skipping => higher framerate
* start image flip in same nodeletmanager as the cam
* changed softkinetic_params
* include base collision observer
* add dep to rostopic
* fix launch syntax
* use fake collission monitor for cob4-2 too
* use dummy state publisher instead of real collission monitor (not working reliably yet)
* removed unused arguments
* removed unnecesary argument
* remove in xml files the include
* update collision monitor launch file
* remove dependency to cob_obstacle_distance_moveit
* missed dependency
* robot test
* set softkinetic parameters
* Changed namespace of topics
* Renamed incoming command topic to command_in and removed obstacles topic
* test Head 3dof
* Cleaned up base_collision_observer.launch
* setup cob4-5
* Intermediate state
* Adapted base_collision_observer.launch
* add collision_monitor to cob4-1 and cob4-2
* rename launch file
* add obstacle_monitor launch file
* Merge pull request #456 <https://github.com/ipa320/cob_robots/issues/456> from ipa-fxm/cartesian_controller_updates
  prepare using robots with cartesian controller
* Merge pull request #460 <https://github.com/ipa320/cob_robots/issues/460> from ipa-fxm/add_obstacle_distance_moveit_monitor
  prepare obstacle_distance_monitor launch file
* move sound into namespace
* load sound parameter from yaml file
* load sound parameter from yaml file
* add dependencies
* prepare obstacle_distance_monitor launch file
* prepare using robots with cartesian controller
* 0.6.5
* update changelog
* adjust launch file to current head-pc setup
* Merge pull request #448 <https://github.com/ipa320/cob_robots/issues/448> from ipa-nhg/BMSintegration
  added bms driver to bringup
* added bms driver to bringup
* MLR actual version
* Merge branch 'indigo_dev' of github.com:ipa320/cob_robots into feature_canopen_node_name
  Conflicts:
  cob_bringup/drivers/canopen_402.launch
* add missing image_flip nodes to simulation
* adjust launch and yamls
* unify battery_monitor and battery_light_monitor
* rename canopen node and adjust diagnostics
* restructure canopen driver yamls and remove canX yamls
* readded batter_light_monitor to cob4-1 bringup
* Merge branch 'indigo_dev' of github.com:ipa320/cob_robots into feature/battery_light_mode
  Conflicts:
  cob_bringup/robots/cob4-1.xml
  cob_bringup/robots/cob4-2.xml
  cob_bringup/robots/raw3-3.xml
* temporarily do not use head on cob4-2
* temporarily do not use head on cob4-1
* comment overkill
* changed service name remap to component name param
* Merge branch 'indigo_dev' of github.com:ipa-bnm/cob_robots into feature/battery_light_mode
* further tests with torso
* tabs vs spaces
* tabs vs spaces
* use launch arg to switch between old and new base driver
* tabs vs. spaces
* using canopen for base_solo
* update diagnostics analyzer
* add new_base_chain config for cob4-1
* launch ros_canopen for cob4-2 base
* twist_controller base commands cannot go through smoother
* Removed releyboard
* Merge pull request #397 <https://github.com/ipa320/cob_robots/issues/397> from ipa-nhg/NewTorsoPcs
  [cob4-2] New torso pcs
* remap battery_light_monitor topic and service name
* start battery_light_monitor on raw3-3 bringup
* load battery light config to param server
* Update cob4-1.launch
* use phidgets rather than simulated relayboard on raw3-1
* added battery_light_monitor launch to cob4-1 bringup
* added battery light monitor to cob4-2s bringup
* Revert namespace of sick LMS1xx nodes
* Further files corrected
* Corrected odometry topic remapping, error done in 8868a5c
* Correct LMS1xx topic remapping
* Revert indentation changes.
* Change namespace of parameters for laser scanner driver to work properly.
* base collision observer setup
* Merge remote-tracking branch 'origin/raw3-5_battery_voltage' into update_raw3-5
* Merge branch 'indigo_dev' of github.com:iirob/cob_robots into indigo_dev
* review image_flip parameters
* updated base solo
* emergency_stop_state has to be a global topic
* emergency_stop_state has to be a global topic
* remove env config in all robot launch files
* parameterizable scaling factor
* provide twist_mux topic for base_active mode of twist_controller
* update cob4-3 according to lastest updates in cob_robots (twist_mux, vel_smoother, laser_topics)
* Merge branch 'indigo_dev' of github.com:ipa320/cob_robots into feature_cob4-1_without_arms
* Merge pull request #383 <https://github.com/ipa320/cob_robots/issues/383> from ipa-fxm/restructure_laser_topics_unifier
  Restructure laser topics unifier
* Merge pull request #21 <https://github.com/ipa320/cob_robots/issues/21> from ipa320/indigo_dev
  updates from ipa320
* Merge pull request #36 <https://github.com/ipa320/cob_robots/issues/36> from ipa320/indigo_dev
  updates from ipa320
* add missing exec_depends
* rename laser scanner topics
* prepare remapping for twist_mux in cartesian controller
* fix identation
* fix identation
* Merge pull request #371 <https://github.com/ipa320/cob_robots/issues/371> from ipa-bnm/fix/raw3-1_bringup
  fix raw3-1 bringup
* moved collision_velocity_filter to base namespace
* fix typo
* restructure laser topics
* added collision_velocity_filter to twist_mux
* removed yocs_velocity_smoother dependency
* readded group tag
* changed velocity smoother topic name
* added twist_mux and new velocity_smoother to controller launch
* added velocity_smoother launch file and velocity_smoother configs for all robots
* added twist_mux launch file and twist_mux configs for all robots
* Merge branch 'indigo_dev' into feature/twist_mux_vel_smoother
* added twist_mux and vel smoother dependency
* use correct pc names
* fix machine tag
* use cob4-1 as cob4-2 without arms - copying configuration files
* do not stabelize/deadband spacenav twist
* add scan_unifier for cob4-3
* added dependency to cob_scan_unifier
* Merge pull request #364 <https://github.com/ipa320/cob_robots/issues/364> from ipa-bnm/feature/scan_unifier
  added scan unifier to bringup layer
* added missing exec dependency to cob_default_robot_behaviour
* added cob4-3
* fixed launch tag
* added scan unifier to bringup layer
* changed name relayboard to powerboard
* indentation
* start cob_voltage_monitor instead of simulated relayboard
* remap input topics
* removed prosilica cams from raw3-1 startup
* correct topic remaps
* fix copy-and-paste comment
* remove old teleop leftover
* tabs vs spaces
* remove obsolete argument and remap
* Adapt cob4-6 configuration
* test sensorring cam3d on cob4-2
* removed leading / from tf frame names. They are no longer supported in tf2
* addapt cob4-4 configuration
* use relative namespaces
* added script_server bringup to all robots
* changed base namespace from 'base_controller' to 'base' for cob4 and raw3
* do not respawn phidgets, because if no phidget is connected the driver will restart all the time
* start cob_script_server at bringup because new teleop node needs it
* fix xml format in cartesian_controller.launch
* remove trailing whitespaces
* add nodes for debugging
* added new behavior trigger services
* add launch file for teleop_spacenav
* merge
* use local namespaces
* merge error
* merge error
* updated cob_teleop and renamed behaviour package
* new teleop node
* proper remapping for old_base_driver
* merge
* merge
* fix typo
* 0.6.4
* update changelog
* renamed parameter
* new trigger srv and addapted  android.launch file
* making 'sim_enabled' a launch argument
* migrate to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* fix for int16 overflow in vl mode
* Merge branch 'cob_behaviour' of https://github.com/ipa-cob4-2/cob_robots into indigo_dev
* Adapted launch and params.
* cob_behaviour
* robot test
* Torso->can0
* sort dependencies
* revies dependencies
* added mimic.launch
* renamed launch-argument to use_rplidar in raw3-3.xml
* fix indentation in raw3-3.xml
* cob_behaviour
* merge
* include torso in bringup
* Separate launch file for cob_obstacle_distance.
* updates for cartesian_controller yaml
* torso setup
* moved base components of cob3-9 to correct machine tag
* cob_bringup: removed run-dependency of rplidar_ros and trigger start of rplidar-driver via launch-argument as suggested
* unify cob3-X config and launch
* use controller_manager spawn
* last update
* Update raw3-4.xml
* teleop parameters
* defined teleop parameters
* setup cob4-4
* merge
* cob4-4 setup
* cob_bringup: added run_dependency for rplidar_ros
* added rplidar sensor to raw3-3 urdf and bringup
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_robots into indigo_dev
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_robots into raw3-5_battery_voltage
* Updated data for raw3-5
* Raw3-5 phidgets is read properly, data calcualtion/remapping is corrected.
* Enabled and corrected
* Change file name from laser_lms1xx to sick_lms1xx
* Corrected remapping and cleaned config file.
* laser_rear namespace corrected
* Merge branch 'hydro_dev' into indigo_dev
* Contributors: Benjamin Maidel, Denis Štogl, Felix Messmer, Florian Mirus, Florian Weisshardt, Marco Bezzon, Mathias Lüdtke, Nadia Hammoudeh García, bnm, fmw-hb, ipa-bnm, ipa-cob4-2, ipa-cob4-4, ipa-cob4-5, ipa-cob4-6, ipa-fmw, ipa-fxm, ipa-fxm-mb, ipa-nhg, msh, raw3-6, teddy
```
## cob_controller_configuration_gazebo

```
* additional param files and modifications for raw3-6 ur10
* fix error, repeated arms controllers
* Merge github.com:ipa-cob4-5/cob_robots into cob4-5-sim
* review cob4-5 simulation
* fix simulation
* fix camera names for cob4-5 simulation
* remove torso from cob4-5 config
* add 3dof head to cob4-2
* setup cob4-5
* fix sound args in gazebo launch files
* 0.6.5
* update changelog
* add missing image_flip nodes to simulation
* add default_robot_behavior to cob4-1 and cob4-2
* add 3dof head for cob4-1 within simulation only
* add scan unifier to simulated robots
* update cob4-3 according to lastest updates in cob_robots (twist_mux, vel_smoother, laser_topics)
* Merge branch 'indigo_dev' of github.com:ipa320/cob_robots into feature_cob4-1_without_arms
* restructure laser topics
* minor indentation issue
* use cob4-1 as cob4-2 without arms - copying configuration files
* added cob4-3
* remove simulated fake_diagnostics
* consistent arg usage for raw
* 0.6.4
* update changelog
* making 'sim_enabled' a launch argument
* migrate to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* sort dependencies
* revies dependencies
* unify cob3-X config and launch
* Merge branch 'hydro_dev' into indigo_dev
* Contributors: Benjamin Maidel, Denis Štogl, Florian Weisshardt, ipa-cob4-5, ipa-fmw, ipa-fxm, ipa-nhg, msh
```
## cob_default_robot_behavior

```
* clean behavior trigger services
* cleanup behaviours
* unify head and torso poses
* setup cob4-5
* 0.6.5
* fix version
* update changelog
* adjust cob_default_robot_behavior to new sss.say
* tabs vs. spaces
* apply changes to cob4-1 too
* fix PR remarks
* Update trigger_srvs_cob4-2.py
* fix service responses
* make executable
* use cob4-1 as cob4-2 without arms - copying configuration files
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_robots into indigo_dev
* fix behaviour
* divide pick trigger service
* added new behavior trigger services
* updated cob_teleop and renamed behaviour package
* Contributors: Florian Weisshardt, fmw-hb, ipa-cob4-2, ipa-cob4-5, ipa-fmw, ipa-fxm, ipa-nhg
```
## cob_default_robot_config

```
* additional param files and modifications for raw3-6 ur10
* remove unsafe ship buttons from command gui
* add shipping pose for arms
* review configuration files
* clean behavior trigger services
* remove torso from cob4-5
* remove head (is static for cob4-5)
* added arms, hands and cameras
* disable head and sensorring for cob4-2
* disable head and sensorring
* unify head and torso poses
* updated urdf model--> addapt the joint configurations
* add 3dof head to cob4-2
* test Head 3dof
* removed unnecessary command gui buttons
* setup cob4-5
* add head to cob4-2
* use symlinks for cob4-1
* improve head and torso joint configurations
* 0.6.5
* update changelog
* proper stop, init and recover via command_gui
* remove pick from command gui
* fix head positions
* add 3dof head for cob4-1 within simulation only
* update cob4-3 according to lastest updates in cob_robots (twist_mux, vel_smoother, laser_topics)
* adapt twist_mux topic names according to https://github.com/ipa320/orga/pull/1#issuecomment-159195427
* changed base_configurations to twist_mux input topic
* remove pick from knoeppkes
* use cob4-1 as cob4-2 without arms - copying configuration files
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_robots into indigo_dev
* remove show gripper
* added cob4-3
* upload correct light params
* modified default colors, more yellow looking color
* fix behaviour
* remove lookat
* fix and consistent services and topics in base config
* arm calibration
* arm calibration and adapted the default positions
* divide pick trigger service
* wave without side start
* added led_off configuration for all robots equiped with lights
* changed base namespace from 'base_controller' to 'base' for cob4 and raw3
* all raws still use old namespace for base
* raws bases still use old namespace '/base_controller' instead of '/base/driver'
* corrected light_configuration.yaml
* added new behavior trigger services
* updated cob_teleop and renamed behaviour package
* more parameter updates for cob4-2
* 0.6.4
* update changelog
* merge
* migrate to package format 2
* remove obsolete autogenerated mainpage.dox files
* robot test
* sort dependencies
* revies dependencies
* cob_behaviour
* merge
* update arm configurations
* unify cob3-X config and launch
* right arm mount position and removed arm trajectories
* Contributors: Benjamin Maidel, Florian Weisshardt, fmw-hb, ipa-bnm, ipa-cob3-9, ipa-cob4-2, ipa-cob4-5, ipa-fmw, ipa-fxm, ipa-nhg, msh
```
## cob_hardware_config

```
* adapt to multi topic hz monitor
* reduce network load by using camera info instead of image for hz monitors
* enable sound fading for cob4-1
* added sound config for fading
* fix framerate setting for head cam
* adapt phidget config to raw3-6
* aggregate arm joint states
* additional param files and modifications for raw3-6 ur10
* added ur10 to raw3-6 urdf
* fix cob homeing velocity sign
* added configs for bringup
* introduced param to set homing velocity
* review cob4-5 simulation
* increase error rate for hz monitor
* increase velocity thresholds for safety fields
* fix framerate for head cam
* add diagnostics hz monitor to cob4-1 and cob4-2 for cameras
* remove now unused reflector referencing config (is now in stations.yaml
* unify docking configuration, now only one station config file per robot
* fix powerstate full voltage
* add image flip config for sensorring front and back
* add image flip for tordo down camera for cob4-5
* fix softlink
* use imageflip with torso_cam3d_down camera
* use docking on cob4-2
* corrected empty voltage for cob
* enable roslaunch check for cob_hardware_config
* changed params
* use powerstate from phidget node
* move docking config and launch to cob_hardware_config and cob_bringup
* made diagnostics consistent with command gui
* review configuration files
* use current values in joint states
* do not turn back wheel after homing
* include/configure stuck detector
* read currents from Elmos
* base calibration
* ignore BMS entry for diagnostic_aggregator
* calibration torso_3dcam_left
* update rviz configuration
* add grippers to teleop
* remove torso from cob4-5
* remove phidget from cob4-5
* use common dcf
* no homing for sensorring
* fix light setting for cob4-5
* fix color code for cyan
* add arms and grippers to joint state aggregator
* disable sound for battery monitor
* comment bms in diagnostics
* rename hand to gripper
* add grippers to urdf
* add grippers to urdf
* Merge github.com:ipa-fmw/cob_robots into indigo_dev
  Conflicts:
  cob_hardware_config/cob4-2/config/battery_monitor.yaml
* adapted num_leds for battery_monitor
* enable light in battery monitor
* make base move smoother
* added arms, hands and cameras
* disable head and sensorring for cob4-2
* disable head and sensorring
* move base smoother
* fix diagnostics analyser
* added realsense camera to cob4-1 description
* create softlink instead of copy
* added usb head cam launch file and added it to cob4 bringup
* moved phidget config to cob4-2 and created softlink in cob4-1 config
* added current to phidget config
* added phidget config for cob4-1
* changed params for new led ring
* disabled battery monitor sound/light and emmonitor sound
* Set enable sound false
* never allow collissions for base/torso and torso/head
* load srdf in upload_robot.launch
* add SRDF to cob_hardware_config (initially empty)
* add safe mode for teleop
* tuned vel smoother params
* robot test
* add 3dof head to cob4-2
* test Head 3dof
* Migrated local_costmap_params.yaml to new layout
* Removed obstacle_threshold as for now it's not really relevant
* Removed topic parameter
* Reverted test settings to previous values
* added head controller files
* Remove inflation_layer from costmap for collision_velocity_filter
* removed arms and hands calibration
* setup cob4-5
* Changed raw3-3 config for new collision_velocity_filter
* Intermediate state
* add missing sound config files
* use cepstral
* load sound parameter from yaml file
* use cepstral
* load sound parameter from yaml file
* reduce laser fiel of view to not see robot casing
* add pc monitor config for h32
* use base_controller values from ini file
* prepare using robots with cartesian controller
* 0.6.5
* update changelog
* use lowercase instead capital letters for the analyzers
* cob4-6 has not base light
* deleted unused parameter
* added BMS to diagnostics
* readded scanners yaml files
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_robots into indigo_dev
* base controller updates
* added bms driver to bringup
* MLR actual version
* remove joint_group_interpol_position_controller
* enable velocity sensor for um2 mode
* sort by priority
* fix priority conflict
* disable abortion checking as default
* set old hardcoded default values in yaml for backwards compatibility
* parameter name consistency
* fix parameters
* configurable battery thresholds
* adjust launch and yamls
* rename canopen node and adjust diagnostics
* restructure canopen driver yamls and remove canX yamls
* changed service name remap to component name param
* further tests with torso
* enable sound and light for teleop for cob4
* apply torso updates to cob4-2 config
* finalize symlinks
* Update twist_mux_locks.yaml
* Update twist_mux_locks.yaml
* Merge pull request #429 <https://github.com/ipa320/cob_robots/issues/429> from ipa-fmw/feature/cob4-1
  comment head in cob4-1
* use base_link as root
* use JointGroupVelocityController for TwistController for Torso
* cleanup teleop parameters (unused button parameters)
* comment head config in teleop
* comment head config in diagnostics analyzer
* reduce deceleration factor
* set lock priority for twistmux
* use softlinks for most configs
* delete unused base ini files (not used any more using canopen driver)
* delete old and unused base velocity smoother config
* Merge pull request #414 <https://github.com/ipa320/cob_robots/issues/414> from ipa-fmw/feature/cob4-1
  add 3dof head for cob4-1 within simulation only
* update diagnostics analyzer
* add new_base_chain config for cob4-1
* canopen config for old cob4-2 base using new joint names
* remove obsolete robot_modules.yaml files
* remove head config from cob4-2
* fix typo
* add 3dof head for cob4-1 within simulation only
* configure lookat offset
* update cartesian parameters for torso
* adjusted to latest parameter layout
* new serial for new phidget board + sensor naming for battery_light_monitor
* added battery_light_monitor config
* use phidgets rather than simulated relayboard on raw3-1
* ros_canopen config for cob4-2 base
* tf2 compatible frames
* Revert some paramters
* Revert some paramters
* revert raw3-4 conf file
* Merge remote-tracking branch 'origin/raw3-5_battery_voltage' into update_raw3-5
* Merge branch 'indigo_dev' of github.com:iirob/cob_robots into indigo_dev
* update diagnostics analyzer for cob4-6
* update diagnostics analyzer for cob4-4
* update diagnostics analyzer for cob4-3
* updated rviz configuration
* review image_flip parameters
* New torso pcs
* integrate twist_mux into base diagnostics for all robots
* integrate twist_mux into base diagnostics
* integrate twist_mux into base diagnostics
* remove head and arms from teleop config
* remove simulated diagnostics from analyzer
* optimize parameter for torso cartesian controller
* provide twist_mux topic for base_active mode of twist_controller
* update cob4-3 according to lastest updates in cob_robots (twist_mux, vel_smoother, laser_topics)
* Merge branch 'indigo_dev' of github.com:ipa320/cob_robots into feature_cob4-1_without_arms
* add missing scan_unifier_config.yaml file for cob3-9
* rename laser scanner topics
* rename laser scanner topics
* set ramp parameter for all robots
* adapt twist_mux topic names according to https://github.com/ipa320/orga/pull/1#issuecomment-159195427
* velocity_smoother params adjustments (tested on raw3-3)
* added additional parameter to velocity_smoother (decel_factor_safe) and dissabled teleops ramp
* restructure laser topics
* added collision_velocity_filter to twist_mux
* adjusted velocity_smoother params on raw3-3
* moved twist_mux config to common folder and added softlinks for robot specific config
* use correct dcf file
* changed teleop configs base command topic to new twist_mux topic
* added velocity_smoother launch file and velocity_smoother configs for all robots
* added twist_mux launch file and twist_mux configs for all robots
* use correct pc names
* do  not use velocity controllers for Elmo devices
* use cob4-1 as cob4-2 without arms - copying configuration files
* update cartesian controller configs
* cartesian parameter updates for video shooting
* remove obsolete mu
* use STACK_OF_TASK as default
* disable acceleration limiter as default
* update limiter parameters
* scan unifier config files missed
* add scan_unifier for cob4-3
* Update teleop.yaml
* Update cob4-3.urdf.xacro
* Updated test file, robot name wrong
* added cob4-3
* removed torso from robot_modules config
* added scan unifier to bringup layer
* added led offset param to torso light config
* changed rplidar orientation
* cleaned config files
* cleaned up diagnostics analyzer config for raw3-3
* corrected phidgets config for raw3-3
* Merge pull request #349 <https://github.com/ipa320/cob_robots/issues/349> from ipa-nhg/sensorring
  [cob4-2] Sensorring with asus camera
* remove lookat
* remove obsolete parameter
* added sensorring diagnostics
* Adapt cob4-6 configuration
* test sensorring cam3d on cob4-2
* added kinect to sensorring
* same base diagnostics analyzer params for all robs because base_drive_chain driver was fixed
* cob4-4 and cob4-6 use ipa-mdl's base controller. This sends correct diagnostics
* Merge branch 'indigo_dev' of github.com:ipa320/cob_robots into fix/base_configuration
  Conflicts:
  cob_hardware_config/cob4-4/config/diagnostics_analyzers.yaml
* Merge branch 'indigo_dev' of github.com:ipa-bnm/cob_robots into fix/base_configuration
* removed comment
* wrong parameter vel_from_device
* addapt cob4-4 configuration
* arm calibration
* arm calibration and adapted the default positions
* adapted diagnostic analyzers base path to new namespaces
* adapted diagnostics analyzer to new base namespaces
* add footprint parameters for all cob4s and unify config
* changed base namespace from 'base_controller' to 'base' for cob4 and raw3
* sync cob4-1 and cob4-2
* use folded position as default
* use action server light
* using light service
* added new behavior trigger services
* renaming: hardware_interface to controller_interface
* introducing joint_group_interpol_position_controller
* add joint_group_interpol_position_controller
* enable GPM with CA as default
* base_compensation now selectable throuth kinematic_extension
* renaming frame - link
* parameterizable marker_scale
* less strict abortion checking for actived publishHoldTwist
* added white spaces
* apply relevant parameter updates for cob4-1
* cartessian controller updates cob4-2
* exponential smoothing for velocities in torso joint_states
* correct drive_modes for torso
* updated cob_teleop and renamed behaviour package
* new teleop node
* calibration update
* more parameter updates for cob4-2
* fixed some warnings
* 0.6.4
* update changelog
* add marker_frame parameter to all light yamls
* merge with 320
* Update gripper_driver.yaml
* merge
* emergency stop monitor parameters
* making 'sim_enabled' a launch argument
* fixes for cob3-9
* migrate to package format 2
* remove trailing whitespaces
* remove obsolete autogenerated mainpage.dox files
* fix for int16 overflow in vl mode
* fix for int16 overflow in vl mode
* Changed structure of self-collision yaml. Now only the components given here are considered for self-collision.
* Added more links to ignore.
* Corrected order and naming.
* Made k_H smaller. Because adapted constraints.
* Adapted launch and params.
* sort dependencies
* revies dependencies
* cob_behaviour
* fix leading space
* updates for cartesian_controller yaml
* torso setup
* torso setup
* unify cob3-X config and launch
* even better layout
* cartesian_controller yaml updates
* added safety marker
* added mlr rviz default configuration
* last update
* needed effort limits
* setup cob4-4
* cob4-4 setup
* added rplidar sensor to raw3-3 urdf and bringup
* merge
* merge
* Merge branch 'indigo_dev' of github.com:ipa-nhg/cob_robots into indigo_dev
* renamed torso urdfs
* Updated data for raw3-5
* Update footprint_observer_params.yaml
* Merge pull request #1 <https://github.com/ipa320/cob_robots/issues/1> from ipa-nhg/indigo_dev
  update ipa320
* right arm mount position and removed arm trajectories
* Added config files
* Raw3-5 phidgets is read properly, data calcualtion/remapping is corrected.
* Changed path to pcan device
* Corrected remapping and cleaned config file.
* Contributors: Benjamin Maidel, Denis Štogl, Felix Messmer, Florian Mirus, Florian Weisshardt, Mathias Lüdtke, Nadia Hammoudeh García, bnm, cob4-2, fmw-hb, ipa-bnm, ipa-cob3-9, ipa-cob4-2, ipa-cob4-4, ipa-cob4-5, ipa-cob4-6, ipa-fmw, ipa-fxm, ipa-fxm-mb, ipa-nhg, msh, raw3-6, teddy
```
## cob_robots

```
* 0.6.5
* update changelog
* 0.6.4
* update changelog
* migrate to package format 2
* remove trailing whitespaces
* cob_behaviour
* revies dependencies
* cob_behaviour
* Contributors: ipa-cob4-2, ipa-fxm
```
