### PR TITLE
pyros_utils: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9009,7 +9009,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/pyros-utils-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/asmodehn/pyros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_utils` to `0.1.3-0`:

- upstream repository: https://github.com/asmodehn/pyros-utils.git
- release repository: https://github.com/asmodehn/pyros-utils-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.2-0`

## pyros_utils

```
* adding trick to patch import behavior from rospy generated __init__ relay.
* now using ros-shadow-fixed in docker for travis
* fixing typo in travis_checks
* now testing with docker. added kinetic test. bumped catkin_pip requirements.
* Contributors: AlexV, alexv
```
