### PR TITLE
universal_robot: 1.1.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13812,7 +13812,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/universal_robot-release.git
-      version: 1.1.7-0
+      version: 1.1.8-0
     source:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robot` to `1.1.8-0`:

- upstream repository: https://github.com/ros-industrial/universal_robot.git
- release repository: https://github.com/ros-industrial-release/universal_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.1.6-0`

## universal_robot

```
* all: update maintainers.
* Contributors: gavanderhoorn
```

## ur10_moveit_config

```
* all: update maintainers.
* Contributors: gavanderhoorn
```

## ur3_moveit_config

```
* all: update maintainers.
* Contributors: gavanderhoorn
```

## ur5_moveit_config

```
* all: update maintainers.
* Contributors: gavanderhoorn
```

## ur_bringup

```
* all: update maintainers.
* Contributors: gavanderhoorn
```

## ur_description

```
* all: update maintainers.
* Contributors: gavanderhoorn
```

## ur_driver

```
* all: update maintainers.
* Contributors: gavanderhoorn
```

## ur_gazebo

```
* ur_gazebo: escape underscore in changelog (#279 <https://github.com/ros-industrial/universal_robot/issues/279>).
* all: update maintainers.
* Contributors: gavanderhoorn
```

## ur_kinematics

```
* all: update maintainers.
* Contributors: gavanderhoorn
```

## ur_msgs

```
* all: update maintainers.
* Contributors: gavanderhoorn
```
