### PR TITLE
urdfdom_py: 0.3.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14198,7 +14198,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/urdf_parser_py.git
-      version: 0.3.1
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6848,7 +6848,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/urdf_parser_py.git
-      version: 0.3.1
+      version: indigo-devel
     release:
       tags:
         release: release/jade/{package}/{version}

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7086,7 +7086,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/urdf_parser_py.git
-      version: 0.3.2
+      version: indigo-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -675,5 +675,21 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  urdfdom_py:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: 0.3.2
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/urdfdom_py-release.git
+      version: 0.3.3-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: indigo-devel
+    status: maintained
 type: distribution
 version: 2

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -679,7 +679,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/urdf_parser_py.git
-      version: 0.3.2
+      version: indigo-devel
     release:
       tags:
         release: release/lunar/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_py` to `0.3.3-0`:

- upstream repository: https://github.com/ros/urdf_parser_py/
- release repository: https://github.com/ros-gbp/urdfdom_py-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `null`

## urdfdom_py

```
* Made Chris and Shane the maintainers
* Added python-lxml to the travis build.
* Reverted line break (ros/urdfdom#77 <https://github.com/ros/urdfdom/pull/77>) now that there is a more generic solution. (#5 <https://github.com/ros/urdf_parser_py/issues/5>)
* Added line break to make errors easier to read. (#4 <https://github.com/ros/urdf_parser_py/issues/4>)
* Contributors: Chris Lalancette, Isaac I.Y. Saito
```
