### PR TITLE
moveit: 0.9.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3102,7 +3102,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.9.4-0
+      version: 0.9.5-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.9.5-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.9.4-0`

## moveit

```
* [fix] correct "simplify widget handling" #452 <https://github.com/ros-planning/moveit/pull/452> This reverts "simplify widget handling (#442 <https://github.com/ros-planning/moveit/issues/442>)"
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* [fix] Regression on Ubuntu Xenial; numpy.ndarray indices bug (from #86 <https://github.com/ros-planning/moveit/issues/86>) (#450 <https://github.com/ros-planning/moveit/issues/450>).
* [enhancement] Remove "catch (...)" instances, catch std::exception instead of std::runtime_error (#445 <https://github.com/ros-planning/moveit/issues/445>)
* [enhancement][MoveGroup] Add getLinkNames function (#440 <https://github.com/ros-planning/moveit/issues/440>)
* [doc][moveit_commander] added description for set_start_state (#447 <https://github.com/ros-planning/moveit/issues/447>)
* Contributors: Adam Allevato, Dave Coleman, Bence Magyar, Dave Coleman, Isaac I.Y. Saito, Yannick Jonetzko, Ravi Prakash Joshi
```

## moveit_commander

```
* [fix] Regression on Ubuntu Xenial; numpy.ndarray indices bug (from #86 <https://github.com/ros-planning/moveit/issues/86>) (#450 <https://github.com/ros-planning/moveit/issues/450>).
* [doc][moveit_commander] added description for set_start_state (#447 <https://github.com/ros-planning/moveit/issues/447>)
* Contributors: Adam Allevato, Ravi Prakash Joshi
```

## moveit_controller_manager_example

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dave Coleman
```

## moveit_core

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* [enhancement] Remove "catch (...)" instances, catch std::exception instead of std::runtime_error (#445 <https://github.com/ros-planning/moveit/issues/445>)
* Contributors: Bence Magyar, Dave Coleman
```

## moveit_fake_controller_manager

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* [enhancement] Remove "catch (...)" instances, catch std::exception instead of std::runtime_error (#445 <https://github.com/ros-planning/moveit/issues/445>)
* Contributors: Bence Magyar, Dave Coleman
```

## moveit_kinematics

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dave Coleman
```

## moveit_planners

- No changes

## moveit_planners_ompl

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dave Coleman
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* [enhancement] Remove "catch (...)" instances, catch std::exception instead of std::runtime_error (#445 <https://github.com/ros-planning/moveit/issues/445>)
* Contributors: Bence Magyar, Dave Coleman
```

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* [enhancement] Remove "catch (...)" instances, catch std::exception instead of std::runtime_error (#445 <https://github.com/ros-planning/moveit/issues/445>)
* Contributors: Bence Magyar, Dave Coleman
```

## moveit_ros_move_group

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* [enhancement] Remove "catch (...)" instances, catch std::exception instead of std::runtime_error (#445 <https://github.com/ros-planning/moveit/issues/445>)
* Contributors: Bence Magyar, Dave Coleman
```

## moveit_ros_perception

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* [enhancement] Remove "catch (...)" instances, catch std::exception instead of std::runtime_error (#445 <https://github.com/ros-planning/moveit/issues/445>)
* Contributors: Bence Magyar, Dave Coleman
```

## moveit_ros_planning

```
* [enhancement] Remove "catch (...)" instances, catch std::exception instead of std::runtime_error (#445 <https://github.com/ros-planning/moveit/issues/445>)
* Contributors: Bence Magyar
```

## moveit_ros_planning_interface

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* [enhancement] Remove "catch (...)" instances, catch std::exception instead of std::runtime_error (#445 <https://github.com/ros-planning/moveit/issues/445>)
* [enhancement][MoveGroup] Add getLinkNames function (#440 <https://github.com/ros-planning/moveit/issues/440>)
* Contributors: Bence Magyar, Dave Coleman
```

## moveit_ros_robot_interaction

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* [enhancement] Remove "catch (...)" instances, catch std::exception instead of std::runtime_error (#445 <https://github.com/ros-planning/moveit/issues/445>)
* Contributors: Bence Magyar, Dave Coleman
```

## moveit_ros_visualization

```
* [fix] correct "simplify widget handling" #452 <https://github.com/ros-planning/moveit/pull/452> This reverts "simplify widget handling (#442 <https://github.com/ros-planning/moveit/issues/442>)"
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* [enhancement] Remove "catch (...)" instances, catch std::exception instead of std::runtime_error (#445 <https://github.com/ros-planning/moveit/issues/445>)
* Contributors: Bence Magyar, Dave Coleman, Isaac I.Y. Saito, Yannick Jonetzko
```

## moveit_ros_warehouse

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dave Coleman
```

## moveit_runtime

- No changes

## moveit_setup_assistant

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* Contributors: Dave Coleman
```

## moveit_simple_controller_manager

```
* [fix][moveit_ros_warehouse] gcc6 build error #423 <https://github.com/ros-planning/moveit/pull/423>
* [enhancement] Remove "catch (...)" instances, catch std::exception instead of std::runtime_error (#445 <https://github.com/ros-planning/moveit/issues/445>)
* Contributors: Bence Magyar, Dave Coleman
```
