### PR TITLE
Adding my_repo_name to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7499,6 +7499,16 @@ repositories:
       type: git
       url: https://github.com/autonohm/ohm_tsd_slam.git
       version: indigo-devel
+  omip:
+    doc:
+      type: git
+      url: https://github.com/tu-rbo/omip.git
+      version: indigo
+    source:
+      type: git
+      url: https://github.com/tu-rbo/omip.git
+      version: indigo
+    status: maintained
   ompl:
     release:
       tags:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3148,6 +3148,16 @@ repositories:
       url: https://github.com/OctoMap/octomap_rviz_plugins.git
       version: kinetic-devel
     status: maintained
+  omip:
+    doc:
+      type: git
+      url: https://github.com/tu-rbo/omip.git
+      version: kinetic
+    source:
+      type: git
+      url: https://github.com/tu-rbo/omip.git
+      version: kinetic
+    status: maintained
   ompl:
     release:
       tags:


### PR DESCRIPTION
I'd like omip to be indexed and documented on ros.org (for indigo and kinetic distros)