### PR TITLE
mavros: 0.18.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2339,7 +2339,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.18.3-1
+      version: 0.18.4-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.18.4-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.18.3-1`

## libmavconn

```
* Update README for all packages
* Contributors: Vladimir Ermakov
```

## mavros

```
* lib: Add ArduSub modes
* readme: Fix mavlink rosinstall_generator call
* mavros: README.md: its -> it's
  Here "it's" is a short form for "it is".
* add hil_actuator_controls mavlink message
* lib: Make cog.py scrips compatioble with Py3
* plugin:sys_status: Add logging health report
* Update README for all packages
* Update README.md
  Fix instructions: Only the Kinetic distro actually works for MAVLink 2.0
* Contributors: Beat Küng, Georgii Staroselskii, Lorenz Meier, Vladimir Ermakov
```

## mavros_extras

```
* Code clean-up
* code style fix
* markup changes
* Fake gps plugin
* Update README for all packages
* Contributors: Vilhjalmur, Vladimir Ermakov, vilhjalmur89
```

## mavros_msgs

```
* msgs: Fix #609 <https://github.com/mavlink/mavros/issues/609>
* add hil_actuator_controls mavlink message
* Contributors: Beat Küng, Vladimir Ermakov
```

## test_mavros

```
* Update README for all packages
* Contributors: Vladimir Ermakov
```
