### PR TITLE
aniso8601: 0.8.3-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -217,6 +217,13 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  aniso8601:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/aniso8601-rosrelease.git
+      version: 0.8.3-3
+    status: maintained
   app_manager:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aniso8601` to `0.8.3-3`:

- upstream repository: https://bitbucket.org/nielsenb/aniso8601.git
- release repository: https://github.com/asmodehn/aniso8601-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
