### PR TITLE
dynpick_driver: 0.1.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -821,7 +821,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/dynpick_driver-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/tork-a/dynpick_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynpick_driver` to `0.1.1-0`:

- upstream repository: https://github.com/tork-a/dynpick_driver.git
- release repository: https://github.com/tork-a/dynpick_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.0-0`

## dynpick_driver

```
* [fix] Add a missing folder to be installed #37 <https://github.com/tork-a/dynpick_driver/issues/37>
* [capability] Add a tested product model. #35 <https://github.com/tork-a/dynpick_driver/issues/35>
* Contributors: Isaac I.Y. Saito
```
