### PR TITLE
um7: 0.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6447,6 +6447,21 @@ repositories:
       url: https://github.com/ros-drivers/um6.git
       version: indigo-devel
     status: maintained
+  um7:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/um7.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/um7-release.git
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/um7.git
+      version: indigo-devel
+    status: maintained
   underwater_simulation:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `um7` to `0.0.4-0`:

- upstream repository: https://github.com/ros-drivers/um7
- release repository: https://github.com/ros-drivers-gbp/um7-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
