### PR TITLE
ros_type_introspection: 0.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10527,7 +10527,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/facontidavide/ros_type_introspection-release.git
-      version: 0.3.1-0
+      version: master
     source:
       type: git
       url: https://github.com/facontidavide/ros_type_introspection.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10527,7 +10527,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/facontidavide/ros_type_introspection-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/facontidavide/ros_type_introspection.git
+      version: 0.3.1
     status: developed
   ros_web_video:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10527,11 +10527,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/facontidavide/ros_type_introspection-release.git
-      version: master
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/facontidavide/ros_type_introspection.git
-      version: 0.3.1
+      version: master
     status: developed
   ros_web_video:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_type_introspection` to `0.3.1-0`:
- upstream repository: https://github.com/facontidavide/ros_type_introspection.git
- release repository: https://github.com/facontidavide/ros_type_introspection-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.3.0-0`
## ros_type_introspection

```
* added BSD license
* added an alternative implementation of ShapeShifter
```
