### PR TITLE
Added python-pyftpdlib to rosdep rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3476,6 +3476,9 @@ python-pydot:
   gentoo:
     portage:
       packages: [media-gfx/pydot]
+python-pyftpdlib:
+  debian: [python-pyftpdlib]
+  ubuntu: [python-pyftpdlib]
 python-pygraphviz:
   fedora: [python-pygraphviz]
   gentoo:


### PR DESCRIPTION
* http://packages.ubuntu.com/trusty/python-pyftpdlib
* http://packages.ubuntu.com/xenial/python-pyftpdlib