### PR TITLE
python.yaml: Add python-github-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -781,6 +781,13 @@ python-gi:
   debian: [python-gi]
   fedora: [pygobject3]
   ubuntu: [python-gi]
+python-github-pip:
+  osx:
+    pip:
+      packages: [PyGithub]
+  ubuntu:
+    pip:
+      packages: [PyGithub]
 python-googleapi:
   debian: [python-googleapi]
   fedora: [google-api-python-client]


### PR DESCRIPTION
The installation command is `pip install PyGithub` but for importing,
it is `import github`
