### PR TITLE
naoqi_driver: 0.5.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2725,11 +2725,19 @@ repositories:
       version: master
     status: maintained
   naoqi_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_driver.git
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_driver-release.git
-      version: 0.5.8-1
+      version: 0.5.9-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_driver.git
+      version: master
     status: maintained
   naoqi_libqi:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_driver` to `0.5.9-0`:

- upstream repository: https://github.com/ros-naoqi/alrosbridge.git
- release repository: https://github.com/ros-naoqi/naoqi_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.5.8-1`

## naoqi_driver

```
* -Vincent Rabaud as a maintainer, +Natalia Lyubova
* Merge pull request #75 <https://github.com/ros-naoqi/naoqi_driver/issues/75> from kochigami/rename-tactile-touch-to-head-touch
  rename tactile touch to head touch
* rename boot_config name of hand & head
* rename tactile touch to head touch
* Merge pull request #63 <https://github.com/ros-naoqi/naoqi_driver/issues/63> from kochigami/add-hand-touch-sensor-input-to-touch-programs
  Add hand touch sensor input to touch event and converters
* add hand touch sensor input to touch programs
* Merge pull request #74 <https://github.com/ros-naoqi/naoqi_driver/issues/74> from kochigami/try-depth-raw
  kRawDepthColorSpace for depth image
* Merge pull request #36 <https://github.com/ros-naoqi/naoqi_driver/issues/36> from laurent-george/adding_odom_frame
  Adding odom topic to the bridge
* fix(odom): update code based on comment in pull request
* Adding odom topic to the bridge
* Merge pull request #72 <https://github.com/ros-naoqi/naoqi_driver/issues/72> from furushchev/increase-joint-state-freq
  [share/boot_config.json] increase frequency for publishing joint_states
* [share/boot_config.json] increase frequency for publishing joint_states
* Update package.xml
* kRawDepthColorSpace for depth image
* Contributors: Kanae Kochigami, Karsten Knese, Laurent GEORGE, Mikael Arguedas, Natalia Lyubova, Vincent Rabaud, Yuki Furuta, lgeorge
```
