### PR TITLE
tblib: 1.2.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5312,6 +5312,13 @@ repositories:
       url: https://github.com/swri-robotics/swri_console.git
       version: master
     status: developed
+  tblib:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/asmodehn/tblib-rosrelease.git
+      version: 1.2.0-1
+    status: maintained
   teb_local_planner:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tblib` to `1.2.0-1`:

- upstream repository: https://github.com/ionelmc/python-tblib.git
- release repository: https://github.com/asmodehn/tblib-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## tblib

```
* Fixed handling for tracebacks from generators and other internal improvements
  and optimizations. Contributed by DRayX in #10 <https://github.com/ionelmc/python-tblib/issues/10>
  and #11 <https://github.com/ionelmc/python-tblib/pull/11>.
```
