### PR TITLE
nodelet_core: 1.9.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3784,7 +3784,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.9.9-0
+      version: 1.9.10-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.10-0`:

- upstream repository: https://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `1.9.9-0`

## nodelet

```
* installs the list_nodelets script (#58 <https://github.com/ros/nodelet_core/issues/58>)
  * python3 compatibility
  * pep8
  * install list_nodelets
  * print message with service name
* return outside of try catch
* fix unused var warning
* give node a name, empty node names not supported since https://github.com/ros/ros_comm/commit/bd3af70520648783da8aa4d3610f234a4d2bd41f
* remove tabs
* fix help message
* Contributors: Mikael Arguedas
```

## nodelet_core

- No changes

## nodelet_topic_tools

- No changes
