### PR TITLE
vision_visp: 0.10.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14443,7 +14443,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.9.1-0
+      version: 0.10.0-0
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.10.0-0`:

- upstream repository: https://github.com/lagadic/vision_visp.git
- release repository: https://github.com/lagadic/vision_visp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.9.1-0`

## vision_visp

```
* indigo-0.9.1
* Prepare changelogs
* Contributors: Fabien Spindler
```

## visp_auto_tracker

```
* Fix catkin_lint warnings level 2
* indigo-0.9.1
* Prepare changelogs
* Contributors: Fabien Spindler
```

## visp_bridge

```
* Fix catkin_lint warnings level 2
* indigo-0.9.1
* Prepare changelogs
* Contributors: Fabien Spindler
```

## visp_camera_calibration

```
* Fix catkin_lint warnings level 2
* indigo-0.9.1
* Prepare changelogs
* Contributors: Fabien Spindler
```

## visp_hand2eye_calibration

```
* Fix catkin_lint warnings level 2
* indigo-0.9.1
* Prepare changelogs
* Contributors: Fabien Spindler
```

## visp_tracker

```
* Fix catkin_lint warnings level 2
* Fix OpenCV issue when reconfiguring the visp_tracker (Closes #58 <https://github.com/lagadic/vision_visp/issues/58>)
* indigo-0.9.1
* Prepare changelogs
* Contributors: Fabien Spindler
```
