### PR TITLE
jsk_recognition: 1.1.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2199,6 +2199,23 @@ repositories:
       url: https://github.com/tork-a/jsk_common_msgs-release.git
       version: 4.1.0-0
     status: developed
+  jsk_recognition:
+    release:
+      packages:
+      - checkerboard_detector
+      - imagesift
+      - jsk_pcl_ros
+      - jsk_pcl_ros_utils
+      - jsk_perception
+      - jsk_recognition
+      - jsk_recognition_msgs
+      - jsk_recognition_utils
+      - resized_image_transport
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/jsk_recognition-release.git
+      version: 1.1.0-2
+    status: developed
   jsk_roseus:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `1.1.0-2`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## checkerboard_detector

- No changes

## imagesift

- No changes

## jsk_pcl_ros

```
* remove test_data and move to sample_data (#2017 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2017> )
* Contributors: Shingo Kitagawa
```

## jsk_pcl_ros_utils

- No changes

## jsk_perception

- No changes

## jsk_recognition

- No changes

## jsk_recognition_msgs

- No changes

## jsk_recognition_utils

- No changes

## resized_image_transport

- No changes
