### PR TITLE
ubiquity_motor: 0.5.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6888,11 +6888,19 @@ repositories:
       version: master
     status: maintained
   ubiquity_motor:
+    doc:
+      type: git
+      url: https://github.com/UbiquityRobotics/ubiquity_motor.git
+      version: 0.5.1
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
-      version: 0.5.0-0
+      version: 0.5.1-0
+    source:
+      type: git
+      url: https://github.com/UbiquityRobotics/ubiquity_motor.git
+      version: indigo-devel
     status: developed
   ublox:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ubiquity_motor` to `0.5.1-0`:

- upstream repository: https://github.com/UbiquityRobotics/ubiquity_motor.git
- release repository: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.5.0-0`

## ubiquity_motor

```
* Reduce flakey-ness of the tests
* Try to get firmware version, throw after 10 tries
* Code cleanup
* Use fixed sized arrays (not vectors) where they make sense
* Use a seperate shared_queue class
* Performance improvements
* Contributors: Rohan Agrawal
```
