### PR TITLE
roch_robot: 1.0.13-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10421,6 +10421,7 @@ repositories:
     release:
       packages:
       - roch_base
+      - roch_capabilities
       - roch_control
       - roch_description
       - roch_ftdi
@@ -10431,7 +10432,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_robot-release.git
-      version: 1.0.11-0
+      version: 1.0.13-2
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_robot` to `1.0.13-2`:

- upstream repository: https://github.com/SawYer-Robotics/roch_robot.git
- release repository: https://github.com/SawYerRobotics-release/roch_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.11-0`

## roch_base

```
* Fixed odom rotation which combine encoders and imu, only enconders great errors.
* Add missing dependcies: nodelet.
```

## roch_capabilities

```
* Modified: run depend of roch_capabilities.
```

## roch_control

```
* Update twist_mux.yaml.
* Modified localization file.
```

## roch_description

```
* Modified link transform of rplidar.
```

## roch_ftdi

- No changes

## roch_msgs

- No changes

## roch_robot

- No changes

## roch_safety_controller

```
* Modified output command to twist_mux.
```

## roch_sensorpc

- No changes
