### PR TITLE
dynamic_reconfigure: 1.5.46-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -728,7 +728,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.5.45-0
+      version: 1.5.46-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.5.46-0`:

- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.5.45-0`

## dynamic_reconfigure

```
* Add missing group params to wikidoc (#68 <https://github.com/ros/dynamic_reconfigure/issues/68>)
  The catkin generated wikidoc files were missing parameters defined as groups.
  Both the Dox and UsageDox file were generated correctly, but the wikidoc was
  using the wrong method to traverse all groups.
* Contributors: Mark Horn
```
