### PR TITLE
jsk_model_tools: 0.3.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2220,7 +2220,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.3.3-1
+      version: 0.3.4-0
     status: developed
   jsk_planning:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.3.4-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.3.3-1`

## eus_assimp

- No changes

## euscollada

- No changes

## eusurdf

```
* add python-lxml
* Contributors: Kei Okada
```

## jsk_model_tools

- No changes
