### PR TITLE
rosjava_test_msgs: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4778,6 +4778,13 @@ repositories:
       url: https://github.com/ros-infrastructure/rosdoc_lite.git
       version: master
     status: maintained
+  rosjava_test_msgs:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/rosjava-release/rosjava_test_msgs-release.git
+      version: 0.3.0-0
+    status: maintained
   roslint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_test_msgs` to `0.3.0-0`:

- upstream repository: https://github.com/rosjava/rosjava_test_msgs.git
- release repository: https://github.com/rosjava-release/rosjava_test_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## rosjava_test_msgs

```
* kinetic release
```
