### PR TITLE
openrave_planning: 0.0.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7859,7 +7859,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/openrave_planning-release.git
-      version: 0.0.5-0
+      version: 0.0.5-1
     status: developed
   openreroc_motion_sensor:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrave_planning` to `0.0.5-1`:

- upstream repository: https://github.com/jsk-ros-pkg/openrave_planning.git
- release repository: https://github.com/tork-a/openrave_planning-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.5-0`

## arm_navigation_msgs

- No changes

## collada_robots

- No changes

## openrave

```
* re-enable opende in package.xml
* 99.openarve.sh.in: openrave-config is now global executive
* use production release of Jan/19/2017
* Contributors: Kei Okada
```

## openrave_planning

- No changes
