### PR TITLE
filters: 1.8.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -270,7 +270,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/filters-release.git
-      version: 1.7.5-1
+      version: 1.8.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `1.8.0-0`:

- upstream repository: https://github.com/ros/filters.git
- release repository: https://github.com/ros-gbp/filters-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `1.7.5-1`

## filters

```
* Remove promiscuous filter finding
  When specifying filters, you must now include the package name and exact
  filter name. Previously a workaround would search packages for any filter
  with the specified string in the filter name. This has been deprecated for
  a while, and here we're removing it. #14 <https://github.com/ros/filters/issues/14>
* Contributors: Jon Binney
```
