### PR TITLE
roch: 1.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10139,6 +10139,27 @@ repositories:
       url: https://github.com/RobotnikAutomation/robotnik_sensors.git
       version: indigo-devel
     status: maintained
+  roch:
+    doc:
+      type: git
+      url: https://github.com/SawYer-Robotics/roch.git
+      version: indigo
+    release:
+      packages:
+      - roch
+      - roch_bringup
+      - roch_follower
+      - roch_navigation
+      - roch_teleop
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/SawYerRobotics-release/roch-release.git
+      version: 1.0.7-0
+    source:
+      type: git
+      url: https://github.com/SawYer-Robotics/roch.git
+      version: indigo
+    status: developed
   roch_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch` to `1.0.7-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch.git
- release repository: https://github.com/SawYerRobotics-release/roch-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## roch

- No changes

## roch_bringup

```
* Fixed bugs which will cant not find roch_safety_controller.
```

## roch_follower

- No changes

## roch_navigation

- No changes

## roch_teleop

- No changes
