### PR TITLE
Don't test commits for basler_tof + sick_ldmrs_laser

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -686,7 +686,7 @@ repositories:
       url: https://github.com/uos/basler_tof.git
       version: indigo
     source:
-      test_pull_requests: true
+      test_commits: false
       type: git
       url: https://github.com/uos/basler_tof.git
       version: indigo
@@ -12562,6 +12562,7 @@ repositories:
       url: https://github.com/SICKAG/sick_ldmrs_laser.git
       version: indigo
     source:
+      test_commits: false
       type: git
       url: https://github.com/SICKAG/sick_ldmrs_laser.git
       version: indigo

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -268,7 +268,7 @@ repositories:
       url: https://github.com/uos/basler_tof.git
       version: jade
     source:
-      test_pull_requests: true
+      test_commits: false
       type: git
       url: https://github.com/uos/basler_tof.git
       version: jade
@@ -6288,6 +6288,7 @@ repositories:
       url: https://github.com/SICKAG/sick_ldmrs_laser.git
       version: jade
     source:
+      test_commits: false
       type: git
       url: https://github.com/SICKAG/sick_ldmrs_laser.git
       version: jade

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -305,7 +305,7 @@ repositories:
       url: https://github.com/uos/basler_tof.git
       version: kinetic
     source:
-      test_pull_requests: true
+      test_commits: false
       type: git
       url: https://github.com/uos/basler_tof.git
       version: kinetic
@@ -6152,6 +6152,7 @@ repositories:
       url: https://github.com/SICKAG/sick_ldmrs_laser.git
       version: jade
     source:
+      test_commits: false
       type: git
       url: https://github.com/SICKAG/sick_ldmrs_laser.git
       version: jade


### PR DESCRIPTION
* sick_ldmrs_laser depends on libsick_ldmrs, which is only available as
  source package
* basler_tof depends on external binary library