### PR TITLE
jaguar_robot: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1769,6 +1769,17 @@ repositories:
       url: https://github.com/gstavrinos/jaguar-release.git
       version: 0.1.0-0
     status: developed
+  jaguar_robot:
+    release:
+      packages:
+      - jaguar_base
+      - jaguar_bringup
+      - jaguar_robot
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/gstavrinos/jaguar_robot-release.git
+      version: 0.1.0-1
+    status: developed
   joystick_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jaguar_robot` to `0.1.0-1`:

- upstream repository: https://github.com/gstavrinos/jaguar_robot
- release repository: https://github.com/gstavrinos/jaguar_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## jaguar_base

```
* Functional Indoors Navigation
* Motor controller drivers are stable
* Contributors: George Stavrinos
```

## jaguar_bringup

```
* Added laser bringup launch file
* Added myahrs bringup launch file (external imu)
* Contributors: George Stavrinos
```

## jaguar_robot

```
* Metapackage for the physical robot (not simulated)
* Contributors: George Stavrinos
```
