### PR TITLE
bond_core: 1.7.19-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -833,7 +833,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/bond_core-release.git
-      version: 1.7.18-0
+      version: 1.7.19-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.7.19-0`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.7.18-0`

## bond

- No changes

## bond_core

- No changes

## bondcpp

```
* fix unused var warning
* Contributors: Mikael Arguedas
```

## bondpy

- No changes

## smclib

- No changes
