### PR TITLE
add nvidia-cuda-dev to nvidia-cuda

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3289,9 +3289,9 @@ nvidia-cg:
   gentoo: [media-gfx/nvidia-cg-toolkit]
   ubuntu: [nvidia-cg-toolkit]
 nvidia-cuda:
-  debian: [nvidia-cuda-toolkit]
-  gentoo: [nvidia-cuda-toolkit]
-  ubuntu: [nvidia-cuda-toolkit]
+  debian: [nvidia-cuda-dev, nvidia-cuda-toolkit]
+  gentoo: [nvidia-cuda-dev, nvidia-cuda-toolkit]
+  ubuntu: [nvidia-cuda-dev, nvidia-cuda-toolkit]
 omniidl:
   arch: [omniorb]
   debian: [omniidl, omniorb-idl]


### PR DESCRIPTION
Currently dependency `nvidia-cuda` installs `nvidia-cuda-tool` which has only libraries.
This pull request adds `nvidia-cuda-dev` which includes header files for cuda to `nvidia-cuda`.