### PR TITLE
rqt_robot_plugins: 0.5.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11737,7 +11737,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-      version: 0.5.5-0
+      version: 0.5.6-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins` to `0.5.6-0`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_plugins.git
- release repository: https://github.com/ros-gbp/rqt_robot_plugins-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.5.5-0`

## rqt_moveit

- No changes

## rqt_nav_view

```
* use Python 3 compatible syntax (#121 <https://github.com/ros-visualization/rqt_robot_plugins/pull/121>)
```

## rqt_pose_view

```
* search through message classes for Pose, Quaternion or Point data (#117 <https://github.com/ros-visualization/rqt_robot_plugins/pull/117>)
```

## rqt_robot_dashboard

```
* use Python 3 compatible syntax (#121 <https://github.com/ros-visualization/rqt_robot_plugins/pull/121>)
```

## rqt_robot_monitor

```
* use Python 3 compatible syntax (#121 <https://github.com/ros-visualization/rqt_robot_plugins/pull/121>)
```

## rqt_robot_plugins

- No changes

## rqt_robot_steering

- No changes

## rqt_runtime_monitor

```
* use Python 3 compatible syntax (#121 <https://github.com/ros-visualization/rqt_robot_plugins/pull/121>)
```

## rqt_rviz

- No changes

## rqt_tf_tree

```
* use Python 3 compatible syntax (#121 <https://github.com/ros-visualization/rqt_robot_plugins/pull/121>)
```
