### PR TITLE
Fixing typo,on the package name

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2235,17 +2235,6 @@ repositories:
       url: https://github.com/swri-robotics/mapviz.git
       version: kinetic-devel
     status: developed
-  marker_detection:
-    release:
-      packages:
-      - tuw_aruco
-      - tuw_ellipses
-      - tuw_marker_detection
-      - tuw_marker_pose_estimation
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/tuw-robotics/tuw_marker_detection-release.git
-      version: 0.0.4-0
   marker_msgs:
     doc:
       type: git
@@ -5652,11 +5641,21 @@ repositories:
       type: git
       url: https://github.com/tuw-robotics/tuw_marker_detection.git
       version: kinetic
+    release:
+      packages:
+      - tuw_aruco
+      - tuw_ellipses
+      - tuw_marker_detection
+      - tuw_marker_pose_estimation
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tuw-robotics/tuw_marker_detection-release.git
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/tuw-robotics/tuw_marker_detection.git
       version: kinetic
-    status: developed
+    status: maintained
   tuw_marker_filter:
     doc:
       type: git


### PR DESCRIPTION
Fixing typo, the pkg tuw_marker_detection was wrongly named marker_detection without tuw_ as prefix

Sorry it was my mistake on crating the release with bloom