### PR TITLE
rqt_launchtree: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4972,6 +4972,21 @@ repositories:
       url: https://github.com/OTL/rqt_ez_publisher.git
       version: kinetic-devel
     status: developed
+  rqt_launchtree:
+    doc:
+      type: git
+      url: https://github.com/pschillinger/rqt_launchtree.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pschillinger/rqt_launchtree-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/pschillinger/rqt_launchtree.git
+      version: kinetic
+    status: maintained
   rqt_multiplot_plugin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_launchtree` to `0.2.0-0`:

- upstream repository: https://github.com/pschillinger/rqt_launchtree.git
- release repository: https://github.com/pschillinger/rqt_launchtree-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## rqt_launchtree

```
* Merge branch '130s-impr/save_status' into kinetic
* Store pkg name instead of index and also remember launch args
* Save and restore last pkg and launch file (address #4 <https://github.com/pschillinger/rqt_launchtree/issues/4>).
* Hide old properties if new file is loaded
* Adapted changes of pyqt5
* Contributors: Isaac I.Y. Saito, Philipp Schillinger
```
