### PR TITLE
moveit: 0.8.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3000,7 +3000,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.8.6-0
+      version: 0.8.7-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.8.7-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.8.6-0`

## moveit

```
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* [fix] catkin_make -DCMAKE_ENABLE_TESTING=0 failure (#478 <https://github.com/ros-planning/moveit/issues/478>)
* [fix][moveit_ros_visualization] rviz panel: Don't add object marker if the wrong tab is selected #454 <https://github.com/ros-planning/moveit/pull/454>
* [fix][moveit_ros_visualization] robot state display: subscribe on enable / unsubscribe on disable (#455 <https://github.com/ros-planning/moveit/issues/455>)
* [fix][moveit_ros_planning] undefined symbol in planning_scene_monitor (#463 <https://github.com/ros-planning/moveit/issues/463>)
* [fix][moveit_ros_manipulation] Set planning frame correctly in evaluation of reachable and valid pose filter (#476 <https://github.com/ros-planning/moveit/issues/476>)
* [fix][moveit_planners_ompl] Always update initial robot state to prevent dirty robot state error. #448 <https://github.com/ros-planning/moveit/pull/448>
* [fix][moveit_core] PlanarJointModel::getVariableRandomPositionsNearBy (#464 <https://github.com/ros-planning/moveit/issues/464>)
* Contributors: Ruben Burger, Dave Coleman, Michael Goerner, Henning Kayser, Tamaki Nishino, Dmitry Rozhkov, Yannick Jonetzko
```

## moveit_commander

- No changes

## moveit_controller_manager_example

```
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* Contributors: Dave Coleman
```

## moveit_core

```
* Fix PlanarJointModel::getVariableRandomPositionsNearBy (#464 <https://github.com/ros-planning/moveit/issues/464>)
* Contributors: Dave Coleman, Tamaki Nishino
```

## moveit_fake_controller_manager

```
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* Contributors: Dave Coleman
```

## moveit_kinematics

```
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* Contributors: Dave Coleman
```

## moveit_planners

- No changes

## moveit_planners_ompl

```
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* [fix] Always update initial robot state to prevent dirty robot state error. #448 <https://github.com/ros-planning/moveit/pull/448>
* Contributors: Dave Coleman, Henning Kayser
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* Contributors: Dave Coleman
```

## moveit_ros_benchmarks_gui

```
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* Contributors: Dave Coleman
```

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

```
* [fix] Set planning frame correctly in evaluation of reachable and valid pose filter (#476 <https://github.com/ros-planning/moveit/issues/476>)
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* Contributors: Dave Coleman, Yannick Jonetzko
```

## moveit_ros_move_group

```
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* Contributors: Dave Coleman
```

## moveit_ros_perception

```
* [fix] catkin_make -DCMAKE_ENABLE_TESTING=0 failure (#478 <https://github.com/ros-planning/moveit/issues/478>)
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* Contributors: Dave Coleman, Michael Goerner
```

## moveit_ros_planning

```
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* [fix] undefined symbol in planning_scene_monitor (#463 <https://github.com/ros-planning/moveit/issues/463>)
* Contributors: Dave Coleman, Dmitry Rozhkov, Ruben Burger
```

## moveit_ros_planning_interface

```
* [fix] address gcc6 build error (#458 <https://github.com/ros-planning/moveit/issues/458>)
* Contributors: Dave Coleman
```

## moveit_ros_robot_interaction

```
* [fix] catkin_make -DCMAKE_ENABLE_TESTING=0 failure (#478 <https://github.com/ros-planning/moveit/issues/478>)
* address gcc6 build error (#458 <https://github.com/ros-planning/moveit/issues/458>)
* Contributors: Dave Coleman, Michael Goerner, Dmitry Rozhkov
```

## moveit_ros_visualization

```
* [fix] rviz panel: Don't add object marker if the wrong tab is selected #454 <https://github.com/ros-planning/moveit/pull/454>
* [fix] robot state display: subscribe on enable / unsubscribe on disable (#455 <https://github.com/ros-planning/moveit/issues/455>)
* Contributors: Dave Coleman, Michael Goerner
```

## moveit_ros_warehouse

```
* address gcc6 build error (#458 <https://github.com/ros-planning/moveit/issues/458>)
* Contributors: Dmitry Rozhkov, Dave Coleman
```

## moveit_runtime

- No changes

## moveit_setup_assistant

```
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* Contributors: Dave Coleman
```

## moveit_simple_controller_manager

```
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* Contributors: Dave Coleman
```
