### PR TITLE
add rosdep key libgconf2

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1555,6 +1555,11 @@ libgazebo7-dev:
   gentoo: [sci-electronics/gazebo]
   slackware: [gazebo]
   ubuntu: [libgazebo7-dev]
+libgconf2:
+  arch: [gconf]
+  debian: [libgconf-2-4]
+  fedora: [GConf2]
+  ubuntu: [libgconf-2-4]
 libgeographiclib-dev:
   fedora: [geographiclib]
   gentoo: [sci-geosciences/geographiclib]


### PR DESCRIPTION
Provide libgconf-2.so.4 needed for headless [electron](https://electron.atom.io/) applications.

- [arch package](https://www.archlinux.org/packages/extra/x86_64/gconf/)
- [debian package](https://packages.debian.org/jessie/libgconf-2-4)
- [fedora package](https://admin.fedoraproject.org/pkgdb/package/rpms/GConf2/)
- [ubuntu package](http://packages.ubuntu.com/precise/libgconf-2-4)