### PR TITLE
tornado: 4.2.1-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13536,7 +13536,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/tornado-rosrelease.git
-      version: 4.2.1-1
+      version: 4.2.1-2
     status: maintained
   trac_ik:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `tornado` to `4.2.1-2`:

- upstream repository: https://github.com/tornadoweb/tornado.git
- release repository: https://github.com/asmodehn/tornado-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `4.2.1-1`
