### PR TITLE
robot_upstart: 0.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4476,7 +4476,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/robot_upstart-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/robot_upstart.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart` to `0.2.2-0`:

- upstream repository: https://github.com/clearpathrobotics/robot_upstart.git
- release repository: https://github.com/clearpath-gbp/robot_upstart-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.2.1-0`

## robot_upstart

```
* Added a spin wait until ros processes exit. (#40 <https://github.com/clearpathrobotics/robot_upstart/issues/40>)
* Moved detect_providers to providers.py (#46 <https://github.com/clearpathrobotics/robot_upstart/issues/46>)
* Miscellaneous source code fixups.
* Contributors: Mike Purvis, Tony Baltovski, Zac Witte
```
