### PR TITLE
roch: 1.0.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10284,11 +10284,12 @@ repositories:
       - roch_bringup
       - roch_follower
       - roch_navigation
+      - roch_rapps
       - roch_teleop
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch-release.git
-      version: 1.0.9-0
+      version: 1.0.10-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch` to `1.0.10-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch.git
- release repository: https://github.com/SawYerRobotics-release/roch-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.9-0`

## roch

```
* Adding new package roch_rapps.
```

## roch_bringup

```
* Add Roch Image.
* Remove unused param events/bumper and events/wheel_drop.
* Add rocon_concert files, such as concert_minimal.launch and concert_client.launch.
* Add param files for capabilities.
* Support Orbbec Astra.
* Add interactions.
* Add missing dependences: laser_filters, rgbd_launch, nodelet, robot_sate_publisher, diagnostic_aggregator
* Modify XML file of rplidar that string of serial_port to /dev/rplidar and frame_id to base_laser.
```

## roch_follower

- No changes

## roch_navigation

```
* Remove unused param events/bumper and events/wheel_drop.
* Support Obbrec Astra.
* Add missing package dependencies: nodelet, roch_safety_controller
```

## roch_rapps

```
* Create.
* Constructer: Carl
```

## roch_teleop

- No changes
