### PR TITLE
ros_controllers: 0.12.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5207,7 +5207,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.11.2-0
+      version: 0.12.0-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.12.0-0`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.11.2-0`

## diff_drive_controller

```
* Fix most catkin lint issues
* Change for format2
* Add Enrique and Bence to maintainers
* Add urdf compatibility header
* Add --inorder to xacro calls
* Add missing xacro tags
* Use xacro instead of xacro.py
* Disable angular jerk limit test
* Replace boost::shared_ptr<urdf::XY> with urdf::XYConstSharedPtr when exists
* Contributors: Bence Magyar
```

## effort_controllers

```
* Fix most catkin lint issues
* Remove unused dependency
* Change for format2
* Add Enrique and Bence to maintainers
* Replace boost::shared_ptr<urdf::XY> with urdf::XYConstSharedPtr when exists
* Contributors: Bence Magyar
```

## force_torque_sensor_controller

```
* Fix most catkin lint issues
* Sort dependencies
* Change for format2
* Add Enrique and Bence to maintainers
* Contributors: Bence Magyar
```

## forward_command_controller

```
* Change for format2
* Add Enrique and Bence to maintainers
* Contributors: Bence Magyar
```

## gripper_action_controller

```
* Fix most catkin lint issues
* Change for format2
* Add Enrique and Bence to maintainers
* urdf::Model typedefs had to be added to a different repo first
* Replace boost::shared_ptr<urdf::XY> with urdf::XYConstSharedPtr when exists
* Contributors: Bence Magyar
```

## imu_sensor_controller

```
* Fix most catkin lint issues
* Change for format2
* Add Enrique and Bence to maintainers
* Contributors: Bence Magyar
```

## joint_state_controller

```
* Add Enrique and Bence to maintainers
* Contributors: Bence Magyar
```

## joint_trajectory_controller

```
* Fix missing controller_manager include
* Ordered dependencies & cleanup
* Change for format2
* Add Enrique and Bence to maintainers
* Add test that sends trajectory entirely in past
* Use xacro instead of xacro.py
* urdf::Model typedefs had to be added to a different repo first
* Updated copyright info
* jtc: Enable sending trajectories with a partial set of joints
* Replace boost::shared_ptr<urdf::XY> with urdf::XYConstSharedPtr when exists
* Infrastructure for testing the velocity_controllers::JointTrajectoryController.
* jtc: Enable sending trajectories with a partial set of joints
* Contributors: Beatriz Leon, Bence Magyar, Miguel Prada
```

## position_controllers

```
* Change for format2
* Add Enrique and Bence to maintainers
* Contributors: Bence Magyar
```

## ros_controllers

```
* Ordered dependencies & cleanup
* Change for format2
* Add Enrique and Bence to maintainers
* Contributors: Bence Magyar
```

## rqt_joint_trajectory_controller

```
* Change for format2
* Add Enrique and Bence to maintainers
* Contributors: Bence Magyar
```

## velocity_controllers

```
* Change for format2
* Add Enrique and Bence to maintainers
* Replace boost::shared_ptr<urdf::XY> with urdf::XYConstSharedPtr when exists
* Contributors: Bence Magyar
```
