### PR TITLE
Bump OpenCV3 to 3.1.0-17

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3283,7 +3283,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/opencv3-release.git
-      version: 3.1.0-16
+      version: 3.1.0-17
     status: maintained
   opencv_apps:
     doc:


### PR DESCRIPTION
This fixes OSX compilation: https://github.com/ros-gbp/opencv3-release/issues/6