### PR TITLE
robot_model: 1.12.8-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -837,6 +837,30 @@ repositories:
       url: https://github.com/orocos/rFSM.git
       version: master
     status: maintained
+  robot_model:
+    doc:
+      type: git
+      url: https://github.com/ros/robot_model.git
+      version: kinetic-devel
+    release:
+      packages:
+      - collada_parser
+      - collada_urdf
+      - joint_state_publisher
+      - kdl_parser
+      - kdl_parser_py
+      - robot_model
+      - urdf
+      - urdf_parser_plugin
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/robot_model-release.git
+      version: 1.12.8-1
+    source:
+      type: git
+      url: https://github.com/ros/robot_model.git
+      version: kinetic-devel
+    status: maintained
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.12.8-1`:

- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`

## collada_parser

```
* add Chris and Shane as maintainers (#184 <https://github.com/ros/robot_model/issues/184>)
* fix missed mandatory -std=c++11 flag (#181 <https://github.com/ros/robot_model/issues/181>)
  collada_parser,kdl_parser,urdf: add c++11 flag,
  collada_parser: replace typeof with ansi __typeof__
  builded/tested on gentoo
  Thanks den4ix for the contribution!
* Contributors: Denis Romanchuk, William Woodall
```

## collada_urdf

```
* Remove old gazebo settings.
  Based on an initial patch from YoheiKakiuchi, just totally
  remove old Gazebo 1.0 settings, as they are never used and
  almost certainly will never be used.
* add Chris and Shane as maintainers (#184 <https://github.com/ros/robot_model/issues/184>)
* Do a few cleanup tasks in collada_urdf (#183 <https://github.com/ros/robot_model/issues/183>)
  * Style cleanup within collada_urdf.
  No functional change, just style.
  * Make sure to quit out of urdf_to_collada when invalid file is found.
  Otherwise, we'll just end up segfaulting later on.
  * Re-enable one of the collada-urdf tests.
  In point of fact, we delete the rest of the tests because
  they don't make much sense anymore.  Just enable this one
  for now; we'll enable further ones in the future.
  * Add in another test for collada_urdf.
* remove divide by 2 when writing boxes to collada format (#133 <https://github.com/ros/robot_model/issues/133>)
* Contributors: Chris Lalancette, Jackie Kay, William Woodall
```

## joint_state_publisher

```
* [joint_state_publisher] Handle time moving backwards
  Without this patch, joint_state_publisher dies whenever the ROS time moves backwards (e.g., when running rosbag play --clock --loop).
* Switch a couple more packages over to Chris and Shane.
* Fix rostest dependency.
* Add recursive mimic joint (#177 <https://github.com/ros/robot_model/issues/177>)
  * Add recursive mimic joint
* Contributors: Alessandro Tondo, Chris Lalancette, Martin Günther, Mike Purvis
```

## kdl_parser

```
* add Chris and Shane as maintainers (#184 <https://github.com/ros/robot_model/issues/184>)
* fix missed mandatory -std=c++11 flag (#181 <https://github.com/ros/robot_model/issues/181>)
  collada_parser,kdl_parser,urdf: add c++11 flag,
  collada_parser: replace typeof with ansi __typeof__
  builded/tested on gentoo
  Thanks den4ix for the contribution!
* Contributors: Denis Romanchuk, William Woodall
```

## kdl_parser_py

```
* Switch a couple more packages over to Chris and Shane.
* Contributors: Chris Lalancette
```

## robot_model

```
* add Chris and Shane as maintainers (#184 <https://github.com/ros/robot_model/issues/184>)
* Contributors: William Woodall
```

## urdf

```
* Allow supplying NodeHandle for initParam (#168 <https://github.com/ros/robot_model/issues/168>)
  * Allow supplying NodeHandle for initParam using new function.
  * fixed missing return statement in previous commit.
* add Chris and Shane as maintainers (#184 <https://github.com/ros/robot_model/issues/184>)
* fix missed mandatory -std=c++11 flag (#181 <https://github.com/ros/robot_model/issues/181>)
  collada_parser,kdl_parser,urdf: add c++11 flag,
  collada_parser: replace typeof with ansi __typeof__
  builded/tested on gentoo
  Thanks den4ix for the contribution!
* Contributors: Denis Romanchuk, Piyush Khandelwal, William Woodall
```

## urdf_parser_plugin

```
* add Chris and Shane as maintainers (#184 <https://github.com/ros/robot_model/issues/184>)
* Contributors: William Woodall
```
