### PR TITLE
ar_track_alvar: 0.5.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -73,7 +73,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ar_track_alvar-release.git
-      version: 0.5.4-0
+      version: 0.5.5-0
     source:
       type: git
       url: https://github.com/sniekum/ar_track_alvar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar` to `0.5.5-0`:

- upstream repository: https://github.com/sniekum/ar_track_alvar
- release repository: https://github.com/ros-gbp/ar_track_alvar-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.5.4-0`

## ar_track_alvar

```
* [fix] Marker no longer recognized #93 <https://github.com/sniekum/ar_track_alvar/issues/93>
* [fix] add install rule for bundles folder; fixes #88 <https://github.com/sniekum/ar_track_alvar/issues/88>
* [enhancement] individualMarkers: replace cout with ROS_DEBUG_STREAM (#101 <https://github.com/sniekum/ar_track_alvar/issues/101>)
* Contributors: Hans-Joachim Krauch, Isaac I.Y. Saito, TORK Developer 534
```
