### PR TITLE
vision_opencv: 1.11.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14353,7 +14353,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.11.14-0
+      version: 1.11.15-0
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.11.15-0`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.11.14-0`

## cv_bridge

```
* properly find Boost Python 2 or 3
  This fixes #158 <https://github.com/ros-perception/vision_opencv/issues/158>
* Fill black color to depth nan region
* address gcc6 build error in cv_bridge and tune
  With gcc6, compiling fails with stdlib.h: No such file or directory,
  as including '-isystem /usr/include' breaks with gcc6, cf.,
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129
  This commit addresses this issue for cv_bridge in the same way
  it was done in the commit ead421b8 [1] for image_geometry.
  This issue was also addressed in various other ROS packages.
  A list of related commits and pull requests is at:
  https://github.com/ros/rosdistro/issues/12783
  [1] https://github.com/ros-perception/vision_opencv/commit/ead421b85eeb750cbf7988657015296ed6789bcf
  Signed-off-by: Lukas Bulwahn <mailto:lukas.bulwahn@oss.bmw-carit.de>
* cv_bridge: Add missing test_depend on numpy
* Contributors: Kentaro Wada, Lukas Bulwahn, Maarten de Vries, Vincent Rabaud
```

## image_geometry

```
* Import using __future__ for python 3 compatibility.
* Contributors: Hans Gaiser
```

## vision_opencv

- No changes
