### PR TITLE
ihmc_ros_core: 0.8.0-5 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3955,7 +3955,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ihmcrobotics/ihmc_ros_core-release.git
-      version: 0.8.0-4
+      version: 0.8.0-5
     source:
       type: git
       url: https://github.com/ihmcrobotics/ihmc_ros_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ihmc_ros_core` to `0.8.0-5`:
- upstream repository: https://github.com/ihmcrobotics/ihmc_ros_core.git
- release repository: https://github.com/ihmcrobotics/ihmc_ros_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.8.0-4`
