### PR TITLE
rqt_launchtree: 0.1.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5549,7 +5549,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/pschillinger/rqt_launchtree-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/pschillinger/rqt_launchtree.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_launchtree` to `0.1.5-0`:

- upstream repository: https://github.com/pschillinger/rqt_launchtree.git
- release repository: https://github.com/pschillinger/rqt_launchtree-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.4-0`

## rqt_launchtree

```
* Merge branch '130s-impr/save_status'
* Store pkg name instead of index and also remember launch args
* Save and restore last pkg and launch file (address #4 <https://github.com/pschillinger/rqt_launchtree/issues/4>).
* Hide old properties if new file is loaded
* Contributors: Isaac I.Y. Saito, Philipp Schillinger
```
