### PR TITLE
rospeex: 2.15.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5363,7 +5363,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://bitbucket.org/rospeex/rospeex-release.git
-      version: 2.14.6-0
+      version: 2.15.0-0
     source:
       type: git
       url: https://bitbucket.org/rospeex/rospeex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospeex` to `2.15.0-0`:

- upstream repository: https://bitbucket.org/rospeex/rospeex.git
- release repository: https://bitbucket.org/rospeex/rospeex-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.14.6-0`

## rospeex

- No changes

## rospeex_audiomonitor

- No changes

## rospeex_core

```
* Build Test on Jenkins
* fix saving wavfile
* fix corruption
* Merge branch 'develop' into indigo
```

## rospeex_if

```
* Fix Build Test Error on Jenkins/jade
* fix corruption
```

## rospeex_launch

- No changes

## rospeex_msgs

- No changes

## rospeex_samples

- No changes

## rospeex_webaudiomonitor

```
* Fix correspond to tornado 4.2.1
* Fix number of time out check
* Fix connector reconnection
* Fix vad server reconnection
```
