### PR TITLE
actionlib: 1.11.8-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -12,6 +12,21 @@ release_platforms:
   - yakkety
   - zesty
 repositories:
+  actionlib:
+    doc:
+      type: git
+      url: https://github.com/ros/actionlib.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/actionlib-release.git
+      version: 1.11.8-0
+    source:
+      type: git
+      url: https://github.com/ros/actionlib.git
+      version: indigo-devel
+    status: maintained
   angles:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -23,6 +23,7 @@ repositories:
       url: https://github.com/ros-gbp/actionlib-release.git
       version: 1.11.8-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/actionlib.git
       version: indigo-devel


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.11.8-0`:

- upstream repository: https://github.com/ros/actionlib.git
- release repository: https://github.com/ros-gbp/actionlib-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## actionlib

```
* Fixes a deadlock (#64 <https://github.com/ros/actionlib/issues/64>)
* Removed unused variables warnings (#63 <https://github.com/ros/actionlib/issues/63> #65 <https://github.com/ros/actionlib/issues/65>)
* If using sim time, wait for /clock (#59 <https://github.com/ros/actionlib/issues/59>)
* add parameters to configure queue sizes (#55 <https://github.com/ros/actionlib/pull/55>)
* Contributors: Esteve Fernandez, Jonathan Meyer, Mikael Arguedas, Patrick Beeson, Robin Vanhove
```
