### PR TITLE
vision_opencv: 1.12.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6894,7 +6894,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.12.3-0
+      version: 1.12.4-0
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.12.4-0`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.12.3-0`

## cv_bridge

```
* properly find Boost Python 2 or 3
  This fixes #158 <https://github.com/ros-perception/vision_opencv/issues/158>
* Contributors: Vincent Rabaud
```

## image_geometry

```
* Import using __future__ for python 3 compatibility.
* Contributors: Hans Gaiser
```

## vision_opencv

- No changes
