### PR TITLE
changing tornado debian entry to not use pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2532,9 +2532,7 @@ python-tk:
     xenial: [python-tk]
     xenial_python3: [python3-tk]
 python-tornado:
-  debian:
-    pip:
-      packages: [tornado]
+  debian: [python-tornado]
   fedora: [python-tornado]
   osx:
     pip:


### PR DESCRIPTION
because bloom tells me :
```
Key 'python-tornado' resolved to '['tornado']' with installer 'pip', which does not match the default installer 'apt'.
Failed to resolve python-tornado on debian:jessie with: Error running generator: The Debian generator does not support dependencies which are installed with the 'pip' installer.
```

simplifying debian rule for python-tornado