### PR TITLE
jsk_visualization: 2.1.0-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2227,6 +2227,24 @@ repositories:
       url: https://github.com/tork-a/jsk_roseus-release.git
       version: 1.6.0-0
     status: developed
+  jsk_visualization:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_visualization.git
+      version: master
+    release:
+      packages:
+      - jsk_interactive
+      - jsk_interactive_marker
+      - jsk_interactive_test
+      - jsk_rqt_plugins
+      - jsk_rviz_plugins
+      - jsk_visualization
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/jsk_visualization-release.git
+      version: 2.1.0-3
+    status: developed
   jskeus:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `2.1.0-3`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## jsk_interactive

- No changes

## jsk_interactive_marker

```
* migration to kinetic, which uses qt5 wehre as indig/jade uses qt4 (#662 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/662> )
* Feature to transform markers in rviz (#661 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/661> )
  * Fix for same config in CMakeLists as jsk_rviz_pluginsTo fix error on hydro
  
    * Fix dependency of jsk_interactive_marker
    * Use throttle for ROS_ERROR
    * Move TransformableMarkerOperatorAction to jsk_interactive_marker
    * Update rviz for sample of transformable_markers
    * Use better marker size
    * Support transformation of dimension in transformable_markers_client
  
* Add client node for transformable markers (only boxes) (#658 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/658> )
  * Add TODO to extend transformable_markers_client
  * Rename transformable_boxes_client -> transformable_markers_client
  * Add client node for transformable boxes
* [maker_6dof] support mesh, publish pose topoic periodically ( #657 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/657> )
  * [jsk_interactive_marker/marker_6dof] add sample launch and doc.
  * [jsk_interactive_marker/src/marker_6dof] fix minor bug in line shape color setting.
  * [jsk_interactive_marker/src/marker_6dof] add option to select interactive marker size. default interactive marker size does not change.
  * [jsk_interactive_marker/src/marker_6dof] add option to publish pose periodically. default behavior does not change.
  * [jsk_interactive_marker/src/marker_6dof] supoort mesh as marker shape.
* Fix #655 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/655> : fix frame_id of tf published by marker 6dof( #657 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/657> )
  * Stop using fixed frame_id_ for simplicity
  * Transform pose in feedback with expected frame_id
  * Check frame_id of pose before publishing as TF
  * marker_6dof: publish tf after transformed to frame_id_, update is published with fixed frame of rviz
* Contributors: Kei Okada, Kentaro Wada, Masaki Murooka, Hiroto Mizohana
```

## jsk_interactive_test

- No changes

## jsk_rqt_plugins

- No changes

## jsk_rviz_plugins

```
* migration to kinetic, which uses qt5 wehre as indig/jade uses qt4 (#662 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/662> )
* Feature to transform markers in rviz (#661 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/661> )
  * Not to build transformable_marker_operator in jsk_rviz_plugins
  * Move TransformableMarkerOperatorAction to jsk_interactive_marker
  * Add feature to transform marker to rviz plugin
  * Add server_name for TransformableMarkerOperatorAction
* Contributors: Kentaro Wada, Hiroto Mizohana
```

## jsk_visualization

- No changes
