### PR TITLE
widowx_arm: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14364,7 +14364,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/widowx_arm-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/widowx_arm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `widowx_arm` to `0.0.2-0`:

- upstream repository: https://github.com/RobotnikAutomation/widowx_arm.git
- release repository: https://github.com/RobotnikAutomation/widowx_arm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.0.1-0`

## widowx_arm

- No changes

## widowx_arm_controller

- No changes

## widowx_arm_description

```
* modified cmakelists and package.xml
* DEL: urdf and xacro files
* MOD: changed launch
* NEW: renamed widowx_macro.xacro to widowx.urdf.xacro, created robots/widowx_arm.urdf.xacro
* Contributors: Jose Rapado, carlos3dx
```
