### PR TITLE
phidgets_drivers: 0.2.3-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8336,8 +8336,8 @@ repositories:
       - phidgets_ir
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/muhrix/phidgets_drivers-release.git
-      version: 0.2.2-0
+      url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/phidgets_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `0.2.3-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.2.2-0`

## phidgets_api

```
* Add IMU diagnostics (#24 <https://github.com/ccny-ros-pkg/phidgets_drivers/pull/24>)
* Contributors: Mani Monajjemi, Keshav Iyengar, Martin Günther
```

## phidgets_drivers

```
* Update package.xml meta info
* Contributors: Martin Günther
```

## phidgets_imu

```
* Add IMU diagnostics (#24 <https://github.com/ccny-ros-pkg/phidgets_drivers/pull/24>)
* Set data rate after reattachment
  This fixes a bug where after disconnecting and reconnecting the USB
  cable, the data rate would be set to the default of 125 Hz (= period of
  8ms). By moving the setDataRate call to the attachHandler, the data rate
  is correctly set after each reattachment.
* Contributors: Mani Monajjemi, Keshav Iyengar, Martin Günther
```

## phidgets_ir

```
* Update package.xml meta info
* Contributors: Martin Günther
```
