### PR TITLE
kvh_drivers: 1.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2506,7 +2506,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/kvh_drivers-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/ros-drivers/kvh_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kvh_drivers` to `1.0.3-0`:

- upstream repository: https://github.com/ros-drivers/kvh_drivers.git
- release repository: https://github.com/ros-drivers-gbp/kvh_drivers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `1.0.2-0`

## kvh

```
* fixed pkg name for launch file
* added check for testing to remove builder warning
* added auto generated wiki page for documentation
* Contributors: Geoff Viola, geoffviola
```
