### PR TITLE
fetch_pbd: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2726,7 +2726,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics/fetch_pbd-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_pbd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_pbd` to `0.0.6-0`:
- upstream repository: https://github.com/fetchrobotics/fetch_pbd.git
- release repository: https://github.com/fetchrobotics/fetch_pbd-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.5-0`
## fetch_arm_control
- No changes
## fetch_pbd_interaction

```
* Update install_web_dependencies.sh
* Contributors: Sarah Elliott
```
## fetch_social_gaze
- No changes
