### PR TITLE
tuw_marker_detection: 0.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5650,7 +5650,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tuw-robotics/tuw_marker_detection-release.git
-      version: 0.0.5-1
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/tuw-robotics/tuw_marker_detection.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tuw_marker_detection` to `0.0.6-0`:

- upstream repository: https://github.com/tuw-robotics/tuw_marker_detection.git
- release repository: https://github.com/tuw-robotics/tuw_marker_detection-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.5-1`

## tuw_aruco

```
* was missing in image_geometry package.xml added
* Contributors: Markus Bader
```

## tuw_ellipses

```
* image_geometry was missing in package.xml
* Contributors: Markus Bader
```

## tuw_marker_detection

```
* was missing in image_geometry package.xml added
* Contributors: Markus Bader
```

## tuw_marker_pose_estimation

```
* was missing in image_geometry package.xml added
* Contributors: Markus Bader
```
