### PR TITLE
gennodejs: 2.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1410,7 +1410,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RethinkRobotics-release/gennodejs-release.git
-      version: 1.0.3-0
+      version: 2.0.1-0
     source:
       type: git
       url: https://github.com/RethinkRobotics-opensource/gennodejs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gennodejs` to `2.0.1-0`:

- upstream repository: https://github.com/RethinkRobotics-opensource/gennodejs.git
- release repository: https://github.com/RethinkRobotics-release/gennodejs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.3-0`

## gennodejs

```
* Fix an issue uncovered in checking fixed size message fields
* Contributors: Chris Smith
```
