### PR TITLE
ackermann_msgs: 1.0.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -12,6 +12,21 @@ release_platforms:
   - yakkety
   - zesty
 repositories:
+  ackermann_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/ackermann_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/ackermann_msgs-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/ackermann_msgs.git
+      version: master
+    status: maintained
   actionlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ackermann_msgs` to `1.0.1-0`:

- upstream repository: https://github.com/ros-drivers/ackermann_msgs.git
- release repository: https://github.com/ros-drivers-gbp/ackermann_msgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## ackermann_msgs

```
* Removed Jim Rothrock from the maintainer list. Changed the version to 1.0.1.
```
