### PR TITLE
homer_msgs: 0.1.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1777,6 +1777,16 @@ repositories:
       url: https://github.com/at-wat/hokuyo3d.git
       version: indigo-devel
     status: developed
+  homer_msgs:
+    release:
+      packages:
+      - homer_msgs
+      - homer_ptu_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://gitlab.uni-koblenz.de/robbie/homer_msgs.git
+      version: 0.1.5-1
+    status: developed
   household_objects_database_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_msgs` to `0.1.5-1`:

- upstream repository: git@gitlab.uni-koblenz.de:robbie/homer_msgs.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_msgs.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## homer_msgs

- No changes

## homer_ptu_msgs

```
* homer_ptu_msgs: CenterWorldPoint msg: added header
* Contributors: Niklas Yann Wettengel
```
