### PR TITLE
cost_map: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -628,7 +628,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/stonier/cost_map-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/stonier/cost_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cost_map` to `0.3.1-0`:

- upstream repository: https://github.com/stonier/cost_map.git
- release repository: https://github.com/stonier/cost_map-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.3.0-0`

## cost_map_ros

```
* minor api name fixes for Costmap2D references
```
