### PR TITLE
marker_detection: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2187,6 +2187,17 @@ repositories:
       url: https://github.com/swri-robotics/mapviz.git
       version: kinetic-devel
     status: developed
+  marker_detection:
+    release:
+      packages:
+      - tuw_aruco
+      - tuw_ellipses
+      - tuw_marker_detection
+      - tuw_marker_pose_estimation
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tuw-robotics/tuw_marker_detection-release.git
+      version: 0.0.2-0
   marker_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marker_detection` to `0.0.2-0`:

- upstream repository: https://github.com/tuw-robotics/tuw_marker_detection.git
- release repository: https://github.com/tuw-robotics/tuw_marker_detection-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## tuw_aruco

```
* Initial commit
* Contributors: Markus Bader, Lukas Pfeifhofer
```

## tuw_ellipses

```
* Initial commit
* Contributors: Markus Bader, Lukas Pfeifhofer
```

## tuw_marker_detection

```
* Initial commit
* Contributors: Markus Bader
```

## tuw_marker_pose_estimation

```
* Initial commit
* Contributors: Lukas Pfeifhofer
```
