### PR TITLE
turtlebot: 2.4.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5879,7 +5879,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot-release.git
-      version: 2.4.0-0
+      version: 2.4.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot` to `2.4.2-0`:

- upstream repository: https://github.com/turtlebot/turtlebot.git
- release repository: https://github.com/turtlebot-release/turtlebot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.4.0-0`

## turtlebot

- No changes

## turtlebot_bringup

- No changes

## turtlebot_capabilities

- No changes

## turtlebot_description

```
* update astra urdf by Turtlebot REP (#248 <https://github.com/turtlebot/turtlebot/issues/248>)
  * update astra urdf by Turtlebot REP
  * update astra urdf
  * Update astra.urdf.xacro
* Contributors: hcjung
```

## turtlebot_teleop

```
* Update velocity_smoother.launch.xml to handle namespaces
  Changed topic remapping and nodelet manager to avoid absolute paths. In this way the velocity smoother will work even inside a namespace created with the tag <group ns="">.
* Contributors: Luca Cristoforetti
```
