### PR TITLE
genmsg: 0.5.8-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -28,5 +28,20 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: kinetic-devel
     status: maintained
+  genmsg:
+    doc:
+      type: git
+      url: https://github.com/ros/genmsg.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/genmsg-release.git
+      version: 0.5.8-0
+    source:
+      type: git
+      url: https://github.com/ros/genmsg.git
+      version: indigo-devel
+    status: maintained
 type: distribution
 version: 2

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -39,6 +39,7 @@ repositories:
       url: https://github.com/ros-gbp/genmsg-release.git
       version: 0.5.8-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/genmsg.git
       version: indigo-devel


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.5.8-0`:

- upstream repository: git@github.com:ros/genmsg.git
- release repository: https://github.com/ros-gbp/genmsg-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## genmsg

```
* check target across package for existance (#65 <https://github.com/ros/genmsg/issues/65>)
* do not hardcode errno values (#64 <https://github.com/ros/genmsg/issues/64>)
```
