### PR TITLE
object_recognition_msgs: 0.4.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -651,6 +651,17 @@ repositories:
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel
     status: maintained
+  object_recognition_msgs:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_msgs-release.git
+      version: 0.4.1-0
+    source:
+      type: git
+      url: https://github.com/wg-perception/object_recognition_msgs.git
+      version: master
+    status: maintained
   ocl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_msgs` to `0.4.1-0`:

- upstream repository: https://github.com/wg-perception/object_recognition_msgs.git
- release repository: https://github.com/ros-gbp/object_recognition_msgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## object_recognition_msgs

```
* have the package be architecture independent
* Contributors: Vincent Rabaud
```
