### PR TITLE
rosjava_core 0.2.2-0

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11324,7 +11324,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_core-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/rosjava/rosjava_core.git


### PR DESCRIPTION
Again bloom couldn't find my fork so created manually.

* upstream repository: https://github.com/rosjava/rosjava_core.git
* release repository: https://github.com/rosjava-release/rosjava_core-release.git
* distro file: indigo/distribution.yaml
* previous version for package: 0.2.1-0