### PR TITLE
ftputil: 3.3.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3081,6 +3081,13 @@ repositories:
       url: https://gitlab.com/nasa-jsc-robotics/fsm_utils.git
       version: develop
     status: maintained
+  ftputil:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/ftputil-rosrelease.git
+      version: 3.3.0-1
+    status: maintained
   fulanghua_navigation:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ftputil` to `3.3.0-1`:

- upstream repository: http://hg.sschwarzer.net/ftputil
- release repository: https://github.com/asmodehn/ftputil-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
