### PR TITLE
phidgets_drivers: 0.7.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4181,6 +4181,26 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: kinetic-devel
     status: maintained
+  phidgets_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: kinetic
+    release:
+      packages:
+      - libphidget21
+      - phidgets_api
+      - phidgets_drivers
+      - phidgets_imu
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: kinetic
+    status: maintained
   phoxi_camera:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `0.7.0-0`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## libphidget21

```
* Rename libphidgets => libphidget21
* Copy libphidget21 from cob_extern
* Contributors: Martin Günther, Murilo FM
```

## phidgets_api

```
* Use our own libphidget21 instead of external libphidgets
* Contributors: Martin Günther
```

## phidgets_drivers

```
* Remove phidgets_ir package
  It was a stub anyway. If somebody has such a device and cares to expose
  the data via ROS topics, this can be revived.
* Contributors: Martin Günther
```

## phidgets_imu

```
* Publish MagneticField instead of Vector3Stamped
* Report mag data in Tesla, not Gauss
  This is to conform with sensor_msgs/MagneticField, which requires the
  data to be in Tesla.
* Contributors: Martin Günther
```
