### PR TITLE
webtest: 2.0.18-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6846,7 +6846,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/webtest-rosrelease.git
-      version: 2.0.18-0
+      version: 2.0.18-1
     status: maintained
   wireless:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `webtest` to `2.0.18-1`:

- upstream repository: https://github.com/Pylons/webtest.git
- release repository: https://github.com/asmodehn/webtest-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.0.18-0`

## webtest

```
* Avoid deprecation warning with py3.4
```
