### PR TITLE
Update arni release packages

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -382,14 +382,15 @@ repositories:
   arni:
     release:
       packages:
+      - arni
       - arni_core
       - arni_countermeasure
       - arni_gui
       - arni_msgs
       - arni_nodeinterface
       - arni_processing
-      - rqt_arni_gui_detail
-      - rqt_arni_gui_overview
+      - arni_rqt_detail_plugin
+      - arni_rqt_overview_plugin
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ROS-PSE/arni-release.git


### PR DESCRIPTION
Adds the new arni metapackage which should simplify the installation of the arni packages. Furthermore renames rqt_arni_gui_detail to arni_rqt_detail_plugin and rqt_arni_gui_overview to arni_rqt_overview_plugin