### PR TITLE
uwsim_bullet: 2.82.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6492,6 +6492,13 @@ repositories:
       url: https://github.com/ros-drivers/urg_node.git
       version: indigo-devel
     status: maintained
+  uwsim_bullet:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/uji-ros-pkg/uwsim_bullet-release.git
+      version: 2.82.1-0
+    status: maintained
   variant:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_bullet` to `2.82.1-0`:

- upstream repository: https://github.com/uji-ros-pkg/uwsim_bullet.git
- release repository: https://github.com/uji-ros-pkg/uwsim_bullet-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
