### PR TITLE
Add tilestache to rosdep db

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3890,6 +3890,10 @@ texlive-latex-recommended:
 texmaker:
   fedora: [texmaker]
   ubuntu: [texmaker]
+tilestache:
+  debian: [tilestache]
+  fedora: [python-tilestache]
+  ubuntu: [tilestach]
 time:
   arch: [time]
   debian: [time]


### PR DESCRIPTION
Tilestache (http://tilestache.org/) is a Python-based server application that can serve up map tiles based on rendered geographic data.