### PR TITLE
naoqi_bridge_msgs: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6747,7 +6747,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_bridge_msgs-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_bridge_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge_msgs` to `0.0.6-0`:

- upstream repository: https://github.com/ros-naoqi/naoqi_bridge_msgs.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.5-0`

## naoqi_bridge_msgs

```
* Merge pull request #29 <https://github.com/ros-naoqi/naoqi_bridge_msgs/issues/29> from kochigami/rename-tactile-touch
  [msg] rename TactileTouch to HeadTouch
* [msg] rename TactileTouch to HeadTouch
* Merge pull request #21 <https://github.com/ros-naoqi/naoqi_bridge_msgs/issues/21> from kochigami/add-msg-and-srv-for-naoqi-sound-localization
  add srv and msg for naoqi_apps/launch/soundLocalization.launch
* add srv and msg for naoqi_apps/launch/soundLocalization.launch
* Contributors: Kanae Kochigami, Karsten Knese, Natalia Lyubova
```
