### PR TITLE
rail_object_detector: 1.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9405,7 +9405,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/rail_object_detector-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/GT-RAIL/rail_object_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_object_detector` to `1.0.4-0`:

- upstream repository: https://github.com/GT-RAIL/rail_object_detector.git
- release repository: https://github.com/gt-rail-release/rail_object_detector-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.3-0`

## rail_object_detector

```
* Adding in an automatic build for 32 bit
* Contributors: Siddhartha Banerjee, banerjs
```
