### PR TITLE
Add python-markdown

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1070,6 +1070,10 @@ python-mapnik:
   debian: [python-mapnik]
   fedora: [mapnik-python]
   ubuntu: [python-mapnik]
+python-markdown:
+  debian: [python-markdown]
+  fedora: [python-markdown]
+  ubuntu: [python-markdown]
 python-marshmallow:
   fedora: [python-marshmallow]
   ubuntu:


### PR DESCRIPTION
This replaces the markdown changes in: #12628

Debian: https://packages.debian.org/jessie/python-markdown
Fedora: https://admin.fedoraproject.org/pkgdb/package/rpms/python-markdown/
Ubuntu: http://packages.ubuntu.com/search?keywords=markdown