### PR TITLE
idolink_node: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 141: http://ros.org/reps/rep-0141.html
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   fedora:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -4156,6 +4156,15 @@ repositories:
       type: git
       url: https://github.com/open-rdc/icart_mini.git
       version: indigo-devel
+    status: developed
+  idolink_node:
+    release:
+      packages:
+      - idolink
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pal-gbp/idolink-release.git
+      version: 0.1.1-0
     status: developed
   ihmc-ros-control:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `idolink_node` to `0.1.1-0`:

- upstream repository: https://github.com/pal-robotics/idolink_node.git
- release repository: https://github.com/pal-gbp/idolink-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`

## idolink

```
* initial commit
* Initial commit
* Contributors: Procópio Stein, procopiostein
```
