### PR TITLE
add rosdep key for libxss1

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3023,6 +3023,11 @@ libxslt:
   fedora: [libxslt-devel]
   macports: [libxslt]
   ubuntu: [libxslt1-dev]
+libxss1:
+  arch: [libxss]
+  debian: [libxss1]
+  fedora: [libXScrnSaver]
+  ubuntu: [libxss1]
 libxt-dev:
   arch: [libxt]
   debian: [libxt-dev]


### PR DESCRIPTION
Provide libXss.so.1
Dependency to run headless [electron](https://electron.atom.io/) applications.

- [arch package](https://www.archlinux.org/packages/extra/i686/libxss/)
- [debian package](https://packages.debian.org/search?keywords=libxss1&searchon=names&suite=all&section=all)
- [fedora package](https://admin.fedoraproject.org/pkgdb/package/rpms/libXScrnSaver/)
- [ubuntu package](http://packages.ubuntu.com/search?keywords=libxss1&searchon=names&suite=all&section=all)