### PR TITLE
tornado: 4.2.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13119,6 +13119,13 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/topic_proxy-release.git
       version: 0.1.1-0
     status: maintained
+  tornado:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/tornado-rosrelease.git
+      version: 4.2.1-1
+    status: maintained
   trac_ik:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tornado` to `4.2.1-1`:

- upstream repository: https://github.com/tornadoweb/tornado.git
- release repository: https://github.com/asmodehn/tornado-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
