### PR TITLE
xsens_driver: 2.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -7377,7 +7377,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ethz-asl/ethzasl_xsens_driver-release.git
-      version: 2.0.1-0
+      version: 2.1.0-0
     source:
       type: git
       url: https://github.com/ethz-asl/ethzasl_xsens_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xsens_driver` to `2.1.0-0`:

- upstream repository: https://github.com/ethz-asl/ethzasl_xsens_driver.git
- release repository: https://github.com/ethz-asl/ethzasl_xsens_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.0.1-0`

## xsens_driver

```
* Add no_rotation_duration option
* Fix typo (#39 <https://github.com/ethz-asl/ethzasl_xsens_driver/issues/39>)
* Fix gnss pvt parsing (#37 <https://github.com/ethz-asl/ethzasl_xsens_driver/issues/37>)
* fix GetOptionFlags (#34 <https://github.com/ethz-asl/ethzasl_xsens_driver/issues/34>)
* Contributors: Andersw88, Francis Colas
```
