### PR TITLE
nerian_sp1: 1.6.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3695,7 +3695,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/nerian-vision/nerian_sp1-release.git
-      version: 1.6.0-0
+      version: 1.6.1-0
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_sp1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_sp1` to `1.6.1-0`:

- upstream repository: https://github.com/nerian-vision/nerian_sp1.git
- release repository: https://github.com/nerian-vision/nerian_sp1-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.6.0-0`

## nerian_sp1

```
* Updated libvisiontransfer to version 4.1.2
* Contributors: Konstantin Schauwecker
```
