### PR TITLE
robotnik_sensors: 1.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4338,7 +4338,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotnikAutomation/robotnik_sensors-release.git
-      version: 1.1.0-0
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/robotnik_sensors.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotnik_sensors` to `1.1.1-0`:

- upstream repository: https://github.com/RobotnikAutomation/robotnik_sensors.git
- release repository: https://github.com/RobotnikAutomation/robotnik_sensors-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.1.0-0`

## robotnik_sensors

```
* Merge indigo to kinetic
* 1.0.5
* updated changelog
* 1.0.4
* update changelog
* MOD: Fixed problem with rotations
* --amend
* standarized all sensors: frames, joints, topics and params
* reduced rate drift and associated gaussian noise
* 1.0.3
* updated changelog
* Contributors: Jose Rapado, Marc Bosch-Jorge, carlos3dx, rguzman1
```
