### PR TITLE
srdfdom: 0.4.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1255,6 +1255,22 @@ repositories:
       url: https://github.com/orocos/rtt_ros_integration.git
       version: toolchain-2.9
     status: maintained
+  srdfdom:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/srdfdom-release.git
+      version: 0.4.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: kinetic-devel
+    status: maintained
   stage:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `0.4.2-0`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/ros-gbp/srdfdom-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## srdfdom

```
* [fix] gcc6 build error #28 <https://github.com/ros-planning/srdfdom/issues/28>
* [fix] Compile with -std=c++11 (#29 <https://github.com/ros-planning/srdfdom/issues/29>)
* [enhancement] cleanup urdfdom compatibility (#27 <https://github.com/ros-planning/srdfdom/issues/27>)
* Contributors: Dmitry Rozhkov, Isaac I.Y. Saito, Robert Haschke, Victor Matare
```
