### PR TITLE
Add junit-xml rules (both distribution-wise and PIP)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1023,10 +1023,6 @@ python-jsonschema-pip:
       packages: [jsonschema]
 python-junitxml:
   ubuntu: [python-junitxml]
-python-junitxml-pip:
-  ubuntu:
-    pip:
-      packages: [junit-xml]
 python-kdtree:
   fedora: [libkdtree++-python]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1021,6 +1021,12 @@ python-jsonschema-pip:
   ubuntu:
     pip:
       packages: [jsonschema]
+python-junitxml:
+  ubuntu: [python-junitxml]
+python-junitxml-pip:
+  ubuntu:
+    pip:
+      packages: [junit-xml]
 python-kdtree:
   fedora: [libkdtree++-python]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1022,6 +1022,10 @@ python-jsonschema-pip:
     pip:
       packages: [jsonschema]
 python-junitxml:
+  debian:
+    jessie: [python-junitxml]
+    stretch: [python-junit.xml]
+  fedora: [python-junit_xml]
   ubuntu: [python-junitxml]
 python-kdtree:
   fedora: [libkdtree++-python]


### PR DESCRIPTION
This package helps creating test output (in platforms where rostest cannot be easily used).

- [junit-xml](https://pypi.python.org/pypi/junit-xml)

Two different rules have been done because of different versioning. PIP is currently on 1.7, but [Ubuntu versions vary significantly](http://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=python-junitxml&searchon=names). I am not sure if this is the correct procedure in this case.