### PR TITLE
gauges: 1.0.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1220,10 +1220,13 @@ repositories:
       url: https://github.com/UTNuclearRoboticsPublic/gauges.git
       version: master
     release:
+      packages:
+      - gauges
+      - rqt_gauges
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/UTNuclearRoboticsPublic/gauges-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/UTNuclearRoboticsPublic/gauges.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gauges` to `1.0.3-0`:

- upstream repository: https://github.com/UTNuclearRoboticsPublic/gauges.git
- release repository: https://github.com/UTNuclearRoboticsPublic/gauges-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.2-0`
