### PR TITLE
robotis_controller_msgs: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4087,7 +4087,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-msgs-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework-msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_controller_msgs` to `0.1.1-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework-msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.0-0`

## robotis_controller_msgs

```
* added WriteControlTable.msg
* Contributors: Changhyun Sung, Jay Song, Zerom
```
