### PR TITLE
Adding asr_msgs to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -421,6 +421,11 @@ repositories:
       type: git
       url: https://github.com/ethz-asl/asctec_mav_framework.git
       version: master
+  asr_msgs:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_msgs.git
+      version: master
   astra_camera:
     doc:
       type: git


### PR DESCRIPTION
I would like the repo asr_msgs to be indexed and documented