### PR TITLE
navigation_layers: 0.3.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2990,6 +2990,25 @@ repositories:
       url: https://github.com/ros-planning/navigation.git
       version: kinetic-devel
     status: maintained
+  navigation_layers:
+    doc:
+      type: git
+      url: https://github.com/DLu/navigation_layers.git
+      version: indigo
+    release:
+      packages:
+      - navigation_layers
+      - range_sensor_layer
+      - social_navigation_layers
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/wu-robotics/navigation_layers_release.git
+      version: 0.3.1-1
+    source:
+      type: git
+      url: https://github.com/DLu/navigation_layers.git
+      version: indigo
+    status: maintained
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_layers` to `0.3.1-1`:

- upstream repository: https://github.com/DLu/navigation_layers.git
- release repository: https://github.com/wu-robotics/navigation_layers_release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
