### PR TITLE
geometric_shapes: 0.4.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3425,7 +3425,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.4.4-0
+      version: 0.4.5-0
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.4.5-0`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.4.4-0`

## geometric_shapes

```
* [fix] mesh with too many vertices (#39 <https://github.com/ros-planning/geometric_shapes/issues/39>) (#60 <https://github.com/ros-planning/geometric_shapes/issues/60>)
* [fix] gcc6 build error (#56 <https://github.com/ros-planning/geometric_shapes/issues/55>)
* [fix] Clear root transformation on imported Collada meshes. #52 <https://github.com/ros-planning/geometric_shapes/issues/52>
* [fix] incorrect hint always sent to Assimp, improved STL reading (#24 <https://github.com/ros-planning/geometric_shapes/issues/24>)
* [fix] append cmake module path instead of prepending. Fixes #22 <https://github.com/ros-planning/geometric_shapes/issues/22>
* [fix] FindQhull with non-debian systems (#30 <https://github.com/ros-planning/geometric_shapes/issues/30>)
* [improve] relax mesh containment test (#58 <https://github.com/ros-planning/geometric_shapes/issues/58>)
* [maintenance] Switch boost::shared_ptr to std::shared_ptr. #57 <https://github.com/ros-planning/geometric_shapes/pull/57>
* [maintenance] Fix travis for Indigo (#53 <https://github.com/ros-planning/geometric_shapes/issues/53>)
* [maintenance] catkin_lint and cleanup #43 <https://github.com/ros-planning/geometric_shapes/issues/43>
* [maintenance] add notice that project will be built in Release mode
* [maintenance] cmake cleanup and improvement (#35 <https://github.com/ros-planning/geometric_shapes/issues/35> and others)
* Contributors: Dave Coleman, Ioan A Sucan, Isaac I.Y. Saito, Jochen Sprickerhof, Jorge Santos Simon, Lukas Bulwahn, Maarten de Vries, Michael Goerner,
```
