### PR TITLE
jsk_3rdparty: 2.0.18-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1686,6 +1686,36 @@ repositories:
       url: https://github.com/ros-drivers/joystick_drivers.git
       version: indigo-devel
     status: maintained
+  jsk_3rdparty:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
+      version: master
+    release:
+      packages:
+      - assimp_devel
+      - bayesian_belief_networks
+      - downward
+      - ff
+      - ffha
+      - jsk_3rdparty
+      - julius
+      - libcmt
+      - libsiftfast
+      - lpg_planner
+      - mini_maxwell
+      - nlopt
+      - opt_camera
+      - pgm_learner
+      - rospatlite
+      - rosping
+      - slic
+      - voice_text
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/jsk_3rdparty-release.git
+      version: 2.0.18-1
+    status: developed
   jsk_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.0.18-1`:
- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## assimp_devel
- No changes
## bayesian_belief_networks
- No changes
## downward
- No changes
## ff
- No changes
## ffha
- No changes
## jsk_3rdparty
- No changes
## julius
- No changes
## libcmt

```
* add patch to fix opencv3 https://github.com/delmottea/libCMT/pull/18 (#78 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/78>)
* Contributors: Kei Okada
```
## libsiftfast
- No changes
## lpg_planner
- No changes
## mini_maxwell
- No changes
## nlopt
- No changes
## opt_camera

```
* fir for kinetic (#78 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/78>)
  * fix header file for opencv2/3
  * remove driver_base from OptNM33Camera.cfg
* Contributors: Kei Okada
```
## pgm_learner
- No changes
## rospatlite
- No changes
## rosping
- No changes
## slic
- No changes
## voice_text
- No changes
