### PR TITLE
py_trees_ros: 0.5.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4439,7 +4439,7 @@ repositories:
       version: 0.5.0-0
     source:
       type: git
-      url: https://github.com/stonier/py_trees_release.git
+      url: https://github.com/stonier/py_trees_ros.git
       version: devel
     status: developed
   pyros:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4427,6 +4427,21 @@ repositories:
       url: https://github.com/stonier/py_trees_msgs.git
       version: devel
     status: developed
+  py_trees_ros:
+    doc:
+      type: git
+      url: https://github.com/stonier/py_trees_ros.git
+      version: release/0.5-kinetic
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/stonier/py_trees_ros-release.git
+      version: 0.5.0-0
+    source:
+      type: git
+      url: https://github.com/stonier/py_trees_release.git
+      version: devel
+    status: developed
   pyros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `0.5.0-0`:

- upstream repository: https://github.com/stonier/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## py_trees_ros

```
* [docs] new and shiny index added
* [tutorials] qt dashboard support
* [tutorials] 5 - tree scanning added
* [tutorials] 4 - tree introspection added
* [tutorials] 3 - blackboards added
* [tutorials] 2 - battery low branch added
* [tutorials] 1 - data gathering added
* [mock] a mock robot for tutorials and testing
* [behaviours] action client, battery behaviours added
* [infra] refactoring for kinetic
```
