### PR TITLE
pepper_moveit_config: 0.0.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3815,7 +3815,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_moveit_config-release.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_moveit_config` to `0.0.8-0`:

- upstream repository: https://github.com/ros-naoqi/pepper_moveit_config.git
- release repository: https://github.com/ros-naoqi/pepper_moveit_config-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.7-0`

## pepper_moveit_config

```
* Merge pull request #9 <https://github.com/ros-naoqi/pepper_moveit_config/issues/9> from ros-naoqi/fix_warnings
  Fix deprecated warnings
* put parameters in proper namespace
* use action rather than deprecated service. Use spaces instead of tabs
* fix deprecated xacro call
* Contributors: Mikael Arguedas, Natalia Lyubova
```
