### PR TITLE
gennodejs: 2.0.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -69,7 +69,7 @@ repositories:
         release: release/lunar/{package}/{version}
       url: https://github.com/RethinkRobotics-release/gennodejs-release.git
       version: 2.0.1-0
-    status: developed
+    status: maintained
   genpy:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -69,6 +69,11 @@ repositories:
         release: release/lunar/{package}/{version}
       url: https://github.com/RethinkRobotics-release/gennodejs-release.git
       version: 2.0.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/RethinkRobotics-opensource/gennodejs.git
+      version: kinetic-devel
     status: maintained
   genpy:
     doc:

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -59,6 +59,17 @@ repositories:
       url: https://github.com/ros/genmsg.git
       version: indigo-devel
     status: maintained
+  gennodejs:
+    doc:
+      type: git
+      url: https://github.com/RethinkRobotics-opensource/gennodejs.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/RethinkRobotics-release/gennodejs-release.git
+      version: 2.0.1-0
+    status: developed
   genpy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gennodejs` to `2.0.1-0`:

- upstream repository: https://github.com/RethinkRobotics-opensource/gennodejs.git
- release repository: https://github.com/RethinkRobotics-release/gennodejs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## gennodejs

```
* Fix an issue uncovered in checking fixed size message fields
* Contributors: Chris Smith
```
