### PR TITLE
rosjava_core: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5520,7 +5520,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_core-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/rosjava/rosjava_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_core` to `0.3.1-0`:

- upstream repository: https://github.com/rosjava/rosjava_core
- release repository: https://github.com/rosjava-release/rosjava_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.3.0-0`

## rosjava_core

```
* NativeNodeMain upgraded to upstream error codes to the application.
* Parameter Node added to new Helper module.
* publishMavenJavaPublicationToMavenRepository -> publish
* Gradle 2.2.1 -> 2.14.1
* Contributors: Juan Ignacio Ubeira, Julian Cerruti
```
