### PR TITLE
ihmc_ros_core: 0.9.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4260,7 +4260,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ihmcrobotics/ihmc_ros_core-release.git
-      version: 0.8.0-6
+      version: 0.9.1-0
     source:
       type: git
       url: https://github.com/ihmcrobotics/ihmc_ros_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ihmc_ros_core` to `0.9.1-0`:

- upstream repository: https://github.com/ihmcrobotics/ihmc_ros_core.git
- release repository: https://github.com/ihmcrobotics/ihmc_ros_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.8.0-6`
