### PR TITLE
add nvidia-cuda-dev to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3292,6 +3292,10 @@ nvidia-cuda:
   debian: [nvidia-cuda-toolkit]
   gentoo: [nvidia-cuda-toolkit]
   ubuntu: [nvidia-cuda-toolkit]
+nvidia-cuda-dev:
+  debian: [nvidia-cuda-dev]
+  gentoo: [nvidia-cuda-dev]
+  ubuntu: [nvidia-cuda-dev]
 omniidl:
   arch: [omniorb]
   debian: [omniidl, omniorb-idl]


### PR DESCRIPTION
This adds a rule for installing `nvidia-cuda-dev` which includes header files for CUDA application development.
Overrides PR #13717 