### PR TITLE
aubo_robot: 0.3.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -512,6 +512,7 @@ repositories:
       version: indigo-devel
     release:
       packages:
+      - aubo_control
       - aubo_description
       - aubo_driver
       - aubo_gazebo
@@ -520,12 +521,13 @@ repositories:
       - aubo_msgs
       - aubo_new_driver
       - aubo_panel
+      - aubo_robot
       - aubo_trajectory
       - aubo_trajectory_filters
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/auboliuxin/aubo_robot-release.git
-      version: 0.3.12-1
+      version: 0.3.15-0
     source:
       type: git
       url: https://github.com/auboliuxin/aubo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aubo_robot` to `0.3.15-0`:

- upstream repository: https://github.com/auboliuxin/aubo_robot.git
- release repository: https://github.com/auboliuxin/aubo_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.3.12-1`
