### PR TITLE
moveit_resources: 0.6.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -647,6 +647,22 @@ repositories:
       url: https://github.com/ros-planning/moveit_msgs.git
       version: kinetic-devel
     status: maintained
+  moveit_resources:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_resources.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_resources-release.git
+      version: 0.6.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-planning/moveit_resources.git
+      version: master
+    status: developed
   nodelet_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `0.6.2-0`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros-gbp/moveit_resources-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## moveit_resources

```
* [fix] Missing license to fanuc pkgs imported from ros-industrial/fanuc. #11 <https://github.com/ros-planning/moveit_resources/issues/11>. (#12 <https://github.com/ros-planning/moveit_resources/issues/12>)
* [fix] Missing run depends for [robot|joint]_state_publisher (#14 <https://github.com/ros-planning/moveit_resources/issues/14>)
* [fix] Correct warehouse ros mongo (#13 <https://github.com/ros-planning/moveit_resources/issues/13>)
* [improve] test chomp (#10 <https://github.com/ros-planning/moveit_resources/issues/10>)
* Contributors: Chittaranjan Srinivas Swaminathan, Dave Coleman, G.A. vd. Hoorn, kirstyellis
```
