### PR TITLE
rqt: 0.3.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -569,6 +569,26 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: lunar-devel
     status: maintained
+  rqt:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: kinetic-devel
+    release:
+      packages:
+      - rqt
+      - rqt_gui
+      - rqt_gui_cpp
+      - rqt_gui_py
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/rqt-release.git
+      version: 0.3.2-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: kinetic-devel
+    status: maintained
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `0.3.2-0`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros-gbp/rqt-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## rqt_gui

```
* use Python 3 compatible syntax (#81 <https://github.com/ros-visualization/qt_gui_core/pull/81>)
```

## rqt_gui_cpp

- No changes

## rqt_gui_py

- No changes
