### PR TITLE
ros: 1.14.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -181,6 +181,33 @@ repositories:
       url: https://github.com/ros/message_runtime.git
       version: groovy-devel
     status: maintained
+  ros:
+    doc:
+      type: git
+      url: https://github.com/ros/ros.git
+      version: lunar-devel
+    release:
+      packages:
+      - mk
+      - ros
+      - rosbash
+      - rosboost_cfg
+      - rosbuild
+      - rosclean
+      - roscreate
+      - roslang
+      - roslib
+      - rosmake
+      - rosunit
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/ros-release.git
+      version: 1.14.0-0
+    source:
+      type: git
+      url: https://github.com/ros/ros.git
+      version: lunar-devel
+    status: maintained
   ros_comm_msgs:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -204,6 +204,7 @@ repositories:
       url: https://github.com/ros-gbp/ros-release.git
       version: 1.14.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/ros.git
       version: lunar-devel


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.14.0-0`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## mk

- No changes

## rosbash

- No changes

## rosboost_cfg

- No changes

## rosbuild

- No changes

## rosclean

- No changes

## roscreate

- No changes

## roslang

- No changes

## roslib

```
* update ROS_DISTRO to lunar
```

## rosmake

- No changes

## rosunit

- No changes
