### PR TITLE
Revert "roch_robot: 1.0.13-1 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10421,7 +10421,6 @@ repositories:
     release:
       packages:
       - roch_base
-      - roch_capabilities
       - roch_control
       - roch_description
       - roch_ftdi
@@ -10432,7 +10431,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_robot-release.git
-      version: 1.0.13-1
+      version: 1.0.11-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_robot.git


### PR DESCRIPTION
Reverts ros/rosdistro#14381

@SawYer-Robotics FYI, since it introduced another circular dependency: https://travis-ci.org/ros/rosdistro/builds/216793366

For future PRs this will be checked as of #14385.