### PR TITLE
rosbridge_suite: 0.7.17-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5108,7 +5108,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.7.16-0
+      version: 0.7.17-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.7.17-0`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.7.16-0`

## rosapi

```
* Added bug fix in rosapi
* no rospy needed, just for debug logging
* new service: get actionlib servers
* adjust log level for security globs
  Normal operation (i.e. no globs or successful verification of requests) is now silent, with illegal requests producing a warning.
* correct default values for security globs
  also accept empty list as the default "do not check globs" value in addition to None.
  Finally, append rosapi service glob after processing command line input so it's not overwritten
* Added services_glob to CallServices, added globs to rosbridge_tcp and rosbridge_udp, and other miscellanous fixes.
* As per the suggestions of @T045T, fixed several typos, improved logging, and made some style fixes.
* Fixed time object field definitions to match documentation.
* Two minor fixes.
* Added new parameters for topic and service security.
  Added 3 new parameters to rosapi and rosbridge_server which filter the
  topics, services, and parameters broadcast by the server to match an
  array of glob strings.
* Contributors: Devon Ash, Eric, Marco Arruda, Nils Berg
```

## rosbridge_library

```
* adjust log level for security globs
  Normal operation (i.e. no globs or successful verification of requests) is now silent, with illegal requests producing a warning.
* add missing import
* correct default values for security globs
  also accept empty list as the default "do not check globs" value in addition to None.
  Finally, append rosapi service glob after processing command line input so it's not overwritten
* Added services_glob to CallServices, added globs to rosbridge_tcp and rosbridge_udp, and other miscellanous fixes.
* As per the suggestions of @T045T, fixed several typos, improved logging, and made some style fixes.
* Added new parameters for topic and service security.
  Added 3 new parameters to rosapi and rosbridge_server which filter the
  topics, services, and parameters broadcast by the server to match an
  array of glob strings.
* Contributors: Eric, Nils Berg
```

## rosbridge_server

```
* Fixed the launch files for the tcp and udp service. Without these modifications, the rosapi node fails because some rosparams are not defined properly before. Now the launchfiles comply to the websocket version.
* Added default topics to all launch files, and fixed bug where it would crash if nothing was put into the lists as values
* Fix: Set default to publish all topics
  Without better doc, one does not understand why no topics are published. I thought, something is broken.
  With this defaults, everything is working out of the box. And for a more secure setup, one can change it.
* correct default values for security globs
  also accept empty list as the default "do not check globs" value in addition to None.
  Finally, append rosapi service glob after processing command line input so it's not overwritten
* add missing imports and correct default values for glob parameters
* Added services_glob to CallServices, added globs to rosbridge_tcp and rosbridge_udp, and other miscellanous fixes.
* Two minor fixes.
* Added new parameters for topic and service security.
  Added 3 new parameters to rosapi and rosbridge_server which filter the
  topics, services, and parameters broadcast by the server to match an
  array of glob strings.
* Contributors: Devon Ash, Eric, Nils Berg, Patrick Mania, plieningerweb
```

## rosbridge_suite

- No changes
