### PR TITLE
zbar_ros: 0.0.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6733,5 +6733,20 @@ repositories:
       type: git
       url: https://github.com/youbot/youbot_driver.git
       version: hydro-devel
+  zbar_ros:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/zbar_ros.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/clearpath-gbp/zbar_ros-release.git
+      version: 0.0.5-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/zbar_ros.git
+      version: hydro-devel
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `zbar_ros` to `0.0.5-0`:
- upstream repository: https://github.com/clearpathrobotics/zbar_ros.git
- release repository: https://github.com/clearpath-gbp/zbar_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
## zbar_ros

```
* Fix nodelets.xml installation
* Only create timer if throttling enabled
* Contributors: Paul Bovbel
```
