### PR TITLE
RCLL related packages for Jade and Kinetic

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4710,6 +4710,36 @@ repositories:
       url: https://github.com/KristofRobot/razor_imu_9dof.git
       version: indigo-devel
     status: maintained
+  rcll_refbox_peer:
+    doc:
+      type: git
+      url: https://github.com/timn/ros-rcll_refbox_peer.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/timn/ros-rcll_refbox_peer.git
+      version: master
+    status: developed
+  rcll_ros:
+    doc:
+      type: git
+      url: https://github.com/timn/ros-rcll_ros.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/timn/ros-rcll_ros.git
+      version: master
+    status: developed
+  rcll_ros_msgs:
+    doc:
+      type: git
+      url: https://github.com/timn/ros-rcll_ros_msgs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/timn/ros-rcll_ros_msgs.git
+      version: master
+    status: developed
   realtime_tools:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4382,6 +4382,36 @@ repositories:
       url: https://github.com/RobotnikAutomation/rbcar_sim.git
       version: kinetic-devel
     status: maintained
+  rcll_refbox_peer:
+    doc:
+      type: git
+      url: https://github.com/timn/ros-rcll_refbox_peer.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/timn/ros-rcll_refbox_peer.git
+      version: master
+    status: developed
+  rcll_ros:
+    doc:
+      type: git
+      url: https://github.com/timn/ros-rcll_ros.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/timn/ros-rcll_ros.git
+      version: master
+    status: developed
+  rcll_ros_msgs:
+    doc:
+      type: git
+      url: https://github.com/timn/ros-rcll_ros_msgs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/timn/ros-rcll_ros_msgs.git
+      version: master
+    status: developed
   realsense_camera:
     doc:
       type: git


### PR DESCRIPTION
This pull request adds rcll_ros, rcll_ros_msgs, and rcll_refbox_peer to the Jade and Kinetic distributions (it had been in indigo before). I have fixed an error that prevented proper builds (missing dependencies for message generation).