### PR TITLE
pluginlib: 1.10.5-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -512,7 +512,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.10.4-0
+      version: 1.10.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.10.5-0`:

- upstream repository: https://github.com/ros/pluginlib
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `1.10.4-0`

## pluginlib

```
* Merge pull request #47 <https://github.com/ros/pluginlib/issues/47> from ros/fix_conversion
  fix size_t to int conversion
* fix int conversion
* Contributors: Mikael Arguedas
```
