### PR TITLE
ihmc-ros-control: 0.5.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3932,6 +3932,15 @@ repositories:
       url: https://github.com/open-rdc/icart_mini.git
       version: indigo-devel
     status: developed
+  ihmc-ros-control:
+    release:
+      packages:
+      - ihmc_ros_control
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ihmcrobotics/ihmc-ros-control-release.git
+      version: 0.5.0-0
+    status: developed
   im_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ihmc-ros-control` to `0.5.0-0`:
- upstream repository: https://github.com/ihmcrobotics/ihmc-ros-control.git
- release repository: https://github.com/ihmcrobotics/ihmc-ros-control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
