### PR TITLE
rtmros_nextage: 0.7.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11329,7 +11329,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.7.8-0
+      version: 0.7.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.7.9-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.7.8-0`
## nextage_description

```
* [fix] do not have to fix /WAIST to /world, if you want run static_transform_publisher, see #235 <https://github.com/tork-a/rtmros_nextage/issues/235>
* [improve] set ARM_JOINT0 max effor to 150, ARM_JOINT1 max effor to 200, may be this is larget than real robot
* [improve] set mass of base link to super heavy
* Contributors: Kei Okada
```
## nextage_gazebo

```
* [fix][test] gz.test must be one file to avoid collsion on gazebo master uri
* [fix] Missing installation
* [fix] : test/test_nxo_gz.py, because of changeing contorller parameter?
* [improve] tune pid parameter for gazebo
* Contributors: Kei Okada
```
## nextage_ik_plugin
- No changes
## nextage_moveit_config

```
* [fix] test_moveit.py is very unstalble, run go 3 times
* [fix] NextageROS.desktop.in : now rtmlaunch is installed in global bin
* [fix][test] Better utilization of tests. test/test_moveit.py : botharms.go is very unstable
* [fix][joy.test] fix again, it seems they did not publish joint state publisher, so question is why it passed the test?
* [fix] remove torso from group, that outputs "Group 'torso' is not a chain" ERROR
* [fix] kinematics_ikfast.yaml : no ik fast plugin for head and torso
* Contributors: Kei Okada
```
## nextage_ros_bridge

```
* [fix][nxo client] #262 <https://github.com/tork-a/rtmros_nextage/issues/262> by catching error when ros master is not running
* [fix] nextage_clinet with gazebo under no rtm environment.
* [capability] Activate ImpedanceController RTC. #261 <https://github.com/tork-a/rtmros_nextage/issues/261>
* [improve] better initial hrpsys view
* Contributors: Kei Okada, Isaac I.Y. Saito
```
## rtmros_nextage

```
* [fix][nxo client] #262 <https://github.com/tork-a/rtmros_nextage/issues/262> by catching error when ros master is not running
* [fix] nextage_clinet with gazebo under no rtm environment.
* [fix] test_moveit.py is very unstalble, run go 3 times
* [fix] NextageROS.desktop.in : now rtmlaunch is installed in global bin
* [fix][test] Better utilization of tests. test/test_moveit.py : botharms.go is very unstable
* [fix][joy.test] fix again, it seems they did not publish joint state publisher, so question is why it passed the test?
* [fix] remove torso from group, that outputs "Group 'torso' is not a chain" ERROR
* [fix] kinematics_ikfast.yaml : no ik fast plugin for head and torso
* [fix][test] gz.test must be one file to avoid collsion on gazebo master uri
* [fix] Missing installation
* [fix] : test/test_nxo_gz.py, because of changeing contorller parameter?
* [fix] do not have to fix /WAIST to /world, if you want run static_transform_publisher, see #235 <https://github.com/tork-a/rtmros_nextage/issues/235>
* [capability] Activate ImpedanceController RTC. #261 <https://github.com/tork-a/rtmros_nextage/issues/261>
* [improve] better initial hrpsys view
* [improve] tune pid parameter for gazebo
* [improve] set ARM_JOINT0 max effor to 150, ARM_JOINT1 max effor to 200, may be this is larget than real robot
* [improve] set mass of base link to super heavy
* Contributors: Kei Okada, Isaac I.Y. Saito
```
