### PR TITLE
xacro: 1.12.0-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -963,6 +963,21 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: kinetic
     status: maintained
+  xacro:
+    doc:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: lunar-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/xacro-release.git
+      version: 1.12.0-1
+    source:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: lunar-devel
+    status: developed
   xv_11_laser_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.12.0-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`

## xacro

- No changes
