### PR TITLE
pepper_dcm_robot: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3693,7 +3693,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_dcm_robot-release.git
-      version: 0.0.1-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_dcm_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_dcm_robot` to `0.0.3-0`:

- upstream repository: https://github.com/ros-naoqi/pepper_dcm_robot.git
- release repository: https://github.com/ros-naoqi/pepper_dcm_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.1-0`

## pepper_dcm_bringup

```
* Updating the version
* changes in the launch file to be able to read controllers' joints
* smooth motion
* Update package.xml
  updating links and add documentation link
* adjusting the controller frequency
* fix the motor groups
* removing the unused package
* fixing the source link
* Contributors: Mikael Arguedas, Natalia Lyubova
```
