### PR TITLE
naoqi_bridge_msgs: 0.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2695,11 +2695,19 @@ repositories:
       version: master
     status: maintained
   naoqi_bridge_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_bridge_msgs.git
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_bridge_msgs-release.git
-      version: 0.0.5-3
+      version: 0.0.6-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_bridge_msgs.git
+      version: master
     status: maintained
   naoqi_dcm_driver:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge_msgs` to `0.0.6-0`:

- upstream repository: https://github.com/ros-naoqi/naoqi_bridge_msgs.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.5-3`

## naoqi_bridge_msgs

```
* Merge pull request #29 <https://github.com/ros-naoqi/naoqi_bridge_msgs/issues/29> from kochigami/rename-tactile-touch
  [msg] rename TactileTouch to HeadTouch
* [msg] rename TactileTouch to HeadTouch
* Merge pull request #21 <https://github.com/ros-naoqi/naoqi_bridge_msgs/issues/21> from kochigami/add-msg-and-srv-for-naoqi-sound-localization
  add srv and msg for naoqi_apps/launch/soundLocalization.launch
* add srv and msg for naoqi_apps/launch/soundLocalization.launch
* Contributors: Kanae Kochigami, Karsten Knese, Natalia Lyubova
```
