### PR TITLE
angles: 1.9.11-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -52,7 +52,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/geometry_angles_utils-release.git
-      version: 1.9.10-2
+      version: 1.9.11-0
     source:
       type: git
       url: https://github.com/ros/angles.git


### PR DESCRIPTION
Increasing version of package(s) in repository `angles` to `1.9.11-0`:

- upstream repository: https://github.com/ros/angles.git
- release repository: https://github.com/ros-gbp/geometry_angles_utils-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.9.10-2`

## angles

```
* Add a python implementation of angles
* Do not use catkin_add_gtest if CATKIN_ENABLE_TESTING
* Contributors: David V. Lu, David V. Lu!!, Ryohei Ueda
```
