### PR TITLE
xv_11_laser_driver: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7638,6 +7638,21 @@ repositories:
       url: https://github.com/ethz-asl/ethzasl_xsens_driver.git
       version: master
     status: maintained
+  xv_11_laser_driver:
+    doc:
+      type: git
+      url: https://github.com/rohbotics/xv_11_laser_driver.git
+      version: 0.3.0
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/rohbotics/xv_11_laser_driver-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/rohbotics/xv_11_laser_driver.git
+      version: kinetic-devel
+    status: maintained
   yaml_cpp_0_3:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `xv_11_laser_driver` to `0.3.0-0`:

- upstream repository: https://github.com/rohbotics/xv_11_laser_driver.git
- release repository: https://github.com/rohbotics/xv_11_laser_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## xv_11_laser_driver

```
* update default firmware_version to 2
* Contributors: Rohan Agrawal
```
