### PR TITLE
rosdep: Add entry of python-inject-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -966,6 +966,10 @@ python-impacket:
     trusty: [python-impacket]
     utopic: [python-impacket]
     vivid: [python-impacket]
+python-inject-pip:
+  ubuntu:
+    pip:
+      packages: [inject]
 python-itsdangerous:
   fedora: [python-itsdangerous]
   ubuntu: [python-itsdangerous]


### PR DESCRIPTION
Used by mqtt_bridge. I'm new to rosdep, and any advice would be appreciated.