### PR TITLE
ecl_navigation: 0.60.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2335,7 +2335,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/stonier/ecl_navigation.git
-      version: devel
+      version: release/0.60-indigo-kinetic
     release:
       packages:
       - ecl_mobile_robot
@@ -2347,7 +2347,7 @@ repositories:
     source:
       type: git
       url: https://github.com/stonier/ecl_navigation.git
-      version: devel
+      version: release/0.60-indigo-kinetic
     status: maintained
   ecl_tools:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2343,7 +2343,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_navigation-release.git
-      version: 0.60.1-1
+      version: 0.60.3-0
     source:
       type: git
       url: https://github.com/stonier/ecl_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_navigation` to `0.60.3-0`:

- upstream repository: https://github.com/stonier/ecl_navigation.git
- release repository: https://github.com/yujinrobot-release/ecl_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.60.1-1`
