### PR TITLE
Revert "eigen_stl_containers: 0.1.6-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2464,11 +2464,20 @@ repositories:
       version: master
     status: maintained
   eigen_stl_containers:
+    doc:
+      type: git
+      url: https://github.com/ros/eigen_stl_containers.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/eigen_stl_containers-release.git
       version: 0.1.4-0
+    source:
+      type: git
+      url: https://github.com/ros/eigen_stl_containers.git
+      version: master
+    status: maintained
   ekf_localization:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2464,20 +2464,11 @@ repositories:
       version: master
     status: maintained
   eigen_stl_containers:
-    doc:
-      type: git
-      url: https://github.com/ros/eigen_stl_containers.git
-      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/eigen_stl_containers-release.git
-      version: 0.1.6-0
-    source:
-      type: git
-      url: https://github.com/ros/eigen_stl_containers.git
-      version: master
-    status: maintained
+      version: 0.1.4-0
   ekf_localization:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#12842

@wjwwood This is causing a major regression on Indigo Saucy. http://repositories.ros.org/status_page/ros_indigo_default.html?q=REGRESSION 

Upstream ticket https://github.com/ros/eigen_stl_containers/issues/7