### PR TITLE
fetch_ros: 0.7.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1011,6 +1011,27 @@ repositories:
       url: https://github.com/ros-gbp/fcl-release.git
       version: 0.3.3-0
     status: maintained
+  fetch_ros:
+    doc:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_ros.git
+      version: indigo-devel
+    release:
+      packages:
+      - fetch_calibration
+      - fetch_depth_layer
+      - fetch_description
+      - fetch_ikfast_plugin
+      - fetch_maps
+      - fetch_moveit_config
+      - fetch_navigation
+      - fetch_teleop
+      - freight_calibration
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
+      version: 0.7.10-0
+    status: maintained
   filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.7.10-0`:
- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## fetch_calibration
- No changes
## fetch_depth_layer

```
* updates to handle OpenCV3 changes
* Contributors: Michael Ferguson
```
## fetch_description
- No changes
## fetch_ikfast_plugin

```
* fix build with urdf on kinetic
* update package.xmls, add depend on fetch_ikfast_plugin
* get a version of ikfast plugin working on fetch
* Contributors: Di Sun, Michael Ferguson
```
## fetch_maps
- No changes
## fetch_moveit_config

```
* update package.xmls, add depend on fetch_ikfast_plugin
* load the ikfast kinematics plugin
* Contributors: Di Sun, Michael Ferguson
```
## fetch_navigation
- No changes
## fetch_teleop
- No changes
## freight_calibration
- No changes
