### PR TITLE
rtt_ros_integration: 2.8.4-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5761,7 +5761,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_ros_integration-release.git
-      version: 2.8.3-0
+      version: 2.8.4-1
     source:
       type: git
       url: https://github.com/orocos/rtt_ros_integration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_ros_integration` to `2.8.4-1`:

- upstream repository: https://github.com/orocos/rtt_ros_integration.git
- release repository: https://github.com/orocos-gbp/rtt_ros_integration-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.8.3-0`

## rtt_actionlib

- No changes

## rtt_actionlib_msgs

- No changes

## rtt_common_msgs

- No changes

## rtt_diagnostic_msgs

- No changes

## rtt_dynamic_reconfigure

- No changes

## rtt_geometry_msgs

- No changes

## rtt_kdl_conversions

- No changes

## rtt_nav_msgs

- No changes

## rtt_ros

```
* rtt_ros: fixed comment in rtt_ros/scripts/deployer-corba
* Merge pull request #40 <https://github.com/orocos/rtt_ros_integration/issues/40> from ahoarau/corba-deployer
  add Corba deployer scripts
* rtt_ros: fixed rttlua.launch for the SCREEN:=false case (fix #72 <https://github.com/orocos/rtt_ros_integration/issues/72>)
* Contributors: Johannes Meyer, Antoine Hoarau
```

## rtt_ros_comm

- No changes

## rtt_ros_integration

- No changes

## rtt_ros_msgs

- No changes

## rtt_rosclock

- No changes

## rtt_roscomm

```
* Merge pull request #79 <https://github.com/orocos/rtt_ros_integration/issues/79> from meyerj/added-rtt-rosservice-operations
  rtt_roscomm: added operations disconnect() and disconnectAll() to the rosservice service
* Merge branch 'B`#59 <https://github.com/orocos/rtt_ros_integration/issues/59>`__cleaning_registered_services' of https://github.com/ubi-agni/rtt_ros_integration into indigo-devel
* rtt_roscomm: include exported headers and link typekit and transport plugin to exported libraries
* rtt_roscomm: export build dependency roscpp
* Contributors: Johannes Meyer, Guillaume Walck
```

## rtt_rosdeployment

- No changes

## rtt_rosgraph_msgs

- No changes

## rtt_rosnode

- No changes

## rtt_rospack

- No changes

## rtt_rosparam

- No changes

## rtt_sensor_msgs

- No changes

## rtt_shape_msgs

- No changes

## rtt_std_msgs

- No changes

## rtt_std_srvs

- No changes

## rtt_stereo_msgs

- No changes

## rtt_tf

- No changes

## rtt_trajectory_msgs

- No changes

## rtt_visualization_msgs

- No changes
