### PR TITLE
remove PySide from Zesty for now since upstream doesn't build on it atm

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2043,7 +2043,7 @@ python-qt5-bindings:
     wily: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
     xenial: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
     yakkety: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
-    zesty: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
+    zesty: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
 python-qt5-bindings-gl:
   arch: [python2-pyqt5]
   debian:


### PR DESCRIPTION
This should let `python_qt_binding` pass on Zesty (with PyQt support only).