### PR TITLE
Removing indigo releases that are repeatedly failing on the farm.

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2768,7 +2768,6 @@ repositories:
     release:
       packages:
       - fetch_arm_control
-      - fetch_pbd_interaction
       - fetch_social_gaze
       tags:
         release: release/indigo/{package}/{version}

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6060,7 +6060,6 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/micros-uav/micros_hopfield-release.git
-      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/micros-uav/micros_hopfield.git
@@ -8263,7 +8262,6 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/photoneo/phoxi_camera-release.git
-      version: 1.1.4-0
     status: developed
   pi_tracker:
     doc:
@@ -11251,7 +11249,6 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/rosserial_leonardo_cmake-release.git
-      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/rosserial_leonardo_cmake.git
@@ -13258,7 +13255,6 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/OSLL/tiny-slam-ros-release.git
-      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/OSLL/tiny-slam-ros-cpp.git


### PR DESCRIPTION
All ticketed upstream:

- https://github.com/photoneo/phoxi_camera/issues/5
- https://github.com/micros-uav/micros_hopfield/issues/1
- https://github.com/clearpathrobotics/rosserial_leonardo_cmake/issues/2
- https://github.com/OSLL/tiny-slam-ros-cpp/issues/24