### PR TITLE
rospack: 2.4.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -232,16 +232,17 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/rospack.git
-      version: jade-devel
+      version: lunar-devel
     release:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
       version: 2.4.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/rospack.git
-      version: jade-devel
+      version: lunar-devel
     status: maintained
   std_msgs:
     doc:

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -228,6 +228,21 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: kinetic-devel
     status: maintained
+  rospack:
+    doc:
+      type: git
+      url: https://github.com/ros/rospack.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/rospack-release.git
+      version: 2.4.0-0
+    source:
+      type: git
+      url: https://github.com/ros/rospack.git
+      version: jade-devel
+    status: maintained
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.4.0-0`:

- upstream repository: https://github.com/ros/rospack.git
- release repository: https://github.com/ros-gbp/rospack-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## rospack

```
* make some deps* functions public (#65 <https://github.com/ros/rospack/pull/65>)
* switch from TinyXML to TinyXML2 (#62 <https://github.com/ros/rospack/pull/62>)
```
