### PR TITLE
image_recognition: 0.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1943,7 +1943,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tue-robotics/image_recognition-release.git
-      version: 0.0.2-1
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/tue-robotics/image_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_recognition` to `0.0.4-0`:

- upstream repository: https://github.com/tue-robotics/image_recognition.git
- release repository: https://github.com/tue-robotics/image_recognition-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.2-1`

## image_recognition

- No changes

## image_recognition_msgs

- No changes

## image_recognition_rqt

- No changes

## image_recognition_util

- No changes

## openface_ros

- No changes

## skybiometry_ros

- No changes

## tensorflow_ros

- No changes

## tensorflow_ros_rqt

- No changes
