### PR TITLE
fix libqglviewer-qt4 and libqglviewer-qt4-dev debian jessie rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2319,7 +2319,7 @@ libqglviewer-qt4:
   arch: [libqglviewer-qt4]
   debian:
     jessie: [libqglviewer2]
-    stretch: [libqglviewer-qt4-2]
+    stretch: [libqglviewer2-qt4]
     wheezy: [libqglviewer-qt4-2]
   fedora: [libQGLViewer]
   macports: [libQGLViewer]
@@ -2343,7 +2343,7 @@ libqglviewer-qt4-dev:
   arch: [libqglviewer-qt4]
   debian:
     jessie: [libqglviewer-dev]
-    stretch: [libqglviewer-qt4-dev]
+    stretch: [libqglviewer-dev-qt4]
     wheezy: [libqglviewer-qt4-dev]
   fedora: [libQGLViewer-devel]
   ubuntu:


### PR DESCRIPTION
Follow up of https://github.com/ros/rosdistro/pull/14424/

libqglviewer-qt4-dev: https://packages.debian.org/stretch/libqglviewer-dev-qt4
libqglviewer-qt4: https://packages.debian.org/stretch/libqglviewer2-qt4