### PR TITLE
backports_ssl_match_hostname: 3.5.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -223,6 +223,13 @@ repositories:
       url: https://github.com/po1/axcli-release.git
       version: 0.1.0-0
     status: maintained
+  backports_ssl_match_hostname:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/asmodehn/backports.ssl_match_hostname-rosrelease.git
+      version: 3.5.0-0
+    status: maintained
   battery_monitor_rmp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `backports_ssl_match_hostname` to `3.5.0-0`:

- upstream repository: https://bitbucket.org/asmodehn/backports.ssl_match_hostname
- release repository: https://github.com/asmodehn/backports.ssl_match_hostname-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
