### PR TITLE
mrpt_slam: 0.1.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2906,13 +2906,14 @@ repositories:
       packages:
       - mrpt_ekf_slam_2d
       - mrpt_ekf_slam_3d
+      - mrpt_graphslam_2d
       - mrpt_icp_slam_2d
       - mrpt_rbpf_slam
       - mrpt_slam
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
-      version: 0.1.3-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_slam` to `0.1.5-0`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_slam.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.1.3-0`

## mrpt_ekf_slam_2d

```
* Fix cmakelists typo
* Contributors: Nikos Koukis
```

## mrpt_ekf_slam_3d

```
* Don't instruct cmake to search eigen3, mrpt has it
* Fix cmakelists typo
* avoid cmake errors if eigen is not found
* Contributors: Jose Luis Blanco-Claraco, Nikos Koukis
```

## mrpt_graphslam_2d

```
* mrpt_graphslam_2d: Correct syntax in README file
* mrpt_graphslam_2d: Complete the demo rviz, launch files
  Finish setting up the demos-related files.
  Setup a hierarchy of launchfiles with each each one delegating the
  corresponding tasks to the next one with the sr_graphslam.launch as the
  final link in this chain. This should make up for an easier maintenance
  of the whole setup later on.
* Renamed demo bagfile
* Be consistent with rviz, launchfile names
* Readd demo_short_loop bag
* mrpt_graphslam_2d: Add demo_gt launchfile for launching demo rosbag
* Skip mrpt_graphslam_2d compilation if MRPT version < 1.5.0
* mrpt_graphslam_2d: Add rviz file for complete single-robot SLAM experiment
* mrpt_graphslam_2d: Use tf2 for all tf transformations.
  Commit also includes the following:
  - Introduction of the "anchor node", that is the frame that (a specific)
  robot trajectory starts from, which should also differ from the world
  frame in a multi-robot setup.
  - Odometry input messages are expected to be of type nav_msgs::Odometry,
  instead of the custom msg Pose2DStamped used so far
* mrpt_graphslam_2d: Make changes to graphslam.launch file
* mrpt_graphslam_2d: Add to the launchfiles
* Contributors: Nikos Koukis
```

## mrpt_icp_slam_2d

```
* Fix cmakelists typo
* Contributors: Nikos Koukis
```

## mrpt_rbpf_slam

```
* Include ros/console hdr
* Fix cmakelists typo
* Contributors: Nikos Koukis
```

## mrpt_slam

- No changes
