### PR TITLE
vision_opencv: 1.12.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6103,7 +6103,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.12.2-0
+      version: 1.12.3-0
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.12.3-0`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.12.2-0`

## cv_bridge

```
* Use api in sensor_msgs to get byte_depth and num channels
* Implement cpp conversion of N channel image
  This is cpp version of https://github.com/ros-perception/vision_opencv/pull/141,
  which is one for python.
* Fill black color to depth nan region
* address gcc6 build error in cv_bridge and tune
  With gcc6, compiling fails with stdlib.h: No such file or directory,
  as including '-isystem /usr/include' breaks with gcc6, cf.,
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129
  This commit addresses this issue for cv_bridge in the same way
  it was done in the commit ead421b8 [1] for image_geometry.
  This issue was also addressed in various other ROS packages.
  A list of related commits and pull requests is at:
  https://github.com/ros/rosdistro/issues/12783
  [1] https://github.com/ros-perception/vision_opencv/commit/ead421b85eeb750cbf7988657015296ed6789bcf
  Signed-off-by: Lukas Bulwahn <mailto:lukas.bulwahn@oss.bmw-carit.de>
* cv_bridge: Add missing test_depend on numpy
* Contributors: Kentaro Wada, Lukas Bulwahn, Maarten de Vries
```

## image_geometry

- No changes

## vision_opencv

- No changes
