### PR TITLE
nao_virtual: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6942,7 +6942,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-naoqi/nao_virtual-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_virtual.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_virtual` to `0.0.6-0`:

- upstream repository: https://github.com/ros-nao/nao_virtual.git
- release repository: https://github.com/ros-naoqi/nao_virtual-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.5-0`

## nao_control

```
* Adding missing dependencies
* update maintainers
* Contributors: Mikael Arguedas, Natalia Lyubova
```

## nao_gazebo_plugin

```
* adding back missing dependencies to README
* update maintainers
* [nao_gazebo_plugin/README.rst] clone using https
* Update README.rst
* Update README.rst
* updating links in README
* Contributors: Mikael Arguedas, Natalia Lyubova
```
