### PR TITLE
ros_comm: 1.12.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5130,7 +5130,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.12.6-0
+      version: 1.12.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.12.7-0`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.12.6-0`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

```
* throw exception instead of accessing invalid memory (#971 <https://github.com/ros/ros_comm/pull/971>)
* move headers to include/xmlrpcpp (#962 <https://github.com/ros/ros_comm/issues/962>)
* added option wait-for-subscriber to rosbag play (#959 <https://github.com/ros/ros_comm/issues/959>)
* terminate underlying rosbag play, record  on SIGTERM (#951 <https://github.com/ros/ros_comm/issues/951>)
* add pause service for rosbag player (#949 <https://github.com/ros/ros_comm/issues/949>)
* add rate-control-topic and rate-control-max-delay. (#947 <https://github.com/ros/ros_comm/issues/947>)
```

## rosbag_storage

- No changes

## rosconsole

- No changes

## roscpp

```
* move connection specific log message to new name roscpp_internal.connections (#980 <https://github.com/ros/ros_comm/pull/980>)
* move headers to include/xmlrpcpp (#962 <https://github.com/ros/ros_comm/issues/962>)
* fix UDP block number when EAGAIN or EWOULDBLOCK (#957 <https://github.com/ros/ros_comm/issues/957>)
* fix return code of master execute function (#938 <https://github.com/ros/ros_comm/pull/938>)
* change WallTimerEvent from class to struct (#924 <https://github.com/ros/ros_comm/pull/924>)
```

## rosgraph

- No changes

## roslaunch

```
* improve error message for invalid tags (#989 <https://github.com/ros/ros_comm/pull/989>)
* fix caching logic to improve performance (#931 <https://github.com/ros/ros_comm/pull/931>)
```

## roslz4

- No changes

## rosmaster

```
* add more logging to publisher update calls (#979 <https://github.com/ros/ros_comm/issues/979>)
```

## rosmsg

```
* add rosmsg info as alias of rosmsg show (#941 <https://github.com/ros/ros_comm/issues/941>)
```

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* make get_published_topics threadsafe (#958 <https://github.com/ros/ros_comm/issues/958>)
* use poll in write_header() if available to support higher numbered fileno (#929 <https://github.com/ros/ros_comm/pull/929>)
* use epoll instead of poll if available to gracefully close hung connections (#831 <https://github.com/ros/ros_comm/issues/831>)
* fix Python 3 compatibility issues (#565 <https://github.com/ros/ros_comm/issues/565>)
```

## rosservice

- No changes

## rostest

- No changes

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

- No changes

## xmlrpcpp

```
* move headers to include/xmlrpcpp (#962 <https://github.com/ros/ros_comm/issues/962>)
```
