### PR TITLE
homer_mapping: 0.1.16-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1813,7 +1813,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_mapping.git
-      version: 0.1.11-1
+      version: 0.1.16-0
     status: developed
   homer_msgs:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_mapping` to `0.1.16-0`:

- upstream repository: git@gitlab.uni-koblenz.de:robbie/homer_mapping.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_mapping.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.11-1`

## homer_map_manager

```
* changed maintainer
* Contributors: Raphael Memmesheimer
```

## homer_mapnav_msgs

```
* changed maintainer
* Contributors: Raphael Memmesheimer
```

## homer_mapping

```
* changed maintainer
* Contributors: Raphael Memmesheimer
```

## homer_nav_libs

```
* changed maintainer
* Contributors: Raphael Memmesheimer
```

## homer_navigation

```
* changed maintainer
* Contributors: Raphael Memmesheimer
```
