### PR TITLE
py_trees_ros: 0.5.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4544,7 +4544,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 0.5.0-0
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/stonier/py_trees_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `0.5.2-0`:

- upstream repository: https://github.com/stonier/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.5.0-0`

## py_trees_ros

```
* [infra] add missing actionlib dependencies
```
