### PR TITLE
image_recognition: 0.0.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1779,6 +1779,26 @@ repositories:
       url: https://github.com/ros-perception/image_pipeline.git
       version: indigo
     status: maintained
+  image_recognition:
+    release:
+      packages:
+      - image_recognition
+      - image_recognition_msgs
+      - image_recognition_rqt
+      - image_recognition_util
+      - openface_ros
+      - skybiometry_ros
+      - tensorflow_ros
+      - tensorflow_ros_rqt
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tue-robotics/image_recognition-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/tue-robotics/image_recognition.git
+      version: master
+    status: developed
   image_transport_plugins:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_recognition` to `0.0.2-1`:

- upstream repository: https://github.com/tue-robotics/image_recognition.git
- release repository: https://github.com/tue-robotics/image_recognition-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## image_recognition

- No changes

## image_recognition_msgs

- No changes

## image_recognition_rqt

```
* fix(): Installation targets
* Contributors: Rein Appeldoorn
```

## image_recognition_util

- No changes

## openface_ros

- No changes

## skybiometry_ros

- No changes

## tensorflow_ros

- No changes

## tensorflow_ros_rqt

```
* fix(): Installation targets
* Contributors: Rein Appeldoorn
```
