### PR TITLE
navigation_2d: 0.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3623,7 +3623,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/skasperski/navigation_2d-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/skasperski/navigation_2d.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_2d` to `0.3.2-0`:

- upstream repository: https://github.com/skasperski/navigation_2d.git
- release repository: https://github.com/skasperski/navigation_2d-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `0.3.1-0`
