### PR TITLE
roscpp_core: 0.5.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11198,7 +11198,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.5.7-0
+      version: 0.5.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.5.8-0`:

- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.5.7-0`

## cpp_common

- No changes

## roscpp_serialization

- No changes

## roscpp_traits

- No changes

## rostime

```
* fix rounding errors leading to invalid stored data in ros::TimeBase (#48 <https://github.com/ros/roscpp_core/issues/48>)
```
