### PR TITLE
marti_common: 0.1.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2755,7 +2755,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 0.1.6-0
+      version: 0.1.7-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.1.7-0`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.6-0`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_geometry_util

- No changes

## swri_image_util

```
* Image blending jade (#430 <https://github.com/swri-robotics/marti_common/issues/430>)
  * Initial commit of image blending
  * Adding launch file and various bug fixes
  * Making the base and top image encoding match. Lets us do things like blend a grayscale image onto a color image
  * Removing file globbing from CMakeLists that made QtCreator happy
  * Adding message_filters as a ROS package dependency
* Fix issue with contrast stretching when a grid cell is completely masked out.
* Contributors: Marc Alban, danthony06
```

## swri_math_util

- No changes

## swri_nodelet

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

```
* Increase queue_size in swri_roscpp/Subscriber.
  This commit increases the queue size for subscribers that use the
  store mechanism instead of a callback.  The queue size was set to 1,
  which we have seen problems with, so this will increase it to 2.
* Deprecate LatchedSubscriber. (#392 <https://github.com/swri-robotics/marti_common/issues/392>)
  This commit adds an alternative to LatchedSubscriber and deprecates
  the LatchedSubscriber interface.  LatchedSubscriber should be replaced
  with a swri::Subscriber that is initialized with the address of a
  location to store messages.  For example, instead of:
  swri::LatchedSubscriber<my_package::MyMessage> msg_;
  ...
  msg_.initialize(nh_, "topic_name");
  ...
  ROS_INFO("msg->field = %f", msg->field);
  this becomes:
  swri::Subscriber sub_;
  my_package::MyMessageConstPtr msg_;
  ...
  sub_ = swri::SubscribeR(nh_, "topic_name", &msg_);
  ...
  ROS_INFO("msg->field = %f", msg->field).
  This change makes for a simpler and more consistent interface, and
  avoids the confusion that comes from overloading the -> operator.
* Contributors: Elliot Johnson, P. J. Reed
```

## swri_route_util

- No changes

## swri_serial_util

```
* Support higher serial baud rates (#424 <https://github.com/swri-robotics/marti_common/issues/424>)
  The system header /usr/include/asm-generic/termbits.h has constants for
  supporting baud rates up to 4000000, but swri_serial_util only allows up
  to 230400.  Some devices support these higher rates and there's no reason
  to not support them, so this adds support for them.
* Check for error from ioctl in serial_port
  Fixes #406 <https://github.com/swri-robotics/marti_common/issues/406>
* Contributors: Edward Venator, P. J. Reed
```

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Ignore invalid fixes
  Fixes #431 <https://github.com/swri-robotics/marti_common/issues/431>.
* Simplify dynamic reconfigure usage.
* Add nodelet for publishing a dynamically reconfigurable TF transform.
* Contributors: Marc Alban, P. J. Reed
```

## swri_yaml_util

```
* Make swri_yaml_util build out-of-source.
* Contributors: Marc Alban
```
