### PR TITLE
moveit_msgs: 0.8.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2757,7 +2757,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/moveit_msgs-release.git
-      version: 0.8.3-0
+      version: 0.8.4-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `0.8.4-0`:

- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/ros-gbp/moveit_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.8.3-0`

## moveit_msgs

```
* [capability] new GraspPlanning service to replace manipulation_msgs version (#32 <https://github.com/ros-planning/moveit_msgs/issues/32>)
* [maintenance] Switch travis to moveit_ci (#31 <https://github.com/ros-planning/moveit_msgs/issues/31>)
* [enhancement] Add note in ExecuteKnownTrajectory service to recommend ExecuteTrajectory action. #29 <https://github.com/ros-planning/moveit_msgs/issues/29>
* Contributors: Dave Coleman, Isaac I.Y. Saito, Jntzko
```
