### PR TITLE
ihmc-ros-control: 0.5.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3939,7 +3939,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ihmcrobotics/ihmc-ros-control-release.git
-      version: 0.5.0-0
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/ihmcrobotics/ihmc-ros-control.git
+      version: develop
     status: developed
   im_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ihmc-ros-control` to `0.5.0-1`:
- upstream repository: https://github.com/ihmcrobotics/ihmc-ros-control.git
- release repository: https://github.com/ihmcrobotics/ihmc-ros-control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.5.0-0`
