### PR TITLE
adding thingmagic_rfid to doc index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13658,6 +13658,16 @@ repositories:
       url: https://github.com/davetcoleman/tf_keyboard_cal.git
       version: indigo-devel
     status: developed
+  thingmagic_rfid:
+    doc:
+      type: git
+      url: https://github.com/bsb808/thingmagic_rfid.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/bsb808/thingmagic_rfid.git
+      version: master
+    status: developed
   threemxl:
     doc:
       type: git


### PR DESCRIPTION
I'd like to have thingmagic_rfid indexed by ros.org