### PR TITLE
ros_type_introspection: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10472,7 +10472,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/facontidavide/ros_type_introspection-release.git
-      version: 0.2.0-0
+      version: 0.3.0-0
     status: developed
   ros_web_video:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_type_introspection` to `0.3.0-0`:
- upstream repository: https://github.com/facontidavide/ros_type_introspection.git
- release repository: https://github.com/facontidavide/ros_type_introspection-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.2.0-0`
## ros_type_introspection

```
* Doxygen added
* Moved to gtests instead of Catch.
* Final API (?)
```
