### PR TITLE
jsk_planning: 0.1.8-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2222,6 +2222,19 @@ repositories:
       url: https://github.com/tork-a/jsk_control-release.git
       version: 0.1.11-2
     status: developed
+  jsk_planning:
+    release:
+      packages:
+      - jsk_planning
+      - pddl_msgs
+      - pddl_planner
+      - pddl_planner_viewer
+      - task_compiler
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/jsk_planning-release.git
+      version: 0.1.8-2
+    status: developed
   jsk_recognition:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_planning` to `0.1.8-2`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_planning
- release repository: https://github.com/tork-a/jsk_planning-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## jsk_planning

- No changes

## pddl_msgs

```
* make graph for durative action ( #47 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/47> )
* add durative action mode ( #48 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/48> )
* Contributors: Kamada Hitoshi
```

## pddl_planner

```
* fix for  kinetic (#52 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/52> )
  * CMakeLists.txt : clean up catkin_package() command
  * add lpg_planner to run_depends and remove planners from build_depends
* [pddl_planner] add relationship graph  (#51 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/51> )
* add durative-action graph  (#48 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/48> )
* make graph for durative action (#47 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/47> )
* add durative action mode (#46 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/46> )
* [pddl_planner&task_compiler] add test for task_compiler hook
  functions (#45 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/45> )
* Contributors: Kamada Hitoshi, Kei Okada, Yuki Furuta
```

## pddl_planner_viewer

```
* CMakeLists.txt : clean up catkin_package() command ( #52 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/52> )
* Contributors: Kei Okada
```

## task_compiler

```
* [task_compiler] add iterate mode (#49 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/49> )
  * [task_compiler][execute-pddl.launch] add documentations for arguments
  * [task_compiler][execute-pddl.l]separate execute-pddl-core.l to main executable for exec from launch file and function implementations
  
  implement iterate mode that asks user before each action execution
  
    * [task_compiler][execute-pddl-core.l] cleanup unused codes
    * [task_compiler][execute-pddl-core.l] fix: unpaired parenthenesses
  
* CMakeLists.txt : clean up catkin_package() command (#52 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/52> )
* [pddl_planner&task_compiler] add test for task_compiler hook
  functions (#45 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/45> )
* Contributors: Kei Okada, Yuki Furuta
```
