### PR TITLE
nodelet_core: 1.9.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7041,7 +7041,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.9.5-0
+      version: 1.9.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.7-0`:
- upstream repository: git://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.9.5-0`
## nodelet

```
* Use rospkg instead of roslib in declared_nodelets
  Close https://github.com/ros/nodelet_core/issues/48
* Contributors: Kentaro Wada
```
## nodelet_core
- No changes
## nodelet_topic_tools
- No changes
