### PR TITLE
darknet: 2016.11.27-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2018,6 +2018,13 @@ repositories:
       type: git
       url: https://github.com/GertKanter/cyton_gamma_1500_description.git
       version: master
+  darknet:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/darknet-release.git
+      version: 2016.11.27-1
+    status: developed
   darwin_control:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `darknet` to `2016.11.27-1`:

- upstream repository: https://github.com/pjreddie/darknet.git
- release repository: https://github.com/tork-a/darknet-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
