### PR TITLE
webargs: 1.3.4-7 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14317,7 +14317,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/webargs-rosrelease.git
-      version: 1.3.4-6
+      version: 1.3.4-7
     status: maintained
   webtest:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `webargs` to `1.3.4-7`:

- upstream repository: https://github.com/sloria/webargs.git
- release repository: https://github.com/asmodehn/webargs-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.3.4-6`

## webargs

```
Bug fixes:
* Fix bug in parsing form in Falcon>=1.0.
```
