### PR TITLE
remove aubo_control which is not expected to build and aubo_robot whi…

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -485,7 +485,6 @@ repositories:
       version: indigo-devel
     release:
       packages:
-      - aubo_control
       - aubo_description
       - aubo_driver
       - aubo_gazebo
@@ -494,7 +493,6 @@ repositories:
       - aubo_msgs
       - aubo_new_driver
       - aubo_panel
-      - aubo_robot
       - aubo_trajectory
       - aubo_trajectory_filters
       tags:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -187,7 +187,6 @@ repositories:
       version: jade-devel
     release:
       packages:
-      - aubo_control
       - aubo_description
       - aubo_driver
       - aubo_gazebo
@@ -196,7 +195,6 @@ repositories:
       - aubo_msgs
       - aubo_new_driver
       - aubo_panel
-      - aubo_robot
       - aubo_trajectory
       - aubo_trajectory_filters
       tags:


### PR DESCRIPTION
…ch depends on aubo_control

Removing since it has an external dependency: https://github.com/auboliuxin/aubo_robot/issues/4