### PR TITLE
mapviz: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5622,7 +5622,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `0.0.7-0`:
- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.0.6-0`
## mapviz

```
* Add a GUI for controlling the Image Transport (#432 <https://github.com/swri-robotics/mapviz/issues/432>)
  This will add a sub-menu under the "View" menu that will:
  - List all available image transports
  - Indicate which one is currently the default
  - Allow the user to choose which one will be used for new ImageTransport subscriptions
  - Save and restore this setting to Mapviz's config file
  - Cause any image plugins using the default transport to resubscribe
  In addition, the image plugin now has a menu that can be used to change the
  transport for that specific plugin so that it is different from the default.
  Fixes #430 <https://github.com/swri-robotics/mapviz/issues/430>
* Fix icon colors for point drawing plugins (#433 <https://github.com/swri-robotics/mapviz/issues/433>)
  This was probably broken back when all of these were refactored to have a
  single base class.  It looks like the member variable that holds the color
  used to draw the icon was never actually being updated.
  Fixes #426 <https://github.com/swri-robotics/mapviz/issues/426>
* Contributors: P. J. Reed
```
## mapviz_plugins

```
* General code cleanup of mapviz_plugins
  This doesn't change any functionality; it's just cleaning up code.  Notably, this will:
  - Fix all warnings (notably lots of ones about type casting)
  - Move all .ui files to their own directory
  - Remove unused variables
  - Remove commented-out code
  - Make spacing and indentation consistent
  - Make brace style consistent
* Add a GUI for controlling the Image Transport (#432 <https://github.com/swri-robotics/mapviz/issues/432>)
  This will add a sub-menu under the "View" menu that will:
  - List all available image transports
  - Indicate which one is currently the default
  - Allow the user to choose which one will be used for new ImageTransport subscriptions
  - Save and restore this setting to Mapviz's config file
  - Cause any image plugins using the default transport to resubscribe
  In addition, the image plugin now has a menu that can be used to change the
  transport for that specific plugin so that it is different from the default.
  Fixes #430 <https://github.com/swri-robotics/mapviz/issues/430>
* Fix icon colors for point drawing plugins (#433 <https://github.com/swri-robotics/mapviz/issues/433>)
  This was probably broken back when all of these were refactored to have a
  single base class.  It looks like the member variable that holds the color
  used to draw the icon was never actually being updated.
  Fixes #426 <https://github.com/swri-robotics/mapviz/issues/426>
* Add option to not scale arrows with zoom level
  This adds a checkbox to all of the plugins that can draw a series of
  coordinates as arrows; i. e., the GPS, NavSatFix, Odometry, and TF Frame
  plugins.  This checkbox will control whether the arrows are drawn at a fixed
  size regardless of zoom level or whether they are scaled with the zoom level.
  Resolves #414 <https://github.com/swri-robotics/mapviz/issues/414>
* Contributors: P. J. Reed
```
## multires_image
- No changes
## tile_map

```
* Rewrite tile_map loading to be more reliable
  This changes how the tile_map plugin handles making network requires for tiles.
  It will now:
  - Use thread conditions to prompt loading rather than spinning
  - Prioritize loading tiles in the visible area
  - Retry a failed network request up to 5 times
  - Not discard tile requests if there are more than 100 in the queue
  This changes should significantly reduce (if not completely eliminate) the
  number of tiles that fail to load and hopefully make tiles within the visible
  area appear faster when there are many in the queue.
  Fixes #342 <https://github.com/swri-robotics/mapviz/issues/342> and #421 <https://github.com/swri-robotics/mapviz/issues/421>.
* Use Saucy-compatible YAML API for Indigo
  Fixes #420 <https://github.com/swri-robotics/mapviz/issues/420>
* Contributors: P. J. Reed
```
