### PR TITLE
uwsim_osgworks: 3.0.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6499,6 +6499,13 @@ repositories:
       url: https://github.com/uji-ros-pkg/uwsim_bullet-release.git
       version: 2.82.1-0
     status: maintained
+  uwsim_osgworks:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/uji-ros-pkg/uwsim_osgworks-release.git
+      version: 3.0.3-1
+    status: maintained
   variant:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_osgworks` to `3.0.3-1`:

- upstream repository: https://github.com/uji-ros-pkg/uwsim_osgworks.git
- release repository: https://github.com/uji-ros-pkg/uwsim_osgworks-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
