### PR TITLE
nao_dcm_robot: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6491,6 +6491,23 @@ repositories:
       url: https://github.com/yujinrobot-release/nanomsg-release.git
       version: 0.4.0-1
     status: maintained
+  nao_dcm_robot:
+    doc:
+      type: git
+      url: https://github.com/ros-aldebaran/nao_dcm_robot.git
+      version: master
+    release:
+      packages:
+      - nao_dcm_bringup
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-aldebaran/nao_dcm_robot-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/ros-aldebaran/nao_dcm_robot.git
+      version: master
+    status: maintained
   nao_extras:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_dcm_robot` to `0.0.2-0`:
- upstream repository: https://github.com/ros-aldebaran/nao_dcm_robot.git
- release repository: https://github.com/ros-aldebaran/nao_dcm_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## nao_dcm_bringup

```
* updating config params
* changing the dependence nao_dcm_driver on naoqi_dcm_driver
* adding a launch file for position controllers
* Delete nao_dcm_H25_bringup.launch
* configuring to use with moveit
* light nao_dcm to Control NAO without NAOqi's motion module
* Contributors: Mikael Arguedas, Natalia Lyubova
```
