### PR TITLE
Revert "remove roch_viz release"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10449,6 +10449,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_viz-release.git
+      version: 1.0.8-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_viz.git


### PR DESCRIPTION
Reverts ros/rosdistro#14377

This wasn't necessary the 1.0.8 didn't propgate to the rosdistro cache for 20 minutes so my tests were using the older version. 