### PR TITLE
rosdep/python: add gitpython

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -848,6 +848,10 @@ python-github-pip:
   ubuntu:
     pip:
       packages: [PyGithub]
+python-gitpython-pip:
+  ubuntu:
+    pip:
+      packages: [gitpython]
 python-googleapi:
   debian: [python-googleapi]
   fedora: [google-api-python-client]


### PR DESCRIPTION
I am a bit unsure about the naming. I followed the general format `python-<PACKAGE><-pip IF PIP PACKAGE>`, but as the package is called `gitpython` in pip, this ends up with the weird `python-gitpython-pip` key. What do you think?

[pypi](https://pypi.python.org/pypi/GitPython/)

[gitpython documentation](https://gitpython.readthedocs.io/en/stable/)

Description:
> GitPython is a python library used to interact with git repositories, high-level like git-porcelain, or low-level like git-plumbing.
> 
> It provides abstractions of git objects for easy access of repository data, and additionally allows you to access the git repository more directly using either a pure python implementation, or the faster, but more resource intensive git command implementation.

Purpose:
Interact with repositories in large workspaces using the scripts, mainly for logging purposes.

