### PR TITLE
jsk_roseus: 1.6.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2323,10 +2323,11 @@ repositories:
       - jsk_roseus
       - roseus
       - roseus_smach
+      - roseus_tutorials
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.6.0-0
+      version: 1.6.1-0
     status: developed
   jsk_visualization:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.6.1-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `1.6.0-0`

## jsk_roseus

- No changes

## roseus

```
* remove compiler warning from roseus.cpp (#510 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/510>)
  * [hydro] do not eliminate -> warning: deleting object of polymorphic class type ‘tf2_ros::BufferClient’ which has non-virtual destructor might cause undefined behaviour [-Wdelete-non-virtual-dtor]
* [roseus][eustf.l] fix: pass :init args (#506 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/506>)
* add kinetic test (#505 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/505>)
  * test-geneus.test : use rosrun roseus roseus to run test code
  * roseus/CMakeLists.txt : add -DNDEBUG option, see https://github.com/jsk-ros-pkg/jsk_planning/pull/49#issuecomment-280302156
* test/test-tf.test: not sure why but test-tf fails within travis, but works in droplet 2G/2CPU (#499 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/499>)
* default queue size of subscribe/advertise is 1, add this information to documentation (#493 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/493>)
* Fix #417 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/417> (#486 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/486>)
  * [roseus/roseus.cpp] fix: segfault when no response is returned on service callback
  * [roseus] add test-service-callback.test
  * [roseus/roseus.cpp] return false when service callback returns invalid response
  * [roseus/roseus.cpp] use C++ bool for return value
* add aarch64 for arm processors (#484 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/484>)
* [roseus] add example of actionlib feedback (#479 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/479>)
  * [roseus/test/fibonacci-client.l] remove unnecessary new lines.
  * [roseus/test/fibonacci-client.l] add feedback callback.
  * [roseus/test/fibonacci-server.l] remove unnecessary new lines.
  * [roseus/test/fibonacci-client.l] fix correspondence of brackets.
  * [roseus/test/fibonacci-server.l] publish feedback of fibonacci action in loop.
* Contributors: Kei Okada, Masaki Murooka, Yuki Furuta
```

## roseus_smach

```
* Merge smach exec (#507 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/507>)
  * [roseus_smach] rename smach-exec-with-spin -> exec-state-machine
  * [roseus_smach/src/pddl2smach.l] use function namespace to call
* Contributors: Yuki Furuta
```

## roseus_tutorials

- No changes
