### PR TITLE
plotjuggler: 0.9.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4257,6 +4257,21 @@ repositories:
       url: https://github.com/amineHorseman/pioneer_teleop.git
       version: master
     status: maintained
+  plotjuggler:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/facontidavide/plotjuggler-release.git
+      version: 0.9.0-0
+    source:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: master
+    status: developed
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `0.9.0-0`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## plotjuggler

```
* bug fixes
* QWT submodule removed
* removed boost dependency
* Contributors: Davide Faconti
* remove submodule
* Contributors: Davide Faconti
```
