### PR TITLE
motoman: 0.3.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6470,7 +6470,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/motoman-release.git
-      version: 0.3.5-0
+      version: 0.3.6-0
     source:
       type: git
       url: https://github.com/ros-industrial/motoman.git


### PR DESCRIPTION
Increasing version of package(s) in repository `motoman` to `0.3.6-0`:

- upstream repository: https://github.com/ros-industrial/motoman.git
- release repository: https://github.com/ros-industrial-release/motoman-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.3.5-0`

## motoman

```
* No changes
```

## motoman_driver

```
* v1.3.7 MotoROS Driver
  Based on updates from Rosen Diankov (Mujin):
  > Detection of "energy savings" mode.
  > Fix support for R3 and R4 robots.
  > Add function to read torque values. (Not implemented in messaging
  yet.)
  > Improve detection of robot's starting position.
  > Allow for multiple packets to be received in single Recv command.
  > Add command for servo power.
  > Add command to clear alarms/errors.
* driver: fix whitespace inconsistencies in launch files. (#120 <https://github.com/ros-industrial/motoman/issues/120>)
* driver: update err msg displayed when 'port' param is not found. (#119 <https://github.com/ros-industrial/motoman/issues/119>)
  IP doesn't have any 'ports', only TCP has those.
* v1.3.5 MotoROS Driver (#114 <https://github.com/ros-industrial/motoman/issues/114>)
  * v1.3.5 MotoROS Driver
  Update prevents error that would occur if the user's robot controller
  has more control-groups than what is supported by MotoROS and ROS-I.
* v1.3.6 MotoROS Driver
  Force user to acknowledge that extra control groups are being ignored.
* v1.3.5 MotoROS Driver
  Update prevents error that would occur if the user's robot controller
  has more control-groups than what is supported by MotoROS and ROS-I.
* Contributors: G.A. vd. Hoorn, Patrick Beeson, Shaun Edwards, Ted Miller, gavanderhoorn
```

## motoman_mh5_support

```
* No changes
```

## motoman_msgs

```
* No changes
```

## motoman_sda10f_moveit_config

```
* No changes
```

## motoman_sda10f_support

```
* sda10f_support: fix malformed stl warning. Fix #123 <https://github.com/ros-industrial/motoman/issues/123>.
  This simply changes the 'solid' that occurs in the STL header to 'dilos', which
  should be enough to not result in ASCII vs Binary STL loader problems.
* Contributors: gavanderhoorn
```

## motoman_sia10d_support

```
* sia10: add 'base' coordinate frame to xacro. For #45 <https://github.com/ros-industrial/motoman/issues/45>.
  This corresponds to the Motoman 'Robot Frame' (not the 'Base Frame'). This
  frame has its origin at the intersection of the S axis and a horizontal
  plane going through the L axis.
  Note: the frame was added manually to the urdf, so the '.urdf' is still out
  of sync with the xacro macro (issue #107 <https://github.com/ros-industrial/motoman/issues/107>).
* Fix for issue #104 <https://github.com/ros-industrial/motoman/issues/104>: fix incorrect joint limits in SIA10 urdf/xacro (#108 <https://github.com/ros-industrial/motoman/issues/108>)
  * sia10: fix joint limits S, R & T. Fix #104 <https://github.com/ros-industrial/motoman/issues/104>.
  This floors PI, instead of rounding. This makes the joint limits slightly
  stricter than what is specced, but will avoid OOB errors on the controller.
  * sia10: make all joint limits correspond to specsheet.
  All values truncated after the 4th digit.
* Contributors: G.A. vd. Hoorn, gavanderhoorn
```

## motoman_sia10f_support

```
* sia10: add 'base' coordinate frame to xacro. For #45 <https://github.com/ros-industrial/motoman/issues/45>.
  This corresponds to the Motoman 'Robot Frame' (not the 'Base Frame'). This
  frame has its origin at the intersection of the S axis and a horizontal
  plane going through the L axis.
  Note: the frame was added manually to the urdf, so the '.urdf' is still out
  of sync with the xacro macro (issue #107 <https://github.com/ros-industrial/motoman/issues/107>).
* Fix for issue #106 <https://github.com/ros-industrial/motoman/issues/106>: use full-precision PI for tool0 transform (#110 <https://github.com/ros-industrial/motoman/issues/110>)
  * sia10f: don't round PI in joint_t-tool0 transform.
  Leads to incorrect 'base->tool0' transform orientations.
  * sia20: don't round PI in joint_t-tool0 transform. Fix #106 <https://github.com/ros-industrial/motoman/issues/106>.
  Leads to incorrect 'base->tool0' transform orientations.
* Fix for issue #104 <https://github.com/ros-industrial/motoman/issues/104>: fix incorrect joint limits in SIA10 urdf/xacro (#108 <https://github.com/ros-industrial/motoman/issues/108>)
  * sia10: fix joint limits S, R & T. Fix #104 <https://github.com/ros-industrial/motoman/issues/104>.
  This floors PI, instead of rounding. This makes the joint limits slightly
  stricter than what is specced, but will avoid OOB errors on the controller.
  * sia10: make all joint limits correspond to specsheet.
  All values truncated after the 4th digit.
* Contributors: G.A. vd. Hoorn, gavanderhoorn
```

## motoman_sia20d_moveit_config

```
* No changes
```

## motoman_sia20d_support

```
* sia20: add 'base' coordinate frame to xacro. For #45 <https://github.com/ros-industrial/motoman/issues/45>.
  This corresponds to the Motoman 'Robot Frame' (not the 'Base Frame'). This
  frame has its origin at the intersection of the S axis and a horizontal
  plane going through the L axis.
* Fix for issue #106 <https://github.com/ros-industrial/motoman/issues/106>: use full-precision PI for tool0 transform (#110 <https://github.com/ros-industrial/motoman/issues/110>)
  * sia10f: don't round PI in joint_t-tool0 transform.
  Leads to incorrect 'base->tool0' transform orientations.
  * sia20: don't round PI in joint_t-tool0 transform. Fix #106 <https://github.com/ros-industrial/motoman/issues/106>.
  Leads to incorrect 'base->tool0' transform orientations.
* Fix for issue #102 <https://github.com/ros-industrial/motoman/issues/102>: fix incorrect joint limits in SIA20 urdf/xacro (#109 <https://github.com/ros-industrial/motoman/issues/109>)
  * sia20d: fix joint limits S, R & T. Fix #102 <https://github.com/ros-industrial/motoman/issues/102>.
  This floors PI, instead of rounding. This makes the joint limits slightly
  stricter than what is specced, but will avoid OOB errors on the controller.
  * sia20d: make all joint limits correspond to specsheet.
  All values truncated after the 4th digit.
* Contributors: G.A. vd. Hoorn, gavanderhoorn
```

## motoman_sia5d_support

```
* sia5: add 'base' coordinate frame to xacro. For #45 <https://github.com/ros-industrial/motoman/issues/45>.
  This corresponds to the Motoman 'Robot Frame' (not the 'Base Frame'). This
  frame has its origin at the intersection of the S axis and a horizontal
  plane going through the L axis.
* Contributors: gavanderhoorn
```
