### PR TITLE
realsense_camera: 1.6.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3948,7 +3948,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/intel-ros/realsense-release.git
-      version: 1.6.0-0
+      version: 1.6.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_camera` to `1.6.1-0`:

- upstream repository: https://github.com/intel-ros/realsense.git
- release repository: https://github.com/intel-ros/realsense-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.6.0-0`

## realsense_camera

```
* Clean up system process calls
* Display warning for hardcoded extrinsic
* Added exception handling
* Improve error messages
* Prevent double freeing of error data
* Added enable_ir args to modify_params tests for R200,SR300,F200
* Added enable IR and IR2 flags to rgbd launch file
* Added RVIZ file for viewing RGBD pointcloud
* Added realsense_default rviz file
* Added ability to enable IR2 stream for ZR300
* Added ability to enable IR streams independent of depth
* Make building ROS unit tests optional
* Add ROS Issue Tracking to ROS Wiki
* Contributors: Dmitry Rozhkov, Mark D Horn, Matt Hansen
```
