### PR TITLE
resource_retriever: 1.12.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4941,7 +4941,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/resource_retriever-release.git
-      version: 1.12.2-0
+      version: 1.12.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `1.12.3-0`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros-gbp/resource_retriever-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `1.12.2-0`

## resource_retriever

```
* Fix C++11 to use set_directory_properties
* Make Shane and Chris the maintainers.
* Python3 compatibility (#10 <https://github.com/ros/resource_retriever/issues/10>)
  * Replace urlgrabber with urllib[2]
  As urlgrabber is not supported for Python 3 replace it with either the built-in urllib (Python 2) or urllib2 (Python 3)
  * Use rospkg instead of system call for rospack
  * Add test for python functionality
  * Fix rospkg dependency definition
* Update URL in http test to something which exists (#8 <https://github.com/ros/resource_retriever/issues/8>)
  * Update URL in http test to something which exists
* Contributors: Chris Lalancette, Mike Purvis, Ruben Smits
```
