### PR TITLE
 simple_voice-release and rplidar_python-release in both indigo and jade distribution

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12068,6 +12068,23 @@ repositories:
       url: https://github.com/DinnerHowe/simple_voice.git
       version: indigo
     status: maintained
+
+  rplidar_python:
+    doc:
+      type: git
+      url: https://github.com/DinnerHowe/rplidar_python.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/DinnerHowe/rplidar_python-release.git
+      version: 0.0.0-0
+    source:
+      type: git
+      url: https://github.com/DinnerHowe/rplidar_python.git
+      version: master
+    status: maintained
+
   skeleton_markers:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12053,6 +12053,21 @@ repositories:
       url: https://github.com/mikeferguson/simple_grasping.git
       version: master
     status: developed
+  simple_voice:
+    doc:
+      type: git
+      url: https://github.com/DinnerHowe/simple_voice.git
+      version: 0.1.1
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/DinnerHowe/simple_voice-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/DinnerHowe/simple_voice.git
+      version: indigo
+    status: maintained
   skeleton_markers:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11112,6 +11112,21 @@ repositories:
       url: https://github.com/ethz-asl/rotors_simulator.git
       version: master
     status: developed
+  rplidar_python:
+    doc:
+      type: git
+      url: https://github.com/DinnerHowe/rplidar_python.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/DinnerHowe/rplidar_python-release.git
+      version: 0.0.0-0
+    source:
+      type: git
+      url: https://github.com/DinnerHowe/rplidar_python.git
+      version: master
+    status: maintained
   rplidar_ros:
     doc:
       type: git
@@ -12068,23 +12083,6 @@ repositories:
       url: https://github.com/DinnerHowe/simple_voice.git
       version: indigo
     status: maintained
-
-  rplidar_python:
-    doc:
-      type: git
-      url: https://github.com/DinnerHowe/rplidar_python.git
-      version: master
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/DinnerHowe/rplidar_python-release.git
-      version: 0.0.0-0
-    source:
-      type: git
-      url: https://github.com/DinnerHowe/rplidar_python.git
-      version: master
-    status: maintained
-
   skeleton_markers:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5316,6 +5316,21 @@ repositories:
       url: https://github.com/tork-a/roswww.git
       version: develop
     status: maintained
+  rplidar_python:
+    doc:
+      type: git
+      url: https://github.com/DinnerHowe/rplidar_python.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/DinnerHowe/rplidar_python-release.git
+      version: 0.0.0-1
+    source:
+      type: git
+      url: https://github.com/DinnerHowe/rplidar_python.git
+      version: master
+    status: maintained
   rplidar_ros:
     doc:
       type: git
@@ -5831,6 +5846,21 @@ repositories:
       url: https://github.com/fetchrobotics-gbp/simple_grasping-release.git
       version: 0.2.2-0
     status: developed
+  simple_voice:
+    doc:
+      type: git
+      url: https://github.com/DinnerHowe/simple_voice.git
+      version: 0.1.1
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/DinnerHowe/simple_voice-release.git
+      version: 0.0.1-2
+    source:
+      type: git
+      url: https://github.com/DinnerHowe/simple_voice.git
+      version: jade
+    status: maintained
   slam_gmapping:
     doc:
       type: git


### PR DESCRIPTION
please add my repo. to documentation index for distro.

finally i passed travis checking, great thanks for @mikaelarguedas @vrabaud @tfoote. i really appreciate for your helping, thanks again. 

following are 2 repositories which i like to merge into community. 

simple_voice: is a  speech recognition && Text To Speach(TTS) package using baidu speech
rplidar_python: is a driver for RPLIDAR 360 in python, publishing '/scan' topic, supporting gmapping

(…correct distribution by hand and try again)
indigo
    upstream repository: https://github.com/DinnerHowe/simple_voice.git
    release repository: https://github.com/DinnerHowe/simple_voice-release.git
    distro file: indigo/distribution.yaml
    bloom version: 0.5.23
    previous version for package: null

    upstream repository: https://github.com/DinnerHowe/rplidar_python.git
    release repository: https://github.com/DinnerHowe/rplidar_python-release.git
    distro file: indigo/distribution.yaml
    bloom version: 0.5.23
    previous version for package: null

jade
    upstream repository: https://github.com/DinnerHowe/simple_voice.git
    release repository: https://github.com/DinnerHowe/simple_voice-release.git
    distro file: jade/distribution.yaml
    bloom version: 0.5.23
    previous version for package: null

    upstream repository: https://github.com/DinnerHowe/rplidar_python.git
    release repository: https://github.com/DinnerHowe/rplidar_python-release.git
    distro file: jade/distribution.yaml
    bloom version: 0.5.23
    previous version for package: null
