### PR TITLE
revert OpenCV3 on Indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7740,7 +7740,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/opencv3-release.git
-      version: 3.2.0-0
+      version: 3.1.0-1
     status: maintained
   opencv_apps:
     doc:


### PR DESCRIPTION
It does not compile properly with the old protobuf there.
In Indigo, nothing depends on it, it is just there for fun.