### PR TITLE
hls-lfcd-lds-driver: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1598,6 +1598,23 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
       version: 0.3.4-0
     status: maintained
+  hls-lfcd-lds-driver:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
+      version: kinetic-devel
+    release:
+      packages:
+      - hls_lfcd_lds_driver
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
+      version: kinetic-devel
+    status: maintained
   hokuyo3d:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hls-lfcd-lds-driver` to `0.1.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
- release repository: https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## hls_lfcd_lds_driver

```
* modified the package name and related codes
* added a ROS package for HLDS Laser Distance Sensor
* Contributors: JH Yang, SP Kong, Pyo
```
