### PR TITLE
pyros: 0.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4559,7 +4559,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/asmodehn/pyros-rosrelease.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/asmodehn/pyros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros` to `0.3.2-0`:

- upstream repository: https://github.com/asmodehn/pyros.git
- release repository: https://github.com/asmodehn/pyros-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.3.1-0`

## pyros

```
* Changing api for catkin_pip 0.2. [AlexV]
* Now relying on catkin_pip >0.2. [alexv]
```
