### PR TITLE
roch_viz: 1.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10184,6 +10184,21 @@ repositories:
       url: https://github.com/SawYer-Robotics/roch_robot.git
       version: indigo
     status: developed
+  roch_viz:
+    doc:
+      type: git
+      url: https://github.com/SawYer-Robotics/roch_viz.git
+      version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/SawYerRobotics-release/roch_viz-release.git
+      version: 1.0.7-0
+    source:
+      type: git
+      url: https://github.com/SawYer-Robotics/roch_viz.git
+      version: indigo
+    status: developed
   rocon:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_viz` to `1.0.7-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch_viz.git
- release repository: https://github.com/SawYerRobotics-release/roch_viz-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## roch_viz

```
* Add launch file named view_navigation for navigation.
* Load navigation file of rviz.
```
