### PR TITLE
m_explore: 1.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2625,7 +2625,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/hrnr/m-explore-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/hrnr/m-explore.git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2617,7 +2617,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/hrnr/m-explore.git
-      version: master
+      version: jade-devel
     release:
       packages:
       - explore_lite
@@ -2629,7 +2629,7 @@ repositories:
     source:
       type: git
       url: https://github.com/hrnr/m-explore.git
-      version: master
+      version: jade-devel
     status: developed
   maggie_devices_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `m_explore` to `1.0.1-0`:

- upstream repository: https://github.com/hrnr/m-explore.git
- release repository: https://github.com/hrnr/m-explore-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `1.0.0-0`

## explore_lite

```
* update documentation
* Contributors: Jiri Horner
```

## multirobot_map_merge

```
* map_merge: use inverted tranform
  * transform needs to be inverted before using
* map_merge: change package description
  * we support merging with unknown initial positions
* Contributors: Jiri Horner
```
