### PR TITLE
moveit_robots: 1.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6353,7 +6353,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/moveit_robots-release.git
-      version: 1.0.6-0
+      version: 1.0.7-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_robots.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6338,7 +6338,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-planning/moveit_robots.git
-      version: master
+      version: indigo-devel
     release:
       packages:
       - atlas_moveit_config
@@ -6357,7 +6357,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-planning/moveit_robots.git
-      version: master
+      version: indigo-devel
     status: maintained
   moveit_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_robots` to `1.0.7-0`:

- upstream repository: https://github.com/ros-planning/moveit_robots.git
- release repository: https://github.com/tork-a/moveit_robots-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.6-0`

## atlas_moveit_config

- No changes

## atlas_v3_moveit_config

- No changes

## baxter_ikfast_left_arm_plugin

```
* [fix] Added missing dependency on lapack and blas
* Contributors: Dave Coleman
```

## baxter_ikfast_right_arm_plugin

```
* [fix] Added missing dependency on lapack and blas
* Contributors: Dave Coleman
```

## baxter_moveit_config

```
* [enahancement] Add option not to launch db in baxter_moveit_config
* Contributors: Kentaro Wada
```

## clam_moveit_config

- No changes

## iri_wam_moveit_config

```
* [fix] iri_wam: remove broken python install directives
* [capability] Adding Gazebo robot controller iri_wam_trajectory_controller
* [enhancement] updating configuration files and allowing trajectory execution (#36 <https://github.com/ros-planning/moveit_robots/issues/36>)
* Contributors: Michael Goerner, Sergi
```

## moveit_robots

- No changes

## r2_moveit_generated

- No changes
