### PR TITLE
multimaster_fkie: 0.7.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3077,7 +3077,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.7.0-0
+      version: 0.7.2-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.7.2-0`:

- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.7.0-0`

## default_cfg_fkie

- No changes

## master_discovery_fkie

```
* master_discovery_fkie: reverted the cut of domains in hostnames
* Contributors: Alexander Tiderko
```

## master_sync_fkie

- No changes

## multimaster_fkie

```
* node_manager_fkie: added a parameter to hide domain suffix in description panel and node tree view
* mutlimaster_fkie: reverted the cut of domains in hostnames
* Contributors: Alexander Tiderko
```

## multimaster_msgs_fkie

- No changes

## node_manager_fkie

```
* node_manager_fkie: added a parameter to hide domain suffix in description panel and node tree view
* node_manager_fkie: reverted the cut of domains in hostnames
* Contributors: Alexander Tiderko
```
