### PR TITLE
nodelet_core: 1.9.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3593,7 +3593,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.9.8-0
+      version: 1.9.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.9-0`:

- upstream repository: https://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.9.8-0`

## nodelet

```
* drop unused dependency on tinyxml (#54 <https://github.com/ros/nodelet_core/pull/54>)
* Install the declared_nodelets script (#53 <https://github.com/ros/nodelet_core/pull/53>)
* Contributors: Dmitry Rozhkov, Kentaro Wada
```

## nodelet_core

- No changes

## nodelet_topic_tools

- No changes
