### PR TITLE
micros_hopfield: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5847,6 +5847,21 @@ repositories:
       url: https://github.com/yincanben/micros_dynamic_objects_filter.git
       version: master
     status: developed
+  micros_hopfield:
+    doc:
+      type: git
+      url: https://github.com/micros-uav/micros_hopfield.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/micros-uav/micros_hopfield-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/micros-uav/micros_hopfield.git
+      version: master
+    status: developed
   micros_mars_task_alloc:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `micros_hopfield` to `0.0.3-0`:
- upstream repository: https://github.com/micros-uav/micros_hopfield.git
- release repository: https://github.com/micros-uav/micros_hopfield-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## micros_hopfield

```
* 0.0.1
* Contributors: 491734045
```
