### PR TITLE
stage: 4.1.1-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -684,7 +684,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/stage-release.git
-      version: 4.1.1-0
+      version: 4.1.1-1
     source:
       type: git
       url: https://github.com/ros-gbp/stage-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `stage` to `4.1.1-1`:

- upstream repository: https://github.com/rtv/Stage.git
- release repository: https://github.com/ros-gbp/stage-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `4.1.1-0`
