### PR TITLE
flask_restful: 0.3.4-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2855,6 +2855,13 @@ repositories:
       url: https://github.com/asmodehn/flask-cors-rosrelease.git
       version: 3.0.2-1
     status: developed
+  flask_restful:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/flask-restful-rosrelease.git
+      version: 0.3.4-2
+    status: maintained
   flask_reverse_proxy:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `flask_restful` to `0.3.4-2`:

- upstream repository: https://github.com/flask-restful/flask-restful.git
- release repository: https://github.com/asmodehn/flask-restful-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
