### PR TITLE
jsk_common_msgs: 4.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1964,7 +1964,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_common_msgs-release.git
-      version: 4.0.0-0
+      version: 4.1.0-0
     status: developed
   jsk_model_tools:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common_msgs` to `4.1.0-0`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_common_msgs
- release repository: https://github.com/tork-a/jsk_common_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `4.0.0-0`
## jsk_common_msgs
- No changes
## jsk_footstep_msgs
- No changes
## jsk_gui_msgs

```
* [jsk_gui_msgs/msg/SlackMessage.msg] Add msg for posting to slack (#13 <https://github.com/jsk-ros-pkg/jsk_common_msgs/issues/13> )
* Contributors: Kentaro Wada
```
## jsk_hark_msgs
- No changes
## posedetection_msgs
- No changes
## speech_recognition_msgs
- No changes
