### PR TITLE
rviz: 1.12.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4520,7 +4520,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.12.1-0
+      version: 1.12.2-0
     source:
       test_commits: false
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.12.2-0`:
- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.12.1-0`
## rviz

```
* Paths can now be rendered as 3D arrows or pose markers (#1059 <https://github.com/ros-visualization/rviz/issues/1059>)
* Allow float edits to work with different Locales (#1043 <https://github.com/ros-visualization/rviz/issues/1043>)
* Now check for a valid root link before walking the robot model (#1041 <https://github.com/ros-visualization/rviz/issues/1041>)
* Added close() signal to Tool class (#1051 <https://github.com/ros-visualization/rviz/issues/1051>)
* Fix double free in display dialog (#1053 <https://github.com/ros-visualization/rviz/issues/1053>)
* Tweak focal shape size marker depending on focal distance (#1021 <https://github.com/ros-visualization/rviz/issues/1021>)
* Support 3D arrows and axes for visualizing PoseArrays (#1022 <https://github.com/ros-visualization/rviz/issues/1022>)
* Use urdf::*ShredPtr instead of boost::shared_ptr (#1044 <https://github.com/ros-visualization/rviz/issues/1044>)
* Fixed two valgrind-reported issues (#1027 <https://github.com/ros-visualization/rviz/issues/1027>)
  * in ~RenderPanel()
  * in VisualizationManager(): initialization order
* Added option to disable the RViz splash-screen (#1024 <https://github.com/ros-visualization/rviz/issues/1024>)
* Fix compile error due to the user-defined string literals feature (#1010 <https://github.com/ros-visualization/rviz/issues/1010>)
* Fixed some Qt5 related build issues (#1008 <https://github.com/ros-visualization/rviz/issues/1008>)
* Removed dependency on OpenCV (#1009 <https://github.com/ros-visualization/rviz/issues/1009>)
* Contributors: 1r0b1n0, Atsushi Watanabe, Blake Anderson, Jochen Sprickerhof, Kartik Mohta, Maarten de Vries, Michael Görner, Robert Haschke, Victor Lamoine, Víctor Mayoral Vilches, William Woodall
```
