### PR TITLE
roch_robot: 1.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10302,6 +10302,7 @@ repositories:
     release:
       packages:
       - roch_base
+      - roch_capabilities
       - roch_control
       - roch_description
       - roch_ftdi
@@ -10312,7 +10313,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_robot-release.git
-      version: 1.0.11-0
+      version: 1.0.12-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_robot` to `1.0.12-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch_robot.git
- release repository: https://github.com/SawYerRobotics-release/roch_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.11-0`

## roch_base

```
* Add Roch image in image folder.
```

## roch_capabilities

```
* Create.
* Contributors: Carl
```

## roch_control

- No changes

## roch_description

```
* Add Orbbec Astra model.
* Contributors: Carl
```

## roch_ftdi

- No changes

## roch_msgs

- No changes

## roch_robot

```
* Add roch_capabilities.
```

## roch_safety_controller

- No changes

## roch_sensorpc

- No changes
