### PR TITLE
light_scan_sim: 0.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5734,6 +5734,11 @@ repositories:
       url: https://github.com/srv/libvlfeat.git
       version: master
   light_scan_sim:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/josephduchesne/light_scan_sim-release.git
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/josephduchesne/light_scan_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `light_scan_sim` to `0.0.9-0`:

- upstream repository: https://github.com/josephduchesne/light_scan_sim.git
- release repository: https://github.com/josephduchesne/light_scan_sim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
