### PR TITLE
rtmros_nextage: 0.7.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11448,7 +11448,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.7.10-0
+      version: 0.7.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.7.11-0`:

- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.7.10-0`

## nextage_description

- No changes

## nextage_gazebo

- No changes

## nextage_ik_plugin

- No changes

## nextage_moveit_config

- No changes

## nextage_ros_bridge

```
* [improve][nextage.py] Setting default model file location for the real robot so that you'll never need to pass arg from commandline.
* [improve] Add convenient launch file for NXO with hrpsys older than 315.2.7 (related: https://github.com/tork-a/rtmros_nextage/issues/153).
* Contributors: Isaac I.Y. Saito
```

## rtmros_nextage

```
* [improve][nextage.py] Setting default model file location for the real robot so that you'll never need to pass arg from commandline.
* [improve] Add convenient launch file for NXO with hrpsys older than 315.2.7 (related: https://github.com/tork-a/rtmros_nextage/issues/153).
* Contributors: Isaac I.Y. Saito
```
