### PR TITLE
vision_opencv: 1.12.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -698,5 +698,24 @@ repositories:
       url: https://github.com/ros/urdf_parser_py.git
       version: indigo-devel
     status: maintained
+  vision_opencv:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: kinetic
+    release:
+      packages:
+      - cv_bridge
+      - image_geometry
+      - vision_opencv
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/vision_opencv-release.git
+      version: 1.12.4-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: kinetic
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.12.4-0`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `null`

## cv_bridge

```
* properly find Boost Python 2 or 3
  This fixes #158 <https://github.com/ros-perception/vision_opencv/issues/158>
* Contributors: Vincent Rabaud
```

## image_geometry

```
* Import using __future__ for python 3 compatibility.
* Contributors: Hans Gaiser
```

## vision_opencv

- No changes
