### PR TITLE
genty: 1.3.0-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1372,6 +1372,13 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: indigo-devel
     status: maintained
+  genty:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/asmodehn/genty-rosrelease.git
+      version: 1.3.0-1
+    status: maintained
   geographic_info:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genty` to `1.3.0-1`:

- upstream repository: https://github.com/box/genty.git
- release repository: https://github.com/asmodehn/genty-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`
