### PR TITLE
Add python-pyaudio-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1740,6 +1740,16 @@ python-pyaudio:
   debian: [python-pyaudio]
   fedora: [pyaudio]
   ubuntu: [python-pyaudio]
+python-pyaudio-pip:
+  debian:
+    pip:
+      packages: [pyaudio]
+  osx:
+    pip:
+      packages: [pyaudio]
+  ubuntu:
+    pip:
+      packages: [pyaudio]
 python-pydot:
   arch: [python2-pydot]
   debian: [python-pydot]


### PR DESCRIPTION
https://pypi.python.org/pypi/PyAudio

This installs newer versions of PyAudio than with apt.