### PR TITLE
Add 'libserial-dev'

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2514,8 +2514,8 @@ libsensors4-dev:
   fedora: [lm_sensors-devel]
   ubuntu: [libsensors4-dev]
 libserial-dev:
-  debian: [libserial0 libserial-dev]
-  ubuntu: [libserial0 libserial-dev]
+  debian: [libserial0, libserial-dev]
+  ubuntu: [libserial0, libserial-dev]
 libsimage-dev:
   arch: [simage]
   debian: [libsimage-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2513,6 +2513,9 @@ libsensors4-dev:
   debian: [libsensors4-dev]
   fedora: [lm_sensors-devel]
   ubuntu: [libsensors4-dev]
+libserial-dev:
+  debian: [libserial0 libserial-dev]
+  ubuntu: [libserial0 libserial-dev]
 libsimage-dev:
   arch: [simage]
   debian: [libsimage-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2514,8 +2514,8 @@ libsensors4-dev:
   fedora: [lm_sensors-devel]
   ubuntu: [libsensors4-dev]
 libserial-dev:
-  debian: [libserial0, libserial-dev]
-  ubuntu: [libserial0, libserial-dev]
+  debian: [libserial-dev]
+  ubuntu: [libserial-dev]
 libsimage-dev:
   arch: [simage]
   debian: [libsimage-dev]


### PR DESCRIPTION
- This pull adds the `libserial-dev` dependency target for both ubuntu and debian
- Using it to create drivers to interact with arduino based devices 
- Submitting on behalf of [UBC-Snowbots](https://github.com/UBC-Snowbots) (Engineering team at the University of British Columbia - Canada)

I think I've covered everything, please give me a shout if I missed anything. Thanks for being maintainers, rosdep's make my life **way** easier! :+1: 