### PR TITLE
Removing roch_robot release from kinetic due to circular dependency

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5226,7 +5226,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_robot-release.git
-      version: 2.0.13-1
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_robot.git


### PR DESCRIPTION
https://github.com/ros/rosdistro/issues/14360

Reverts: #14306 and #14299 combined for release targets