### PR TITLE
robot_self_filter: 0.1.30-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4403,6 +4403,17 @@ repositories:
       url: https://github.com/GT-RAIL/robot_pose_publisher.git
       version: develop
     status: maintained
+  robot_self_filter:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pr2-gbp/robot_self_filter-gbp.git
+      version: 0.1.30-1
+    source:
+      type: git
+      url: https://github.com/pr2/robot_self_filter.git
+      version: indigo-devel
+    status: maintained
   robot_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_self_filter` to `0.1.30-1`:

- upstream repository: https://github.com/pr2/robot_self_filter.git
- release repository: https://github.com/pr2-gbp/robot_self_filter-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## robot_self_filter

```
* Fix typo in CMakeLists.txt: CATKIN-DEPENDS -> CATKIN_DEPENDS
* Add ~max_queue_size parameter for subscription queue size
* Contributors: Devon Ash, Kentaro Wada, Ryohei Ueda
```
