### PR TITLE
navigation_2d: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3514,6 +3514,27 @@ repositories:
       url: https://github.com/ros-planning/navigation.git
       version: kinetic-devel
     status: maintained
+  navigation_2d:
+    release:
+      packages:
+      - nav2d
+      - nav2d_exploration
+      - nav2d_karto
+      - nav2d_localizer
+      - nav2d_msgs
+      - nav2d_navigator
+      - nav2d_operator
+      - nav2d_remote
+      - nav2d_tutorials
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/skasperski/navigation_2d-release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/skasperski/navigation_2d.git
+      version: kinetic
+    status: maintained
   navigation_layers:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3515,6 +3515,10 @@ repositories:
       version: kinetic-devel
     status: maintained
   navigation_2d:
+    doc:
+      type: git
+      url: https://github.com/skasperski/navigation_2d.git
+      version: kinetic
     release:
       packages:
       - nav2d


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_2d` to `0.3.1-0`:

- upstream repository: https://github.com/skasperski/navigation_2d.git
- release repository: https://github.com/skasperski/navigation_2d-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
