### PR TITLE
feed_the_troll: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1115,6 +1115,21 @@ repositories:
       url: https://github.com/ros/executive_smach.git
       version: indigo-devel
     status: maintained
+  feed_the_troll:
+    doc:
+      type: git
+      url: https://github.com/stonier/feed_the_troll.git
+      version: release/0.1-kinetic
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/stonier/feed_the_troll-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/stonier/feed_the_troll.git
+      version: devel
+    status: developed
   feed_the_troll_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `feed_the_troll` to `0.1.1-0`:

- upstream repository: https://github.com/stonier/feed_the_troll.git
- release repository: https://github.com/stonier/feed_the_troll-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## feed_the_troll

```
* [reconfiguration] clear/reset parameters, not namespace on start server
* [feeders] often anon, so clean up private namespace after shutting down
```
