### PR TITLE
nodelet_core: 1.9.9-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -277,6 +277,7 @@ repositories:
       url: https://github.com/ros-gbp/nodelet_core-release.git
       version: 1.9.9-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -262,6 +262,25 @@ repositories:
       url: https://github.com/ros/message_runtime.git
       version: groovy-devel
     status: maintained
+  nodelet_core:
+    doc:
+      type: git
+      url: https://github.com/ros/nodelet_core.git
+      version: indigo-devel
+    release:
+      packages:
+      - nodelet
+      - nodelet_core
+      - nodelet_topic_tools
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/nodelet_core-release.git
+      version: 1.9.9-0
+    source:
+      type: git
+      url: https://github.com/ros/nodelet_core.git
+      version: indigo-devel
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.9-0`:

- upstream repository: https://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## nodelet

```
* drop unused dependency on tinyxml (#54 <https://github.com/ros/nodelet_core/pull/54>)
* Install the declared_nodelets script (#53 <https://github.com/ros/nodelet_core/pull/53>)
* Contributors: Dmitry Rozhkov, Kentaro Wada
```

## nodelet_core

- No changes

## nodelet_topic_tools

- No changes
