### PR TITLE
trac_ik: 1.4.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5816,6 +5816,16 @@ repositories:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git
       version: no_moveit_plugin-kinetic
+    release:
+      packages:
+      - trac_ik
+      - trac_ik_examples
+      - trac_ik_kinematics_plugin
+      - trac_ik_lib
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/traclabs/trac_ik-release.git
+      version: 1.4.5-0
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `trac_ik` to `1.4.5-0`:

- upstream repository: https://bitbucket.org/traclabs/trac_ik.git
- release repository: https://github.com/traclabs/trac_ik-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## trac_ik

```
* Updated CMake file to work with Eigen on 14.04 through 16.04
```
