### PR TITLE
Added python-redis for 14.10 -> 16.10

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2051,6 +2051,7 @@ python-redis:
     wily: [python-redis]
     xenial: [python-redis]
     yakkety: [python-redis]
+    zesty: [python-redis]
 python-redis-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2046,6 +2046,11 @@ python-redis:
     raring: [python-redis]
     saucy: [python-redis]
     trusty: [python-redis]
+    utopic: [python-redis]
+    vivid: [python-redis]
+    wily: [python-redis]
+    xenial: [python-redis]
+    yakkety: [python-redis]
 python-redis-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2036,22 +2036,7 @@ python-readchar-pip:
 python-redis:
   debian: [python-redis]
   fedora: [python-redis]
-  ubuntu:
-    lucid: [python-redis]
-    maverick: [python-redis]
-    natty: [python-redis]
-    oneiric: [python-redis]
-    precise: [python-redis]
-    quantal: [python-redis]
-    raring: [python-redis]
-    saucy: [python-redis]
-    trusty: [python-redis]
-    utopic: [python-redis]
-    vivid: [python-redis]
-    wily: [python-redis]
-    xenial: [python-redis]
-    yakkety: [python-redis]
-    zesty: [python-redis]
+  ubuntu: [python-redis]
 python-redis-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
Updated rosdep python package list for ubuntu 14.10 through 16.10 for the python-redis package.