### PR TITLE
rtmros_hironx: 1.1.18-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11417,7 +11417,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.17-0
+      version: 1.1.18-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.18-0`:
- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.1.17-0`
## hironx_calibration
- No changes
## hironx_moveit_config

```
* [fix][moveit config] Fix Interactive Marker size.
* Contributors: Isaac I.Y. Saito
```
## hironx_ros_bridge

```
* [fix] servoOn error that returns always -1 for robots without Servo Controller RTC for hands. See https://github.com/start-jsk/rtmros_hironx/pull/398#pullrequestreview-5575278
* Contributors: Isaac I.Y. Saito
```
## rtmros_hironx

```
* [fix] servoOn error that returns always -1 for robots without Servo Controller RTC for hands. See https://github.com/start-jsk/rtmros_hironx/pull/398#pullrequestreview-5575278
* [fix][moveit config] Fix Interactive Marker size.
* Contributors: Isaac I.Y. Saito
```
