### PR TITLE
jsk_apc: 2.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4562,7 +4562,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_apc-release.git
-      version: 1.5.1-0
+      version: 2.0.0-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_apc` to `2.0.0-0`:
- upstream repository: https://github.com/start-jsk/jsk_apc.git
- release repository: https://github.com/tork-a/jsk_apc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.5.1-0`
## jsk_2015_05_baxter_apc

```
* Add arm2str as util and use it
* Adjust kiva pod pose to base
* Contributors: Kentaro Wada
```
## jsk_2016_01_baxter_apc

```
* fix error Unknown limb is passed: :arms
* format to pass test work_order_server
* rqt_select_target use service to update work_order
* rosparam pass work_order bin_contents from json
* use class and rospy.timer for work_order_server
* rename work_order.py -> work_order_server.py
* rename node: work_order -> strategic_work_order
* Merge pull request #1895 <https://github.com/start-jsk/jsk_apc/issues/1895> from knorth55/param-contents
  use param to pass bin contents and tote contents
* Merge pull request #1896 <https://github.com/start-jsk/jsk_apc/issues/1896> from start-jsk/fit-apply-context-to-label-probability
  Fit to apply_context_to_label_proba which is merged to jsk_perception
* Add yes_no_button for user input
* Launch rviz for user input in main.launch
* use rosparam to pass bin_contents
* change set_tote_contents_param to json_to_rosparam
* Use yes_no_button panel in rviz for user input
* Slower fold-pose-back initialization for apc task
* Add method to set object segmentation candidates to ri
* Fit to apply_context_to_label_proba which is merged to jsk_perception
* add json utils in util.l
* fix apc2016 simulation for baxter_simulator v1.2
* use arm2str in baxter-interface
* use object_segmentation_3d launch for stow task
* update tote pose
* Set initial target bin to check sanity
* Add checking sanity script for setup_for_pick.launch
* Add rviz config for pick demo
* Remove no need nodes from main.launch
* Use new 3D object segmentaion pipeline with euslisp controller
* Introduce new 3D object segmentation pipeline
  As proposed in https://github.com/start-jsk/jsk_apc/issues/1865
* Support non-list arg for ros::set-dynparam
* Add arm2str as util and use it
* Skip verification because of its unreliability
* Calibrate extrinsic parameters of astra cameras
* add astra intrinsic calibration file
* Add args to astra_hand.launch
* Add calibboard stickers
* Calibrate right hand mounted camera depth
  Also this updates the rvizconfig
  Conflicts:
  jsk_2016_01_baxter_apc/launch/include/astra_hand.launch
* add calib-pressure option in main program
* Use nodes to test arm-to-bin motion instead of rosbag
* Publish bin bounding boxes in baxter.launch
  This is useful because we can use baxter-interface.l without main.launch or main_stow.lauch.
* CMakeLists.txt: need to set current directory to ROS_PACKAGE_PATH
* Merge pull request #1871 <https://github.com/start-jsk/jsk_apc/issues/1871> from knorth55/test-stow-work-order
  add stow_work_order test
* add stow_work_order test
* add stow_work_order option not to output json
* add ik test in tote for stow task
* Adjust right gripper firmware to gripper-v4
* minor fix for real robot
* use protected/private for variable
* add minjerk class
* include pub/sub within c++ object
* use Object Oriented callback style
* Adjust astra hand
* Adjust calib pressure threshold again
* minjerk and continuous feedback
* depth register works with explicit arg
* Contributors: Kei Okada, Kentaro Wada, Shingo Kitagawa, Yusuke Niitani, pazeshun
```
## jsk_apc
- No changes
## jsk_apc2015_common
- No changes
## jsk_apc2016_common

```
* rqt_select_target use service to update work_order
* reinforce rqt_select_target to show target image
* add rqt_select_target GUI
* rosparam pass work_order bin_contents from json
* Add json for picking demonstration
* Introduce new 3D object segmentation pipeline
  As proposed in https://github.com/start-jsk/jsk_apc/issues/1865
* Add mode to display json with --display
* add publish bin bbox test
* Contributors: Kentaro Wada, Shingo Kitagawa
```
