### PR TITLE
rocon_app_platform: 0.7.13-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9808,7 +9808,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_app_platform-release.git
-      version: 0.7.13-0
+      version: 0.7.13-1
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9798,7 +9798,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git
-      version: indigo
+      version: release/0.7-indigo
     release:
       packages:
       - rocon_app_manager
@@ -9812,7 +9812,7 @@ repositories:
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git
-      version: indigo
+      version: release/0.7-indigo
     status: developed
   rocon_concert:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_app_platform` to `0.7.13-1`:
- upstream repository: http://github.com/robotics-in-concert/rocon_app_platform
- release repository: https://github.com/yujinrobot-release/rocon_app_platform-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.7.13-0`
## rocon_app_manager

```
* the cancel_flag should be False in start_app
* attempts to flip public interface a couple of times. Then stopps rapp if it fails after all attempts. closes #297 <https://github.com/robotics-in-concert/rocon_app_platform/issues/297>
* fix start_rapp stop rapp flipping #299 <https://github.com/robotics-in-concert/rocon_app_platform/issues/299>
* cleans up flip connection logic in start/stop rapp closes #299 <https://github.com/robotics-in-concert/rocon_app_platform/issues/299>
* print should not be here closes #298 <https://github.com/robotics-in-concert/rocon_app_platform/issues/298>
* add gatewayname as launch arg only if it exists closes #295 <https://github.com/robotics-in-concert/rocon_app_platform/issues/295>
* [rocon_app_manager] trivial
* [rocon_app_manager] pass a ros compatible name to the rapp.
* [rocon_app_manager] remove unnecessary, and old, comment.
* [rocon_app_manager] bugfix the bugfix for status publishing
  Didn't look around properly - this corrects the last bugfix to make sure
  all variables are properly defined before publishing the status.
* [rocon_app_manager] remove debug print.
* [rocon_app_manager] base name handling should be same for uuids or not.
  Wasn't applying the correct conversion rules (lower, space->'_') for
  standalone mode so that the namespaced topics/services conform to ros
  conventions.
* [rocon_app_manager] bugfix handling of nonexistant current rapp.
  Was mistakenly assuming that this is always available. This handles the
  case when it is None.
* removing running rapps from listrapps
* Contributors: AlexV, Daniel Stonier, Jihoon Lee
```
## rocon_app_platform
- No changes
## rocon_app_utilities

```
* Merge pull request #292 <https://github.com/robotics-in-concert/rocon_app_platform/issues/292> from robotics-in-concert/gopher
  Delivery ancestor rapp and some bugfixes
* [rocon_app_manager] trivial
* [rocon_app_utilities] syntax highlighting for rocon_app cmd output.
* [rocon_app_utilites] pep8 for rapp_cmd.py
* [rocon_app_utilities] bugfix undefined variable call to ancestor_name.
  Must be in scope before the exception branching is executed.
* [rocon_app_utilities] pep8 fixes.
* Contributors: Daniel Stonier, Jihoon Lee
```
## rocon_apps

```
* add image stream app
* add text to speech app closes #293 <https://github.com/robotics-in-concert/rocon_app_platform/issues/293>
* add install rule for typing to string script closes #294 <https://github.com/robotics-in-concert/rocon_app_platform/issues/294>
* [rocon_apps] delivery rapp moved out.
* add typing to string launch file
* renaming the script
* add commander
* [rocon_apps] next iteration of the delivery rapp interface.
* [rocon_apps] first iteration of the delivery ancestor rapp.
* Contributors: Daniel Stonier, Jihoon Lee
```
