### PR TITLE
grid_map: 1.4.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1370,6 +1370,8 @@ repositories:
       url: https://github.com/ethz-asl/grid_map-release.git
       version: 1.4.1-0
     source:
+      test_commits: true
+      test_pull_requests: true
       type: git
       url: https://github.com/ethz-asl/grid_map.git
       version: master

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1370,7 +1370,6 @@ repositories:
       url: https://github.com/ethz-asl/grid_map-release.git
       version: 1.4.1-0
     source:
-      test_commits: true
       test_pull_requests: true
       type: git
       url: https://github.com/ethz-asl/grid_map.git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1361,13 +1361,14 @@ repositories:
       - grid_map_filters
       - grid_map_loader
       - grid_map_msgs
+      - grid_map_pcl
       - grid_map_ros
       - grid_map_rviz_plugin
       - grid_map_visualization
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ethz-asl/grid_map-release.git
-      version: 1.4.0-0
+      version: 1.4.1-0
     source:
       type: git
       url: https://github.com/ethz-asl/grid_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `1.4.1-0`:
- upstream repository: https://github.com/ethz-asl/grid_map.git
- release repository: https://github.com/ethz-asl/grid_map-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.4.0-0`
## grid_map

```
* Added new grid_map_pcl package.
* Contributors: Peter Fankhauser, Dominic Jud
```
## grid_map_core

```
* Improved line iterator with start and end positions.
* Added method to retrieve submap size for iterators.
* Improved transformation of images to color grid map layers.
* Fixing issues with order of include with Eigen (#67 <https://github.com/ethz-asl/grid_map/issues/67>).
* Contributors: Peter Fankhauser, Dominic Jud
```
## grid_map_cv

```
* Improved transformation of images to color grid map layers.
* Contributors: Peter Fankhauser
```
## grid_map_demos
- No changes
## grid_map_filters
- No changes
## grid_map_loader
- No changes
## grid_map_msgs
- No changes
## grid_map_pcl

```
* Added new grid_map_pcl package to convert from PCL mesh to grid map.
* Contributors: Dominic Jud
```
## grid_map_ros

```
* Improved transformation of images to color grid map layers.
* Contributors: Peter Fankhauser
```
## grid_map_rviz_plugin

```
* Added functionality to display color from grid map layer.
* Added better handling of basic layers in Grid Map RViz plugin.
* Added functionality to invert rainbow colors in RViz plugin.
* Contributors: Philipp Kruesi, Péter Fankhauser
```
## grid_map_visualization
- No changes
