### PR TITLE
flask_cors: 3.0.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2837,6 +2837,13 @@ repositories:
       url: https://github.com/Ikergune/firos.git
       version: master
     status: maintained
+  flask_cors:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/flask-cors-rosrelease.git
+      version: 3.0.2-1
+    status: developed
   flatbuffers:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `flask_cors` to `3.0.2-1`:

- upstream repository: https://github.com/corydolphin/flask-cors.git
- release repository: https://github.com/asmodehn/flask-cors-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
