### PR TITLE
costmap_prohibition_layer: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -580,6 +580,21 @@ repositories:
       url: https://github.com/rst-tu-dortmund/costmap_converter.git
       version: master
     status: developed
+  costmap_prohibition_layer:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/costmap_prohibition_layer.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/rst-tu-dortmund/costmap_prohibition_layer-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/rst-tu-dortmund/costmap_prohibition_layer.git
+      version: kinetic-devel
+    status: developed
   cpf_segmentation_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `costmap_prohibition_layer` to `0.0.2-0`:
- upstream repository: https://github.com/rst-tu-dortmund/costmap_prohibition_layer.git
- release repository: https://github.com/rst-tu-dortmund/costmap_prohibition_layer-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
## costmap_prohibition_layer

```
* Initial package version
```
