### PR TITLE
image_common: 1.11.12-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1900,7 +1900,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/image_common-release.git
-      version: 1.11.11-0
+      version: 1.11.12-0
     source:
       type: git
       url: https://github.com/ros-perception/image_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `1.11.12-0`:

- upstream repository: https://github.com/ros-perception/image_common.git
- release repository: https://github.com/ros-gbp/image_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.11.11-0`

## camera_calibration_parsers

```
* Properly detect Boost Python 2 or 3
  This fixes #59 <https://github.com/ros-perception/image_common/issues/59>
* 1.11.11
* update changelogs
* Contributors: Vincent Rabaud
```

## camera_info_manager

```
* 1.11.11
* update changelogs
* Return empty CameraInfo when !ros::ok()
* Contributors: Enrique Fernandez, Vincent Rabaud
```

## image_common

```
* 1.11.11
* update changelogs
* Contributors: Vincent Rabaud
```

## image_transport

```
* Fix CMake of image_transport/tutorial and polled_camera
  Fix loads of problems with the CMakeLists.
* image_transport/tutorial: Add dependency on generated msg
  Without this, build fails on Kinetic because ResizedImage.h has not been
  generated yet.
* image_transport/tutorial: Add missing catkin_INCLUDE_DIRS
  Without this, compilation files on Kinetic because ros.h cannot be found.
* 1.11.11
* update changelogs
* Contributors: Martin Guenther, Vincent Rabaud
```

## polled_camera

```
* Fix CMake of image_transport/tutorial and polled_camera
  Fix loads of problems with the CMakeLists.
* 1.11.11
* update changelogs
* address gcc6 build error in polled_camera
  With gcc6, compiling fails with stdlib.h: No such file or directory,
  as including '-isystem /usr/include' breaks with gcc6, cf.,
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.
  This commit addresses this issue for this package in the same way
  it was addressed in various other ROS packages. A list of related
  commits and pull requests is at:
  https://github.com/ros/rosdistro/issues/12783
  Signed-off-by: Lukas Bulwahn <mailto:lukas.bulwahn@oss.bmw-carit.de>
* Contributors: Lukas Bulwahn, Martin Guenther, Vincent Rabaud
```
