### PR TITLE
phoxi_camera: 1.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8062,7 +8062,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/photoneo/phoxi_camera-release.git
-      version: 1.1.3-0
+      version: 1.1.4-0
     status: developed
   pi_tracker:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `phoxi_camera` to `1.1.4-0`:
- upstream repository: https://github.com/photoneo/phoxi_camera.git
- release repository: https://github.com/photoneo/phoxi_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.1.3-0`
## phoxi_camera

```
* Update README.md
* Merge remote-tracking branch 'origin/master'
* add launch file
* Update README.md
* fix
* fix cmake_minimum_version
  fix package.xml
* Update README.md
* Update README.md
* Update README.md
* disable opencv, add pcl to package.xml
* fix bug
* Merge remote-tracking branch 'origin/master'
* fix normal_map
* change pointcloud values from mm to meters
* Update README.md
  add Generate package to README
* Contributors: Matej Sladek, jzizka
```
