### PR TITLE
mapviz: 0.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2331,7 +2331,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 0.2.0-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `0.2.2-0`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.2.0-0`

## mapviz

```
* Migrated OpenCV to 3.1 (default in Kinetic)
* Contributors: Brian Holt
```

## mapviz_plugins

```
* Migrated OpenCV to 3.1 (default in Kinetic)
* General code cleanup of mapviz_plugins
  This doesn't change any functionality; it's just cleaning up code.  Notably, this will:
  - Fix all warnings (notably lots of ones about type casting)
  - Move all .ui files to their own directory
  - Remove unused variables
  - Remove commented-out code
  - Make spacing and indentation consistent
  - Make brace style consistent
* Contributors: Brian Holt, Marc Alban, P. J. Reed
```

## multires_image

```
* Migrated OpenCV to 3.1 (default in Kinetic)
* Contributors: Brian Holt
```

## tile_map

- No changes
