### PR TITLE
marti_common: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2133,7 +2133,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 0.2.0-1
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.2.1-0`:
- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.2.0-1`
## marti_data_structures
- No changes
## swri_console_util
- No changes
## swri_geometry_util
- No changes
## swri_image_util
- No changes
## swri_math_util
- No changes
## swri_nodelet

```
* Add C++ and CMake macros for wrapper nodes
  Defines a C++ macro to replace the normal nodelet export wrapper that
  also creates a factory function returning a pointer to that nodelet.
  Defines a CMake macro
  swri_nodelet_add_node(NODELET_NODENAME NODELET_NAMESPACE NODELET_CLASS)
  that automatically generates the c++ code for a node wrapper with node
  name NODELET_NODENAME that wraps the nodelet and makes a CMake target
  to build the node.
* Add tests for swri_nodelet with manager and standalone
* Contributors: Ed Venator, Edward Venator
```
## swri_opencv_util
- No changes
## swri_prefix_tools
- No changes
## swri_roscpp
- No changes
## swri_route_util

```
* Changing the order of include dirs
  "${catkin_INCLUDE_DIRS}" needs to be listed after "include", otherwise gcc may
  try to compile this component's cpp files using headers from a system-installed
  version of swri_route_util.
* Contributors: P. J. Reed
```
## swri_serial_util
- No changes
## swri_string_util
- No changes
## swri_system_util
- No changes
## swri_transform_util

```
* Improve georeferencing warnings.
* Contributors: Marc Alban
```
## swri_yaml_util
- No changes
