### PR TITLE
rqt_common_plugins: 0.4.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11194,7 +11194,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.3.13-0
+      version: 0.4.3-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `0.4.3-0`:

- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/ros-gbp/rqt_common_plugins-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.3.13-0`

## rqt_action

- No changes

## rqt_bag

- No changes

## rqt_bag_plugins

- No changes

## rqt_common_plugins

- No changes

## rqt_console

- No changes

## rqt_dep

- No changes

## rqt_graph

- No changes

## rqt_image_view

```
* generate UI headers in devel space to avoid CMake warning (#401 <https://github.com/ros-visualization/rqt_common_plugins/pull/401>)
```

## rqt_launch

- No changes

## rqt_logger_level

- No changes

## rqt_msg

- No changes

## rqt_plot

- No changes

## rqt_publisher

- No changes

## rqt_py_common

- No changes

## rqt_py_console

- No changes

## rqt_reconfigure

- No changes

## rqt_service_caller

```
* catch all exceptions thrown when loading services classes and only show services that loaded without exception
```

## rqt_shell

- No changes

## rqt_srv

- No changes

## rqt_top

- No changes

## rqt_topic

- No changes

## rqt_web

- No changes
