### PR TITLE
Update eigen-stl-containers to 0.1.8

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2609,7 +2609,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/eigen_stl_containers-release.git
-      version: 0.1.4-0
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/ros/eigen_stl_containers.git


### PR DESCRIPTION
This is a "by-hand" pull request because I answered "no" by accident on the last part of "bloom-release".