### PR TITLE
catkin_pip: 0.1.17-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -440,7 +440,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/catkin_pip-release.git
-      version: 0.1.16-0
+      version: 0.1.17-0
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pip.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pip` to `0.1.17-0`:

- upstream repository: https://github.com/asmodehn/catkin_pip.git
- release repository: https://github.com/asmodehn/catkin_pip-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.16-0`

## catkin_pip

```
* now always ignore-installed when installing requirements.
* pinned pip to 8.1.2 because of https://github.com/asmodehn/catkin_pip/issues/58
* Merge pull request #57 <https://github.com/asmodehn/catkin_pip/issues/57> from asmodehn/devel
  upgrading gopher_devel
* Merge pull request #56 <https://github.com/asmodehn/catkin_pip/issues/56> from asmodehn/gopher-devel
  drop some echoing
* drop some echoing
* Contributors: AlexV, Daniel Stonier, alexv
```
