### PR TITLE
jsk_pr2eus: 0.3.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2275,7 +2275,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_pr2eus-release.git
-      version: 0.3.9-1
+      version: 0.3.10-0
     status: developed
   jsk_recognition:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.3.10-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_pr2eus
- release repository: https://github.com/tork-a/jsk_pr2eus-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.3.9-1`

## jsk_pr2eus

- No changes

## pr2eus

```
* [pr2eus][pr2-interface.l] move move-to / go-pos callback for simulation to robot-interface.l (#288 <https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/288>)
* [pr2eus] fix: remove the first '/' from frame (#287 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/287>)
* fix: use movebaseaction name for clear-costmap (#286 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/286>)
  * [pr2eus/robot-interface.l] fix: use move-base-action name for clear-costmap
  * [pr2eus][robot-interface.l] soft tab
* Contributors: Kei Okada, Yuki Furuta
```

## pr2eus_moveit

- No changes

## pr2eus_tutorials

- No changes
