### PR TITLE
range_msgs: 1.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 141: http://ros.org/reps/rep-0141.html
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   fedora:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -9403,6 +9403,13 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  range_msgs:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pal-gbp/range_msgs-release.git
+      version: 1.1.1-0
+    status: developed
   rangeonly_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `range_msgs` to `1.1.1-0`:

- upstream repository: https://github.com/robotics-upo/range_msgs.git
- release repository: https://github.com/pal-gbp/range_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`

## range_msgs

```
* Initial version
* Initial commit
* Contributors: Fernando Caballero
```
