### PR TITLE
adding libffi-dev in rosdep base

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1510,6 +1510,10 @@ libfcl-dev:
   debian: [libfcl-0.5-dev]
   fedora: [fcl-devel]
   ubuntu: [libfcl-0.5-dev]
+libffi-dev:
+  debian: [libffi-dev]
+  fedora: [libffi-devel]
+  ubuntu: [libffi-dev]
 libfftw3:
   arch: [fftw]
   debian: [libfftw3-3, libfftw3-dev]


### PR DESCRIPTION
Because I encountered this problem : http://stackoverflow.com/questions/22073516/failed-to-install-python-cryptography-package-with-pip-and-setup-py

in here : https://travis-ci.org/asmodehn/catkin_pip/jobs/195449698