### PR TITLE
Adding microstrain_3dm_gx5_45 to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6238,6 +6238,16 @@ repositories:
       url: https://github.com/xuefengchang/micros_swarm_framework.git
       version: master
     status: developed
+  microstrain_3dm_gx5_45:
+    doc:
+      type: git
+      url: https://github.com/bsb808/microstrain_3dm_gx5_45.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/bsb808/microstrain_3dm_gx5_45.git
+      version: master
+    status: developed
   microstrain_3dmgx2_imu:
     doc:
       type: git


### PR DESCRIPTION
I'd like microstrain_3dm_gx5_45 to be indexed and documented on ros.org