### PR TITLE
rqt_py_trees: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6128,7 +6128,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/stonier/rqt_py_trees-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/stonier/rqt_py_trees.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_py_trees` to `0.3.1-0`:

- upstream repository: https://github.com/stonier/rqt_py_trees.git
- release repository: https://github.com/stonier/rqt_py_trees-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.3.0-0`

## rqt_py_trees

```
* add missing python-pygraphviz dependency
```
