### PR TITLE
swri_console: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4984,6 +4984,21 @@ repositories:
       url: https://github.com/RobotnikAutomation/summit_xl_sim.git
       version: kinetic-devel
     status: maintained
+  swri_console:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/swri_console-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: master
+    status: developed
   teb_local_planner:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `0.2.0-0`:
- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/swri-robotics-gbp/swri_console-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## swri_console

```
* Port to Qt5 #16 <https://github.com/swri-robotics/swri_console/issues/16>
* Contributors: Edward Venator, P. J. Reed
```
