### PR TITLE
arni: 1.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -380,6 +380,20 @@ repositories:
       url: https://github.com/voxel-dot-at/argos3d_p100_ros_pkg.git
       version: master
   arni:
+    release:
+      packages:
+      - arni_core
+      - arni_countermeasure
+      - arni_gui
+      - arni_msgs
+      - arni_nodeinterface
+      - arni_processing
+      - rqt_arni_gui_detail
+      - rqt_arni_gui_overview
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ROS-PSE/arni-release.git
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/ROS-PSE/arni.git


### PR DESCRIPTION
Increasing version of package(s) in repository `arni` to `1.1.1-0`:

- upstream repository: https://github.com/ROS-PSE/arni.git
- release repository: https://github.com/ROS-PSE/arni-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
