### PR TITLE
rviz: 1.11.15-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5571,7 +5571,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.11.14-0
+      version: 1.11.15-0
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.11.15-0`:
- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.11.14-0`
## rviz

```
* Pose arrays can now be rendered as 3D arrows or pose markers (#1016 <https://github.com/ros-visualization/rviz/issues/1016>)
* Allow float edits to work with different Locales
  * (#1043 <https://github.com/ros-visualization/rviz/issues/1043>)
  * (#1058 <https://github.com/ros-visualization/rviz/issues/1058>)
* Fix double free in display dialog.
  * (#1053 <https://github.com/ros-visualization/rviz/issues/1053>)
  * (#1057 <https://github.com/ros-visualization/rviz/issues/1057>)
* Now check for a valid root link before walking the robot model (#1039 <https://github.com/ros-visualization/rviz/issues/1039>)
* Fixed two valgrind-reported issues (#1001 <https://github.com/ros-visualization/rviz/issues/1001>)
  * in ~RenderPanel()
  * in VisualizationManager(): initialization order
* Updated the marker display and tf plugins to save the enabled namespaces and frames when changed.
  * Also updated the plugins so that is saved whenever the plugin is reset.
  * This also allows the currently selected namespaces/frames to remain selected after the "Reset" button is pressed.
  * (#988 <https://github.com/ros-visualization/rviz/issues/988>)
  * (#989 <https://github.com/ros-visualization/rviz/issues/989>)
* Generalized the WrenchVisual class (#982 <https://github.com/ros-visualization/rviz/issues/982>)
  * generalized WrenchStampedVisual::setMessage()
  * alternative API: WrenchStampedVisual::setWrench(OgreVector3 force, OgreVector3 torque)
  * expose SceneNode::setVisible()
  * separate scene nodes for force and torque marker
  * retain API compatibility
  * retain ABI compatibility
* Contributors: Maarten de Vries, Michael Görner, Robert Haschke, Ron Tajima, William Woodall
```
