### PR TITLE
geographic_info: 0.5.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -370,6 +370,25 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: kinetic-devel
     status: maintained
+  geographic_info:
+    doc:
+      type: git
+      url: https://github.com/ros-geographic-info/geographic_info.git
+      version: master
+    release:
+      packages:
+      - geodesy
+      - geographic_info
+      - geographic_msgs
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-geographic-info/geographic_info-release.git
+      version: 0.5.1-0
+    source:
+      type: git
+      url: https://github.com/ros-geographic-info/geographic_info.git
+      version: master
+    status: maintained
   geometric_shapes:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geographic_info` to `0.5.1-0`:

- upstream repository: https://github.com/ros-geographic-info/geographic_info.git
- release repository: https://github.com/ros-geographic-info/geographic_info-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## geodesy

- No changes

## geographic_info

- No changes

## geographic_msgs

```
* Add GeoPath message with poses.
* Add GetGeoPath service (#7 <https://github.com/ros-geographic-info/geographic_info/issues/7>).
```
