### PR TITLE
catkin: 0.6.19-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1242,7 +1242,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.6.18-0
+      version: 0.6.19-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.6.19-0`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.6.18-0`

## catkin

```
* update --pkg help for catkin_make_isolated (#853 <https://github.com/ros/catkin/issues/853>)
* add skipped / disabled tests to catkin_test_results summary (#848 <https://github.com/ros/catkin/issues/848>)
* fix rollback logic for more than one value per environment variable and workspace (#819 <https://github.com/ros/catkin/issues/819>)
* fix quoting of paths to handle spaces (#808 <https://github.com/ros/catkin/issues/808>)
* improve doc about catkin_package(CFG_EXTRAS) (#805 <https://github.com/ros/catkin/issues/805>)
* doc: fix format 2 howto to suggest to declare a build export dependency on "message_runtime"
* update documentation (#847 <https://github.com/ros/catkin/pull/847> #849 <https://github.com/ros/catkin/pull/849> #854 <https://github.com/ros/catkin/pull/854>)
```
