### PR TITLE
uwsim_osgocean: 1.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6499,6 +6499,13 @@ repositories:
       url: https://github.com/uji-ros-pkg/uwsim_bullet-release.git
       version: 2.82.1-0
     status: maintained
+  uwsim_osgocean:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/uji-ros-pkg/uwsim_osgocean-release.git
+      version: 1.0.3-0
+    status: maintained
   uwsim_osgworks:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_osgocean` to `1.0.3-0`:

- upstream repository: https://github.com/uji-ros-pkg/uwsim_osgocean.git
- release repository: https://github.com/uji-ros-pkg/uwsim_osgocean-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
