### PR TITLE
webtest: 2.0.18-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14328,7 +14328,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/webtest-rosrelease.git
-      version: 2.0.18-0
+      version: 2.0.18-1
     status: maintained
   wge100_driver:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `webtest` to `2.0.18-1`:

- upstream repository: https://github.com/Pylons/webtest.git
- release repository: https://github.com/asmodehn/webtest-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.0.18-0`

## webtest

```
* Avoid deprecation warning with py3.4
```
