### PR TITLE
aubo_robot: 0.3.12-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -500,7 +500,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/auboliuxin/aubo_robot-release.git
-      version: 0.3.6-0
+      version: 0.3.12-1
     source:
       type: git
       url: https://github.com/auboliuxin/aubo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aubo_robot` to `0.3.12-1`:

- upstream repository: https://github.com/auboliuxin/aubo_robot.git
- release repository: https://github.com/auboliuxin/aubo_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.3.6-0`
