### PR TITLE
universal_robot: 1.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13812,7 +13812,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/universal_robot-release.git
-      version: 1.1.6-0
+      version: 1.1.7-0
     source:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robot` to `1.1.7-0`:

- upstream repository: https://github.com/ros-industrial/universal_robot.git
- release repository: https://github.com/ros-industrial-release/universal_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.1.6-0`

## universal_robot

```
* No changes.
```

## ur10_moveit_config

```
* Don't depend on moveit_plugins metapackage
* Fix xacro warnings in Jade
* Contributors: Dave Coleman, Jon Binney
```

## ur3_moveit_config

```
* Don't depend on moveit_plugins metapackage
* Fix xacro warnings in Jade
* Contributors: Dave Coleman, Jon Binney
```

## ur5_moveit_config

```
* Don't depend on moveit_plugins metapackage
* Fix xacro warnings in Jade
* Contributors: Dave Coleman, Jon Binney
```

## ur_bringup

```
* Add prefix parameter in common launch
* Contributors: Yannick Jonetzko
```

## ur_description

```
* Fix xacro warnings in Jade (#251 <https://github.com/ros-industrial/universal_robot/issues/251>)
* added default values to xacro macro
* tested joint limits modification
* Contributors: Dave Coleman, G.A. vd. Hoorn, philip 14.04
```

## ur_driver

```
* No changes.
```

## ur_gazebo

```
* ur_gazebo: add controller_manager as run dependency.
* Contributors: Hans-Joachim Krauch
```

## ur_kinematics

```
* Depend on new moveit_kinematics package (#274 <https://github.com/ros-industrial/universal_robot/issues/274>).
* Contributors: Isaac I.Y. Saito
```

## ur_msgs

```
* Add message definition for ToolData.
* Contributors: Nikolas Engelhard
```
