### PR TITLE
remove explicit call for apt

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -84,9 +84,7 @@ armadillo:
   gentoo:
     portage:
       packages: [sci-libs/armadillo]
-  ubuntu:
-    apt:
-      packages: [libarmadillo-dev]
+  ubuntu: [libarmadillo-dev]
 assimp:
   arch: [assimp]
   debian:
@@ -102,45 +100,19 @@ assimp:
   rhel: [assimp-devel]
   slackware: [assimp]
   ubuntu:
-    lucid:
-      apt:
-        packages: [assimp-dev]
-    maverick:
-      apt:
-        packages: [assimp-dev]
-    oneiric:
-      apt:
-        packages: [assimp-dev]
-    precise:
-      apt:
-        packages: [libassimp-dev]
-    quantal:
-      apt:
-        packages: [libassimp-dev]
-    raring:
-      apt:
-        packages: [libassimp-dev]
-    saucy:
-      apt:
-        packages: [libassimp-dev]
-    trusty:
-      apt:
-        packages: [libassimp-dev]
-    trusty_python3:
-      apt:
-        packages: [libassimp-dev]
-    utopic:
-      apt:
-        packages: [libassimp-dev]
-    vivid:
-      apt:
-        packages: [libassimp-dev]
-    wily:
-      apt:
-        packages: [libassimp-dev]
-    xenial:
-      apt:
-        packages: [libassimp-dev]
+    lucid: [assimp-dev]
+    maverick: [assimp-dev]
+    oneiric: [assimp-dev]
+    precise: [libassimp-dev]
+    quantal: [libassimp-dev]
+    raring: [libassimp-dev]
+    saucy: [libassimp-dev]
+    trusty: [libassimp-dev]
+    trusty_python3: [libassimp-dev]
+    utopic: [libassimp-dev]
+    vivid: [libassimp-dev]
+    wily: [libassimp-dev]
+    xenial: [libassimp-dev]
 assimp-dev:
   arch: [assimp]
   debian:
@@ -155,45 +127,19 @@ assimp-dev:
   rhel: [assimp-devel]
   slackware: [assimp]
   ubuntu:
-    lucid:
-      apt:
-        packages: [assimp-dev]
-    maverick:
-      apt:
-        packages: [assimp-dev]
-    oneiric:
-      apt:
-        packages: [assimp-dev]
-    precise:
-      apt:
-        packages: [libassimp-dev]
-    quantal:
-      apt:
-        packages: [libassimp-dev]
-    raring:
-      apt:
-        packages: [libassimp-dev]
-    saucy:
-      apt:
-        packages: [libassimp-dev]
-    trusty:
-      apt:
-        packages: [libassimp-dev]
-    trusty_python3:
-      apt:
-        packages: [libassimp-dev]
-    utopic:
-      apt:
-        packages: [libassimp-dev]
-    vivid:
-      apt:
-        packages: [libassimp-dev]
-    wily:
-      apt:
-        packages: [libassimp-dev]
-    xenial:
-      apt:
-        packages: [libassimp-dev]
+    lucid: [assimp-dev]
+    maverick: [assimp-dev]
+    oneiric: [assimp-dev]
+    precise: [libassimp-dev]
+    quantal: [libassimp-dev]
+    raring: [libassimp-dev]
+    saucy: [libassimp-dev]
+    trusty: [libassimp-dev]
+    trusty_python3: [libassimp-dev]
+    utopic: [libassimp-dev]
+    vivid: [libassimp-dev]
+    wily: [libassimp-dev]
+    xenial: [libassimp-dev]
 atlas:
   arch: [atlas-lapack]
   debian: [libatlas-base-dev]
@@ -337,54 +283,22 @@ boost:
     slackpkg:
       packages: [boost]
   ubuntu:
