### PR TITLE
Adding lpms_imu and timesync_ros to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6635,11 +6635,11 @@ repositories:
   timesync_ros:
     doc:
       type: git
-      url: https://github.com/larics/timesync_ros
+      url: https://github.com/larics/timesync_ros.git
       version: master
     source:
       type: git
-      url: https://github.com/larics/timesync_ros
+      url: https://github.com/larics/timesync_ros.git
       version: master
     status: developed
   tiny_slam:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2688,6 +2688,16 @@ repositories:
       url: https://github.com/clearpathrobotics/lms1xx.git
       version: master
     status: maintained
+  lpms_imu:
+    doc:
+      type: git
+      url: https://github.com/larics/lpms_imu.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/larics/lpms_imu.git
+      version: master
+    status: maintained
   lusb:
     doc:
       type: hg
@@ -6622,6 +6632,16 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Tools.git
       version: kinetic-devel
     status: maintained
+  timesync_ros:
+    doc:
+      type: git
+      url: https://github.com/larics/timesync_ros
+      version: master
+    source:
+      type: git
+      url: https://github.com/larics/timesync_ros
+      version: master
+    status: developed
   tiny_slam:
     doc:
       type: git


### PR DESCRIPTION
I would like the lpms_imu and timesync_ros packages to be indexed and documented on ros.org