### PR TITLE
mrpt_navigation: 0.1.15-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2541,7 +2541,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 0.1.14-0
+      version: 0.1.15-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `0.1.15-0`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.14-0`

## mrpt_bridge

```
* mrpt_bridge: Fix bug in laserScans conversion
* Fix new scanRange API in MRPT 1.5.0
* Contributors: Jose-Luis Blanco-Claraco, Nikos Koukis
```

## mrpt_local_obstacles

- No changes

## mrpt_localization

```
* Fix build against MRPT 1.5.0
* Use ros::Time::now() to time stamp first 10 poses
  If not, they contain wall time, what when working on simulation prevents robot_localization fusion to work.
  Other than that, the change is innocuous
* PR #33 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/33> prevented pose initialization with the robot stopped; fix it!
* Stop mrpt_localization updating when robot is not moving (odom twist is zero)
* Contributors: Jorge Santos, Jorge Santos Simón, Jose-Luis Blanco-Claraco
```

## mrpt_map

- No changes

## mrpt_msgs

```
* Add Pose2DStamped ROS message
* Contributors: Nikos Koukis
```

## mrpt_navigation

- No changes

## mrpt_rawlog

```
* Fix build against MRPT 1.5.0
* Contributors: Jose-Luis Blanco-Claraco
```

## mrpt_reactivenav2d

```
* Fix mrpt-reactivenav2d compilation errors
* Fix compilation for MRPT < 1.5.0
* Add include guard  for MRPT >= 1.5.0, fill timestamp entries
* Add include guard for CVehicleVelCmd_DiffDriven in mrpt >= 1.5.0
* Fix mrpt-reactivenav2d compilation errors
* Contributors: Nikos Koukis, bergercookie
```

## mrpt_tutorials

- No changes
