### PR TITLE
roscpp_core: 0.6.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -59,5 +59,26 @@ repositories:
       url: https://github.com/ros/genmsg.git
       version: indigo-devel
     status: maintained
+  roscpp_core:
+    doc:
+      type: git
+      url: https://github.com/ros/roscpp_core.git
+      version: kinetic-devel
+    release:
+      packages:
+      - cpp_common
+      - roscpp_core
+      - roscpp_serialization
+      - roscpp_traits
+      - rostime
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/roscpp_core-release.git
+      version: 0.6.2-0
+    source:
+      type: git
+      url: https://github.com/ros/roscpp_core.git
+      version: kinetic-devel
+    status: maintained
 type: distribution
 version: 2

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -76,6 +76,7 @@ repositories:
       url: https://github.com/ros-gbp/roscpp_core-release.git
       version: 0.6.2-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/roscpp_core.git
       version: kinetic-devel


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.6.2-0`:

- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## cpp_common

- No changes

## roscpp_serialization

```
* fix warning when compiling with -Wpedantic (#53 <https://github.com/ros/roscpp_core/issues/53>)
```

## roscpp_traits

```
* fix warning when compiling with -Wpedantic (#53 <https://github.com/ros/roscpp_core/issues/53>)
* fix warning about unused parameters (#52 <https://github.com/ros/roscpp_core/issues/52>)
```

## rostime

- No changes
