### PR TITLE
flask_restful: 0.3.4-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3015,7 +3015,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/flask-restful-rosrelease.git
-      version: 0.3.4-2
+      version: 0.3.4-3
     status: maintained
   flask_reverse_proxy:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `flask_restful` to `0.3.4-3`:

- upstream repository: https://github.com/flask-restful/flask-restful.git
- release repository: https://github.com/asmodehn/flask-restful-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.3.4-2`
