### PR TITLE
changed release url for aruco_ros from personal to organization repo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -405,7 +405,7 @@ repositories:
       - aruco_ros
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/bmagyar/aruco_ros-release.git
+      url: https://github.com/pal-gbp/aruco_ros-release.git
       version: 0.1.0-0
     source:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -151,7 +151,7 @@ repositories:
       - aruco_ros
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/bmagyar/aruco_ros-release.git
+      url: https://github.com/pal-gbp/aruco_ros-release.git
       version: 0.1.0-0
     source:
       type: git


### PR DESCRIPTION
The release url is still in the name of the maintainer, instead of being the company official release url.
