### PR TITLE
jaguar: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1757,6 +1757,18 @@ repositories:
       url: https://github.com/ros/ivcon.git
       version: kinetic-devel
     status: maintained
+  jaguar:
+    release:
+      packages:
+      - jaguar_control
+      - jaguar_description
+      - jaguar_msgs
+      - jaguar_navigation
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/gstavrinos/jaguar-release.git
+      version: 0.1.0-0
+    status: developed
   joystick_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jaguar` to `0.1.0-0`:

- upstream repository: https://github.com/gstavrinos/jaguar
- release repository: https://github.com/gstavrinos/jaguar-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## jaguar_control

```
* Functional Indoors Navigation
* Contributors: George Stavrinos
```

## jaguar_description

```
* Stable robot description
* Contributors: George Stavrinos
```

## jaguar_msgs

```
* Added Jaguar message definitions
* Contributors: George Stavrinos
```

## jaguar_navigation

```
* Functional Indoors Navigation
* Contributors: George Stavrinos
```
