### PR TITLE
grid_map: 1.4.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3557,7 +3557,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-asl/grid_map-release.git
-      version: 1.4.1-0
+      version: 1.4.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `1.4.2-0`:

- upstream repository: https://github.com/ethz-asl/grid_map.git
- release repository: https://github.com/ethz-asl/grid_map-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.4.1-0`

## grid_map

- No changes

## grid_map_core

```
* Added linear interpolation method for data access.
* Increased efficiency for linear interpolation method.
* Addressing C++ compiler warnings.
* Contributors: Dominic Jud, Peter Fankhauser, Horatiu George Todoran
```

## grid_map_cv

```
* Fixed conversion to/from images in float&double format.
* Contributors: Peter Fankhauser
```

## grid_map_demos

```
* Addressing C++ compiler warnings.
* Contributors: Peter Fankhauser
```

## grid_map_filters

- No changes

## grid_map_loader

- No changes

## grid_map_msgs

- No changes

## grid_map_pcl

```
* Addressing C++ compiler warnings.
* Contributors: Peter Fankhauser
```

## grid_map_ros

```
* Added conversion for Costmap2D from ROS Navigation (#84 <https://github.com/ethz-asl/grid_map/issues/84>).
* Added Grid Map message traits to simplify code of the Grid Map RViz plugin (#87 <https://github.com/ethz-asl/grid_map/issues/87>).
* Contributors: Peter Fankhauser, Stefan Kohlbrecher, Daniel Stonier
```

## grid_map_rviz_plugin

```
* Cleanup thanks to message traits.
* Contributors: Peter Fankhauser
```

## grid_map_visualization

- No changes
