### PR TITLE
gennodejs: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1318,7 +1318,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RethinkRobotics-release/gennodejs-release.git
-      version: 1.0.3-0
+      version: 2.0.0-0
     source:
       type: git
       url: https://github.com/RethinkRobotics-opensource/gennodejs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gennodejs` to `2.0.0-0`:

- upstream repository: https://github.com/RethinkRobotics-opensource/gennodejs.git
- release repository: https://github.com/RethinkRobotics-release/gennodejs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.3-0`

## gennodejs

```
* The following changes make 2.0 incompatible with JavaScript
messages objects generated in gennodejs 1.x
* Bundled updates
* Contributors: Chris Smith, Ian McMahon
```
