### PR TITLE
tele_dir: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13180,7 +13180,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rdelgadov/tele_dir-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/rdelgadov/tele_dir.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tele_dir` to `0.0.4-0`:

- upstream repository: https://github.com/rdelgadov/tele_dir
- release repository: https://github.com/rdelgadov/tele_dir-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.3-0`

## tele_dir

```
* Create setup.py
* Update CMakeLists.txt
* Update CMakeLists.txt
* Delete CMakeLists.txt~
* Delete package.xml~
* Contributors: Rodrigo Alexis Delgado Vega
```
