### PR TITLE
light_scan_sim: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5738,7 +5738,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/josephduchesne/light_scan_sim-release.git
-      version: 0.0.9-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/josephduchesne/light_scan_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `light_scan_sim` to `0.1.0-0`:

- upstream repository: https://github.com/josephduchesne/light_scan_sim.git
- release repository: https://github.com/josephduchesne/light_scan_sim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.9-0`
