### PR TITLE
plotjuggler: 0.9.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4165,15 +4165,20 @@ repositories:
       version: master
     status: maintained
   plotjuggler:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 0.8.1-0
+      version: 0.9.0-2
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git
       version: master
+    status: developed
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `0.9.0-2`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.8.1-0`

## plotjuggler

```
* bug fixes
* QWT submodule removed
* removed boost dependency
* Contributors: Davide Faconti
* remove submodule
* Contributors: Davide Faconti
```
