### PR TITLE
multimaster_fkie: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6592,7 +6592,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.6.2-0`:

- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.6.1-0`

## default_cfg_fkie

```
* Drop roslib.load_manifest, unneeded with catkin
* Contributors: Alexander Tiderko, Mike Purvis
```

## master_discovery_fkie

```
* Drop roslib.load_manifest, unneeded with catkin
* Contributors: Alexander Tiderko, Mike Purvis
```

## master_sync_fkie

```
* Increased logging in master sync.
  Added more logging around synchronization to help with
  tracking changes in the local ROS master due to multimaster.
* Drop roslib.load_manifest, unneeded with catkin
* Contributors: Alexander Tiderko, Denise Eng, Mike Purvis
```

## multimaster_fkie

```
* master_sync_fkie: Increased logging.
  Added more logging around synchronization to help with
  tracking changes in the local ROS master due to multimaster.
* node_manager_fkie: fixed node view for multiple cores on the same host
* node_manager_fkie: fixed capabilities view
* node_manager_fkie: fixed view of group description by groups with one node
* Drop roslib.load_manifest, unneeded with catkin
* node_manager_fkie: moved controls in group description to the top
* node_manager_fkie: fixed the link to node in group description
* node_manager_fkie: fixed crash while kill screen on remote host
* Contributors: Alexander Tiderko, Denise Eng, Mike Purvis
```

## multimaster_msgs_fkie

- No changes

## node_manager_fkie

```
* node_manager_fkie: fixed node view for multiple cores on the same host
* node_manager_fkie: fixed capabilities view
* node_manager_fkie: fixed view of group description by groups with one node
* Drop roslib.load_manifest, unneeded with catkin
* node_manager_fkie: moved controls in group description to the top
* node_manager_fkie: fixed the link to node in group description
* node_manager_fkie: fixed crash while kill screen on remote host
* Contributors: Alexander Tiderko
```
