### PR TITLE
ecl_core: 0.61.15-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -799,7 +799,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_core-release.git
-      version: 0.61.14-0
+      version: 0.61.15-0
     source:
       type: git
       url: https://github.com/stonier/ecl_core.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -770,7 +770,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/stonier/ecl_core.git
-      version: devel
+      version: release/0.61-indigo-kinetic
     release:
       packages:
       - ecl_command_line
@@ -803,7 +803,7 @@ repositories:
     source:
       type: git
       url: https://github.com/stonier/ecl_core.git
-      version: devel
+      version: release/0.61-indigo-kinetic
     status: developed
   ecl_lite:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_core` to `0.61.15-0`:

- upstream repository: https://github.com/stonier/ecl_core.git
- release repository: https://github.com/yujinrobot-release/ecl_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.61.14-0`

## ecl_geometry

```
* pose -> legacy pose
* new pose (function only) library started, should eliminate the need for most type conversions
```

## ecl_statistics

```
* Class added for computing cumulative means and variances
```
