### PR TITLE
Added libi2c-dev rosdep rule

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1811,6 +1811,10 @@ libhdf5-dev:
   debian: [libhdf5-dev]
   fedora: [hdf5-devel]
   ubuntu: [libhdf5-dev]
+libi2c-dev:
+  arch: [linux-api-headers]
+  debian: [libi2c-dev]
+  ubuntu: [libi2c-dev]
 libicu-dev:
   fedora: [libicu-devel]
   ubuntu: [libicu-dev]


### PR DESCRIPTION
This package includes headers that allow for i2c devices to be accessed from userspace programs.

The particular use case that this was necessary for is a ROS node that fetches data from a Lidar-Lite v2 laser rangefinder.

On Arch, the required header is contained in this package:

https://www.archlinux.org/packages/core/x86_64/linux-api-headers/

On Debian and Ubuntu respectively:

https://packages.debian.org/jessie/libi2c-dev

https://packages.ubuntu.com/xenial/libi2c-dev

