### PR TITLE
robot_state_publisher: 1.13.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4344,7 +4344,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/robot_state_publisher-release.git
-      version: 1.13.3-0
+      version: 1.13.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `1.13.4-0`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros-gbp/robot_state_publisher-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.13.3-0`

## robot_state_publisher

```
* Use ``urdf::*ShredPtr`` instead of ``boost::shared_ptr`` (#60 <https://github.com/ros/robot_state_publisher/issues/60>)
* Error log for empty JointState.position was downgraded to a throttled warning (#64 <https://github.com/ros/robot_state_publisher/issues/64>)
* Contributors: Jochen Sprickerhof, Sébastien BARTHÉLÉMY
```
