### PR TITLE
vrpn_client_ros: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5871,6 +5871,21 @@ repositories:
       url: https://github.com/vrpn/vrpn.git
       version: master
     status: maintained
+  vrpn_client_ros:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/vrpn_client_ros.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/vrpn_client_ros-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/vrpn_client_ros.git
+      version: indigo-devel
+    status: maintained
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn_client_ros` to `0.1.0-0`:
- upstream repository: https://github.com/clearpathrobotics/vrpn_client_ros.git
- release repository: https://github.com/clearpath-gbp/vrpn_client_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
## vrpn_client_ros

```
* Add separate publishers for each sensor id
* Add Possibility to Append Sensor Id to TF Client Frame
* Update 'supported devices' link in README
* Contributors: Karljohan Lundin Palmerius, Paul Bovbel
```
