### PR TITLE
geometry2: 0.5.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3400,7 +3400,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.5.14-0
+      version: 0.5.15-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.5.15-0`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.5.14-0`

## geometry2

- No changes

## geometry_experimental

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

```
* fixup #186 <https://github.com/ros/geometry2/issues/186>: inline template specializations (#200 <https://github.com/ros/geometry2/issues/200>)
* Contributors: Robert Haschke
```

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* tf2_ros: add option to unregister TransformListener (#201 <https://github.com/ros/geometry2/issues/201>)
* Contributors: Hans-Joachim Krauch
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
