### PR TITLE
gauges: 1.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1152,10 +1152,13 @@ repositories:
       url: https://github.com/UTNuclearRoboticsPublic/gauges.git
       version: master
     release:
+      packages:
+      - gauges
+      - rqt_gauges
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UTNuclearRoboticsPublic/gauges-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/UTNuclearRoboticsPublic/gauges.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gauges` to `1.0.3-0`:

- upstream repository: https://github.com/UTNuclearRoboticsPublic/gauges.git
- release repository: https://github.com/UTNuclearRoboticsPublic/gauges-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.2-0`
