### PR TITLE
parrot_arsdk: 3.11.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4091,7 +4091,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/AutonomyLab/parrot_arsdk-release.git
-      version: 3.10.1-0
+      version: 3.11.0-0
     source:
       type: git
       url: https://github.com/AutonomyLab/parrot_arsdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `parrot_arsdk` to `3.11.0-0`:

- upstream repository: https://github.com/AutonomyLab/parrot_arsdk.git
- release repository: https://github.com/AutonomyLab/parrot_arsdk-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `3.10.1-0`

## parrot_arsdk

```
* Update to SDK 3.11.0
  SDK Changelog:
  - Fixed non-ack commands (camera orientation was always sent)
  - Updated features list in the device controllers
  - Old and deprecated Unix samples have been removed
  - Coverity fixes
* Contributors: Mani Monajjemi
```
