### PR TITLE
fetch_gazebo: 0.8.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1076,6 +1076,20 @@ repositories:
       url: https://github.com/ros-gbp/fcl-release.git
       version: 0.3.3-0
     status: maintained
+  fetch_gazebo:
+    doc:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_gazebo.git
+      version: gazebo5
+    release:
+      packages:
+      - fetch_gazebo
+      - fetch_gazebo_demo
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/fetch_gazebo-release.git
+      version: 0.8.0-0
+    status: maintained
   fetch_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_gazebo` to `0.8.0-0`:

- upstream repository: https://github.com/fetchrobotics/fetch_gazebo.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_gazebo-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## fetch_gazebo

```
* update rosdeps for gazebo5
* add arg z/yaw for spawning robot
* Contributors: Michael Ferguson, Yuki Furuta
```

## fetch_gazebo_demo

```
* Add rviz config for pickplace demo
* Contributors: Kentaro Wada
```
