### PR TITLE
nodelet_core: 1.9.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3321,7 +3321,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.9.7-0
+      version: 1.9.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.8-0`:

- upstream repository: https://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.9.7-0`

## nodelet

```
* Fix bond handling during nodelet unloading (#51 <https://github.com/ros/nodelet_core/issues/51>)
  * add test whether bond breaking on unload works (tests #50 <https://github.com/ros/nodelet_core/issues/50>)
  * disable callback for broken bond when we are breaking it
  This avoids the nodelet::LoaderROS::unload() method to be called
  twice for the same nodelet, causing an error output.
  * use AsyncSpinner for nodelet load in order for the shutdown procedure to work
  During shutdown, the bonds still need to communicate their status in order
  for the nodelet to properly/cleanly/quickly unload. This requires the node
  to spin.
  * add test whether LoaderROS::unload() is called twice (tests #50 <https://github.com/ros/nodelet_core/issues/50>)
* Contributors: Daniel Seifert
```

## nodelet_core

- No changes

## nodelet_topic_tools

- No changes
