### PR TITLE
rospeex: 2.15.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5628,7 +5628,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://bitbucket.org/rospeex/rospeex-release.git
-      version: 2.15.2-0
+      version: 2.15.4-0
     source:
       type: git
       url: https://bitbucket.org/rospeex/rospeex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospeex` to `2.15.4-0`:

- upstream repository: https://bitbucket.org/rospeex/rospeex.git
- release repository: https://bitbucket.org/rospeex/rospeex-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.15.2-0`

## rospeex

- No changes

## rospeex_audiomonitor

```
* Mod rospeex-audiomonitor size
```

## rospeex_core

- No changes

## rospeex_if

- No changes

## rospeex_launch

- No changes

## rospeex_msgs

- No changes

## rospeex_samples

- No changes

## rospeex_webaudiomonitor

- No changes
