### PR TITLE
[Indigo][moveit] Add/update metapackages.

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6391,6 +6391,8 @@ repositories:
       - moveit_controller_manager_example
       - moveit_core
       - moveit_fake_controller_manager
+      - moveit_full
+      - moveit_full_pr2
       - moveit_kinematics
       - moveit_planners
       - moveit_planners_ompl
@@ -6407,6 +6409,7 @@ repositories:
       - moveit_ros_robot_interaction
       - moveit_ros_visualization
       - moveit_ros_warehouse
+      - moveit_runtime
       - moveit_setup_assistant
       - moveit_simple_controller_manager
       tags:
@@ -6435,24 +6438,6 @@ repositories:
     source:
       type: git
       url: https://github.com/JenniferBuehler/moveit-pkgs.git
-      version: master
-    status: maintained
-  moveit_metapackages:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/moveit_metapackages.git
-      version: master
-    release:
-      packages:
-      - moveit_full
-      - moveit_full_pr2
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/moveit_metapackages-release.git
-      version: 0.7.6-0
-    source:
-      type: git
-      url: https://github.com/ros-planning/moveit_metapackages.git
       version: master
     status: maintained
   moveit_msgs:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2908,6 +2908,7 @@ repositories:
       - moveit_ros_robot_interaction
       - moveit_ros_visualization
       - moveit_ros_warehouse
+      - moveit_runtime
       - moveit_setup_assistant
       - moveit_simple_controller_manager
       tags:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2935,6 +2935,7 @@ repositories:
       - moveit_ros_robot_interaction
       - moveit_ros_visualization
       - moveit_ros_warehouse
+      - moveit_runtime
       - moveit_setup_assistant
       - moveit_simple_controller_manager
       tags:


### PR DESCRIPTION
- Moving existing metapackages from an individual repo to `moveit` repo (for Indigo).
- Adding a new metapackage (IJK).

**Question**: in both cases above, `bloom` has not yet been run (ie. release repo not updated). I'm afraid this PR would fail without those packages being bloomed? (If so I think I'll have to close this).

(Changes here is discussed in https://github.com/ros-planning/moveit_metapackages/issues/11)
