### PR TITLE
vision_visp: 0.10.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6974,7 +6974,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.9.3-0
+      version: 0.10.0-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.10.0-0`:

- upstream repository: https://github.com/lagadic/vision_visp.git
- release repository: https://github.com/lagadic/vision_visp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.9.3-0`

## vision_visp

```
* kinetic-0.9.3
* Prepare changelogs
* Contributors: Fabien Spindler
```

## visp_auto_tracker

```
* Fix catkin_lint warnings level 2
* kinetic-0.9.3
* Prepare changelogs
* Contributors: Fabien Spindler
```

## visp_bridge

```
* Fix catkin_lint warnings level 2
* kinetic-0.9.3
* Prepare changelogs
* Contributors: Fabien Spindler
```

## visp_camera_calibration

```
* Fix catkin_lint warnings level 2
* kinetic-0.9.3
* Prepare changelogs
* Contributors: Fabien Spindler
```

## visp_hand2eye_calibration

```
* Fix catkin_lint warnings level 2
* kinetic-0.9.3
* Prepare changelogs
* Contributors: Fabien Spindler
```

## visp_tracker

```
* Fix catkin_lint warnings level 2
* Fix OpenCV issue when reconfiguring the visp_tracker (Closes #58 <https://github.com/lagadic/vision_visp/issues/58>)
* kinetic-0.9.3
* Prepare changelogs
* Contributors: Fabien Spindler
```
