### PR TITLE
ihmc_ros_core: 0.8.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3945,6 +3945,22 @@ repositories:
       url: https://github.com/ihmcrobotics/ihmc-ros-control.git
       version: develop
     status: developed
+  ihmc_ros_core:
+    release:
+      packages:
+      - ihmc_msgs
+      - ihmc_ros_common
+      - ihmc_ros_core
+      - ihmc_ros_java_adapter
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ihmcrobotics/ihmc_ros_core-release.git
+      version: 0.8.0-0
+    source:
+      type: git
+      url: https://github.com/ihmcrobotics/ihmc_ros_core.git
+      version: develop
+    status: developed
   im_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ihmc_ros_core` to `0.8.0-0`:
- upstream repository: https://github.com/ihmcrobotics/ihmc_ros_core.git
- release repository: https://github.com/ihmcrobotics/ihmc_ros_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
