### PR TITLE
genjava: 0.3.2-1 in 'kinetic/distribution.yaml' [manual]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1379,7 +1379,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosjava-release/genjava-release.git
-      version: 0.3.1-0
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/rosjava/genjava.git


### PR DESCRIPTION
This is created manually, for some reason bloom can't find my fork

Increasing version of package(s) in repository `genjava` to `0.3.2-1`:

- upstream repository: https://github.com/rosjava/genjava.git
- release repository: https://github.com/rosjava-release/genjava-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: N/A
- previous version for package: `0.3.1-0`

## genjava

```
* bugfix abspath problems for gradle
```
