### PR TITLE
pepper_dcm_robot: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8076,7 +8076,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_dcm_robot-release.git
-      version: 0.0.1-1
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_dcm_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_dcm_robot` to `0.0.3-0`:

- upstream repository: https://github.com/ros-naoqi/pepper_dcm_robot.git
- release repository: https://github.com/ros-naoqi/pepper_dcm_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.1-1`

## pepper_dcm_bringup

```
* Updating the version
* changes in the launch file to be able to read controllers' joints
* smooth motion
* Update package.xml
  updating links and add documentation link
* adjusting the controller frequency
* fix the motor groups
* removing the unused package
* fixing the source link
* Contributors: Mikael Arguedas, Natalia Lyubova
```
