### PR TITLE
certifi: 2015.11.20-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -487,7 +487,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/asmodehn/certifi-rosrelease.git
-      version: 2015.11.20-0
+      version: 2015.11.20-3
     status: maintained
   class_loader:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `certifi` to `2015.11.20-3`:

- upstream repository: https://github.com/certifi/python-certifi.git
- release repository: https://github.com/asmodehn/certifi-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `2015.11.20-0`
