### PR TITLE
dynamixel-workbench: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -766,7 +766,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
-      version: 0.1.2-1
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel-workbench` to `0.1.3-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
- release repository: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.2-1`

## dynamixel_workbench

```
* update torque controller
* add control parameters
* modified ros nodehandle
* Contributors: Darby Lim
```

## dynamixel_workbench_controllers

```
* update torque controller
* add control parameters
* modified ros nodehandle
* Contributors: Darby Lim
```

## dynamixel_workbench_msgs

```
* add drive_mode in XM series
* modified msgs files
* Contributors: Darby Lim
```

## dynamixel_workbench_single_manager

```
* add drive_mode in XM series
* update single manager and GUI
* modified msgs files
* Contributors: Darby Lim
```

## dynamixel_workbench_single_manager_gui

```
* add drive_mode in XM series
* update single manager and GUI
* modified msgs files
* Contributors: Darby Lim
```

## dynamixel_workbench_toolbox

```
* modifiy folder path
* add drive_mode in XM series
* Contributors: Darby Lim
```

## dynamixel_workbench_tutorials

```
* update torque controller
* add control parameters
* modified ros nodehandle
* Contributors: Darby Lim
```
