### PR TITLE
rviz_visual_tools: 3.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4818,7 +4818,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/davetcoleman/rviz_visual_tools-release.git
-      version: 3.3.0-0
+      version: 3.4.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `3.4.0-0`:

- upstream repository: https://github.com/davetcoleman/rviz_visual_tools.git
- release repository: https://github.com/davetcoleman/rviz_visual_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `3.3.0-0`

## rviz_visual_tools

```
* Consolidated publishing into RemoteReciever class
* Improve console output
* Add RvizGui and KeyTool
* Enable remote control from withing rviz_visual_tools
* New publishPath() function
* Shorten number of lines printTranslation() requires
* Contributors: Dave Coleman
```
