### PR TITLE
homer_mapping: 0.1.17-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1813,7 +1813,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.uni-koblenz.de/robbie/homer_mapping.git
-      version: 0.1.16-0
+      version: 0.1.17-1
     status: developed
   homer_msgs:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_mapping` to `0.1.17-1`:

- upstream repository: git@gitlab.uni-koblenz.de:robbie/homer_mapping.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_mapping.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.16-0`

## homer_map_manager

```
* Eigen3 INCLUDE_DIR fix
* Contributors: Niklas Yann Wettengel
```

## homer_mapnav_msgs

- No changes

## homer_mapping

```
* Eigen3 INCLUDE_DIR fix
* Contributors: Niklas Yann Wettengel
```

## homer_nav_libs

```
* Eigen3 INCLUDE_DIR fix
* Contributors: Niklas Yann Wettengel
```

## homer_navigation

```
* Eigen3 INCLUDE_DIR fix
* Contributors: Niklas Yann Wettengel
```
