### PR TITLE
fzi_icl_comm: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3042,6 +3042,11 @@ repositories:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_comm.git
       version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_comm-release.git
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fzi_icl_comm` to `0.0.2-0`:

- upstream repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_comm.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_comm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## fzi_icl_comm

```
* corrected maintainer's email address
* moved fzi prefix from roscpp to icl_core
  this error was introduced before
* Contributors: Felix Mauch
```
