### PR TITLE
geometry2: 0.5.14-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1413,6 +1413,7 @@ repositories:
       version: indigo-devel
     release:
       packages:
+      - geometry2
       - geometry_experimental
       - tf2
       - tf2_bullet
@@ -1427,7 +1428,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.5.13-0
+      version: 0.5.14-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.5.14-0`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.5.13-0`

## geometry2

```
* create geometry2 metapackage and make geometry_experimental depend on it for clarity of reverse dependency walking.
* Contributors: Tully Foote
```

## geometry_experimental

```
* create geometry2 metapackage and make geometry_experimental depend on it for clarity of reverse dependency walking.
* Contributors: Tully Foote
```

## tf2

```
* fixes #194 <https://github.com/ros/geometry2/issues/194> check for quaternion normalization before inserting into storage (#196 <https://github.com/ros/geometry2/issues/196>)
  * check for quaternion normalization before inserting into storage
  * Add test to check for transform failure on invalid quaternion input
* updating getAngleShortestPath() (#187 <https://github.com/ros/geometry2/issues/187>)
* Move internal cache functions into a namespace
  Fixes https://github.com/ros/geometry2/issues/175
* Link properly to convert.h
* Landing page for tf2 describing the conversion interface
* Fix comment on BufferCore::MAX_GRAPH_DEPTH.
* Contributors: Jackie Kay, Phil Osteen, Tully Foote, alex, gavanderhoorn
```

## tf2_bullet

```
* Improve documentation
* Contributors: Jackie Kay
```

## tf2_eigen

```
* Add tf2_eigen conversions for Pose and Point (not stamped) (#186 <https://github.com/ros/geometry2/issues/186>)
  * tf2_eigen: added conversions for Point msg type (not timestamped) to Eigen::Vector3d
  * tf2_eigen: added conversions for Pose msg type (not timestamped) to Eigen::Affine3d
  * tf2_eigen: new functions are inline now
  * tf2_eigen test compiling again
  * tf2_eigen: added tests for Affine3d and Vector3d conversion
  * tf2_eigen: added redefinitions of non-stamped conversion function to make usage in tf2::convert() possible
  * tf2_eigen: reduced redundancy by reusing non-stamped conversion-functions in their stamped counterparts
  * tf2_eigen: added notes at doTransform-implementations which can not work with tf2_ros::BufferInterface::transform
  * tf2_eigen: fixed typos
* Don't export local include dirs (#180 <https://github.com/ros/geometry2/issues/180>)
* Improve documentation.
* Contributors: Jackie Kay, Jochen Sprickerhof, cwecht
```

## tf2_geometry_msgs

```
* Add doxygen documentation for tf2_geometry_msgs
* Contributors: Jackie Kay
```

## tf2_kdl

```
* Add Python documentation for tf2_kdl
* Document kdl
* Contributors: Jackie Kay
```

## tf2_msgs

- No changes

## tf2_py

```
* Improve tf compatibility (#192 <https://github.com/ros/geometry2/issues/192>)
  getLatestCommonTime() is needed to implement the TF API.
  See ros/geometry#134 <https://github.com/ros/geometry/issues/134>
* Add missing type checks at Python/C++ tf2 transform interface #159 <https://github.com/ros/geometry2/issues/159> (#197 <https://github.com/ros/geometry2/issues/197>)
* Make tf2_py compatible with python3. (#173 <https://github.com/ros/geometry2/issues/173>)
  * tf2_py: Use PyUnicode objects for text in python3.
  * tf2_py: Make module initialization python3 compatible.
  * tf2_py: Fix type definition for python3.
  * tf2_py: Move and rename PyObject_BorrowAttrString.
* Contributors: Maarten de Vries, Timo Röhling, alex
```

## tf2_ros

```
* Drop roslib.load_manifest (#191 <https://github.com/ros/geometry2/issues/191>)
* Adds ability to load TF from the ROS parameter server.
* Code linting & reorganization
* Fix indexing beyond end of array
* added a static transform broadcaster in python
* lots more documentation
* remove BufferCore doc, add BufferClient/BufferServer doc for C++, add Buffer/BufferInterface Python documentation
* Better overview for Python
* Contributors: Eric Wieser, Felix Duvallet, Jackie Kay, Mikael Arguedas, Mike Purvis
```

## tf2_sensor_msgs

- No changes

## tf2_tools

```
* Remove old load_manifest from view_frames (#182 <https://github.com/ros/geometry2/issues/182>)
* Contributors: Jochen Sprickerhof
```
