### PR TITLE
jsk_roseus: 1.6.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1633,6 +1633,17 @@ repositories:
       url: https://github.com/tork-a/jsk_common_msgs-release.git
       version: 4.0.0-0
     status: developed
+  jsk_roseus:
+    release:
+      packages:
+      - jsk_roseus
+      - roseus
+      - roseus_smach
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/jsk_roseus-release.git
+      version: 1.6.0-0
+    status: developed
   jskeus:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.6.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## jsk_roseus
- No changes
## roseus

```
* Support private/under-namespace topic name in roseus client
  Node            nRelative (default)      Global          Private
  /node1          bar -> /bar             /bar -> /bar    ~bar -> /node1/bar
  /wg/node2       bar -> /wg/bar          /bar -> /bar    ~bar -> /wg/node2/bar
  /wg/node3       foo/bar -> /wg/foo/bar  /foo/bar -> /foo/bar    ~foo/bar -> /wg/node3/foo/bar
* Fix test to fail when no message came
* when pkg is target package do not need to find_package, just to set SOURCE_PREFIX, this will solve https://github.com/jsk-ros-pkg/jsk_robot/issues/597
* Remove definition of unused variables
* [roseus-utils.l] fix dump-pointcloud-to-pcd-file file
* [roseus/test/param-test.l] fix: param test for cache
* [roseus/roseus.cpp] fix typo: ros::get-param-cashed -> ros::get-param-cached
* [roseus/roseus.cpp] add ros::delete-param
  [roseus/test/param-test.l] add test for ros::delete-param
* [roseus/CMakeLists.txt] remove coreutils from DEPENDS
* [roseus/package.xml] add coreutils to build_depend
* [roseus/CMakeLists.txt] add CATKIN_ENABLE_TESTING section for testing
* Contributors: Kei Okada, Kentaro Wada, Yohei Kakiuchi, Yuki Furuta
```
## roseus_smach

```
* [roseus/src/state-machine-utils.l] add document string for exec-smach-with-spin
* [roseus_smach/src/state-machine-utils.l] support y-or-n-p when iterate mode
* Contributors: Yuki Furuta
```
