### PR TITLE
Adding genrs to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1433,6 +1433,10 @@ repositories:
       version: kinetic-devel
     status: maintained
   genrs:
+    doc:
+      type: git
+      url: https://github.com/adnanademovic/genrs.git
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}


### PR DESCRIPTION
I'd like genrs to be indexed and documented on ros.org