### PR TITLE
imu_pipeline: 0.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1863,6 +1863,25 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
       version: 0.2.3-0
+  imu_pipeline:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/imu_pipeline.git
+      version: indigo-devel
+    release:
+      packages:
+      - imu_pipeline
+      - imu_processors
+      - imu_transformer
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/imu_pipeline-release.git
+      version: 0.2.2-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/imu_pipeline.git
+      version: indigo-devel
+    status: maintained
   imu_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_pipeline` to `0.2.2-0`:

- upstream repository: https://github.com/ros-perception/imu_pipeline
- release repository: https://github.com/ros-gbp/imu_pipeline-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## imu_pipeline

- No changes

## imu_processors

- No changes

## imu_transformer

```
* imu_transformer: Fix build with CATKIN_ENABLE_TESTIING=OFF
* Contributors: Alexis Ballier
```
