### PR TITLE
add libfreetype6-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1579,6 +1579,8 @@ libfreenect-dev:
 libfreetype6:
   fedora: [freetype-devel]
   ubuntu: [libfreetype6]
+libfreetype6-dev:
+  ubuntu: [libfreetype6-dev]
 libftdi-dev:
   arch: [libftdi]
   debian: [libftdi-dev]


### PR DESCRIPTION
Is the new key `libfreetype6-dev` ok or should I add `libfreetype6-dev` to the existing `libfreetype6` key?