### PR TITLE
jsk_model_tools: 0.2.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4623,7 +4623,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.2.4-0
+      version: 0.2.5-0
     status: developed
   jsk_planning:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.2.5-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.2.4-0`
## eus_assimp
- No changes
## euscollada

```
* [collada2eus] fix closing /dev/null (#186 <https://github.com/jsk-ros-pkg/jsk_model_tools/pull/186>)
* Add documentation for predefined poses (#174 <https://github.com/jsk-ros-pkg/jsk_model_tools/pull/174>)
* Contributors: Kentaro Wada, Yohei Kakiuchi
```
## eusurdf

```
* [eusurdf] add test of model conversion (#181 <https://github.com/jsk-ros-pkg/jsk_model_tools/pull/181>)
  * [eusurdf/CMakeLists.txt,package.xml] test model conversion in eusurdf package.
  * [eusurdf/test] add test directory in eusurdf. add script and launch to test model conversion.
  * [eusurdf/package.xml] add maintainer of eusurdf package.
  * [eusurdf/euslisp/convert-eus-to-urdf.l] add documentation of euslisp function to convert irteus->urdf.
* [eusurdf/euslisp/convert-eus-to-urdf.l] get name from converted eus model if the argument name is not passed. (#169 <https://github.com/jsk-ros-pkg/jsk_model_tools/pull/169>)
* Contributors: Masaki Murooka
```
## jsk_model_tools
- No changes
