### PR TITLE
rqt_common_plugins: 0.4.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5784,7 +5784,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.4.5-0
+      version: 0.4.6-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `0.4.6-0`:

- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/ros-gbp/rqt_common_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.4.5-0`

## rqt_action

- No changes

## rqt_bag

- No changes

## rqt_bag_plugins

- No changes

## rqt_common_plugins

- No changes

## rqt_console

- No changes

## rqt_dep

- No changes

## rqt_graph

- No changes

## rqt_image_view

- No changes

## rqt_launch

- No changes

## rqt_logger_level

- No changes

## rqt_msg

- No changes

## rqt_plot

```
* add support for plotting bool field values (#427 <https://github.com/ros-visualization/rqt_common_plugins/issues/427>)
```

## rqt_publisher

- No changes

## rqt_py_common

- No changes

## rqt_py_console

- No changes

## rqt_reconfigure

- No changes

## rqt_service_caller

- No changes

## rqt_shell

- No changes

## rqt_srv

- No changes

## rqt_top

- No changes

## rqt_topic

```
* remove usage of undocumented cStringIO.StringIO len attribute (#434 <https://github.com/ros-visualization/rqt_common_plugins/pull/434>)
```

## rqt_web

- No changes
