### PR TITLE
move_base_to_manip: 1.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6430,6 +6430,21 @@ repositories:
       url: https://github.com/ros-industrial/motoman.git
       version: indigo-devel
     status: maintained
+  move_base_to_manip:
+    doc:
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip.git
+      version: master
+    status: maintained
   moveit:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_to_manip` to `1.0.1-1`:

- upstream repository: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip.git
- release repository: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## move_base_to_manip

```
* Adding another error message.
* Making the while loop exit gracefully.
* Updating a comment in provide_target.cpp.
* Taking out the extra height.
* Modifying CMakeLists to install, too.
* Adding the source files.
* Initial commit
* Contributors: AndyZe, nrgadmin, vaultbot
```
