### PR TITLE
robot_model: 1.12.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3825,7 +3825,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.12.4-0
+      version: 1.12.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.12.5-0`:
- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.12.4-0`
## collada_parser
- No changes
## collada_urdf
- No changes
## joint_state_publisher

```
* Fix initial position of sliders in joint_state_publisher GUI (#148 <https://github.com/ros/robot_model/issues/148>)
  Caused by a regression in 8c6cf9841cb, the slider positions are not initialized correctly
  from the provided zero positions at startup.
  This commit fixes the issue, by adding the call to center() again that got lost.
* Contributors: Timm Linder
```
## kdl_parser

```
* fix segfault: safely handle empty robot model (#154 <https://github.com/ros/robot_model/issues/154>)
* Contributors: Robert Haschke
```
## kdl_parser_py
- No changes
## robot_model
- No changes
## urdf

```
* Added urdf_compatibility.h header to define SharedPtr types (#160 <https://github.com/ros/robot_model/issues/160>)
  This provides portability for downstream packages allowing them to use urdfdom 0.3 or 0.4.
* urdf: Explicitly cast shared_ptr to bool in unit test. (#158 <https://github.com/ros/robot_model/issues/158>)
* Add smart ptr typedefs (#153 <https://github.com/ros/robot_model/issues/153>)
* Addressed gcc6 build error in urdf which was related to use of the isystem flag (#157 <https://github.com/ros/robot_model/issues/157>)
* Remove unneeded dependency on libpcrecpp (#155 <https://github.com/ros/robot_model/issues/155>)
* Contributors: Bence Magyar, Jochen Sprickerhof, Lukas Bulwahn, Maarten de Vries, Robert Haschke
```
## urdf_parser_plugin
- No changes
