### PR TITLE
catkin: 0.7.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -455,7 +455,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.4-0
+      version: 0.7.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.5-0`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.7.4-0`

## catkin

```
* update --pkg help for catkin_make_isolated (#853 <https://github.com/ros/catkin/issues/853>)
* add skipped / disabled tests to catkin_test_results summary (#848 <https://github.com/ros/catkin/issues/848>)
* use functions instead of macros where possible to avoid leaking variables (#835 <https://github.com/ros/catkin/issues/835>)
* write output of parsing package xml as UTF-8 for Python 3 (#828 <https://github.com/ros/catkin/issues/828>)
* update documentation
```
