### PR TITLE
nao_dcm_robot: 0.0.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3022,6 +3022,23 @@ repositories:
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
       version: master
     status: maintained
+  nao_dcm_robot:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/nao_dcm_robot.git
+      version: master
+    release:
+      packages:
+      - nao_dcm_bringup
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-naoqi/nao_dcm_robot-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/nao_dcm_robot.git
+      version: master
+    status: maintained
   nao_extras:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_dcm_robot` to `0.0.3-0`:

- upstream repository: https://github.com/ros-naoqi/nao_dcm_robot.git
- release repository: https://github.com/ros-naoqi/nao_dcm_robot-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## nao_dcm_bringup

```
* fixing package.xml
* update links after moving repo + update maintainer (#1 <https://github.com/ros-naoqi/nao_dcm_robot/issues/1>)
  * update links after moving repo + update maintainer
  * add documentation link
* Contributors: Mikael Arguedas, Natalia Lyubova
```
