### PR TITLE
ros_comm: 1.11.21-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5251,7 +5251,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.11.20-0
+      version: 1.11.21-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.11.21-0`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `1.11.20-0`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

```
* throw exception instead of accessing invalid memory (#971 <https://github.com/ros/ros_comm/pull/971>)
* terminate underlying rosbag play, record  on SIGTERM (#951 <https://github.com/ros/ros_comm/issues/951>)
* fix BagMigrationException in migrate_raw (#917 <https://github.com/ros/ros_comm/issues/917>)
* set default values for min_space and min_space_str (#883 <https://github.com/ros/ros_comm/issues/883>)
* update rosbag filter progress meter to use raw uncompressed input size (#857 <https://github.com/ros/ros_comm/issues/857>)
```

## rosbag_storage

- No changes

## rosconsole

```
* fix building on GCC-6 (#911 <https://github.com/ros/ros_comm/pull/911>)
```

## roscpp

```
* fix UDP block number when EAGAIN or EWOULDBLOCK (#957 <https://github.com/ros/ros_comm/issues/957>)
* improve stacktrace for exceptions thrown in callbacks (#811 <https://github.com/ros/ros_comm/pull/811>)
```

## rosgraph

```
* increase request_queue_size for xmlrpc server (#849 <https://github.com/ros/ros_comm/issues/849>)
```

## roslaunch

```
* improve error message for invalid tags (#989 <https://github.com/ros/ros_comm/pull/989>)
* fix caching logic to improve performance (#931 <https://github.com/ros/ros_comm/pull/931>)
```

## roslz4

- No changes

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* make get_published_topics threadsafe (#958 <https://github.com/ros/ros_comm/issues/958>)
* fix wrong type in docstring for rospy.Timer (#878 <https://github.com/ros/ros_comm/pull/878>)
* add logXXX_throttle functions (#812 <https://github.com/ros/ros_comm/pull/812>)
```

## rosservice

- No changes

## rostest

```
* fix test type handling (#722 <https://github.com/ros/ros_comm/issues/722>)
* add_rostest_gtest does now add the created gtest-target as a dependeny to the created rostest (#830 <https://github.com/ros/ros_comm/pull/830>)
```

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

- No changes

## xmlrpcpp

- No changes
