### PR TITLE
katana_driver: 1.0.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2308,7 +2308,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/uos-gbp/katana_driver-release.git
-      version: 1.0.5-1
+      version: 1.0.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `katana_driver` to `1.0.6-0`:

- upstream repository: https://github.com/uos/katana_driver.git
- release repository: https://github.com/uos-gbp/katana_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.5-1`

## katana

```
* Initial release to Kinetic
* Contributors: Martin Günther
```

## katana_arm_gazebo

```
* Initial release to Kinetic
* Contributors: Martin Günther
```

## katana_description

```
* Initial release to Kinetic
* Contributors: Martin Günther
```

## katana_driver

```
* Initial release to Kinetic
* Contributors: Martin Günther
```

## katana_gazebo_plugins

```
* Initial release to Kinetic
* Contributors: Martin Günther
```

## katana_moveit_ikfast_plugin

```
* Initial release to Kinetic
* Build with C++11
* Contributors: Martin Günther
```

## katana_msgs

```
* Initial release to Kinetic
* Contributors: Martin Günther
```

## katana_teleop

```
* Initial release to Kinetic
* Contributors: Martin Günther
```

## katana_tutorials

```
* Initial release to Kinetic
* Contributors: Martin Günther
```

## kni

```
* Fix deprecation warning (#20 <https://github.com/uos/katana_driver/issues/20>)
* Initial release to Kinetic
* Contributors: Martin Günther
```
