### PR TITLE
webtest: 2.0.18-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6176,6 +6176,13 @@ repositories:
       url: https://github.com/jihoonl/waypoint.git
       version: master
     status: developed
+  webtest:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/asmodehn/webtest-rosrelease.git
+      version: 2.0.18-0
+    status: maintained
   wireless:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webtest` to `2.0.18-0`:

- upstream repository: https://github.com/Pylons/webtest.git
- release repository: https://github.com/asmodehn/webtest-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## webtest

```
* Avoid deprecation warning with py3.4
```
