### PR TITLE
click: 6.2.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1347,7 +1347,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/click-rosrelease.git
-      version: 6.2.0-0
+      version: 6.2.0-1
     status: maintained
   cmake_modules:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `click` to `6.2.0-1`:

- upstream repository: https://github.com/pallets/click.git
- release repository: https://github.com/asmodehn/click-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `6.2.0-0`
