### PR TITLE
Add rosdep keys for OpenVDB

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2177,6 +2177,24 @@ libopenscenegraph:
     portage:
       packages: [dev-games/openscenegraph]
   ubuntu: [openscenegraph, libopenscenegraph-dev]
+libopenvdb-dev:
+  arch: [openvdb]
+  debian: [libopenvdb-dev]
+  gentoo:
+    portage:
+      packages: [media-gfx/openvdb]
+  ubuntu: [libopenvdb-dev]
+libopenvdb:
+  arch: [openvdb]
+  debian:
+    jessie: [libopenvdb2.3]
+    sid: [libopenvdb3.2]
+  gentoo:
+    portage:
+      packages: [media-gfx/openvdb]
+  ubuntu:
+    trusty: [libopenvdb2.1]
+    xenial: [libopenvdb3.1]
 libosmesa6-dev:
   arch: [mesa]
   debian: [libosmesa6-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2186,7 +2186,11 @@ libopenvdb:
     portage:
       packages: [media-gfx/openvdb]
   ubuntu:
+    saucy: [libopenvdb1.1]
     trusty: [libopenvdb2.1]
+    utopic: [libopenvdb2.3]
+    vivid: [libopenvdb2.3]
+    wily: [libopenvdb3.0]
     xenial: [libopenvdb3.1]
     yakkety: [libopenvdb3.1]
     zesty: [libopenvdb3.2]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2188,6 +2188,8 @@ libopenvdb:
   ubuntu:
     trusty: [libopenvdb2.1]
     xenial: [libopenvdb3.1]
+    yakkety: [libopenvdb3.1]
+    zesty: [libopenvdb3.2]
 libopenvdb-dev:
   arch: [openvdb]
   debian: [libopenvdb-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2177,13 +2177,6 @@ libopenscenegraph:
     portage:
       packages: [dev-games/openscenegraph]
   ubuntu: [openscenegraph, libopenscenegraph-dev]
-libopenvdb-dev:
-  arch: [openvdb]
-  debian: [libopenvdb-dev]
-  gentoo:
-    portage:
-      packages: [media-gfx/openvdb]
-  ubuntu: [libopenvdb-dev]
 libopenvdb:
   arch: [openvdb]
   debian:
@@ -2195,6 +2188,13 @@ libopenvdb:
   ubuntu:
     trusty: [libopenvdb2.1]
     xenial: [libopenvdb3.1]
+libopenvdb-dev:
+  arch: [openvdb]
+  debian: [libopenvdb-dev]
+  gentoo:
+    portage:
+      packages: [media-gfx/openvdb]
+  ubuntu: [libopenvdb-dev]
 libosmesa6-dev:
   arch: [mesa]
   debian: [libosmesa6-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2181,7 +2181,7 @@ libopenvdb:
   arch: [openvdb]
   debian:
     jessie: [libopenvdb2.3]
-    sid: [libopenvdb3.2]
+    stretch: [libopenvdb3.2]
   gentoo:
     portage:
       packages: [media-gfx/openvdb]


### PR DESCRIPTION
This is a library for the efficient storage & manipulation of sparse volumetric data on a 3D grid.  It's developed and used by DreamWorks Animation for use in feature film production.  We're using it to manipulate LIDAR point clouds.  Home page: http://www.openvdb.org/

Arch: https://www.archlinux.org/packages/?sort=&q=openvdb&maintainer=&flagged=
Debian: https://packages.debian.org/search?keywords=openvdb&searchon=names&suite=stable&section=all
Gentoo: https://packages.gentoo.org/packages/media-gfx/openvdb
Ubuntu: http://packages.ubuntu.com/search?suite=all&searchon=names&keywords=openvdb

No packages in Fedora.