### PR TITLE
rail_object_detector: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9410,7 +9410,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/GT-RAIL/rail_object_detector.git
-      version: develop
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9406,6 +9406,21 @@ repositories:
       url: https://github.com/GT-RAIL/rail_maps.git
       version: develop
     status: maintained
+  rail_object_detector:
+    doc:
+      type: git
+      url: https://github.com/GT-RAIL/rail_object_detector.git
+      version: develop
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/gt-rail-release/rail_object_detector-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/GT-RAIL/rail_object_detector.git
+      version: develop
+    status: developed
   rail_pick_and_place:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_object_detector` to `1.0.2-0`:

- upstream repository: https://github.com/GT-RAIL/rail_object_detector.git
- release repository: https://github.com/gt-rail-release/rail_object_detector-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
