### PR TITLE
hironx_rpc: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3975,7 +3975,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/hironx_rpc-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/tork-a/hironx_rpc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hironx_rpc` to `0.0.5-0`:

- upstream repository: https://github.com/tork-a/hironx_rpc.git
- release repository: https://github.com/tork-a/hironx_rpc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.4-0`

## hironx_rpc

- No changes

## hironx_rpc_msgs

- No changes

## hironx_rpc_server

```
* [fix] Install location of script folder. #5 <https://github.com/tork-a/hironx_rpc/pull/5>
* [test] Adjust to upstream change #495 <https://github.com/start-jsk/rtmros_hironx/pull/495>
* Contributors: Isaac I.Y. Saito
```
