### PR TITLE
interactive_markers: 1.11.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -441,6 +441,22 @@ repositories:
       url: https://github.com/ros-perception/image_common.git
       version: hydro-devel
     status: maintained
+  interactive_markers:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/interactive_markers-release.git
+      version: 1.11.3-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: indigo-devel
+    status: maintained
   log4cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `1.11.3-0`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros-gbp/interactive_markers-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## interactive_markers

```
* The ``processFeedback`` function of the menu handler no longer catches the ``KeyErrors`` of the feedback_cb.
  See: #29 <https://github.com/ros-visualization/interactive_markers/issues/29>
* Added the ``empty()`` and ``size()`` members to ``InteractiveMarkerServer`` interface.
  See: #30 <https://github.com/ros-visualization/interactive_markers/issues/30>
* Contributors: Blake Anderson, Guglielmo Gemignani
```
