### PR TITLE
parrot_arsdk: 3.11.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3955,7 +3955,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/AutonomyLab/parrot_arsdk-release.git
-      version: 3.10.1-0
+      version: 3.11.0-0
     source:
       type: git
       url: https://github.com/AutonomyLab/parrot_arsdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `parrot_arsdk` to `3.11.0-0`:

- upstream repository: https://github.com/AutonomyLab/parrot_arsdk.git
- release repository: https://github.com/AutonomyLab/parrot_arsdk-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `3.10.1-0`

## parrot_arsdk

```
* Update to SDK 3.11.0
  SDK Changelog:
  - Fixed non-ack commands (camera orientation was always sent)
  - Updated features list in the device controllers
  - Old and deprecated Unix samples have been removed
  - Coverity fixes
* Contributors: Mani Monajjemi
```
