### PR TITLE
Add python-imaging and libgazebo7-dev rosdep rules for fedora 25

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1607,6 +1607,8 @@ libgazebo5-dev:
 libgazebo7-dev:
   arch: [gazebo]
   debian: [libgazebo7-dev]
+  fedora:
+    '25': [gazebo-devel]
   gentoo: [sci-electronics/gazebo]
   ubuntu: [libgazebo7-dev]
 libgeographiclib-dev:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -909,6 +909,7 @@ python-imaging:
     '22': [python-pillow, python-pillow-qt]
     '23': [python-pillow, python-pillow-qt]
     '24': [python-pillow, python-pillow-qt]
+    '25': [python-pillow, python-pillow-qt]
     beefy: [python-imaging]
     heisenbug: [python-pillow, python-pillow-qt]
     schrödinger’s: [python-pillow, python-pillow-qt]


### PR DESCRIPTION
Resolving the dependencies to build Kinetic in Fedora 25 fails with the following errors:

```shell
$ rosdep install --from-paths src --ignore-src --rosdistro kinetic -y
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
rqt_bag_plugins: No definition of [python-imaging] for OS version [25]
rosbag: No definition of [python-imaging] for OS version [25]
gazebo_ros: No definition of [libgazebo7-dev] for OS [fedora]
gazebo_plugins: No definition of [libgazebo7-dev] for OS [fedora]
```

This pull request have patches that fix both issues:

```shell
$ rosdep resolve python-imaging --os=fedora:25
#dnf
python-pillow python-pillow-qt

$ rosdep resolve libgazebo7-dev --os=fedora:25
#dnf
gazebo-devel

$ rosdep install --from-paths src --ignore-src --rosdistro kinetic -y
#All required rosdeps installed successfully
```