### PR TITLE
Add pylibftdi

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1840,6 +1840,15 @@ python-pykalman:
   ubuntu:
     pip:
       packages: [pykalman]
+python-pylibftdi-pip:
+  debian:
+    pip: [pylibftdi]
+  fedora:
+    pip: [pylibftdi]
+  osx:
+    pip: [pylibftdi]
+  ubuntu:
+    pip: [pylibftdi]
 python-pylint:
   debian: [pylint]
   fedora: [pylint]


### PR DESCRIPTION
This PR adds [pylibftdi](https://pypi.python.org/pypi/pylibftdi) to the Python packages list.

pylibftdi is a minimal Pythonic interface to FTDI devices using libftdi (which is available as `libftdi-dev` in `base.yaml` and `osx-homebrew.yaml`.