### PR TITLE
Adding viodom to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13832,6 +13832,11 @@ repositories:
       url: https://github.com/team-vigir/vigir_step_control.git
       version: master
     status: maintained
+  viodom:
+    doc:
+      type: git
+      url: https://github.com/fjperezgrau/viodom.git
+      version: master
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
I'd like viodom to be indexed and documented on ros-org.
