### PR TITLE
static_tf: 0.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13346,7 +13346,6 @@ repositories:
       url: https://github.com/wu-robotics/static_tf_release.git
       version: 0.0.1-1
     source:
-      test_pull_requests: false
       type: git
       url: https://github.com/DLu/static_tf.git
       version: master

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13346,7 +13346,7 @@ repositories:
       url: https://github.com/wu-robotics/static_tf_release.git
       version: 0.0.1-1
     source:
-      test_pull_requests: true
+      test_pull_requests: false
       type: git
       url: https://github.com/DLu/static_tf.git
       version: master

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13335,6 +13335,22 @@ repositories:
       url: https://github.com/ros-simulation/stage_ros.git
       version: master
     status: maintained
+  static_tf:
+    doc:
+      type: git
+      url: https://github.com/DLu/static_tf.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wu-robotics/static_tf_release.git
+      version: 0.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/DLu/static_tf.git
+      version: master
+    status: developed
   staubli:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `static_tf` to `0.0.1-1`:

- upstream repository: https://github.com/DLu/static_tf.git
- release repository: https://github.com/wu-robotics/static_tf_release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`
