### PR TITLE
angles: 1.9.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -107,7 +107,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/geometry_angles_utils-release.git
-      version: 1.9.10-0
+      version: 1.9.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `angles` to `1.9.11-0`:

- upstream repository: https://github.com/ros/angles.git
- release repository: https://github.com/ros-gbp/geometry_angles_utils-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.9.10-0`

## angles

```
* Add a python implementation of angles
* Do not use catkin_add_gtest if CATKIN_ENABLE_TESTING
* Contributors: David V. Lu, David V. Lu!!, Ryohei Ueda
```
