### PR TITLE
python-termcolor for debian

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2562,8 +2562,12 @@ python-telegram-bot:
       packages: [python-telegram-bot]
 python-termcolor:
   debian:
-    pip:
-      packages: [termcolor]
+    jessie: [python-termcolor]
+    sid: [python-termcolor]
+    stretch: [python-termcolor]
+    wheezy:
+      pip:
+        packages: [termcolor]
   fedora: [python-termcolor]
   osx:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2563,7 +2563,6 @@ python-telegram-bot:
 python-termcolor:
   debian:
     jessie: [python-termcolor]
-    sid: [python-termcolor]
     stretch: [python-termcolor]
     wheezy:
       pip:


### PR DESCRIPTION
So packages can be built on the build farm that have this as a dependency