### PR TITLE
Add tuple space lindypy rule

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1053,6 +1053,16 @@ python-libpgm-pip:
   ubuntu:
     pip:
       packages: [libpgm]
+python-lindypy-pip:
+  debian:
+    pip:
+      packages: [lindypy]
+  fedora:
+    pip:
+      packages: [lindypy]
+  ubuntu:
+    pip:
+      packages: [lindypy]
 python-lttngust:
   debian:
     pip:
@@ -2911,13 +2921,3 @@ xdot:
   debian: [xdot]
   fedora: [python-xdot]
   ubuntu: [xdot]
-python-lindypy-pip:
-  ubuntu:
-    pip:
-      packages: [lindypy]
-  debian:
-    pip:
-      packages: [lindypy]
-  fedora:
-    pip:
-      packages: [lindypy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2911,3 +2911,7 @@ xdot:
   debian: [xdot]
   fedora: [python-xdot]
   ubuntu: [xdot]
+python-lindypy-pip:
+  ubuntu:
+    pip:
+      packages: [lindypy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2915,3 +2915,9 @@ python-lindypy-pip:
   ubuntu:
     pip:
       packages: [lindypy]
+  debian:
+    pip:
+      packages: [lindypy]
+  fedora:
+    pip:
+      packages: [lindypy]


### PR DESCRIPTION
## General
The lindypy package provides a tuple space

## Package url
https://pypi.python.org/pypi/lindypy/0.2

## Usecase: 
The lindypy package is used for implementing a knowledge base as ros node