### PR TITLE
Added the tensorflow pip package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2560,6 +2560,10 @@ python-telegram-bot:
   ubuntu:
     pip:
       packages: [python-telegram-bot]
+python-tensorflow:
+  ubuntu:
+    pip:
+      packages: [tensorflow]
 python-termcolor:
   debian:
     jessie: [python-termcolor]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2560,7 +2560,7 @@ python-telegram-bot:
   ubuntu:
     pip:
       packages: [python-telegram-bot]
-tensorflow-pip:
+python-tensorflow-pip:
   debian:
     pip:
       packages: [tensorflow]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2560,7 +2560,16 @@ python-telegram-bot:
   ubuntu:
     pip:
       packages: [python-telegram-bot]
-python-tensorflow:
+tensorflow-pip:
+  debian:
+    pip:
+      packages: [tensorflow]
+  fedora:
+    pip:
+      packages: [tensorflow]
+  osx:
+    pip:
+      packages: [tensorflow]
   ubuntu:
     pip:
       packages: [tensorflow]


### PR DESCRIPTION
https://pypi.python.org/pypi/tensorflow/0.12.1.

Google's framework for neural networks. This only provides the python interface; the C++ API is trickier to get.