### PR TITLE
ros: 1.13.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5055,7 +5055,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.13.4-0
+      version: 1.13.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.13.5-0`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.13.4-0`

## mk

- No changes

## rosbash

```
* add completion for "rosmsg info" (#138 <https://github.com/ros/ros/pull/138>)
* add "rostopic pub" completion for message type (#132 <https://github.com/ros/ros/pull/132>)
* fix "rostopic pub" completion when options are provided (#131 <https://github.com/ros/ros/pull/131>)
```

## rosboost_cfg

- No changes

## rosbuild

- No changes

## rosclean

```
* add --size option to rosclean purge (#126 <https://github.com/ros/ros/issues/126>)
```

## roscreate

- No changes

## roslang

- No changes

## roslib

```
* fix missing export depends (#128 <https://github.com/ros/ros/issues/128>)
```

## rosmake

- No changes

## rosunit

```
* improve error message when creating test directory fails (#134 <https://github.com/ros/ros/pull/134>)
* fix race condition creating folder (#130 <https://github.com/ros/ros/pull/130>)
```
