### PR TITLE
rtmros_hironx: 1.1.17-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11306,7 +11306,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.16-0
+      version: 1.1.17-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.17-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.1.16-0`
## hironx_calibration
- No changes
## hironx_moveit_config
- No changes
## hironx_ros_bridge

```
* [fix] Fix versioning; use StrictVersion to compare version string
* [improve] acceptancetest_hironx.py: display what to do
* [fix] acceptancetest to work with gazebo environment
* [improve] ros_client.py : for ros_clinet to use control_msgs instaed of pr2_controllers, this should work on latest hrpsys_ros_bridge which support both interface
* Contributors: Kei Okada
```
## rtmros_hironx

```
* [fix] Fix versioning; use StrictVersion to compare version string
* [improve] acceptancetest_hironx.py: display what to do
* [fix] acceptancetest to work with gazebo environment
* [improve] ros_client.py : for ros_clinet to use control_msgs instaed of pr2_controllers, this should work on latest hrpsys_ros_bridge which support both interface
* Contributors: Kei Okada
```
