### PR TITLE
bond_core: 1.7.19-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -67,7 +67,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/bond_core-release.git
-      version: 1.7.18-0
+      version: 1.7.19-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.7.19-0`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `1.7.18-0`

## bond

- No changes

## bond_core

- No changes

## bondcpp

```
* fix unused var warning
* Contributors: Mikael Arguedas
```

## bondpy

- No changes

## smclib

- No changes
