### PR TITLE
csm: 1.0.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -716,6 +716,11 @@ repositories:
       type: git
       url: https://github.com/AndreaCensi/csm.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/csm-release.git
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/AndreaCensi/csm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `csm` to `1.0.2-1`:

- upstream repository: https://github.com/AndreaCensi/csm.git
- release repository: https://github.com/tork-a/csm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `1.0.2-0`
