### PR TITLE
flask_restful: 0.3.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1072,6 +1072,13 @@ repositories:
       url: https://github.com/introlab/find_object_2d-release.git
       version: 0.5.1-0
     status: maintained
+  flask_restful:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/asmodehn/flask-restful-rosrelease.git
+      version: 0.3.4-0
+    status: maintained
   force_torque_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `flask_restful` to `0.3.4-0`:

- upstream repository: https://github.com/flask-restful/flask-restful.git
- release repository: https://github.com/asmodehn/flask-restful-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
