### PR TITLE
mongodb_store: 0.1.28-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6054,7 +6054,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.1.27-1
+      version: 0.1.28-1
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.28-1`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.27-1`

## mongodb_log

- No changes

## mongodb_store

```
* Mongo C++ header location now exposed.
* Fixed missing return value
* Fixing the compatibility issues of messagestore cpp client with old SOMA versions
* Fixed issue with projection query including fields instead of excluding
* [mongodb_store/scripts/mongodb_server.py] connect with localhost when shutdown server
* geotype of ROI has been added
* The geospatial indexing of SOMA ROI objects is added
* Contributors: Hakan, Nick Hawes, Yuki Furuta
```

## mongodb_store_msgs

- No changes
