### PR TITLE
turtlebot: 2.3.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13380,7 +13380,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot-release.git
-      version: 2.3.13-0
+      version: 2.3.14-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot` to `2.3.14-0`:

- upstream repository: https://github.com/turtlebot/turtlebot.git
- release repository: https://github.com/turtlebot-release/turtlebot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.3.13-0`

## turtlebot

- No changes

## turtlebot_bringup

```
* Modify R200 launch file.
  Modified the R200 3D sensor launch file
  to conform more closely to the other
  open_ni2-style sensor launch files. This
  allows the data processing arguments passed
  in to correctly pass through and control
  image processing.
  This allows the turtlebot_follower package,
  for example, to set "depth_processing" to
  true to enable the /camera/depth/depth_rect/
  topic with the R200 as it can with other
  cameras.
* Refactor cmd_vel_mux.
  Moved mobile_base_nodelet_manager and cmd_vel_mux to a
  common, higher-level launch file.
  Currently each base-specific mobile_base.launch.xml
  loaded the same cmd_vel_mux node with the same configuration.
  To reduce this redundancy, launching this nodelet has been
  moved to the common, higher-level mobile_base.launch.xml.
  The mobile_base_nodelet_manager has been moved up to facilitate
  this change.
* Remove concert reference to mobile_base.launch
  Added mobile_base.launch.xml back in for backward compatability
  with deprecation message.
* Remove unnecessary mobile_base.launch.xml layer
  mobile_base.launch.xml currently is just a pass-through to
  include the TURTLEBOT_BASE-specific launch file.  Simply
  removed this unnecessary layer.
* Contributors: Kevin C. Wells
```

## turtlebot_capabilities

- No changes

## turtlebot_description

```
* update astra urdf by Turtlebot REP (#248 <https://github.com/turtlebot/turtlebot/issues/248>)
  * update astra urdf by Turtlebot REP
  * update astra urdf
  * Update astra.urdf.xacro
* Update R200 URDF
  The name of the camera link has been changed to
  conform to the common standard.
* Refactor urdf.xacro files to stop loading unnecessary content.
  Currently, every robot configuration (e.g.,
  turtlebot_description/robots/kobuki_hexagons_kinect.urdf.xacro)
  simply includes a catch-all turtlebot_library.urdf.xacro file.
  This file includes EVERY base, stacks, and sensor combination,
  and thus a lot of unnecessary data is loaded into memory.
  Refactored the turtlebot_library.urdf.xacro to include only
  the data common to all turtlebot configurations, and modified
  each robot configuration file to include only the additional base,
  stacks, and sensor urdf files that apply.
* Contributors: Kevin C. Wells, hcjung
```

## turtlebot_teleop

```
* Update velocity_smoother.launch.xml to handle namespaces
  Changed topic remapping and nodelet manager to avoid absolute paths. In this way the velocity smoother will work even inside a namespace created with the tag <group ns="">.
* Contributors: Luca Cristoforetti
```
