### PR TITLE
Revert "mrpt_navigation: 0.1.16-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2860,7 +2860,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 0.1.16-0
+      version: 0.1.15-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Reverts ros/rosdistro#13405

Failing to build due to missing release branches.: https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/58

