### PR TITLE
actionlib: 1.11.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -36,7 +36,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.11.6-0
+      version: 1.11.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.11.7-0`:
- upstream repository: https://github.com/ros/actionlib.git
- release repository: https://github.com/ros-gbp/actionlib-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.11.6-0`
## actionlib

```
* Merge pull request #57 <https://github.com/ros/actionlib/issues/57> from stonier/patch-1
  Remove misleading error log
* Remove misleading error log
  This was introduced in https://github.com/ros/actionlib/pull/43.
  It is not actually correct - you can feasibly get feedback here before a new goal is confirmed. See send_goal()....
```

  def send_goal(self, goal, done_cb=None, active_cb=None, feedback_cb=None):
  # destroys the old goal handle
  self.stop_tracking_goal()
  ...
  self.gh = self.action_client.send_goal(goal, self._handle_transition, self._handle_feedback)

```
  and of course it will take more time on top of this for the server to actually process the incoming goal and confirm it. Meantime, it may have sent us feedback messages.
* Improved the const-correctness of some actionlib classes. (#50 <https://github.com/ros/actionlib/issues/50>)
* Issue #51 <https://github.com/ros/actionlib/issues/51>: Remove annoying debug messages that make useless to enable debug on Python nodes, as they overwhelm less spamming messages (#54 <https://github.com/ros/actionlib/issues/54>)
* reduce change of unncessary exception on shutdown bu checking directly in before publishing for a shutdown (#53 <https://github.com/ros/actionlib/issues/53>)
* Contributors: Blake Anderson, Daniel Stonier, Jorge Santos Simón, Mikael Arguedas, uliklank
```
