### PR TITLE
rtmros_gazebo: 0.1.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11675,7 +11675,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_gazebo-release.git
-      version: 0.1.11-0
+      version: 0.1.12-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_gazebo` to `0.1.12-0`:

- upstream repository: https://github.com/start-jsk/rtmros_gazebo.git
- release repository: https://github.com/tork-a/rtmros_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.11-0`

## eusgazebo

- No changes

## hrpsys_gazebo_general

```
* [hrpsys_gazebo_general][iob/CMakeLists.txt] fix: remove build type specification from install
* [hrpsys_gazebo_general] Pass CONF_FILE option to hrpsys_ros_bridge.launch
* Contributors: Yuki Furuta, Iori Kumagai
```

## hrpsys_gazebo_msgs

- No changes

## staro_moveit_config

- No changes
