### PR TITLE
rosjava_extras: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4955,6 +4955,17 @@ repositories:
       url: https://github.com/rosjava/rosjava_core.git
       version: kinetic
     status: maintained
+  rosjava_extras:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/rosjava-release/rosjava_extras-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/rosjava/rosjava_extras.git
+      version: kinetic
+    status: maintained
   rosjava_messages:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_extras` to `0.3.0-0`:

- upstream repository: https://github.com/rosjava/rosjava_extras.git
- release repository: https://github.com/rosjava-release/rosjava_extras-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## rosjava_extras

```
* Updates for kinetic release.
```
