### PR TITLE
bcap: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -325,6 +325,12 @@ repositories:
       url: https://github.com/uos/basler_tof.git
       version: kinetic
     status: developed
+  bcap:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/fsuarez6/bcap-release.git
+      version: 0.1.0-0
   bebop_autonomy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bcap` to `0.1.0-0`:

- upstream repository: https://github.com/fsuarez6/bcap.git
- release repository: https://github.com/fsuarez6/bcap-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
