### PR TITLE
pose_cov_ops: 0.1.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4179,6 +4179,21 @@ repositories:
       url: https://github.com/ros-drivers/pointgrey_camera_driver.git
       version: master
     status: maintained
+  pose_cov_ops:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
+      version: 0.1.5-0
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
+      version: master
+    status: maintained
   power_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pose_cov_ops` to `0.1.5-0`:

- upstream repository: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
- release repository: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## pose_cov_ops

- No changes
