### PR TITLE
control_toolbox: 1.15.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -196,6 +196,11 @@ repositories:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
       version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/control_toolbox-release.git
+      version: 1.15.0-0
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `1.15.0-0`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros-gbp/control_toolbox-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`

## control_toolbox

```
* avoid ABI breaks in PID class
* fix add_dependencies call
* rollback API changes in PID class
* cfg: removed rosbuild support related error handling
* Contributors: Bence Magyar, Igor Napolskikh, ipa-mig
```
