### PR TITLE
[Indigo][moveit] Remove some metapackages temporarilly.

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6443,24 +6443,6 @@ repositories:
       url: https://github.com/JenniferBuehler/moveit-pkgs.git
       version: master
     status: maintained
-  moveit_metapackages:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/moveit_metapackages.git
-      version: master
-    release:
-      packages:
-      - moveit_full
-      - moveit_full_pr2
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/moveit_metapackages-release.git
-      version: 0.7.6-0
-    source:
-      type: git
-      url: https://github.com/ros-planning/moveit_metapackages.git
-      version: master
-    status: maintained
   moveit_msgs:
     doc:
       type: git


### PR DESCRIPTION
Reopen https://github.com/ros/rosdistro/pull/13767

As soon as this gets merged, I'll immediately run `bloom` for moveit, where the removed metapackages will be released from the new repo.
