### PR TITLE
bfl: 0.7.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -43,6 +43,15 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  bfl:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/bfl-release.git
+      version: 0.7.0-0
+    status: end-of-life
+    status_description: Currently this is minimally used and is on 0.7. It needs a
+      maintainer and users to go forward.
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bfl` to `0.7.0-0`:

- upstream repository: http://svn.mech.kuleuven.be/repos/orocos/branches/bfl/branch-0.7/
- release repository: https://github.com/ros-gbp/bfl-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`
