### PR TITLE
pr2_robot: 1.6.16-4 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8539,7 +8539,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_robot-release.git
-      version: 1.6.16-2
+      version: 1.6.16-4
     source:
       type: git
       url: https://github.com/pr2/pr2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_robot` to `1.6.16-4`:
- upstream repository: https://github.com/pr2/pr2_robot.git
- release repository: https://github.com/pr2-gbp/pr2_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.6.16-2`
