### PR TITLE
rosdep: updated and unified ruby keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3579,9 +3579,6 @@ ruby:
     trusty: [ruby1.9.1-dev, libruby1.9.1, ruby1.9.1]
     utopic: [ruby1.9.1-dev, libruby1.9.1, ruby1.9.1]
     vivid: [ruby1.9.1-dev, libruby1.9.1, ruby1.9.1]
-ruby-sass:
-  fedora: [rubygem-sass]
-  ubuntu: [ruby-sass]
 ruby1.9.3:
   ubuntu:
     precise: [ruby1.9.3]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3559,33 +3559,6 @@ rsync:
   gentoo: [net-misc/rsync]
   opensuse: [rsync]
   ubuntu: [rsync]
-ruby:
-  arch: [ruby]
-  debian: [ruby, ruby-dev]
-  fedora: [ruby, ruby-devel, openssl-devel, rubygems]
-  gentoo:
-    portage:
-      packages: [dev-lang/ruby]
-  macports: [ruby]
-  ubuntu:
-    lucid: [ruby1.8-dev, libopenssl-ruby1.8, rubygems1.8]
-    maverick: [ruby1.8-dev, libruby1.8, rubygems1.8]
-    natty: [ruby1.8-dev, libruby1.8, rubygems1.8]
-    oneiric: [ruby1.8-dev, libruby1.8, rubygems1.8]
-    precise: [ruby1.8-dev, libruby1.8, rubygems1.8]
-    quantal: [ruby, ruby-dev]
-    raring: [ruby, ruby-dev]
-    saucy: [ruby, ruby-dev]
-    trusty: [ruby, ruby-dev]
-    utopic: [ruby, ruby-dev]
-    vivid: [ruby, ruby-dev]
-    wily: [ruby, ruby-dev]
-    xenial: [ruby, ruby-dev]
-    yakkety: [ruby, ruby-dev]
-    zesty: [ruby, ruby-dev]
-ruby1.9.3:
-  ubuntu:
-    precise: [ruby1.9.3]
 sbcl:
   arch: [sbcl]
   debian: [sbcl]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3561,7 +3561,7 @@ rsync:
   ubuntu: [rsync]
 ruby:
   arch: [ruby]
-  debian: [ruby1.8-dev, libruby1.8, rubygems1.8]
+  debian: [ruby, ruby-dev]
   fedora: [ruby, ruby-devel, openssl-devel, rubygems]
   gentoo:
     portage:
@@ -3573,12 +3573,16 @@ ruby:
     natty: [ruby1.8-dev, libruby1.8, rubygems1.8]
     oneiric: [ruby1.8-dev, libruby1.8, rubygems1.8]
     precise: [ruby1.8-dev, libruby1.8, rubygems1.8]
-    quantal: [ruby1.9.1-dev, libruby1.9.1, ruby1.9.1]
-    raring: [ruby1.9.1-dev, libruby1.9.1, ruby1.9.1]
-    saucy: [ruby1.9.1-dev, libruby1.9.1, ruby1.9.1]
-    trusty: [ruby1.9.1-dev, libruby1.9.1, ruby1.9.1]
-    utopic: [ruby1.9.1-dev, libruby1.9.1, ruby1.9.1]
-    vivid: [ruby1.9.1-dev, libruby1.9.1, ruby1.9.1]
+    quantal: [ruby, ruby-dev]
+    raring: [ruby, ruby-dev]
+    saucy: [ruby, ruby-dev]
+    trusty: [ruby, ruby-dev]
+    utopic: [ruby, ruby-dev]
+    vivid: [ruby, ruby-dev]
+    wily: [ruby, ruby-dev]
+    xenial: [ruby, ruby-dev]
+    yakkety: [ruby, ruby-dev]
+    zesty: [ruby, ruby-dev]
 ruby1.9.3:
   ubuntu:
     precise: [ruby1.9.3]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -45,3 +45,7 @@ rdoc:
   debian: [ruby]
   fedora: [rubygem-rdoc]
   ubuntu: [ruby]
+ruby-sass:
+  debian: [ruby-sass]
+  fedora: [rubygem-sass]
+  ubuntu: [ruby-sass]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -50,7 +50,34 @@ rdoc:
   debian: [ruby]
   fedora: [rubygem-rdoc]
   ubuntu: [ruby]
