### PR TITLE
multisense_ros: 4.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3101,7 +3101,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
-      version: 3.4.7-0
+      version: 4.0.0-0
     source:
       type: hg
       url: https://bitbucket.org/crl/multisense_ros


### PR DESCRIPTION
Increasing version of package(s) in repository `multisense_ros` to `4.0.0-0`:

- upstream repository: https://bitbucket.org/crl/multisense_ros
- release repository: https://github.com/carnegieroboticsllc/multisense_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `3.4.7-0`

## multisense

```
* Added support for new firmware version 3.5 features.
  Rewrote urdf and launch files for ease of use.
* Contributors: Ryan Keating <mailto:rkeating@carnegierobotics.com>
```

## multisense_bringup

```
* Added support for new firmware version 3.5 features.
  Rewrote urdf and launch files for ease of use.
* Contributors: Ryan Keating <mailto:rkeating@carnegierobotics.com>
```

## multisense_cal_check

```
* Added support for new firmware version 3.5 features.
  Rewrote urdf and launch files for ease of use.
* Contributors: Ryan Keating <mailto:rkeating@carnegierobotics.com>
```

## multisense_description

```
* Added support for new firmware version 3.5 features.
  Rewrote urdf and launch files for ease of use.
* Contributors: Ryan Keating <mailto:rkeating@carnegierobotics.com>
```

## multisense_lib

```
* Added support for new firmware version 3.5 features.
  Rewrote urdf and launch files for ease of use.
* Contributors: Ryan Keating <mailto:rkeating@carnegierobotics.com>
```

## multisense_ros

```
* Added support for new firmware version 3.5 features.
  Rewrote urdf and launch files for ease of use.
* Contributors: Ryan Keating <mailto:rkeating@carnegierobotics.com>
```
