### PR TITLE
Add 'nvidia-cuda-ocl'

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3315,6 +3315,19 @@ nvidia-cuda-dev:
   debian: [nvidia-cuda-dev]
   gentoo: [nvidia-cuda-dev]
   ubuntu: [nvidia-cuda-dev]
+nvidia-cuda-icd:
+  debian:
+    depends: [ocl-icd-opencl-dev]
+    packages: [nvidia-cuda-toolkit]
+  gentoo:
+    depends: [ocl-icd-opencl-dev]
+    packages: [nvidia-cuda-toolkit]
+  ubuntu:
+    depends: [ocl-icd-opencl-dev]
+    packages: [nvidia-cuda-toolkit]
+ocl-icd-opencl-dev:
+  debian: [ocl-icd-opencl-dev]
+  ubuntu: [ocl-icd-opencl-dev]
 omniidl:
   arch: [omniorb]
   debian: [omniidl, omniorb-idl]


### PR DESCRIPTION
## tl;dr
This pull request adds `nvidia-cuda-ocl` dependency target.
This is assumed to install `ocl-icd-opencl-dev` at first, then install `nvidia-cuda-toolkit`.

## Description

rosdep has install target `nvidia-cuda` which installs `nvidia-cuda-toolkit` via `apt-get`.
`nvidia-cuda-toolkit` has a conditional dependency to `nvidia-opencl-dev | opencl-dev`.
`nvidia-opencl-dev` package depends on `nvidia-340` which is a legacy driver for nvidia video card and if this is installed all other newer drivers are removed instead.
Since this driver does not support the latest nvidia video cards any more, this causes black screen on reboot on some computers after installation.
The dependency `nvidia-opencl-dev | opencl-dev` means that if `opencl-dev` is already installed before installing `nvidia-cuda-toolkit`, then `nvidia-opencl-dev` is not installed, which means we can keep both `nvidia-cuda-toolkit` and, for example, `nvidia-367` (> 340).
`opencl-dev` is actually a virtual package and is `nvidia-opencl-dev` or `ocl-icd-opencl-dev`.
So to avoid this problem, I'd like to add a dependency that installs `ocl-icd-opencl-dev` first and then installs `nvidia-cuda-toolkit`.