### PR TITLE
kobuki_desktop: 0.5.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2462,7 +2462,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki_desktop-release.git
-      version: 0.5.5-0
+      version: 0.5.6-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_desktop` to `0.5.6-0`:

- upstream repository: https://github.com/yujinrobot/kobuki_desktop.git
- release repository: https://github.com/yujinrobot-release/kobuki_desktop-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.5.5-0`

## kobuki_gazebo_plugins

```
* update at the end of the event loop so the bumper sensor can be caught
```
