### PR TITLE
random_numbers: 0.3.1-1 in 'lunar/distribution.yaml'

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -558,6 +558,10 @@ repositories:
       version: kinetic-devel
     status: maintained
   random_numbers:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: master
     release:
       tags:
         release: release/lunar/{package}/{version}
@@ -566,7 +570,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-planning/random_numbers.git
-      version: 0.3.1
+      version: master
     status: maintained
   realtime_tools:
     doc:

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -557,6 +557,17 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: kinetic-devel
     status: maintained
+  random_numbers:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/random_numbers-release.git
+      version: 0.3.1-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: 0.3.1
+    status: maintained
   realtime_tools:
     doc:
       type: git


### PR DESCRIPTION
Releasing random_numbers for lunar.

upstream repository: https://github.com/ros-planning/random_numbers.git
release repository: https://github.com/ros-gbp/random_numbers-release.git
distro file: `lunar/distribution.yaml`
bloom version: `0.5.25`