### PR TITLE
Adding asr_msgs to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -144,6 +144,11 @@ repositories:
       url: https://github.com/AutonomyLab/ardrone_autonomy.git
       version: indigo-devel
     status: developed
+  asr_msgs:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_msgs.git
+      version: master
   astra_camera:
     doc:
       type: git


### PR DESCRIPTION
I'd like asr_msgs to be indexed and documented under kinetic.