### PR TITLE
ros_type_introspection: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4130,6 +4130,17 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: kinetic-devel
     status: maintained
+  ros_type_introspection:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/facontidavide/ros_type_introspection-release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/facontidavide/ros_type_introspection.git
+      version: master
+    status: developed
   rosauth:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_type_introspection` to `0.3.1-0`:
- upstream repository: https://github.com/facontidavide/ros_type_introspection.git
- release repository: https://github.com/facontidavide/ros_type_introspection-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## ros_type_introspection

```
* added BSD license
* added an alternative implementation of ShapeShifter
```
