### PR TITLE
genjava: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1257,6 +1257,17 @@ repositories:
       url: https://github.com/jsk-ros-pkg/geneus.git
       version: master
     status: developed
+  genjava:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/rosjava-release/genjava-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/rosjava/genjava.git
+      version: kinetic
+    status: maintained
   genlisp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genjava` to `0.3.0-0`:

- upstream repository: https://github.com/rosjava/genjava.git
- release repository: https://github.com/rosjava-release/genjava-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## genjava

```
* Updates for Kinetic release.
```
