### PR TITLE
gazebo_ros_pkgs: 2.6.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1288,7 +1288,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.6.1-0
+      version: 2.6.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.6.2-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.6.1-0`

## gazebo_msgs

- No changes

## gazebo_plugins

```
* Fix timestamp issues for rendering sensors (#538 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/538>)
  It affects to gazebo_ros_comera_utils, gazebo_ros_openni_kinnect and gazebo_ros_prosilica.
* Correct the timestamp used by the camera (#410 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/410>)
  Fix for issue #408 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/408>. The last measurement time is the time that gazebo generated the sensor data, so ought to be used.  updateRate doesn't seem that useful.
* fill in child_frame_id of odom topic
* Contributors: Kei Okada, Lucas Walter, Ian Chen
```

## gazebo_ros

- No changes

## gazebo_ros_control

- No changes

## gazebo_ros_pkgs

- No changes
