### PR TITLE
rosjava: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4922,6 +4922,17 @@ repositories:
       url: https://github.com/ros-infrastructure/rosdoc_lite.git
       version: master
     status: maintained
+  rosjava:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/rosjava-release/rosjava-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/rosjava/rosjava.git
+      version: kinetic
+    status: maintained
   rosjava_bootstrap:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava` to `0.3.0-0`:

- upstream repository: https://github.com/rosjava/rosjava.git
- release repository: https://github.com/rosjava-release/rosjava-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## rosjava

```
* Updates for kinetic release.
```
