### PR TITLE
geometry2: 0.5.15-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -355,6 +355,34 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: kinetic-devel
     status: maintained
+  geometry2:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry2.git
+      version: indigo-devel
+    release:
+      packages:
+      - geometry2
+      - tf2
+      - tf2_bullet
+      - tf2_eigen
+      - tf2_geometry_msgs
+      - tf2_kdl
+      - tf2_msgs
+      - tf2_py
+      - tf2_ros
+      - tf2_sensor_msgs
+      - tf2_tools
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/geometry2-release.git
+      version: 0.5.15-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/geometry2.git
+      version: indigo-devel
+    status: maintained
   gl_dependency:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.5.15-0`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

```
* fixup #186 <https://github.com/ros/geometry2/issues/186>: inline template specializations (#200 <https://github.com/ros/geometry2/issues/200>)
* Contributors: Robert Haschke
```

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* tf2_ros: add option to unregister TransformListener (#201 <https://github.com/ros/geometry2/issues/201>)
* Contributors: Hans-Joachim Krauch
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
