### PR TITLE
srv_tools: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6098,6 +6098,24 @@ repositories:
       url: https://github.com/ros-planning/srdfdom.git
       version: kinetic-devel
     status: maintained
+  srv_tools:
+    release:
+      packages:
+      - bag_tools
+      - launch_tools
+      - plot_tools
+      - pointcloud_tools
+      - srv_tools
+      - tf_tools
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/srv/srv_tools-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/srv/srv_tools.git
+      version: kinetic
+    status: developed
   stage:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `srv_tools` to `0.0.2-0`:

- upstream repository: https://github.com/srv/srv_tools.git
- release repository: https://github.com/srv/srv_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## bag_tools

```
* Add missing changes
* Forgot to remove extract_image_positions target
* Fix #12 <https://github.com/srv/srv_tools/issues/12>: Remove old field from camera_info msg
* Remove extract_image_positions and auv_msgs depencency
* add auv_msgs deps in CMake
* Fix #10 <https://github.com/srv/srv_tools/issues/10>
* add extract_image_positions
* Merge branch 'indigo' of github.com:srv/srv_tools into indigo
* Minnor changes
* Merge branch 'indigo' of github.com:srv/srv_tools into indigo
* add missing rospy node init
* Merge branch 'indigo' of github.com:srv/srv_tools into indigo
* Fix camera info tool
* Fix bag_tools scripts install
* Added stereo_sequence_publisher.py
* fix seq publisher for indigo
* Addapt the pointlcoud_to_webgl script to the new format of the website
* Contributors: Enrique Fernandez, Miquel Massot, matlabbe, plnegre
* typo on console_bridge dependency
* added -this- to reference the same class
* Of course, we must clear the tmp folder...
* This is the "intersting" patch I did : Now extract_image works also with rosbag containing compressed images, if these images are decodable by opencv (this is the case for JPG and PNG compression).
* In this python script, I added "import rospy" to be able to run this script in a Catkin environment.
  Then, I removed the option "sameq" of the ffmpeg process. In ubuntu 14.04, ffmpeg is now called avconv, on my computer I have a symlink from avconv to ffmpeg, so calling ffmpeg still work. But with this version of FFMPEG (avconv 9.16), there is nolonger the sameq argument. Maybe it could be interesting to call avconc and rather than ffmpeg is ffmpeg executable is not found...
* Syntax error fixed in this script.
* Changes for indigo
* preparing for indigo. changed prints for ros logs
* added gps_to_std_gt and services_timer from fuerte
* added missing dependency
* hydro catkinization changes
* added python setup files and wet'ed plot tools
* wet repo
* new script for topic extraction
* remove_tf now removes child tfs as well
* new script for changing a topic in a bagfile
* added bag processor for single cameras
* added export flags to manifest
* made camera info optional
* added batch processing script
* new script for tf manipulation
* improved help text
* added script for making videos from bagfiles
* removed unused method
* new binary for image extraction
* changed logging output
* added param for file pattern
* added link to boost signals
* added some more processing
* new executable for stereo processing inbag->outbag, some refactoring
* added license for cut script
* Merge branch 'master' of github.com:srv/srv_tools
* changed manifests
* added BSD license
* new script for cutting bagfiles
* removed unused import
* changed parameter handling for image sequence publisher node to use rosparams instead of command line arguments
* added parsers to the python scripts
* added main README and bag_tools README
* fixed boost dependency for fuerte
* removed extract_images script as now there is a better c++ code for that
* new binary for extraction of stereo images from a bagfile
* new image sequence publisher
* added camera info parser as seperate script
* fixed launch, added cv_bridge to manifest
* added launch files for image extraction
* fixed wrong package name
* new script for header time modification
* added median calc and support for /tf topic
* added support for multiple bagfile input in check_delay
* new script for delay check
* new script for camera info changing
* bugfix, output bagfile contained only changed topics before
* bugfixes
* added script: change frame id of topics in bagfile
* added script: replaces bagfile message time with header timestamp
* first working version of bag_add_time_offset.py
* added missing packages in manifest
* initial commit
* Contributors: Miquel Massot, Stephan Wirth, aba
```

## launch_tools

```
* preparing for indigo. changed prints for ros logs
* added gps_to_std_gt and services_timer from fuerte
* hydro catkinization changes
* catched exception on xml parse error
* added python setup files and wet'ed plot tools
* wet repo
* added params for stdout and stderr files
* new node that executes a command
* changed manifests
* added BSD license
* added launchViz and launch_tools package
* Contributors: Miquel Massot, Stephan Wirth
```

## plot_tools

```
* hydro catkinization changes
* added python setup files and wet'ed plot tools
* Legend now is the filename
* changed odom plot to open as many files as required
* changed the private name topics to input and output.
* NEW: plot_tools pkg with a python script for 3D real-time odometry visualization
* Contributors: Miquel Massot, plnegre
```

## pointcloud_tools

```
* Minnor changes
* fixed pointcloud mapper
* fixed bug with XYZ clouds
* Addapt the pointlcoud_to_webgl script to the new format of the website
* Fix ros timers to work when bagfile finishes
* Fix save problem in pointlcoud viewer
* Publish the pointcloud at the same rate
* Add info message when save pointcloud
* added waitForTransform to mapper
* changed to use system VTK paths
* Contributors: Miquel Massot, Scott K Logan, plnegre
* added pointcloud_to_webgl from fuerte branch
* New node: pointcloud_mapper_for_slam
* Fix dependency for hydro compliance
* hydro changes
* updated to master branch
* wet repo
* Variable renaming to accomplish standards
* Grammatical change
* FIX: allow enable/disable filter types
* added filter to map
* NEW: outlier filtering
* changed the private name topics to input and output.
* Changed the color handler for point clouds with no rgb field
* changed to global namespace topic subscription
* NEW: plot_tools pkg with a python script for 3D real-time odometry visualization
* NEW: timer in pcd_publisher to control the frequency. Point cloud viewer improved.
* Added new package of point clouds tools
* Contributors: Miquel Massot, plnegre
```

## srv_tools

```
* added python setup files and wet'ed plot tools
* wet repo
* Contributors: Miquel Massot
```

## tf_tools

```
* Minnor changes
* Add new tf tool
* Contributors: plnegre
* tf_filter added
* hydro catkinization changes
* added python setup files and wet'ed plot tools
* wet repo
* minor output tweak
* changed manifests
* added BSD license
* better tf logger, more options
* changed README, again
* changed README to markup language
* changed README to markup language
* added README and cleaned up tf_logger
* Added tf_logger
* new package for tf related tools
* Contributors: Miquel Massot, Stephan Wirth, plnegre
```
