### PR TITLE
rosdep: Fix and update python-fcn-pip depends

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -696,7 +696,7 @@ python-falcon:
 python-fcn-pip:
   osx:
     pip:
-      depends: [libhdf5-dev, liblapack-dev, leveldb]
+      depends: [hdf5, gfortran]
       packages: [fcn]
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -700,7 +700,7 @@ python-fcn-pip:
       packages: [fcn]
   ubuntu:
     pip:
-      depends: [libhdf5-dev, liblapack-dev, leveldb]
+      depends: [libhdf5-dev, liblapack-dev]
       packages: [fcn]
 python-flake8:
   fedora:


### PR DESCRIPTION
- `leveldb` is no more needed 
- `libhdf5-dev`, `liblapack-dev` is not found on osx

cc. @wkentaro 