### PR TITLE
jsk_common: 2.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4928,7 +4928,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.2.2-1
+      version: 2.2.3-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.2.3-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.2.2-1`

## dynamic_tf_publisher

- No changes

## image_view2

- No changes

## jsk_common

- No changes

## jsk_data

```
* jsk_data/node_scripts/data_collection_server.py: Dump numpy.ndarray as npz file in data_collection_server.py (#1508 <https://github.com/jsk-ros-pkg/jsk_common/issues/1508>)
  * Fix for flake8
  * Dump numpy.ndarray as npz file, For small size data using npz_compressed.
* Add my name to package.xml as a maintainer
* Contributors: Kentaro Wada
```

## jsk_network_tools

- No changes

## jsk_tilt_laser

- No changes

## jsk_tools

```
* jsk_tools/src/jsk_tools/migration.py: Fix migration of from XXX.[srv|msg] import YYY (#1506 <https://github.com/jsk-ros-pkg/jsk_common/issues/1506>)
* jsk_tools/src/generate_deb_status_table.py: Add python-tabulate-pip as a dependency (#1505 <https://github.com/jsk-ros-pkg/jsk_common/issues/1505>)
* [jsk_tools] Improve test_topic_published.py (check /use_sim_time neatly) (#1504 <https://github.com/jsk-ros-pkg/jsk_common/issues/1504>)
  * jsk_tools/src/test_topic_published.py: Simplify negative check in test_topic_published.py
  * Check /clock publication neatly and fails if timed out
  * Use PublishChecker merge in ros/ros_comm
* jsk_tools/src/generate_deb_status_table.py: Cope with arm64 for deb status table (#1503 <https://github.com/jsk-ros-pkg/jsk_common/issues/1503>)
* Contributors: Kentaro Wada
```

## jsk_topic_tools

```
* jsk_topic_tools/scripts/tf_to_transform.py: Use different value for duration and rate in tf_to_transform.py (#1509 <https://github.com/jsk-ros-pkg/jsk_common/issues/1509>)
  * Rate can be 50 - 100 for example, but duration should be ~1 [s] evenso. In previous implementation, the duration will be 1/100 - 1/50 [s]
  and it is too small to resolve tf.
  
    * Fix for flake8
  
* Contributors: Kentaro Wada
```

## multi_map_server

- No changes

## virtual_force_publisher

- No changes
