### PR TITLE
rqt_common_plugins: 0.4.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11620,7 +11620,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.4.3-0
+      version: 0.4.4-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `0.4.4-0`:

- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/ros-gbp/rqt_common_plugins-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.4.3-0`

## rqt_action

- No changes

## rqt_bag

```
* use Python 3 compatible syntax (#421 <https://github.com/ros-visualization/rqt_common_plugins/pull/421>)
* fix race condition reading bag files (#412 <https://github.com/ros-visualization/rqt_common_plugins/pull/412>)
```

## rqt_bag_plugins

```
* use Python 3 compatible syntax (#421 <https://github.com/ros-visualization/rqt_common_plugins/pull/421>)
```

## rqt_common_plugins

- No changes

## rqt_console

```
* fix regression with Qt 4 (#414 <https://github.com/ros-visualization/rqt_common_plugins/issues/414>)
* fix missing dependency on rqt_py_common (#408 <https://github.com/ros-visualization/rqt_common_plugins/pull/408>)
```

## rqt_dep

```
* use Python 3 compatible syntax (#421 <https://github.com/ros-visualization/rqt_common_plugins/pull/421>)
```

## rqt_graph

```
* use Python 3 compatible syntax (#421 <https://github.com/ros-visualization/rqt_common_plugins/pull/421>)
```

## rqt_image_view

```
* add checkbox for optional smooth image scaling (#385 <https://github.com/ros-visualization/rqt_common_plugins/issues/385>)
```

## rqt_launch

```
* add button to load all params in a launch config onto parameter server (#341 <https://github.com/ros-visualization/rqt_common_plugins/issues/341>)
```

## rqt_logger_level

- No changes

## rqt_msg

```
* use Python 3 compatible syntax (#421 <https://github.com/ros-visualization/rqt_common_plugins/pull/421>)
```

## rqt_plot

```
* automatically use the value field from std_msgs.Bool messages (#420 <https://github.com/ros-visualization/rqt_common_plugins/pull/420>)
* use Python 3 compatible syntax (#421 <https://github.com/ros-visualization/rqt_common_plugins/pull/421>)
* reenable PyQtGraph when version >= 0.10 (#407 <https://github.com/ros-visualization/rqt_common_plugins/issues/407>)
```

## rqt_publisher

```
* use Python 3 compatible syntax (#421 <https://github.com/ros-visualization/rqt_common_plugins/pull/421>)
```

## rqt_py_common

```
* use Python 3 compatible syntax (#421 <https://github.com/ros-visualization/rqt_common_plugins/pull/421>)
* add helper functions to find a slot inside a message by type
```

## rqt_py_console

```
* use Python 3 compatible syntax (#421 <https://github.com/ros-visualization/rqt_common_plugins/pull/421>)
```

## rqt_reconfigure

```
* replace setShown with setVisible (#418 <https://github.com/ros-visualization/rqt_common_plugins/issues/418>)
* use Python 3 compatible syntax (#421 <https://github.com/ros-visualization/rqt_common_plugins/pull/421>)
* add buttons to 'save' to and 'load' from file (#406 <https://github.com/ros-visualization/rqt_common_plugins/pull/406>)
```

## rqt_service_caller

- No changes

## rqt_shell

```
* use Python 3 compatible syntax (#421 <https://github.com/ros-visualization/rqt_common_plugins/pull/421>)
```

## rqt_srv

- No changes

## rqt_top

```
* use Python 3 compatible syntax (#421 <https://github.com/ros-visualization/rqt_common_plugins/pull/421>)
```

## rqt_topic

```
* use Python 3 compatible syntax (#421 <https://github.com/ros-visualization/rqt_common_plugins/pull/421>)
* catch unhandled exceptions when rosmaster disappears while widget is running (#419 <https://github.com/ros-visualization/rqt_common_plugins/pull/419>)
```

## rqt_web

```
* use Python 3 compatible syntax (#421 <https://github.com/ros-visualization/rqt_common_plugins/pull/421>)
```
