### PR TITLE
ihmc_ros_diagnostics: 0.8.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3961,6 +3961,17 @@ repositories:
       url: https://github.com/ihmcrobotics/ihmc_ros_core.git
       version: develop
     status: developed
+  ihmc_ros_diagnostics:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ihmcrobotics/ihmc_ros_diagnostics-release.git
+      version: 0.8.0-0
+    source:
+      type: git
+      url: https://github.com/ihmcrobotics/ihmc_ros_diagnostics.git
+      version: 0.8.0
+    status: developed
   im_msgs:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3970,7 +3970,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ihmcrobotics/ihmc_ros_diagnostics.git
-      version: 0.8.0
+      version: develop
     status: developed
   im_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ihmc_ros_diagnostics` to `0.8.0-0`:
- upstream repository: https://github.com/ihmcrobotics/ihmc_ros_diagnostics.git
- release repository: https://github.com/ihmcrobotics/ihmc_ros_diagnostics-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