-    lucid:
-      apt:
-        packages: [libboost1.40-all-dev]
-    maverick:
-      apt:
-        packages: [libboost1.42-all-dev]
-    natty:
-      apt:
-        packages: [libboost1.42-all-dev]
-    oneiric:
-      apt:
-        packages: [libboost1.46-all-dev]
-    precise:
-      apt:
-        packages: [libboost-all-dev]
-    quantal:
-      apt:
-        packages: [libboost-all-dev]
-    raring:
-      apt:
-        packages: [libboost-all-dev]
-    saucy:
-      apt:
-        packages: [libboost-all-dev]
-    trusty:
-      apt:
-        packages: [libboost-all-dev]
-    trusty_python3:
-      apt:
-        packages: [libboost-all-dev]
-    utopic:
-      apt:
-        packages: [libboost-all-dev]
-    vivid:
-      apt:
-        packages: [libboost-all-dev]
-    wily:
-      apt:
-        packages: [libboost-all-dev]
-    xenial:
-      apt:
-        packages: [libboost-all-dev]
-    yakkety:
-      apt:
-        packages: [libboost-all-dev]
-    zesty:
-      apt:
-        packages: [libboost-all-dev]
+    lucid: [libboost1.40-all-dev]
+    maverick: [libboost1.42-all-dev]
+    natty: [libboost1.42-all-dev]
+    oneiric: [libboost1.46-all-dev]
+    precise: [libboost-all-dev]
+    quantal: [libboost-all-dev]
+    raring: [libboost-all-dev]
+    saucy: [libboost-all-dev]
+    trusty: [libboost-all-dev]
+    trusty_python3: [libboost-all-dev]
+    utopic: [libboost-all-dev]
+    vivid: [libboost-all-dev]
+    wily: [libboost-all-dev]
+    xenial: [libboost-all-dev]
+    yakkety: [libboost-all-dev]
+    zesty: [libboost-all-dev]
 box2d-dev:
   arch: [box2d]
   debian: [libbox2d-dev]
@@ -402,36 +316,16 @@ bullet:
   macports: [bullet]
   opensuse: [libbullet]
   ubuntu:
-    precise:
-      apt:
-        packages: [libbullet-dev]
-    quantal:
-      apt:
-        packages: [libbullet-dev]
-    raring:
-      apt:
-        packages: [libbullet-dev]
-    saucy:
-      apt:
-        packages: [libbullet-dev]
-    trusty:
-      apt:
-        packages: [libbullet-dev]
-    trusty_python3:
-      apt:
-        packages: [libbullet-dev]
-    utopic:
-      apt:
-        packages: [libbullet-dev]
-    vivid:
-      apt:
-        packages: [libbullet-dev]
-    wily:
-      apt:
-        packages: [libbullet-dev]
-    xenial:
-      apt:
-        packages: [libbullet-dev]
+    precise: [libbullet-dev]
+    quantal: [libbullet-dev]
+    raring: [libbullet-dev]
+    saucy: [libbullet-dev]
+    trusty: [libbullet-dev]
+    trusty_python3: [libbullet-dev]
+    utopic: [libbullet-dev]
+    vivid: [libbullet-dev]
+    wily: [libbullet-dev]
+    xenial: [libbullet-dev]
 bzip2:
   arch: [bzip2]
   cygwin: [bzip2]
@@ -476,17 +370,11 @@ cgal:
   gentoo:
     portage:
       packages: [sci-mathematics/cgal]
-  ubuntu:
-    apt:
-      packages: [libcgal-dev]
+  ubuntu: [libcgal-dev]
 checkinstall:
   arch: [checkinstall]
-  debian:
-    apt:
-      packages: [checkinstall]
-  ubuntu:
-    apt:
-      packages: [checkinstall]
+  debian: [checkinstall]
+  ubuntu: [checkinstall]
 chromium-browser:
   gentoo: [www-client/chromium]
   ubuntu: [chromium-browser]
@@ -701,16 +589,12 @@ eigen:
   slackware:
     slackpkg:
       packages: [eigen3]
