### PR TITLE
pepper_robot: 0.1.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8168,7 +8168,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_robot-release.git
-      version: 0.1.7-0
+      version: 0.1.9-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_robot` to `0.1.9-0`:

- upstream repository: https://github.com/ros-naoqi/pepper_robot.git
- release repository: https://github.com/ros-naoqi/pepper_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.7-0`

## pepper_bringup

```
* correct old emailaddress in package.xml
* [pepper_bringup] add perception.launch.xml
* add naoqi_pose/launch/pose_manager.launch + ns pepper_robot
* add an explicit dependency to get tests to pass on Travis.
* launch/pepper_full.launch : support nao_port in launch/naoqi_driver.launch https://github.com/ros-naoqi/naoqi_driver/pull/52
* Contributors: Kanae Kochigami, Karsten Knese, Kei Okada, Vincent Rabaud, Yuki Furuta
```

## pepper_description

```
* correct old emailaddress in package.xml
* remove code duplication
* fix deprecated xacro call
* cleaning pepperGazebo.xacro
* fixing bugs in wheels
* adding sensors to Gazebo
* fixing wheels
* cleaning pepperGazebo.xacro and adding pepperTransmission.xacro
* re-generating the latest Pepper URDF
* adding pepperGazebo.xacro
* urdf.rviz, add laser, range, camera, depth sensors
* Contributors: Karsten Knese, Kei Okada, Mikael Arguedas, Natalia Lyubova, nlyubova
```

## pepper_robot

```
* correct old emailaddress in package.xml
* Contributors: Karsten Knese
```

## pepper_sensors_py

```
* correct old emailaddress in package.xml
* Contributors: Karsten Knese
```
