### PR TITLE
marti_common: 0.2.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2934,7 +2934,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.2.4-0`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.3-0`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_geometry_util

- No changes

## swri_image_util

```
* Image blending kinetic (#429 <https://github.com/swri-robotics/marti_common/issues/429>)
  * Initial commit of image blending
  * Adding launch file and various bug fixes
  * Making the base and top image encoding match. Lets us do things like blend a grayscale image onto a color image
  * Removing file globbing from CMakeLists that made QtCreator happy
  * Adding message_filters as a ROS package dependency
* Contributors: danthony06
```

## swri_math_util

- No changes

## swri_nodelet

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

```
* Port #385 <https://github.com/swri-robotics/marti_common/issues/385> and #419 <https://github.com/swri-robotics/marti_common/issues/419> to kinetic. (#420 <https://github.com/swri-robotics/marti_common/issues/420>)
  A common error when using unfamiliar ROS nodes is to accidentally set parameters
  by the wrong name. This feature allows the node author to output a WARNING
  for any unused parameters.
  Ported forward from indigo-devel
* Contributors: Edward Venator
```

## swri_route_util

- No changes

## swri_serial_util

```
* Support higher serial baud rates
  The system header /usr/include/asm-generic/termbits.h has constants for
  supporting baud rates up to 4000000, but swri_serial_util only allows up
  to 230400.  Some devices support these higher rates and there's no reason
  to not support them, so this adds support for them.
* Check for error from ioctl in serial_port
  Fixes #406 <https://github.com/swri-robotics/marti_common/issues/406>
* Contributors: Edward Venator, P. J. Reed
```

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Ignore invalid fixes
  Fixes #431 <https://github.com/swri-robotics/marti_common/issues/431>.
* Remove unused gps_common dependency (#422 <https://github.com/swri-robotics/marti_common/issues/422>)
  Fix #421 <https://github.com/swri-robotics/marti_common/issues/421> by removing gps_common from the swri_transform_util CMakeLists.txt in kinetic.
* Simplify dynamic reconfigure usage.
* Add nodelet for publishing a dynamically reconfigurable TF transform.
* Contributors: Edward Venator, Marc Alban, P. J. Reed
```

## swri_yaml_util

```
* Make swri_yaml_util build out-of-source.
* Contributors: Marc Alban
```
