### PR TITLE
qt_gui_core: 0.3.4-2 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -471,7 +471,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.3.4-1
+      version: 0.3.4-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.3.4-2`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.3.4-1`

## qt_dotgraph

```
* use Python 3 compatible syntax (#81 <https://github.com/ros-visualization/qt_gui_core/pull/81>)
* fix label size in dot graphs (#75 <https://github.com/ros-visualization/qt_gui_core/pull/75>)
```

## qt_gui

```
* use Python 3 compatible syntax (#81 <https://github.com/ros-visualization/qt_gui_core/pull/81>)
* fix leftover dock widgets when using --command-switch-perspective (#80 <https://github.com/ros-visualization/qt_gui_core/pull/80>)
* make finding new parent logic more robust (#76 <https://github.com/ros-visualization/qt_gui_core/pull/76>)
```

## qt_gui_app

- No changes

## qt_gui_cpp

- No changes

## qt_gui_py_common

```
* use Python 3 compatible syntax (#81 <https://github.com/ros-visualization/qt_gui_core/pull/81>)
```
