### PR TITLE
mavros: 0.18.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2864,7 +2864,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.18.6-0
+      version: 0.18.7-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.18.7-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.18.6-0`

## libmavconn

```
* readme: Add serial-hwfc:// proto
* libmavconn #649 <https://github.com/mavlink/mavros/issues/649>: Add serial-hwfc:// proto (serial + hardware flow control)
  Note: not all platforms support setting
  Boost::asio::serial_port_base::flow_control::hardware option.
* Contributors: Vladimir Ermakov
```

## mavros

```
* readme: Add serial-hwfc:// proto
* trigger interface : rename to cycle_time to be consistent with PX4
* Contributors: Kabir Mohammed, Vladimir Ermakov
```

## mavros_extras

```
* vision plugin : Add missing transform
* Contributors: Kabir Mohammed
```

## mavros_msgs

```
* trigger interface : rename to cycle_time to be consistent with PX4
* Contributors: Kabir Mohammed
```

## test_mavros

- No changes
