### PR TITLE
gps_umd: 0.1.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1345,6 +1345,25 @@ repositories:
       url: https://github.com/ros-visualization/gl_dependency.git
       version: indigo-devel
     status: maintained
+  gps_umd:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: master
+    release:
+      packages:
+      - gps_common
+      - gps_umd
+      - gpsd_client
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/gps_umd-release.git
+      version: 0.1.8-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: master
+    status: maintained
   graft:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `0.1.8-0`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/swri-robotics-gbp/gps_umd-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## gps_common

```
* Fixing orientation in UTM odometry message
  Before the fix, the orientation in the odometry message was set to x = 1, y = 0, z = 0, w = 0. This corresponds to Euler angles of roll = pi, pitch = 0, yaw = 0. I believe the intent was for the orientation to be the identity, which is x = 0, y = 0, z = 0, w = 1.
* Contributors: Tom Moore
```

## gps_umd

- No changes

## gpsd_client

```
* Use pre-processor defines to handle different libgps API versions
  Fixes #1 <https://github.com/swri-robotics/gps_umd/issues/1>
* Contributors: P. J. Reed
```
