### PR TITLE
arni: 1.1.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -394,7 +394,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ROS-PSE/arni-release.git
-      version: 1.1.5-0
+      version: 1.1.6-0
     source:
       type: git
       url: https://github.com/ROS-PSE/arni.git


### PR DESCRIPTION
Increasing version of package(s) in repository `arni` to `1.1.6-0`:

- upstream repository: https://github.com/ROS-PSE/arni.git
- release repository: https://github.com/ROS-PSE/arni-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.1.5-0`
