### PR TITLE
zeroconf_jmdns_suite: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6767,6 +6767,17 @@ repositories:
       url: https://github.com/stonier/zeroconf_avahi_suite.git
       version: indigo
     status: maintained
+  zeroconf_jmdns_suite:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/rosjava-release/zeroconf_jmdns_suite-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/rosjava/zeroconf_jmdns_suite.git
+      version: kinetic
+    status: maintained
   zeroconf_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `zeroconf_jmdns_suite` to `0.3.0-0`:

- upstream repository: https://github.com/rosjava/zeroconf_jmdns_suite.git
- release repository: https://github.com/rosjava-release/zeroconf_jmdns_suite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## zeroconf_jmdns_suite

```
* Updates for kinetic release.
```
