### PR TITLE
rtmros_hironx: 1.1.22-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12020,7 +12020,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.21-0
+      version: 1.1.22-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.22-0`:

- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `1.1.21-0`

## hironx_calibration

- No changes

## hironx_moveit_config

- No changes

## hironx_ros_bridge

```
* [Improve][rtm py] Return more specific error when actual error occurs. #487 <https://github.com/start-jsk/rtmros_hironx/issues/487>.
* [test] Export a common test py module. #490 <https://github.com/start-jsk/rtmros_hironx/issues/490>.
* Contributors: Isaac I.Y. Saito
```

## rtmros_hironx

- No changes
