### PR TITLE
bond_core: 1.7.18-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -27,6 +27,27 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  bond_core:
+    doc:
+      type: git
+      url: https://github.com/ros/bond_core.git
+      version: master
+    release:
+      packages:
+      - bond
+      - bond_core
+      - bondcpp
+      - bondpy
+      - smclib
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/bond_core-release.git
+      version: 1.7.18-0
+    source:
+      type: git
+      url: https://github.com/ros/bond_core.git
+      version: master
+    status: maintained
   catkin:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -44,6 +44,7 @@ repositories:
       url: https://github.com/ros-gbp/bond_core-release.git
       version: 1.7.18-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/bond_core.git
       version: master


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.7.18-0`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## bond

- No changes

## bond_core

- No changes

## bondcpp

```
* fix -isystem /usr/include build breakage in gcc6
* Contributors: Mikael Arguedas
```

## bondpy

- No changes

## smclib

- No changes
