### PR TITLE
libg2o added to lunar

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -472,6 +472,13 @@ repositories:
       url: https://github.com/ros-perception/laser_geometry.git
       version: indigo-devel
     status: maintained
+  libg2o:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/libg2o-release.git
+      version: 2017.4.2-1
+    status: maintained
   log4cpp:
     doc:
       type: git


### PR DESCRIPTION
This is the initial release of third party package _g2o_ into lunar.