### PR TITLE
robot_self_filter: 0.1.30-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4831,7 +4831,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/pr2-gbp/robot_self_filter-gbp.git
-      version: 0.1.29-0
+      version: 0.1.30-0
     source:
       type: git
       url: https://github.com/pr2/robot_self_filter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_self_filter` to `0.1.30-0`:

- upstream repository: https://github.com/pr2/robot_self_filter.git
- release repository: https://github.com/pr2-gbp/robot_self_filter-gbp.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.29-0`

## robot_self_filter

```
* Fix typo in CMakeLists.txt: CATKIN-DEPENDS -> CATKIN_DEPENDS
* Add ~max_queue_size parameter for subscription queue size
* Contributors: Devon Ash, Kentaro Wada, Ryohei Ueda
```
