### PR TITLE
actionlib: 1.11.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -36,7 +36,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.11.8-0
+      version: 1.11.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.11.9-0`:

- upstream repository: https://github.com/ros/actionlib.git
- release repository: https://github.com/ros-gbp/actionlib-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `1.11.8-0`

## actionlib

```
* Python3 compatibility + pep8 compliance (#71 <https://github.com/ros/actionlib/issues/71>) follow-up of (#43 <https://github.com/ros/actionlib/issues/43>)
* 
  
    * wait for ros::Time::now to become valid before init of connection_monitor (#62 <https://github.com/ros/actionlib/issues/62>)
    * bugfix : connection_monitor should wait for result
  
* fixed default value for rosparam. closes #69 <https://github.com/ros/actionlib/issues/69> (#70 <https://github.com/ros/actionlib/issues/70>)
* Contributors: 1r0b1n0, Mikael Arguedas, Piyush Khandelwal
```
