### PR TITLE
costmap_prohibition_layer: 0.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -589,7 +589,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/costmap_prohibition_layer-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/rst-tu-dortmund/costmap_prohibition_layer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `costmap_prohibition_layer` to `0.0.4-0`:
- upstream repository: https://github.com/rst-tu-dortmund/costmap_prohibition_layer.git
- release repository: https://github.com/rst-tu-dortmund/costmap_prohibition_layer-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.3-0`
## costmap_prohibition_layer

```
* Enable recognizing Integer values in single points
* restored deleted line
```
