### PR TITLE
catch_ros: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -399,6 +399,21 @@ repositories:
       url: https://github.com/davetcoleman/cartesian_msgs.git
       version: jade-devel
     status: maintained
+  catch_ros:
+    doc:
+      type: git
+      url: https://github.com/AIS-Bonn/catch_ros.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/AIS-Bonn/catch_ros-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/AIS-Bonn/catch_ros.git
+      version: kinetic-devel
+    status: developed
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catch_ros` to `0.1.0-0`:
- upstream repository: https://github.com/AIS-Bonn/catch_ros
- release repository: https://github.com/AIS-Bonn/catch_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## catch_ros

```
* initial proper release
* Contributors: Max Schwarz
```
