### PR TITLE
rqt_multiplot_plugin: 0.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5250,7 +5250,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ethz-asl/rqt_multiplot_plugin-release.git
-      version: 0.0.5-1
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/ethz-asl/rqt_multiplot_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_multiplot_plugin` to `0.0.6-0`:

- upstream repository: https://github.com/ethz-asl/rqt_multiplot_plugin.git
- release repository: https://github.com/ethz-asl/rqt_multiplot_plugin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.5-1`

## rqt_multiplot

```
* reduce min plot size
* run all plots on startup
* flexible command line url input for config files
* arg parsing for the command line script
* add time frame as a new curve data type
  This gives the option to plot e.g. only the last 10 seconds and
  remove older data.
* fix plot resizing
* Contributors: Daniel Stonier, Samuel Bachmann
```
