### PR TITLE
csapex: 0.9.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -618,7 +618,12 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/betwo/csapex-release.git
-      version: 0.9.1-0
+      version: 0.9.2-0
+    source:
+      type: git
+      url: https://github.com/cogsys-tuebingen/csapex.git
+      version: master
+    status: developed
   csm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `csapex` to `0.9.2-0`:

- upstream repository: https://github.com/cogsys-tuebingen/csapex.git
- release repository: https://github.com/betwo/csapex-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.9.1-0`

## csapex

```
* added missing dependencies for qt5
* Contributors: buck
```
