### PR TITLE
Temporarily drop cost_map

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1893,29 +1893,6 @@ repositories:
       url: https://github.com/ros/convex_decomposition.git
       version: indigo-devel
     status: maintained
-  cost_map:
-    doc:
-      type: git
-      url: https://github.com/stonier/cost_map.git
-      version: release/0.3-indigo-kinetic
-    release:
-      packages:
-      - cost_map
-      - cost_map_core
-      - cost_map_cv
-      - cost_map_demos
-      - cost_map_msgs
-      - cost_map_ros
-      - cost_map_visualisations
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/stonier/cost_map-release.git
-      version: 0.3.0-0
-    source:
-      type: git
-      url: https://github.com/stonier/cost_map.git
-      version: release/0.3-indigo-kinetic
-    status: developed
   costmap_converter:
     doc:
       type: git


### PR DESCRIPTION
Waiting for an update from grid_map, but that is taking a while, so dropping it for now until that gets re-released.