### PR TITLE
jsk_model_tools: 0.3.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2222,6 +2222,18 @@ repositories:
       url: https://github.com/tork-a/jsk_control-release.git
       version: 0.1.11-2
     status: developed
+  jsk_model_tools:
+    release:
+      packages:
+      - eus_assimp
+      - euscollada
+      - eusurdf
+      - jsk_model_tools
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/jsk_model_tools-release.git
+      version: 0.3.3-1
+    status: developed
   jsk_planning:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.3.3-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## eus_assimp

- No changes

## euscollada

```
* urdfdom is for hydro, now we can drop (forget to remove run_depends)
* Contributors: Kei Okada
```

## eusurdf

- No changes

## jsk_model_tools

- No changes
