### PR TITLE
ros_canopen distro updates

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10450,7 +10450,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git
-      version: indigo_release_candidate
+      version: indigo
     release:
       packages:
       - can_msgs

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4889,6 +4889,16 @@ repositories:
       url: https://github.com/ros/ros.git
       version: jade-devel
     status: maintained
+  ros_canopen:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/ros_canopen.git
+      version: jade-devel
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ros_canopen.git
+      version: jade-devel
+    status: maintained
   ros_comm:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4452,6 +4452,16 @@ repositories:
       url: https://github.com/ros/ros.git
       version: kinetic-devel
     status: maintained
+  ros_canopen:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/ros_canopen.git
+      version: jade-devel
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ros_canopen.git
+      version: jade-devel
+    status: maintained
   ros_comm:
     doc:
       type: git


### PR DESCRIPTION
I'd like to run prerelease tests for ros_canopen on jade and kinetic (`jade-devel` branch for  both).