### PR TITLE
laser_filters: 1.8.4-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -516,7 +516,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/laser_filters-release.git
-      version: 1.8.3-0
+      version: 1.8.4-1
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `1.8.4-1`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros-gbp/laser_filters-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.8.3-0`

## laser_filters

```
* Specify packages names for filters in tests
* Use std:: namespace for c++11 compat.
* Contributors: Jon Binney, Jonathan Binney, Mike Purvis
```
