### PR TITLE
flask_cors: 3.0.2-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3008,7 +3008,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/flask-cors-rosrelease.git
-      version: 3.0.2-1
+      version: 3.0.2-2
     status: developed
   flask_restful:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `flask_cors` to `3.0.2-2`:

- upstream repository: https://github.com/corydolphin/flask-cors.git
- release repository: https://github.com/asmodehn/flask-cors-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `3.0.2-1`
