### PR TITLE
roslisp: 1.9.20-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -256,6 +256,21 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: kinetic-devel
     status: maintained
+  roslisp:
+    doc:
+      type: git
+      url: https://github.com/ros/roslisp.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/roslisp-release.git
+      version: 1.9.20-0
+    source:
+      type: git
+      url: https://github.com/ros/roslisp.git
+      version: master
+    status: maintained
   rospack:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp` to `1.9.20-0`:

- upstream repository: git://github.com/ros/roslisp.git
- release repository: https://github.com/ros-gbp/roslisp-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## roslisp

```
* Merge pull request #28 <https://github.com/ros/roslisp/issues/28> from gaya-/master
  In ADD_LISP_EXECUTABLE added a check for slashes in first argument
* in cmake script minor nicification
* [cmake] in ADD_LISP_EXECUTABLE added a check for slashes in first argument
* Contributors: Gayane Kazhoyan, Georg Bartels
```
