### PR TITLE
aubo_robot: 0.3.16-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -193,6 +193,7 @@ repositories:
       version: jade-devel
     release:
       packages:
+      - aubo_control
       - aubo_description
       - aubo_driver
       - aubo_gazebo
@@ -201,12 +202,13 @@ repositories:
       - aubo_msgs
       - aubo_new_driver
       - aubo_panel
+      - aubo_robot
       - aubo_trajectory
       - aubo_trajectory_filters
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/auboliuxin/aubo_robot-release.git
-      version: 0.3.10-1
+      version: 0.3.16-0
     source:
       type: git
       url: https://github.com/auboliuxin/aubo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aubo_robot` to `0.3.16-0`:

- upstream repository: https://github.com/auboliuxin/aubo_robot.git
- release repository: https://github.com/auboliuxin/aubo_robot-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.3.10-1`
