### PR TITLE
flask_restful: 0.3.4-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1177,7 +1177,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/flask-restful-rosrelease.git
-      version: 0.3.4-0
+      version: 0.3.4-1
     status: maintained
   flask_reverse_proxy:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `flask_restful` to `0.3.4-1`:

- upstream repository: https://github.com/flask-restful/flask-restful.git
- release repository: https://github.com/asmodehn/flask-restful-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.3.4-0`
