### PR TITLE
homer_robot_face: 1.0.18-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1890,6 +1890,16 @@ repositories:
       url: https://gitlab.uni-koblenz.de/robbie/homer_robbie_architecture.git
       version: 1.0.2-3
     status: maintained
+  homer_robot_face:
+    release:
+      packages:
+      - homer_mary_tts
+      - homer_robot_face
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://gitlab.uni-koblenz.de/robbie/homer_robot_face-release.git
+      version: 1.0.18-1
+    status: developed
   household_objects_database_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `homer_robot_face` to `1.0.18-1`:

- upstream repository: git@gitlab.uni-koblenz.de:robbie/homer_robot_face.git
- release repository: https://gitlab.uni-koblenz.de/robbie/homer_robot_face-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`

## homer_mary_tts

```
* test
* homer_mary_tts: added mary_tts to doc toc
* Contributors: Niklas Yann Wettengel
```

## homer_robot_face

```
* bigger text size for expected input
* Contributors: Lisa
```
