### PR TITLE
range_msgs: 1.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 141: http://ros.org/reps/rep-0141.html
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   fedora:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -9422,7 +9422,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pal-gbp/range_msgs-release.git
-      version: 1.1.1-0
+      version: 1.1.2-0
     status: developed
   rangeonly_driver:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `range_msgs` to `1.1.2-0`:

- upstream repository: https://github.com/robotics-upo/range_msgs.git
- release repository: https://github.com/pal-gbp/range_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.1-0`

## range_msgs

```
* Merge pull request #1 <https://github.com/robotics-upo/range_msgs/issues/1> from procopiostein/fix-compilation
  Fix compilation
* cosmetic identation fixes
* removed unnecessary install rules that were causing compilation error
* changed package to format 2
  also added url info for repo and issues
* Contributors: Fernando Caballero, Procópio Stein
```
