### PR TITLE
Add python periphery pip lib

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1575,6 +1575,19 @@ python-percol:
   ubuntu:
     pip:
       packages: [percol]
+python-periphery:
+  debian:
+    pip:
+      packages: [python-periphery]
+  fedora:
+    pip:
+      packages: [python-periphery]
+  osx:
+    pip:
+      packages: [python-periphery]
+  ubuntu:
+    pip:
+      packages: [python-periphery]
 python-pexpect:
   arch: [python2-pexpect]
   debian: [python-pexpect]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1575,7 +1575,7 @@ python-percol:
   ubuntu:
     pip:
       packages: [percol]
-python-periphery:
+python-periphery-pip:
   debian:
     pip:
       packages: [python-periphery]


### PR DESCRIPTION
This PR adds support for the [python-periphery](https://github.com/vsergeev/python-periphery) library, a 1.x-quality library for interacting with GPIO, I2C and others:

> python-periphery is a pure Python library for GPIO, LED, PWM, SPI, I2C, MMIO, and Serial peripheral I/O interface access in userspace Linux. It is useful in embedded Linux environments (including Raspberry Pi, BeagleBone, etc. platforms) for interfacing with external peripherals. python-periphery is compatible with Python 2 and Python 3, is written in pure Python, and is MIT licensed.