### PR TITLE
rocon_msgs: 0.9.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3753,7 +3753,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-      version: 0.9.0-0
+      version: 0.9.0-1
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3735,7 +3735,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git
-      version: kinetic
+      version: release/0.9-kinetic
     release:
       packages:
       - concert_msgs
@@ -3757,7 +3757,7 @@ repositories:
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git
-      version: kinetic
+      version: release/0.9-kinetic
     status: developed
   rocon_multimaster:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs` to `0.9.0-1`:
- upstream repository: http://github.com/robotics-in-concert/rocon_msgs.git
- release repository: https://github.com/yujinrobot-release/rocon_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.9.0-0`
## rocon_std_msgs

```
* adding type field (e.g. std_msgs/String) to the connection message
```
