### PR TITLE
Add portaudio2

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3426,6 +3426,10 @@ portaudio:
   debian: [libportaudio-dev]
   fedora: [portaudio-devel]
   ubuntu: [libportaudio-dev]
+portaudio19-dev:
+  debian: [libportaudio19-dev]
+  fedora: [libportaudio-devel]
+  ubuntu: [libportaudio19-dev]
 postgresql:
   fedora: [postgresql-server, postgresql-contrib]
   ubuntu: [postgresql, postgresql-contrib]


### PR DESCRIPTION
https://packages.debian.org/jessie/libportaudio2
http://packages.ubuntu.com/yakkety/libportaudio2

Provides PortAudio v19