### PR TITLE
laser_geometry: 1.6.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -441,6 +441,21 @@ repositories:
       url: https://github.com/ros-perception/image_common.git
       version: hydro-devel
     status: maintained
+  laser_geometry:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/laser_geometry-release.git
+      version: 1.6.4-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: indigo-devel
+    status: maintained
   log4cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `1.6.4-0`:

- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros-gbp/laser_geometry-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## laser_geometry

```
* Fix segfault when laserscan ranges[] is empty
* Contributors: Timm Linder, Vincent Rabaud
```
