### PR TITLE
marti_common: 0.1.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2419,7 +2419,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.1.6-0`:
- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.1.5-0`
## marti_data_structures
- No changes
## swri_console_util
- No changes
## swri_geometry_util

```
* Add cubic spline interface for tf::Vector3 type.
* Contributors: Marc Alban
```
## swri_image_util
- No changes
## swri_math_util
- No changes
## swri_nodelet

```
* Add missing dependencies to swri_console
* Add C++ and CMake macros for wrapper nodes
  Defines a C++ macro to replace the normal nodelet export wrapper that
  also creates a factory function returning a pointer to that nodelet.
  Defines a CMake macro
  swri_nodelet_add_node(NODELET_NODENAME NODELET_NAMESPACE NODELET_CLASS)
  that automatically generates the c++ code for a node wrapper with node
  name NODELET_NODENAME that wraps the nodelet and makes a CMake target
  to build the node.
* Add tests for swri_nodelet with manager and standalone
* Contributors: Ed Venator, Edward Venator
```
## swri_opencv_util
- No changes
## swri_prefix_tools
- No changes
## swri_roscpp

```
* Add swri_roscpp functions for reading float values.
  These add support for reading float values directly instead of
  doubles.
* Contributors: Elliot Johnson
```
## swri_route_util

```
* Change the order of include dirs
  "${catkin_INCLUDE_DIRS}" needs to be listed after "include", otherwise gcc may
  try to compile this component's cpp files using headers from a system-installed
  version of swri_route_util.
* Add support for stop point metadata.
* Add sru::projectOntoRouteWindow
  This is a utility function to project a point onto a window of the
  route.
* Fix projectOntoRoute for points past the end of the route.
  This fixes projectOntoRoute to return a normalized route coordinate
  when the point is past the end of the route.
* Fix distance bug affecting projectOntoRoute.
  This commit fixes a major bug in nearestDistanceToLineSegment that was
  affecting projectOntoRoute.  A mis-named variable v_len was actually
  the square of v_len and caused the reported distance along the route
  segment to be the square of the desired answer.  This commit takes the
  appropriate square root and changes the variable name to avoid
  confusion in the future.
* Add error message for non-unique route point IDs.
  This commit adds an error check when a sru::Route rebuilds it's point
  index.  If the point IDs are not unique, the route will output an
  error message that should make tracking down problems easier.  This
  check is extremely lightweight and should not have a performance
  impact.
* Contributors: Elliot Johnson, P. J. Reed
```
## swri_serial_util
- No changes
## swri_string_util
- No changes
## swri_system_util
- No changes
## swri_transform_util

```
* Improve georeferencing warnings.
* Contributors: Marc Alban
```
## swri_yaml_util
- No changes
