### PR TITLE
nao_moveit_config: 0.0.11-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3151,7 +3151,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-naoqi/nao_moveit_config-release.git
-      version: 0.0.10-0
+      version: 0.0.11-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_moveit_config` to `0.0.11-0`:

- upstream repository: https://github.com/ros-nao/nao_moveit_config.git
- release repository: https://github.com/ros-naoqi/nao_moveit_config-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.10-0`

## nao_moveit_config

```
* Merge pull request #18 <https://github.com/ros-naoqi/nao_moveit_config/issues/18> from ros-naoqi/update_maintainers
  update maintainers
* update maintainers
* Merge pull request #17 <https://github.com/ros-naoqi/nao_moveit_config/issues/17> from ros-naoqi/nlyubova-patch-2
  Update the execution time
* Update the execution time
* Merge pull request #16 <https://github.com/ros-naoqi/nao_moveit_config/issues/16> from ros-naoqi/fix-deprecated-warnings
  Fix deprecated warnings
* update parameter namespace
* fix deprecated xacro call
* use action rather than service for trajectory execution
* Contributors: Mikael Arguedas, Natalia Lyubova
```
