### PR TITLE
roch_simulator: 1.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10184,6 +10184,24 @@ repositories:
       url: https://github.com/SawYer-Robotics/roch_robot.git
       version: indigo
     status: developed
+  roch_simulator:
+    doc:
+      type: git
+      url: https://github.com/SawYer-Robotics/roch_simulator.git
+      version: indigo
+    release:
+      packages:
+      - roch_gazebo
+      - roch_simulator
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/SawYerRobotics-release/roch_simulator-release.git
+      version: 1.0.7-0
+    source:
+      type: git
+      url: https://github.com/SawYer-Robotics/roch_simulator.git
+      version: indigo
+    status: developed
   rocon:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_simulator` to `1.0.7-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch_simulator.git
- release repository: https://github.com/SawYerRobotics-release/roch_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## roch_gazebo

```
* Modify some websites to correct.
```

## roch_simulator

```
* Modify some websites to correct.
```
