### PR TITLE
volksbot_kinetic: Add doc job for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7168,6 +7168,11 @@ repositories:
       url: https://github.com/ros-visualization/visualization_tutorials.git
       version: kinetic-devel
     status: maintained
+  volksbot_driver:
+    doc:
+      type: git
+      url: https://github.com/uos/volksbot_driver.git
+      version: kinetic
   vrpn:
     doc:
       type: git


### PR DESCRIPTION
Don't add source job, because it fails anyway (requires external
libepos2-dev).