### PR TITLE
Revert "moveit: 0.9.2-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2421,7 +2421,6 @@ repositories:
       - moveit_fake_controller_manager
       - moveit_kinematics
       - moveit_planners
-      - moveit_planners_chomp
       - moveit_planners_ompl
       - moveit_plugins
       - moveit_ros
@@ -2440,7 +2439,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.9.2-0
+      version: 0.9.1-2
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Reverts ros/rosdistro#13138

All the sourcedebs are failing. it appears that the release tags were pushed successfully, but not the debian and rpm generated tags: https://github.com/ros-gbp/moveit-release/releases?after=release%2Fkinetic%2Fmoveit_ros_robot_interaction%2F0.9.2-0 from the 2nd stage of bloom.

For example: http://build.ros.org:8080/job/Ksrc_uX__moveit_planners__ubuntu_xenial__source/

@davetcoleman 
