### PR TITLE
cob_extern: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1452,7 +1452,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_extern-release.git
-      version: 0.6.5-0
+      version: 0.6.6-0
     source:
       type: git
       url: https://github.com/ipa320/cob_extern.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_extern` to `0.6.6-0`:
- upstream repository: https://github.com/ipa320/cob_extern.git
- release repository: https://github.com/ipa320/cob_extern-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.6.5-0`
## cob_extern
- No changes
## libconcorde_tsp_solver

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* use package format 2
* Update package.xml
* Contributors: Florian Weisshardt
```
## libdlib

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* Update package.xml
* Contributors: Florian Weisshardt
```
## libntcan
- No changes
## libopengm

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* Update package.xml
* Contributors: Florian Weisshardt
```
## libpcan
- No changes
## libphidgets
- No changes
