### PR TITLE
roch: 1.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10223,7 +10223,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch-release.git
-      version: 1.0.8-0
+      version: 1.0.9-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch` to `1.0.9-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch.git
- release repository: https://github.com/SawYerRobotics-release/roch-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.8-0`

## roch

- No changes

## roch_bringup

- No changes

## roch_follower

- No changes

## roch_navigation

```
* Add run depend yocs_cmd_vel_mux.
* Add rplidar supported files with amcl and gmapping.
* Add rplidar supported navigation param files.
* Remove some files not used.
```

## roch_teleop

```
* Add run depend yocs_cmd_vel_mux.
```
