### PR TITLE
xsens_driver: 2.1.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1363,6 +1363,21 @@ repositories:
       url: https://github.com/ros/xacro.git
       version: lunar-devel
     status: developed
+  xsens_driver:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/ethzasl_xsens_driver.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ethz-asl/ethzasl_xsens_driver-release.git
+      version: 2.1.0-0
+    source:
+      type: git
+      url: https://github.com/ethz-asl/ethzasl_xsens_driver.git
+      version: master
+    status: developed
   xv_11_laser_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xsens_driver` to `2.1.0-0`:

- upstream repository: https://github.com/ethz-asl/ethzasl_xsens_driver.git
- release repository: https://github.com/ethz-asl/ethzasl_xsens_driver-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## xsens_driver

```
* Add no_rotation_duration option
* Fix typo (#39 <https://github.com/ethz-asl/ethzasl_xsens_driver/issues/39>)
* Fix gnss pvt parsing (#37 <https://github.com/ethz-asl/ethzasl_xsens_driver/issues/37>)
* fix GetOptionFlags (#34 <https://github.com/ethz-asl/ethzasl_xsens_driver/issues/34>)
* Contributors: Andersw88, Francis Colas
```
