### PR TITLE
fiducials: 0.6.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1190,7 +1190,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/fiducials-release.git
-      version: 0.5.1-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/fiducials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fiducials` to `0.6.0-0`:

- upstream repository: https://github.com/UbiquityRobotics/fiducials
- release repository: https://github.com/UbiquityRobotics-release/fiducials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.5.1-0`

## aruco_detect

```
* moved documentation to ROS wiki
* added utilities to generate PDF files of fiducials
* Expose aruco detection parameters
* Publish one set of fiducial_vertices per image
* Parameterized the dictionary used
* Contributors: Jim Vaughan, Rohan Agrawal
```

## fiducial_detect

```
* moved documentation to ROS wiki
* Removed unused code
* Added transform test
* Contributors: Jim Vaughan, Rohan Agrawal
```

## fiducial_lib

```
* moved documentation to ROS wiki
* Contributors: Jim Vaughan, Rohan Agrawal
```

## fiducial_pose

- No changes

## fiducial_slam

```
* Split Python into separate files
* Ddded median filter option
* Better exception/handling
* Contributors: Jim Vaughan, Rohan Agrawal
```

## fiducials

```
* Update package.xml
* 0.5.1
* add changelogs
* Contributors: Jim Vaughan, Rohan Agrawal
```
