### PR TITLE
ros_canopen: 0.7.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5232,7 +5232,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_canopen-release.git
-      version: 0.7.0-0
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.7.1-0`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.7.0-0`

## can_msgs

- No changes

## canopen_402

```
* do quickstop for halt only if operation is enabled
* Contributors: Mathias Lüdtke
```

## canopen_chain_node

```
* refactored EMCY handling into separate layer
* do not reset thread for recover
* properly stop run thread if init failed
* deprecation warning for SHM-based master implementations
* implemented canopen_sync_node
* wait only if sync is disabled
* added object access services
* implement level-based object logging
* added node name lookup
* Contributors: Mathias Lüdtke
```

## canopen_master

```
* refactored EMCY handling into separate layer
* print EMCY to stdout
* send node start on recover
  needed for external sync to work properly
* pass halt on error unconditionally
* added canopen_bcm_sync
* implemented ExternalMaster
* added object access services
* implemented ObjectStorage::getStringReader
* Contributors: Mathias Lüdtke
```

## canopen_motor_node

```
* Decouble RobotLayer by introducing HandleLayerBase
* Split layers into different headers and compile units
* do not call handleReadread in HandleLayer::handleRecover
  this prevents a race condition, it is not needed anyway.
* protect ObjectVariables with mutex
* added test for norm function
* fix for joint limit handling
* introduced per-controller enforce_limits parameter
* implemented per-joint limits handling
* check if hardware interface matches mode
* implemented mixed-mode switching (#197 <https://github.com/ipa-mdl/ros_canopen/issues/197>)
* introduced joint reference for *res_it
* Contributors: Mathias Lüdtke, Michael Stoll
```

## ros_canopen

- No changes

## socketcan_bridge

- No changes

## socketcan_interface

```
* stop CAN driver on read errors as well
* expose socketcan handle
* implemented BCMsocket
* introduced BufferedReader::readUntil
* Contributors: Mathias Lüdtke
```
