### PR TITLE
pid: 0.0.19-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3385,7 +3385,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/AndyZelenak/pid-release.git
-      version: 0.0.18-0
+      version: 0.0.19-0
     source:
       type: git
       url: https://bitbucket.org/AndyZe/pid.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pid` to `0.0.19-0`:
- upstream repository: https://bitbucket.org/AndyZe/pid
- release repository: https://github.com/AndyZelenak/pid-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.0.18-0`
