### PR TITLE
rqt_wrapper: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4405,6 +4405,17 @@ repositories:
       url: https://github.com/ros-visualization/rqt_robot_plugins.git
       version: master
     status: maintained
+  rqt_wrapper:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/rqt_wrapper-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/stonier/rqt_wrapper.git
+      version: devel
+    status: developed
   rtabmap:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_wrapper` to `0.1.3-0`:
- upstream repository: https://github.com/stonier/rqt_wrapper.git
- release repository: https://github.com/yujinrobot-release/rqt_wrapper-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
