### PR TITLE
visp: 3.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14444,7 +14444,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 3.0.0-4
+      version: 3.0.1-1
     status: maintained
   visp_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `3.0.1-1`:

- upstream repository: https://github.com/lagadic/visp.git
- release repository: https://github.com/lagadic/visp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `3.0.0-4`
