### PR TITLE
common_tutorials: 0.1.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1724,7 +1724,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/common_tutorials.git
-      version: hydro-devel
+      version: indigo-devel
     release:
       packages:
       - actionlib_tutorials
@@ -1739,7 +1739,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/common_tutorials.git
-      version: hydro-devel
+      version: indigo-devel
     status: maintained
   concert_scheduling:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1735,7 +1735,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/common_tutorials-release.git
-      version: 0.1.8-0
+      version: 0.1.9-0
     source:
       type: git
       url: https://github.com/ros/common_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_tutorials` to `0.1.9-0`:

- upstream repository: https://github.com/ros/common_tutorials.git
- release repository: https://github.com/ros-gbp/common_tutorials-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.8-0`

## actionlib_tutorials

```
* Fix the runtime error 'SyntaxError: from __future__ imports must occur at the beginning of the file'
* Fix on comments
* Remove roslib references that catkin doesn't need
* Pull old fibonacci python scripts from those linked on the wiki page
* Contributors: Isaac I.Y. Saito, Kei Okada, Steven Peters, Vincent Rabaud
```

## common_tutorials

```
* re-insert some old, missing actionlib tutorials
* minor bugfixes here and there
```
