### PR TITLE
kobuki_core: 0.7.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2369,7 +2369,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki_core-release.git
-      version: 0.7.2-0
+      version: 0.7.3-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core` to `0.7.3-0`:

- upstream repository: https://github.com/yujinrobot/kobuki_core.git
- release repository: https://github.com/yujinrobot-release/kobuki_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.7.2-0`

## kobuki_ftdi

```
* bugfix the missing prefix in the pkg_search_module calls
```
