### PR TITLE
cepton: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1272,6 +1272,13 @@ repositories:
       url: https://github.com/asmodehn/catkin_pip.git
       version: indigo
     status: developed
+  cepton:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ceptontech/cepton_ros-release.git
+      version: 0.1.0-0
+    status: developed
   certifi:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `cepton` to `0.1.0-0`:

- upstream repository: https://github.com/ceptontech/cepton_ros
- release repository: https://github.com/ceptontech/cepton_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`

## cepton

```
* Initial point cloud publisher.
* Contributors: Jonathan Allen
```
