### PR TITLE
tf2_web_republisher: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6435,6 +6435,21 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  tf2_web_republisher:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/tf2_web_republisher.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotWebTools-release/tf2_web_republisher-release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/tf2_web_republisher.git
+      version: master
+    status: maintained
   thormang3_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_web_republisher` to `0.3.1-0`:

- upstream repository: https://github.com/RobotWebTools/tf2_web_republisher.git
- release repository: https://github.com/RobotWebTools-release/tf2_web_republisher-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `null`

## tf2_web_republisher

```
* Merge pull request #17 <https://github.com/RobotWebTools/tf2_web_republisher/issues/17> from T045T/develop
  Only log errors for the first exception on each source/target pair
* set is_okay in TFPair default c'tor
* don't log every exception, but only changes in state for each pair of source and target frame
* Contributors: Nils Berg, Russell Toris
```
