### PR TITLE
marti_messages: 0.0.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2441,7 +2441,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_messages-release.git
-      version: 0.0.4-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `0.0.6-0`:
- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.0.4-0`
## marti_can_msgs
- No changes
## marti_common_msgs

```
* Add StringArrayStamped message.
* Contributors: Marc Alban
```
## marti_nav_msgs
- No changes
## marti_perception_msgs
- No changes
## marti_sensor_msgs
- No changes
## marti_visualization_msgs
- No changes
