### PR TITLE
adding daemontools for fedora ?

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -512,6 +512,7 @@ cython:
 daemontools:
   arch: [daemontools]
   debian: [daemontools]
+  fedora: [daemontools]
   gentoo:
     portage:
       packages: [sys-process/daemontools]


### PR DESCRIPTION
I am not sure about this... I found the package there : https://pkgs.org/download/daemontools but not there : https://admin.fedoraproject.org/pkgdb/packages/daemontools%2A/
I cannot test on any fedora system.
Anyway I need this https://cr.yp.to/daemontools.html as a dependency on one of my package and it is not declared for fedora.
Please advise...