### PR TITLE
ros_canopen: 0.6.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10453,16 +10453,18 @@ repositories:
       version: indigo_release_candidate
     release:
       packages:
+      - can_msgs
       - canopen_402
       - canopen_chain_node
       - canopen_master
       - canopen_motor_node
       - ros_canopen
+      - socketcan_bridge
       - socketcan_interface
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_canopen-release.git
-      version: 0.6.4-0
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.6.5-1`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.6.4-0`

## can_msgs

```
* hamonized versions
* styled and sorted CMakeLists.txt
  * removed boilerplate comments
  * indention
  * reviewed exported dependencies
* styled and sorted package.xml
* Adds message_runtime to can_msgs dependencies.
  Added the missing dependency, also changes message_generation to a build_depend.
* Finalizes work on the socketcan_bridge and can_msgs.
  Readies the packages socketcan_bridge and can_msgs for the merge with ros_canopen.
  Bumps the version for both packages to 0.1.0. Final cleanup in CMakeLists, added
  comments to the shell script and launchfile used for testing.
* Introduces the can_msgs package for message types.
  Package to hold CAN message types, the Frame message type can contain the data
  as returned by SocketCAN.
* Contributors: Ivor Wanders, Mathias Lüdtke
```

## canopen_402

```
* stop on internal limit only if limit was not reached before
* hardened code with the help of cppcheck
* Do not send control if it was not changed
  Otherwise invalid state machine transitions might get commanded
* styled and sorted CMakeLists.txt
  * removed boilerplate comments
  * indention
  * reviewed exported dependencies
* styled and sorted package.xml
* update package URLs
* added option to turn off mode monitor
* reset Fault_Reset bit in output only
* enforce rising edge on fault reset bit on init and recover
* Revert "Enforce rising edge on fault reset bit on init and recover"
* enforce rising edge on fault reset bit on init and recover
* Merge pull request #117 <https://github.com/ipa-mdl/ros_canopen/issues/117> from ipa-mdl/condvars
  Reviewed condition variables
* use boost::numeric_cast for limit checks since it handles 64bit values right
* add clamping test
* enforce target type limits
* ModeTargetHelper is now template
* readability fix
* simplified State402::waitForNewState and Motor402::switchState
* Set Halt bit unless current mode releases it
* Contributors: Mathias Lüdtke
```

## canopen_chain_node

```
* protect MotorChain setup with RosChain lock
* added include to <boost/scoped_ptr.hpp>; solving #177 <https://github.com/ipa-mdl/ros_canopen/issues/177>
* default to canopen::SimpleMaster::Allocator (#71 <https://github.com/ipa-mdl/ros_canopen/issues/71>)
* exit code for generic error should be 1, not -1
* styled and sorted CMakeLists.txt
  * removed boilerplate comments
  * indention
  * reviewed exported dependencies
* styled and sorted package.xml
* update package URLs
* moved roslib include into source file
* renamed chain_ros.h to ros_chain.h, fixes #126 <https://github.com/ipa-mdl/ros_canopen/issues/126>
* Use of catkin_EXPORTED_TARGETS
  Install target for canopen_ros_chain
* Splitted charn_ros.h into chain_ros.h and ros_chain.cpp
* Revert "stop heartbeat after stack was shutdown"
  This reverts commit de985b5e9664edbbcc4f743fff3e2a2391e1bf8f.
* improve failure handling in init service callback
* improved excetion handling in init and recover callback
* Merge pull request #109 <https://github.com/ipa-mdl/ros_canopen/issues/109> from ipa-mdl/shutdown-crashes
  Fix for pluginlib-related crashes on shutdown
* catch std::exception instead of canopen::Exception (#110 <https://github.com/ipa-mdl/ros_canopen/issues/110>)
* call to detroy is not needed anymore
* added GuardedClassLoader implementation
* minor shutdown improvements
* Contributors: Mathias Lüdtke, Michael Stoll, xaedes
```

## canopen_master

