### PR TITLE
webtest: 2.0.18-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7500,7 +7500,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/asmodehn/webtest-rosrelease.git
-      version: 2.0.18-0
+      version: 2.0.18-1
     status: maintained
   wireless:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `webtest` to `2.0.18-1`:

- upstream repository: https://github.com/Pylons/webtest.git
- release repository: https://github.com/asmodehn/webtest-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `2.0.18-0`

## webtest

```
* Avoid deprecation warning with py3.4
```
