### PR TITLE
urg_node: 0.1.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6888,11 +6888,19 @@ repositories:
       version: 1.0.404-0
     status: maintained
   urg_node:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_node.git
+      version: indigo-devel
     release:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/urg_node-release.git
-      version: 0.1.9-0
+      version: 0.1.10-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/urg_node.git
+      version: indigo-devel
     status: maintained
   usb_cam:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node` to `0.1.10-0`:

- upstream repository: https://github.com/ros-drivers/urg_node.git
- release repository: https://github.com/ros-gbp/urg_node-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.1.9-0`

## urg_node

```
* Updated maintainer.
* Error handling for connection failures
* Created urg_lidar.launch
* Installed getID
* Contributors: Eric Tappan, Jeff Schmidt, Kei Okada, Tony Baltovski
```
