### PR TITLE
gazebo_ros_pkgs: 2.5.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1322,7 +1322,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.5.8-0
+      version: 2.5.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.5.9-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.5.8-0`

## gazebo_msgs

```
* Removed all trailing whitespace
* Contributors: Dave Coleman
```

## gazebo_plugins

```
* Fix gazebo catkin warning, cleanup CMakeLists (#537 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/537>)
* Fix timestamp issues for rendering sensors (kinetic-devel)
* Namespace console output (#543 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/543>)
* Adding depth camera world to use in test to make depth camera have right timestamp #408 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/408>- appears to be working (though only looking at horizon) but getting these sdf errors:
* #408 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/408> Make the multi camera timestamps current rather than outdated, also reuse the same update code
* Fix merge with kinetic branch
* #408 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/408> Making a test for multicamra that shows the timestamps are currently outdated, will fix them similar to how the regular camera was fixed.
* Fix for issue #408 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/408>. The last measurement time is the time that gazebo generated the sensor data, so ought to be used. updateRate doesn't seem that useful.
  The other cameras need similar fixes to have the proper timestamps.
* Bugfix: duplicated tf prefix resolution
* fill in child_frame_id of odom topic
* Fix gazebo and sdformat catkin warnings
* Contributors: Dave Coleman, Jose Luis Rivero, Kei Okada, Lucas Walter, Yuki Furuta
```

## gazebo_ros

```
* Fix gazebo catkin warning, cleanup CMakeLists (#537 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/537>)
* Namespace console output (#543 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/543>)
* Removed all trailing whitespace
* Contributors: Dave Coleman
```

## gazebo_ros_control

```
* Fix gazebo catkin warning, cleanup CMakeLists (#537 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/537>)
* Namespace console output (#543 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/543>)
* Print name of joint with wrong interface
* Removed all trailing whitespace
* Change boost::shared_ptr to urdf::JointConstSharedPtr
* Contributors: Bence Magyar, Dave Coleman, Jochen Sprickerhof
```

## gazebo_ros_pkgs

- No changes