```
* Merge pull request #179 <https://github.com/ipa-mdl/ros_canopen/issues/179> from ipa-mdl/mixed_case_access
  support mixed-case access strings in EDS
* decouple listener initialization from 1003 binding
* introduced THROW_WITH_KEY and ObjectDict::key_info
* added access type tests
* convert access string to lowercase
* Do not remove shared memory automatically
* hardened code with the help of cppcheck
* throw verbose exception if AccessType is missing (#64 <https://github.com/ipa-mdl/ros_canopen/issues/64>)
* styled and sorted CMakeLists.txt
  * removed boilerplate comments
  * indention
  * reviewed exported dependencies
* styled and sorted package.xml
* canopen_master needs to depend on rosunit for gtest
* update package URLs
* fixed typo
* do not reset PDO COB-ID if it is not writable
* Do not recurse into sub-objects, handle them as simple data
* strip string before searching for $NODEID
* added NodeID/hex parser test
* do full recover if if driver is not ready
* wait for driver to be shutdown in run()
* limit SDO reader to size of 1
* do not send abort twice
* removed unnecessary sleep (added for tests only)
* catch all std exceptions in layer handlers
* migrated SDOClient to BufferedReader
* getter for LayerState
* fixed lost wake-up condition, unified SDO accessors
* minor NMT improvements
* removed cond from PDOMapper, it does not wait on empty buffer anymore
* Simple master counts nodes as well
* throw exception on read from empty buffer
* proper initialisation of PDO data from SDOs
* change sync subscription only on change
* shutdown and restart CAN layer on recover
* canopen::Exception is now based on std::runtime_error
* Merge pull request #109 <https://github.com/ipa-mdl/ros_canopen/issues/109> from ipa-mdl/shutdown-crashes
  Fix for pluginlib-related crashes on shutdown
* stop after heartbeat was disabled, do not wait for state switch
* added virtual destructor to SyncCounter
* Use getHeartbeatInterval()
* minor shutdown improvements
* removed unstable StateWaiter::wait_for
* Revert change to handleShutdown
* Heartbeat interval is uint16, not double
* Added validity check to heartbeat_ (Some devices do not support heartbeat)
* Contributors: Florian Weisshardt, Mathias Lüdtke, Michael Stoll
```

## canopen_motor_node

```
* protect MotorChain setup with RosChain lock
* Merge pull request #153 <https://github.com/ipa-mdl/ros_canopen/issues/153> from ipa-mdl/deprecated-canswitch
  deprecated canSwitch
* fix for issue #171 <https://github.com/ipa-mdl/ros_canopen/issues/171>
* Merge pull request #168 <https://github.com/ipa-mdl/ros_canopen/issues/168> from ipa-mdl/state-filters
  added filter chain for state values
* do not start driver if filter config fails
* added filter chain for state values
* log control period settings
* use update_period_ for controll unless use_realtime_period is set true
* better initialize last_time_
* removed canSwitch implementation, added compile-time check for prepareSwitch
* exit code for generic error should be 1, not -1
* styled and sorted CMakeLists.txt
  * removed boilerplate comments
  * indention
  * reviewed exported dependencies
* styled and sorted package.xml
* update package URLs
* foward commands ony if enabled in doSwitch
* moved switch implemenation to non-RT prepareSwitch
* migrated to non-const prepareSwitch
* Splitted control_node.cpp into control_node.cpp, robot_layer.cpp and robot_layer.h
* renamed chain_ros.h to ros_chain.h, fixes #126 <https://github.com/ipa-mdl/ros_canopen/issues/126>
* added strictness to service call, extend error message for doSwitch fails
* stop controllers that failed switching via service call
* stop all cotnroller joints if one failed to switch
* check for ready state before controller/mode switching
* improved init bevaviour:
  * URDF is not read again (was not needed anyway=
  * register interfaces only of first init
* remove unnecessary atomic reads
* halt motor if switch failed
* Fix for switching controllers with same mode
* More expressive comments for compile-time check
* Contributors: Mathias Lüdtke, Michael Stoll
```

