### PR TITLE
carl_moveit: 0.0.18-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1121,7 +1121,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/carl_moveit-release.git
-      version: 0.0.17-0
+      version: 0.0.18-0
     source:
       type: git
       url: https://github.com/GT-RAIL/carl_moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carl_moveit` to `0.0.18-0`:

- upstream repository: https://github.com/WPI-RAIL/carl_moveit.git
- release repository: https://github.com/gt-rail-release/carl_moveit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.17-0`

## carl_moveit

```
* Updated for new version of rail_manipulation_msgs
* Contributors: David Kent, Russell Toris
```
