### PR TITLE
moveit: 0.8.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2893,6 +2893,7 @@ repositories:
       - moveit_controller_manager_example
       - moveit_core
       - moveit_fake_controller_manager
+      - moveit_kinematics
       - moveit_planners
       - moveit_planners_ompl
       - moveit_plugins
@@ -2908,12 +2909,13 @@ repositories:
       - moveit_ros_robot_interaction
       - moveit_ros_visualization
       - moveit_ros_warehouse
+      - moveit_runtime
       - moveit_setup_assistant
       - moveit_simple_controller_manager
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.8.3-0
+      version: 0.8.5-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.8.5-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.8.3-0`
