### PR TITLE
octomap_mapping: 0.6.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2767,6 +2767,24 @@ repositories:
       url: https://github.com/OctoMap/octomap.git
       version: devel
     status: developed
+  octomap_mapping:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_mapping.git
+      version: kinetic-devel
+    release:
+      packages:
+      - octomap_mapping
+      - octomap_server
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_mapping-release.git
+      version: 0.6.1-0
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_mapping.git
+      version: kinetic-devel
+    status: maintained
   octomap_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping` to `0.6.1-0`:
- upstream repository: https://github.com/OctoMap/octomap_mapping
- release repository: https://github.com/ros-gbp/octomap_mapping-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## octomap_mapping

```
* Adjust maintainer email
* Contributors: Armin Hornung
```
## octomap_server

```
* Fix for Colored Octomap: Use PCLPoint everywhere
  Fixes compiler error when enabling the define
  for color.
* Fixed maxRange bug in OctomapServer.cpp for clearing
* Adjust maintainer email
* Contributors: Armin Hornung, Brandon Kinman, Felix Endres
```
