### PR TITLE
katana_driver: 1.0.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2237,7 +2237,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/katana_driver-release.git
-      version: 1.0.6-0
+      version: 1.0.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `katana_driver` to `1.0.7-0`:

- upstream repository: https://github.com/uos/katana_driver.git
- release repository: https://github.com/uos-gbp/katana_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.6-0`

## katana

```
* KNIKinematics: Remove GetKinematicSolverInfo service
  The service definition was removed from moveit_msgs on Kinetic in commit 2f3f97b9.
* Contributors: Martin Guenther
```

## katana_arm_gazebo

- No changes

## katana_description

- No changes

## katana_driver

- No changes

## katana_gazebo_plugins

- No changes

## katana_moveit_ikfast_plugin

- No changes

## katana_msgs

- No changes

## katana_teleop

- No changes

## katana_tutorials

- No changes

## kni

- No changes
