### PR TITLE
ros_wild: 0.4.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4596,6 +4596,17 @@ repositories:
       url: https://github.com/facontidavide/ros_type_introspection.git
       version: master
     status: developed
+  ros_wild:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yuma-m/ros_wild-release.git
+      version: 0.4.2-0
+    source:
+      type: git
+      url: https://github.com/yuma-m/ros_wild.git
+      version: master
+    status: developed
   rosauth:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_wild` to `0.4.2-0`:

- upstream repository: https://github.com/yuma-m/ros_wild.git
- release repository: https://github.com/yuma-m/ros_wild-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
