### PR TITLE
aniso8601: 0.8.3-4 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -222,7 +222,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/aniso8601-rosrelease.git
-      version: 0.8.3-3
+      version: 0.8.3-4
     status: maintained
   app_manager:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `aniso8601` to `0.8.3-4`:

- upstream repository: https://bitbucket.org/nielsenb/aniso8601.git
- release repository: https://github.com/asmodehn/aniso8601-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.8.3-3`
