### PR TITLE
Adding thingmagic_usbpro to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13750,6 +13750,16 @@ repositories:
       url: https://github.com/bsb808/thingmagic_rfid.git
       version: master
     status: developed
+  thingmagic_usbpro:
+    doc:
+      type: git
+      url: https://gitlab.com/chambana/thingmagic_usbpro.git
+      version: master
+    source:
+      type: git
+      url: https://gitlab.com/chambana/thingmagic_usbpro.git
+      version: master
+    status: developed
   threemxl:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6835,6 +6835,16 @@ repositories:
       url: https://github.com/RobotWebTools/tf2_web_republisher.git
       version: master
     status: maintained
+  thingmagic_usbpro:
+    doc:
+      type: git
+      url: https://gitlab.com/chambana/thingmagic_usbpro.git
+      version: master
+    source:
+      type: git
+      url: https://gitlab.com/chambana/thingmagic_usbpro.git
+      version: master
+    status: developed
   thormang3_common:
     doc:
       type: git


### PR DESCRIPTION
I'd like thingmagic_usbpro to be indexed and documented on ros.org