### PR TITLE
pyros_test: 0.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3553,7 +3553,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/asmodehn/pyros-test-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/asmodehn/pyros-test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_test` to `0.0.6-0`:

- upstream repository: https://github.com/asmodehn/pyros-test.git
- release repository: https://github.com/asmodehn/pyros-test-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.5-0`

## pyros_test

```
* Merge pull request #5 <https://github.com/asmodehn/pyros-test/issues/5> from asmodehn/string_sub_node
  implementing a simple string_sub_node
* implementing a simple string_sub_node
* now able to name nodes via first command argument.
* Contributors: AlexV, alexv
```
