### PR TITLE
Add python-shapely for wily and xenial

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2021,6 +2021,8 @@ python-shapely:
     wily_python3: [python3-shapely]
     xenial: [python-shapely]
     xenial_python3: [python3-shapely]
+    yakkety: [python-shapely]
+    yakkety_python3: [python3-shapely]
 python-simplejson:
   debian: [python-simplejson]
   fedora: [python-simplejson]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2017,6 +2017,10 @@ python-shapely:
     utopic_python3: [python3-shapely]
     vivid: [python-shapely]
     vivid_python3: [python3-shapely]
+    wily: [python-shapely]
+    wily_python3: [python3-shapely]
+    xenial: [python-shapely]
+    xenial_python3: [python3-shapely]
 python-simplejson:
   debian: [python-simplejson]
   fedora: [python-simplejson]


### PR DESCRIPTION
http://packages.ubuntu.com/xenial/python/python-shapely
http://packages.ubuntu.com/xenial/python/python3-shapely

Wily is EOL, but without it this seems incomplete.