### PR TITLE
Adding golang-go and libgoogle-glog-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -876,6 +876,9 @@ gnuplot:
     portage:
       packages: [sci-visualization/gnuplot]
   ubuntu: [gnuplot]
+golang-go:
+  debian: [golang-go]
+  ubuntu: [golang-go]
 google-mock:
   arch: [gmock]
   debian: [google-mock]
@@ -1616,6 +1619,7 @@ libgmp:
   fedora: [gmp-devel]
   ubuntu: [libgmp-dev]
 libgoogle-glog-dev:
+  debian: [libgoogle-glog-dev]
   fedora: [glog-devel]
   gentoo:
     portage:


### PR DESCRIPTION
Adding:
* golang-go
  *  [debian](https://packages.debian.org/jessie/golang-go)
  * [ubuntu](http://packages.ubuntu.com/xenial/golang-go)
* libgoogle-glog-dev
  * [debian](https://packages.debian.org/jessie/libgoogle-glog-dev)