### PR TITLE
address removal of old formula from homebrew-core

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -290,7 +290,7 @@ libpq-dev:
 libqglviewer-qt4-dev:
   osx:
     homebrew:
-      packages: [libqglviewer]
+      packages: [ros/deps/libqglviewer]
 libqhull:
   osx:
     homebrew:
@@ -298,15 +298,15 @@ libqhull:
 libqt4:
   osx:
     homebrew:
-      packages: [qt]
+      packages: [osrf/simulation/qt4-no-webkit]
 libqt4-dev:
   osx:
     homebrew:
-      packages: [qt]
+      packages: [osrf/simulation/qt4-no-webkit]
 libqt4-opengl-dev:
   osx:
     homebrew:
-      packages: [qt]
+      packages: [osrf/simulation/qt4-no-webkit]
 libqt5-core:
   osx:
     homebrew:
@@ -611,11 +611,11 @@ python-pyproj:
 python-qt-bindings:
   osx:
     homebrew:
-      packages: [pyside, shiboken, pyqt, sip]
+      packages: [ros/deps/pyside, ros/deps/shiboken, ros/deps/pyqt, sip]
 python-qt-bindings-gl:
   osx:
     homebrew:
-      packages: [pyqt]
+      packages: [ros/deps/pyqt]
 python-qt-bindings-qwt5:
   osx:
     homebrew:
@@ -669,7 +669,7 @@ python-yaml:
 qt4-qmake:
   osx:
     homebrew:
-      packages: [qt]
+      packages: [osrf/simulation/qt4-no-webkit]
 qt5-qmake:
   osx:
     homebrew:


### PR DESCRIPTION
Most were migrated to ros/homebrew-deps, see:

https://github.com/ros/homebrew-deps/pull/31