### PR TITLE
pyros_config: 0.2.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4574,7 +4574,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/pyros-config-rosrelease.git
-      version: 0.1.5-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/asmodehn/pyros-config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_config` to `0.2.0-0`:

- upstream repository: https://github.com/asmodehn/pyros-config.git
- release repository: https://github.com/asmodehn/pyros-config-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.1.5-0`

## pyros_config

```
* Getting rid of config import to avoid deep complex behavior. Lets not
  care about imports here... [AlexV]
* Update gitchangelog from 2.4.1 to 2.5.1. [pyup-bot]
* Pin pytest to latest version 3.0.4. [pyup-bot]
* Pin gitchangelog to latest version 2.4.1. [pyup-bot]
```
