### PR TITLE
pepper_moveit_config: 0.0.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3806,6 +3806,21 @@ repositories:
       url: https://github.com/ros-naoqi/pepper_meshes-release.git
       version: 0.2.3-2
     status: maintained
+  pepper_moveit_config:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_moveit_config.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-naoqi/pepper_moveit_config-release.git
+      version: 0.0.7-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_moveit_config.git
+      version: master
+    status: maintained
   pepper_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_moveit_config` to `0.0.7-0`:

- upstream repository: https://github.com/ros-naoqi/pepper_moveit_config.git
- release repository: https://github.com/ros-naoqi/pepper_moveit_config-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## pepper_moveit_config

```
* fix allowed_execution_duration_scaling
* fixing the robot visualization
* changing the type of virtual_odom
* fixing both arms
* adding wheels as passive joints
* Contributors: Natalia Lyubova
```
