### PR TITLE
yaml_cpp_0_3: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6934,6 +6934,13 @@ repositories:
       url: https://github.com/ethz-asl/ethzasl_xsens_driver.git
       version: master
     status: maintained
+  yaml_cpp_0_3:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/yaml_cpp_0_3-release.git
+      version: 0.3.1-0
+    status: maintained
   yocs_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_0_3` to `0.3.1-0`:

- upstream repository: https://github.com/stonier/yaml_cpp_0_3.git
- release repository: https://github.com/yujinrobot-release/yaml_cpp_0_3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## yaml_cpp_0_3

```
* refactored the actual library namespace (previously just renamed the library)
```
