### PR TITLE
interactive_marker_proxy: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2036,6 +2036,21 @@ repositories:
       url: https://github.com/ros-industrial/industrial_core.git
       version: kinetic
     status: maintained
+  interactive_marker_proxy:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/interactive_marker_proxy.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotWebTools-release/interactive_marker_proxy-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/interactive_marker_proxy.git
+      version: master
+    status: maintained
   interactive_marker_twist_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_marker_proxy` to `0.1.2-0`:

- upstream repository: https://github.com/RobotWebTools/interactive_marker_proxy.git
- release repository: https://github.com/RobotWebTools-release/interactive_marker_proxy-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `null`

## interactive_marker_proxy

```
* cleanup
* Contributors: Russell Toris
```
