### PR TITLE
hironx_rpc: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3938,6 +3938,25 @@ repositories:
       url: https://github.com/heron/heron.git
       version: indigo-devel
     status: developed
+  hironx_rpc:
+    doc:
+      type: git
+      url: https://github.com/tork-a/hironx_rpc.git
+      version: master
+    release:
+      packages:
+      - hironx_rpc
+      - hironx_rpc_msgs
+      - hironx_rpc_server
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/hironx_rpc-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/tork-a/hironx_rpc.git
+      version: master
+    status: maintained
   hokuyo3d:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hironx_rpc` to `0.0.2-0`:

- upstream repository: https://github.com/tork-a/hironx_rpc.git
- release repository: https://github.com/tork-a/hironx_rpc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`

## hironx_rpc

```
* Initial release into ROS buildfarm Indigo.
* Apply package.xml format 2. Use Apache license.
* Contributors: Isaac I.Y. Saito
```

## hironx_rpc_msgs

- No changes

## hironx_rpc_server

- No changes
