### PR TITLE
moveit_python: 0.2.17-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2262,7 +2262,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mikeferguson/moveit_python-release.git
-      version: 0.2.17-0
+      version: 0.2.17-1
     status: developed
   moveit_resources:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_python` to `0.2.17-1`:
- upstream repository: https://github.com/mikeferguson/moveit_python.git
- release repository: https://github.com/mikeferguson/moveit_python-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.2.17-0`
## moveit_python

```
* Merge pull request #9 <https://github.com/mikeferguson/moveit_python/issues/9> from mikeferguson/pyassimp_fix
  pyassimp is broken in 16.04, temporary work around so we can release
* Contributors: Michael Ferguson
```
