### PR TITLE
euslisp: 9.22.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1064,7 +1064,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/euslisp-release.git
-      version: 9.21.0-1
+      version: 9.22.0-0
     status: developed
   executive_smach:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `euslisp` to `9.22.0-0`:

- upstream repository: https://github.com/euslisp/EusLisp
- release repository: https://github.com/tork-a/euslisp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `9.21.0-1`
