### PR TITLE
move_base_to_manip: 1.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2979,6 +2979,21 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/mobility_base_simulator
       version: default
     status: developed
+  move_base_to_manip:
+    doc:
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip.git
+      version: master
+    status: maintained
   moveit:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_to_manip` to `1.0.2-0`:

- upstream repository: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip.git
- release repository: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## move_base_to_manip

```
* Adding CMakeLists to install everything.
* Contributors: nrgadmin
```
