### PR TITLE
rtmros_nextage: 0.7.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11972,7 +11972,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.7.13-0
+      version: 0.7.14-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.7.14-0`:

- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.7.13-0`

## nextage_description

```
* [capability] hand camera now available on hrpsys simulator.
* Contributors: Kei Okada
```

## nextage_gazebo

- No changes

## nextage_ik_plugin

- No changes

## nextage_moveit_config

```
* [Maintenance] Enable tests for track_ik.
* Contributors: Isaac I.Y. Saito
```

## nextage_ros_bridge

```
* [capability] hand camera now available on hrpsys simulator.
* Contributors: Kei Okada, Isaac I.Y. Saito
```

## rtmros_nextage

```
* [capability] hand camera now available on hrpsys simulator.
* Contributors: Kei Okada, Isaac I.Y. Saito
```
