### PR TITLE
nao_robot: 0.5.15-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3069,7 +3069,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/nao_robot-release.git
-      version: 0.5.14-0
+      version: 0.5.15-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_robot` to `0.5.15-0`:

- upstream repository: https://github.com/ros-naoqi/nao_robot.git
- release repository: https://github.com/ros-naoqi/nao_robot-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.5.14-0`

## nao_apps

```
* add missing dependencies
* renamed tacticle to tactile
* [nao_apps] Fixing bug generated when renaming in naoqi_bridge_msgs TactileTouch to HeadTouch
* Fix hard-coded node name in dynamic_reconfigure.client, closes #26 <https://github.com/ros-naoqi/nao_robot/issues/26>
* Contributors: Felip Marti, Mikael Arguedas, Stefan Osswald
```

## nao_bringup

- No changes

## nao_description

- No changes

## nao_robot

- No changes
