### PR TITLE
ar_track_alvar: 0.6.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -108,7 +108,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ar_track_alvar-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/sniekum/ar_track_alvar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar` to `0.6.3-0`:

- upstream repository: https://github.com/sniekum/ar_track_alvar
- release repository: https://github.com/ros-gbp/ar_track_alvar-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.6.2-0`

## ar_track_alvar

```
* [fix] Marker no longer recognized, for IndividualMarkersNoKinect #93 <https://github.com/sniekum/ar_track_alvar/issues/93>
* [capability] Add param to derive camera frame from pointcloud message frame (#111 <https://github.com/sniekum/ar_track_alvar/issues/111>)
* [capability ] individual marker nodes: replace command line args with ros parameters (#99 <https://github.com/sniekum/ar_track_alvar/issues/99>)
* [maintenance] Add system test using .bag. (#106 <https://github.com/sniekum/ar_track_alvar/issues/106>)
* Contributors: Hans-Joachim Krauch, Isaac I.Y. Saito
```
