### PR TITLE
moveit_sim_controller: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2348,6 +2348,21 @@ repositories:
       url: https://github.com/ros-planning/moveit_resources.git
       version: master
     status: developed
+  moveit_sim_controller:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/moveit_sim_controller.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/davetcoleman/moveit_sim_controller-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/moveit_sim_controller.git
+      version: kinetic-devel
+    status: maintained
   moveit_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_sim_controller` to `0.1.0-0`:
- upstream repository: https://github.com/davetcoleman/moveit_sim_controller.git
- release repository: https://github.com/davetcoleman/moveit_sim_controller-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## moveit_sim_controller

```
* Add C++11 support
* Fixed occational Nan
* Minor formatting
* added roslint and roslint changes
* Contributors: Dave Coleman
```
