### PR TITLE
angles: 1.9.10-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -21,7 +21,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/geometry_angles_utils-release.git
-      version: 1.9.10-0
+      version: 1.9.10-1
     source:
       type: git
       url: https://github.com/ros/angles.git


### PR DESCRIPTION
Increasing version of package(s) in repository `angles` to `1.9.10-1`:

- upstream repository: https://github.com/ros/angles.git
- release repository: https://github.com/ros-gbp/geometry_angles_utils-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.9.10-0`

## angles

```
* Export architecture_independent flag in package.xml
* Simply and improve performance of shortest_angular_distance(). adding two unit test cases
* check for CATKIN_ENABLE_TESTING
* Contributors: Derek King, Lukas Bulwahn, Scott K Logan, Tully Foote
```
