### PR TITLE
realsense_camera: 1.8.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9865,7 +9865,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/intel-ros/realsense-release.git
-      version: 1.7.2-0
+      version: 1.8.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_camera` to `1.8.0-0`:

- upstream repository: https://github.com/intel-ros/realsense.git
- release repository: https://github.com/intel-ros/realsense-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.24`
- previous version for package: `1.7.2-0`

## realsense_camera

```
* Enable configuration of the TF publication rate when using tf_dynamic
* Enable roslint when CATKIN_ENABLE_TESTING is True
* Add option to link against non-catkin librealsense
* Fixed LR auto exposure (#131)
* Dynamic reconfig autoexposure/exposure control SR300/F200/R200 (#213)
* Added check for depth_enable dynamic change
* Update Debug Tool
* Added SyncNodelet class as new base for F200/SR300/R200 (#207, #210)
* Contributors: Amanda Brindle, Dmitry Rozhkov, James Sergeant, Mark Horn, Matthew Hansen, Reagan Lopez, Séverin Lemaignan
```
