### PR TITLE
sick_visionary_t_driver: 0.0.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11887,7 +11887,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SICKAG/sick_visionary_t-release.git
-      version: 0.0.2-0
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_visionary_t.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_visionary_t_driver` to `0.0.3-1`:
- upstream repository: https://github.com/SICKAG/sick_visionary_t.git
- release repository: https://github.com/SICKAG/sick_visionary_t-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.0.2-0`
## sick_visionary_t_driver

```
* rename to visionary in changelog
* rename to visionary
* Contributors: Florian Weisshardt, Marco Dierschke
```
