### PR TITLE
navigation_2d: 0.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7288,7 +7288,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/skasperski/navigation_2d-release.git
-      version: 0.1.4-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/skasperski/navigation_2d.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_2d` to `0.3.2-0`:

- upstream repository: https://github.com/skasperski/navigation_2d.git
- release repository: https://github.com/skasperski/navigation_2d-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.1.4-0`
