### PR TITLE
stdr_simulator: 0.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13185,7 +13185,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `stdr_simulator` to `0.3.2-0`:

- upstream repository: https://github.com/stdr-simulator-ros-pkg/stdr_simulator.git
- release repository: https://github.com/stdr-simulator-ros-pkg/stdr_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.3.1-0`

## stdr_gui

```
* Fix cmakes, no more cmake warnings
```

## stdr_launchers

- No changes

## stdr_msgs

- No changes

## stdr_parser

```
* Fix cmakes, no more cmake warnings
```

## stdr_resources

- No changes

## stdr_robot

```
* Fix cmakes, no more cmake warnings
* Add forgotten install target for omni_motion_controller (#195 <https://github.com/stdr-simulator-ros-pkg/stdr_simulator/issues/195>)
```

## stdr_samples

```
* Fix cmakes, no more cmake warnings
* Include forgotten roslib dependency
```

## stdr_server

```
* Fix cmakes, no more cmake warnings
```

## stdr_simulator

- No changes
