### PR TITLE
Add RCLL simulation wrapper packages

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9616,6 +9616,26 @@ repositories:
       url: https://bitbucket.org/rbdl/rbdl
       version: default
     status: developed
+  rcll_fawkes_sim:
+    doc:
+      type: git
+      url: https://github.com/timn/ros-rcll_fawkes_sim.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/timn/ros-rcll_fawkes_sim.git
+      version: master
+    status: developed
+  rcll_fawkes_sim_msgs:
+    doc:
+      type: git
+      url: https://github.com/timn/ros-rcll_fawkes_sim_msgs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/timn/ros-rcll_fawkes_sim_msgs.git
+      version: master
+    status: developed
   rcll_refbox_peer:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4737,6 +4737,26 @@ repositories:
       url: https://github.com/KristofRobot/razor_imu_9dof.git
       version: indigo-devel
     status: maintained
+  rcll_fawkes_sim:
+    doc:
+      type: git
+      url: https://github.com/timn/ros-rcll_fawkes_sim.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/timn/ros-rcll_fawkes_sim.git
+      version: master
+    status: developed
+  rcll_fawkes_sim_msgs:
+    doc:
+      type: git
+      url: https://github.com/timn/ros-rcll_fawkes_sim_msgs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/timn/ros-rcll_fawkes_sim_msgs.git
+      version: master
+    status: developed
   rcll_refbox_peer:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4508,6 +4508,26 @@ repositories:
       url: https://github.com/RobotnikAutomation/rbcar_sim.git
       version: kinetic-devel
     status: maintained
+  rcll_fawkes_sim:
+    doc:
+      type: git
+      url: https://github.com/timn/ros-rcll_fawkes_sim.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/timn/ros-rcll_fawkes_sim.git
+      version: master
+    status: developed
+  rcll_fawkes_sim_msgs:
+    doc:
+      type: git
+      url: https://github.com/timn/ros-rcll_fawkes_sim_msgs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/timn/ros-rcll_fawkes_sim_msgs.git
+      version: master
+    status: developed
   rcll_refbox_peer:
     doc:
       type: git


### PR DESCRIPTION
This adds packages that wrap RCLL simulation based on Fawkes for ROS.