### PR TITLE
moveit_visual_tools: 3.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2342,6 +2342,21 @@ repositories:
       type: git
       url: https://github.com/ros-planning/moveit_tutorials.git
       version: kinetic-devel
+  moveit_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/moveit_visual_tools.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/davetcoleman/moveit_visual_tools-release.git
+      version: 3.2.0-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/moveit_visual_tools.git
+      version: kinetic-devel
+    status: developed
   mrpt_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `3.2.0-0`:
- upstream repository: https://github.com/davetcoleman/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## moveit_visual_tools

```
* Added publishState() to imarker_robot_state
* New publishTrajectoryLine() function that automatically chooses end effectors to visualize
* New collision table function that takes z input
* Fixed callbacks for multiple EEFs
* Allow for two end effectors
* Ability to use two end effectors for interactive markers
* Make ik solving at any end effector link, not just end of kinematic chain
* Better debugging for collision
* Only save when mouse up
* Fix API for changes in rviz_visual_tools
* Allow collision walls to have variable z location
* Make applyVirtualJointTransform() static
* Make checkForVirtualJoint() static
* IMarkerRobotState remove offset capability
* IMarkerRobotState remove imarker box control
* Switched travis to MoveIt! CI
* Added new IMarker Robot control method
* Cleaned up code base: catkin lint, roslint
* Fixed bug in planning scene triggering
* Optimize planning scene updates to only update GEOMETRY
* Fix xacro
* Upgrade to Eigen3 per ROS Kinetic requirements
* New publishRobotState() function
* Fix Eigen bugs
* Removed deprecated code
* Converted to C++11
* Optional blocking publisher calls
* Added getter for getRobotRootState()
* Contributors: Dave Coleman
```
