### PR TITLE
roch_simulator: 1.0.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10280,7 +10280,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_simulator-release.git
-      version: 1.0.8-1
+      version: 1.0.10-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_simulator` to `1.0.10-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch_simulator.git
- release repository: https://github.com/SawYerRobotics-release/roch_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.8-1`

## roch_gazebo

```
* Add two launch files of gmapping and amcl.
* Fixed bug that can not find empty_world.launch in gazebo_ros.
* Add map files in directory of maps.
* Changes gazebo worlds that origin is too big.
```

## roch_simulator

- No changes
