### PR TITLE
std_capabilities: 0.1.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -589,6 +589,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: kinetic-devel
     status: maintained
+  std_capabilities:
+    doc:
+      type: git
+      url: https://github.com/osrf/std_capabilities.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/std_capabilities-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/osrf/std_capabilities.git
+      version: master
+    status: maintained
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `std_capabilities` to `0.1.0-0`:

- upstream repository: https://github.com/osrf/std_capabilities.git
- release repository: https://github.com/ros-gbp/std_capabilities-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `null`

## std_capabilities

```
* Initial Release
* Contributors: Marcus Liebhardt, William Woodall
```
