### PR TITLE
mapviz: 0.2.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2341,7 +2341,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `0.2.3-0`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.2.2-0`

## mapviz

```
* Fix mapviz kinetic build. (#456 <https://github.com/evenator/mapviz/issues/456>)
  Add a missing rosdep dependency on libxi-dev.
* Contributors: Edward Venator
```

## mapviz_plugins

```
* Delete markers that have expired and remove error message. (#454 <https://github.com/evenator/mapviz/issues/454>)
* Fix segfault in pointcloud2 plug-in when pointcloud is empty. (#450 <https://github.com/evenator/mapviz/issues/450>)
* Initialize buffer size variable. (#447 <https://github.com/evenator/mapviz/issues/447>)
* Contributors: Marc Alban
```

## multires_image

- No changes

## tile_map

- No changes
