### PR TITLE
certifi: 2015.11.20-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -462,7 +462,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/certifi-rosrelease.git
-      version: 2015.11.20-0
+      version: 2015.11.20-1
     status: maintained
   class_loader:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `certifi` to `2015.11.20-1`:

- upstream repository: https://github.com/certifi/python-certifi.git
- release repository: https://github.com/asmodehn/certifi-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `2015.11.20-0`
