### PR TITLE
pyzmp: 0.0.14-7 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4630,7 +4630,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/asmodehn/pyzmp-rosrelease.git
-      version: 0.0.14-6
+      version: 0.0.14-7
     source:
       type: git
       url: https://github.com/asmodehn/pyzmp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyzmp` to `0.0.14-7`:

- upstream repository: https://github.com/asmodehn/pyzmp.git
- release repository: https://github.com/asmodehn/pyzmp-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.0.14-6`

## pyzmp

```
* Removing release shell script. now done from setup.py. [alexv]
* Removing package.xml. doing thirdparty release from release repo now.
  [alexv]
* Moving docs to doc. [alexv]
* Merge branch 'docs' of https://github.com/asmodehn/pyzmp. [alexv]Conflicts:
  
  CHANGELOG.rst
* Added doc-requirements. [AlexV]
* Added tutorial and example changelog generated with gitchangelog.
  [AlexV]
* More docs about process managers... [AlexV]
* Added very basic rpc tutorial. [AlexV]
* First doc version generated with sphinx-apidoc. added CHANGELOG.
  [AlexV]
```
