### PR TITLE
srv_tools: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6129,7 +6129,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/srv/srv_tools-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/srv/srv_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `srv_tools` to `0.0.3-0`:

- upstream repository: https://github.com/srv/srv_tools.git
- release repository: https://github.com/srv/srv_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.2-0`

## bag_tools

```
* Fix release
* Add missing changes
* Forgot to remove extract_image_positions target
* Fix #12 <https://github.com/srv/srv_tools/issues/12>: Remove old field from camera_info msg
* Remove extract_image_positions and auv_msgs depencency
* add auv_msgs deps in CMake
* Fix #10 <https://github.com/srv/srv_tools/issues/10>
* add extract_image_positions
* Merge branch 'indigo' of github.com:srv/srv_tools into indigo
* Minnor changes
* Merge branch 'indigo' of github.com:srv/srv_tools into indigo
* add missing rospy node init
* Merge branch 'indigo' of github.com:srv/srv_tools into indigo
* Fix camera info tool
* Fix bag_tools scripts install
* Added stereo_sequence_publisher.py
* fix seq publisher for indigo
* Addapt the pointlcoud_to_webgl script to the new format of the website
* Contributors: Enrique Fernandez, Miquel Massot, matlabbe, plnegre
```

## launch_tools

```
* Fix release
* Contributors: Miquel Massot
```

## plot_tools

```
* Fix release
* Contributors: Miquel Massot
```

## pointcloud_tools

```
* Fix release
* Minnor changes
* fixed pointcloud mapper
* fixed bug with XYZ clouds
* Addapt the pointlcoud_to_webgl script to the new format of the website
* Fix ros timers to work when bagfile finishes
* Fix save problem in pointlcoud viewer
* Publish the pointcloud at the same rate
* Add info message when save pointcloud
* added waitForTransform to mapper
* changed to use system VTK paths
* Contributors: Miquel Massot, Scott K Logan, plnegre
```

## srv_tools

```
* Fix release
* Contributors: Miquel Massot
```

## tf_tools

```
* Fix release
* Minnor changes
* Add new tf tool
* Contributors: Miquel Massot, plnegre
```
