### PR TITLE
turtlebot_exploration_3d: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13530,7 +13530,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_exploration_3d` to `0.0.6-0`:

- upstream repository: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git
- release repository: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.5-0`

## turtlebot_exploration_3d

```
* add install
* update parameters, bug false alarm cleared
* fix bug, n--num_of_samples
* Contributors: mailto:baishi.bona@gmail.com, bona_desk_1
```
