### PR TITLE
gazebo_ros_pkgs: 2.4.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3247,7 +3247,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.4.12-0
+      version: 2.4.13-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.4.13-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `2.4.12-0`

## gazebo_msgs

- No changes

## gazebo_plugins

```
* Fix timestamp issues for rendering sensors (indigo-devel) (#551 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/551>)
* Contributors: Ian Chen, Jose Luis Rivero
```

## gazebo_ros

- No changes

## gazebo_ros_control

- No changes

## gazebo_ros_pkgs

- No changes
