### PR TITLE
cmake_modules: 0.4.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -496,7 +496,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/cmake_modules-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/ros/cmake_modules.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules` to `0.4.1-0`:

- upstream repository: https://github.com/ros/cmake_modules.git
- release repository: https://github.com/ros-gbp/cmake_modules-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.4.0-0`

## cmake_modules

```
* Add FindTinyXML2 module (#42 <https://github.com/ros/cmake_modules/issues/42>)
  Signed-off-by: Dmitry Rozhkov <mailto:dmitry.rozhkov@linux.intel.com>
* Add FindGflags for supporting Gflags
* Contributors: Dave Coleman, Dmitry Rozhkov, William Woodall
```
