### PR TITLE
rtmros_hironx: 1.1.21-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11959,7 +11959,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.20-0
+      version: 1.1.21-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.21-0`:

- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `1.1.20-0`

## hironx_calibration

- No changes

## hironx_moveit_config

- No changes

## hironx_ros_bridge

```
* [fix][hironx py] Let setTargetPose fail when invalid kinematic group name passed. #470 <https://github.com/start-jsk/rtmros_hironx/pull/470>
* [capability][hrpsys-sim] Add hand camera feature.
* [capability] Add rviz.launch. Now you can run RViz with a default view (without running MoveIt! when you don't need to).
```

## rtmros_hironx

```
* [fix][hironx py] Let setTargetPose fail when invalid kinematic group name passed. #470 <https://github.com/start-jsk/rtmros_hironx/pull/470>
* [capability][hrpsys-sim] Add hand camera feature.
* [capability] Add rviz.launch. Now you can run RViz with a default view (without running MoveIt! when you don't need to).
* Contributors: Isaac I.Y. Saito
```
