### PR TITLE
notify about new package so that prerelease test can be triggered

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3037,6 +3037,16 @@ repositories:
       url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can.git
       version: master
     status: maintained
+  fzi_icl_comm:
+    doc:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_comm.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_comm.git
+      version: master
+    status: maintained
   fzi_icl_core:
     doc:
       type: git


### PR DESCRIPTION
This is a new package about to being released. It's basically pulled out of schunk_svh_driver.