### PR TITLE
orocos_kinematics_dynamics: 1.3.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -497,7 +497,10 @@ repositories:
       - orocos_kdl
       - orocos_kinematics_dynamics
       - python_orocos_kdl
+      tags:
+        release: release/lunar/{package}/{version}
       url: https://github.com/smits/orocos-kdl-release.git
+      version: 1.3.1-0
     source:
       type: git
       url: https://github.com/orocos/orocos_kinematics_dynamics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kinematics_dynamics` to `1.3.1-0`:

- upstream repository: https://github.com/orocos/orocos_kinematics_dynamics.git
- release repository: https://github.com/smits/orocos-kdl-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`
