### PR TITLE
jsk_control: 0.1.11-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2202,6 +2202,29 @@ repositories:
       url: https://github.com/tork-a/jsk_common_msgs-release.git
       version: 4.1.0-0
     status: developed
+  jsk_control:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_control.git
+      version: master
+    release:
+      packages:
+      - contact_states_observer
+      - eus_nlopt
+      - eus_qp
+      - eus_qpoases
+      - joy_mouse
+      - jsk_calibration
+      - jsk_control
+      - jsk_footstep_controller
+      - jsk_footstep_planner
+      - jsk_ik_server
+      - jsk_teleop_joy
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/jsk_control-release.git
+      version: 0.1.11-1
+    status: developed
   jsk_model_tools:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_control` to `0.1.11-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_control.git
- release repository: https://github.com/tork-a/jsk_control-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## contact_states_observer

```
* [contact_states_observer/euslisp/contact-states-observer.l] Use robot-init and update for latest jaxon methods
* Contributors: Shunichi Nozawa
```

## eus_nlopt

```
* add install rules
* Contributors: Kei Okada
```

## eus_qp

```
* [eus_qp/README.md] Add readme for eus_qp and euslisp programs.
* [eus_qp/euslisp/cfr-cwc-calculation.l] Use obj env constraint in calc-dynamic-min-max-cog-pos
* [eus_qp/euslisp/cfr-cwc-calculation.l] Remove unused argument for calc-constraint-matrix-vector-for-obj-env-constraint
* Contributors: Shunichi Nozawa
```

## eus_qpoases

```
* Set include path of qpoases in eus_qpoases
* Contributors: Kei Okada, Kentaro Wada
```

## joy_mouse

- No changes

## jsk_calibration

- No changes

## jsk_control

- No changes

## jsk_footstep_controller

- No changes

## jsk_footstep_planner

- No changes

## jsk_ik_server

- No changes

## jsk_teleop_joy

- No changes
