### PR TITLE
librealsense: 1.11.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2109,7 +2109,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/intel-ros/librealsense-release.git
-      version: 1.11.1-0
+      version: 1.11.1-1
     source:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense` to `1.11.1-1`:

- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/intel-ros/librealsense-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.11.1-0`
