### PR TITLE
frontier_exploration: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1028,6 +1028,21 @@ repositories:
       url: https://github.com/ros-drivers/freenect_stack.git
       version: master
     status: maintained
+  frontier_exploration:
+    doc:
+      type: git
+      url: https://github.com/paulbovbel/frontier_exploration.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/paulbovbel/frontier_exploration-release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/paulbovbel/frontier_exploration.git
+      version: indigo-devel
+    status: maintained
   fzi_icl_can:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `frontier_exploration` to `0.3.1-0`:
- upstream repository: https://github.com/paulbovbel/frontier_exploration.git
- release repository: https://github.com/paulbovbel/frontier_exploration-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
## frontier_exploration

```
* Update to BSD license
* Update LICENSE
* [Travis config] Use Ubuntu 14.04 and test ROS I+
* fixed wrong order of footprint coordinates (was hourglass shape)
* Contributors: Achim Krauch, Isaac I.Y. Saito, Paul Bovbel
```
