### PR TITLE
pyros: 0.3.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4359,11 +4359,19 @@ repositories:
       version: master
     status: developed
   pyros:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/pyros.git
+      version: indigo
     release:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/pyros-rosrelease.git
-      version: 0.3.0-1
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/asmodehn/pyros.git
+      version: indigo
     status: developed
   pyros_config:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros` to `0.3.1-0`:

- upstream repository: https://github.com/asmodehn/pyros.git
- release repository: https://github.com/asmodehn/pyros-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.3.0-1`

## pyros

```
* Disabling cache test on jade since rocon_python_comms not available
  yet. [alexv]
* Being less strict about mock depend. [alexv]
* Fixing optional dependency for travis tests. [alexv]
* Small comments for tests. [alexv]
* Skipping travis test of rpm & debian branches. [alexv]
* Removing old gone six submodule. [alexv]
* Changed dependency to tblib third party released package to allow
  build for any ROS platform. [alexv]
* Making python-mock a full dependency (used in package, for
  transitivity). commenting tblib, might not be needed. [alexv]
```
