### PR TITLE
nao_virtual: 0.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3233,6 +3233,23 @@ repositories:
       url: https://github.com/ros-naoqi/nao_robot.git
       version: master
     status: maintained
+  nao_virtual:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/nao_virtual.git
+      version: master
+    release:
+      packages:
+      - nao_control
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-naoqi/nao_virtual-release.git
+      version: 0.0.6-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/nao_virtual.git
+      version: master
+    status: maintained
   naoqi_bridge:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_virtual` to `0.0.6-0`:

- upstream repository: https://github.com/ros-nao/nao_virtual.git
- release repository: https://github.com/ros-naoqi/nao_virtual-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## nao_control

```
* Adding missing dependencies
* update maintainers
* Contributors: Mikael Arguedas, Natalia Lyubova
```
