### PR TITLE
cob_extern: 0.6.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1445,7 +1445,6 @@ repositories:
     release:
       packages:
       - cob_extern
-      - libconcorde_tsp_solver
       - libdlib
       - libntcan
       - libopengm
@@ -1454,7 +1453,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_extern-release.git
-      version: 0.6.7-0
+      version: 0.6.9-0
     source:
       type: git
       url: https://github.com/ipa320/cob_extern.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_extern` to `0.6.9-0`:
- upstream repository: https://github.com/ipa320/cob_extern.git
- release repository: https://github.com/ipa320/cob_extern-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.6.7-0`
## cob_extern
- No changes
## libdlib
- No changes
## libntcan
- No changes
## libopengm
- No changes
## libpcan
- No changes
## libphidgets
- No changes