+ruby:
+  arch: [ruby]
+  debian: [ruby, ruby-dev]
+  fedora: [ruby, ruby-devel, openssl-devel, rubygems]
+  gentoo:
+    portage:
+      packages: [dev-lang/ruby]
+  macports: [ruby]
+  ubuntu:
+    lucid: [ruby1.8-dev, libopenssl-ruby1.8, rubygems1.8]
+    maverick: [ruby1.8-dev, libruby1.8, rubygems1.8]
+    natty: [ruby1.8-dev, libruby1.8, rubygems1.8]
+    oneiric: [ruby1.8-dev, libruby1.8, rubygems1.8]
+    precise: [ruby1.8-dev, libruby1.8, rubygems1.8]
+    quantal: [ruby, ruby-dev]
+    raring: [ruby, ruby-dev]
+    saucy: [ruby, ruby-dev]
+    trusty: [ruby, ruby-dev]
+    utopic: [ruby, ruby-dev]
+    vivid: [ruby, ruby-dev]
+    wily: [ruby, ruby-dev]
+    xenial: [ruby, ruby-dev]
+    yakkety: [ruby, ruby-dev]
+    zesty: [ruby, ruby-dev]
 ruby-sass:
   debian: [ruby-sass]
   fedora: [rubygem-sass]
   ubuntu: [ruby-sass]
+ruby1.9.3:
+  ubuntu:
+    precise: [ruby1.9.3]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -1,58 +1,21 @@
 facets:
   arch: [ruby-facets]
+  debian: [ruby-facets]
   fedora: [rubygem-facets]
   osx:
     macports: [rb-facets]
-  ubuntu:
-    lucid:
-      apt: [libfacets-ruby]
-    oneiric:
-      apt: [libfacets-ruby]
-    precise:
-      apt: [ruby-facets]
-    quantal:
-      apt: [ruby-facets]
-    raring:
-      apt: [ruby-facets]
-    saucy:
-      apt: [ruby-facets]
-    trusty:
-      apt: [ruby-facets]
+  ubuntu: [ruby-facets]
 flexmock:
+  debian: [ruby-flexmock]
   fedora: [rubygem-flexmock]
   osx:
     macports: [rb-flexmock]
-  ubuntu:
-    lucid:
-      apt: [libflexmock-ruby]
-    oneiric:
-      apt: [libflexmock-ruby]
-    precise:
-      apt: [ruby-flexmock]
-    quantal:
-      apt: [ruby-flexmock]
-    raring:
-      apt: [ruby-flexmock]
-    saucy:
-      apt: [ruby-flexmock]
-    trusty:
-      apt: [ruby-flexmock]
+  ubuntu: [ruby-flexmock]
 hoe:
   arch: [ruby-hoe]
+  debian: [ruby-hoe]
   fedora: [rubygem-hoe]
-  ubuntu:
-    oneiric:
-      apt: [ruby-hoe]
-    precise:
-      apt: [ruby-hoe]
-    quantal:
-      apt: [ruby-hoe]
-    raring:
-      apt: [ruby-hoe]
-    saucy:
-      apt: [ruby-hoe]
-    trusty:
-      apt: [ruby-hoe]
+  ubuntu: [ruby-hoe]
 jekyll:
   ubuntu:
     precise:
@@ -61,37 +24,24 @@ jekyll:
         packages: [jekyll]
 nokogiri:
   arch: [ruby-nokogiri]
+  debian: [ruby-nokogiri]
   fedora: [rubygem-nokogiri]
   osx:
     macports: [rb-nokogiri]
-  ubuntu:
-    lucid:
-      apt: [libnokogiri-ruby]
-    oneiric:
-      apt: [libnokogiri-ruby]
-    precise:
-      apt: [ruby-nokogiri]
-    quantal:
-      apt: [ruby-nokogiri]
-    raring:
-      apt: [ruby-nokogiri]
-    saucy:
-      apt: [ruby-nokogiri]
-    trusty:
-      apt: [ruby-nokogiri]
+  ubuntu: [ruby-nokogiri]
 rake:
   arch: [ruby]
+  debian: [rake]
   fedora: [rubygem-rake, rubygem-rake-compiler]
   macports: [rb-rake]
-  ubuntu:
-    apt: [rake]
+  ubuntu: [rake]
 rake-compiler:
   arch: [ruby-rake-compiler]
+  debian: [rake-compiler]
   fedora: [rubygem-rake-compiler]
-  ubuntu:
-    apt: [rake-compiler]
+  ubuntu: [rake-compiler]
 rdoc:
   arch: [ruby]
+  debian: [ruby]
   fedora: [rubygem-rdoc]
