### PR TITLE
raspicam_node: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4578,6 +4578,12 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  raspicam_node:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/UbiquityRobotics-release/raspicam_node-release.git
+      version: 0.2.0-0
   razor_imu_9dof:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspicam_node` to `0.2.0-0`:

- upstream repository: https://github.com/UbiquityRobotics/raspicam_node.git
- release repository: https://github.com/UbiquityRobotics-release/raspicam_node-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## raspicam_node

```
* Add launch files and camera calibrations
* Add documentation to get pi-deps
* Proper dependancy declaration
* Pull in all SV-ROS development
* Dynamic reconfigure support
* Support for both CameraV1 and V2
* Contributors: Girts Linde, Jim Vaughan, Rohan Agrawal
```
