### PR TITLE
moveit: 0.7.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6599,7 +6599,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.7.8-0
+      version: 0.7.9-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.7.9-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.7.8-0`

## moveit

```
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* [fix][moveit_ros_planning] undefined symbol in planning_scene_monitor (#463 <https://github.com/ros-planning/moveit/issues/463>)
* [fix][moveit_ros_manipulation] Set planning frame correctly in evaluation of reachable and valid pose filter (#476 <https://github.com/ros-planning/moveit/issues/476>)
* [fix][moveit_planners_ompl] Always update initial robot state to prevent dirty robot state error. #448 <https://github.com/ros-planning/moveit/pull/448>
* [fix][moveit_core] PlanarJointModel::getVariableRandomPositionsNearBy (#464 <https://github.com/ros-planning/moveit/issues/464>)
* [fix][moveit_ros_visualization] rviz panel: Don't add object marker if the wrong tab is selected #454 <https://github.com/ros-planning/moveit/pull/454>
* Contributors: Yannick Jonetzko, Henning Kayser, Tamaki Nishino, Dmitry Rozhkov, Ruben Burger, Michael Goerner
```

## moveit_commander

- No changes

## moveit_controller_manager_example

- No changes

## moveit_core

```
* [fix][moveit_core] PlanarJointModel::getVariableRandomPositionsNearBy (#464 <https://github.com/ros-planning/moveit/issues/464>)
* Contributors: Tamaki Nishino
```

## moveit_fake_controller_manager

- No changes

## moveit_full

- No changes

## moveit_full_pr2

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_ompl

```
* [fix][moveit_planners_ompl] Always update initial robot state to prevent dirty robot state error. #448 <https://github.com/ros-planning/moveit/pull/448>
* Contributors: Henning Kayser
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_benchmarks_gui

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

```
* [fix][moveit_ros_manipulation] Set planning frame correctly in evaluation of reachable and valid pose filter (#476 <https://github.com/ros-planning/moveit/issues/476>)
* Contributors: Yannick Jonetzko
```

## moveit_ros_move_group

- No changes

## moveit_ros_perception

```
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* Contributors: Michael Goerner
```

## moveit_ros_planning

```
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* [fix][moveit_ros_planning] undefined symbol in planning_scene_monitor (#463 <https://github.com/ros-planning/moveit/issues/463>)
* Contributors: Dmitry Rozhkov, Ruben Burger
```

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

```
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* Contributors: Michael Goerner
```

## moveit_ros_visualization

```
* [fix][moveit_ros_visualization] rviz panel: Don't add object marker if the wrong tab is selected #454 <https://github.com/ros-planning/moveit/pull/454>
* Contributors: Michael Goerner
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_setup_assistant

- No changes

## moveit_simple_controller_manager

- No changes
