### PR TITLE
joystick_drivers: 1.11.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4778,7 +4778,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/joystick_drivers-release.git
-      version: 1.10.1-0
+      version: 1.11.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: indigo-devel
     status: maintained
   joystick_sdl:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `1.11.0-1`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros-gbp/joystick_drivers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.10.1-0`

## joy

```
* fixed joy/Cmakelists for osx
* Update dependencies to remove warnings
* Contributors: Marynel Vazquez, Mark D Horn
```

## joystick_drivers

- No changes

## ps3joy

```
* Update dependencies to remove warnings
* Contributors: Mark D Horn
```

## spacenav_node

```
* Update dependencies to remove warnings
* Contributors: Mark D Horn
```

## wiimote

```
* Sample Teleop Implementation for Wiimote
* C++ Implementation of Wiimote Controller Node
* Add queue_size to remove ROS Warning
* Update dependencies to remove warnings
* Contributors: Mark D Horn
```
