### PR TITLE
realtime_tools: 1.9.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -503,6 +503,11 @@ repositories:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git
       version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/realtime_tools-release.git
+      version: 1.9.2-0
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `1.9.2-0`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros-gbp/realtime_tools-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`
