### PR TITLE
Adding cirkit_unit03_common/navigation/robot/simulator to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1267,8 +1267,8 @@ repositories:
       version: master
     release:
       packages:
+      - cirkit_unit03_base
       - cirkit_unit03_bringup
-      - cirkit_unit03_driver
       - cirkit_unit03_robot
       tags:
         release: release/indigo/{package}/{version}
@@ -1278,6 +1278,25 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_robot.git
+      version: master
+    status: maintained
+  cirkit_unit03_simulator:
+    doc:
+      type: git
+      url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_simulator.git
+      version: master
+    release:
+      packages:
+      - cirkit_unit03_gazebo
+      - cirkit_unit03_simulator
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_simulator-release.git
+      version: 0.1.0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_simulator.git
       version: master
     status: maintained
   cit_adis_imu:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1260,6 +1260,26 @@ repositories:
       url: https://github.com/asmodehn/certifi-rosrelease.git
       version: 2015.11.20-1
     status: maintained
+  cirkit_unit03_robot:
+    doc:
+      type: git
+      url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_robot.git
+      version: master
+    release:
+      packages:
+      - cirkit_unit03_bringup
+      - cirkit_unit03_driver
+      - cirkit_unit03_robot
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_robot-release.git
+      version: 0.1.0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_robot.git
+      version: master
+    status: maintained
   cit_adis_imu:
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1280,6 +1280,27 @@ repositories:
       url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_common.git
       version: master
     status: maintained
+  cirkit_unit03_navigation:
+    doc:
+      type: git
+      url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_navigation.git
+      version: master
+    release:
+      packages:
+      - cirkit_unit03_amcl
+      - cirkit_unit03_gmapping
+      - cirkit_unit03_move_base
+      - cirkit_unit03_navigation
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_navigation-release.git
+      version: 0.1.0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_navigation.git
+      version: master
+    status: maintained
   cirkit_unit03_robot:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1260,6 +1260,26 @@ repositories:
       url: https://github.com/asmodehn/certifi-rosrelease.git
       version: 2015.11.20-1
     status: maintained
+  cirkit_unit03_common:
+    doc:
+      type: git
+      url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_common.git
+      version: master
+    release:
+      packages:
+      - cirkit_unit03_common
+      - cirkit_unit03_control
+      - cirkit_unit03_description
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_common-release.git
+      version: 0.1.0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_common.git
+      version: master
+    status: maintained
   cirkit_unit03_robot:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1265,15 +1265,6 @@ repositories:
       type: git
       url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_common.git
       version: master
-    release:
-      packages:
-      - cirkit_unit03_common
-      - cirkit_unit03_control
-      - cirkit_unit03_description
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_common-release.git
-      version: 0.1.0
     source:
       test_pull_requests: true
       type: git
@@ -1285,16 +1276,6 @@ repositories:
       type: git
       url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_navigation.git
       version: master
-    release:
-      packages:
-      - cirkit_unit03_amcl
-      - cirkit_unit03_gmapping
-      - cirkit_unit03_move_base
-      - cirkit_unit03_navigation
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_navigation-release.git
-      version: 0.1.0
     source:
       test_pull_requests: true
       type: git
@@ -1306,15 +1287,6 @@ repositories:
       type: git
       url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_robot.git
       version: master
-    release:
-      packages:
-      - cirkit_unit03_base
-      - cirkit_unit03_bringup
-      - cirkit_unit03_robot
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_robot-release.git
-      version: 0.1.0
     source:
       test_pull_requests: true
       type: git
@@ -1326,14 +1298,6 @@ repositories:
       type: git
       url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_simulator.git
       version: master
-    release:
-      packages:
-      - cirkit_unit03_gazebo
-      - cirkit_unit03_simulator
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/CIR-KIT-Unit03/cirkit_unit03_simulator-release.git
-      version: 0.1.0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
I'd like to cirkit_unit03_common, cirkit_unit03_navigation, cirkit_unit03_robot and cirkit_unit03_simulator to be indexed and documented on ros.org.