### PR TITLE
genjava: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1364,7 +1364,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosjava-release/genjava-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/rosjava/genjava.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genjava` to `0.3.1-0`:

- upstream repository: https://github.com/rosjava/genjava.git
- release repository: https://github.com/rosjava-release/genjava-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.3.0-0`

## genjava

```
* publishMavenJavaPublicationToMavenRepository -> publish
* Gradle 2.2.1 -> 2.14.1
* Contributors: Julian Cerruti
```
