### PR TITLE
stage: 4.1.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -589,6 +589,16 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: kinetic-devel
     status: maintained
+  stage:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/stage-release.git
+      version: 4.1.1-0
+    source:
+      type: git
+      url: https://github.com/ros-gbp/stage-release.git
+      version: release/kinetic/stage
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stage` to `4.1.1-0`:

- upstream repository: https://github.com/rtv/Stage.git
- release repository: https://github.com/ros-gbp/stage-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `null`
