### PR TITLE
feed_the_troll_msgs: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1115,6 +1115,17 @@ repositories:
       url: https://github.com/ros/executive_smach.git
       version: indigo-devel
     status: maintained
+  feed_the_troll_msgs:
+    doc:
+      type: git
+      url: https://github.com/stonier/feed_the_troll_msgs.git
+      version: release/0.1-indigo-kinetic
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/stonier/feed_the_troll_msgs-release.git
+      version: 0.1.1-0
+    status: developed
   fiducials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `feed_the_troll_msgs` to `0.1.1-0`:

- upstream repository: https://github.com/stonier/feed_the_troll_msgs.git
- release repository: https://github.com/stonier/feed_the_troll_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## feed_the_troll_msgs

```
* initial prototype
```
