### PR TITLE
jsk_model_tools: 0.3.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2235,7 +2235,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.2.5-0
+      version: 0.3.5-0
     status: developed
   jsk_planning:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.3.5-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.2.5-0`

## eus_assimp

- No changes

## euscollada

- No changes

## eusurdf

```
* add gazebo_ros to build_depend
* Contributors: Kei Okada
```

## jsk_model_tools

- No changes
