### PR TITLE
remote_manipulation_markers: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9643,6 +9643,21 @@ repositories:
       type: git
       url: https://github.com/toddhester/rl-texplore-ros-pkg.git
       version: master
+  remote_manipulation_markers:
+    doc:
+      type: git
+      url: https://github.com/GT-RAIL/remote_manipulation_markers.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/gt-rail-release/remote_manipulation_markers-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/GT-RAIL/remote_manipulation_markers.git
+      version: develop
+    status: maintained
   remote_monitor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `remote_manipulation_markers` to `1.0.0-0`:

- upstream repository: https://github.com/GT-RAIL/remote_manipulation_markers.git
- release repository: https://github.com/gt-rail-release/remote_manipulation_markers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## remote_manipulation_markers

```
* Moved meshes into package to remove dependency on robotiq_85_description
* travis integration
* interactive marker servers for the free positioning, constrained positioning, and point-and-click approaches
* Initial commit
* Contributors: David Kent
```
