### PR TITLE
tornado: 4.2.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6245,6 +6245,13 @@ repositories:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/topic_proxy.git
       version: master
+  tornado:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/asmodehn/tornado-rosrelease.git
+      version: 4.2.1-0
+    status: maintained
   trac_ik:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tornado` to `4.2.1-0`:

- upstream repository: https://github.com/tornadoweb/tornado.git
- release repository: https://github.com/asmodehn/tornado-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
