### PR TITLE
homer_mapping: 0.1.11-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1810,6 +1810,19 @@ repositories:
       url: https://github.com/at-wat/hokuyo3d.git
       version: indigo-devel
     status: developed
+  homer_mapping:
+    release:
+      packages:
+      - homer_map_manager
+      - homer_mapnav_msgs
+      - homer_mapping
+      - homer_nav_libs
+      - homer_navigation
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://gitlab.uni-koblenz.de/robbie/homer_mapping.git
+      version: 0.1.11-1
+    status: developed
   homer_msgs:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_mapping` to `0.1.11-1`:

- upstream repository: git@gitlab.uni-koblenz.de:robbie/homer_mapping.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_mapping.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## homer_map_manager

```
* cool changelogs
* dynamic masking map
* masking manager dynamic map
* reworking map_manager to use dynamic map sizes
* Contributors: Florian Polster, Lisa
* dynamic masking map
* masking manager dynamic map
* reworking map_manager to use dynamic map sizes
* Contributors: Florian Polster, Lisa
```

## homer_mapnav_msgs

```
* cool changelogs
* Contributors: Lisa
```

## homer_mapping

```
* cool changelogs
* navigation with dynamic maps
* dynamic masking map
* no more squared maps
* dynamic map size and wall kernel
* dynamic map size
* Contributors: Lisa
* navigation with dynamic maps
* dynamic masking map
* no more squared maps
* dynamic map size and wall kernel
* dynamic map size
* Contributors: Lisa
```

## homer_nav_libs

```
* cool changelogs
* Contributors: Lisa
```

## homer_navigation

```
* no debug
* cool changelogs
* navigation with dynamic maps
* Contributors: Lisa
* navigation with dynamic maps
* Contributors: Lisa
```
