### PR TITLE
robot_upstart: 0.2.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4783,7 +4783,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/clearpath-gbp/robot_upstart-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/robot_upstart.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart` to `0.2.1-0`:

- upstream repository: https://github.com/clearpathrobotics/robot_upstart.git
- release repository: https://github.com/clearpath-gbp/robot_upstart-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.0-0`

## robot_upstart

```
* Added option to install under systemd rather than upstart (#41 <https://github.com/clearpathrobotics/robot_upstart/issues/41>)
* Added option to add launch files as symbolic link (#43 <https://github.com/clearpathrobotics/robot_upstart/issues/43>)
* Fix title underline to silence doc job warning.
* Update README.md
  Use latest_available URL for documentation link.
* Merge pull request #31 <https://github.com/clearpathrobotics/robot_upstart/issues/31> from clearpathrobotics/roslint_fix
  Remove unwanted whitespace
* Remove unwanted whitespace
* Merge pull request #28 <https://github.com/clearpathrobotics/robot_upstart/issues/28> from clearpathrobotics/install_multiple_files
  Updated install script to allow adding multiple launch files to a job
* Ensure script aborts if one of the provided launch files cannot be found
* Updated install script to allow adding multiple launch files to a job at once
* Fix leftover {user} tokens in template.
* Formatting changes for new pep8.
* Contributors: Jonathan Jekir, Kazumi Malhan, Mike Purvis, Niklas Casaril
```
