### PR TITLE
robotnik_sensors: 1.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10079,7 +10079,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotnikAutomation/robotnik_sensors-release.git
-      version: 1.0.3-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/robotnik_sensors.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotnik_sensors` to `1.0.5-0`:

- upstream repository: https://github.com/RobotnikAutomation/robotnik_sensors.git
- release repository: https://github.com/RobotnikAutomation/robotnik_sensors-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.0.3-0`

## robotnik_sensors

```
* 1.0.4
* update changelog
* MOD: Fixed problem with rotations
* --amend
* standarized all sensors: frames, joints, topics and params
* reduced rate drift and associated gaussian noise
* 1.0.3
* updated changelog
* Contributors: Jose Rapado, Marc Bosch-Jorge, carlos3dx, rguzman1
```
