### PR TITLE
tblib: 1.2.0-4 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13494,7 +13494,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/tblib-rosrelease.git
-      version: 1.2.0-3
+      version: 1.2.0-4
     status: maintained
   teb_local_planner:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `tblib` to `1.2.0-4`:

- upstream repository: https://github.com/ionelmc/python-tblib.git
- release repository: https://github.com/asmodehn/tblib-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `1.2.0-3`

## tblib

```
* Fixed handling for tracebacks from generators and other internal improvements
  and optimizations. Contributed by DRayX in #10 <https://github.com/ionelmc/python-tblib/issues/10>
  and #11 <https://github.com/ionelmc/python-tblib/pull/11>.
```
