### PR TITLE
cpr_multimaster_tools: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -656,6 +656,28 @@ repositories:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/cpp_introspection.git
       version: master
+  cpr_multimaster_tools:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr_multimaster_tools.git
+      version: kinetic-devel
+    release:
+      packages:
+      - clock_relay
+      - cpr_multimaster_tools
+      - message_relay
+      - multimaster_launch
+      - multimaster_msgs
+      - tf2_relay
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/cpr_multimaster_tools-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr_multimaster_tools.git
+      version: kinetic-devel
+    status: developed
   create_autonomy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_multimaster_tools` to `0.0.1-0`:

- upstream repository: https://github.com/clearpathrobotics/cpr_multimaster_tools.git
- release repository: https://github.com/clearpath-gbp/cpr_multimaster_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## clock_relay

```
* Initial commit
* Contributors: Paul Bovbel
```

## cpr_multimaster_tools

```
* Initial commit
* Contributors: Paul Bovbel
```

## message_relay

```
* Initial commit
* Contributors: Paul Bovbel, Tony Baltovski
```

## multimaster_launch

```
* Initial commit
* Contributors: Paul Bovbel
```

## multimaster_msgs

```
* Initial commit
* Contributors: Paul Bovbel
```

## tf2_relay

```
* Initial commit
* Contributors: Paul Bovbel
```
