### PR TITLE
marker_rviz_plugin: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2211,7 +2211,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tuw-robotics/marker_rviz_plugin-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/tuw-robotics/marker_rviz_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marker_rviz_plugin` to `0.0.2-0`:

- upstream repository: https://github.com/tuw-robotics/marker_rviz_plugin.git
- release repository: https://github.com/tuw-robotics/marker_rviz_plugin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.1-0`

## marker_rviz_plugin

```
* Lable color change able.
* Implemented scale and marker size property for all marker visual types.
* Contributors: Markus Bader, Lukas Pfeifhofer
```
