### PR TITLE
jsk_demos: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4957,7 +4957,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_demos-release.git
-      version: 0.0.3-1
+      version: 0.0.4-0
     status: developed
   jsk_model_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_demos` to `0.0.4-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_demos.git
- release repository: https://github.com/tork-a/jsk_demos-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.0.3-1`

## drc_com_common

```
* [drc_task_common] no-UI valve rotation and opening door
* [drc_task_common] Add /map frame_id
* remove old dynamic_reconfigure.parameter_generator, now everything runnning with catkin
* remove depends to rosbuild/mk
* Contributors: Kei Okada, Ryohei Ueda
```

## elevator_move_base_pr2

```
* add catkin_INCLUDE_DIRS
* [elevator_move_base_pr2/src/push-elevator-button.l] use require instead of load pr2-interface
* Contributors: Furushchev, Kei Okada
```

## jsk_demo_common

```
* [jsk_demo_common][pr2-action.l] remove implicit dependency to jsk_smart_gui
* [jsk_demo_common][pr2-action.l] temp fix until jsk-ros-pkg/jsk_smart_apps#70 <https://github.com/jsk-ros-pkg/jsk_smart_apps/issues/70> is merged
* [jsk_demo_common/euslisp/pr2-action.l] refactor grasp-can move state
* Contributors: Yuki Furuta
```

## jsk_maps

```
* [jsk_maps] add README.md
* [jsk_maps] cleanup; add option: launch_map_server
* [jsk_maps][dump-map-info.l] fix: indent
* add ARCHDIR for LinuxARM
* use image filename relative to current yaml file
* [jsk_maps/raw_maps/eng2-7f-0.05.pgm] update 73b2 7f map
* Contributors: Kei Okada, Yuki Furuta
```
