### PR TITLE
actionlib: 1.11.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -36,7 +36,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.11.7-0
+      version: 1.11.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.11.8-0`:

- upstream repository: https://github.com/ros/actionlib.git
- release repository: https://github.com/ros-gbp/actionlib-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.11.7-0`

## actionlib

```
* Fixes a deadlock (#64 <https://github.com/ros/actionlib/issues/64>)
* Removed unused variables warnings (#63 <https://github.com/ros/actionlib/issues/63> #65 <https://github.com/ros/actionlib/issues/65>)
* If using sim time, wait for /clock (#59 <https://github.com/ros/actionlib/issues/59>)
* add parameters to configure queue sizes (#55 <https://github.com/ros/actionlib/pull/55>)
* Contributors: Esteve Fernandez, Jonathan Meyer, Mikael Arguedas, Patrick Beeson, Robin Vanhove
```
