### PR TITLE
ros_canopen: 0.7.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5247,7 +5247,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_canopen-release.git
-      version: 0.7.1-0
+      version: 0.7.2-0
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.7.2-0`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.7.1-0`

## can_msgs

- No changes

## canopen_402

- No changes

## canopen_chain_node

- No changes

## canopen_master

```
* fix: handle EMCY as error, not as warning
* Contributors: Mathias Lüdtke
```

## canopen_motor_node

- No changes

## ros_canopen

- No changes

## socketcan_bridge

- No changes

## socketcan_interface

- No changes
