### PR TITLE
geofrenzy: 0.0.4-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1447,6 +1447,21 @@ repositories:
       url: https://github.com/adnanademovic/genrs.git
       version: master
     status: developed
+  geofrenzy:
+    doc:
+      type: git
+      url: http://gfbot@git.geofrenzy.net:7990/scm/ros/release-test.git
+      version: 0.0.4
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: http://gfbot@git.geofrenzy.net:7990/scm/ros/release-test.git
+      version: 0.0.4-2
+    source:
+      type: git
+      url: http://gfbot@git.geofrenzy.net:7990/scm/ros/release-test.git
+      version: 0.0.4
+    status: developed
   geographic_info:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geofrenzy` to `0.0.4-2`:

- upstream repository: http://gfbot@git.geofrenzy.net:7990/scm/ros/geofrenzy.git
- release repository: http://gfbot@git.geofrenzy.net:7990/scm/ros/release-test.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## geofrenzy

- No changes
