### PR TITLE
catkin_simple: 0.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -459,6 +459,21 @@ repositories:
       url: https://github.com/asmodehn/catkin_pip.git
       version: jade
     status: developed
+  catkin_simple:
+    doc:
+      type: git
+      url: https://github.com/fmina/catkin_simple.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/fmina/catkin_simple-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/fmina/catkin_simple.git
+      version: master
+    status: maintained
   certifi:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_simple` to `0.1.2-0`:

- upstream repository: https://github.com/fmina/catkin_simple.git
- release repository: https://github.com/fmina/catkin_simple-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
