### PR TITLE
pointcloud_to_laserscan: 1.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3397,6 +3397,21 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: indigo-devel
     status: maintained
+  pointcloud_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/pointcloud_to_laserscan.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/pointcloud_to_laserscan-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/pointcloud_to_laserscan.git
+      version: indigo-devel
+    status: maintained
   pointgrey_camera_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointcloud_to_laserscan` to `1.3.0-1`:
- upstream repository: https://github.com/ros-perception/pointcloud_to_laserscan.git
- release repository: https://github.com/ros-gbp/pointcloud_to_laserscan-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
## pointcloud_to_laserscan

```
* Fix pointcloud to laserscan transform tolerance issues
* Move pointcloud_to_laserscan to new repository
* Contributors: Paul Bovbel
```
