### PR TITLE
backports_ssl_match_hostname: 3.5.0-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -260,7 +260,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/backports.ssl_match_hostname-rosrelease.git
-      version: 3.5.0-0
+      version: 3.5.0-1
     status: maintained
   basler_tof:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `backports_ssl_match_hostname` to `3.5.0-1`:

- upstream repository: https://bitbucket.org/asmodehn/backports.ssl_match_hostname
- release repository: https://github.com/asmodehn/backports.ssl_match_hostname-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `3.5.0-0`
