### PR TITLE
filters: 1.7.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1244,7 +1244,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/filters-release.git
-      version: 1.7.4-1
+      version: 1.7.5-0
     source:
       type: git
       url: https://github.com/ros/filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `1.7.5-0`:

- upstream repository: https://github.com/ros/filters.git
- release repository: https://github.com/ros-gbp/filters-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `1.7.4-1`

## filters

```
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* check for CATKIN_ENABLE_TESTING
* Add support for boolean parameters (fix #6 <https://github.com/ros/filters/issues/6>)
* Contributors: Boris Gromov, Lukas Bulwahn, Tully Foote
```
