### PR TITLE
pyros_config: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4574,7 +4574,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/asmodehn/pyros-config-rosrelease.git
-      version: 0.1.5-1
+      version: 0.2.0-0
     status: developed
   pyros_test:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_config` to `0.2.0-0`:

- upstream repository: https://github.com/asmodehn/pyros-config.git
- release repository: https://github.com/asmodehn/pyros-config-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.1.5-1`

## pyros_config

```
* Getting rid of config import to avoid deep complex behavior. Lets not
  care about imports here... [AlexV]
* Update gitchangelog from 2.4.1 to 2.5.1. [pyup-bot]
* Pin pytest to latest version 3.0.4. [pyup-bot]
* Pin gitchangelog to latest version 2.4.1. [pyup-bot]
```
