### PR TITLE
roslint: 0.11.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -678,6 +678,21 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: kinetic-devel
     status: maintained
+  roslint:
+    doc:
+      type: git
+      url: https://github.com/ros/roslint.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/roslint-release.git
+      version: 0.11.1-0
+    source:
+      type: git
+      url: https://github.com/ros/roslint.git
+      version: master
+    status: maintained
   roslisp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslint` to `0.11.1-0`:

- upstream repository: https://github.com/ros/roslint.git
- release repository: https://github.com/ros-gbp/roslint-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`

## roslint

```
* Set testcase class name, simplify result XML. (#53 <https://github.com/ros/roslint/issues/53>)
* Contributors: Mike Purvis
```
