### PR TITLE
simple_voice-release: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12053,6 +12053,23 @@ repositories:
       url: https://github.com/mikeferguson/simple_grasping.git
       version: master
     status: developed
+  simple_voice-release:
+    doc:
+      type: git
+      url: https://github.com/DinnerHowe/simple_voice.git
+      version: 0.0.1
+    release:
+      packages:
+      - simple_voice
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/DinnerHowe/simple_voice-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/DinnerHowe/simple_voice.git
+      version: 0.0.1
+    status: maintained
   skeleton_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_voice-release` to `0.0.1-0`:

- upstream repository: https://github.com/DinnerHowe/simple_voice.git
- release repository: https://github.com/DinnerHowe/simple_voice-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
