### PR TITLE
rqt_common_plugins: 0.4.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5614,7 +5614,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.4.4-0
+      version: 0.4.5-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `0.4.5-0`:

- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/ros-gbp/rqt_common_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.4.4-0`

## rqt_action

- No changes

## rqt_bag

```
* fix Python 2 regression from version 0.4.4 (#424 <https://github.com/ros-visualization/rqt_common_plugins/issues/424>)
```

## rqt_bag_plugins

```
* fix Python 2 regression from version 0.4.4 (#426 <https://github.com/ros-visualization/rqt_common_plugins/issues/426>)
```

## rqt_common_plugins

- No changes

## rqt_console

- No changes

## rqt_dep

- No changes

## rqt_graph

- No changes

## rqt_image_view

- No changes

## rqt_launch

```
* remove __slots__ declaration preventing the plugin to load (#423 <https://github.com/ros-visualization/rqt_common_plugins/pull/423>)
```

## rqt_logger_level

- No changes

## rqt_msg

- No changes

## rqt_plot

- No changes

## rqt_publisher

- No changes

## rqt_py_common

- No changes

## rqt_py_console

- No changes

## rqt_reconfigure

- No changes

## rqt_service_caller

- No changes

## rqt_shell

```
* add command line option --init-script (#296 <https://github.com/ros-visualization/rqt_common_plugins/issues/296>)
```

## rqt_srv

- No changes

## rqt_top

- No changes

## rqt_topic

- No changes

## rqt_web

- No changes
