### PR TITLE
moveit: 0.7.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6294,6 +6294,45 @@ repositories:
       url: https://github.com/ros-industrial/motoman.git
       version: indigo-devel
     status: maintained
+  moveit:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit.git
+      version: indigo-devel
+    release:
+      packages:
+      - moveit
+      - moveit_commander
+      - moveit_controller_manager_example
+      - moveit_core
+      - moveit_fake_controller_manager
+      - moveit_kinematics
+      - moveit_planners
+      - moveit_planners_ompl
+      - moveit_plugins
+      - moveit_ros
+      - moveit_ros_benchmarks
+      - moveit_ros_benchmarks_gui
+      - moveit_ros_control_interface
+      - moveit_ros_manipulation
+      - moveit_ros_move_group
+      - moveit_ros_perception
+      - moveit_ros_planning
+      - moveit_ros_planning_interface
+      - moveit_ros_robot_interaction
+      - moveit_ros_visualization
+      - moveit_ros_warehouse
+      - moveit_setup_assistant
+      - moveit_simple_controller_manager
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/moveit-release.git
+      version: 0.7.3-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit.git
+      version: indigo-devel
+    status: developed
   moveit_helpers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.7.3-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## moveit

```
* [maintenance] Fix #84 <https://github.com/ros-planning/moveit/issues/84> (line-break is mandatory).
* Contributors: Isaac I.Y. Saito
```

## moveit_kinematics

```
* [maintenance] Move moveit_ikfast into moveit_kinematics
* [maintenance] add full VERSIONs / SONAMEs to all libraries (#273 <https://github.com/ros-planning/moveit/issues/273>)
* [maintenance] Auto code formatted Indigo branch using clang-format (#313 <https://github.com/ros-planning/moveit/issues/313>)
* Contributors: Dave Coleman, Michael Goerner
```
