### PR TITLE
rosconsole_bridge: 0.4.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -283,6 +283,7 @@ repositories:
       url: https://github.com/ros-gbp/rosconsole_bridge-release.git
       version: 0.4.4-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/rosconsole_bridge.git
       version: indigo-devel

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -272,6 +272,21 @@ repositories:
       url: https://github.com/ros-gbp/rosbag_migration_rule-release.git
       version: 1.0.0-0
     status: maintained
+  rosconsole_bridge:
+    doc:
+      type: git
+      url: https://github.com/ros/rosconsole_bridge.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/rosconsole_bridge-release.git
+      version: 0.4.4-0
+    source:
+      type: git
+      url: https://github.com/ros/rosconsole_bridge.git
+      version: indigo-devel
+    status: maintained
   roscpp_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole_bridge` to `0.4.4-0`:

- upstream repository: https://github.com/ros/rosconsole_bridge.git
- release repository: https://github.com/ros-gbp/rosconsole_bridge-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
