### PR TITLE
rqt_py_trees: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5883,6 +5883,21 @@ repositories:
       url: https://github.com/ethz-asl/rqt_multiplot_plugin.git
       version: master
     status: developed
+  rqt_py_trees:
+    doc:
+      type: git
+      url: https://github.com/stonier/rqt_py_trees.git
+      version: release/0.3-kinetic
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/stonier/rqt_py_trees-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/stonier/rqt_py_trees.git
+      version: devel
+    status: developed
   rqt_robot_plugins:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_py_trees` to `0.3.0-0`:

- upstream repository: https://github.com/stonier/rqt_py_trees.git
- release repository: https://github.com/stonier/rqt_py_trees-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## rqt_py_trees

```
* getting ready for first kinetic release
```
