### PR TITLE
realsense_camera: 1.7.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4156,7 +4156,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/intel-ros/realsense-release.git
-      version: 1.6.1-0
+      version: 1.7.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_camera` to `1.7.0-0`:

- upstream repository: https://github.com/intel-ros/realsense.git
- release repository: https://github.com/intel-ros/realsense-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.6.1-0`

## realsense_camera

```
* Enable ROS Lint
* Update RGBD launch files
* Add Dynamic Transforms support -- multi-cam (#120)
* Change color stream default to 30fps
* Major code refactor to use librealsense callbacks
* Added imu_start_ts for imu sync
* Make system wrapper function generic
* Don't ignore linker flags set by user (Yocto fix)
* Changed nodelet to use camera timestamps
* Migrate README.md content to ROS wiki
* Contributors: Dmitry Rozhkov, Mark D Horn, Matt Hansen
```
