### PR TITLE
micros_swarm_framework: 0.0.15-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2466,6 +2466,21 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: kinetic-devel
     status: maintained
+  micros_swarm_framework:
+    doc:
+      type: git
+      url: https://github.com/xuefengchang/micros_swarm_framework.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/xuefengchang/micros_swarm_framework-release.git
+      version: 0.0.15-2
+    source:
+      type: git
+      url: https://github.com/xuefengchang/micros_swarm_framework.git
+      version: master
+    status: developed
   mobility_base_ros:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `micros_swarm_framework` to `0.0.15-2`:

- upstream repository: https://github.com/xuefengchang/micros_swarm_framework.git
- release repository: https://github.com/xuefengchang/micros_swarm_framework-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## micros_swarm_framework

```
* release to kinetic rosdistro
* repair bugs in getParam
* repair bugs in opensplice dds publisher and subscriber
* repair bugs in MsgQueueManager
* complete MsgQueueManager class
* complete msg queue cache
```
