### PR TITLE
ros_type_introspection: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4083,6 +4083,14 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: kinetic-devel
     status: maintained
+  ros_type_introspection:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/facontidavide/ros_type_introspection-release.git
+      version: 0.2.0-0
+    status: developed
+    status_description: Fully funtional implementation, but more testing is needed.
   rosauth:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_type_introspection` to `0.2.0-0`:
- upstream repository: https://github.com/facontidavide/ros_type_introspection.git
- release repository: https://github.com/facontidavide/ros_type_introspection-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## ros_type_introspection

```
* All unit tests pass, but coverage is not very high.
* By default is uses the custom string implementation.
* Stable (?) API
```
