### PR TITLE
rtabmap, rtabmap_ros: 0.11.13 in kinetic/distribution.yaml

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5336,7 +5336,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.11.8-4
+      version: 0.11.13-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -5351,7 +5351,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.11.8-1
+      version: 0.11.13-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository rtabmap and rtabmap_ros to 0.11.13-0:

    upstream repository: https://github.com/introlab/rtabmap.git, https://github.com/introlab/rtabmap_ros.git
    release repository: https://github.com/introlab/rtabmap-release.git, https://github.com/introlab/rtabmap_ros-release.git
    distro file: kinetic/distribution.yaml
    bloom version: 0.5.23
    previous version for package: 0.11.8
