### PR TITLE
urdfdom_py: 0.3.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14108,7 +14108,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/urdfdom_py-release.git
-      version: 0.3.1-1
+      version: 0.3.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_py` to `0.3.3-1`:

- upstream repository: https://github.com/ros/urdf_parser_py/
- release repository: https://github.com/ros-gbp/urdfdom_py-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.3.1-1`

## urdfdom_py

```
* Made Chris and Shane the maintainers
* Added python-lxml to the travis build.
* Reverted line break (ros/urdfdom#77 <https://github.com/ros/urdfdom/pull/77>) now that there is a more generic solution. (#5 <https://github.com/ros/urdf_parser_py/issues/5>)
* Added line break to make errors easier to read. (#4 <https://github.com/ros/urdf_parser_py/issues/4>)
* Contributors: Chris Lalancette, Isaac I.Y. Saito
```
