### PR TITLE
web_video_server: 0.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6655,6 +6655,21 @@ repositories:
       url: https://github.com/jihoonl/waypoint.git
       version: master
     status: developed
+  web_video_server:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/web_video_server.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotWebTools-release/web_video_server-release.git
+      version: 0.0.6-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/web_video_server.git
+      version: master
+    status: maintained
   webtest:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `web_video_server` to `0.0.6-0`:

- upstream repository: https://github.com/RobotWebTools/web_video_server.git
- release repository: https://github.com/RobotWebTools-release/web_video_server-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## web_video_server

```
* Fixed topic list to display all image topics, fixing Issue #18 <https://github.com/RobotWebTools/web_video_server/issues/18>.
* Contributors: Eric
```
