### PR TITLE
nao_moveit_config: 0.0.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3002,6 +3002,21 @@ repositories:
       url: https://github.com/ros-naoqi/nao_meshes.git
       version: master
     status: maintained
+  nao_moveit_config:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/nao_moveit_config.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-naoqi/nao_moveit_config-release.git
+      version: 0.0.11-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/nao_moveit_config.git
+      version: master
+    status: maintained
   nao_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_moveit_config` to `0.0.11-0`:

- upstream repository: https://github.com/ros-nao/nao_moveit_config.git
- release repository: https://github.com/ros-naoqi/nao_moveit_config-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## nao_moveit_config

```
* Merge pull request #18 <https://github.com/ros-naoqi/nao_moveit_config/issues/18> from ros-naoqi/update_maintainers
  update maintainers
* update maintainers
* Merge pull request #17 <https://github.com/ros-naoqi/nao_moveit_config/issues/17> from ros-naoqi/nlyubova-patch-2
  Update the execution time
* Update the execution time
* Merge pull request #16 <https://github.com/ros-naoqi/nao_moveit_config/issues/16> from ros-naoqi/fix-deprecated-warnings
  Fix deprecated warnings
* update parameter namespace
* fix deprecated xacro call
* use action rather than service for trajectory execution
* Contributors: Mikael Arguedas, Natalia Lyubova
```
