### PR TITLE
roswww: 0.1.10-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5816,7 +5816,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/roswww-release.git
-      version: 0.1.9-0
+      version: 0.1.10-0
     source:
       type: git
       url: https://github.com/tork-a/roswww.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roswww` to `0.1.10-0`:

- upstream repository: https://github.com/tork-a/roswww.git
- release repository: https://github.com/tork-a/roswww-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.9-0`

## roswww

```
* [capability] Add dis/enabling cache feature #39 <https://github.com/tork-a/roswww/issues/39>
* [fix] Add missing dependency for test for Xenial. #38 <https://github.com/tork-a/roswww/issues/38>
* Contributors: Taiji Fukaya, Isaac I.Y. Saito
```
