### PR TITLE
marti_common: 0.2.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2409,7 +2409,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.2.3-0`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.2.2-0`

## marti_data_structures

- No changes

## swri_console_util

```
* Fix OpenCV dependencies for Kinetic build (#400 <https://github.com/swri-robotics/marti_common/issues/400>)
* Contributors: P. J. Reed
```

## swri_geometry_util

```
* Fix OpenCV dependencies for Kinetic build (#400 <https://github.com/swri-robotics/marti_common/issues/400>)
* Contributors: P. J. Reed
```

## swri_image_util

```
* Fix OpenCV dependencies for Kinetic build (#400 <https://github.com/swri-robotics/marti_common/issues/400>)
* Contributors: P. J. Reed
```

## swri_math_util

- No changes

## swri_nodelet

- No changes

## swri_opencv_util

```
* Fix OpenCV dependencies for Kinetic build (#400 <https://github.com/swri-robotics/marti_common/issues/400>)
* Contributors: P. J. Reed
```

## swri_prefix_tools

- No changes

## swri_roscpp

- No changes

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

- No changes

## swri_yaml_util

- No changes
