### PR TITLE
rtmros_nextage: 0.7.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11381,7 +11381,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.7.9-0
+      version: 0.7.10-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.7.10-0`:
- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.7.9-0`
## nextage_description
- No changes
## nextage_gazebo
- No changes
## nextage_ik_plugin
- No changes
## nextage_moveit_config

```
* [improve] moderate Interactive Marker size.
* Contributors: Isaac I.Y. Saito
```
## nextage_ros_bridge

```
* [improve] getRTCList now inherits the behavior from the super class, HIRONX, to avoid duplicate.
* Contributors: Isaac I.Y. Saito
```
## rtmros_nextage

```
* [improve] getRTCList now inherits the behavior from the super class, HIRONX, to avoid duplicate.
* [improve] moderate Interactive Marker size.
* Contributors: Isaac I.Y. Saito
```
