### PR TITLE
imu_tools: 1.1.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1993,7 +1993,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.1.2-0
+      version: 1.1.3-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/imu_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.1.3-0`:

- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `1.1.2-0`

## imu_complementary_filter

```
* complementary_filter: move const initializations out of header
  Initialization of static consts other than int (here: float) inside the
  class declaration is not permitted in C++. It works in gcc (due to a
  non-standard extension), but throws an error in C++11.
* Contributors: Martin Guenther
```

## imu_filter_madgwick

```
* Return precisely normalized quaternions
  Fixes #67 <https://github.com/ccny-ros-pkg/imu_tools/issues/67> : TF_DENORMALIZED_QUATERNION warning added in TF2 0.5.14.
* Tests: Check that output quaternions are normalized
* Fixed lock so it stays in scope until end of method.
* Contributors: Jason Mercer, Martin Guenther, Martin Günther
```

## imu_tools

- No changes

## rviz_imu_plugin

- No changes
