### PR TITLE
plotjuggler: 0.15.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4411,7 +4411,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 0.14.2-0
+      version: 0.15.0-0
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `0.15.0-0`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.14.2-0`

## plotjuggler

```
* Multiple problems fixed with streaming interface nd XY plots
* Contributors: Davide Faconti
```
