### PR TITLE
realsense_camera: 1.7.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9612,7 +9612,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/intel-ros/realsense-release.git
-      version: 1.7.0-0
+      version: 1.7.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_camera` to `1.7.1-0`:

- upstream repository: https://github.com/intel-ros/realsense.git
- release repository: https://github.com/intel-ros/realsense-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.7.0-0`

## realsense_camera

```
* Generate Warning for non-validated camera firmware
* Use shared timestamp for SR300/F200 cameras
* Added retry in tests to avoid random failures
* Contributors: Amanda Brindle, Mark D Horn, Ning Wang
```
