### PR TITLE
qt_gui_core: 0.2.32-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4549,7 +4549,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.2.31-0
+      version: 0.2.32-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.2.32-0`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.2.31-0`

## qt_dotgraph

```
* fix label size in dot graphs (#75 <https://github.com/ros-visualization/qt_gui_core/pull/75>)
* work with newer pydot versions (#70 <https://github.com/ros-visualization/qt_gui_core/pull/70>)
```

## qt_gui

```
* fix leftover dock widgets when using --command-switch-perspective (#80 <https://github.com/ros-visualization/qt_gui_core/pull/80>)
* make finding new parent logic more robust (#76 <https://github.com/ros-visualization/qt_gui_core/pull/76>)
```

## qt_gui_app

- No changes

## qt_gui_cpp

- No changes

## qt_gui_py_common

- No changes
