### PR TITLE
backports_ssl_match_hostname: 3.5.0-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -622,7 +622,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/backports.ssl_match_hostname-rosrelease.git
-      version: 3.5.0-2
+      version: 3.5.0-3
     status: maintained
   barrett_hand:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `backports_ssl_match_hostname` to `3.5.0-3`:

- upstream repository: https://bitbucket.org/asmodehn/backports.ssl_match_hostname
- release repository: https://github.com/asmodehn/backports.ssl_match_hostname-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `3.5.0-2`
