### PR TITLE
laser_filters: 1.8.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -457,6 +457,21 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: indigo-devel
     status: maintained
+  laser_filters:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_filters.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/laser_filters-release.git
+      version: 1.8.3-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_filters.git
+      version: indigo-devel
+    status: maintained
   laser_geometry:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -457,21 +457,6 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: indigo-devel
     status: maintained
-  laser_filters:
-    doc:
-      type: git
-      url: https://github.com/ros-perception/laser_filters.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/lunar/{package}/{version}
-      url: https://github.com/ros-gbp/laser_filters-release.git
-      version: 1.8.3-0
-    source:
-      type: git
-      url: https://github.com/ros-perception/laser_filters.git
-      version: indigo-devel
-    status: maintained
   laser_assembler:
     doc:
       type: git
@@ -486,6 +471,21 @@ repositories:
       type: git
       url: https://github.com/ros-perception/laser_assembler.git
       version: hydro-devel
+    status: maintained
+  laser_filters:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_filters.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/laser_filters-release.git
+      version: 1.8.3-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_filters.git
+      version: indigo-devel
     status: maintained
   laser_geometry:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `1.8.3-0`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros-gbp/laser_filters-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## laser_filters

```
* Replaced the invalid value of scans for the footprint_filter by NaN
* Contributors: Alain Minier
```
