### PR TITLE
split libpng and update rules for latest distros

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2196,7 +2196,7 @@ libpng-dev:
     jessie: [libpng12-dev]
     stretch: [libpng-dev]
     wheezy: [libpng12-dev]
-  fedora: [libpng12-devel]
+  fedora: [libpng-devel]
   gentoo:
     portage:
       packages: [media-libs/libpng]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2192,7 +2192,11 @@ libpng++-dev:
   ubuntu: [libpng++-dev]
 libpng12-dev:
   arch: [libpng]
-  debian: [libpng12-dev]
+  debian:
+    jessie: [libpng12-dev]
+    sid: [libpng12-dev]
+    stretch: [libpng-dev]
+    wheezy: [libpng12-dev]
   fedora: [libpng12-devel]
   gentoo:
     portage:
@@ -2200,7 +2204,18 @@ libpng12-dev:
   macports: [libpng]
   opensuse: [libpng12-devel]
   slackware: [libpng]
-  ubuntu: [libpng12-dev]
+  ubuntu:
+    precise: [libpng12-dev]
+    quantal: [libpng12-dev]
+    raring: [libpng12-dev]
+    saucy: [libpng12-dev]
+    trusty: [libpng12-dev]
+    utopic: [libpng12-dev]
+    vivid: [libpng12-dev]
+    wily: [libpng12-dev]
+    xenial: [libpng12-dev]
+    yakkety: [libpng-dev]
+    zesty: [libpng-dev]
 libpoco-dev:
   arch: [poco]
   debian: [libpoco-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2190,11 +2190,10 @@ libphonon-dev:
   ubuntu: [libphonon-dev]
 libpng++-dev:
   ubuntu: [libpng++-dev]
-libpng12-dev:
+libpng-dev:
   arch: [libpng]
   debian:
     jessie: [libpng12-dev]
-    sid: [libpng12-dev]
     stretch: [libpng-dev]
     wheezy: [libpng12-dev]
   fedora: [libpng12-devel]
@@ -2216,6 +2215,17 @@ libpng12-dev:
     xenial: [libpng12-dev]
     yakkety: [libpng-dev]
     zesty: [libpng-dev]
+libpng12-dev:
+  arch: [libpng]
+  debian: [libpng12-dev]
+  fedora: [libpng12-devel]
+  gentoo:
+    portage:
+      packages: [media-libs/libpng]
+  macports: [libpng]
+  opensuse: [libpng12-devel]
+  slackware: [libpng]
+  ubuntu: [libpng12-dev]
 libpoco-dev:
   arch: [poco]
   debian: [libpoco-dev]


### PR DESCRIPTION
follow up on https://github.com/ros/rosdistro/pull/14163#issuecomment-286331857
@ros/ros_team I kept the key name as is (`libpng12-dev`) even if it's not accurate anymore. Would it be better to create a new `libpng-dev` key with all these rules?

@vrabaud FYI