### PR TITLE
geometric_shapes: 0.5.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1165,7 +1165,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.5.1-0
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.5.2-0`:
- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.5.1-0`
## geometric_shapes

```
* [fix] mesh with too many vertices (#39 <https://github.com/ros-planning/geometric_shapes/issues/39>) (#60 <https://github.com/ros-planning/geometric_shapes/issues/60>)
* [fix] gcc6 build error (#56 <https://github.com/ros-planning/geometric_shapes/issues/56>)
* [fix] Clear root transformation on imported Collada meshes. #52 <https://github.com/ros-planning/geometric_shapes/issues/52>
* [improve] relax mesh containment test (#58 <https://github.com/ros-planning/geometric_shapes/issues/58>)
* [maintenance] Switch boost::shared_ptr to std::shared_ptr. #57 <https://github.com/ros-planning/geometric_shapes/pull/57>
* Contributors: Dave Coleman, Isaac I.Y. Saito, Lukas Bulwahn, Maarten de Vries, Michael Goerner
```
