### PR TITLE
cv_camera: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -590,6 +590,21 @@ repositories:
       url: https://github.com/AutonomyLab/create_autonomy.git
       version: indigo-devel
     status: developed
+  cv_camera:
+    doc:
+      type: git
+      url: https://github.com/OTL/cv_camera.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/OTL/cv_camera-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/OTL/cv_camera.git
+      version: master
+    status: developed
   demo_pioneer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cv_camera` to `0.1.0-0`:
- upstream repository: https://github.com/OTL/cv_camera
- release repository: https://github.com/OTL/cv_camera-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
## cv_camera

```
* Fix opencv2 to libopencv-dev
* Contributors: Takashi Ogura
```
