### PR TITLE
Add Orocos packages to kinetic and lunar distribution files

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2715,6 +2715,18 @@ repositories:
       url: https://github.com/clearpathrobotics/lms1xx.git
       version: master
     status: maintained
+  log4cpp:
+    doc:
+      type: git
+      url: https://github.com/orocos-toolchain/log4cpp.git
+      version: toolchain-2.9
+    release:
+      url: https://github.com/orocos-gbp/log4cpp-release.git
+    source:
+      type: git
+      url: https://github.com/orocos-toolchain/log4cpp.git
+      version: toolchain-2.9
+    status: maintained
   lpms_imu:
     doc:
       type: git
@@ -3848,6 +3860,18 @@ repositories:
       url: https://github.com/wg-perception/transparent_objects.git
       version: master
     status: maintained
+  ocl:
+    doc:
+      type: git
+      url: https://github.com/orocos-toolchain/ocl.git
+      version: toolchain-2.9
+    release:
+      url: https://github.com/orocos-gbp/ocl-release.git
+    source:
+      type: git
+      url: https://github.com/orocos-toolchain/ocl.git
+      version: toolchain-2.9
+    status: maintained
   octomap:
     doc:
       type: git
@@ -4897,6 +4921,18 @@ repositories:
       type: git
       url: https://github.com/ros/resource_retriever.git
       version: kinetic-devel
+    status: maintained
+  rfsm:
+    doc:
+      type: git
+      url: https://github.com/orocos/rFSM.git
+      version: master
+    release:
+      url: https://github.com/orocos-gbp/rfsm-release.git
+    source:
+      type: git
+      url: https://github.com/orocos/rFSM.git
+      version: master
     status: maintained
   rgbd_launch:
     doc:
@@ -6098,6 +6134,74 @@ repositories:
       url: https://github.com/tork-a/rtsprofile-release.git
       version: 2.0.0-0
     status: developed
+  rtt:
+    doc:
+      type: git
+      url: https://github.com/orocos-toolchain/rtt.git
+      version: toolchain-2.9
+    release:
+      url: https://github.com/orocos-gbp/rtt-release.git
+    source:
+      type: git
+      url: https://github.com/orocos-toolchain/rtt.git
+      version: toolchain-2.9
+    status: maintained
+  rtt_geometry:
+    doc:
+      type: git
+      url: https://github.com/orocos/rtt_geometry.git
+      version: toolchain-2.9
+    release:
+      packages:
+      - eigen_typekit
+      - kdl_typekit
+      - rtt_geometry
+      url: https://github.com/orocos-gbp/rtt_geometry-release.git
+    source:
+      type: git
+      url: https://github.com/orocos/rtt_geometry.git
+      version: toolchain-2.9
+    status: maintained
+  rtt_ros_integration:
+    doc:
+      type: git
+      url: https://github.com/orocos/rtt_ros_integration.git
+      version: toolchain-2.9
+    release:
+      packages:
+      - rtt_actionlib
+      - rtt_actionlib_msgs
+      - rtt_common_msgs
+      - rtt_diagnostic_msgs
+      - rtt_dynamic_reconfigure
+      - rtt_geometry_msgs
+      - rtt_kdl_conversions
+      - rtt_nav_msgs
+      - rtt_ros
+      - rtt_ros_comm
+      - rtt_ros_integration
+      - rtt_ros_msgs
+      - rtt_rosclock
+      - rtt_roscomm
+      - rtt_rosdeployment
+      - rtt_rosgraph_msgs
+      - rtt_rosnode
+      - rtt_rospack
+      - rtt_rosparam
+      - rtt_sensor_msgs
+      - rtt_shape_msgs
+      - rtt_std_msgs
+      - rtt_std_srvs
+      - rtt_stereo_msgs
+      - rtt_tf
+      - rtt_trajectory_msgs
+      - rtt_visualization_msgs
+      url: https://github.com/orocos-gbp/rtt_ros_integration-release.git
+    source:
+      type: git
+      url: https://github.com/orocos/rtt_ros_integration.git
+      version: toolchain-2.9
+    status: maintained
   rviz:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -391,6 +391,18 @@ repositories:
       url: https://github.com/ros-perception/image_common.git
       version: hydro-devel
     status: maintained
+  log4cpp:
+    doc:
+      type: git
+      url: https://github.com/orocos-toolchain/log4cpp.git
+      version: toolchain-2.9
+    release:
+      url: https://github.com/orocos-gbp/log4cpp-release.git
+    source:
+      type: git
+      url: https://github.com/orocos-toolchain/log4cpp.git
+      version: toolchain-2.9
+    status: maintained
   media_export:
     doc:
       type: git
