### PR TITLE
jsk_control: 0.1.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4915,7 +4915,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_control-release.git
-      version: 0.1.10-0
+      version: 0.1.11-0
     status: developed
   jsk_demos:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_control` to `0.1.11-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_control.git
- release repository: https://github.com/tork-a/jsk_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.10-0`

## contact_states_observer

```
* [contact_states_observer/euslisp/contact-states-observer.l] Use robot-init and update for latest jaxon methods
* Contributors: Shunichi Nozawa
```

## eus_nlopt

```
* add install rules
* Contributors: Kei Okada
```

## eus_qp

```
* [eus_qp/README.md] Add readme for eus_qp and euslisp programs.
* [eus_qp/euslisp/cfr-cwc-calculation.l] Use obj env constraint in calc-dynamic-min-max-cog-pos
* [eus_qp/euslisp/cfr-cwc-calculation.l] Remove unused argument for calc-constraint-matrix-vector-for-obj-env-constraint
* Contributors: Shunichi Nozawa
```

## eus_qpoases

```
* Set include path of qpoases in eus_qpoases
* Contributors: Kei Okada, Kentaro Wada
```

## joy_mouse

- No changes

## jsk_calibration

- No changes

## jsk_control

- No changes

## jsk_footstep_controller

- No changes

## jsk_footstep_planner

- No changes

## jsk_ik_server

- No changes

## jsk_teleop_joy

- No changes
