### PR TITLE
robotis_framework: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4107,7 +4107,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_framework` to `0.2.1-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.2.0-0`

## robotis_controller

```
* Merge the changes and update
* 
  
    * Direct Control Mode bug fixed.
  
* update
* 
  
    * added writeControlTableCallback
  
* 
  
    * added WriteControlTable msg callback
  
* mode change debugging
* 
  
    * optimized cpu usage by spin loop (by astumpf)
  
* 
  
    * robotis_controller process() : processing order changed.
  
  
    * 1st : packet communication
    * 2nd : processing modules
  
* 
  
    * dependencies fixed. (Pull requests #26 <https://github.com/ROBOTIS-GIT/ROBOTIS-Framework/issues/26>)
  
* 
  
    * make setJointCtrlModuleCallback() to the thread function & improved.
  
* 
  
    * modified dependency problem.
  
* 
  
    * reduce CPU consumption
  
* Contributors: Jay Song, Pyo, Zerom, SCH
```

## robotis_device

```
* Merge the changes and update
* mode change debugging
* 
  
    * convertRadian2Value / convertValue2Radian : commented out the code that limits the maximum/minimum value.
  
* 
  
    * modified dependency problem.
  
* Contributors: Jay Song, Pyo, Zerom, SCH
```

## robotis_framework

```
* Merge the changes and update
```

## robotis_framework_common

```
* Merge the changes and update
* 
  
    * dependencies fixed. (Pull requests #26 <https://github.com/ROBOTIS-GIT/ROBOTIS-Framework/issues/26>)
  
* 
  
    * modified dependency problem.
  
* Contributors: Jay Song, Pyo, Zerom
```
