### PR TITLE
euslisp: 9.23.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2693,7 +2693,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/euslisp-release.git
-      version: 9.22.0-0
+      version: 9.23.0-0
     status: developed
   evapc_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `euslisp` to `9.23.0-0`:

- upstream repository: https://github.com/euslisp/EusLisp
- release repository: https://github.com/tork-a/euslisp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `9.22.0-0`
