### PR TITLE
pepper_robot: 0.1.10-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8168,7 +8168,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_robot-release.git
-      version: 0.1.9-0
+      version: 0.1.10-1
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_robot` to `0.1.10-1`:

- upstream repository: https://github.com/ros-naoqi/pepper_robot.git
- release repository: https://github.com/ros-naoqi/pepper_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.9-0`

## pepper_bringup

```
* Merge pull request #34 <https://github.com/ros-naoqi/pepper_robot/issues/34> from ros-naoqi/change_maintainer
  change maintainership
* change maintainership
* Contributors: Karsten Knese
```

## pepper_description

```
* Merge pull request #34 <https://github.com/ros-naoqi/pepper_robot/issues/34> from ros-naoqi/change_maintainer
  change maintainership
* change maintainership
* Contributors: Karsten Knese
```

## pepper_robot

```
* Merge pull request #34 <https://github.com/ros-naoqi/pepper_robot/issues/34> from ros-naoqi/change_maintainer
  change maintainership
* change maintainership
* Contributors: Karsten Knese
```

## pepper_sensors_py

```
* Merge pull request #34 <https://github.com/ros-naoqi/pepper_robot/issues/34> from ros-naoqi/change_maintainer
  change maintainership
* change maintainership
* Contributors: Karsten Knese
```
