### PR TITLE
webtest: 2.0.18-2 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -7264,7 +7264,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/webtest-rosrelease.git
-      version: 2.0.18-1
+      version: 2.0.18-2
     status: maintained
   wireless:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `webtest` to `2.0.18-2`:

- upstream repository: https://github.com/Pylons/webtest.git
- release repository: https://github.com/asmodehn/webtest-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `2.0.18-1`

## webtest

```
* Avoid deprecation warning with py3.4
```
