### PR TITLE
rqt_robot_plugins: 0.5.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4724,7 +4724,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-      version: 0.5.4-0
+      version: 0.5.5-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins` to `0.5.5-0`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_plugins.git
- release repository: https://github.com/ros-gbp/rqt_robot_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.5.4-0`

## rqt_moveit

- No changes

## rqt_nav_view

- No changes

## rqt_pose_view

- No changes

## rqt_robot_dashboard

- No changes

## rqt_robot_monitor

- No changes

## rqt_robot_plugins

- No changes

## rqt_robot_steering

- No changes

## rqt_runtime_monitor

- No changes

## rqt_rviz

- No changes

## rqt_tf_tree

```
* fix tf parent to always convert to string (#113 <https://github.com/ros-visualization/rqt_robot_plugins/pull/113>)
```
