### PR TITLE
Adding auction_methods_stack to documentation index for groovy

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -153,6 +153,11 @@ repositories:
       type: git
       url: https://github.com/ethz-asl/asctec_mav_framework.git
       version: master
+  auction_methods_stack:
+    doc:
+      type: git
+      url: https://github.com/joaoquintas/auction_methods_stack
+      version: master
   audio_common:
     doc:
       type: hg


### PR DESCRIPTION
I'd like auction_methods_stack to be indexed and documented on ros.org.