### PR TITLE
yujin_ocs: 0.8.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6793,7 +6793,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/yujin_ocs-release.git
-      version: 0.8.1-0
+      version: 0.8.2-0
     source:
       type: git
       url: https://github.com/yujinrobot/yujin_ocs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yujin_ocs` to `0.8.2-0`:

- upstream repository: https://github.com/yujinrobot/yujin_ocs.git
- release repository: https://github.com/yujinrobot-release/yujin_ocs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.8.1-0`
