### PR TITLE
rocon_msgs: 0.7.12-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9848,7 +9848,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git
-      version: indigo
+      version: release/0.7-indigo
     release:
       packages:
       - concert_msgs
@@ -9870,7 +9870,7 @@ repositories:
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git
-      version: indigo
+      version: release/0.7-indigo
     status: developed
   rocon_multimaster:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9866,7 +9866,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_msgs-release.git
-      version: 0.7.12-0
+      version: 0.7.12-1
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs` to `0.7.12-1`:
- upstream repository: http://github.com/robotics-in-concert/rocon_msgs.git
- release repository: https://github.com/yujinrobot-release/rocon_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.7.12-0`
## concert_msgs
- No changes
## concert_service_msgs
- No changes
## concert_workflow_engine_msgs
- No changes
## gateway_msgs
- No changes
## rocon_app_manager_msgs
- No changes
## rocon_device_msgs

```
* rename name to label
* add srv and device info
* add devices messages
* Contributors: Jihoon Lee
```
## rocon_interaction_msgs
- No changes
## rocon_msgs
- No changes
## rocon_service_pair_msgs
- No changes
## rocon_std_msgs
- No changes
## rocon_tutorial_msgs
- No changes
## scheduler_msgs
- No changes
