### PR TITLE
jskeus: 1.0.14-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1980,7 +1980,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jskeus-release.git
-      version: 1.0.13-1
+      version: 1.0.14-0
     status: developed
   kobuki:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.0.14-0`:

- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.13-1`

## jskeus

```
* update bvh2eus (#400 <https://github.com/EusLisp/jskeus/issues/400>)
  * fix documentation of bvh2eus
  * support :objects keyword for bvh2eus
  * check if the robot has correspond joint
  * add copy-state-to to rikiya-bvh-model
  * add {rikiya/cmu/tmu}-bvh2eus
* add :makecurrent in :draw-on, this will fix https://github.com/euslisp/jskeus/issues/401 (#402 <https://github.com/EusLisp/jskeus/issues/402> )
* irtrobot.l: :inverse-kinematics-loop-for-look-at : use joint-list from joint of link-liste (#408 <https://github.com/EusLisp/jskeus/issues/408> )
* load lib/llib/time.l from .so object. Fix https://github.com/euslisp/jskeus/issues/292 (#409 <https://github.com/EusLisp/jskeus/issues/409> )
* irtviewer.l: Add :makecurrent in :change-background. Fix https://github.com/euslisp/jskeus/issues/404 (#406 <https://github.com/EusLisp/jskeus/issues/406> )
* Update kalmanlib (#396 <https://github.com/EusLisp/jskeus/issues/396>)
  * [irteus/kalmanlib.l] add kalmanlib sample of accelerated motion
  * [irteus/kalmanlib.l] allow larger dimension of H than A in kalman filter model
  * [irteus/kalmanlib.l] add controller term in model
* add circle.yaml : run make doc in circleci (#395 <https://github.com/EusLisp/jskeus/issues/395>)
* add test/queue.l for https://github.com/euslisp/EusLisp/pull/185 (#394 <https://github.com/EusLisp/jskeus/issues/394> )
* Contributors: Ryo Koyama, Kei Okada, Shun Hasegawa
```
