### PR TITLE
kobuki_desktop: 0.5.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2376,6 +2376,10 @@ repositories:
       version: kinetic
     status: maintained
   kobuki_desktop:
+    doc:
+      type: git
+      url: https://github.com/yujinrobot/kobuki_desktop.git
+      version: kinetic
     release:
       packages:
       - kobuki_dashboard
@@ -2387,7 +2391,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki_desktop-release.git
-      version: 0.5.1-0
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_desktop` to `0.5.3-0`:

- upstream repository: https://github.com/yujinrobot/kobuki_desktop.git
- release repository: https://github.com/yujinrobot-release/kobuki_desktop-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.5.1-0`

## kobuki_gazebo_plugins

```
* add_dependencies with catkin_EXPORTED_TARGETS, not xyz_gencpp targets which might not be there
```
