### PR TITLE
certifi: 2015.11.20-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -414,6 +414,13 @@ repositories:
       url: https://github.com/asmodehn/catkin_pip.git
       version: jade
     status: developed
+  certifi:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/asmodehn/certifi-rosrelease.git
+      version: 2015.11.20-0
+    status: maintained
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `certifi` to `2015.11.20-0`:

- upstream repository: https://github.com/certifi/python-certifi.git
- release repository: https://github.com/asmodehn/certifi-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
