### PR TITLE
industrial_core: 0.6.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1834,6 +1834,30 @@ repositories:
       url: https://github.com/ros-industrial/industrial_ci.git
       version: master
     status: maintained
+  industrial_core:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/industrial_core.git
+      version: kinetic
+    release:
+      packages:
+      - industrial_core
+      - industrial_deprecated
+      - industrial_msgs
+      - industrial_robot_client
+      - industrial_robot_simulator
+      - industrial_trajectory_filters
+      - industrial_utils
+      - simple_message
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/industrial_core-release.git
+      version: 0.6.0-0
+    source:
+      type: git
+      url: https://github.com/ros-industrial/industrial_core.git
+      version: kinetic
+    status: maintained
   interactive_marker_twist_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_core` to `0.6.0-0`:

- upstream repository: https://github.com/ros-industrial/industrial_core.git
- release repository: https://github.com/ros-industrial-release/industrial_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## industrial_core

```
* Added C++ 11 compile option
* Contributors: Victor Lamoine
```

## industrial_deprecated

```
* Added C++ 11 compile option
* Contributors: Victor Lamoine
```

## industrial_msgs

```
* Added C++ 11 compile option
* Contributors: Victor Lamoine
```

## industrial_robot_client

```
* Added C++ 11 compile option
* Contributors: Victor Lamoine
```

## industrial_robot_simulator

```
* Added C++ 11 compile option
* Contributors: Victor Lamoine
```

## industrial_trajectory_filters

```
* Added C++ 11 compile option
* Contributors: Victor Lamoine
```

## industrial_utils

```
* Added C++ 11 compile option
* Contributors: Victor Lamoine
```

## simple_message

```
* Added C++ 11 compile option
* Contributors: Victor Lamoine
```
