### PR TITLE
hypothesis: 3.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4222,6 +4222,13 @@ repositories:
       url: https://github.com/husky/husky_simulator.git
       version: indigo-devel
     status: maintained
+  hypothesis:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/hypothesis-rosrelease.git
+      version: 3.0.1-0
+    status: maintained
   iai_common_msgs:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `hypothesis` to `3.0.1-0`:

- upstream repository: https://github.com/HypothesisWorks/hypothesis-python.git
- release repository: https://github.com/asmodehn/hypothesis-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
