### PR TITLE
cmake_modules: 0.4.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -28,6 +28,21 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: kinetic-devel
     status: maintained
+  cmake_modules:
+    doc:
+      type: git
+      url: https://github.com/ros/cmake_modules.git
+      version: 0.4-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/cmake_modules-release.git
+      version: 0.4.1-0
+    source:
+      type: git
+      url: https://github.com/ros/cmake_modules.git
+      version: 0.4-devel
+    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules` to `0.4.1-0`:

- upstream repository: https://github.com/ros/cmake_modules.git
- release repository: https://github.com/ros-gbp/cmake_modules-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`

## cmake_modules

```
* Add FindTinyXML2 module (#42 <https://github.com/ros/cmake_modules/issues/42>)
  Signed-off-by: Dmitry Rozhkov <mailto:dmitry.rozhkov@linux.intel.com>
* Add FindGflags for supporting Gflags
* Contributors: Dave Coleman, Dmitry Rozhkov, William Woodall
```
