### PR TITLE
csapex: 0.9.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -625,7 +625,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/betwo/csapex-release.git
-      version: 0.9.3-0
+      version: 0.9.4-0
     source:
       type: git
       url: https://github.com/cogsys-tuebingen/csapex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `csapex` to `0.9.4-0`:

- upstream repository: https://github.com/cogsys-tuebingen/csapex.git
- release repository: https://github.com/betwo/csapex-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.9.3-0`

## csapex

```
* removed debug ouputs; builds on kinetic
* ported to kinetic
* use tempoary file name based on pid to get unique file handles
* fixed cmake installing
* suppress plugin.xml files that do not exist
* fixed race-condition when multiple instances want to persist settings
* added observer class to generalize reactive observing behaviour
* Contributors: buck, robot
```
