### PR TITLE
certifi: 2015.11.20-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1269,7 +1269,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/certifi-rosrelease.git
-      version: 2015.11.20-1
+      version: 2015.11.20-2
     status: maintained
   cirkit_unit03_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `certifi` to `2015.11.20-2`:

- upstream repository: https://github.com/certifi/python-certifi.git
- release repository: https://github.com/asmodehn/certifi-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `2015.11.20-1`
