### PR TITLE
rqt_multiplot_plugin: 0.0.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5642,7 +5642,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ethz-asl/rqt_multiplot_plugin-release.git
-      version: 0.0.5-1
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/ethz-asl/rqt_multiplot_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_multiplot_plugin` to `0.0.6-0`:

- upstream repository: https://github.com/ethz-asl/rqt_multiplot_plugin.git
- release repository: https://github.com/ethz-asl/rqt_multiplot_plugin-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.5-1`

## rqt_multiplot

```
* reduce min plot size
* run all plots on startup
* flexible command line url input for config files
* arg parsing for the command line script
* add time frame as a new curve data type
  This gives the option to plot e.g. only the last 10 seconds and
  remove older data.
* fix plot resizing
* Contributors: Daniel Stonier, Samuel Bachmann
```
