### PR TITLE
click: 6.2.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -437,6 +437,13 @@ repositories:
       url: https://github.com/ros/class_loader.git
       version: indigo-devel
     status: maintained
+  click:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/asmodehn/click-rosrelease.git
+      version: 6.2.0-0
+    status: maintained
   cmake_modules:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `click` to `6.2.0-0`:

- upstream repository: https://github.com/pallets/click.git
- release repository: https://github.com/asmodehn/click-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
