### PR TITLE
add doc and source entries for metapackages in Indigo and Jade

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6206,6 +6206,10 @@ repositories:
       version: master
     status: maintained
   metapackages:
+    doc:
+      type: git
+      url: https://github.com/ros/metapackages.git
+      version: indigo-devel
     release:
       packages:
       - desktop
@@ -6220,6 +6224,10 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/metapackages-release.git
       version: 1.1.4-0
+    source:
+      type: git
+      url: https://github.com/ros/metapackages.git
+      version: indigo-devel
     status: maintained
   metaruby:
     release:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2867,6 +2867,10 @@ repositories:
       version: master
     status: maintained
   metapackages:
+    doc:
+      type: git
+      url: https://github.com/ros/metapackages.git
+      version: jade-devel
     release:
       packages:
       - desktop
@@ -2881,6 +2885,10 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/metapackages-release.git
       version: 1.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros/metapackages.git
+      version: jade-devel
     status: maintained
   microstrain_3dm_gx5_45:
     doc:


### PR DESCRIPTION
In order to extract metapackages for the wiki as well as to work with `rosinstall_generator`.