### PR TITLE
roch_robot: 1.0.6-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10139,6 +10139,30 @@ repositories:
       url: https://github.com/RobotnikAutomation/robotnik_sensors.git
       version: indigo-devel
     status: maintained
+  roch_robot:
+    doc:
+      type: git
+      url: https://github.com/SawYer-Robotics/roch_robot.git
+      version: indigo
+    release:
+      packages:
+      - roch_base
+      - roch_control
+      - roch_description
+      - roch_ftdi
+      - roch_msgs
+      - roch_robot
+      - roch_safety_controller
+      - roch_sensorpc
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/SawYerRobotics-release/roch_robot-release.git
+      version: 1.0.6-1
+    source:
+      type: git
+      url: https://github.com/SawYer-Robotics/roch_robot.git
+      version: indigo
+    status: developed
   rocon:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_robot` to `1.0.6-1`:

- upstream repository: https://github.com/SawYer-Robotics/roch_robot.git
- release repository: https://github.com/SawYerRobotics-release/roch_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## roch_base

- No changes

## roch_control

- No changes

## roch_description

- No changes

## roch_ftdi

- No changes

## roch_msgs

```
* add roch project of roch
* Contributors: SawYer-Robotics
```

## roch_robot

- No changes

## roch_safety_controller

- No changes

## roch_sensorpc

- No changes
