### PR TITLE
romeo_robot: 0.1.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4938,7 +4938,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-aldebaran/romeo_robot-release.git
-      version: 0.1.3-1
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/ros-aldebaran/romeo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_robot` to `0.1.5-0`:

- upstream repository: https://github.com/ros-aldebaran/romeo_robot.git
- release repository: https://github.com/ros-aldebaran/romeo_robot-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.3-1`

## romeo_bringup

```
* update maintainers
* Contributors: Mikael Arguedas
```

## romeo_description

```
* update maintainers
* reuse existing launchfile
* fix deprecated xacro call
* Fix maintainer's name
  follow up of a99e3f53fa7dcedf1a3786dfceefa513a7aba4b8 for consistency
* updating romeo.urdf after regenerating it from updated xacro files
* adding config for Gazebo: Gazebo xacro files and full list of controllers
* updating URDF for eyes including inertia matrices and orientation
* Contributors: Mikael Arguedas, Natalia Lyubova, nlyubova
```

## romeo_robot

```
* update maintainers
* Contributors: Mikael Arguedas
```

## romeo_sensors_py

```
* update maintainers
* make Natalia a maintainer
* Contributors: Mikael Arguedas, Vincent Rabaud
```
