### PR TITLE
industrial_moveit: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4493,7 +4493,6 @@ repositories:
       url: https://github.com/ros-industrial-release/industrial_moveit-release.git
       version: 0.1.0-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros-industrial/industrial_moveit.git
       version: indigo

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4472,6 +4472,32 @@ repositories:
       url: https://github.com/ros-industrial/industrial_metapackages.git
       version: indigo
     status: developed
+  industrial_moveit:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/industrial_moveit.git
+      version: indigo
+    release:
+      packages:
+      - constrained_ik
+      - industrial_collision_detection
+      - industrial_moveit
+      - industrial_moveit_benchmarking
+      - stomp_core
+      - stomp_moveit
+      - stomp_plugins
+      - stomp_test_kr210_moveit_config
+      - stomp_test_support
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-industrial-release/industrial_moveit-release.git
+      version: 0.1.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-industrial/industrial_moveit.git
+      version: indigo
+    status: developed
   innok_heros_control:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_moveit` to `0.1.0-0`:

- upstream repository: https://github.com/ros-industrial/industrial_moveit.git
- release repository: https://github.com/ros-industrial-release/industrial_moveit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `null`

## constrained_ik

```
* Initial release
* Contributors: Jeremy Zoss, Levi Armstrong, Jonathan W Meyer, Dan Solomon
```

## industrial_collision_detection

```
* Initial release
* Contributors: Levi H Armstrong, Jorge Nicho
```

## industrial_moveit

```
* Initial release
* Contributors: Shaun Edwards, Dan Solomon
```

## industrial_moveit_benchmarking

```
* Initial release
* Contributors: Jonathan Meyer, Levi Armstrong, Jorge Nicho
```

## stomp_core

```
* Initial release
* Contributors: Levi H Armstrong, Jorge Nicho
```

## stomp_moveit

```
* Initial release
* Contributors: Jonathan Meyer, Levi Armstrong, Jorge Nicho
```

## stomp_plugins

```
* Initial release
* Contributors: Jorge Nicho
```

## stomp_test_kr210_moveit_config

```
* Initial release
* Contributors: Jonathan Meyer, Levi Armstrong, Jorge Nicho
```

## stomp_test_support

```
* Initial release
* Contributors: Levi Armstrong, Jorge Nicho
```
