### PR TITLE
rocon_tools: 0.3.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3787,7 +3787,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/robotics-in-concert/rocon_tools.git
-      version: kinetic
+      version: release/0.3-kinetic
     release:
       packages:
       - rocon_bubble_icons
@@ -3811,7 +3811,7 @@ repositories:
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_tools.git
-      version: kinetic
+      version: release/0.3-kinetic
     status: developed
   romeo_robot:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3807,7 +3807,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_tools-release.git
-      version: 0.3.2-0
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_tools` to `0.3.2-1`:
- upstream repository: https://github.com/robotics-in-concert/rocon_tools.git
- release repository: https://github.com/yujinrobot-release/rocon_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.3.2-0`
## rocon_interactions

```
* test case for global executable with args
* longer looping between warning messages when checking for the rapp list
```
## rocon_python_comms

```
* master check via the rosparam server bugfix
* allow named services in batching functions
* drop pyros_test
```
