### PR TITLE
Fix typo in tilestache key for Ubuntu

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3893,7 +3893,7 @@ texmaker:
 tilestache:
   debian: [tilestache]
   fedora: [python-tilestache]
-  ubuntu: [tilestach]
+  ubuntu: [tilestache]
 time:
   arch: [time]
   debian: [time]


### PR DESCRIPTION
The correct package name is tilestache, not tilestach.