### PR TITLE
Adding omip_msgs to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7509,6 +7509,16 @@ repositories:
       url: https://github.com/tu-rbo/omip.git
       version: indigo
     status: maintained
+  omip_msgs:
+    doc:
+      type: git
+      url: https://github.com/tu-rbo/omip_msgs.git
+      version: indigo
+    source:
+      type: git
+      url: https://github.com/tu-rbo/omip_msgs.git
+      version: indigo
+    status: maintained
   ompl:
     release:
       tags:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3158,6 +3158,16 @@ repositories:
       url: https://github.com/tu-rbo/omip.git
       version: kinetic
     status: maintained
+  omip_msgs:
+    doc:
+      type: git
+      url: https://github.com/tu-rbo/omip_msgs.git
+      version: kinetic
+    source:
+      type: git
+      url: https://github.com/tu-rbo/omip_msgs.git
+      version: kinetic
+    status: maintained
   ompl:
     release:
       tags:


### PR DESCRIPTION
I'd like to add omip_msgs (dependency of omip) to be indexed and documented at ros.org