### PR TITLE
multimaster_fkie: 0.6.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2361,7 +2361,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.6.1-0`:
- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.6.0-0`
## default_cfg_fkie
- No changes
## master_discovery_fkie

```
* fix for issue #50: do not sent and reply requests while own state is not available
* Contributors: Alexander Tiderko
```
## master_sync_fkie
- No changes
## multimaster_fkie

```
* fix for issue #50: do not sent and reply requests while own state is not available
* Contributors: Alexander Tiderko, deng02
```
## multimaster_msgs_fkie
- No changes
## node_manager_fkie
- No changes
