### PR TITLE
industrial_moveit: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4498,7 +4498,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/industrial_moveit-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ros-industrial/industrial_moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_moveit` to `0.1.1-0`:

- upstream repository: https://github.com/ros-industrial/industrial_moveit.git
- release repository: https://github.com/ros-industrial-release/industrial_moveit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.1.0-0`

## constrained_ik

- No changes

## industrial_collision_detection

- No changes

## industrial_moveit

- No changes

## industrial_moveit_benchmarking

- No changes

## stomp_core

- No changes

## stomp_moveit

- No changes

## stomp_plugins

- No changes

## stomp_test_kr210_moveit_config

- No changes

## stomp_test_support

- No changes
