### PR TITLE
yumi: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14870,7 +14870,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/OrebroUniversity/yumi_release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/OrebroUniversity/yumi.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yumi` to `0.0.4-0`:

- upstream repository: https://github.com/OrebroUniversity/yumi.git
- release repository: https://github.com/OrebroUniversity/yumi_release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.3-0`

## gazebo_mimic

- No changes

## yumi_control

- No changes

## yumi_description

- No changes

## yumi_hw

```
* Fix for message generation dependency
* Contributors: Todor Stoyanov
```

## yumi_launch

- No changes

## yumi_moveit_config

- No changes

## yumi_support

- No changes
