### PR TITLE
vrpn_client_ros: 0.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6602,7 +6602,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/clearpath-gbp/vrpn_client_ros-release.git
-      version: 0.0.2-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/vrpn_client_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn_client_ros` to `0.1.0-0`:
- upstream repository: https://github.com/clearpathrobotics/vrpn_client_ros.git
- release repository: https://github.com/clearpath-gbp/vrpn_client_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.2-0`
## vrpn_client_ros

```
* Add separate publishers for each sensor id
* Add Possibility to Append Sensor Id to TF Client Frame
* Update 'supported devices' link in README
* Contributors: Karljohan Lundin Palmerius, Paul Bovbel
```
