### PR TITLE
srdfdom: 0.3.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13078,7 +13078,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/srdfdom-release.git
-      version: 0.3.4-0
+      version: 0.3.5-0
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `0.3.5-0`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/ros-gbp/srdfdom-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.3.4-0`

## srdfdom

```
* [Indigo] cleanup urdfdom compatibility (cherry-picking #27 <https://github.com/ros-planning/srdfdom/issues/27>) #30 <https://github.com/ros-planning/srdfdom/issues/30>
* Contributors: Isaac I.Y. Saito, Michael Goerner, Robert Haschke
```
