### PR TITLE
ros_control: 0.11.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -981,6 +981,23 @@ repositories:
       type: git
       url: https://github.com/ros-controls/ros_control.git
       version: kinetic-devel
+    release:
+      packages:
+      - combined_robot_hw
+      - combined_robot_hw_tests
+      - controller_interface
+      - controller_manager
+      - controller_manager_msgs
+      - controller_manager_tests
+      - hardware_interface
+      - joint_limits_interface
+      - ros_control
+      - rqt_controller_manager
+      - transmission_interface
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/ros_control-release.git
+      version: 0.11.4-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.11.4-0`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## combined_robot_hw

- No changes

## combined_robot_hw_tests

- No changes

## controller_interface

- No changes

## controller_manager

```
* controller_manager: drop unused inclusion of tinyxml.h
* Contributors: Dmitry Rozhkov
```

## controller_manager_msgs

- No changes

## controller_manager_tests

- No changes

## hardware_interface

- No changes

## joint_limits_interface

- No changes

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
