### PR TITLE
jsk_3rdparty: 2.0.19-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4855,7 +4855,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.0.17-0
+      version: 2.0.19-0
     status: developed
   jsk_apc:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.0.19-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.0.17-0`

## assimp_devel

- No changes

## bayesian_belief_networks

- No changes

## collada_urdf_jsk_patch

```
* update patch for https://github.com/ros/robot_model/commit/3e5a220 (#86 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/86>)
  * [collada_urdf_jsk_patch][README.md] update readme
  * [collada_urdf_jsk_patch][use_assimp_devel.patch] update patch according to latest commit at collada_urdf
  * [collada_urdf_jsk_patch][Makefile] don't apply collada_urdf_latest_gazebo.patch (see https://github.com/ros/robot_model/commit/3e5a220a67cf063d1e389cfbce3f05147c46f547)
* Contributors: Yuki Furuta
```

## downward

```
* add gawk to run_depend (#85 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/85>)
* Contributors: Kei Okada
```

## ff

- No changes

## ffha

- No changes

## jsk_3rdparty

- No changes

## julius

- No changes

## laser_filters_jsk_patch

- No changes

## libcmt

- No changes

## libsiftfast

- No changes

## lpg_planner

- No changes

## mini_maxwell

- No changes

## nlopt

```
* nlopt/CMakeLists.txt: cp .so, .so.0, .so.0.7.0 (#88 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/88>)
* Contributors: Kei Okada
```

## opt_camera

- No changes

## pgm_learner

- No changes

## rospatlite

- No changes

## rosping

```
* CMakeLists.txt: fix for cmake 3.5.1 (#87 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/87>)
* Contributors: Kei Okada
```

## rostwitter

- No changes

## slic

- No changes

## voice_text

- No changes
