### PR TITLE
ros_comm: 1.13.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -242,6 +242,7 @@ repositories:
       url: https://github.com/ros-gbp/ros_comm-release.git
       version: 1.13.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/ros_comm.git
       version: lunar-devel

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -209,6 +209,43 @@ repositories:
       url: https://github.com/ros/ros.git
       version: lunar-devel
     status: maintained
+  ros_comm:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_comm.git
+      version: lunar-devel
+    release:
+      packages:
+      - message_filters
+      - ros_comm
+      - rosbag
+      - rosbag_storage
+      - rosconsole
+      - roscpp
+      - rosgraph
+      - roslaunch
+      - roslz4
+      - rosmaster
+      - rosmsg
+      - rosnode
+      - rosout
+      - rosparam
+      - rospy
+      - rosservice
+      - rostest
+      - rostopic
+      - roswtf
+      - topic_tools
+      - xmlrpcpp
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/ros_comm-release.git
+      version: 1.13.0-0
+    source:
+      type: git
+      url: https://github.com/ros/ros_comm.git
+      version: lunar-devel
+    status: maintained
   ros_comm_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.13.0-0`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

- No changes

## rosbag_storage

- No changes

## rosconsole

- No changes

## roscpp

```
* remove support for multiple spinners on the same queue which existed only for backward compatibily (#988 <https://github.com/ros/ros_comm/pull/988>)
```

## rosgraph

- No changes

## roslaunch

- No changes

## roslz4

- No changes

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

- No changes

## rosout

```
* modify rosout log rotation to actually "rotate" old files (#854 <https://github.com/ros/ros_comm/issues/854>)
* add node name to the output in rosout.log (#912 <https://github.com/ros/ros_comm/issues/912>)
```

## rosparam

- No changes

## rospy

- No changes

## rosservice

- No changes

## rostest

- No changes

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

- No changes

## xmlrpcpp

- No changes
