### PR TITLE
opencv_apps: 1.11.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7880,7 +7880,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-perception/opencv_apps-release.git
-      version: 1.11.14-0
+      version: 1.11.15-0
     source:
       type: git
       url: https://github.com/ros-perception/opencv_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `opencv_apps` to `1.11.15-0`:

- upstream repository: https://github.com/ros-perception/opencv_apps.git
- release repository: https://github.com/ros-perception/opencv_apps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `1.11.14-0`

## opencv_apps

```
* New Nodes
  
    * [color_filter_nodelet.cpp] Add color_filter nodelet (#48 <https://github.com/ros-perception/opencv_apps/issues/48>)
      * use BGR2HSB, support H from 0-360 and 350 - 360+a
      * Unified hsl -> hls
      * Add hsv_color_filter test
      * Modified hls_color_filter's test paramter.  Extracting skin color.
    * [corner_harris_nodelet.cpp] Add corner-harris (#38 <https://github.com/ros-perception/opencv_apps/issues/38> )
    * [discrete_fourier_transform_nodelet.cpp] Add discrete_fourier_transform_nodelet (#36 <https://github.com/ros-perception/opencv_apps/issues/36> )
  
* New Feature
* Fix / Improvement
* Contributors: Isaac I.Y. Saito, Kei Okada, Kentaro Wada, Yuki Furuta, Iori Yanokura
```
