### PR TITLE
Fixing libuv-dev rosdep rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2862,7 +2862,12 @@ libusb-dev:
 libuv-dev:
   fedora: [libuv-devel]
   ubuntu:
+    precise: [libuv-dev]
+    saucy: [libuv-dev]
     trusty: [libuv-dev]
+    utopic: [libuv-dev]
+    vivid: [libuv0.10-dev]
+    wily: [libuv0.10-dev]
     xenial: [libuv0.10-dev]
     yakkety: [libuv0.10-dev]
     zesty: [libuv0.10-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2861,7 +2861,11 @@ libusb-dev:
   ubuntu: [libusb-dev]
 libuv-dev:
   fedora: [libuv-devel]
-  ubuntu: [libuv-dev]
+  ubuntu:
+    trusty: [libuv-dev]
+    xenial: [libuv0.10-dev]
+    yakkety: [libuv0.10-dev]
+    zesty: [libuv0.10-dev]
 libv4l-dev:
   arch: [v4l-utils]
   debian: [libv4l-dev]


### PR DESCRIPTION
I was getting an error when running rosdep in kinetic for libuv-dev. Since xenial it is libuv0.10-dev.
http://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libuv-dev&searchon=names

This pr will fix this.