### PR TITLE
marker_detection: 0.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2212,7 +2212,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tuw-robotics/tuw_marker_detection-release.git
-      version: 0.0.2-0
+      version: 0.0.4-0
   marker_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marker_detection` to `0.0.4-0`:

- upstream repository: https://github.com/tuw-robotics/tuw_marker_detection.git
- release repository: https://github.com/tuw-robotics/tuw_marker_detection-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.2-0`

## tuw_aruco

- No changes

## tuw_ellipses

```
* dynamic reconfiger compile order fixed for ellipses_nodelet
* Contributors: Markus Bader @ munin
```

## tuw_marker_detection

- No changes

## tuw_marker_pose_estimation

- No changes
