### PR TITLE
tork_rpc: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13641,6 +13641,25 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/topic_proxy-release.git
       version: 0.1.1-0
     status: maintained
+  tork_rpc:
+    doc:
+      type: git
+      url: https://github.com/tork-a/tork_rpc.git
+      version: master
+    release:
+      packages:
+      - tork_rpc
+      - tork_rpc_util
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/tork_rpc-release.git
+      version: 0.0.3-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/tork-a/tork_rpc.git
+      version: master
+    status: developed
   tornado:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `tork_rpc` to `0.0.3-0`:

- upstream repository: https://github.com/tork-a/tork_rpc.git
- release repository: https://github.com/tork-a/tork_rpc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `null`

## tork_rpc

- No changes

## tork_rpc_util

- No changes
