### PR TITLE
Reverting roch_viz to remove circular dependency

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10449,7 +10449,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_viz-release.git
-      version: 1.0.8-0  
+      version: 1.0.8-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_viz.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10449,7 +10449,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_viz-release.git
-      version: 1.0.9-1
+      version: 1.0.8-0  
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_viz.git


### PR DESCRIPTION
As flagged in #14360 

@SawYer-Robotics FYI

Reverts: https://github.com/ros/rosdistro/pull/14273 
