### PR TITLE
object_recognition_core: 0.6.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7378,7 +7378,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/object_recognition_core-release.git
-      version: 0.6.5-0
+      version: 0.6.7-0
     source:
       type: git
       url: https://github.com/wg-perception/object_recognition_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_core` to `0.6.7-0`:

- upstream repository: https://github.com/wg-perception/object_recognition_core.git
- release repository: https://github.com/ros-gbp/object_recognition_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.6.5-0`

## object_recognition_core

```
* Merge pull request #46 <https://github.com/wg-perception/object_recognition_core/issues/46> from hris2003/master
  (fix #45 <https://github.com/wg-perception/object_recognition_core/issues/45>)(ModelDocument)Get _id field directly from ViewIterator
* (fix)(ModelDocument)Get _id field directly from ViewIterator
* fix the rosinstall files
* Contributors: Ha Dang, Vincent Rabaud
```
