### PR TITLE
moveit: 0.9.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2421,6 +2421,7 @@ repositories:
       - moveit_fake_controller_manager
       - moveit_kinematics
       - moveit_planners
+      - moveit_planners_chomp
       - moveit_planners_ompl
       - moveit_plugins
       - moveit_ros
@@ -2439,7 +2440,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.9.1-2
+      version: 0.9.2-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.9.2-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.9.1-2`

## moveit

- No changes

## moveit_commander

- No changes

## moveit_core

```
* [Fix] CHANGELOG encoding for 0.9.1 (Fix #318 <https://github.com/ros-planning/moveit/issues/318>). (#327 <https://github.com/ros-planning/moveit/issues/327>)
* [Capability] compatibility to urdfdom < 0.4 (#317 <https://github.com/ros-planning/moveit/issues/317>)
* [Capability] New isValidVelocityMove() for checking maximum velocity between two robot states given time delta
* [Maintenance] Travis check code formatting (#309 <https://github.com/ros-planning/moveit/issues/309>)
* [Maintenance] Auto format codebase using clang-format (#284 <https://github.com/ros-planning/moveit/issues/284>)
* Contributors: Dave Coleman, Isaac I. Y. Saito, Robert Haschke
```

## moveit_kinematics

```
* [Maintenance] Auto format codebase using clang-format (#284 <https://github.com/ros-planning/moveit/issues/284>)
* Contributors: Dave Coleman
```

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

- No changes

## moveit_ros

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_perception

```
* [Maintenace] Auto format codebase using clang-format (#284 <https://github.com/ros-planning/moveit/issues/284>)
* Contributors: Dave Coleman
```

## moveit_ros_planning

```
* [Capability] compatibility to urdfdom < 0.4 (#317 <https://github.com/ros-planning/moveit/issues/317>)
* [Maintenance] Auto format codebase using clang-format (#284 <https://github.com/ros-planning/moveit/issues/284>)
* Contributors: Dave Coleman, Robert Haschke
```

## moveit_ros_robot_interaction

```
* [Maintenance] Auto format codebase using clang-format (#284 <https://github.com/ros-planning/moveit/issues/284>)
* Contributors: Dave Coleman
```

## moveit_ros_visualization

```
* [Maintenance] Auto format codebase using clang-format (#284 <https://github.com/ros-planning/moveit/issues/284>)
* Contributors: Dave Coleman
```

## moveit_setup_assistant

```
* [Fix] xacro warnings in Kinetic (#334 <https://github.com/ros-planning/moveit/issues/334>)
  [Capability] Allows for smaller collision objects at the cost of increased planning time
* [Improve] Increase the default discretization of collision checking motions (#321 <https://github.com/ros-planning/moveit/issues/321>)
* [Maintenance] Auto format codebase using clang-format (#284 <https://github.com/ros-planning/moveit/issues/284>)
* Contributors: Dave Coleman
```
