### PR TITLE
ros_tutorials: 0.8.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -532,7 +532,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/ros_tutorials-release.git
-      version: 0.7.1-0
+      version: 0.8.0-0
     source:
       test_pull_requests: true
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -522,7 +522,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/ros_tutorials.git
-      version: kinetic-devel
+      version: lunar-devel
     release:
       packages:
       - ros_tutorials
@@ -537,7 +537,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/ros_tutorials.git
-      version: kinetic-devel
+      version: lunar-devel
     status: maintained
   rosbag_migration_rule:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `0.8.0-0`:

- upstream repository: git@github.com:ros/ros_tutorials.git
- release repository: https://github.com/ros-gbp/ros_tutorials-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.7.1-0`

## ros_tutorials

- No changes

## roscpp_tutorials

- No changes

## rospy_tutorials

- No changes

## turtlesim

```
* add lunar turtle (#39 <https://github.com/ros/ros_tutorials/pull/39>)
```
