### PR TITLE
jsk_recognition: 1.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2278,6 +2278,10 @@ repositories:
       version: 0.3.9-1
     status: developed
   jsk_recognition:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_recognition.git
+      version: master
     release:
       packages:
       - checkerboard_detector
@@ -2292,7 +2296,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.1.0-2
+      version: 1.1.1-0
     status: developed
   jsk_roseus:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `1.1.1-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `1.1.0-2`

## checkerboard_detector

- No changes

## imagesift

- No changes

## jsk_pcl_ros

```
* incldue flann before any opencv includes, fix #2022 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2022> (#2023 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2023> )
* Contributors: Kei Okada
```

## jsk_pcl_ros_utils

```
* Remove unnecessary cmake messages (#2010 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2010>)
* Contributors: Kentaro Wada
```

## jsk_perception

- No changes

## jsk_recognition

- No changes

## jsk_recognition_msgs

- No changes

## jsk_recognition_utils

- No changes

## resized_image_transport

- No changes
