### PR TITLE
rosdep: Add python-future package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -759,6 +759,13 @@ python-freezegun-pip:
   ubuntu:
     pip:
       packages: [freezegun]
+python-future:
+  debian: [python-future]
+  fedora: [python-future]
+  osx:
+    pip:
+      packages: [future]
+  ubuntu: [python-future]
 python-fysom:
   debian:
     pip:


### PR DESCRIPTION
This patch add python-future package: https://pypi.python.org/pypi/future

Used by upcoming mavlink (new dependencies: lxml, future).