### PR TITLE
universal_robot: 1.1.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13812,7 +13812,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/universal_robot-release.git
-      version: 1.1.8-0
+      version: 1.1.9-0
     source:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robot` to `1.1.9-0`:

- upstream repository: https://github.com/ros-industrial/universal_robot.git
- release repository: https://github.com/ros-industrial-release/universal_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.1.8-0`

## universal_robot

```
* No changes.
```

## ur10_moveit_config

```
* use '--inorder' for jade+ xacro as well.
* make RViz load MoveIt display by default.
* Contributors: gavanderhoorn
```

## ur3_moveit_config

```
* use '--inorder' for jade+ xacro as well.
* make RViz load MoveIt display by default.
* Contributors: gavanderhoorn
```

## ur5_moveit_config

```
* use '--inorder' for jade+ xacro as well.
* make RViz load MoveIt display by default.
* Contributors: gavanderhoorn
```

## ur_bringup

```
* No changes.
```

## ur_description

```
* reintroduce 'pi', unbrake dependent xacros.
* use '--inorder' to trigger use of jade+ xacro on Indigo.
* Contributors: gavanderhoorn
```

## ur_driver

```
* No changes.
```

## ur_gazebo

```
* No changes.
```

## ur_kinematics

```
* No changes.
```

## ur_msgs

```
* No changes.
```
