### PR TITLE
fiducials: 0.5.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1088,7 +1088,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/fiducials-release.git
-      version: 0.5.0-0
+      version: 0.5.1-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/fiducials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fiducials` to `0.5.1-0`:

- upstream repository: https://github.com/UbiquityRobotics/fiducials
- release repository: https://github.com/UbiquityRobotics-release/fiducials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.5.0-0`

## aruco_detect

```
* Install aruco_detect launch dir
* Use raw transport for aruco test
* Contributors: Rohan Agrawal
```

## fiducial_detect

```
* Add fiducial_transform_test
* Rename images_test to verticies test
* Remove legacy features that are no longer used/supported
* Contributors: Rohan Agrawal
```

## fiducial_lib

```
* Remove old configuration params
* Remove Tag and CameraTag completely
* Get rid of the slam stuff in fiducial_lib
* Delete unused executables from fiducial_lib
* Contributors: Rohan Agrawal
```

## fiducial_pose

- No changes

## fiducial_slam

```
* Map pub srv (#36 <https://github.com/UbiquityRobotics/fiducials/issues/36>)
  * Added publishing of map (#28 <https://github.com/UbiquityRobotics/fiducials/issues/28>) and reset service call (#35 <https://github.com/UbiquityRobotics/fiducials/issues/35>)
  * Updated documentation
* Contributors: Jim Vaughan
```

## fiducials

- No changes
