### PR TITLE
rail_manipulation_msgs: 0.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9327,7 +9327,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/rail_manipulation_msgs-release.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/GT-RAIL/rail_manipulation_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_manipulation_msgs` to `0.0.9-0`:

- upstream repository: https://github.com/GT-RAIL/rail_manipulation_msgs.git
- release repository: https://github.com/gt-rail-release/rail_manipulation_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.8-0`

## rail_manipulation_msgs

```
* Added optional flag for attaching object collision model after pickup
* Updated Cartesian Path service to use stamped poses
* Primitive action for simple Cartesian actions
* added grasp id to grasp messages
* Added joint state difference to optionally prevent large changes in joint configuration
* Contributors: Aaron St. Clair, David Kent, Russell Toris
```
