### PR TITLE
gencpp: 0.5.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1353,7 +1353,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/gencpp-release.git
-      version: 0.5.4-0
+      version: 0.5.5-0
     source:
       type: git
       url: https://github.com/ros/gencpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gencpp` to `0.5.5-0`:

- upstream repository: git@github.com:ros/gencpp.git
- release repository: https://github.com/ros-gbp/gencpp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.5.4-0`

## gencpp

```
* fix extra semicolon warning (#26 <https://github.com/ros/gencpp/issues/26>)
```
