### PR TITLE
gauges: 1.0.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1226,7 +1226,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/UTNuclearRoboticsPublic/gauges-release.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/UTNuclearRoboticsPublic/gauges.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gauges` to `1.0.5-0`:

- upstream repository: https://github.com/UTNuclearRoboticsPublic/gauges.git
- release repository: https://github.com/UTNuclearRoboticsPublic/gauges-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.4-0`
