### PR TITLE
warehouse_ros: 0.9.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1364,6 +1364,22 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: kinetic
     status: maintained
+  warehouse_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/warehouse_ros-release.git
+      version: 0.9.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: jade-devel
+    status: maintained
   xacro:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `0.9.0-0`:

- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/ros-gbp/warehouse_ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## warehouse_ros

```
* [fix] Omit dependency on mongo (and replace with pluginlib) #32 <https://github.com/ros-planning/warehouse_ros/issues/22>
* [fix] Specifically including a header that seems to be required from Ubuntu Xenial.
* [sys] Ensure headers and libraries are present for downstream pkgs #17 <https://github.com/ros-planning/warehouse_ros/issues/17>
* [sys] Update CI config to test Jade and Kinetic #30 <https://github.com/ros-planning/warehouse_ros/issues/30>
* [sys] Add rostest file and configs.
* Contributors: Connor Brew, Dave Coleman, Ioan A Sucan, Isaac I.Y. Saito, Michael Ferguson, Scott K Logan
```
