### PR TITLE
rtt_ros_integration: 2.8.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6142,7 +6142,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_ros_integration-release.git
-      version: 2.8.4-1
+      version: 2.8.5-0
     source:
       type: git
       url: https://github.com/orocos/rtt_ros_integration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_ros_integration` to `2.8.5-0`:

- upstream repository: https://github.com/orocos/rtt_ros_integration.git
- release repository: https://github.com/orocos-gbp/rtt_ros_integration-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `2.8.4-1`

## rtt_actionlib

- No changes

## rtt_actionlib_msgs

- No changes

## rtt_common_msgs

- No changes

## rtt_diagnostic_msgs

- No changes

## rtt_dynamic_reconfigure

```
* Merge pull request #86 <https://github.com/orocos/rtt_ros_integration/issues/86> from orocos/rtt_dynamic_reconfigure-check-updated-properties
  rtt_dynamic_reconfigure: report updated property values in the service response (indigo-devel)
* Contributors: Johannes Meyer
```

## rtt_geometry_msgs

- No changes

## rtt_kdl_conversions

- No changes

## rtt_nav_msgs

- No changes

## rtt_ros

```
* Merge pull request #85 <https://github.com/orocos/rtt_ros_integration/issues/85> from meyerj/ros-primitives-transport-indigo-devel
  Added a ROS transport plugin for primitive types (indigo-devel)
* Contributors: Johannes Meyer
```

## rtt_ros_comm

- No changes

## rtt_ros_integration

- No changes

## rtt_ros_msgs

- No changes

## rtt_rosclock

- No changes

## rtt_roscomm

```
* Merge pull request #85 <https://github.com/orocos/rtt_ros_integration/issues/85> from meyerj/ros-primitives-transport-indigo-devel
  Added a ROS transport plugin for primitive types (indigo-devel)
* rtt_roscomm: fix caller engine in RosServiceServerProxyBase to make sure that OwnThread operations are executed in the owner's thread
* rtt_roscomm: added topicLatched() method to rtt_rostopic service
* rtt_roscomm: only set CMAKE_BUILD_TYPE to MinSizeRel if either not set or if it was Release before
  This enables debugging of ROS typekits.
* Contributors: Johannes Meyer
```

## rtt_rosdeployment

- No changes

## rtt_rosgraph_msgs

- No changes

## rtt_rosnode

- No changes

## rtt_rospack

- No changes

## rtt_rosparam

- No changes

## rtt_sensor_msgs

- No changes

## rtt_shape_msgs

- No changes

## rtt_std_msgs

```
* Merge pull request #85 <https://github.com/orocos/rtt_ros_integration/issues/85> from meyerj/ros-primitives-transport-indigo-devel
  Added a ROS transport plugin for primitive types (indigo-devel)
* Contributors: Johannes Meyer
```

## rtt_std_srvs

- No changes

## rtt_stereo_msgs

- No changes

## rtt_tf

- No changes

## rtt_trajectory_msgs

- No changes

## rtt_visualization_msgs

- No changes
