### PR TITLE
xv_11_laser_driver: 0.3.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -834,5 +834,20 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: kinetic
     status: maintained
+  xv_11_laser_driver:
+    doc:
+      type: git
+      url: https://github.com/rohbotics/xv_11_laser_driver.git
+      version: 0.3.0
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/rohbotics/xv_11_laser_driver-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/rohbotics/xv_11_laser_driver.git
+      version: kinetic-devel
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `xv_11_laser_driver` to `0.3.0-0`:

- upstream repository: https://github.com/rohbotics/xv_11_laser_driver.git
- release repository: https://github.com/rohbotics/xv_11_laser_driver-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## xv_11_laser_driver

```
* update default firmware_version to 2
* Contributors: Rohan Agrawal
```
