### PR TITLE
interactive_marker_twist_server: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1786,6 +1786,21 @@ repositories:
       url: https://github.com/ros-industrial/industrial_ci.git
       version: master
     status: maintained
+  interactive_marker_twist_server:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
+      version: kinetic-devel
+    status: maintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_marker_twist_server` to `1.1.0-0`:

- upstream repository: https://github.com/ros-visualization/interactive_marker_twist_server.git
- release repository: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`

## interactive_marker_twist_server

```
* Added additional degrees of freedom (YZ) to linear interactive markers. (#7 <https://github.com/ros-visualization/interactive_marker_twist_server/issues/7>)
* Fix YZ rotation. (#6 <https://github.com/ros-visualization/interactive_marker_twist_server/issues/6>)
* Contributors: Mike Purvis, Paul Bovbel, Tony Baltovski
```
