### PR TITLE
cost_map: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1893,6 +1893,29 @@ repositories:
       url: https://github.com/ros/convex_decomposition.git
       version: indigo-devel
     status: maintained
+  cost_map:
+    doc:
+      type: git
+      url: https://github.com/stonier/cost_map.git
+      version: release/0.3-indigo-kinetic
+    release:
+      packages:
+      - cost_map
+      - cost_map_core
+      - cost_map_cv
+      - cost_map_demos
+      - cost_map_msgs
+      - cost_map_ros
+      - cost_map_visualisations
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/stonier/cost_map-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/stonier/cost_map.git
+      version: release/0.3-indigo-kinetic
+    status: developed
   costmap_converter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cost_map` to `0.3.0-0`:

- upstream repository: https://github.com/stonier/cost_map.git
- release repository: https://github.com/stonier/cost_map-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## cost_map_core

```
* interpolations for atPosition
* full implementation of line iterator
* full implementation of polygon iterator
* setPosition method for the CostMap class
```

## cost_map_cv

```
* image bundling now supports multiple layers
```

## cost_map_demos

```
* launchers and tests for Costmap2DROS conversions
* image bundling extended to handle multiple layers
```

## cost_map_ros

```
* Costmap2DROS converters
* Bugfix missing data copy in the toGridMap conversion
```
