### PR TITLE
rocon_multimaster: 0.8.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3777,7 +3777,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_multimaster-release.git
-      version: 0.8.1-1
+      version: 0.8.1-2
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_multimaster.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3763,7 +3763,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/robotics-in-concert/rocon_multimaster.git
-      version: kinetic
+      version: release/0.8-kinetic
     release:
       packages:
       - rocon_gateway
@@ -3781,7 +3781,7 @@ repositories:
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_multimaster.git
-      version: kinetic
+      version: release/0.8-kinetic
     status: developed
   rocon_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_multimaster` to `0.8.1-2`:
- upstream repository: https://github.com/robotics-in-concert/rocon_multimaster.git
- release repository: https://github.com/yujinrobot-release/rocon_multimaster-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.8.1-1`
## rocon_gateway

```
* handle flip problems when connections go down
```
