### PR TITLE
ecl_tools: 0.61.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1013,7 +1013,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_tools-release.git
-      version: 0.61.4-2
+      version: 0.61.6-0
     source:
       type: git
       url: https://github.com/stonier/ecl_tools.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1004,7 +1004,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/stonier/ecl_tools.git
-      version: devel
+      version: release/0.61-indigo-kinetic
     release:
       packages:
       - ecl_build


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_tools` to `0.61.6-0`:

- upstream repository: https://github.com/stonier/ecl_tools.git
- release repository: https://github.com/yujinrobot-release/ecl_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.61.4-2`

## ecl_build

```
* add additional ubuntu releases to ecl_detect_distro
* cmake message bugfixes to always include type flag (removes warnings)
```
