### PR TITLE
web_video_server: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13964,7 +13964,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/web_video_server-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/RobotWebTools/web_video_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `web_video_server` to `0.0.5-0`:
- upstream repository: https://github.com/RobotWebTools/web_video_server.git
- release repository: https://github.com/RobotWebTools-release/web_video_server-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.0.4-0`
## web_video_server

```
* Merge pull request #23 <https://github.com/RobotWebTools/web_video_server/issues/23> from iki-wgt/develop
  More information when server creation is failed
* Removed empty line
* More detailed exception message
  Programm behavior is not changed since the exception is rethrown.
* Contributors: BennyRe, Russell Toris
```
