### PR TITLE
pruning kinetic packages that have not built in at least 1 month

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2234,7 +2234,6 @@ repositories:
     release:
       packages:
       - manipulator_h
-      - manipulator_h_base_module
       - manipulator_h_base_module_msgs
       - manipulator_h_bringup
       - manipulator_h_description
@@ -3581,7 +3580,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/photoneo/phoxi_camera-release.git
-      version: 1.1.3-1
     status: developed
   pid:
     doc:
@@ -4100,7 +4098,6 @@ repositories:
       version: kinetic-devel
     release:
       packages:
-      - robotis_controller
       - robotis_device
       - robotis_framework
       - robotis_framework_common
@@ -5440,20 +5437,11 @@ repositories:
       version: kinetic-devel
     release:
       packages:
-      - ati_ft_sensor
-      - motion_module_tutorial
-      - sensor_module_tutorial
-      - thormang3_action_module
       - thormang3_balance_control
-      - thormang3_base_module
       - thormang3_feet_ft_module
-      - thormang3_head_control_module
-      - thormang3_imu_3dm_gx4
       - thormang3_kinematics_dynamics
       - thormang3_manager
-      - thormang3_manipulation_module
       - thormang3_mpc
-      - thormang3_walking_module
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-MPC-release.git
@@ -5494,8 +5482,6 @@ repositories:
       version: kinetic-devel
     release:
       packages:
-      - thormang3_action_script_player
-      - thormang3_foot_step_generator
       - thormang3_offset_tuner_client
       - thormang3_opc
       tags:
@@ -5517,7 +5503,6 @@ repositories:
       - thormang3_manipulation_demo
       - thormang3_ppc
       - thormang3_sensors
-      - thormang3_walking_demo
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-PPC-release.git
@@ -5554,7 +5539,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/OSLL/tiny-slam-ros-release.git
-      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/OSLL/tiny-slam-ros-cpp.git


### PR DESCRIPTION
@robotpilot @krinkin @matejsladek You made the most recent releases of these packages. 

Failures on Xenial amd64
![x64_failures](https://cloud.githubusercontent.com/assets/447804/20646692/19089694-b435-11e6-9940-841e99962b17.png)

And these are failing on other architectures too for example armv8
![xv8_failures](https://cloud.githubusercontent.com/assets/447804/20646698/335ac512-b435-11e6-9d41-0958b2d344dd.png)


These packages are failing to build every night. Removing these entries means that we won't use resources trying to rebuild them. Most of them appear to be missing dependencies. 

There are archives of the notifications here: https://groups.google.com/forum/#!forum/ros-buildfarm-kinetic  The jobs themselves will dissapear when the farm reconfigures. 


