### PR TITLE
aubo_robot: 0.3.10-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -180,6 +180,34 @@ repositories:
       url: https://github.com/GT-RAIL/async_web_server_cpp.git
       version: develop
     status: maintained
+  aubo_robot:
+    doc:
+      type: git
+      url: https://github.com/auboliuxin/aubo_robot.git
+      version: jade-devel
+    release:
+      packages:
+      - aubo_control
+      - aubo_description
+      - aubo_driver
+      - aubo_gazebo
+      - aubo_i5_moveit_config
+      - aubo_kinematics
+      - aubo_msgs
+      - aubo_new_driver
+      - aubo_panel
+      - aubo_robot
+      - aubo_trajectory
+      - aubo_trajectory_filters
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/auboliuxin/aubo_robot-release.git
+      version: 0.3.10-1
+    source:
+      type: git
+      url: https://github.com/auboliuxin/aubo_robot.git
+      version: jade-devel
+    status: developed
   audio_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aubo_robot` to `0.3.10-1`:

- upstream repository: https://github.com/auboliuxin/aubo_robot.git
- release repository: https://github.com/auboliuxin/aubo_robot-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## aubo_i5_moveit_config

- No changes
