### PR TITLE
remote_manipulation_markers: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9652,7 +9652,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/remote_manipulation_markers-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/GT-RAIL/remote_manipulation_markers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `remote_manipulation_markers` to `1.0.1-0`:

- upstream repository: https://github.com/GT-RAIL/remote_manipulation_markers.git
- release repository: https://github.com/gt-rail-release/remote_manipulation_markers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.0-0`

## remote_manipulation_markers

```
* Message generation dependencies
* Contributors: David Kent
```
