### PR TITLE
ros: 1.12.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5189,7 +5189,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.12.7-0
+      version: 1.12.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.12.8-0`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `1.12.7-0`

## mk

- No changes

## rosbash

```
* add "rostopic pub" completion for message type (#132 <https://github.com/ros/ros/pull/132>)
* fix spelling of 'rosed' in usage (#118 <https://github.com/ros/ros/pull/118>)
* add missing verbs to rosservice completion (#117 <https://github.com/ros/ros/pull/117>)
```

## rosboost_cfg

- No changes

## rosbuild

- No changes

## rosclean

- No changes

## roscreate

- No changes

## roslang

- No changes

## roslib

```
* fix missing export depends (#128 <https://github.com/ros/ros/issues/128>)
```

## rosmake

- No changes

## rosunit

```
* improve error message when creating test directory fails (#134 <https://github.com/ros/ros/pull/134>)
* fix race condition creating folder (#130 <https://github.com/ros/ros/pull/130>)
* fix check of test type (#121 <https://github.com/ros/ros/issues/121>, #123 <https://github.com/ros/ros/issues/123>)
```
