### PR TITLE
genlisp: 0.4.16-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -43,6 +43,21 @@ repositories:
       url: https://github.com/ros/gencpp.git
       version: indigo-devel
     status: maintained
+  genlisp:
+    doc:
+      type: git
+      url: https://github.com/ros/genlisp.git
+      version: groovy-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/genlisp-release.git
+      version: 0.4.16-0
+    source:
+      type: git
+      url: https://github.com/ros/genlisp.git
+      version: groovy-devel
+    status: maintained
   genmsg:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genlisp` to `0.4.16-0`:

- upstream repository: git@github.com:ros/genlisp.git
- release repository: https://github.com/ros-gbp/genlisp-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
