### PR TITLE
orocos_kinematics_dynamics: 1.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3370,7 +3370,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/smits/orocos-kdl-release.git
-      version: 1.3.0-0
+      version: 1.3.1-0
     source:
       type: git
       url: https://github.com/orocos/orocos_kinematics_dynamics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kinematics_dynamics` to `1.3.1-0`:

- upstream repository: https://github.com/orocos/orocos_kinematics_dynamics.git
- release repository: https://github.com/smits/orocos-kdl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.3.0-0`
