### PR TITLE
romea_controllers: 0.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10530,7 +10530,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/Romea/romea_controllers-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/Romea/romea_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `romea_controllers` to `0.2.2-0`:

- upstream repository: https://github.com/Romea/romea_controllers.git
- release repository: https://github.com/Romea/romea_controllers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.2.1-0`

## ackermann_controller

- No changes

## four_wheel_steering_controller

```
* Add test depend
* Contributors: Vincent Rousseau
```

## four_wheel_steering_msgs

- No changes

## urdf_vehicle_kinematic

```
* [urdf_kinematic] Install header file
* Contributors: Vincent Rousseau
```
