### PR TITLE
gauges: 1.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1128,6 +1128,21 @@ repositories:
       url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core.git
       version: master
     status: maintained
+  gauges:
+    doc:
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/gauges.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/UTNuclearRoboticsPublic/gauges-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/gauges.git
+      version: master
+    status: maintained
   gazebo_ros_pkgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gauges` to `1.0.1-0`:

- upstream repository: https://github.com/UTNuclearRoboticsPublic/gauges.git
- release repository: https://github.com/UTNuclearRoboticsPublic/gauges-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
