### PR TITLE
mavros: 0.18.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2777,7 +2777,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.18.5-0
+      version: 0.18.6-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.18.6-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.18.5-0`

## libmavconn

```
* lib #626 <https://github.com/mavlink/mavros/issues/626>: Porting of PR #650 <https://github.com/mavlink/mavros/issues/650> - Fix OSX pthread set name.
* Contributors: Fadri Furrer
```

## mavros

```
* lib #626 <https://github.com/mavlink/mavros/issues/626>: Porting of PR #650 <https://github.com/mavlink/mavros/issues/650> - Fix OSX pthread set name.
* uas fix #639 <https://github.com/mavlink/mavros/issues/639>: Remove Boost::signals2 from UAS
* Plugins: system_status change status field to system_status
  Add comment to State.msg for system_status enum
* Plugins: add system_status to state message
* Contributors: Fadri Furrer, Pierre Kancir, Vladimir Ermakov
```

## mavros_extras

- No changes

## mavros_msgs

```
* Plugins: system_status change status field to system_status
  Add comment to State.msg for system_status enum
* Plugins: add system_status to state message
* Contributors: Pierre Kancir
```

## test_mavros

- No changes
