### PR TITLE
rosjava_build_tools: 0.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4961,7 +4961,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_build_tools-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/rosjava/rosjava_build_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_build_tools` to `0.3.2-0`:

- upstream repository: https://github.com/rosjava/rosjava_build_tools.git
- release repository: https://github.com/rosjava-release/rosjava_build_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.3.1-0`

## rosjava_build_tools

```
* Changed default Gradle target publishMavenJavaPublicationToMavenRepository -> publish
* Contributors: Julian Cerruti
```
