### PR TITLE
moveit: 0.7.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6397,6 +6397,8 @@ repositories:
       - moveit_controller_manager_example
       - moveit_core
       - moveit_fake_controller_manager
+      - moveit_full
+      - moveit_full_pr2
       - moveit_kinematics
       - moveit_planners
       - moveit_planners_ompl
@@ -6413,12 +6415,13 @@ repositories:
       - moveit_ros_robot_interaction
       - moveit_ros_visualization
       - moveit_ros_warehouse
+      - moveit_runtime
       - moveit_setup_assistant
       - moveit_simple_controller_manager
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.7.6-0
+      version: 0.7.7-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.7.7-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.7.6-0`

## moveit

- No changes

## moveit_commander

- No changes

## moveit_controller_manager_example

```
* clang-format upgraded to 3.8 (#404 <https://github.com/ros-planning/moveit/issues/404>)
* Contributors: Dave Coleman
```

## moveit_core

```
* [enhancement] Handle multiple shapes in an attached collision object #421 <https://github.com/ros-planning/moveit/issues/421>
* [enhancement] Improved IPTP by fitting a cubic spline (#382 <https://github.com/ros-planning/moveit/issues/382>)
* [maintenance] Use static_cast to cast to const. (#434 <https://github.com/ros-planning/moveit/issues/434>)
* [capability] Handle multiple shapes in an attached collision object (#421 <https://github.com/ros-planning/moveit/pull/421>)
* [capability] Addition of Set Joint Model Group Velocities and Accelerations Functions (#402 <https://github.com/ros-planning/moveit/issues/402>)
* Contributors: Dave Coleman, G.A. vd. Hoorn, Isaac I.Y. Saito, Maarten de Vries, Mike Lautman, Ruben Burger, Michael Goerner
```

## moveit_fake_controller_manager

```
* [maintenance] clang-format upgraded to 3.8 (#404 <https://github.com/ros-planning/moveit/issues/404>)
* Contributors: Dave Coleman
```

## moveit_full

```
* [Indigo] Move metapackages from moveit_metapackage repo.
* Contributors: Isaac I.Y. Saito
```

## moveit_full_pr2

```
* [Indigo] Move metapackages from moveit_metapackage repo.
* Contributors: Isaac I.Y. Saito
```

## moveit_kinematics

```
* [maintenance] clang-format upgraded to 3.8 (#404 <https://github.com/ros-planning/moveit/issues/404>)
* Contributors: Dave Coleman
```

## moveit_planners

- No changes

## moveit_planners_ompl

```
* [maintenance] clang-format upgraded to 3.8 (#404 <https://github.com/ros-planning/moveit/issues/404>)
* Contributors: Dave Coleman
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* [maintenance] clang-format upgraded to 3.8 (#404 <https://github.com/ros-planning/moveit/issues/404>)
* Contributors: Dave Coleman
```

## moveit_ros_benchmarks_gui

```
* clang-format upgraded to 3.8 (#404 <https://github.com/ros-planning/moveit/issues/404>)
* Contributors: Dave Coleman
```

## moveit_ros_control_interface

```
* [maintenance] clang-format upgraded to 3.8 (#404 <https://github.com/ros-planning/moveit/issues/404>)
* Contributors: Dave Coleman
```

## moveit_ros_manipulation

```
* [maintenance] clang-format upgraded to 3.8 (#404 <https://github.com/ros-planning/moveit/issues/404>)
* Contributors: Dave Coleman
```

## moveit_ros_move_group

```
* clang-format upgraded to 3.8 (#404 <https://github.com/ros-planning/moveit/issues/404>)
* Contributors: Dave Coleman
```

## moveit_ros_perception

```
* clang-format upgraded to 3.8 (#404 <https://github.com/ros-planning/moveit/issues/404>)
* Contributors: Dave Coleman
```

## moveit_ros_planning

```
* [maintenance] Use static_cast to cast to const. (#434 <https://github.com/ros-planning/moveit/issues/434>)
* [enhancement] Improved IPTP by fitting a cubic spline (#382 <https://github.com/ros-planning/moveit/issues/382>)
* Contributors: Dave Coleman, Maarten de Vries, Ruben Burger
```

## moveit_ros_planning_interface

```
* move_group.cpp: seg fault bug fix (#426 <https://github.com/ros-planning/moveit/issues/426>)
  Fixed a bug with casting CallbackQueueInterface * to ros::CallbackQueue * without a check.
  https://github.com/ros-planning/moveit/issues/425
* install planning_interface python test
  This test is reference in the tutorials and should also work with installed workspaces
  http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html#integration-test
* [moveit_ros] Missing test_depend. (#412 <https://github.com/ros-planning/moveit/issues/412>)
* clang-format
* PSI: make all logs _NAMED
* PSI: point out synchronicity behavior of apply* and add/removeObjects interfaces
* remove obsolete mutable declaration
  This was only required for the proposal to change the behavior of the add/remove functions.
  Now that I added the apply* interfaces, this is not relevant anymore.
* PSI: add apply* functions that use ApplyPlanningScene.srv
  to update move_group's PlanningScene
* Use ApplyPlanningSceneService in planning_scene_interface
  Added helper function to call ApplyPlanningScene service
  with fallback to asynchronous processing via "planning_scene"
  topic.
* clang-format upgraded to 3.8 (#404 <https://github.com/ros-planning/moveit/issues/404>)
* Contributors: Andreas Köpf, Bastian Gaspers, Dave Coleman, Isaac I.Y. Saito, v4hn
```

## moveit_ros_robot_interaction

```
* [maintenance] clang-format upgraded to 3.8 (#404 <https://github.com/ros-planning/moveit/issues/404>)
* Contributors: Dave Coleman
```

## moveit_ros_visualization

```
* clang-format upgraded to 3.8 (#404 <https://github.com/ros-planning/moveit/issues/404>)
* Contributors: Dave Coleman
```

## moveit_ros_warehouse

```
* [maintenance] clang-format upgraded to 3.8 (#404 <https://github.com/ros-planning/moveit/issues/404>)
* Contributors: Dave Coleman
```

## moveit_runtime

```
* [indigo] missing changelog.
* [Indigo] Move metapackages from moveit_metapackage repo.
* Contributors: Isaac I.Y. Saito
* Initial release
* Contributors: Isaac I.Y. Saito
```

## moveit_setup_assistant

```
* [maintenance] clang-format upgraded to 3.8 (#404 <https://github.com/ros-planning/moveit/issues/404>)
* Contributors: Dave Coleman
```

## moveit_simple_controller_manager

```
* clang-format upgraded to 3.8 (#404 <https://github.com/ros-planning/moveit/issues/404>)
* Fix spelling (#398 <https://github.com/ros-planning/moveit/issues/398>)
* Contributors: Dave Coleman
```
