### PR TITLE
multimaster_fkie: 0.7.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3009,7 +3009,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.6.2-0
+      version: 0.7.0-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.7.0-0`:

- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.6.2-0`

## default_cfg_fkie

```
* default_cfg_fkie: fixed start nodes with same name and different namespaces
* default_cfg_fkie: fix the namespace for rqt-cpp-plugins
* Contributors: Alexander Tiderko
```

## master_discovery_fkie

```
* master_discovery_fkie: added detection for timejumps into the past
* master_discovery_fkie: fixed the shutdown process
  
  sometimes blocks the SimpleXMLRPCServer the shutdown process. Added a
  timer to kill the own process at the end.
* master_discovery_fkie: #55 <https://github.com/fkie/multimaster_fkie/issues/55> change the message handling routines
  Introduced a send and receive Queue. It was need to implement new
  features like hub/client structure.
  Added more debug output.
* master_discovery_fkie: splitted send_mcast into send_mcast and listen_mcast to get a hub functionality
* Contributors: Alexander Tiderko, deng02
```

## master_sync_fkie

- No changes

## multimaster_fkie

```
* master_discovery_fkie: added detection for timejumps into the past
* master_discovery_fkie: fixed the shutdown process
  
  sometimes blocks the SimpleXMLRPCServer the shutdown process. Added a
  timer to kill the own process at the end.
* master_discovery_fkie: #55 <https://github.com/fkie/multimaster_fkie/issues/55> change the message handling routines
  Introduced a send and receive Queue. It was need to implement new
  features like hub/client structure.
  Added more debug output.
* master_discovery_fkie: splitted send_mcast into send_mcast and listen_mcast to get a hub functionality
* node_manager_fkie: fixed visualisation of not local nodes
  
  repaired gui_resources.py for Qt5 compatibility
  restore Qt5 compatibility
* node_manager_fkie: added update/set time dialog to update time with ntpdate or date
* node_manager_fkie: added rosbag record to rqt menu
* node_manager_fkie: copy now all selected nodes, topics, services or parameter names to clipboard by pressing Ctrl+C
* node_manager_fkie: added cursor position number to editor
* node_manager_fkie: added indent before hostname in description panel
* node_manager_fkie: added a colorize_host settings parameter
  
  the color of the host will be now determine automatically
  you can also set own color for each host by double-click on the
  hostname in description panel.
* node_manager_fkie: fixed error after cancel color selection
* node_manager_fkie: use gradient to set color
* node_manager_fkie: now you can define colors for each robot
* node_manager_fkie: removed a broken import
* node_manager_fkie: fixed: no longer clear the search result on click into editor
* node_manager_fkie: find dialog in xml-editor shows now all results in as list
* node_manager_fkie: added clear button to filder lines in dialogs
* node_manager_fkie: add filter to nodes view
  added also a clear button (also ESC) to all filter lines
* node_manager_fkie: fixed some extended visualization for synced nodes
* default_cfg_fkie: fixed start nodes with same name and different namespaces
* default_cfg_fkie: fix the namespace for rqt-cpp-plugins
* Contributors: Alexander Tiderko, Sr4l, deng02
```

## multimaster_msgs_fkie

- No changes

## node_manager_fkie

```
* node_manager_fkie: fixed visualisation of not local nodes
  
  repaired gui_resources.py for Qt5 compatibility
  restore Qt5 compatibility
* node_manager_fkie: added update/set time dialog to update time with ntpdate or date
* node_manager_fkie: added rosbag record to rqt menu
* node_manager_fkie: copy now all selected nodes, topics, services or parameter names to clipboard by pressing Ctrl+C
* node_manager_fkie: added cursor position number to editor
* node_manager_fkie: added indent before hostname in description panel
* node_manager_fkie: added a colorize_host settings parameter
  
  the color of the host will be now determine automatically
  you can also set own color for each host by double-click on the
  hostname in description panel.
* node_manager_fkie: fixed error after cancel color selection
* node_manager_fkie: use gradient to set color
* node_manager_fkie: now you can define colors for each robot
* node_manager_fkie: removed a broken import
* node_manager_fkie: fixed: no longer clear the search result on click into editor
* node_manager_fkie: find dialog in xml-editor shows now all results in as list
* node_manager_fkie: added clear button to filder lines in dialogs
* node_manager_fkie: add filter to nodes view
  added also a clear button (also ESC) to all filter lines
* node_manager_fkie: fixed some extended visualization for synced nodes
* Contributors: Alexander Tiderko, Sr4l
```
