### PR TITLE
moveit: 0.7.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6489,7 +6489,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.7.7-0
+      version: 0.7.8-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.7.8-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.7.7-0`

## moveit

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* [fix] correct "simplify widget handling" #452 <https://github.com/ros-planning/moveit/pull/452> This reverts "simplify widget handling (#442 <https://github.com/ros-planning/moveit/issues/442>)"
* [fix][moveit_ros_planning] Remove unnecessary dependency on Qt4
* [enhancement][MoveGroup] Add getLinkNames function (#440 <https://github.com/ros-planning/moveit/issues/440>)
* [enhancement] Add set_max_acceleration_scaling_factor to moveit_commander. #377 <https://github.com/ros-planning/moveit/issues/377>, #437 <https://github.com/ros-planning/moveit/issues/437>, #451 <https://github.com/ros-planning/moveit/issues/451>
* [doc][moveit_commander] added description for set_start_state (#447 <https://github.com/ros-planning/moveit/issues/447>)
* Contributors: Dmitry Rozhkov, Yannick Jonetzko, Isaac I.Y. Saito, henhenhen, Ravi Prakash Joshi
```

## moveit_commander

```
* [enhancement] Add set_max_acceleration_scaling_factor to moveit_commander. #377 <https://github.com/ros-planning/moveit/issues/377>, #437 <https://github.com/ros-planning/moveit/issues/437>, #451 <https://github.com/ros-planning/moveit/issues/451>
* [doc][moveit_commander] added description for set_start_state (#447 <https://github.com/ros-planning/moveit/issues/447>)
* Contributors: Isaac I.Y. Saito, Ravi Prakash Joshi
```

## moveit_controller_manager_example

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dmitry Rozhkov
```

## moveit_core

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dmitry Rozhkov
```

## moveit_fake_controller_manager

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dmitry Rozhkov
```

## moveit_full

- No changes

## moveit_full_pr2

- No changes

## moveit_kinematics

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dmitry Rozhkov
```

## moveit_planners

- No changes

## moveit_planners_ompl

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dmitry Rozhkov
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dmitry Rozhkov
```

## moveit_ros_benchmarks_gui

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dmitry Rozhkov
```

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dmitry Rozhkov
```

## moveit_ros_move_group

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dmitry Rozhkov
```

## moveit_ros_perception

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dmitry Rozhkov
```

## moveit_ros_planning

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* [fix][moveit_ros_planning] Remove unnecessary dependency on Qt4
* Contributors: Dave Coleman, Dmitry Rozhkov
```

## moveit_ros_planning_interface

```
* [enhancement][MoveGroup] Add getLinkNames function (#440 <https://github.com/ros-planning/moveit/issues/440>)
* [doc][moveit_commander] added description for set_start_state (#447 <https://github.com/ros-planning/moveit/issues/447>)
* Contributors: Dmitry Rozhkov, Isaac I.Y. Saito, henhenhen
```

## moveit_ros_robot_interaction

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dmitry Rozhkov
```

## moveit_ros_visualization

```
* [fix] correct "simplify widget handling" #452 <https://github.com/ros-planning/moveit/pull/452> This reverts "simplify widget handling (#442 <https://github.com/ros-planning/moveit/issues/442>)"
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dmitry Rozhkov, Yannick Jonetzko
```

## moveit_ros_warehouse

```
* [fix] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dmitry Rozhkov
```

## moveit_runtime

- No changes

## moveit_setup_assistant

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dmitry Rozhkov
```

## moveit_simple_controller_manager

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dmitry Rozhkov
```
