### PR TITLE
moveit_metapackages: 0.7.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6402,6 +6402,24 @@ repositories:
       url: https://github.com/JenniferBuehler/moveit-pkgs.git
       version: master
     status: maintained
+  moveit_metapackages:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_metapackages.git
+      version: master
+    release:
+      packages:
+      - moveit_full
+      - moveit_full_pr2
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_metapackages-release.git
+      version: 0.7.6-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_metapackages.git
+      version: master
+    status: maintained
   moveit_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_metapackages` to `0.7.6-0`:

- upstream repository: https://github.com/ros-planning/moveit_metapackages.git
- release repository: https://github.com/ros-gbp/moveit_metapackages-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## moveit_full

```
* [improve] Delegate moveit_full to moveit metapackage. (#8 <https://github.com/ros-planning/moveit_metapackages/issues/8>)
* Contributors: Isaac I.Y. Saito
```

## moveit_full_pr2

- No changes
