### PR TITLE
range_msgs: 1.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 141: http://ros.org/reps/rep-0141.html
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   fedora:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -4639,6 +4639,13 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  range_msgs:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/pal-gbp/range_msgs-release.git
+      version: 1.1.2-0
+    status: developed
   razor_imu_9dof:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `range_msgs` to `1.1.2-0`:

- upstream repository: https://github.com/robotics-upo/range_msgs.git
- release repository: https://github.com/pal-gbp/range_msgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`

## range_msgs

```
* Merge pull request #1 <https://github.com/robotics-upo/range_msgs/issues/1> from procopiostein/fix-compilation
  Fix compilation
* cosmetic identation fixes
* removed unnecessary install rules that were causing compilation error
* changed package to format 2
  also added url info for repo and issues
* Contributors: Fernando Caballero, Procópio Stein
```
