### PR TITLE
rocon_app_platform: 0.9.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3725,7 +3725,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/rocon_app_platform-release.git
-      version: 0.8.0-0
+      version: 0.9.1-0
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3715,7 +3715,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git
-      version: kinetic
+      version: release/0.9-indigo-kinetic-gopher
     release:
       packages:
       - rocon_app_manager
@@ -3729,7 +3729,7 @@ repositories:
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git
-      version: kinetic
+      version: release/0.9-indigo-kinetic-gopher
     status: developed
   rocon_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_app_platform` to `0.9.1-0`:
- upstream repository: http://github.com/robotics-in-concert/rocon_app_platform
- release repository: https://github.com/yujinrobot-release/rocon_app_platform-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.8.0-0`
## rocon_app_manager

```
* drop the master relay
```
