### PR TITLE
catkin_simple: 0.1.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1274,6 +1274,21 @@ repositories:
       url: https://github.com/asmodehn/catkin_pip.git
       version: indigo
     status: developed
+  catkin_simple:
+    doc:
+      type: git
+      url: https://github.com/fmina/catkin_simple.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/fmina/catkin_simple-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/fmina/catkin_simple.git
+      version: master
+    status: maintained
   cepton:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_simple` to `0.1.2-1`:

- upstream repository: https://github.com/fmina/catkin_simple.git
- release repository: https://github.com/fmina/catkin_simple-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
