### PR TITLE
rtmros_nextage: 0.7.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11973,6 +11973,7 @@ repositories:
       version: indigo-devel
     release:
       packages:
+      - nextage_calibration
       - nextage_description
       - nextage_gazebo
       - nextage_ik_plugin
@@ -11982,7 +11983,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.7.14-0
+      version: 0.7.15-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.7.15-0`:

- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.7.14-0`

## nextage_calibration

```
* [capability] add package nextage_calibration
* Contributors: Yamamoto Yosuke Design
```

## nextage_description

```
* [fix] Model file copyrights.
```

## nextage_gazebo

- No changes

## nextage_ik_plugin

- No changes

## nextage_moveit_config

- No changes

## nextage_ros_bridge

- No changes

## rtmros_nextage

```
* [capability] add package nextage_calibration
* [fix] Model file copyrights.
* Contributors: Yamamoto Yosuke Design, Isaac I.Y. Saito
```
