### PR TITLE
jsk_3rdparty: 2.0.16-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1896,11 +1896,12 @@ repositories:
       - rospatlite
       - rosping
       - rostwitter
+      - slic
       - voice_text
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.0.14-0
+      version: 2.0.16-0
     status: developed
   jsk_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.0.16-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `2.0.14-0`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## collada_urdf_jsk_patch
- No changes
## downward
- No changes
## ff
- No changes
## ffha
- No changes
## jsk_3rdparty

```
* jsk_3rdparty/package.xml: sklearn is no longer exists #53 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/53>
* Contributors: Kei Okada
```
## julius
- No changes
## libcmt
- No changes
## libsiftfast
- No changes
## mini_maxwell
- No changes
## nlopt
- No changes
## opt_camera
- No changes
## pgm_learner
- No changes
## rospatlite
- No changes
## rosping
- No changes
## rostwitter
- No changes
## slic
- No changes
## voice_text
- No changes
