### PR TITLE
navigation_tutorials: 0.2.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2568,6 +2568,30 @@ repositories:
       url: https://github.com/ros-gbp/navigation_msgs-release.git
       version: 1.13.0-0
     status: maintained
+  navigation_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation_tutorials.git
+      version: indigo-devel
+    release:
+      packages:
+      - laser_scan_publisher_tutorial
+      - navigation_stage
+      - navigation_tutorials
+      - odometry_publisher_tutorial
+      - point_cloud_publisher_tutorial
+      - robot_setup_tf_tutorial
+      - roomba_stage
+      - simple_navigation_goals_tutorial
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/navigation_tutorials-release.git
+      version: 0.2.3-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/navigation_tutorials.git
+      version: indigo-devel
+    status: maintained
   nerian_sp1:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_tutorials` to `0.2.3-0`:
- upstream repository: https://github.com/ros-planning/navigation_tutorials.git
- release repository: https://github.com/ros-gbp/navigation_tutorials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
