### PR TITLE
roch: 1.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10154,7 +10154,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch-release.git
-      version: 1.0.7-0
+      version: 1.0.8-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch` to `1.0.8-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch.git
- release repository: https://github.com/SawYerRobotics-release/roch-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.7-0`

## roch

```
* Adding some websites for roch packages.
```

## roch_bringup

```
* Changes permissions of python files.
```

## roch_follower

```
* Changes permissions of python and config files.
```

## roch_navigation

```
* Remove some not uesd maps.
```

## roch_teleop

```
* Changes permissions of python files.
```
