### PR TITLE
jsk_pr2eus: 0.3.9-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2235,6 +2235,18 @@ repositories:
       url: https://github.com/tork-a/jsk_planning-release.git
       version: 0.1.8-2
     status: developed
+  jsk_pr2eus:
+    release:
+      packages:
+      - jsk_pr2eus
+      - pr2eus
+      - pr2eus_moveit
+      - pr2eus_tutorials
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/jsk_pr2eus-release.git
+      version: 0.3.9-1
+    status: developed
   jsk_recognition:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.3.9-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_pr2eus
- release repository: https://github.com/tork-a/jsk_pr2eus-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## jsk_pr2eus

- No changes

## pr2eus

```
* cleanup CMakeLists.txt, use PR2_CONTROLLERS_MSGS_PACKAGE variable and add geneus for hydro (#285 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/285> )
* Support Kinetic (#284 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/284> )
  * need to add geneus for hydro? https://s3.amazonaws.com/archive.travis-ci.org/jobs/203074134/log.txt
  * robot-init-test.l: disable test for jade/kinetic, which did not load pr2-interface.l, beacuse of missing pr2_controller_msgs
  * CMakeLists.txt: using PR2_CONTROLLERS_MSGS_PACKAGE variable to control find_package does not work on hydro
  * pr2-interface.l exits without error on kinetic
  * pr2_controllers_msgs is not released on J/K
  * pr2eus/CMakeLists.txt: pr2_controllers_msgs is not released on J/K
* Contributors: Kei Okada
```

## pr2eus_moveit

```
* Support Kinetic (#284 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/284> )
  * pr2_controllers_msgs is not released on J/K
* [pr2eus_moveit/collision-object-publisher.l] fix bug in :wipe-all (#283 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/283> )
  * separate wipe-all and fix bug
  * set new hash-table in :clear-all
* [pr2eus_moveit/robot-moveit.l] support angle-vector-sequence with MoveIt! (#282 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/282> )
  * support angle-vector-sequence for motion plan
  * remove trajectory-constraints for motion plan
* Contributors: Kei Okada, Shingo Kitagawa
```

## pr2eus_tutorials

- No changes
