### PR TITLE
jsk_control: 0.1.12-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2208,7 +2208,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_control-release.git
-      version: 0.1.11-2
+      version: 0.1.12-0
     status: developed
   jsk_model_tools:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_control` to `0.1.12-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_control.git
- release repository: https://github.com/tork-a/jsk_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.11-2`

## contact_states_observer

```
* [contact_states_observer/euslisp/contact-states-observer.l] Check length of data list in contact states observer publishing parts.
* Contributors: Shunichi Nozawa
```

## eus_nlopt

- No changes

## eus_qp

- No changes

## eus_qpoases

```
* mv .gitignore to .placeholder
* Contributors: Kei Okada
```

## joy_mouse

- No changes

## jsk_calibration

```
* CMakeLists.txt: remove pr2_* dependency, add install
* Contributors: Kei Okada
```

## jsk_control

- No changes

## jsk_footstep_controller

- No changes

## jsk_footstep_planner

- No changes

## jsk_ik_server

- No changes

## jsk_teleop_joy

- No changes
