### PR TITLE
kobuki_core: 0.6.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4952,7 +4952,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki_core-release.git
-      version: 0.6.4-0
+      version: 0.6.5-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core` to `0.6.5-0`:

- upstream repository: https://github.com/yujinrobot/kobuki_core.git
- release repository: https://github.com/yujinrobot-release/kobuki_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.6.4-0`

## kobuki_driver

```
* Pose2D -> LegacyPose2D upgrade
```
