### PR TITLE
plotjuggler: 0.8.0-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8404,7 +8404,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 0.8.0-3
+      version: master
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8399,6 +8399,16 @@ repositories:
       type: git
       url: https://github.com/silviomaeta/plot_util.git
       version: master
+  plotjuggler:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/facontidavide/plotjuggler-release.git
+      version: 0.8.0-3
+    source:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: master
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `0.8.0-3`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## plotjuggler

```
* First official beta of PJ
* Contributors: Arturo Martín-de-Nicolás, Davide Faconti, Kartik Mohta, Mikael Arguedas
```
