### PR TITLE
eigen_stl_containers: 0.1.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1038,7 +1038,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/eigen_stl_containers-release.git
-      version: 0.1.6-0
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/ros/eigen_stl_containers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigen_stl_containers` to `0.1.8-0`:

- upstream repository: https://github.com/ros/eigen_stl_containers
- release repository: https://github.com/ros-gbp/eigen_stl_containers-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.1.6-0`

## eigen_stl_containers

```
* Fix it up so we can correctly find Eigen everywhere.
* Contributors: Chris Lalancette, Kei Okada
```
