### PR TITLE
moveit_resources: 0.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6683,7 +6683,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_resources-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `0.6.2-0`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros-gbp/moveit_resources-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.6.1-0`

## moveit_resources

```
* [fix] Missing license to fanuc pkgs imported from ros-industrial/fanuc. #11 <https://github.com/ros-planning/moveit_resources/issues/11>. (#12 <https://github.com/ros-planning/moveit_resources/issues/12>)
* [fix] Missing run depends for [robot|joint]_state_publisher (#14 <https://github.com/ros-planning/moveit_resources/issues/14>)
* [fix] Correct warehouse ros mongo (#13 <https://github.com/ros-planning/moveit_resources/issues/13>)
* [improve] test chomp (#10 <https://github.com/ros-planning/moveit_resources/issues/10>)
* Contributors: Chittaranjan Srinivas Swaminathan, Dave Coleman, G.A. vd. Hoorn, kirstyellis
```
