### PR TITLE
pluginlib: 1.10.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -230,6 +230,7 @@ repositories:
       url: https://github.com/ros-gbp/pluginlib-release.git
       version: 1.10.4-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/pluginlib.git
       version: indigo-devel

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -219,6 +219,21 @@ repositories:
       url: https://github.com/ros/message_runtime.git
       version: groovy-devel
     status: maintained
+  pluginlib:
+    doc:
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/pluginlib-release.git
+      version: 1.10.4-0
+    source:
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: indigo-devel
+    status: maintained
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.10.4-0`:

- upstream repository: https://github.com/ros/pluginlib
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## pluginlib

```
* Merge pull request #42 <https://github.com/ros/pluginlib/issues/42> from delftrobotics-forks/unique-ptr
  Add std::unique_ptr API
* Add unit test for unique_ptr API.
* Simplify unit tests with ASSERT_THROW.
* Add ClassLoader::createUniqueInstance.
* Wrap long comment on createInstance and friend.
* Throw exception if plugin.xml is broken (#41 <https://github.com/ros/pluginlib/issues/41>)
  * added test case for broken xml files with missing attributes of class tag
  * added checks if all needed attributes of the class tag are existing
  * removed comment and empty line
* Contributors: Maarten de Vries, Mikael Arguedas, cwecht
```
