### PR TITLE
pyros_common: 0.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9008,6 +9008,13 @@ repositories:
       url: https://github.com/asmodehn/pyros.git
       version: indigo
     status: developed
+  pyros_common:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/pyros-common-rosrelease.git
+      version: 0.4.0-0
+    status: developed
   pyros_config:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_common` to `0.4.0-0`:

- upstream repository: https://github.com/asmodehn/pyros-common.git
- release repository: https://github.com/asmodehn/pyros-common-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## pyros_common

```
* More fixes to get other tests to pass. [alexv]
* Restructuring pyros_common to simplify things. added cmakelists and
  package.xml temporarily, while we get everything working together from
  source... [alexv]
* Adding pyros protocol. [alexv]
* Fixed setup.py. [alexv]
* Moving code from pyros. [alexv]
* Initial commit. [AlexV]
```