@@ -455,6 +467,18 @@ repositories:
       type: git
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel
+    status: maintained
+  ocl:
+    doc:
+      type: git
+      url: https://github.com/orocos-toolchain/ocl.git
+      version: toolchain-2.9
+    release:
+      url: https://github.com/orocos-gbp/ocl-release.git
+    source:
+      type: git
+      url: https://github.com/orocos-toolchain/ocl.git
+      version: toolchain-2.9
     status: maintained
   opencv3:
     release:
@@ -531,6 +555,18 @@ repositories:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git
       version: kinetic-devel
+    status: maintained
+  rfsm:
+    doc:
+      type: git
+      url: https://github.com/orocos/rFSM.git
+      version: master
+    release:
+      url: https://github.com/orocos-gbp/rfsm-release.git
+    source:
+      type: git
+      url: https://github.com/orocos/rFSM.git
+      version: master
     status: maintained
   ros:
     doc:
@@ -767,6 +803,74 @@ repositories:
       type: git
       url: https://github.com/ros-visualization/rqt.git
       version: kinetic-devel
+    status: maintained
+  rtt:
+    doc:
+      type: git
+      url: https://github.com/orocos-toolchain/rtt.git
+      version: toolchain-2.9
+    release:
+      url: https://github.com/orocos-gbp/rtt-release.git
+    source:
+      type: git
+      url: https://github.com/orocos-toolchain/rtt.git
+      version: toolchain-2.9
+    status: maintained
+  rtt_geometry:
+    doc:
+      type: git
+      url: https://github.com/orocos/rtt_geometry.git
+      version: toolchain-2.9
+    release:
+      packages:
+      - eigen_typekit
+      - kdl_typekit
+      - rtt_geometry
+      url: https://github.com/orocos-gbp/rtt_geometry-release.git
+    source:
+      type: git
+      url: https://github.com/orocos/rtt_geometry.git
+      version: toolchain-2.9
+    status: maintained
+  rtt_ros_integration:
+    doc:
+      type: git
+      url: https://github.com/orocos/rtt_ros_integration.git
+      version: toolchain-2.9
+    release:
+      packages:
+      - rtt_actionlib
+      - rtt_actionlib_msgs
+      - rtt_common_msgs
+      - rtt_diagnostic_msgs
+      - rtt_dynamic_reconfigure
+      - rtt_geometry_msgs
+      - rtt_kdl_conversions
+      - rtt_nav_msgs
+      - rtt_ros
+      - rtt_ros_comm
+      - rtt_ros_integration
+      - rtt_ros_msgs
+      - rtt_rosclock
+      - rtt_roscomm
+      - rtt_rosdeployment
+      - rtt_rosgraph_msgs
+      - rtt_rosnode
+      - rtt_rospack
+      - rtt_rosparam
+      - rtt_sensor_msgs
+      - rtt_shape_msgs
+      - rtt_std_msgs
+      - rtt_std_srvs
+      - rtt_stereo_msgs
+      - rtt_tf
+      - rtt_trajectory_msgs
+      - rtt_visualization_msgs
+      url: https://github.com/orocos-gbp/rtt_ros_integration-release.git
+    source:
+      type: git
+      url: https://github.com/orocos/rtt_ros_integration.git
+      version: toolchain-2.9
     status: maintained
   stage:
     release:

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -487,6 +487,22 @@ repositories:
       url: https://github.com/ros-gbp/opencv3-release.git
       version: 3.2.0-6
     status: maintained
+  orocos_kinematics_dynamics:
+    doc:
+      type: git
+      url: https://github.com/orocos/orocos_kinematics_dynamics.git
+      version: master
+    release:
+      packages:
+      - orocos_kdl
+      - orocos_kinematics_dynamics
+      - python_orocos_kdl
+      url: https://github.com/smits/orocos-kdl-release.git
+    source:
+      type: git
+      url: https://github.com/orocos/orocos_kinematics_dynamics.git
+      version: master
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
- log4cpp
- rtt
- ocl
- rfsm
- rtt_ros_integration
- rtt_geometry
- orocos_kinematics_dynamics (lunar only)

I only added the release repository URLs to the `release` keys, without a `tags` or `version` entry. I hope that's okay and bloom will add the version number once the packages are released. The release repositories do not yet have kinetic or lunar tracks. All tests run fine.