### PR TITLE
message_generation: 0.4.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -151,6 +151,21 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: kinetic-devel
     status: maintained
+  message_generation:
+    doc:
+      type: git
+      url: https://github.com/ros/message_generation.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/message_generation-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/ros/message_generation.git
+      version: kinetic-devel
+    status: maintained
   rosbag_migration_rule:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `message_generation` to `0.4.0-0`:

- upstream repository: https://github.com/ros/message_generation.git
- release repository: https://github.com/ros-gbp/message_generation-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
