### PR TITLE
csm: 1.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -711,6 +711,13 @@ repositories:
       url: https://github.com/AutonomyLab/create_autonomy.git
       version: indigo-devel
     status: developed
+  csm:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/csm-release.git
+      version: 1.0.2-0
+    status: developed
   cv_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `csm` to `1.0.2-0`:

- upstream repository: https://github.com/AndreaCensi/csm.git
- release repository: https://github.com/tork-a/csm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `null`
