### PR TITLE
turtlebot_exploration_3d: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13547,6 +13547,11 @@ repositories:
       type: git
       url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git
       version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d-release.git
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_exploration_3d` to `0.0.3-0`:

- upstream repository: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git
- release repository: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## turtlebot_exploration_3d

- No changes
