### PR TITLE
motoman: 0.3.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6470,7 +6470,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/motoman-release.git
-      version: 0.3.6-0
+      version: 0.3.7-0
     source:
       type: git
       url: https://github.com/ros-industrial/motoman.git


### PR DESCRIPTION
Increasing version of package(s) in repository `motoman` to `0.3.7-0`:

- upstream repository: https://github.com/ros-industrial/motoman.git
- release repository: https://github.com/ros-industrial-release/motoman-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.3.6-0`

## motoman

```
* No changes
```

## motoman_driver

```
* Add dep on std_srvs. Fix #159 <https://github.com/ros-industrial/motoman/issues/159>.
* Contributors: Shaun Edwards, gavanderhoorn
```

## motoman_mh5_support

```
* No changes
```

## motoman_msgs

```
* No changes
```

## motoman_sda10f_moveit_config

```
* No changes
```

## motoman_sda10f_support

```
* No changes
```

## motoman_sia10d_support

```
* No changes
```

## motoman_sia10f_support

```
* No changes
```

## motoman_sia20d_moveit_config

```
* No changes
```

## motoman_sia20d_support

```
* No changes
```

## motoman_sia5d_support

```
* No changes
```
