### PR TITLE
robot_state_publisher: 1.13.5-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -877,6 +877,21 @@ repositories:
       url: https://github.com/ros/robot_model.git
       version: kinetic-devel
     status: maintained
+  robot_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/robot_state_publisher.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/robot_state_publisher-release.git
+      version: 1.13.5-0
+    source:
+      type: git
+      url: https://github.com/ros/robot_state_publisher.git
+      version: kinetic-devel
+    status: maintained
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `1.13.5-0`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros-gbp/robot_state_publisher-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## robot_state_publisher

```
* Style cleanup throughout the tree.
* add Chris and Shane as maintainers (#70 <https://github.com/ros/robot_state_publisher/issues/70>)
* Contributors: Chris Lalancette, William Woodall
```
