### PR TITLE
moveit: 0.9.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2524,7 +2524,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.9.2-1
+      version: 0.9.3-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.9.3-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.9.2-1`

## moveit

```
* [maintenance] Updated package.xml maintainers and author emails #330 <https://github.com/ros-planning/moveit/issues/330>
* Contributors: Dave Coleman, Ian McMahon
```

## moveit_commander

```
* [maintenance] Updated package.xml maintainers and author emails #330 <https://github.com/ros-planning/moveit/issues/330>
* Contributors: Dave Coleman, Ian McMahon
```

## moveit_controller_manager_example

- No changes

## moveit_core

```
* [fix] Replace unused service dependency with msg dep (#361 <https://github.com/ros-planning/moveit/issues/361>)
* [fix] cleanup urdfdom compatibility (#319 <https://github.com/ros-planning/moveit/issues/319>)
* [fix] Fix missing compatibility header for Wily #364 <https://github.com/ros-planning/moveit/issues/364>)
* [enhancement] Improved RobotState feedback for setFromIK() (#342 <https://github.com/ros-planning/moveit/issues/342>)
* [maintenance] Updated package.xml maintainers and author emails #330 <https://github.com/ros-planning/moveit/issues/330>
* Contributors: Dave Coleman, Ian McMahon, Robert Haschke
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

```
* [fix] Replace unused service dependency with msg dep (#361 <https://github.com/ros-planning/moveit/issues/361>)
* [maintenance] Updated package.xml maintainers and author emails #330 <https://github.com/ros-planning/moveit/issues/330>
* Contributors: Dave Coleman, Ian McMahon
```

## moveit_planners

```
* [maintenance] Updated package.xml maintainers and author emails #330 <https://github.com/ros-planning/moveit/issues/330>
* Contributors: Dave Coleman, Ian McMahon
```

## moveit_planners_ompl

```
* [capability] Exposed planners from latest ompl release. (#338 <https://github.com/ros-planning/moveit/issues/338>)
* [maintenance] Updated package.xml maintainers and author emails #330 <https://github.com/ros-planning/moveit/issues/330>
* Contributors: Dave Coleman, Ian McMahon, Ruben Burger
```

## moveit_plugins

- No changes

## moveit_ros

```
* [capability] add list of default capabilities #359 <https://github.com/ros-planning/moveit/pull/359>
* [maintenance] Updated package.xml maintainers and author emails #330 <https://github.com/ros-planning/moveit/issues/330>
* Contributors: Dave Coleman, Michael Goerner, Ian McMahon
```

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

```
* [maintenance] Updated package.xml maintainers and author emails #330 <https://github.com/ros-planning/moveit/issues/330>
* [enhancement] remove grasp service support from pick_place's fillGrasp (#328 <https://github.com/ros-planning/moveit/issues/328>)
* [maintenance] Updated package.xml maintainers and author emails #330 <https://github.com/ros-planning/moveit/issues/330>
* Contributors: Dave Coleman, Ian McMahon, Michael Goerner
```

## moveit_ros_move_group

```
* [maintenance] Updated package.xml maintainers and author emails #330 <https://github.com/ros-planning/moveit/issues/330>
* Contributors: Dave Coleman, Ian McMahon
```

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* [fix] cleanup urdfdom compatibility (#319 <https://github.com/ros-planning/moveit/issues/319>)
* [maintenance] Updated package.xml maintainers and author emails #330 <https://github.com/ros-planning/moveit/issues/330>
* Contributors: Dave Coleman, Ian McMahon, Robert Haschke
```

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

```
* [maintenance] Updated package.xml maintainers and author emails #330 <https://github.com/ros-planning/moveit/issues/330>
* Contributors: Dave Coleman, Ian McMahon
```

## moveit_ros_visualization

```
* [maintenance] Updated package.xml maintainers and author emails #330 <https://github.com/ros-planning/moveit/issues/330>
* Contributors: Dave Coleman, Ian McMahon
```

## moveit_ros_warehouse

- No changes

## moveit_setup_assistant

```
* [capability] Exposed planners from latest ompl release. (#338 <https://github.com/ros-planning/moveit/issues/338>)
* [enhancement] Increase collision checking interval (#337 <https://github.com/ros-planning/moveit/issues/337>)
* [maintenance] Updated package.xml maintainers and author emails #330 <https://github.com/ros-planning/moveit/issues/330>
* Contributors: Dave Coleman, Ian McMahon, Ruben Burger
```

## moveit_simple_controller_manager

- No changes
