### PR TITLE
Revert "Add junit-xml rules (both distribution-wise and PIP)"

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1068,12 +1068,6 @@ python-jsonschema-pip:
   ubuntu:
     pip:
       packages: [jsonschema]
-python-junitxml:
-  debian:
-    jessie: [python-junitxml]
-    stretch: [python-junit.xml]
-  fedora: [python-junit_xml]
-  ubuntu: [python-junitxml]
 python-kdtree:
   fedora: [libkdtree++-python]
   ubuntu:


### PR DESCRIPTION
Reverts ros/rosdistro#14161

As per the discussion in #14161 this is an inconsistent state bringing in two different libraries, junitxml and juint_xml are different. I'd like to revert this and make sure we have a a single library. 