### PR TITLE
microstrain_3dmgx2_imu: 1.5.12-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3055,6 +3055,21 @@ repositories:
       url: https://github.com/xuefengchang/micros_swarm_framework.git
       version: master
     status: developed
+  microstrain_3dmgx2_imu:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/microstrain_3dmgx2_imu.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/microstrain_3dmgx2_imu-release.git
+      version: 1.5.12-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/microstrain_3dmgx2_imu.git
+      version: indigo-devel
+    status: maintained
   mobility_base_ros:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_3dmgx2_imu` to `1.5.12-1`:

- upstream repository: https://github.com/ros-drivers/microstrain_3dmgx2_imu.git
- release repository: https://github.com/ros-gbp/microstrain_3dmgx2_imu-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`

## microstrain_3dmgx2_imu

```
* Added dependency on log4cxx.
* Contributors: Chad Rockey
```
