### PR TITLE
rqt_ez_publisher: 0.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4548,6 +4548,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_common_plugins.git
       version: master
     status: maintained
+  rqt_ez_publisher:
+    doc:
+      type: git
+      url: https://github.com/OTL/rqt_ez_publisher.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/OTL/rqt_ez_publisher-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/OTL/rqt_ez_publisher.git
+      version: kinetic-devel
+    status: developed
   rqt_multiplot_plugin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_ez_publisher` to `0.4.0-0`:
- upstream repository: https://github.com/OTL/rqt_ez_publisher.git
- release repository: https://github.com/OTL/rqt_ez_publisher-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
## rqt_ez_publisher

```
* Update config dialog for Qt5
* Migrate to Qt5
* Merge pull request #23 <https://github.com/OTL/rqt_ez_publisher/issues/23> from felixduvallet/travis_fix
  Fix travis script
* Fix python import path by sourcing devel/setup.bash.
* Contributors: Felix Duvallet, Takashi Ogura
```
