### PR TITLE
robot_model keys for lunar

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -437,6 +437,8 @@ collada-dom:
     vivid: [collada-dom-dev]
     wily: [collada-dom-dev]
     xenial: [libcollada-dom2.4-dp-dev]
+    yakkety: [libcollada-dom2.4-dp-dev]
+    zesty: [libcollada-dom2.4-dp-dev]
 comedi:
   fedora: [comedilib-devel]
   ubuntu: [libcomedi-dev]
@@ -2796,26 +2798,14 @@ liburdfdom-dev:
   fedora: [urdfdom-devel]
   gentoo: [dev-libs/urdfdom]
   slackware: [urdfdom]
-  ubuntu:
-    saucy: [liburdfdom-dev]
-    trusty: [liburdfdom-dev]
-    utopic: [liburdfdom-dev]
-    vivid: [liburdfdom-dev]
-    wily: [liburdfdom-dev]
-    xenial: [liburdfdom-dev]
+  ubuntu: [liburdfdom-dev]
 liburdfdom-headers-dev:
   arch: [urdfdom-headers]
   debian: [liburdfdom-headers-dev]
   fedora: [urdfdom-headers-devel]
   gentoo: [dev-libs/urdfdom_headers]
   slackware: [urdfdom_headers]
-  ubuntu:
-    saucy: [liburdfdom-headers-dev]
-    trusty: [liburdfdom-headers-dev]
-    utopic: [liburdfdom-headers-dev]
-    vivid: [liburdfdom-headers-dev]
-    wily: [liburdfdom-headers-dev]
-    xenial: [liburdfdom-headers-dev]
+  ubuntu: [liburdfdom-headers-dev]
 liburdfdom-tools:
   arch: [urdfdom]
   debian: [liburdfdom-tools]


### PR DESCRIPTION
collapsed the ubuntu entries given that they're all the same and will likely not change names in the future

collada-dom:
- yakkety: http://packages.ubuntu.com/yakkety/libcollada-dom2.4-dp-dev
- zesty: http://packages.ubuntu.com/zesty/libcollada-dom2.4-dp-dev

urdfdom-headers-dev:
- yakkety: http://packages.ubuntu.com/yakkety/liburdfdom-headers-dev
- zesty: http://packages.ubuntu.com/zesty/liburdfdom-headers-dev

urdfdom-dev:
- yakkety: http://packages.ubuntu.com/yakkety/liburdfdom-dev
- zesty: http://packages.ubuntu.com/zesty/liburdfdom-dev

Thanks @sloretz for cross-checking the missing keys!