### PR TITLE
[rosdep] Add Adafruit BNO055 python library

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -112,6 +112,16 @@ python:
     yakkety_python3: [python3-dev]
     zesty: [python-dev]
     zesty_python3: [python3-dev]
+python-adafruit-bno055:
+  debian:
+    pip:
+      packages: [adafruit_bno055]
+  fedora:
+    pip:
+      packages: [adafruit_bno055]
+  ubuntu:
+    pip:
+      packages: [adafruit_bno055]
 python-alembic:
   fedora: [python-alembic]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -112,7 +112,7 @@ python:
     yakkety_python3: [python3-dev]
     zesty: [python-dev]
     zesty_python3: [python3-dev]
-python-adafruit-bno055:
+python-adafruit-bno055-pip:
   debian:
     pip:
       packages: [adafruit_bno055]


### PR DESCRIPTION
Added python-adafruit-bno055 to rosdep as used by https://github.com/markusgrotz/ros_bno055_driver

Let me know if python-adafruit-bno055-pip is the better name here.