### PR TITLE
stf: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13174,6 +13174,21 @@ repositories:
       type: git
       url: https://github.com/srv/stereo_slam.git
       version: indigo
+  stf:
+    doc:
+      type: git
+      url: https://github.com/jstnhuang/stf.git
+      version: 0.1.0
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/jstnhuang-release/stf-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/jstnhuang/stf.git
+      version: 0.1.0
+    status: developed
   straf_recovery:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stf` to `0.1.0-0`:

- upstream repository: https://github.com/jstnhuang/stf.git
- release repository: https://github.com/jstnhuang-release/stf-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## stf

```
The initial release of stf.
```
