### PR TITLE
py_trees_msgs: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4408,6 +4408,21 @@ repositories:
       url: https://github.com/stonier/py_trees.git
       version: devel
     status: developed
+  py_trees_msgs:
+    doc:
+      type: git
+      url: https://github.com/stonier/py_trees_msgs.git
+      version: release/0.3-kinetic
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/stonier/py_trees_msgs-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/stonier/py_trees_msgs.git
+      version: git
+    status: developed
   pyros:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4421,7 +4421,7 @@ repositories:
     source:
       type: git
       url: https://github.com/stonier/py_trees_msgs.git
-      version: git
+      version: devel
     status: developed
   pyros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_msgs` to `0.3.0-0`:

- upstream repository: https://github.com/stonier/py_trees_msgs.git
- release repository: https://github.com/stonier/py_trees_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
