### PR TITLE
ecl_navigation: 0.60.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -860,7 +860,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_navigation-release.git
-      version: 0.60.1-0
+      version: 0.60.3-0
     source:
       type: git
       url: https://github.com/stonier/ecl_navigation.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -852,7 +852,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/stonier/ecl_navigation.git
-      version: devel
+      version: release/0.60-indigo-kinetic
     release:
       packages:
       - ecl_mobile_robot
@@ -864,7 +864,7 @@ repositories:
     source:
       type: git
       url: https://github.com/stonier/ecl_navigation.git
-      version: devel
+      version: release/0.60-indigo-kinetic
     status: developed
   ecl_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_navigation` to `0.60.3-0`:

- upstream repository: https://github.com/stonier/ecl_navigation.git
- release repository: https://github.com/yujinrobot-release/ecl_navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.60.1-0`
