### PR TITLE
octomap_msgs: 0.3.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -695,6 +695,21 @@ repositories:
     status: developed
     status_description: Prerelease based on version 1.8.0. The final version for ROS
       Lunar will (1.9.0)
+  octomap_msgs:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_msgs.git
+      version: lunar-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_msgs-release.git
+      version: 0.3.3-0
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_msgs.git
+      version: lunar-devel
+    status: maintained
   opencv3:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_msgs` to `0.3.3-0`:

- upstream repository: https://github.com/OctoMap/octomap_msgs.git
- release repository: https://github.com/ros-gbp/octomap_msgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## octomap_msgs

```
* Fix for binary ColorOcTrees messages
* Removed check for "OcTree" id in binary deserialization, see Issue #4 <https://github.com/OctoMap/octomap_msgs/issues/4> and #5 <https://github.com/OctoMap/octomap_msgs/issues/5>
* Contributors: Armin Hornung, Felix Endres
```
