### PR TITLE
remove partial duplicate eigen3 rosdep rule

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -689,12 +689,7 @@ eigen2:
   opensuse: [libeigen2-devel]
   ubuntu:
     apt:
-      packages: [libeigen2-dev]
-eigen3:
-  fedora: [eigen3-devel]
-  gentoo:
-    portage:
-      packages: [dev-cpp/eigen]
+      packages: [libeigen2-dev
 emacs:
   arch: [emacs]
   debian: [emacs]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -689,7 +689,7 @@ eigen2:
   opensuse: [libeigen2-devel]
   ubuntu:
     apt:
-      packages: [libeigen2-dev
+      packages: [libeigen2-dev]
 emacs:
   arch: [emacs]
   debian: [emacs]


### PR DESCRIPTION
Both of these rules are defined above in the `eigen` tag. The `eigen3` tag looks to have been added in a sweeping update for gentoo and then changed in a sweeping fedora update where it should have been merged with the existing entry.

[From this question](http://answers.ros.org/question/247968/build_depend-for-eigen3-kinetic-in-packagexml/?answer=247981#post-id-247981)