### PR TITLE
tblib: 1.2.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6479,7 +6479,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/asmodehn/tblib-rosrelease.git
-      version: 1.2.0-1
+      version: 1.2.0-2
     status: maintained
   teb_local_planner:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `tblib` to `1.2.0-2`:

- upstream repository: https://github.com/ionelmc/python-tblib.git
- release repository: https://github.com/asmodehn/tblib-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `1.2.0-1`

## tblib

```
* Fixed handling for tracebacks from generators and other internal improvements
  and optimizations. Contributed by DRayX in #10 <https://github.com/ionelmc/python-tblib/issues/10>
  and #11 <https://github.com/ionelmc/python-tblib/pull/11>.
```
