### PR TITLE
sick_tim: 0.0.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6019,7 +6019,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/uos-gbp/sick_tim-release.git
-      version: 0.0.9-0
+      version: 0.0.10-0
     source:
       type: git
       url: https://github.com/uos/sick_tim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_tim` to `0.0.10-0`:

- upstream repository: https://github.com/uos/sick_tim
- release repository: https://github.com/uos-gbp/sick_tim-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.9-0`

## sick_tim

```
* Automatically reboot scanner if it reports an error code. (#44 <https://github.com/uos/sick_tim/issues/44>)
* Update strtok logic. Fixes #42 <https://github.com/uos/sick_tim/issues/42> (#43 <https://github.com/uos/sick_tim/issues/43>)
* Contributors: Derek King, Jochen Sprickerhof, Martin Guenther
```
