### PR TITLE
move_base_to_manip: 1.0.10-4 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6439,7 +6439,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip-release.git
-      version: 1.0.6-0
+      version: 1.0.10-4
     source:
       type: git
       url: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_to_manip` to `1.0.10-4`:

- upstream repository: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip.git
- release repository: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.6-0`
