### PR TITLE
filters: 1.7.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1148,7 +1148,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/filters-release.git
-      version: 1.7.4-3
+      version: 1.7.5-0
     source:
       type: git
       url: https://github.com/ros/filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `1.7.5-0`:

- upstream repository: https://github.com/ros/filters.git
- release repository: https://github.com/ros-gbp/filters-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `1.7.4-3`

## filters

```
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* check for CATKIN_ENABLE_TESTING
* Add support for boolean parameters (fix #6 <https://github.com/ros/filters/issues/6>)
* Contributors: Boris Gromov, Lukas Bulwahn, Tully Foote
```
