### PR TITLE
ursa_driver: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14347,6 +14347,21 @@ repositories:
       url: https://github.com/ros-drivers/urg_node.git
       version: indigo-devel
     status: maintained
+  ursa_driver:
+    doc:
+      type: git
+      url: https://github.com/mikehosmar/ursa_driver.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/mikehosmar/ursa_driver-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/mikehosmar/ursa_driver.git
+      version: master
+    status: maintained
   usb_cam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ursa_driver` to `0.1.1-0`:

- upstream repository: https://github.com/mikehosmar/ursa_driver.git
- release repository: https://github.com/mikehosmar/ursa_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`

## ursa_driver

```
* 0.1.1 <https://github.com/mars-uoit/URSAII-Driver/compare/0.1.0...0.1.1> Diff
* Changelog fixes.
* Added frame to publisher
* Added Travis CI and roslaunch check.
* Fixed changelog for github
* fixed README.md
* Contributors: Mike Hosmar, Tony Baltovski, mikehosmar
```
