### PR TITLE
swri_console: 1.0.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1058,6 +1058,21 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  swri_console:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/swri_console-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: master
+    status: developed
   urdfdom_py:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `1.0.0-0`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/swri-robotics-gbp/swri_console-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## swri_console

```
* Add kinetic and lunar and simplify CI
  - Remove cruft from CI configuration
  - Add ROS kinetic to CI configuration
  - Add ROS lunar to CI configuration
  - Remove shadow-fixed builds from CI configuration. Since this repository has very few catkin dependencies, there's no reason to build for both shadow-fixed and released.
* Fix compiler warnings
* Contributors: Edward Venator, P. J. Reed, elliotjo
```
