### PR TITLE
nmea_comms: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3087,6 +3087,21 @@ repositories:
       url: https://github.com/UTNuclearRoboticsPublic/netft_utils.git
       version: master
     status: maintained
+  nmea_comms:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/nmea_comms.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/nmea_comms-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/nmea_comms.git
+      version: jade-devel
+    status: maintained
   nodelet_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_comms` to `1.1.0-0`:

- upstream repository: https://github.com/ros-drivers/nmea_comms.git
- release repository: https://github.com/ros-drivers-gbp/nmea_comms-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`

## nmea_comms

```
* Release to Jade.
```
