### PR TITLE
turtlebot_exploration_3d: 0.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13754,7 +13754,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d-release.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_exploration_3d` to `0.0.9-0`:

- upstream repository: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d.git
- release repository: https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.8-0`

## turtlebot_exploration_3d

```
* Merge branch 'master' of https://github.com/RobustFieldAutonomyLab/turtlebot_exploration_3d
* minor change to screen output
* update installation guide, dependency
* update installation guide, dependency
* update launch file, no need for scan_to_pcl
* Contributors: mailto:baishi.bona@gmail.com, baishibona
* update launch file, no need for scan_to_pcl
* Contributors: mailto:baishi.bona@gmail.com
```
