### PR TITLE
rospeex: 2.15.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11397,7 +11397,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://bitbucket.org/rospeex/rospeex-release.git
-      version: 2.15.2-0
+      version: 2.15.3-0
     source:
       type: git
       url: https://bitbucket.org/rospeex/rospeex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospeex` to `2.15.3-0`:

- upstream repository: https://bitbucket.org/rospeex/rospeex.git
- release repository: https://bitbucket.org/rospeex/rospeex-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.15.2-0`

## rospeex

- No changes

## rospeex_audiomonitor

- No changes

## rospeex_core

```
* Mod update microsoft speech api from Oxford Project to Cognitive Services
* Fix corruption
* Fix problem at changing recoginize engine language
```

## rospeex_if

```
* Mod decrease gain accept.wav
* Mod update microsoft speech api from Oxford Project to Cognitive Services
* Add test case for speech recognize node
* Fix problem at changing recoginize engine language
```

## rospeex_launch

```
* Mod update microsoft speech api from Oxford Project to Cognitive Services
```

## rospeex_msgs

- No changes

## rospeex_samples

- No changes

## rospeex_webaudiomonitor

- No changes
