### PR TITLE
pyros_test: 0.0.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4147,7 +4147,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/pyros-test-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/asmodehn/pyros-test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_test` to `0.0.5-0`:
- upstream repository: https://github.com/asmodehn/pyros-test.git
- release repository: https://github.com/asmodehn/pyros-test-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.0.4-0`
## pyros_test

```
* now using params within nodes exposing a service.
  added gitignore.
* adding message type definition for pyros to use optional ros fields.
* installing build-essential in container seems needed by catkin.
* lowering std_msgs requirements. attempt to fix travis issues.
* fixing travis_checks
* now testing with docker. added kinetic.
* Contributors: alexv
```
