### PR TITLE
ros_canopen: 0.7.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4894,6 +4894,20 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git
       version: jade-devel
+    release:
+      packages:
+      - can_msgs
+      - canopen_402
+      - canopen_chain_node
+      - canopen_master
+      - canopen_motor_node
+      - ros_canopen
+      - socketcan_bridge
+      - socketcan_interface
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-industrial-release/ros_canopen-release.git
+      version: 0.7.0-0
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4893,7 +4893,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git
-      version: jade-devel
+      version: jade
     release:
       packages:
       - can_msgs


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.7.0-0`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## can_msgs

- No changes

## canopen_402

- No changes

## canopen_chain_node

- No changes

## canopen_master

- No changes

## canopen_motor_node

```
* multi-mode controllers are not supported (#197 <https://github.com/ros-industrial/ros_canopen/issues/197>)
* Adaption to https://github.com/ros-controls/ros_control/commit/afaf9403d1daf6e7f0a93e4a06aa9695e2883632
* Contributors: Mathias Lüdtke, Michael Stoll
```

## ros_canopen

- No changes

## socketcan_bridge

- No changes

## socketcan_interface

- No changes
