### PR TITLE
rtmros_nextage: 0.7.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11860,7 +11860,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.7.12-0
+      version: 0.7.13-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.7.13-0`:

- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.7.12-0`

## nextage_description

- No changes

## nextage_gazebo

- No changes

## nextage_ik_plugin

```
* [fix] Left arm position issue with IKFast #277 <https://github.com/tork-a/rtmros_nextage/issues/277>
* Contributors: Kei Okada
```

## nextage_moveit_config

```
* [capability] Add config for trac_ik.
* Contributors: Isaac I.Y. Saito
```

## nextage_ros_bridge

- No changes

## rtmros_nextage

```
* [fix] Left arm position issue with IKFast #277 <https://github.com/tork-a/rtmros_nextage/issues/277>
* [capability] Add config for trac_ik.
* Contributors: Kei Okada, Isaac I.Y. Saito
```
