### PR TITLE
jsk_recognition: 0.3.29-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2124,7 +2124,11 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 0.3.25-0
+      version: 0.3.29-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_recognition.git
+      version: master
     status: developed
   jsk_roseus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `0.3.29-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.3.25-0`

## checkerboard_detector

- No changes

## imagesift

- No changes

## jsk_pcl_ros

```
* CMakeLists.txt: install nodelet.xml: for get to care about install process in #1929
* Contributors: Kei Okada
```

## jsk_pcl_ros_utils

- No changes

## jsk_perception

```
* CMakeLists.txt: install nodelet.xml: for get to care about install process in #1929
* Contributors: Kei Okada
```

## jsk_recognition

- No changes

## jsk_recognition_msgs

- No changes

## jsk_recognition_utils

- No changes

## resized_image_transport

- No changes
