### PR TITLE
tornado: 4.2.1-2 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6687,7 +6687,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/tornado-rosrelease.git
-      version: 4.2.1-1
+      version: 4.2.1-2
     status: maintained
   trac_ik:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `tornado` to `4.2.1-2`:

- upstream repository: https://github.com/tornadoweb/tornado.git
- release repository: https://github.com/asmodehn/tornado-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `4.2.1-1`
