### PR TITLE
m_explore: 2.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2767,6 +2767,24 @@ repositories:
       url: https://bitbucket.org/AndyZe/lyap_control.git
       version: master
     status: maintained
+  m_explore:
+    doc:
+      type: git
+      url: https://github.com/hrnr/m-explore.git
+      version: kinetic-devel
+    release:
+      packages:
+      - explore_lite
+      - multirobot_map_merge
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/hrnr/m-explore-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/hrnr/m-explore.git
+      version: kinetic-devel
+    status: developed
   manipulation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `m_explore` to `2.0.0-1`:

- upstream repository: https://github.com/hrnr/m-explore.git
- release repository: https://github.com/hrnr/m-explore-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`

## explore_lite

```
* explore: migrate to package format 2
* explore: remove internal version of navfn_ros
  * my changes are included in the ros since kinetic
* Contributors: Jiri Horner
```

## multirobot_map_merge

```
* map_merge: upgrade to package format 2
* node completely rewritten based on my work included in opencv
* uses more reliable features by default -> more robust merging
* known_init_poses is now by default false to make it easy to start for new users
* Contributors: Jiri Horner
```
