### PR TITLE
robot_model: 1.11.13-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5050,7 +5050,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.11.12-0
+      version: 1.11.13-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.11.13-0`:

- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `1.11.12-0`

## collada_parser

```
* Use urdf::*ShredPtr instead of boost::shared_ptr (#144 <https://github.com/ros/robot_model/issues/144>)
* add Chris and Shane as maintainers (#185 <https://github.com/ros/robot_model/issues/185>)
* Contributors: Jochen Sprickerhof, William Woodall
```

## collada_urdf

```
* Use urdf::*ShredPtr instead of boost::shared_ptr (#144 <https://github.com/ros/robot_model/issues/144>)
* Remove old gazebo settings.
  Based on an initial patch from YoheiKakiuchi, just totally
  remove old Gazebo 1.0 settings, as they are never used and
  almost certainly will never be used.
* add Chris and Shane as maintainers (#185 <https://github.com/ros/robot_model/issues/185>)
* remove divide by 2 when writing boxes to collada format (#133 <https://github.com/ros/robot_model/issues/133>)
* Contributors: Chris Lalancette, Jackie Kay, Jochen Sprickerhof, William Woodall
```

## joint_state_publisher

```
* [joint_state_publisher] Handle time moving backwards
  Without this patch, joint_state_publisher dies whenever the ROS time moves backwards (e.g., when running rosbag play --clock --loop).
* Switch a couple more packages over to Chris and Shane.
* Contributors: Chris Lalancette, Martin Günther
```

## kdl_parser

```
* Use urdf::*ShredPtr instead of boost::shared_ptr (#144 <https://github.com/ros/robot_model/issues/144>)
* add Chris and Shane as maintainers (#185 <https://github.com/ros/robot_model/issues/185>)
* Contributors: Jochen Sprickerhof, William Woodall
```

## kdl_parser_py

```
* Switch a couple more packages over to Chris and Shane.
* Contributors: Chris Lalancette
```

## robot_model

```
* add Chris and Shane as maintainers (#185 <https://github.com/ros/robot_model/issues/185>)
* Contributors: William Woodall
```

## urdf

```
* Use urdf::*ShredPtr instead of boost::shared_ptr (#144 <https://github.com/ros/robot_model/issues/144>)
* add Chris and Shane as maintainers (#185 <https://github.com/ros/robot_model/issues/185>)
* Contributors: Jochen Sprickerhof, William Woodall
```

## urdf_parser_plugin

```
* Use urdf::*ShredPtr instead of boost::shared_ptr (#144 <https://github.com/ros/robot_model/issues/144>)
* add Chris and Shane as maintainers (#185 <https://github.com/ros/robot_model/issues/185>)
* Contributors: Jochen Sprickerhof, William Woodall
```
