### PR TITLE
catch_ros: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -408,7 +408,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/AIS-Bonn/catch_ros-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/AIS-Bonn/catch_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catch_ros` to `0.1.1-0`:
- upstream repository: https://github.com/AIS-Bonn/catch_ros
- release repository: https://github.com/AIS-Bonn/catch_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.0-0`
## catch_ros

```
* actually install header files
* Contributors: Max Schwarz
```
