### PR TITLE
ros_canopen: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10764,7 +10764,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_canopen-release.git
-      version: 0.6.5-1
+      version: 0.6.6-0
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.6.6-0`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.6.5-1`

## can_msgs

- No changes

## canopen_402

```
* do quickstop for halt only if operation is enabled
* Contributors: Mathias Lüdtke
```

## canopen_chain_node

```
* refactored EMCY handling into separate layer
* do not reset thread for recover
* properly stop run thread if init failed
* Merge pull request #201 <https://github.com/ros-industrial/ros_canopen/issues/201> from ipa-mdl/bcm-sync
  Added support for external sync providers
* deprecation warning for SHM-based master implementations
* implemented canopen_sync_node
* added object access services
* implement level-based object logging
* added node name lookup
* wait only if sync is disabled
* Contributors: Mathias Lüdtke
```

## canopen_master

```
* refactored EMCY handling into separate layer
* print EMCY to stdout
* send node start on recover
  needed for external sync to work properly
* pass halt on error unconditionally
* added canopen_bcm_sync
* added object access services
* implemented ObjectStorage::getStringReader
* implemented ExternalMaster
* Contributors: Mathias Lüdtke
```

## canopen_motor_node

```
* do not call handleReadread in HandleLayer::handleRecover
  this prevents a race condition, it is not needed anyway.
* protect ObjectVariables with mutex
* added test for norm function
* introduced per-controller enforce_limits parameter
* implemented per-joint limits handling
* backport: check if hardware interface matches mode
* Contributors: Mathias Lüdtke
```

## ros_canopen

- No changes

## socketcan_bridge

- No changes

## socketcan_interface

```
* stop CAN driver on read errors as well
* expose socketcan handle
* implemented BCMsocket
* introduced BufferedReader::readUntil
* Contributors: Mathias Lüdtke
```
