### PR TITLE
mrpt_navigation: 0.1.16-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2752,7 +2752,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 0.1.15-0
+      version: 0.1.16-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `0.1.16-0`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.15-0`

## mrpt_bridge

- No changes

## mrpt_local_obstacles

- No changes

## mrpt_localization

```
* Fix for issue #50 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/50>
* Tabs to spaces
* Fix for issue #48 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/48>
* Remove unneeded include
* Allow robot poses from external algorithms to be integrated into mrpt particles filter
* fix typo
* Contributors: Jorge Santos, Jorge Santos Simón, Jose-Luis Blanco-Claraco
```

## mrpt_map

- No changes

## mrpt_msgs

```
* Remove unecessary Pose2DStamped msg
* Contributors: Nikos Koukis
```

## mrpt_navigation

- No changes

## mrpt_rawlog

- No changes

## mrpt_reactivenav2d

```
* Fix #52 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/52>
* Contributors: Jose-Luis Blanco-Claraco
```

## mrpt_tutorials

- No changes
