### PR TITLE
roch_robot: 1.0.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10247,7 +10247,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_robot-release.git
-      version: 1.0.10-0
+      version: 1.0.11-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_robot` to `1.0.11-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch_robot.git
- release repository: https://github.com/SawYerRobotics-release/roch_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.10-0`

## roch_base

```
* Add install executable of test application.
```

## roch_control

```
* Add missing dependence: create_node
```

## roch_description

```
* Add mesh of rplidar.
```

## roch_ftdi

- No changes

## roch_msgs

- No changes

## roch_robot

- No changes

## roch_safety_controller

```
* Modify website.
* Add application of roch_safety_controoler used in install.
```

## roch_sensorpc

```
* Modify websites.
* Add application of roch_sensorpc_nodelet used in install.
```
