### PR TITLE
ecl_core: 0.61.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2282,7 +2282,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_core-release.git
-      version: 0.61.14-0
+      version: 0.61.15-0
     source:
       type: git
       url: https://github.com/stonier/ecl_core.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2253,7 +2253,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/stonier/ecl_core.git
-      version: devel
+      version: release/0.61-indigo-kinetic
     release:
       packages:
       - ecl_command_line
@@ -2286,7 +2286,7 @@ repositories:
     source:
       type: git
       url: https://github.com/stonier/ecl_core.git
-      version: devel
+      version: release/0.61-indigo-kinetic
     status: maintained
   ecl_lite:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_core` to `0.61.15-0`:

- upstream repository: https://github.com/stonier/ecl_core.git
- release repository: https://github.com/yujinrobot-release/ecl_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.61.14-0`

## ecl_geometry

```
* pose -> legacy pose
* new pose (function only) library started, should eliminate the need for most type conversions
```

## ecl_statistics

```
* Class added for computing cumulative means and variances
```
