### PR TITLE
multimaster_fkie: 0.6.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6413,7 +6413,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.5.8-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.6.0-0`:
- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.5.8-0`
## default_cfg_fkie
- No changes
## master_discovery_fkie
- No changes
## master_sync_fkie

```
* master_sync_fkie: updated launch file
* master_sync_fkie: added a 'resync_on_reconnect_timeout' parameter that controls how long the offline-online period is before the resync. see enhancement #48 <https://github.com/fkie/multimaster_fkie/issues/48>
* Contributors: Alexander Tiderko
```
## multimaster_fkie

```
* master_sync_fkie: updated launch file
* master_sync_fkie: added a 'resync_on_reconnect_timeout' parameter that controls how long the offline-online period is before the resync. see enhancement #48 <https://github.com/fkie/multimaster_fkie/issues/48>
* node_manager_fkie: changed find-replace doalog to dockable widget
* node_manager_fkie: changed highlight colors
* node_manager_fkie: added more info for search error
* node_manager_fkie: fixed: comment lines with less then 4 characters
* node_manager_fkie: fixed: #49 <https://github.com/fkie/multimaster_fkie/issues/49>
* node_manager_fkie: added highlightning for yaml stuff inside of a launch file
* node_manager_fkie: fixed: comment of lines with less then 4 characters in xml editor
* node_manager_fkie: fixed: activation of network window after join from network discovery
* node_manager_fkie: fixed: does not open a second configuration editor for a selected node.
* node_manager_fkie: added: 'subst_value' to xml highlighter
* node_manager_fkie: fixed: network discovery
* node_manager_fkie: comment/uncomment fixed
* node_manager_fkie: fixed: detection of included files
* Contributors: Alexander Tiderko
```
## multimaster_msgs_fkie
- No changes
## node_manager_fkie

```
* node_manager_fkie: changed find-replace doalog to dockable widget
* node_manager_fkie: changed highlight colors
* node_manager_fkie: added more info for search error
* node_manager_fkie: fixed: comment lines with less then 4 characters
* node_manager_fkie: fixed: #49 <https://github.com/fkie/multimaster_fkie/issues/49>
* node_manager_fkie: added highlightning for yaml stuff inside of a launch file
* node_manager_fkie: fixed: comment of lines with less then 4 characters in xml editor
* node_manager_fkie: fixed: activation of network window after join from network discovery
* node_manager_fkie: fixed: does not open a second configuration editor for a selected node.
* node_manager_fkie: added: 'subst_value' to xml highlighter
* node_manager_fkie: fixed: network discovery
* node_manager_fkie: comment/uncomment fixed
* node_manager_fkie: fixed: detection of included files
* Contributors: Alexander Tiderko
```
