### PR TITLE
[rosdep] pyqt5-dev-tools rule for fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3502,6 +3502,7 @@ pyqt4-dev-tools:
   ubuntu: [pyqt4-dev-tools]
 pyqt5-dev-tools:
   debian: [pyqt5-dev-tools]
+  fedora: [python-qt5-devel]
   ubuntu: [pyqt5-dev-tools]
 python-cairo:
   fedora: [pycairo]


### PR DESCRIPTION
so it can bloom