### PR TITLE
plotjuggler: 0.8.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8399,6 +8399,16 @@ repositories:
       type: git
       url: https://github.com/silviomaeta/plot_util.git
       version: master
+  plotjuggler:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/facontidavide/plotjuggler-release.git
+      version: 0.8.1-0
+    source:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: master
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `0.8.1-0`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## plotjuggler

```
* removing the old name "SuperPlotter"
* bug fix that affected data streaming
* this explicit dependency might be needed by bloom
```
