### PR TITLE
ar_track_alvar: 0.6.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -108,7 +108,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ar_track_alvar-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/sniekum/ar_track_alvar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar` to `0.6.2-0`:

- upstream repository: https://github.com/sniekum/ar_track_alvar
- release repository: https://github.com/ros-gbp/ar_track_alvar-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.6.1-0`

## ar_track_alvar

```
* [fix] Marker no longer recognized #93 <https://github.com/sniekum/ar_track_alvar/issues/93>
* [fix] add install rule for bundles folder; fixes #88 <https://github.com/sniekum/ar_track_alvar/issues/88>
* [fix] Shutdown camera info sub after called
* [enhancement] add mark_resolution and mark_marge as input option
* [enhancement] individualMarkers: replace cout with ROS_DEBUG_STREAM (#101 <https://github.com/sniekum/ar_track_alvar/issues/101>)
* Contributors: Alex Reimann, Hans-Joachim Krauch, Isaac I.Y. Saito, TORK Developer 534
```
