### PR TITLE
joystick_drivers: 1.11.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2119,7 +2119,11 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/joystick_drivers-release.git
-      version: 1.10.1-0
+      version: 1.11.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: indigo-devel
     status: maintained
   jsk_3rdparty:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `1.11.0-0`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros-gbp/joystick_drivers-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.10.1-0`

## joy

```
* fixed joy/Cmakelists for osx
* Update dependencies to remove warnings
* Contributors: Marynel Vazquez, Mark D Horn
```

## joystick_drivers

- No changes

## ps3joy

```
* Update dependencies to remove warnings
* Contributors: Mark D Horn
```

## spacenav_node

```
* Update dependencies to remove warnings
* Contributors: Mark D Horn
```

## wiimote

```
* Sample Teleop Implementation for Wiimote
* C++ Implementation of Wiimote Controller Node
* Add queue_size to remove ROS Warning
* Update dependencies to remove warnings
* Contributors: Mark D Horn
```
