### PR TITLE
turtlebot_exploration_3d: 0.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13530,7 +13530,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d-release.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_exploration_3d` to `0.0.8-0`:

- upstream repository: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git
- release repository: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.7-0`

## turtlebot_exploration_3d

```
* update install list
* Contributors: mailto:baishi.bona@gmail.com
```
