### PR TITLE
dynamixel-workbench: 0.1.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -730,7 +730,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
-      version: 0.1.0-0
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel-workbench` to `0.1.2-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
- release repository: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.0-0`

## dynamixel_workbench

```
* add stop sign in velocity controller
* modify beta test feedback
* Contributors: Darby Lim
```

## dynamixel_workbench_controllers

```
* add stop sign in velocity controller
* modify beta test feedback
* Contributors: Darby Lim
```

## dynamixel_workbench_msgs

```
* add comment in msgs file
* modify beta test feedback
* Contributors: Darby Lim
```

## dynamixel_workbench_single_manager

```
* add comment in msgs file
* add stop sign in velocity controller
* modify beta test feedback
* Contributors: Darby Lim
```

## dynamixel_workbench_single_manager_gui

```
* add comment in msgs file
* add stop sign in velocity controller
* modify beta test feedback
* Contributors: Darby Lim
```

## dynamixel_workbench_toolbox

```
* modify beta test feedback
* Contributors: Darby Lim
```

## dynamixel_workbench_tutorials

```
* add stop sign in velocity controller
* modify beta test feedback
* Contributors: Darby Lim
```
