### PR TITLE
romea_controllers: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10511,13 +10511,24 @@ repositories:
       version: indigo
     status: developed
   romea_controllers:
+    doc:
+      type: git
+      url: https://github.com/Romea/romea_controllers.git
+      version: master
     release:
       packages:
       - ackermann_controller
+      - four_wheel_steering_controller
+      - four_wheel_steering_msgs
+      - urdf_vehicle_kinematic
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/Romea/romea_controllers-release.git
-      version: 0.1.2-0
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/Romea/romea_controllers.git
+      version: master
     status: developed
   romeo_moveit_actions:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `romea_controllers` to `0.2.1-0`:

- upstream repository: https://github.com/Romea/romea_controllers.git
- release repository: https://github.com/Romea/romea_controllers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.2-0`

## ackermann_controller

```
* [ackermann] Change package description
* Update computation of virtual steering
* Update test for four_wheel_steering_controller
* Contributors: Vincent Rousseau
```

## four_wheel_steering_controller

```
* [4ws] Add crab travel test
* [4ws] Update test
* [4ws] Add test on non symmetric steering
* [4ws] Revert to use only rear speed for odom
* [4ws] Use front and rear speed for odometry
* Update computation of virtual steering
* [4ws] Remove debug
* [4ws] Update command with 4ws msg
* Update test for four_wheel_steering_controller
* Contributors: Vincent Rousseau
```

## four_wheel_steering_msgs

- No changes

## urdf_vehicle_kinematic

```
* Update computation of virtual steering
* Contributors: Vincent Rousseau
```
