### PR TITLE
laser_pipeline: 1.6.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -502,6 +502,21 @@ repositories:
       url: https://github.com/ros-perception/laser_geometry.git
       version: indigo-devel
     status: maintained
+  laser_pipeline:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_pipeline.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/laser_pipeline-release.git
+      version: 1.6.2-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_pipeline.git
+      version: hydro-devel
+    status: maintained
   libg2o:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_pipeline` to `1.6.2-0`:

- upstream repository: https://github.com/ros-perception/laser_pipeline.git
- release repository: https://github.com/ros-gbp/laser_pipeline-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
