### PR TITLE
marvelmind_nav: 1.0.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4051,6 +4051,12 @@ repositories:
       type: git
       url: https://github.com/larsys/markov_decision_making.git
       version: master
+  marvelmind_nav:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
+      version: 1.0.6-0
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marvelmind_nav` to `1.0.6-0`:

- upstream repository: https://bitbucket.org/marvelmind_robotics/ros_marvelmind_package
- release repository: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`

## marvelmind_nav

- No changes
