### PR TITLE
rosjava_core: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4944,6 +4944,17 @@ repositories:
       url: https://github.com/rosjava/rosjava_build_tools.git
       version: kinetic
     status: maintained
+  rosjava_core:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/rosjava-release/rosjava_core-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/rosjava/rosjava_core.git
+      version: kinetic
+    status: maintained
   rosjava_messages:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_core` to `0.3.0-0`:

- upstream repository: https://github.com/rosjava/rosjava_core
- release repository: https://github.com/rosjava-release/rosjava_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## rosjava_core

```
* Updates for Kinetic release.
* NativeNodeMain for C++ node integration.
```
