### PR TITLE
robot_model: 1.12.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4313,7 +4313,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.12.5-0
+      version: 1.12.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.12.6-0`:

- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.12.5-0`

## collada_parser

```
* Now using urdf::*ShredPtr instead of boost::shared_ptr (#144 <https://github.com/ros/robot_model/issues/144>)
* Contributors: Jochen Sprickerhof
```

## collada_urdf

```
* Now using urdf::*ShredPtr instead of boost::shared_ptr (#144 <https://github.com/ros/robot_model/issues/144>)
* Contributors: Jochen Sprickerhof
```

## joint_state_publisher

```
* Migrated slots in joint state publisher gui to Qt5 (#147 <https://github.com/ros/robot_model/issues/147>)
* Now uses GridLayout to support large numbers of joints and small screens (#150 <https://github.com/ros/robot_model/issues/150>)
* Contributors: Bence Magyar, Michał Barciś
```

## kdl_parser

```
* Now using urdf::*ShredPtr instead of boost::shared_ptr (#144 <https://github.com/ros/robot_model/issues/144>)
* Contributors: Jochen Sprickerhof
```

## kdl_parser_py

- No changes

## robot_model

- No changes

## urdf

```
* Addressed gcc6 build error in the urdf package, forward port of #156 <https://github.com/ros/robot_model/issues/156> (#173 <https://github.com/ros/robot_model/issues/173>)
* Now using urdf::*ShredPtr instead of boost::shared_ptr (#144 <https://github.com/ros/robot_model/issues/144>)
* Contributors: Jochen Sprickerhof, William Woodall
```

## urdf_parser_plugin

```
* Now using urdf::*ShredPtr instead of boost::shared_ptr (#144 <https://github.com/ros/robot_model/issues/144>)
* Contributors: Jochen Sprickerhof
```
