### PR TITLE
marti_messages: 0.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6053,7 +6053,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_messages-release.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `0.0.8-0`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.0.7-0`

## marti_can_msgs

- No changes

## marti_common_msgs

- No changes

## marti_nav_msgs

```
* Add GridMap message.
* Contributors: Marc Alban
```

## marti_perception_msgs

- No changes

## marti_sensor_msgs

- No changes

## marti_visualization_msgs

- No changes
