### PR TITLE
nerian_sp1: 1.5.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3403,7 +3403,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/nerian-vision/nerian_sp1-release.git
-      version: 1.5.0-0
+      version: 1.5.1-0
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_sp1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_sp1` to `1.5.1-0`:

- upstream repository: https://github.com/nerian-vision/nerian_sp1.git
- release repository: https://github.com/nerian-vision/nerian_sp1-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.5.0-0`

## nerian_sp1

```
* Added proper error reporting in case of exceptions
* Contributors: Konstantin Schauwecker
```
