### PR TITLE
ros_rpc: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10777,6 +10777,21 @@ repositories:
       url: https://github.com/ros/ros_realtime.git
       version: hydro-devel
     status: maintained
+  ros_rpc:
+    doc:
+      type: git
+      url: https://github.com/tork-a/ros_rpc.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/ros_rpc-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/tork-a/ros_rpc.git
+      version: master
+    status: developed
   ros_statistics_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_rpc` to `0.0.1-0`:

- upstream repository: https://github.com/tork-a/ros_rpc.git
- release repository: https://github.com/tork-a/ros_rpc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## ros_rpc

```
* Initial release into ROS public repository.
* Initial commit.
* Contributors: Isaac I.Y. Saito
```
