### PR TITLE
added rosdep rule for muparser on debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3188,6 +3188,7 @@ mrpt:
     xenial: [libmrpt-dev]
     yakkety: [libmrpt-dev]
 muparser:
+  debian: [libmuparser-dev]
   fedora: [muParser-devel]
   ubuntu: [libmuparser-dev]
 nasm:


### PR DESCRIPTION
Available for wheezy, jessie, stretch, and sid.
(https://packages.debian.org/search?suite=all&searchon=names&keywords=libmuparser-dev)