### PR TITLE
marvelmind_nav: 1.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6016,6 +6016,12 @@ repositories:
       url: https://github.com/swri-robotics/marti_messages.git
       version: indigo-devel
     status: developed
+  marvelmind_nav:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
+      version: 1.0.6-0
   mastering_ros_demo_pkg:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `marvelmind_nav` to `1.0.6-0`:

- upstream repository: https://bitbucket.org/marvelmind_robotics/ros_marvelmind_package
- release repository: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`

## marvelmind_nav

- No changes
