### PR TITLE
roch: 1.0.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10331,11 +10331,12 @@ repositories:
       - roch_bringup
       - roch_follower
       - roch_navigation
+      - roch_rapps
       - roch_teleop
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch-release.git
-      version: 1.0.9-0
+      version: 1.0.11-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch` to `1.0.11-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch.git
- release repository: https://github.com/SawYerRobotics-release/roch-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.9-0`

## roch

- No changes

## roch_bringup

```
* Add missing dependences: rocon_app_manager.
* Modified lidar launch files.
* Add rocon to Roch.
```

## roch_follower

```
* Add twist_mux node link.
* Fixed bug will cause can not promote speed of Roch.
```

## roch_navigation

```
* Update safety_controll.launch.xml.
* Update dwa_local_planner_params.yaml.
* Reduce map file size.
* Modified lidar launch files.
* Adjusted all launch files.
```

## roch_rapps

```
* Update README.md
* Modified some launch files.
```

## roch_teleop

```
* Fixed send command can not move.
* Update velocity_smoother.launch.xml.
```
