### PR TITLE
ros_comm: 1.12.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4130,7 +4130,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.12.5-0
+      version: 1.12.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.12.6-0`:
- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.12.5-0`
## message_filters

```
* use boost::bind to bind the callback function (#906 <https://github.com/ros/ros_comm/pull/906>)
```
## ros_comm
- No changes
## rosbag

```
* fix BagMigrationException in migrate_raw (#917 <https://github.com/ros/ros_comm/issues/917>)
```
## rosbag_storage
- No changes
## rosconsole

```
* add missing walltime to roscpp logging (#879 <https://github.com/ros/ros_comm/pull/879>)
* fix building on GCC-6 (#911 <https://github.com/ros/ros_comm/pull/911>)
```
## roscpp
- No changes
## rosgraph

```
* change rospy default rosconsole format for consistency with roscpp (#879 <https://github.com/ros/ros_comm/pull/879>)
* increase request_queue_size for xmlrpc server (#849 <https://github.com/ros/ros_comm/issues/849>)
```
## roslaunch

```
* add USE_TEST_DEPENDENCIES option to roslaunch_add_file_check() (#910 <https://github.com/ros/ros_comm/pull/910>)
```
## roslz4
- No changes
## rosmaster
- No changes
## rosmsg
- No changes
## rosnode
- No changes
## rosout
- No changes
## rosparam
- No changes
## rospy

```
* improve reconnection logic on timeout and other common errors (#851 <https://github.com/ros/ros_comm/pull/851>)
* remove duplicated function (#783 <https://github.com/ros/ros_comm/pull/783>)
```
## rosservice
- No changes
## rostest
- No changes
## rostopic

```
* fix typo of arg for _str_plot function (#915 <https://github.com/ros/ros_comm/issues/915>)
```
## roswtf
- No changes
## topic_tools
- No changes
## xmlrpcpp
- No changes
