### PR TITLE
homer_robbie_architecture: 1.0.2-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1777,6 +1777,13 @@ repositories:
       url: https://github.com/at-wat/hokuyo3d.git
       version: indigo-devel
     status: developed
+  homer_robbie_architecture:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://gitlab.uni-koblenz.de/robbie/homer_robbie_architecture.git
+      version: 1.0.2-3
+    status: maintained
   household_objects_database_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_robbie_architecture` to `1.0.2-3`:

- upstream repository: git@gitlab.uni-koblenz.de:robbie/homer_robbie_architecture.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_robbie_architecture.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## homer_robbie_architecture

```
* changed install targets
* Contributors: Niklas Yann Wettengel
```
