### PR TITLE
add htop

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1157,6 +1157,7 @@ htop:
   arch: [htop]
   debian: [htop]
   fedora: [htop]
+  gentoo: [htop]
   ubuntu: [htop]
 i2c-tools:
   debian: [i2c-tools]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1153,6 +1153,11 @@ hostname:
   fedora: [hostname]
   gentoo: [dev-haskell/hostname]
   ubuntu: [hostname]
+htop:
+  arch: [htop]
+  debian: [htop]
+  fedora: [htop]
+  ubuntu: [htop]
 i2c-tools:
   debian: [i2c-tools]
   fedora: [i2c-tools]


### PR DESCRIPTION
debian: https://packages.debian.org/de/wheezy/htop
ubuntu: http://packages.ubuntu.com/de/precise/utils/htop
fedora: https://admin.fedoraproject.org/pkgdb/package/rpms/htop/
arch: https://www.archlinux.org/packages/extra/i686/htop/
gentoo: https://packages.gentoo.org/packages/sys-process/htop