### PR TITLE
robot_state_publisher: 1.13.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3673,7 +3673,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/robot_state_publisher-release.git
-      version: 1.13.2-0
+      version: 1.13.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `1.13.3-0`:
- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros-gbp/robot_state_publisher-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.13.2-0`
## robot_state_publisher

```
* Added a new parameter "ignore_timestamp" (#65 <https://github.com/ros/robot_state_publisher/issues/65>)
* Fixed joints are not published over tf_static by default (#56 <https://github.com/ros/robot_state_publisher/issues/56>)
* Fixed segfault on undefined robot_description (#61 <https://github.com/ros/robot_state_publisher/issues/61>)
* Fixed cmake eigen3 warning (#62 <https://github.com/ros/robot_state_publisher/issues/62>)
* Contributors: Davide Faconti, Ioan A Sucan, Johannes Meyer, Robert Haschke
```
