### PR TITLE
jsk_visualization: 2.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2186,7 +2186,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 1.0.34-0
+      version: 2.0.0-0
     status: developed
   jskeus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `2.0.0-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.34-0`

## jsk_interactive

- No changes

## jsk_interactive_marker

```
* ** Major Release** : Migrate srv files from jsk_pcl_ros to jsk_recognition_msgs ( #644 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/644> )
  see
  - https://github.com/jsk-ros-pkg/jsk_recognition/pull/1827
  - https://github.com/jsk-ros-pkg/jsk_recognition/pull/1914
  from this version, this package requires jsk_recognition higher than 1.0.0
* Remove dependency: jsk_interactive_marker on jsk_pcl_ros
* Stop using deprecated jsk_topic_tools/log_utils.h
  see
  - https://github.com/jsk-ros-pkg/jsk_common/pull/1462
  - https://github.com/jsk-ros-pkg/jsk_common/issues/1461
* Contributors: Kei Okada, Kentaro Wada
```

## jsk_interactive_test

- No changes

## jsk_rqt_plugins

- No changes

## jsk_rviz_plugins

```
* Stop using deprecated jsk_topic_tools/log_utils.h
  see
  - https://github.com/jsk-ros-pkg/jsk_common/pull/1462
  - https://github.com/jsk-ros-pkg/jsk_common/issues/1461
* [jsk_rviz_plugins/src/empty_service_call_interface.cpp] remove unused variables.
* Contributors: Kentaro Wada, MasakiMurooka
```

## jsk_visualization

- No changes
