### PR TITLE
frontier_exploration: 0.3.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1062,6 +1062,21 @@ repositories:
       url: https://github.com/freefloating-gazebo/freefloating_gazebo.git
       version: jade-devel
     status: maintained
+  frontier_exploration:
+    doc:
+      type: git
+      url: https://github.com/paulbovbel/frontier_exploration.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/paulbovbel/frontier_exploration-release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/paulbovbel/frontier_exploration.git
+      version: indigo-devel
+    status: maintained
   fzi_icl_can:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `frontier_exploration` to `0.3.1-0`:
- upstream repository: https://github.com/paulbovbel/frontier_exploration.git
- release repository: https://github.com/paulbovbel/frontier_exploration-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
## frontier_exploration

```
* Update to BSD license
* Update LICENSE
* [Travis config] Use Ubuntu 14.04 and test ROS I+
* fixed wrong order of footprint coordinates (was hourglass shape)
* Contributors: Achim Krauch, Isaac I.Y. Saito, Paul Bovbel
```
