### PR TITLE
add release of "turtlebot_exploration_3d"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12689,6 +12689,13 @@ repositories:
       type: git
       url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git
       version: indigo
+    release:
+      packages:
+      - turtlebot_exploration_3d
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d-release.git
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12692,7 +12692,7 @@ repositories:
     source:
       type: git
       url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git
-      version: release
+      version: indigo
     status: maintained
   turtlebot_interactions:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12684,6 +12684,21 @@ repositories:
       url: https://github.com/turtlebot/turtlebot_create_desktop.git
       version: indigo
     status: maintained
+  turtlebot_exploration_3d:
+    doc:
+      type: git
+      url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git
+      version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git
+      version: 0.0.1
+    source:
+      type: git
+      url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git
+      version: release
+    status: maintained
   turtlebot_interactions:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12689,11 +12689,6 @@ repositories:
       type: git
       url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git
       version: indigo
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git
-      version: 0.0.1
     source:
       type: git
       url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git


### PR DESCRIPTION
Hi I run "bloom-release" on my repository and got the following:
Everything went as expected, you should check that the new tags match your expectations, and then push to the release repo with:
  git push --all && git push --tags  # You might have to add --force to the second command if you are over-writing existing tags
<== Released 'turtlebot_exploration_3d' using release track 'indigo' successfully
==> git remote -v
origin	https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d-release.git (fetch)
origin	https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d-release.git (push)
Releasing complete, push to release repository?
Continue [Y/n]? 


However, failed with git  push --all to the release repository... Was it successfully released?
Please let me know if there is anything wrong with the release, sorry that this is the first time I am been doing this, thanks a lot!!
