### PR TITLE
roch_robot: 1.0.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10188,7 +10188,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_robot-release.git
-      version: 1.0.8-0
+      version: 1.0.10-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_robot` to `1.0.10-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch_robot.git
- release repository: https://github.com/SawYerRobotics-release/roch_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.8-0`

## roch_base

```
* Add author Mike Purvis and Paul Bovbel of Clearpath.
* Modify BSD lisence.
```

## roch_control

```
* Add author Paul Bovbel of Clearpath.
```

## roch_description

```
* Add Gazebo plugin of ros control for Roch model.
* Modify Gazebo plugin of laser and put into roch_gazebo.urdf.xacro.
* Adjust context in *.urdf.xacro.
* Fiex bug that model in Gazebo will shack.
```

## roch_ftdi

```
* Modify README.md
```

## roch_msgs

```
* Add author Paul Bovbel.
```

## roch_robot

- No changes

## roch_safety_controller

- No changes

## roch_sensorpc

```
* Add author Jorge Santos Simon.
```
