### PR TITLE
genmsg: 0.5.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1349,7 +1349,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/genmsg-release.git
-      version: 0.5.7-0
+      version: 0.5.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.5.8-0`:

- upstream repository: git@github.com:ros/genmsg.git
- release repository: https://github.com/ros-gbp/genmsg-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.5.7-0`

## genmsg

```
* check target across package for existance (#65 <https://github.com/ros/genmsg/issues/65>)
* do not hardcode errno values (#64 <https://github.com/ros/genmsg/issues/64>)
```
