### PR TITLE
jsk_planning: 0.1.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2263,7 +2263,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_planning-release.git
-      version: 0.1.9-0
+      version: 0.1.10-0
     status: developed
   jsk_pr2eus:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_planning` to `0.1.10-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_planning
- release repository: https://github.com/tork-a/jsk_planning-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.1.9-0`

## jsk_planning

- No changes

## pddl_msgs

- No changes

## pddl_planner

```
* [task_compiler] fix: symbol is compared with string (#60 <https://github.com/jsk-ros-pkg/jsk_planning/issues/60>)
* Contributors: Yuki Furuta
```

## pddl_planner_viewer

- No changes

## task_compiler

```
* [task_compiler] fix: symbol is compared with string (#60 <https://github.com/jsk-ros-pkg/jsk_planning/issues/60>)
* Contributors: Yuki Furuta
```
