### PR TITLE
rtmros_nextage: 0.7.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11718,7 +11718,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.7.11-0
+      version: 0.7.12-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
<s>**Please hold the merge yet**. </s>

Increasing version of package(s) in repository `rtmros_nextage` to `0.7.12-0`:

- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.7.11-0`

## nextage_description

- No changes

## nextage_gazebo

- No changes

## nextage_ik_plugin

```
* [capability] Release nextage_ik_plugin #281 <https://github.com/tork-a/rtmros_nextage/pull/281>
* Contributors: Isaac I.Y. Saito
```

## nextage_moveit_config

- No changes

## nextage_ros_bridge

```
* [fix][nxo client] Fix wrong string print that could stop the script to work. #276 <https://github.com/tork-a/rtmros_nextage/pull/276>
* [capability] Release nextage_ik_plugin #281 <https://github.com/tork-a/rtmros_nextage/pull/281>
* [enhance] Add simple rviz.launch that can be run without extra processes (e.g. moveit) to be running. #282 <https://github.com/tork-a/rtmros_nextage/pull/282>
* [enhance][nextage.py script] users with older dio spec robot can specify dio version upon starting the script (enhance for #274 <https://github.com/tork-a/rtmros_nextage/issues/274>).
* [maintenance] clean up for catkin lint #283 <https://github.com/tork-a/rtmros_nextage/pull/283>
* [maintenance][fix][test] Correct api version number for dio.
* Contributors: Kei Okada, Isaac I.Y. Saito
```

## rtmros_nextage

```
* [fix][nxo client] Fix wrong string print that could stop the script to work. #276 <https://github.com/tork-a/rtmros_nextage/pull/276>
* [capability] Release nextage_ik_plugin #281 <https://github.com/tork-a/rtmros_nextage/pull/281>
* [enhance] Add simple rviz.launch that can be run without extra processes (e.g. moveit) to be running. #282 <https://github.com/tork-a/rtmros_nextage/pull/282>
* [enhance][nextage.py script] users with older dio spec robot can specify dio version upon starting the script (enhance for #274 <https://github.com/tork-a/rtmros_nextage/issues/274>).
* [maintenance] clean up for catkin lint #283 <https://github.com/tork-a/rtmros_nextage/pull/283>
* [maintenance][fix][test] Correct api version number for dio.
* Contributors: Kei Okada, Isaac I.Y. Saito
```
