### PR TITLE
Adding auction_methods_stack to documentation index for kinetic

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -153,6 +153,11 @@ repositories:
       type: git
       url: https://github.com/ethz-asl/asctec_mav_framework.git
       version: master
+  auction_methods_stack:
+    doc:
+      type: git
+      url: https://github.com/joaoquintas/auction_methods_stack
+      version: master
   audio_common:
     doc:
       type: hg

--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -153,11 +153,6 @@ repositories:
       type: git
       url: https://github.com/ethz-asl/asctec_mav_framework.git
       version: master
-  auction_methods_stack:
-    doc:
-      type: git
-      url: https://github.com/joaoquintas/auction_methods_stack
-      version: master
   audio_common:
     doc:
       type: hg

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -198,7 +198,7 @@ repositories:
   auction_methods_stack:
     doc:
       type: git
-      url: https://github.com/joaoquintas/auction_methods_stack
+      url: https://github.com/joaoquintas/auction_methods_stack.git
       version: master
   audio_common:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -195,6 +195,11 @@ repositories:
       url: https://github.com/iirob/ati_force_torque.git
       version: kinetic-devel
     status: developed
+  auction_methods_stack:
+    doc:
+      type: git
+      url: https://github.com/joaoquintas/auction_methods_stack
+      version: master
   audio_common:
     doc:
       type: git


### PR DESCRIPTION
I'd like auction_methods_stack to be indexed and documented on ros.org.