### PR TITLE
[Kinetic] Remove csm (revert #14128); not building on ROS buildfarm.

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -712,12 +712,15 @@ repositories:
       version: indigo-devel
     status: developed
   csm:
-    release:
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/tork-a/csm-release.git
-      version: 1.0.2-0
-    status: developed
+    doc:
+      type: git
+      url: https://github.com/AndreaCensi/csm.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/AndreaCensi/csm.git
+      version: master
+    status: maintained
   cv_camera:
     doc:
       type: git


### PR DESCRIPTION
Reported at https://github.com/ccny-ros-pkg/scan_tools/issues/51#issuecomment-285772050
