### PR TITLE
mqtt_bridge: 0.1.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2687,11 +2687,15 @@ repositories:
       version: kinetic-devel
     status: developed
   mqtt_bridge:
+    doc:
+      type: git
+      url: https://github.com/groove-x/mqtt_bridge.git
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/groove-x/mqtt_bridge-release.git
-      version: 0.1.2-0
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/groove-x/mqtt_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_bridge` to `0.1.2-1`:

- upstream repository: https://github.com/groove-x/mqtt_bridge.git
- release repository: https://github.com/groove-x/mqtt_bridge-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.2-0`

## mqtt_bridge

```
* Fix CMakeLists.txt and package.xml
```
