### PR TITLE
leap_motion: 0.0.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2232,16 +2232,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/leap_motion.git
-      version: master
+      version: hydro
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/leap_motion-release.git
-      version: 0.0.10-0
+      version: 0.0.11-0
     source:
       type: git
       url: https://github.com/ros-drivers/leap_motion.git
-      version: master
+      version: hydro
     status: maintained
   leptrino_force_torque:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `leap_motion` to `0.0.11-0`:

- upstream repository: https://github.com/ros-drivers/leap_motion
- release repository: https://github.com/ros-gbp/leap_motion-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.10-0`

## leap_motion

```
* [fix] ROS Hydro onward requires queue_size option #31 <https://github.com/ros-drivers/leap_motion/issues/31>
* Contributors: Kei Okada
```
