### PR TITLE
roch: 1.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10408,7 +10408,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch-release.git
-      version: 1.0.11-0
+      version: 1.0.12-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch` to `1.0.12-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch.git
- release repository: https://github.com/SawYerRobotics-release/roch-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.11-0`

## roch

- No changes

## roch_bringup

```
* [roch_bringup]: Comment roch_viz due to circle dependencies.
```

## roch_follower

- No changes

## roch_navigation

- No changes

## roch_rapps

- No changes

## roch_teleop

- No changes
