### PR TITLE
dynamic_reconfigure: 1.5.46-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -121,7 +121,8 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/common_msgs.git
-      version: jade-devel    
+      version: jade-devel
+    status: maintained
   dynamic_reconfigure:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -107,6 +107,7 @@ repositories:
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
       version: 1.5.46-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/dynamic_reconfigure.git
       version: master

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -96,6 +96,21 @@ repositories:
       url: https://github.com/ros/cmake_modules.git
       version: 0.4-devel
     status: maintained
+  dynamic_reconfigure:
+    doc:
+      type: git
+      url: https://github.com/ros/dynamic_reconfigure.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
+      version: 1.5.46-0
+    source:
+      type: git
+      url: https://github.com/ros/dynamic_reconfigure.git
+      version: master
+    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.5.46-0`:

- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## dynamic_reconfigure

```
* Add missing group params to wikidoc (#68 <https://github.com/ros/dynamic_reconfigure/issues/68>)
  The catkin generated wikidoc files were missing parameters defined as groups.
  Both the Dox and UsageDox file were generated correctly, but the wikidoc was
  using the wrong method to traverse all groups.
* Contributors: Mark Horn
```
