### PR TITLE
gazebo_ros_pkgs: 2.5.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1199,7 +1199,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.5.7-0
+      version: 2.5.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.5.8-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.5.7-0`

## gazebo_msgs

- No changes

## gazebo_plugins

```
* Fix camera distortion coefficients order. Now {k1, k2, p1, p2, k3}
* Added an interface to gazebo's harness plugin
* Contributors: Enrique Fernandez, Steven Peters, Nate Koenig
```

## gazebo_ros

```
* Workaround to support gazebo and ROS arguments in the command line
* Fix ROS remapping by reverting "Remove ROS remapping arguments from gazebo_ros launch scripts.
* Fixed getlinkstate service's angular velocity return
* Honor GAZEBO_MASTER_URI in gzserver and gzclient
* Contributors: Jared, Jon Binney, Jordan Liviero, Jose Luis Rivero, Martin Pecka
```

## gazebo_ros_control

- No changes

## gazebo_ros_pkgs

- No changes
