### PR TITLE
darknet: 2016.11.27-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2034,7 +2034,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/darknet-release.git
-      version: 2016.11.27-1
+      version: 2016.11.27-2
     status: developed
   darwin_control:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `darknet` to `2016.11.27-2`:

- upstream repository: https://github.com/pjreddie/darknet.git
- release repository: https://github.com/tork-a/darknet-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2016.11.27-1`
