### PR TITLE
Added smartmontools to rosdep rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3726,6 +3726,11 @@ sixad:
 slime:
   fedora: [emacs-slime]
   ubuntu: [slime]
+smartmontools:
+  arch: [smartmontools]
+  debian: [smartmontools]
+  fedora: [smartmontools]
+  ubuntu: [smartmontools]
 snappy:
   arch: [snappy]
   fedora: [snappy]


### PR DESCRIPTION
* https://www.archlinux.org/packages/extra/x86_64/smartmontools/
* https://packages.debian.org/stretch/smartmontools
* https://admin.fedoraproject.org/pkgdb/package/rpms/smartmontools/
* http://packages.ubuntu.com/xenial/smartmontools