### PR TITLE
class_loader: 0.3.6-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -54,6 +54,7 @@ repositories:
       url: https://github.com/ros-gbp/class_loader-release.git
       version: 0.3.6-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/class_loader.git
       version: indigo-devel

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -43,6 +43,21 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: kinetic-devel
     status: maintained
+  class_loader:
+    doc:
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/class_loader-release.git
+      version: 0.3.6-0
+    source:
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: indigo-devel
+    status: maintained
   cmake_modules:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `0.3.6-0`:

- upstream repository: https://github.com/ros/class_loader
- release repository: https://github.com/ros-gbp/class_loader-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## class_loader

```
* Made changes to two locking mechanisms inside class loader core's loadLibrary() function: 1) I added a lock to the 'addClassLoaderOwnerFor...' function to protect it against a race condition with the unloadLibrary() function. 2) I also raised the loader lock to cover the whole function. Previously the check to see if a library is already loaded and the actual loading of the library was not atomic. Multiple threads could create shared library objects, for example.
* Contributors: Jonathan Meyer
```
