### PR TITLE
bond_core: 1.7.18-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -314,7 +314,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/bond_core-release.git
-      version: 1.7.17-0
+      version: 1.7.18-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.7.18-0`:
- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.7.17-0`
## bond
- No changes
## bond_core
- No changes
## bondcpp

```
* fix -isystem /usr/include build breakage in gcc6
* Contributors: Mikael Arguedas
```
## bondpy
- No changes
## smclib
- No changes
