### PR TITLE
Added python-tornado to rosdep rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3534,6 +3534,11 @@ python-qrencode:
 python-sphinx:
   fedora: [python-sphinx]
   gentoo: [dev-python/sphinx]
+python-tornado:
+  arch: [python-tornado]
+  debian: [python-tornado]
+  fedora: [python-tornado]
+  ubuntu: [python-tornado]
 python-vtk:
   fedora: [vtk-python]
   gentoo: [dev-python/pyvtk]


### PR DESCRIPTION
* https://www.archlinux.org/packages/community/x86_64/python-tornado/
* https://packages.debian.org/stretch/python-tornado
* https://admin.fedoraproject.org/pkgdb/package/rpms/python-tornado/
* http://packages.ubuntu.com/xenial/python-tornado