### PR TITLE
rosjava_bootstrap: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4948,7 +4948,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_bootstrap-release.git
-      version: 0.3.0-1
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/rosjava/rosjava_bootstrap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_bootstrap` to `0.3.1-0`:

- upstream repository: https://github.com/rosjava/rosjava_bootstrap
- release repository: https://github.com/rosjava-release/rosjava_bootstrap-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.3.0-1`

## rosjava_bootstrap

```
* Switch Gradle target for rosjava libraries to publish
* Switch from Maven Central to jcenter
* Gradle 2.2.1 -> 2.14.1
* Android SDK Build Tools 21.1.2 -> 25.0.2
* Contributors: Daniel Stonier, Julian Cerruti
```
