### PR TITLE
mav_comm: 3.2.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6180,7 +6180,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-asl/mav_comm-release.git
-      version: 3.0.0-0
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/ethz-asl/mav_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mav_comm` to `3.2.0-1`:

- upstream repository: https://github.com/ethz-asl/mav_comm.git
- release repository: https://github.com/ethz-asl/mav_comm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `3.0.0-0`

## mav_comm

```
* See mav_msgs changelog for details.
```

## mav_msgs

```
* Access covariance in eigen odometry
* External force default topic
* External wind speed default topic
```
