### PR TITLE
geometric_shapes: 0.5.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -370,6 +370,21 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: kinetic-devel
     status: maintained
+  geometric_shapes:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/geometric_shapes-release.git
+      version: 0.5.2-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: kinetic-devel
+    status: maintained
   geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.5.2-0`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## geometric_shapes

```
* [fix] mesh with too many vertices (#39 <https://github.com/ros-planning/geometric_shapes/issues/39>) (#60 <https://github.com/ros-planning/geometric_shapes/issues/60>)
* [fix] gcc6 build error (#56 <https://github.com/ros-planning/geometric_shapes/issues/56>)
* [fix] Clear root transformation on imported Collada meshes. #52 <https://github.com/ros-planning/geometric_shapes/issues/52>
* [improve] relax mesh containment test (#58 <https://github.com/ros-planning/geometric_shapes/issues/58>)
* [maintenance] Switch boost::shared_ptr to std::shared_ptr. #57 <https://github.com/ros-planning/geometric_shapes/pull/57>
* Contributors: Dave Coleman, Isaac I.Y. Saito, Lukas Bulwahn, Maarten de Vries, Michael Goerner
```
