### PR TITLE
Add fcl support for fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1490,6 +1490,7 @@ libexpat1-dev:
 libfcl-dev:
   arch: [fcl]
   debian: [libfcl-0.5-dev]
+  fedora: [fcl-devel]
   ubuntu: [libfcl-0.5-dev]
 libfftw3:
   arch: [fftw]


### PR DESCRIPTION
fcl is now included in the fedora repositories; added a fedora key to libfcl-dev
https://bugzilla.redhat.com/show_bug.cgi?id=1103555

The fedora fcl packages won't be in the stable repositories for about a week, but I wanted to get the PR created so it doesn't fall off the radar.  You can watch the above bug for status, and I'll comment once I submit them to stable.

This should solve https://github.com/ros-gbp/fcl-release/issues/1
