### PR TITLE
imu_pipeline: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4355,7 +4355,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/imu_pipeline-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/ros-perception/imu_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_pipeline` to `0.2.2-0`:

- upstream repository: https://github.com/ros-perception/imu_pipeline
- release repository: https://github.com/ros-gbp/imu_pipeline-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.2.1-0`

## imu_pipeline

- No changes

## imu_processors

- No changes

## imu_transformer

```
* imu_transformer: Fix build with CATKIN_ENABLE_TESTIING=OFF
* Contributors: Alexis Ballier
```
