### PR TITLE
rosserial: 0.7.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5720,13 +5720,14 @@ repositories:
       - rosserial_msgs
       - rosserial_python
       - rosserial_server
+      - rosserial_test
       - rosserial_tivac
       - rosserial_windows
       - rosserial_xbee
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rosserial-release.git
-      version: 0.7.5-0
+      version: 0.7.6-0
     source:
       type: git
       url: https://github.com/ros-drivers/rosserial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial` to `0.7.6-0`:

- upstream repository: https://github.com/ros-drivers/rosserial.git
- release repository: https://github.com/ros-gbp/rosserial-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.7.5-0`

## rosserial

- No changes

## rosserial_arduino

```
* Fixed issue with CMake CMP0054 (#273 <https://github.com/ros-drivers/rosserial/issues/273>)
* Add Teensy LC support (#270 <https://github.com/ros-drivers/rosserial/issues/270>)
* Support Teensy 3.5, 3.6. (#259 <https://github.com/ros-drivers/rosserial/issues/259>)
* Contributors: Brent Yi, FirefoxMetzger, Mike Purvis
```

## rosserial_client

```
* Fixing message has no attribute _md5sum (#257 <https://github.com/ros-drivers/rosserial/issues/257>)
* Contributors: Mike O'Driscoll
```

## rosserial_embeddedlinux

- No changes

## rosserial_mbed

- No changes

## rosserial_msgs

- No changes

## rosserial_python

```
* Fix typo in serial error message (#253 <https://github.com/ros-drivers/rosserial/issues/253>)
* Contributors: Jonathan Binney
```

## rosserial_server

- No changes

## rosserial_test

- No changes

## rosserial_tivac

```
* Allows to specify chip's silicon revision for TivaWare. (#268 <https://github.com/ros-drivers/rosserial/issues/268>)
* Updating rosserial_tivac for new TivaWare compilation flags (#260 <https://github.com/ros-drivers/rosserial/issues/260>)
* Contributors: Vitor Matos
```

## rosserial_windows

- No changes

## rosserial_xbee

- No changes
