### PR TITLE
ftputil: 3.3.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3157,7 +3157,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/ftputil-rosrelease.git
-      version: 3.3.0-1
+      version: 3.3.0-2
     status: maintained
   fulanghua_navigation:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `ftputil` to `3.3.0-2`:

- upstream repository: http://hg.sschwarzer.net/ftputil
- release repository: https://github.com/asmodehn/ftputil-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `3.3.0-1`
