### PR TITLE
fiducials: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2831,7 +2831,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/fiducials-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/fiducials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fiducials` to `0.0.2-0`:

- upstream repository: https://github.com/UbiquityRobotics/fiducials
- release repository: https://github.com/UbiquityRobotics-release/fiducials-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.1-0`
