### PR TITLE
zbar_ros: 0.0.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6075,6 +6075,21 @@ repositories:
       url: https://github.com/yujinrobot/yujin_ocs.git
       version: kinetic
     status: developed
+  zbar_ros:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/zbar_ros.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/zbar_ros-release.git
+      version: 0.0.5-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/zbar_ros.git
+      version: hydro-devel
+    status: maintained
   zeroconf_avahi_suite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `zbar_ros` to `0.0.5-0`:
- upstream repository: https://github.com/clearpathrobotics/zbar_ros.git
- release repository: https://github.com/clearpath-gbp/zbar_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
## zbar_ros

```
* Fix nodelets.xml installation
* Only create timer if throttling enabled
* Contributors: Paul Bovbel
```
