### PR TITLE
sbg_driver: 1.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4927,6 +4927,13 @@ repositories:
       url: https://github.com/davetcoleman/rviz_visual_tools.git
       version: kinetic-devel
     status: developed
+  sbg_driver:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver-release.git
+      version: 1.0.2-0
+    status: developed
   schunk_canopen_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `1.0.2-0`:

- upstream repository: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git
- release repository: https://github.com/ENSTABretagneRobotics/sbg_ros_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
