### PR TITLE
python_qt_binding: 0.3.2-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -449,7 +449,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/python_qt_binding-release.git
-      version: 0.3.2-0
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `0.3.2-1`:

- upstream repository: git://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros-gbp/python_qt_binding-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.3.2-0`

## python_qt_binding

```
* Fix problems on OS X (#40 <https://github.com/ros-visualization/python_qt_binding/pull/40>)
```
