### PR TITLE
plotjuggler: 0.12.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8491,7 +8491,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 0.12.1-0
+      version: 0.12.2-0
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `0.12.2-0`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.12.1-0`

## plotjuggler

```
* Left curve list will display current value from vertical tracker
* new splashscreen phrases
* Temporarily disabilig Qt5Svg
* Contributors: Davide Faconti
```
