### PR TITLE
moveit_visual_tools: 3.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2515,7 +2515,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 3.2.0-0
+      version: 3.2.1-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `3.2.1-0`:

- upstream repository: https://github.com/davetcoleman/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `3.2.0-0`

## moveit_visual_tools

```
* New publishTrajectoryPath() functions
* New publishTrajectoryLine() functions
* getRobotState() return by reference
* Trajectory path has smaller vertices
* IMarkerRobotState: added isStateValid()
* Contributors: Dave Coleman
```
