### PR TITLE
jsk_common: 2.1.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1619,6 +1619,28 @@ repositories:
       url: https://github.com/ros-drivers/joystick_drivers.git
       version: indigo-devel
     status: maintained
+  jsk_common:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common.git
+      version: master
+    release:
+      packages:
+      - dynamic_tf_publisher
+      - image_view2
+      - jsk_common
+      - jsk_data
+      - jsk_network_tools
+      - jsk_tilt_laser
+      - jsk_tools
+      - jsk_topic_tools
+      - multi_map_server
+      - virtual_force_publisher
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/jsk_common-release.git
+      version: 2.1.2-1
+    status: developed
   jsk_common_msgs:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.1.2-1`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## dynamic_tf_publisher
- No changes
## image_view2
- No changes
## jsk_common
- No changes
## jsk_data

```
* src/jsk_data/download_data.py : create path direcotory before download data and return if permission denied, catch resourceNotFound
* Contributors: Kei Okada
```
## jsk_network_tools
- No changes
## jsk_tilt_laser
- No changes
## jsk_tools
- No changes
## jsk_topic_tools
- No changes
## multi_map_server
- No changes
## virtual_force_publisher
- No changes
