### PR TITLE
rtmros_hironx: 1.1.20-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11889,7 +11889,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.19-0
+      version: 1.1.20-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.20-0`:

- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.1.19-0`

## hironx_calibration

- No changes

## hironx_moveit_config

- No changes

## hironx_ros_bridge

```
* [Capability] Enable head cameras for hrpsys simulator.
* Contributors: Kei Okada
```

## rtmros_hironx

```
* [Capability] Enable head cameras for hrpsys simulator.
* Contributors: Kei Okada
```
