### PR TITLE
mavros: 0.18.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2473,7 +2473,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.18.4-0
+      version: 0.18.5-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.18.5-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.18.4-0`

## libmavconn

- No changes

## mavros

```
* lib: update ArduPilot modes
* Contributors: Randy Mackay
```

## mavros_extras

- No changes

## mavros_msgs

- No changes

## test_mavros

- No changes
