### PR TITLE
urdfdom_py: 0.3.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6774,7 +6774,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/urdfdom_py-release.git
-      version: 0.3.1-0
+      version: 0.3.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_py` to `0.3.3-0`:

- upstream repository: https://github.com/ros/urdf_parser_py/
- release repository: https://github.com/ros-gbp/urdfdom_py-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.3.1-0`

## urdfdom_py

```
* Made Chris and Shane the maintainers
* Added python-lxml to the travis build.
* Reverted line break (ros/urdfdom#77 <https://github.com/ros/urdfdom/pull/77>) now that there is a more generic solution. (#5 <https://github.com/ros/urdf_parser_py/issues/5>)
* Added line break to make errors easier to read. (#4 <https://github.com/ros/urdf_parser_py/issues/4>)
* Contributors: Chris Lalancette, Isaac I.Y. Saito
```
