### PR TITLE
flask_cors: 3.0.2-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1170,7 +1170,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/flask-cors-rosrelease.git
-      version: 3.0.2-0
+      version: 3.0.2-1
     status: developed
   flask_restful:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `flask_cors` to `3.0.2-1`:

- upstream repository: https://github.com/corydolphin/flask-cors.git
- release repository: https://github.com/asmodehn/flask-cors-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `3.0.2-0`
