### PR TITLE
roch_simulator: 1.0.8-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10206,7 +10206,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_simulator-release.git
-      version: 1.0.6-0
+      version: 1.0.8-1
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_simulator` to `1.0.8-1`:

- upstream repository: https://github.com/SawYer-Robotics/roch_simulator.git
- release repository: https://github.com/SawYerRobotics-release/roch_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.6-0`

## roch_gazebo

```
* Adjust structure of roch_gazebo.
* Add new gazebo world and delete old world file.
* Add new robot.launch.xml for load model.
* Modify all mainly files for suit Roch.
```

## roch_simulator

- No changes