-  ubuntu:
-    apt:
-      packages: [libeigen3-dev]
+  ubuntu: [libeigen3-dev]
 eigen2:
   arch: [eigen2]
   fedora: [eigen2-devel]
   opensuse: [libeigen2-devel]
-  ubuntu:
-    apt:
-      packages: [libeigen2-dev]
+  ubuntu: [libeigen2-dev]
 emacs:
   arch: [emacs]
   debian: [emacs]
@@ -1475,16 +1359,12 @@ libdc1394-dev:
   arch:
     pacman:
       packages: [libdc1394]
-  debian:
-    apt:
-      packages: [libdc1394-22-dev]
+  debian: [libdc1394-22-dev]
   fedora: [libdc1394-devel]
   osx:
     macports:
       packages: [libdc1394]
-  ubuntu:
-    apt:
-      packages: [libdc1394-22-dev]
+  ubuntu: [libdc1394-22-dev]
 libdevil-dev:
   arch: [devil]
   debian: [libdevil-dev]
@@ -1838,12 +1718,8 @@ libhal-dev:
   arch:
     pacman:
       packages: [hal]
-  debian:
-    apt:
-      packages: [libhal-dev]
-  ubuntu:
-    apt:
-      packages: [libhal-dev]
+  debian: [libhal-dev]
+  ubuntu: [libhal-dev]
 libhdf5-dev:
   debian: [libhdf5-dev]
   fedora: [hdf5-devel]
@@ -2235,17 +2111,13 @@ libpcap:
   arch:
     pacman:
       packages: [libpcap]
-  debian:
-    apt:
-      packages: [libpcap0.8-dev]
+  debian: [libpcap0.8-dev]
   fedora: [libpcap-devel]
   gentoo:
     portage:
       packages: [net-libs/libpcap]
   macports: [libpcap]
-  ubuntu:
-    apt:
-      packages: [libpcap0.8-dev]
+  ubuntu: [libpcap0.8-dev]
 libpcl-all:
   arch: [pcl]
   debian: [libpcl1.7]
@@ -2297,15 +2169,11 @@ libpcsclite-dev:
 libphonon:
   debian: [libphonon4]
   fedora: [phonon]
-  ubuntu:
-    apt:
-      packages: [libphonon4]
+  ubuntu: [libphonon4]
 libphonon-dev:
   debian: [libphonon-dev]
   fedora: [phonon-devel]
-  ubuntu:
-    apt:
-      packages: [libphonon-dev]
+  ubuntu: [libphonon-dev]
 libpng++-dev:
   ubuntu: [libpng++-dev]
 libpng12-dev:
@@ -2577,16 +2445,12 @@ libqtwebkit-dev:
   ubuntu: [libqtwebkit-dev]
 libqwt5-qt4-dev:
   arch: [qwt5]
-  debian:
-    apt:
-      packages: [libqwt5-qt4-dev]
+  debian: [libqwt5-qt4-dev]
   fedora: [qwt-devel]
   gentoo:
     portage:
       packages: [x11-libs/qwtplot3d]
-  ubuntu:
-    apt:
-      packages: [libqwt5-qt4-dev]
+  ubuntu: [libqwt5-qt4-dev]
 libqwt6:
   arch: [qwt]
   fedora: [qwt-devel]
@@ -2602,30 +2466,22 @@ libqwt6:
     xenial: [libqwt-qt5-dev]
 libqwtplot3d-qt4-dev:
   arch: [qwtplot3d]
-  debian:
-    apt:
-      packages: [libqwtplot3d-qt4-dev]
+  debian: [libqwtplot3d-qt4-dev]
   fedora: [qwtplot3d-qt4-devel]
   gentoo:
     portage:
       packages: [x11-libs/qwtplot3d]
-  ubuntu:
-    apt:
-      packages: [libqwtplot3d-qt4-dev]
+  ubuntu: [libqwtplot3d-qt4-dev]
 libraw1394-dev:
   arch:
     pacman:
       packages: [libraw1394]
