### PR TITLE
rosserial: 0.7.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4753,13 +4753,14 @@ repositories:
       - rosserial_msgs
       - rosserial_python
       - rosserial_server
+      - rosserial_test
       - rosserial_tivac
       - rosserial_windows
       - rosserial_xbee
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rosserial-release.git
-      version: 0.7.4-0
+      version: 0.7.5-0
     source:
       type: git
       url: https://github.com/ros-drivers/rosserial.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4753,7 +4753,6 @@ repositories:
       - rosserial_msgs
       - rosserial_python
       - rosserial_server
-      - rosserial_test
       - rosserial_tivac
       - rosserial_windows
       - rosserial_xbee


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial` to `0.7.5-0`:

- upstream repository: https://github.com/ros-drivers/rosserial.git
- release repository: https://github.com/ros-gbp/rosserial-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.7.4-0`

## rosserial

- No changes

## rosserial_arduino

```
* Missing 'h' inside constructor ArduinoHardware(ArduinoHardware& h) (#251 <https://github.com/ros-drivers/rosserial/issues/251>)
* Contributors: MalcolmReynlods
```

## rosserial_client

```
* rosserial client variable typedefs (#254 <https://github.com/ros-drivers/rosserial/issues/254>)
  * Add typedefs to generated messages
  This brings rosserial message headers in line with
  roscpp headers that provide a typedef for the message
  variable member.
  * Removing unused imports and variables.
* Added functions for endian-agnostic memory copying (#240 <https://github.com/ros-drivers/rosserial/issues/240>)
* Contributors: Mike O'Driscoll, ivan
```

## rosserial_embeddedlinux

- No changes

## rosserial_mbed

- No changes

## rosserial_msgs

- No changes

## rosserial_python

- No changes

## rosserial_server

```
* Fixing build errors for boost >=1.60 (#226 <https://github.com/ros-drivers/rosserial/issues/226>) (#250 <https://github.com/ros-drivers/rosserial/issues/250>)
* Contributors: Malte Splietker
```

## rosserial_test

- No changes

## rosserial_tivac

- No changes

## rosserial_windows

- No changes

## rosserial_xbee

- No changes
