### PR TITLE
hypothesis: 3.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1864,6 +1864,13 @@ repositories:
       url: https://github.com/ahornung/humanoid_msgs.git
       version: devel
     status: maintained
+  hypothesis:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/asmodehn/hypothesis-rosrelease.git
+      version: 3.0.1-0
+    status: maintained
   iai_common_msgs:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `hypothesis` to `3.0.1-0`:

- upstream repository: https://github.com/HypothesisWorks/hypothesis-python.git
- release repository: https://github.com/asmodehn/hypothesis-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`
