### PR TITLE
rosdep: python-future available since Ubuntu 15.10

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -772,7 +772,19 @@ python-future:
   osx:
     pip:
       packages: [future]
-  ubuntu: [python-future]
+  ubuntu:
+    trusty:
+      pip:
+        packages: [future]
+    utopic:
+      pip:
+        packages: [future]
+    vivid:
+      pip:
+        packages: [future]
+    wily: [python-future]
+    xenial: [python-future]
+    yakkety: [python-future]
 python-fysom:
   debian:
     pip:


### PR DESCRIPTION
That patch should fix rosdep resolving on old ubuntu releases.
Example is Travis CI...

Trusty - Vivid should use PYPI package.