### PR TITLE
roch: 2.0.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5123,6 +5123,27 @@ repositories:
       url: https://github.com/RobotnikAutomation/robotnik_sensors.git
       version: kinetic-devel
     status: maintained
+  roch:
+    doc:
+      type: git
+      url: https://github.com/SawYer-Robotics/roch.git
+      version: kinetic
+    release:
+      packages:
+      - roch
+      - roch_follower
+      - roch_navigation
+      - roch_rapps
+      - roch_teleop
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/SawYerRobotics-release/roch-release.git
+      version: 2.0.11-0
+    source:
+      type: git
+      url: https://github.com/SawYer-Robotics/roch.git
+      version: kinetic
+    status: maintained
   roch_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch` to `2.0.11-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch.git
- release repository: https://github.com/SawYerRobotics-release/roch-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## roch

- No changes

## roch_follower

- No changes

## roch_navigation

- No changes

## roch_rapps

- No changes

## roch_teleop

- No changes
