### PR TITLE
Adding CIR-KIT utilities to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3966,6 +3966,16 @@ repositories:
       url: https://github.com/fkanehiro/hrpsys-base.git
       version: master
     status: developed
+  human_detector:
+    doc:
+      type: git
+      url: https://github.com/CIR-KIT/human_detector.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/CIR-KIT/human_detector.git
+      version: master
+    status: maintained
   humanoid_msgs:
     doc:
       type: git
@@ -5737,6 +5747,16 @@ repositories:
       type: git
       url: https://github.com/orocos-toolchain/log4cpp.git
       version: toolchain-2.8
+    status: maintained
+  lower_step_detector:
+    doc:
+      type: git
+      url: https://github.com/CIR-KIT/remote_monitor.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/CIR-KIT/remote_monitor.git
+      version: master
     status: maintained
   lsd_slam:
     doc:
@@ -12863,6 +12883,16 @@ repositories:
       url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator.git
       version: indigo-devel
     status: developed
+  steer_drive_ros:
+    doc:
+      type: git
+      url: https://github.com/CIR-KIT/steer_drive_ros.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/CIR-KIT/steer_drive_ros.git
+      version: master
+    status: maintained
   stereo_slam:
     doc:
       type: git
@@ -13195,6 +13225,16 @@ repositories:
     source:
       type: git
       url: https://github.com/wcaarls/threemxl.git
+      version: master
+    status: maintained
+  timed_roslaunch:
+    doc:
+      type: git
+      url: https://github.com/MoriKen254/timed_roslaunch.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/MoriKen254/timed_roslaunch.git
       version: master
     status: maintained
   tinkerforge_laser_transform:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5748,16 +5748,6 @@ repositories:
       url: https://github.com/orocos-toolchain/log4cpp.git
       version: toolchain-2.8
     status: maintained
-  lower_step_detector:
-    doc:
-      type: git
-      url: https://github.com/CIR-KIT/remote_monitor.git
-      version: master
-    source:
-      type: git
-      url: https://github.com/CIR-KIT/remote_monitor.git
-      version: master
-    status: maintained
   lsd_slam:
     doc:
       type: git
@@ -9551,6 +9541,16 @@ repositories:
       type: git
       url: https://github.com/toddhester/rl-texplore-ros-pkg.git
       version: master
+  remote_monitor:
+    doc:
+      type: git
+      url: https://github.com/CIR-KIT/remote_monitor.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/CIR-KIT/remote_monitor.git
+      version: master
+    status: maintained
   report_card:
     doc:
       type: git


### PR DESCRIPTION
I'd like to some utility packages for our autonomous robot to be indexed and documented on ros.org.