### PR TITLE
genrs: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1340,6 +1340,17 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: kinetic-devel
     status: maintained
+  genrs:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/adnanademovic/genrs-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/adnanademovic/genrs.git
+      version: master
+    status: developed
   geographic_info:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genrs` to `0.1.0-1`:

- upstream repository: https://github.com/adnanademovic/genrs.git
- release repository: https://github.com/adnanademovic/genrs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## genrs

```
* Create Rust message generation based on gencpp
* Contributors: Adnan Ademovic
```
