### PR TITLE
turtlebot: 2.3.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13094,7 +13094,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot-release.git
-      version: 2.3.11-0
+      version: 2.3.13-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot` to `2.3.13-0`:

- upstream repository: https://github.com/turtlebot/turtlebot.git
- release repository: https://github.com/turtlebot-release/turtlebot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.3.11-0`

## turtlebot

- No changes

## turtlebot_bringup

```
* Add support for Intel R200 camera
  Added necessary launch, urdf, etc. files to
  add support for the R200 camera in Turtlebot.
  Updated r200 URDF to inclue proper mounting.
  Added runtime dependency on realsense_camera package.
* [bringup] remove outdated broken comment
* Contributors: Daniel Stonier, Kevin C. Wells
```

## turtlebot_capabilities

- No changes

## turtlebot_description

```
* Fix image format on Gazebo using B8G8R8
  Related to https://github.com/ros-simulation/gazebo_ros_pkgs/issues/484
* Add support for Intel R200 camera
  Added necessary launch, urdf, etc. files to
  add support for the R200 camera in Turtlebot.
  Updated r200 URDF to inclue proper mounting.
  Added runtime dependency on realsense_camera package.
* Contributors: Kentaro Wada, Kevin C. Wells
```

## turtlebot_teleop

- No changes
