### PR TITLE
rosjava_core-0.3.2

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5626,7 +5626,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_core-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/rosjava/rosjava_core.git


### PR DESCRIPTION
Another manual one

* upstream repository: https://github.com/rosjava/rosjava_core.git
* release repository: https://github.com/rosjava-release/rosjava_core-release.git
* distro file: kinetic/distribution.yaml
* previous version for package: 0.3.1-0