### PR TITLE
ros_tutorials: 0.7.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -362,6 +362,7 @@ repositories:
       url: https://github.com/ros-gbp/ros_tutorials-release.git
       version: 0.7.1-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/ros_tutorials.git
       version: kinetic-devel

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -346,6 +346,26 @@ repositories:
       url: https://github.com/ros/ros_comm_msgs.git
       version: indigo-devel
     status: maintained
+  ros_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ros_tutorials
+      - roscpp_tutorials
+      - rospy_tutorials
+      - turtlesim
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/ros_tutorials-release.git
+      version: 0.7.1-0
+    source:
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: kinetic-devel
+    status: maintained
   rosbag_migration_rule:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `0.7.1-0`:

- upstream repository: git@github.com:ros/ros_tutorials.git
- release repository: https://github.com/ros-gbp/ros_tutorials-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## ros_tutorials

- No changes

## roscpp_tutorials

- No changes

## rospy_tutorials

```
* add example of periodical publishing with rospy.Timer (#34 <https://github.com/ros/ros_tutorials/issues/34>)
```

## turtlesim

```
* check pen_on_ when processing teleport requests (#35 <https://github.com/ros/ros_tutorials/pull/35>)
```
