### PR TITLE
rospeex: 3.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11615,7 +11615,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://bitbucket.org/rospeex/rospeex-release.git
-      version: 2.15.4-0
+      version: 3.0.0-0
     source:
       type: git
       url: https://bitbucket.org/rospeex/rospeex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospeex` to `3.0.0-0`:

- upstream repository: https://bitbucket.org/rospeex/rospeex.git
- release repository: https://bitbucket.org/rospeex/rospeex-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.15.4-0`

## rospeex

- No changes

## rospeex_audiomonitor

- No changes

## rospeex_core

```
* Update request url to nict engine
```

## rospeex_if

- No changes

## rospeex_launch

- No changes

## rospeex_msgs

- No changes

## rospeex_samples

- No changes

## rospeex_webaudiomonitor

- No changes
