### PR TITLE
roch_robot: 1.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10157,7 +10157,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_robot-release.git
-      version: 1.0.6-1
+      version: 1.0.7-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_robot` to `1.0.7-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch_robot.git
- release repository: https://github.com/SawYerRobotics-release/roch_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.6-1`

## roch_base

```
* fixed bug that will cause can not compile without tf package.
```

## roch_control

- No changes

## roch_description

- No changes

## roch_msgs

- No changes

## roch_robot

- No changes

## roch_safety_controller

- No changes

## roch_sensorpc

- No changes
