### PR TITLE
unique_identifier: 1.0.6-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1161,6 +1161,25 @@ repositories:
       url: https://github.com/swri-robotics/swri_console.git
       version: master
     status: developed
+  unique_identifier:
+    doc:
+      type: git
+      url: https://github.com/ros-geographic-info/unique_identifier.git
+      version: master
+    release:
+      packages:
+      - unique_id
+      - unique_identifier
+      - uuid_msgs
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-geographic-info/unique_identifier-release.git
+      version: 1.0.6-0
+    source:
+      type: git
+      url: https://github.com/ros-geographic-info/unique_identifier.git
+      version: master
+    status: maintained
   urdfdom_py:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `unique_identifier` to `1.0.6-0`:

- upstream repository: https://github.com/ros-geographic-info/unique_identifier.git
- release repository: https://github.com/ros-geographic-info/unique_identifier-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## unique_id

- No changes

## unique_identifier

- No changes

## uuid_msgs

- No changes
