### PR TITLE
realsense_camera: 1.7.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4842,7 +4842,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/intel-ros/realsense-release.git
-      version: 1.7.1-0
+      version: 1.7.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_camera` to `1.7.2-0`:

- upstream repository: https://github.com/intel-ros/realsense.git
- release repository: https://github.com/intel-ros/realsense-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `1.7.1-0`

## realsense_camera

```
* Create tool to get debug info
* Change tf to using setRPY for consistency
* Changed fisheye_strobe and fisheye_external_trigger to static params
* Contributors: Amanda Brindle, Mark D Horn, Mark Horn, Matthew Hansen, Wang Jinliang
```
