### PR TITLE
rqt_wrapper: 0.1.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5887,7 +5887,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/rqt_wrapper-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/stonier/rqt_wrapper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_wrapper` to `0.1.4-0`:

- upstream repository: https://github.com/stonier/rqt_wrapper.git
- release repository: https://github.com/yujinrobot-release/rqt_wrapper-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.3-0`

## rqt_wrapper

```
* update to handle QtGui->QtWidgets in pyqt5
```
