### PR TITLE
Added pocketsphinx to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3358,6 +3358,14 @@ pkg-config:
 pocketsphinx:
   fedora: [pocketsphinx]
   ubuntu:
+    precise: [libsphinxbase1]
+    quantal: [libsphinxbase1]
+    raring: [libsphinxbase1]
+    saucy: [libsphinxbase1]
+    trusty: [libsphinxbase1]
+    utopic: [libsphinxbase1]
+    vivid: [libsphinxbase1]
+    wily: [libsphinxbase1]
     xenial: [pocketsphinx]
     yakkety: [pocketsphinx]
     zesty: [pocketsphinx]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3355,6 +3355,12 @@ pkg-config:
     slackpkg:
       packages: [pkg-config]
   ubuntu: [pkg-config]
+pocketsphinx:
+  fedora: [pocketsphinx]
+  ubuntu:
+    xenial: [pocketsphinx]
+    yakkety: [pocketsphinx]
+    zesty: [pocketsphinx]
 portaudio:
   arch: [portaudio]
   debian: [libportaudio-dev]


### PR DESCRIPTION
It is available after xenial:
http://packages.ubuntu.com/search?keywords=pocketsphinx+&searchon=sourcenames

https://admin.fedoraproject.org/pkgdb/package/rpms/pocketsphinx/