### PR TITLE
roch_robot: 2.0.13-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5123,6 +5123,32 @@ repositories:
       url: https://github.com/RobotnikAutomation/robotnik_sensors.git
       version: kinetic-devel
     status: maintained
+  roch_robot:
+    doc:
+      type: git
+      url: https://github.com/SawYer-Robotics/roch_robot.git
+      version: kinetic
+    release:
+      packages:
+      - roch_base
+      - roch_bringup
+      - roch_capabilities
+      - roch_control
+      - roch_description
+      - roch_ftdi
+      - roch_msgs
+      - roch_robot
+      - roch_safety_controller
+      - roch_sensorpc
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/SawYerRobotics-release/roch_robot-release.git
+      version: 2.0.13-0
+    source:
+      type: git
+      url: https://github.com/SawYer-Robotics/roch_robot.git
+      version: kinetic
+    status: maintained
   rocon_app_platform:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_robot` to `2.0.13-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch_robot.git
- release repository: https://github.com/SawYerRobotics-release/roch_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## roch_base

- No changes

## roch_bringup

- No changes

## roch_capabilities

- No changes

## roch_control

- No changes

## roch_description

- No changes

## roch_ftdi

- No changes

## roch_msgs

- No changes

## roch_robot

- No changes

## roch_safety_controller

- No changes

## roch_sensorpc

- No changes
