### PR TITLE
mavros: 0.17.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2750,7 +2750,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.17.4-0
+      version: 0.17.5-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.17.5-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.17.4-0`

## libmavconn

```
* Pthread fix for OSX (#650 <https://github.com/mavlink/mavros/issues/650>)
  * fix pthread and missing defines for osx
  * adapted their style using tabs
  * fix elif to else
* Contributors: Fadri Furrer
```

## mavros

```
* Pthread fix for OSX (#650 <https://github.com/mavlink/mavros/issues/650>)
  * fix pthread and missing defines for osx
  * adapted their style using tabs
  * fix elif to else
* Fixing a typo in HIL_CONTROLS plugin
* Contributors: Fadri Furrer, Pavel
```

## mavros_extras

- No changes

## mavros_msgs

- No changes

## test_mavros

- No changes
