### PR TITLE
hiqp_release: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1672,6 +1672,18 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_worldmodel-release.git
       version: 0.3.4-0
     status: maintained
+  hiqp_release:
+    release:
+      packages:
+      - hiqp
+      - hiqp_core
+      - hiqp_msgs
+      - hiqp_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/neckutrek/hiqp-release.git
+      version: 0.0.1-0
+    status: developed
   hls-lfcd-lds-driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hiqp_release` to `0.0.1-0`:

- upstream repository: https://github.com/neckutrek/hiqp.git
- release repository: https://github.com/neckutrek/hiqp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## hiqp

```
* Added emtapackage hiqp
* update
* Added base_controller to hiqp_ros
* update
* Fixed hiqp_ros
* Moved files
* Changed package name hiqp_msgs_srvs -> hiqp_msgs
* Changed project name hiqp_controllers -> hiqp
* Contributors: neckutrek
```

## hiqp_core

```
* Added emtapackage hiqp
* Contributors: neckutrek
```

## hiqp_msgs

```
* Changed package name hiqp_msgs_srvs -> hiqp_msgs
* Contributors: neckutrek
```

## hiqp_ros

```
* Added emtapackage hiqp
* update
* Added base_controller to hiqp_ros
* Fixed hiqp_ros
* Changed package name hiqp_msgs_srvs -> hiqp_msgs
* Changed project name hiqp_controllers -> hiqp
* Added hiqp_ros package
* Contributors: neckutrek
```
