### PR TITLE
jsk_common: 2.2.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4841,7 +4841,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.1.2-4
+      version: 2.2.2-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.2.2-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.1.2-4`

## dynamic_tf_publisher

- No changes

## image_view2

```
* test/publish_lena.py: lena() is not included in scipy from 0.17
* src/image_view2.cpp: add cv::waitKey for opencv3 installed from source to fix freezing issue
* Contributors: Kei Okada
```

## jsk_common

- No changes

## jsk_data

```
* package.xml : Fix rosdep key: python-gdown -> python-gdown-pip
  According to https://github.com/ros/rosdistro/pull/13397
* jsk_data/download_data.py : Check if specified md5 has 32 charactors
* Contributors: Kentaro Wada
```

## jsk_network_tools

- No changes

## jsk_tilt_laser

- No changes

## jsk_tools

```
* package.xml : rosemacs-el is only available until precise, from indigo, we uses rosemacs (#1497 <https://github.com/jsk-ros-pkg/jsk_common/issues/1497>)
* src/rostopic_host_sanity : Check host sanity with a script
* Contributors: Kei Okada, Kentaro Wada
```

## jsk_topic_tools

- No changes

## multi_map_server

- No changes

## virtual_force_publisher

- No changes
