### PR TITLE
tele_dir: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13155,7 +13155,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rdelgadov/tele_dir-release.git
-      version: 0.0.2-2
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/rdelgadov/tele_dir.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tele_dir` to `0.0.3-0`:

- upstream repository: https://github.com/rdelgadov/tele_dir
- release repository: https://github.com/rdelgadov/tele_dir-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.2-2`

## tele_dir

```
* Change package description
* Merge branch 'master' of https://github.com/rdelgadov/tele_dir
* Delete some prints
* Merge pull request #1 <https://github.com/rdelgadov/tele_dir/issues/1> from rdelgadov/rdelgadov-patch-1
  Update package.xml
* Update package.xml
* resolve test problems with the path of the configs files
* Contributors: Rodrigo Alexis Delgado Vega, rdelgadov
```
