### PR TITLE
[indigo][moveit_*] Remove entries that will be replaced by moveit metapackage.

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6294,42 +6294,6 @@ repositories:
       url: https://github.com/ros-industrial/motoman.git
       version: indigo-devel
     status: maintained
-  moveit_commander:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/moveit_commander.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/moveit_commander-release.git
-      version: 0.6.1-0
-    source:
-      type: git
-      url: https://github.com/ros-planning/moveit_commander.git
-      version: indigo-devel
-    status: maintained
-  moveit_core:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/moveit_core.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/moveit_core-release.git
-      version: 0.7.2-0
-    source:
-      type: git
-      url: https://github.com/ros-planning/moveit_core.git
-      version: indigo-devel
-    status: maintained
-  moveit_experimental:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/moveit_experimental.git
-      version: master
-    status: developed
   moveit_helpers:
     doc:
       type: git
@@ -6349,35 +6313,6 @@ repositories:
       url: https://github.com/JenniferBuehler/moveit-pkgs.git
       version: master
     status: maintained
-  moveit_ikfast:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/moveit_ikfast.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/moveit_ikfast-release.git
-      version: 3.1.1-0
-    source:
-      type: git
-      url: https://github.com/ros-planning/moveit_ikfast.git
-      version: indigo-devel
-    status: maintained
-  moveit_metapackages:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/moveit_metapackages.git
-      version: master
-    release:
-      packages:
-      - moveit_full
-      - moveit_full_pr2
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/moveit_metapackages-release.git
-      version: 0.6.1-0
-    status: maintained
   moveit_msgs:
     doc:
       type: git
@@ -6391,44 +6326,6 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git
-      version: indigo-devel
-    status: maintained
-  moveit_planners:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/moveit_planners.git
-      version: indigo-devel
-    release:
-      packages:
-      - moveit_planners
-      - moveit_planners_ompl
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/moveit_planners-release.git
-      version: 0.7.0-0
-    source:
-      type: git
-      url: https://github.com/ros-planning/moveit_planners.git
-      version: indigo-devel
-    status: maintained
-  moveit_plugins:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/moveit_plugins.git
-      version: indigo-devel
-    release:
-      packages:
-      - moveit_fake_controller_manager
-      - moveit_plugins
-      - moveit_ros_control_interface
-      - moveit_simple_controller_manager
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/moveit_plugins-release.git
-      version: 0.5.7-0
-    source:
-      type: git
-      url: https://github.com/ros-planning/moveit_plugins.git
       version: indigo-devel
     status: maintained
   moveit_pr2:
@@ -6504,48 +6401,6 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-planning/moveit_robots.git
-      version: indigo-devel
-    status: maintained
-  moveit_ros:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/moveit_ros.git
-      version: indigo-devel
-    release:
-      packages:
-      - moveit_ros
-      - moveit_ros_benchmarks
-      - moveit_ros_benchmarks_gui
-      - moveit_ros_manipulation
-      - moveit_ros_move_group
-      - moveit_ros_perception
-      - moveit_ros_planning
-      - moveit_ros_planning_interface
-      - moveit_ros_robot_interaction
-      - moveit_ros_visualization
-      - moveit_ros_warehouse
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/moveit_ros-release.git
-      version: 0.7.2-0
-    source:
-      type: git
-      url: https://github.com/ros-planning/moveit_ros.git
-      version: indigo-devel
-    status: maintained
-  moveit_setup_assistant:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/moveit_setup_assistant.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/moveit_setup_assistant-release.git
-      version: 0.7.2-0
-    source:
-      type: git
-      url: https://github.com/ros-planning/moveit_setup_assistant.git
       version: indigo-devel
     status: maintained
   moveit_sim_controller:


### PR DESCRIPTION
Same as for Jade and Kinetic, some core packages of `moveit` that are currently released from multiple repositories for Indigo are now gathered at a single repo. As soon as this PR gets merged to remove those entries a new release request will be sent from the aggregated repo.

CC: @davetcoleman @v4hn 

Ref. MoveIt! Indigo release task https://github.com/ros-planning/moveit/issues/100