### PR TITLE
dynamic_reconfigure: 1.5.48-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -804,7 +804,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.5.47-0
+      version: 1.5.48-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.5.48-0`:

- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.5.47-0`

## dynamic_reconfigure

```
* [Bugfix] dont enforce ROS names for constants (#84 <https://github.com/ros/dynamic_reconfigure/issues/84>)
* [Compiler warnings] avoid unused-parameter compiler warnings in specialized ParamDescription<std::string>::clamp() (#83 <https://github.com/ros/dynamic_reconfigure/issues/83>)
* Contributors: Johannes Meyer, Mikael Arguedas
```
