### PR TITLE
turtlebot: 2.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5402,7 +5402,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot-release.git
-      version: 2.3.12-0
+      version: 2.4.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot` to `2.4.0-0`:

- upstream repository: https://github.com/turtlebot/turtlebot.git
- release repository: https://github.com/turtlebot-release/turtlebot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.3.12-0`

## turtlebot

- No changes

## turtlebot_bringup

```
* Add support for Intel R200 camera
  Added necessary launch, urdf, etc. files to
  add support for the R200 camera in Turtlebot.
  Updated r200 URDF to inclue proper mounting.
  Added runtime dependency on realsense_camera package.
* [bringup] remove outdated broken comment
* refactor concert content out of minimal and create separate concert_minimal.launch
  The concert_minimal.launch includes minmal.launch
* propagate netbook battery to other similar launch file
* disable the battery node if TURTLEBOT_BATTERY is set to None
  Fixes #224 <https://github.com/turtlebot/turtlebot/issues/224>
* Contributors: Daniel Stonier, Kevin C. Wells, Tully Foote
```

## turtlebot_capabilities

- No changes

## turtlebot_description

```
* Fix image format on Gazebo using B8G8R8
  Related to https://github.com/ros-simulation/gazebo_ros_pkgs/issues/484
* Add support for Intel R200 camera
  Added necessary launch, urdf, etc. files to
  add support for the R200 camera in Turtlebot.
  Updated r200 URDF to inclue proper mounting.
  Added runtime dependency on realsense_camera package.
* Contributors: Kentaro Wada, Kevin C. Wells
```

## turtlebot_teleop

- No changes