## ros_canopen

```
* updated metapackage
  * format 2
  * updated maintaner
  * added new packages
* update package URLs
* Contributors: Mathias Lüdtke
```

## socketcan_bridge

```
* hamonized versions
* styled and sorted CMakeLists.txt
  * removed boilerplate comments
  * indention
  * reviewed exported dependencies
* styled and sorted package.xml
* Removes gtest from test dependencies.
  This dependency is covered by the rosunit dependency.
* Removes dependency on Boost, adds rosunit dependency.
  The dependency on Boost was unnecessary, rosunit is required for gtest.
* Improves StateInterface implementation of the DummyInterface.
  The doesLoopBack() method now returns the correct value. A state change is
  correctly dispatched when the init() method is called.
* Changes the exit code of the nodes if device init fails.
  Now exits with 1 if the initialization of the can device fails.
* Changes the frame field for the published messages.
  An empty frame name is more commonly used to denote that there is no frame
  associated with the message.
* Changes return type of setup() method.
  Setup() calls the CreateMsgListener and CreateStateListener, it does not attempt
  to verify if the interface is ready, which makes void more applicable.
* Cleanup, fixes and improvements in CmakeLists.
  Adds the REQUIRED COMPONENTS packages to the CATKIN_DEPENDS.
  Improves add_dependency on the messages to be built.
  Removes unnecessary FILES_MATCHING.
  Moves the roslint_cpp macro to the testing block.
* Finalizes work on the socketcan_bridge and can_msgs.
  Readies the packages socketcan_bridge and can_msgs for the merge with ros_canopen.
  Bumps the version for both packages to 0.1.0. Final cleanup in CMakeLists, added
  comments to the shell script and launchfile used for testing.
* Adds tests for socketcan_bridge and bugfixes.
  Uses rostests and the modified DummyInterface to test whether behaviour
  is correct. Prevented possible crashes when can::tostring was called on
  invalid frames.
* Adds conversion test between msg and SocketCAN Frame.
  This test only covers the conversion between the can_msgs::Frame message and can::Frame from SocketCAN.
* Introduces topic_to_socketcan and the bridge.
  Adds TopicToSocketCAN, the counterpart to the SocketCANToTopic class.
  Also introduces a node to use this class and a node which combines the two
  classes into a bidirectional bridge.
  Contrary to the previous commit message the send() method appears to be
  available from the ThreadedSocketCANInterface afterall.
* Introduces socketcan_to_topic and its node.
  This is based on the ThreadedSocketCANInterface from the socketcan_interface package. Sending might become problematic with this class however, as the send() method is not exposed through the Threading wrappers.
* Contributors: Ivor Wanders, Mathias Lüdtke
```

## socketcan_interface

```
* removed Baseclass typedef since its use prevented virtual functions calls
* add missing chrono dependency
* Added catch-all features in BufferedReader
* hardened code with the help of cppcheck
* styled and sorted CMakeLists.txt
  * removed boilerplate comments
  * indention
  * reviewed exported dependencies
* styled and sorted package.xml
* update package URLs
* Improves StateInterface implementation of the DummyInterface.
  The doesLoopBack() method now returns the correct value. A state change is
  correctly dispatched when the init() method is called.
* Changes inheritance of DummyInterface to DriverInterface.
  Such that this interface can also be used for tests requiring a DriverInterface
  class.
  Test results of the socketcan_interface tests are unchanged by this
  modification as it only uses the CommInterface methods.
* added socketcan_interface_string to test
* moved string functions into separate lib
* Introduced setNotReady, prevent enqueue() to switch from closed to open
* Reading state_ should be protected by lock
* improved BufferedReader interface and ScopedEnabler
* added flush() and max length support to BufferedReader
* added BufferedReader
* wake multiple waiting threads if needed
* pad hex buffer strings in all cases
* removed unstable StateWaiter::wait_for
* Contributors: Ivor Wanders, Mathias Lüdtke, Michael Stoll
```
