### PR TITLE
srdfdom: 0.4.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5904,7 +5904,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/srdfdom-release.git
-      version: 0.4.1-0
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `0.4.2-1`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/ros-gbp/srdfdom-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.4.1-0`

## srdfdom

```
* [fix] gcc6 build error #28 <https://github.com/ros-planning/srdfdom/issues/28>
* [fix] Compile with -std=c++11 (#29 <https://github.com/ros-planning/srdfdom/issues/29>)
* [enhancement] cleanup urdfdom compatibility (#27 <https://github.com/ros-planning/srdfdom/issues/27>)
* Contributors: Dmitry Rozhkov, Isaac I.Y. Saito, Robert Haschke, Victor Matare
```
