### PR TITLE
openrave_planning: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7813,7 +7813,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/openrave_planning-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     status: developed
   openreroc_motion_sensor:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrave_planning` to `0.0.4-0`:

- upstream repository: https://github.com/jsk-ros-pkg/openrave_planning.git
- release repository: https://github.com/tork-a/openrave_planning-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.3-0`

## arm_navigation_msgs

- No changes

## collada_robots

- No changes

## openrave

```
* use dist-packages as python install dir instad of site-packages
* Contributors: Kei Okada
```

## openrave_planning

- No changes
