### PR TITLE
mqtt_bridge: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2686,6 +2686,17 @@ repositories:
       url: https://github.com/davetcoleman/moveit_visual_tools.git
       version: kinetic-devel
     status: developed
+  mqtt_bridge:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/groove-x/mqtt_bridge-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/groove-x/mqtt_bridge.git
+      version: master
+    status: developed
   mrpt_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_bridge` to `0.1.1-1`:

- upstream repository: https://github.com/groove-x/mqtt_bridge.git
- release repository: https://github.com/groove-x/mqtt_bridge-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## mqtt_bridge

```
* Add CHANGELOG.rst
```
