### PR TITLE
genpy: 0.6.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -44,5 +44,20 @@ repositories:
       url: https://github.com/ros/genmsg.git
       version: indigo-devel
     status: maintained
+  genpy:
+    doc:
+      type: git
+      url: https://github.com/ros/genpy.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/genpy-release.git
+      version: 0.6.3-0
+    source:
+      type: git
+      url: https://github.com/ros/genpy.git
+      version: kinetic-devel
+    status: maintained
 type: distribution
 version: 2

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -55,6 +55,7 @@ repositories:
       url: https://github.com/ros-gbp/genpy-release.git
       version: 0.6.3-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/genpy.git
       version: kinetic-devel


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.6.3-0`:

- upstream repository: git@github.com:ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## genpy

```
* fix Python 3 regressions (#71 <https://github.com/ros/genpy/issues/71>)
* use Python safe subfields for nested types (#69 <https://github.com/ros/genpy/issues/69>)
```
