### PR TITLE
rtmros_hironx: 1.1.23-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12085,7 +12085,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.22-0
+      version: 1.1.23-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.23-0`:

- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.1.22-0`

## hironx_calibration

```
* [doc][calib] Cleanup pkg description.
* Contributors: Isaac I.Y. Saito
```

## hironx_moveit_config

- No changes

## hironx_ros_bridge

```
* [enhancement][test] Common testcase module location change #490 <https://github.com/start-jsk/rtmros_hironx/issues/490>.
* [doc] More elaboration on startImpedance* methods.
* Contributors: Isaac I.Y. Saito
```

## rtmros_hironx

```
* [enhancement][test] Common testcase module location change #490 <https://github.com/start-jsk/rtmros_hironx/issues/490>.
* [doc] More elaboration on startImpedance* methods.
* [doc][calib] Cleanup pkg description.
* Contributors: Isaac I.Y. Saito
```
