### PR TITLE
jsk_visualization: 2.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2266,7 +2266,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 2.1.0-3
+      version: 2.1.1-0
     status: developed
   jskeus:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `2.1.1-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.1.0-3`

## jsk_interactive

- No changes

## jsk_interactive_marker

```
* CMakeLists.txt: fix to support qt5
* package.xml: remove pr2eus_moveit from dependency
* Contributors: Yuki Furuta, Kei Okada
```

## jsk_interactive_test

- No changes

## jsk_rqt_plugins

- No changes

## jsk_rviz_plugins

```
* remove depends to wxwidgets https://github.com/ros/rosdistro/pull/13886#issuecomment-279832181
* Contributors: Kei Okada
```

## jsk_visualization

- No changes
