### PR TITLE
plotjuggler: 0.9.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8414,15 +8414,20 @@ repositories:
       url: https://github.com/silviomaeta/plot_util.git
       version: master
   plotjuggler:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 0.8.1-0
+      version: 0.9.0-2
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git
       version: master
+    status: developed
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `0.9.0-2`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.8.1-0`

## plotjuggler

```
* bug fixes
* QWT submodule removed
* removed boost dependency
* Contributors: Davide Faconti
* remove submodule
* Contributors: Davide Faconti
```
