### PR TITLE
tork_rpc: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13709,7 +13709,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/tork_rpc-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tork_rpc` to `0.0.4-0`:

- upstream repository: https://github.com/tork-a/tork_rpc.git
- release repository: https://github.com/tork-a/tork_rpc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.0.3-0`

## tork_rpc

```
* Add some .msg files.
* Doc update, cleanup.
* Contributors: Isaac I.Y. Saito
```

## tork_rpc_util

```
* Add some .msg files.
* Doc update, cleanup.
* Contributors: Isaac I.Y. Saito
```
