### PR TITLE
rviz: 1.12.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4543,7 +4543,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.12.2-0
+      version: 1.12.3-0
     source:
       test_commits: false
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.12.3-0`:
- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.12.2-0`
## rviz

```
* Revert "Use urdf::*ShredPtr instead of boost::shared_ptr" (#1060 <https://github.com/ros-visualization/rviz/issues/1060>)
* Contributors: William Woodall
```
