### PR TITLE
robot_model: 1.11.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9933,7 +9933,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.11.11-0
+      version: 1.11.12-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.11.12-0`:

- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.11.11-0`

## collada_parser

- No changes

## collada_urdf

- No changes

## joint_state_publisher

- No changes

## kdl_parser

- No changes

## kdl_parser_py

- No changes

## robot_model

- No changes

## urdf

```
* Added ``urdf_compatibility.h`` to define ``SharedPtr`` types, copy of #160 <https://github.com/ros/robot_model/issues/160> (#170 <https://github.com/ros/robot_model/issues/170>)
* Addressed gcc6 build error in the urdf package (#156 <https://github.com/ros/robot_model/issues/156>)
* Contributors: Lukas Bulwahn, Michael Görner
```

## urdf_parser_plugin

- No changes
