### PR TITLE
Revert "roch_robot: 1.0.13-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10417,7 +10417,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_robot-release.git
-      version: 1.0.13-0
+      version: 1.0.12-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_robot.git


### PR DESCRIPTION
Reverts ros/rosdistro#14268

Rolling back to 1.0.12 without the circular dependency blocking reconfigure: https://github.com/ros/rosdistro/issues/14360