### PR TITLE
dynamixel_motor: 0.4.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -812,7 +812,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/arebgun/dynamixel_motor-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/arebgun/dynamixel_motor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_motor` to `0.4.1-0`:

- upstream repository: https://github.com/arebgun/dynamixel_motor.git
- release repository: https://github.com/arebgun/dynamixel_motor-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.4.0-0`

## dynamixel_controllers

```
* bug fixes for issue #33 <https://github.com/arebgun/dynamixel_motor/issues/33> and warnnings on queue_size
* Fixed syntax error due to missing parentheses
* add error message when joint names did not match
* added in a queue size as none to remove warning messages
* Readback echo for simple one-wire (TTL) converters
* Support for reading current, setting acceleration, torque control mode (mainly MX series). Available features specified for each model.
* Always release lock on return
* Do not modify a controllers list we are iterating over.
  It's probably a bad idea to modify a list we are looping over as is the case with meta controller dependencies. List copies everywhere!
* Acquire lock before manipulating controllers.
  Make sure that no two threads can manipulate (start, stop or restart) controllers simultaneously.
* Allow negative speed values.
  There was a copy paste error where we were checking to make sure the speed wasn't set to 0 (meaning maximum speed), even though speed has different meaning when in wheel mode (0 is for stop, negative values for counterclockwise rotation and positive - for clockwise rotation). The slave motor should rotate in the opposite direction (assumes motors are mounted back to back with horns facing in opposite directions).
* fixed multi_packet[port] indentation
* added test to fix process_motor_states bug
* got action controller working with dual motor controller, still get an occasional key error with dual motor controller process_motor_states
* patch so action controller works with dual motor controllers
* Merge pull request #3 <https://github.com/arebgun/dynamixel_motor/issues/3> from arebgun/groovy
  Velocity bug fix
* Fix bug for velocity raw to radsec conversion in all remaining controllers
* Fix bug in velocity conversion
  The factor for the velocity conversion from raw to radsec and the other way
  round is model-specific and does not depend on the maximum motor speed.
  Therefore, a conversion factor is added to the motor data and employed
  for all velocity conversions. The set motor velocity and the motor velocity
  in the servo state does now correspond with the real servo speed in
  radians per second.
* Contributors: Andreas Wachaja, Antons Rebguns, Kei Okada, Nicolas, Nicolas Alt, Richard-Lab, Russell Toris, Tyler Slabinski, Yam Geva, richard-virtualros
```

## dynamixel_driver

```
* Don't set return delay time if value is invalid
* Fix typo valie -> valid
* Add EX-106, rename EX-106+ accordingly (Fixes #60 <https://github.com/arebgun/dynamixel_motor/issues/60>)
* Merge pull request #49 <https://github.com/arebgun/dynamixel_motor/issues/49> from anuragmakineni/master
  remove Serial set/get functions from dynamixel_io
* Update dynamixel_io.py
  In set_p_gain, set_i_gain, set_d_gain, small spelling mistake. Instead of 'slope', it should be p/i/d_gain, since slope is not defined for the given function.
* remove deprecated functions from dynamixel_io
* bug fixes for issue #33 <https://github.com/arebgun/dynamixel_motor/issues/33> and warnnings on queue_size
* Adds couple of methods for LED status fetching and changing.
* Catch occurancies when error_code is parsed as float
* added in a queue size as none to remove warning messages
* Readback echo for simple one-wire (TTL) converters
* Support for reading current, setting acceleration, torque control mode (mainly MX series). Available features specified for each model.
* New model MX-12W
* fix typo ;; min -> max
* Fix bug in velocity conversion
  The factor for the velocity conversion from raw to radsec and the other way
  round is model-specific and does not depend on the maximum motor speed.
  Therefore, a conversion factor is added to the motor data and employed
  for all velocity conversions. The set motor velocity and the motor velocity
  in the servo state does now correspond with the real servo speed in
  radians per second.
* Contributors: Andreas Wachaja, Antons Rebguns, Anurag Makineni, Gabrielius Mickevicius, Nicolas Alt, Russell Toris, Stefan Kohlbrecher, Yam Geva, Zilvinas, nozawa, parijat10, pazeshun
```

## dynamixel_motor

- No changes

## dynamixel_msgs

- No changes

## dynamixel_tutorials

- No changes
