### PR TITLE
turtlebot_apps: 2.3.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5425,7 +5425,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_apps-release.git
-      version: 2.3.6-0
+      version: 2.3.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_apps` to `2.3.7-0`:

- upstream repository: https://github.com/turtlebot/turtlebot_apps.git
- release repository: https://github.com/turtlebot-release/turtlebot_apps-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.3.6-0`

## turtlebot_actions

- No changes

## turtlebot_apps

- No changes

## turtlebot_calibration

- No changes

## turtlebot_follower

```
* fixed bad printf format
* clean up cmake dependencies
* Included depth_image_proc in cmake deps
* Contributors: Mr-Yellow, Rohan Agrawal, Tully Foote
```

## turtlebot_navigation

```
* Parameterize AMCL and GMapping launch files for individual cameras.
  Changed amcl_demo.launch and gmapping_demo.launch to use the
  TURTLEBOT_3D_SENSOR environment variable to choose which version of
  the XXXX_amcl.launch.xml, XXXX_costmap_param.yaml, and
  XXXX_gmapping.launch.xml files it includes.
  This is done to allow custom AMCL or GMapping parameters specific to
  the 3D camera being used. These have also been parameterized to allow
  you to pass an argument to override these values.
  For cameras that do not have custom param files, their corresponding
  launch files are simply symlinks to the default files.
* remove superfluous leading '/' in topic names
  These are not needed as all topics in question are in the
  same namespace as the nodes. However, the '/' breaks namespacing,
  so it becomes impossible to move the whole launch file into
  a new namespace.
* Contributors: Kevin Wells, v4hn
```

## turtlebot_rapps

- No changes
