### PR TITLE
nao_dcm_robot: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6748,7 +6748,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-aldebaran/nao_dcm_robot-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/ros-aldebaran/nao_dcm_robot.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6740,18 +6740,18 @@ repositories:
   nao_dcm_robot:
     doc:
       type: git
-      url: https://github.com/ros-aldebaran/nao_dcm_robot.git
+      url: https://github.com/ros-naoqi/nao_dcm_robot.git
       version: master
     release:
       packages:
       - nao_dcm_bringup
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ros-aldebaran/nao_dcm_robot-release.git
+      url: https://github.com/ros-naoqi/nao_dcm_robot-release.git
       version: 0.0.3-0
     source:
       type: git
-      url: https://github.com/ros-aldebaran/nao_dcm_robot.git
+      url: https://github.com/ros-naoqi/nao_dcm_robot.git
       version: master
     status: maintained
   nao_extras:


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_dcm_robot` to `0.0.3-0`:

- upstream repository: https://github.com/ros-naoqi/nao_dcm_robot.git
- release repository: https://github.com/ros-aldebaran/nao_dcm_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.2-0`

## nao_dcm_bringup

```
* fixing package.xml
* update links after moving repo + update maintainer (#1 <https://github.com/ros-naoqi/nao_dcm_robot/issues/1>)
  * update links after moving repo + update maintainer
  * add documentation link
* Contributors: Mikael Arguedas, Natalia Lyubova
```
