### PR TITLE
underwater_simulation: 1.4.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6413,6 +6413,17 @@ repositories:
       url: https://github.com/ros-drivers/um6.git
       version: indigo-devel
     status: maintained
+  underwater_simulation:
+    release:
+      packages:
+      - underwater_sensor_msgs
+      - underwater_vehicle_dynamics
+      - uwsim
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/uji-ros-pkg/underwater_simulation-release.git
+      version: 1.4.1-0
+    status: maintained
   unique_identifier:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `underwater_simulation` to `1.4.1-0`:

- upstream repository: https://github.com/uji-ros-pkg/underwater_simulation.git
- release repository: https://github.com/uji-ros-pkg/underwater_simulation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## underwater_sensor_msgs

- No changes

## underwater_vehicle_dynamics

- No changes

## uwsim

```
* Can use package:// to resolve ROS package location for meshes
* Can use package:// to pull a urdf from a ROS package
* Fixed transform publishing to fit the new robotpublisher interface
* Contributors: Bence Magyar, perezsolerj
```
