### PR TITLE
ros_control: 0.11.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4441,7 +4441,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.11.1-0
+      version: 0.11.2-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.11.2-0`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.11.1-0`

## combined_robot_hw

```
* Add Toni's email to the author fields too
* Add Enrique and Bence to maintainer list
* Clean up export leftovers from rosbuild
* Convert to format2, fix dependency in cmake
* Add combined_robot_hw to metapackage & system figure
* Contributors: Bence Magyar
```

## combined_robot_hw_tests

```
* Add Toni's email to the author fields too
* Add Enrique and Bence to maintainer list
* Convert to format2, fix dependency in cmake
* Contributors: Bence Magyar
```

## controller_interface

```
* Remove boost from depends declaration to fix cmake warning
* sort dependencies
* Add Enrique and Bence to maintainer list
* Clean up export leftovers from rosbuild
* Convert to format2, fix dependency in cmake
* Contributors: Bence Magyar
```

## controller_manager

```
* to[to.size-1] to to.back()
* Remove boost from depends declaration to fix cmake warning
* Add Enrique and Bence to maintainer list
* Clean up export leftovers from rosbuild
* Convert to format2, fix dependency in cmake
* Contributors: Bence Magyar
```

## controller_manager_msgs

```
* Add Enrique and Bence to maintainer list
* Clean up export leftovers from rosbuild
* Convert to format2, fix dependency in cmake
* Contributors: Bence Magyar
```

## controller_manager_tests

```
* Add Enrique and Bence to maintainer list
* Contributors: Bence Magyar
```

## hardware_interface

```
* Add Enrique and Bence to maintainer list
* Clean up export leftovers from rosbuild
* Convert to format2, fix dependency in cmake
* Contributors: Bence Magyar
```

## joint_limits_interface

```
* Add Enrique and Bence to maintainer list
* Clean up export leftovers from rosbuild
* Convert to format2, fix dependency in cmake
* Replace boost::shared_ptr<urdf::XY> with urdf::XYConstSharedPtr
* Contributors: Bence Magyar
```

## ros_control

```
* Add Enrique and Bence to maintainer list
* Convert to format2, fix dependency in cmake
* Add combined_robot_hw to metapackage & system figure
* Contributors: Bence Magyar
```

## rqt_controller_manager

```
* Add Enrique and Bence to maintainer list
* Convert to format2, fix dependency in cmake
* Contributors: Bence Magyar
```

## transmission_interface

```
* Add Enrique and Bence to maintainer list
* Clean up export leftovers from rosbuild
* Convert to format2, fix dependency in cmake
* Contributors: Bence Magyar
```
