### PR TITLE
nerian_sp1: 1.5.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7180,7 +7180,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/nerian-vision/nerian_sp1-release.git
-      version: 1.3.3-0
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_sp1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_sp1` to `1.5.0-1`:

- upstream repository: https://github.com/nerian-vision/nerian_sp1.git
- release repository: https://github.com/nerian-vision/nerian_sp1-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.3.3-0`

## nerian_sp1

```
* Switched to new sp1 software release 4.0.0
* Added example code for operation mode configuration to launch script
* Added example scripts for switching SP1 operation mode
* Separate topic for right image and bugfix for right image output
* Contributors: Konstantin Schauwecker
```
