### PR TITLE
joystick_drivers: 1.11.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2127,7 +2127,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/joystick_drivers-release.git
-      version: 1.10.1-0
+      version: 1.11.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/joystick_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `1.11.0-0`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros-gbp/joystick_drivers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.10.1-0`

## joy

```
* fixed joy/Cmakelists for osx
* Update dependencies to remove warnings
* Contributors: Marynel Vazquez, Mark D Horn
```

## joystick_drivers

- No changes

## ps3joy

```
* Update dependencies to remove warnings
* Contributors: Mark D Horn
```

## spacenav_node

```
* Update dependencies to remove warnings
* Contributors: Mark D Horn
```

## wiimote

```
* Sample Teleop Implementation for Wiimote
* C++ Implementation of Wiimote Controller Node
* Add queue_size to remove ROS Warning
* Update dependencies to remove warnings
* Contributors: Mark D Horn
```
