### PR TITLE
hironx_rpc: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3966,7 +3966,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/hironx_rpc-release.git
-      version: 0.0.2-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/tork-a/hironx_rpc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hironx_rpc` to `0.0.4-0`:

- upstream repository: https://github.com/tork-a/hironx_rpc.git
- release repository: https://github.com/tork-a/hironx_rpc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.2-0`

## hironx_rpc

- No changes

## hironx_rpc_msgs

```
* [fix] More build error. #4 <https://github.com/tork-a/hironx_rpc/pull/4>
* Contributors: Isaac I.Y. Saito
```

## hironx_rpc_server

- No changes
