### PR TITLE
plotjuggler-release: 0.8.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8399,6 +8399,23 @@ repositories:
       type: git
       url: https://github.com/silviomaeta/plot_util.git
       version: master
+  plotjuggler-release:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: master
+    release:
+      packages:
+      - plotjuggler
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/facontidavide/plotjuggler-release.git
+      version: 0.8.0-2
+    source:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: master
+    status: maintained
   pluginlib:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8399,7 +8399,7 @@ repositories:
       type: git
       url: https://github.com/silviomaeta/plot_util.git
       version: master
-  plotjuggler-release:
+  plotjuggler:
     doc:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler-release` to `0.8.0-2`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## plotjuggler

```
* First official beta of PJ
* Contributors: Arturo Martín-de-Nicolás, Davide Faconti, Kartik Mohta, Mikael Arguedas
```