-  debian:
-    apt:
-      packages: [libraw1394-dev]
+  debian: [libraw1394-dev]
   fedora: [libraw1394-devel]
   gentoo:
     portage:
       packages: [sys-libs/libraw1394]
-  ubuntu:
-    apt:
-      packages: [libraw1394-dev]
+  ubuntu: [libraw1394-dev]
 libreadline:
   arch: [readline]
   debian: [libreadline-dev]
@@ -2843,9 +2699,7 @@ libunittest++:
   fedora: [unittest]
   macports: [unittest-cpp]
   rhel: [unittest]
-  ubuntu:
-    apt:
-      packages: [libunittest++-dev]
+  ubuntu: [libunittest++-dev]
 libunwind:
   fedora: [libunwind]
   ubuntu:
@@ -4104,16 +3958,12 @@ unison:
   arch: [unison]
   debian: [unison]
   fedora: [unison240]
-  ubuntu:
-    apt:
-      packages: [unison]
+  ubuntu: [unison]
 unison-gui:
   arch: [unison]
   debian: [unison-gtk]
   fedora: [unison240-gtk]
-  ubuntu:
-    apt:
-      packages: [unison-gtk]
+  ubuntu: [unison-gtk]
 unoconv:
   arch: [unoconv]
   debian: [unoconv]
@@ -4323,18 +4173,10 @@ xulrunner-1.9.2:
     lucid: [xulrunner-1.9.2]
     maverick: [xulrunner-1.9.2]
     natty: [xulrunner-1.9.2]
-    oneiric:
-      apt:
-        packages: []
-    precise:
-      apt:
-        packages: []
-    quantal:
-      apt:
-        packages: []
-    raring:
-      apt:
-        packages: []
+    oneiric: []
+    precise: []
+    quantal: []
+    raring: []
 xulrunner-dev:
   arch: [xulrunner]
   debian: [libv8-dev]
@@ -4360,19 +4202,13 @@ yaml:
 yaml-cpp:
   arch: [yaml-cpp]
   debian:
-    jessie:
-      apt:
-        packages: [libyaml-cpp-dev]
-    sid:
-      apt:
-        packages: [libyaml-cpp-dev]
+    jessie: [libyaml-cpp-dev]
+    sid: [libyaml-cpp-dev]
     squeeze:
       source:
         md5sum: f7fb81fd4a2fbd5022daa7686e816359
         uri: 'https://kforge.ros.org/rosrelease/viewvc/sourcedeps/yaml-cpp/yaml-cpp-0.2.5.rdmanifest'
-    wheezy:
-      apt:
-        packages: [libyaml-cpp-dev]
+    wheezy: [libyaml-cpp-dev]
   fedora: [yaml-cpp-devel]
   gentoo:
     portage:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1875,13 +1875,9 @@ python-pynmea2:
       packages: [pynmea2]
 python-pyproj:
   arch: [python2-pyproj]
-  debian:
-    apt:
-      packages: [python-pyproj]
+  debian: [python-pyproj]
   fedora: [pyproj]
-  ubuntu:
-    apt:
-      packages: [python-pyproj]
+  ubuntu: [python-pyproj]
 python-pyquery:
   debian: [python-pyquery]
   fedora: [python-pyquery]
@@ -2032,13 +2028,9 @@ python-qt-bindings-qwt5:
     wily: [python-qwt5-qt4]
     xenial: [python-qwt5-qt4]
 python-qt4-gl:
-  debian:
-    apt:
-      packages: [python-qt4-gl]
+  debian: [python-qt4-gl]
   fedora: [PyQt4]
-  ubuntu:
-    apt:
-      packages: [python-qt4-gl]
+  ubuntu: [python-qt4-gl]
 python-qt5-bindings:
   arch: [python2-pyqt5]
   debian:


### PR DESCRIPTION
apt being the default for bedian and ubuntu, there is no need to call out apt as the package manager.

Note: this doesn't collapse existing rules when identical but can be added to this PR if deemed relevant