### PR TITLE
control_msgs: 1.4.0-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -181,6 +181,11 @@ repositories:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
       version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/control_msgs-release.git
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `1.4.0-1`:

- upstream repository: git://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros-gbp/control_msgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`

## control_msgs

```
* Add antiwindup to JointControllerState message definition
* Add PidState message
* Contributors: Paul Bovbel
```
