### PR TITLE
moveit: 0.9.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2258,6 +2258,44 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: kinetic-devel
     status: maintained
+  moveit:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit.git
+      version: kinetic-devel
+    release:
+      packages:
+      - moveit
+      - moveit_commander
+      - moveit_controller_manager_example
+      - moveit_core
+      - moveit_fake_controller_manager
+      - moveit_kinematics
+      - moveit_planners
+      - moveit_planners_ompl
+      - moveit_plugins
+      - moveit_ros
+      - moveit_ros_benchmarks
+      - moveit_ros_control_interface
+      - moveit_ros_manipulation
+      - moveit_ros_move_group
+      - moveit_ros_perception
+      - moveit_ros_planning
+      - moveit_ros_planning_interface
+      - moveit_ros_robot_interaction
+      - moveit_ros_visualization
+      - moveit_ros_warehouse
+      - moveit_setup_assistant
+      - moveit_simple_controller_manager
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/moveit-release.git
+      version: 0.9.1-2
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit.git
+      version: kinetic-devel
+    status: developed
   moveit_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.9.1-2`:
- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
