### PR TITLE
industrial_core: 0.5.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1964,7 +1964,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-industrial-release/industrial_core-release.git
-      version: 0.5.0-0
+      version: 0.5.1-0
     source:
       type: git
       url: https://github.com/ros-industrial/industrial_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_core` to `0.5.1-0`:

- upstream repository: https://github.com/ros-industrial/industrial_core.git
- release repository: https://github.com/ros-industrial-release/industrial_core-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.5.0-0`

## industrial_core

```
* No changes
```

## industrial_deprecated

```
* No changes
```

## industrial_msgs

```
* No changes
```

## industrial_robot_client

```
* robot_status: missing reply to SERVICE_REQUEST. Fix in robot_status_message and relay_handler.
* industrial_robot_client: Fix signature of goal and cancel callbacks.
* Contributors: Alberto Marini, Maarten de Vries
```

## industrial_robot_simulator

```
* robot_simulator: clarify err msg when controller_joint_names is missing.
* Make industrial_robot_simulator python3 compatible.
* Contributors: G.A. vd. Hoorn, Maarten de Vries
```

## industrial_trajectory_filters

```
* Fix issue #127 <https://github.com/ros-industrial/industrial_core/issues/127>
  Changed all relevant ROS_INFO_STREAM macros to ROS_DEBUG_STREAM macros. Now the filter only outputs the summary at the end.
* Contributors: Mart (mmj)
```

## industrial_utils

```
* No changes
```

## simple_message

```
* Temporary fix, commented out disabled test to remove unstable build status
* Changed test port numbers to unused range in linux.  utest_message now uses port range defined by macros (addresses failure to init server socket)
* Amend to pull request #153 <https://github.com/ros-industrial/industrial_core/issues/153> (methods moved to TypedMessage)
* robot_status: missing reply to SERVICE_REQUEST. Fix in robot_status_message and relay_handler.
* simple_message: add doc to SpecialSeqValue enum members.
* simple_message: fix SpecialSeqValue typo. Fix #130 <https://github.com/ros-industrial/industrial_core/issues/130>.
* Contributors: Alberto Marini, Shaun Edwards, gavanderhoorn
```
