### PR TITLE
aubo_robot: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -485,7 +485,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/auboliuxin/aubo_robot-release.git
-      version: 0.1.6-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/auboliuxin/aubo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aubo_robot` to `0.2.1-0`:
- upstream repository: https://github.com/auboliuxin/aubo_robot.git
- release repository: https://github.com/auboliuxin/aubo_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.1.6-0`
## aubo_control
- No changes
## aubo_description
- No changes
## aubo_driver
- No changes
## aubo_gazebo
- No changes
## aubo_i5_moveit_config
- No changes
## aubo_kinematics
- No changes
## aubo_msgs
- No changes
## aubo_robot
- No changes
## aubo_trajectory
- No changes
