### PR TITLE
dynamic_reconfigure: 1.5.47-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -804,7 +804,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.5.46-0
+      version: 1.5.47-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.5.47-0`:

- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.5.46-0`

## dynamic_reconfigure

```
* reset received_configuration_ for every request sent (#82 <https://github.com/ros/dynamic_reconfigure/issues/82>)
* Rename arguments (with a_ prefix) to avoid Wshadow warnings. (#80 <https://github.com/ros/dynamic_reconfigure/issues/80>)
  handle infinity in python generation, fixes (#77 <https://github.com/ros/dynamic_reconfigure/issues/77>)
* Add a c++ Dynamic Reconfigure Client (#78 <https://github.com/ros/dynamic_reconfigure/issues/78>)
* Enforce valid descriptions in cfg files (#74 <https://github.com/ros/dynamic_reconfigure/issues/74>)
* Fix callback returned by get_description_callback (#73 <https://github.com/ros/dynamic_reconfigure/issues/73>) from ros/description_cb
* Contributors: Jeff Eberl, Mikael Arguedas
```
