### PR TITLE
Add rosdep python rules for defer, kombu, and sortedcontainers

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -588,7 +588,7 @@ python-debian:
     utopic_python3: [python3-debian]
     vivid: [python-debian]
     vivid_python3: [python3-debian]
-python-defer:
+python-defer-pip:
   ubuntu:
     pip:
       packages: [defer]
@@ -1048,7 +1048,7 @@ python-kitchen:
     vivid: [python-kitchen]
     wily: [python-kitchen]
     xenial: [python-kitchen]
-python-kombu:
+python-kombu-pip:
   ubuntu:
     pip:
       packages: [kombu]
@@ -2423,7 +2423,7 @@ python-slacker-cli:
 python-smbus:
   debian: [python-smbus]
   ubuntu: [python-smbus]
-python-sortedcontainers:
+python-sortedcontainers-pip:
   ubuntu:
     pip:
       packages: [sortedcontainers]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -588,6 +588,10 @@ python-debian:
     utopic_python3: [python3-debian]
     vivid: [python-debian]
     vivid_python3: [python3-debian]
+python-defer:
+  ubuntu:
+    pip:
+      packages: [defer]
 python-defusedxml:
   arch: [python2-defusedxml]
   debian: [python-defusedxml]
@@ -1044,6 +1048,10 @@ python-kitchen:
     vivid: [python-kitchen]
     wily: [python-kitchen]
     xenial: [python-kitchen]
+python-kombu:
+  ubuntu:
+    pip:
+      packages: [kombu]
 python-libpcap:
   debian: [python-libpcap]
   fedora: [pylibpcap]
@@ -2415,6 +2423,10 @@ python-slacker-cli:
 python-smbus:
   debian: [python-smbus]
   ubuntu: [python-smbus]
+python-sortedcontainers:
+  ubuntu:
+    pip:
+      packages: [sortedcontainers]
 python-sparqlwrapper:
   ubuntu:
     trusty: [python-sparqlwrapper]


### PR DESCRIPTION
[PyPi kombu](https://pypi.python.org/pypi/kombu/4.0.2)
[PyPi sortedcontainers](https://pypi.python.org/pypi/sortedcontainers/1.5.7)
[PyPi defer](https://pypi.python.org/pypi/defer/1.0.4)