### PR TITLE
rosjava_build_tools: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4911,6 +4911,17 @@ repositories:
       url: https://github.com/ros-infrastructure/rosdoc_lite.git
       version: master
     status: maintained
+  rosjava_build_tools:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/rosjava-release/rosjava_build_tools-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/rosjava/rosjava_build_tools.git
+      version: kinetic
+    status: maintained
   rosjava_test_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_build_tools` to `0.3.0-0`:

- upstream repository: https://github.com/rosjava/rosjava_build_tools.git
- release repository: https://github.com/rosjava-release/rosjava_build_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## rosjava_build_tools

```
* Updates for Kinetic release.
```
