### PR TITLE
ros: 1.11.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10694,7 +10694,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.11.13-0
+      version: 1.11.14-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.11.14-0`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `1.11.13-0`

## mk

- No changes

## rosbash

```
* add "rostopic pub" completion for message type (#132 <https://github.com/ros/ros/pull/132>)
* fix spelling of 'rosed' in usage (#118 <https://github.com/ros/ros/pull/118>)
* add missing verbs to rosservice completion (#117 <https://github.com/ros/ros/pull/117>)
```

## rosboost_cfg

- No changes

## rosbuild

- No changes

## rosclean

- No changes

## roscreate

- No changes

## roslang

- No changes

## roslib

```
* fix missing export depends (#128 <https://github.com/ros/ros/issues/128>)
```

## rosmake

- No changes

## rosunit

```
* improve error message when creating test directory fails (#134 <https://github.com/ros/ros/pull/134>)
* fix race condition creating folder (#130 <https://github.com/ros/ros/pull/130>)
* fix check of test type (#121 <https://github.com/ros/ros/issues/121>, #123 <https://github.com/ros/ros/issues/123>)
```
