### PR TITLE
rtmros_hironx: 1.1.19-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11720,7 +11720,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.18-0
+      version: 1.1.19-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.19-0`:

- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.1.18-0`

## hironx_calibration

- No changes

## hironx_moveit_config

- No changes

## hironx_ros_bridge

```
* [fix] more precision on end effector's location
* [fix][dynpick qnx driver] compilation.
* [fix][hironx script] Correct exception when no ROS master found.
* [fix] updated translation of last joint to match CAD data. updated arm end translation
* Contributors: Hajime SAITO, Isaac I.Y. Saito, Kei Okada
```

## rtmros_hironx

```
* [fix] more precision on end effector's location
* [fix][dynpick qnx driver] compilation.
* [fix][hironx script] Correct exception when no ROS master found.
* [fix] updated translation of last joint to match CAD data. updated arm end translation
* Contributors: Hajime SAITO, Isaac I.Y. Saito, Kei Okada
```
