### PR TITLE
flask_cors: 3.0.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1079,6 +1079,13 @@ repositories:
       url: https://github.com/introlab/find_object_2d-release.git
       version: 0.5.1-0
     status: maintained
+  flask_cors:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/asmodehn/flask-cors-rosrelease.git
+      version: 3.0.2-0
+    status: developed
   flask_restful:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `flask_cors` to `3.0.2-0`:

- upstream repository: https://github.com/corydolphin/flask-cors.git
- release repository: https://github.com/asmodehn/flask-cors-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
