### PR TITLE
fiducials: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2816,6 +2816,27 @@ repositories:
       url: https://github.com/fetchrobotics/fetch_tools.git
       version: master
     status: developed
+  fiducials:
+    doc:
+      type: git
+      url: https://github.com/UbiquityRobotics/fiducials
+      version: indigo-devel
+    release:
+      packages:
+      - fiducial_detect
+      - fiducial_lib
+      - fiducial_pose
+      - fiducial_slam
+      - fiducials
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/UbiquityRobotics-release/fiducials-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/UbiquityRobotics/fiducials
+      version: indigo-devel
+    status: developed
   filters:
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2819,7 +2819,7 @@ repositories:
   fiducials:
     doc:
       type: git
-      url: https://github.com/UbiquityRobotics/fiducials
+      url: https://github.com/UbiquityRobotics/fiducials.git
       version: indigo-devel
     release:
       packages:
@@ -2834,7 +2834,7 @@ repositories:
       version: 0.0.1-0
     source:
       type: git
-      url: https://github.com/UbiquityRobotics/fiducials
+      url: https://github.com/UbiquityRobotics/fiducials.git
       version: indigo-devel
     status: developed
   filters:


### PR DESCRIPTION
Increasing version of package(s) in repository `fiducials` to `0.0.1-0`:

- upstream repository: https://github.com/UbiquityRobotics/fiducials
- release repository: https://github.com/UbiquityRobotics-release/fiducials-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
