### PR TITLE
Add utopic key for libjsoncpp

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1873,6 +1873,7 @@ libjsoncpp:
     precise: [libjsoncpp0]
     saucy: [libjsoncpp0]
     trusty: [libjsoncpp0]
+    utopic: [libjsoncpp0]
     vivid: [libjsoncpp0]
     wily: [libjsoncpp0v5]
     xenial: [libjsoncpp1]


### PR DESCRIPTION
This is needed to release https://github.com/swri-robotics/mapviz on utopic.  See https://github.com/swri-robotics/mapviz/issues/440 .
