### PR TITLE
robot_model: 1.12.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4599,7 +4599,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.12.6-0
+      version: 1.12.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.12.7-0`:

- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.12.6-0`

## collada_parser

- No changes

## collada_urdf

- No changes

## joint_state_publisher

```
* Fixed a crash which happened when there were ``0`` free joints, opens empty window (#178 <https://github.com/ros/robot_model/issues/178>)
* Contributors: Bence Magyar
```

## kdl_parser

- No changes

## kdl_parser_py

- No changes

## robot_model

- No changes

## urdf

- No changes

## urdf_parser_plugin

- No changes
