### PR TITLE
genjava: 0.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3328,7 +3328,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rosjava-release/genjava-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/rosjava/genjava.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genjava` to `0.1.5-0`:

- upstream repository: https://github.com/rosjava/genjava.git
- release repository: https://github.com/rosjava-release/genjava-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.4-0`

## genjava

```
* Fix bug package directory path, cherry-picked from kinetic
* Added a more descriptive and helpful error message when a required package is not found in the mesasge package index.
* Contributors: Daniel Stonier, Julian Cerruti, Martin Pecka, Perrine Aguiar
```
