### PR TITLE
Adding marker_msgs to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5642,6 +5642,16 @@ repositories:
       url: https://github.com/swri-robotics/mapviz.git
       version: indigo-devel
     status: developed
+  marker_msgs:
+    doc:
+      type: git
+      url: https://github.com/tuw-robotics/marker_msgs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/tuw-robotics/marker_msgs.git
+      version: master
+    status: maintained
   marshmallow:
     release:
       tags:


### PR DESCRIPTION
I like to add marker_msgs also to indigo