-  ubuntu:
-    apt: [rdoc]
+  ubuntu: [ruby]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -1,3 +1,8 @@
+bundler:
+  arch: [ruby-bundler]
+  debian: [bundler]
+  fedora: [rubygem-bundler]
+  ubuntu: [bundler]
 facets:
   arch: [ruby-facets]
   debian: [ruby-facets]


### PR DESCRIPTION
Ubuntu:
- [ruby-defaults](http://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=ruby-defaults&searchon=sourcenames) (source package)
  - 1.9.1 has been the [default version](https://launchpad.net/ubuntu/+source/ruby-defaults/+publishinghistory) from Ubuntu Quantal until Trusty.
  - Since Utopic the default ruby version is 2.1 or newer. Packages `*ruby1.9.1*` do not exist in Utopic and Vivid (added in https://github.com/ros/rosdistro/commit/b979cf3547a6139c134961c7f2d3b033549c6fd6).
  - We can simply use the default version from Quantal on without an effect on existing usages (`ruby-dev` instead of `rubyx.y.z-dev`). Two additional meta-packages would be installed.
  - `rubyx.y.z-dev` already  depends on `librubyx.y.z`. No need to list the library package explicitly?
- [ruby-facets](http://packages.ubuntu.com/search?keywords=ruby-facets&searchon=names&exact=1&suite=all&section=all)
  - replaced [libfacets-ruby](https://launchpad.net/ubuntu/+source/libfacets-ruby/+publishinghistory) since Precise
- [ruby-flexmock](http://packages.ubuntu.com/search?keywords=ruby-flexmock&searchon=names&exact=1&suite=all&section=all)
  - replaced [libflexmock-ruby](https://launchpad.net/ubuntu/+source/libflexmock-ruby/+publishinghistory) since Precise
- [ruby-hoe](http://packages.ubuntu.com/search?keywords=ruby-hoe&searchon=names&exact=1&suite=all&section=all)
- [ruby-nokogiri](http://packages.ubuntu.com/search?keywords=ruby-nokogiri&searchon=names&exact=1&suite=all&section=all)
  - replaced [libnokogiri-ruby](https://launchpad.net/ubuntu/+source/libnokogiri-ruby/+publishinghistory) since Precise
- rdoc never existed as a separate package in Ubuntu. The executable is part of the respective [ruby](http://packages.ubuntu.com/search?keywords=ruby&searchon=names&exact=1&suite=all&section=all) interpreter binary package.
- [ruby-sass](http://packages.ubuntu.com/search?keywords=ruby-sass&searchon=names&exact=1&suite=all&section=all) (moved from base.yaml)

Debian:
- [ruby-defaults](https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=sourcenames&keywords=ruby-defaults) (source package)
- [ruby-facets](https://packages.debian.org/search?keywords=ruby-facets&searchon=names&exact=1&suite=all&section=all)
- [ruby-flexmock](https://packages.debian.org/search?keywords=ruby-flexmock&searchon=names&exact=1&suite=all&section=all)
- [ruby-hoe](https://packages.debian.org/search?keywords=ruby-hoe&searchon=names&exact=1&suite=all&section=all)
- [ruby-nokogiri](https://packages.debian.org/search?keywords=ruby-nokogiri&searchon=names&exact=1&suite=all&section=all)
- [rake](https://packages.debian.org/search?keywords=rake&searchon=names&exact=1&suite=all&section=all)
- [rake-compiler](https://packages.debian.org/search?keywords=rake-compiler&searchon=names&exact=1&suite=all&section=all)
- [ruby-sass](https://packages.debian.org/search?keywords=ruby-sass&searchon=names&exact=1&suite=all&section=all) (moved from base.yaml)

What is the reason why [ruby.yaml](https://github.com/meyerj/rosdistro/blob/f09d3f0560d023eef9f2e8ad6d2bab41c11773f0/rosdep/ruby.yaml) is separate from [base.yaml](https://github.com/meyerj/rosdistro/blob/f09d3f0560d023eef9f2e8ad6d2bab41c11773f0/rosdep/base.yaml)? Has the split any consequences on key lookup or are they treated the same?  Should all (new) ruby library keys have a `ruby-` prefix, similar to the ones in [python.yaml](https://github.com/meyerj/rosdistro/blob/f09d3f0560d023eef9f2e8ad6d2bab41c11773f0/rosdep/python.yaml)? Should `ruby` itself be moved to [ruby.yaml](https://github.com/meyerj/rosdistro/blob/f09d3f0560d023eef9f2e8ad6d2bab41c11773f0/rosdep/ruby.yaml)?