### PR TITLE
cob_simulation: 0.6.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1617,7 +1617,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_simulation-release.git
-      version: 0.6.6-0
+      version: 0.6.7-0
     source:
       type: git
       url: https://github.com/ipa320/cob_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.6.7-0`:
- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.6.6-0`
## cob_bringup_sim

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* make roslaunch a denend (was only exec_depend)
* Contributors: Florian Weisshardt
```
## cob_gazebo
- No changes
## cob_gazebo_objects
- No changes
## cob_gazebo_worlds
- No changes
## cob_simulation
- No changes
