### PR TITLE
cob_extern: 0.6.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1490,7 +1490,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_extern-release.git
-      version: 0.6.9-0
+      version: 0.6.10-0
     source:
       type: git
       url: https://github.com/ipa320/cob_extern.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_extern` to `0.6.10-0`:

- upstream repository: https://github.com/ipa320/cob_extern.git
- release repository: https://github.com/ipa320/cob_extern-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.6.9-0`

## cob_extern

```
* update changelog
* manually fix changelogs
* Contributors: ipa-fxm
```

## libdlib

```
* manually fix changelogs
* Contributors: ipa-fxm
```

## libntcan

```
* update changelog
* manually fix changelogs
* Contributors: ipa-fxm
```

## libopengm

```
* manually fix changelogs
* Contributors: ipa-fxm
```

## libpcan

```
* update changelog
* manually fix changelogs
* Contributors: ipa-fxm
```

## libphidgets

```
* manually fix changelogs
* Contributors: ipa-fxm
```
