### PR TITLE
gazebo_ros_pkgs: 2.6.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1246,7 +1246,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.6.0-0
+      version: 2.6.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.6.1-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.6.0-0`

## gazebo_msgs

- No changes

## gazebo_plugins

```
* Fix camera distortion coefficients order. Now {k1, k2, p1, p2, k3}
* Contributors: Enrique Fernandez
```

## gazebo_ros

```
* Workaround to support gazebo and ROS arguments in the command line
* Fix ROS remappings by reverting "Remove ROS remapping arguments from gazebo_ros launch scripts"
* Added comments regarding 'headless' arg. Added 'recording' arg as switch for -r
* Fixed getlinkstate service's angular velocity return
* Add a roslaunch 'required' argument: enables the 'required' flag on gazebo_gui node
* Add an argument to enable required flag on gazebo gui, same tag name "required" as in ROS
* Contributors: Jared, Jon Binney, Jordan Liviero, Jose Luis Rivero, vincentrou
```

## gazebo_ros_control

- No changes

## gazebo_ros_pkgs

- No changes
