### PR TITLE
jskeus: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2328,11 +2328,15 @@ repositories:
       version: 2.1.1-0
     status: developed
   jskeus:
+    doc:
+      type: git
+      url: https://github.com/euslisp/jskeus.git
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jskeus-release.git
-      version: 1.0.14-0
+      version: 1.1.0-0
     status: developed
   katana_driver:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.1.0-0`:

- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `1.0.14-0`

## jskeus

```
* Add vector-variance and covariance-matrix (#418 <https://github.com/euslisp/jskeus/issues/418>)
  * add documentation to vector-variance and covariance-matrix
  * add vector-variance and covariance-matrix
* [irteus.irtscene.l] add :remove-wall for scene-model (#417 <https://github.com/euslisp/jskeus/issues/417>)
* [irteus/irtpointcloud.l] fix bug of :set-color. (#416 <https://github.com/euslisp/jskeus/issues/416>)
* Adapt to moved formulae: homebrew/homebrew-x11 -> euslisp/homebrew-jskeus
  Fix #412 <https://github.com/euslisp/jskeus/issues/412>
* irtgl.l/irtpointcloud.l: add :aarch64 (#410 <https://github.com/euslisp/jskeus/issues/410>)
* Contributors: Kei Okada, Kentaro Wada, Masaki Murooka, Yohei Kakiuchi, Yuki Furuta
```
