### PR TITLE
marti_common: 0.0.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6113,7 +6113,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 0.0.13-0
+      version: 0.0.14-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.0.14-0`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.13-0`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_geometry_util

- No changes

## swri_image_util

```
* Image blending (#426 <https://github.com/swri-robotics/marti_common/issues/426>)
  * Initial commit of image blending
  * Adding launch file and various bug fixes
  * Making the base and top image encoding match. Lets us do things like blend a grayscale image onto a color image
  * Removing file globbing from CMakeLists that made QtCreator happy
  * Adding message_filters as a ROS package dependency
* Fix issue with contrast stretching when a grid cell is completely masked out.
* Contributors: Marc Alban, danthony06
```

## swri_math_util

- No changes

## swri_nodelet

```
* Include boost/make_shared.hpp
  This header is necessary in the unlikely event that the using cpp file hasn't included boost/make_shared.hpp anywhere else. Also, it's good practice to include what you use.
* Fix include_directories order in swri_roscpp
  Include package-local header files before catkin header files
  so that source is always built against source header files, even
  if the same package exists elsewhere in the catkin tree.
* Contributors: Edward Venator
```

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

```
* Increase queue_size in swri_roscpp/Subscriber.
  This commit increases the queue size for subscribers that use the
  store mechanism instead of a callback.  The queue size was set to 1,
  which we have seen problems with, so this will increase it to 2.
* Add missing qualifiers for swri_roscpp unused parameter functions.
* Merge pull request #385 <https://github.com/swri-robotics/marti_common/issues/385> from evenator/unused-parameter-warnings
  Adds the ability to warn when unused parameters are set in a namespace.
* Add test for getUnusedParamKeys
  Adds an automated test for getUnusedParamKeys based on the example
  code.
* Remove default value of node handle for warnUnusedParams
  This default value may cause unexpected behvavior, especially
  with nodelets.
* Rename param_test to param_example.
  param_test isn't an automated test, just an example of how to use the
  param utilities.
* Document unused parameter functions.
  The set difference algorithms used to determine which parameters
  are used are non-obvious. This adds documentation.
* Mark _used_params static.
* Adds the ability to warn when unused parameters are set in a namespace.
  A common error when using unfamiliar ROS nodes is to accidentally set
  parameters by the wrong name. This features allows the node author
  to output a WARNING for any unused parameters.
  See the param_test node for an example.
* Contributors: Ed Venator, Edward Venator, Elliot Johnson, elliotjo
```

## swri_rospy

- No changes

## swri_route_util

- No changes

## swri_serial_util

```
* Support higher serial baud rates (#423 <https://github.com/swri-robotics/marti_common/issues/423>)
  The system header /usr/include/asm-generic/termbits.h has constants for
  supporting baud rates up to 4000000, but swri_serial_util only allows up
  to 230400.  Some devices support these higher rates and there's no reason
  to not support them, so this adds support for them.
* Check for error from ioctl in serial_port
  Fixes #406 <https://github.com/swri-robotics/marti_common/issues/406>
* Contributors: Edward Venator, P. J. Reed
```

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Merge pull request #435 <https://github.com/swri-robotics/marti_common/issues/435> from swri-robotics/initialize-origin-license
  Fix whitespace and license in initialize_origin.py
* Fix whitespace and license in initialize_origin.py
  Replace "all rights reserved" with standard BSD 3-clause text and remove trailing whitespace in initialize_origin.py
* Fixes #431 <https://github.com/swri-robotics/marti_common/issues/431>
* Simplify dynamic reconfigure usage.
* Add nodelet for publishing a dynamically reconfigurable TF transform.
* Contributors: Edward Venator, Marc Alban, P. J. Reed
```

## swri_yaml_util

```
* Add develspace include directory to swri_yaml_util
  Otherwise, version.h is missing and the package fails to build
* Make swri_yaml_util build out-of-source
  Fixes #411 <https://github.com/swri-robotics/marti_common/issues/411> by generating version.h in the devel space include folder instead of the source space.
  Based heavily on http://answers.ros.org/question/123221/
* Contributors: Edward Venator
```
