### PR TITLE
geographic_info: 0.5.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -383,7 +383,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-geographic-info/geographic_info-release.git
-      version: 0.5.1-0
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/ros-geographic-info/geographic_info.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geographic_info` to `0.5.2-0`:

- upstream repository: https://github.com/ros-geographic-info/geographic_info.git
- release repository: https://github.com/ros-geographic-info/geographic_info-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.5.1-0`

## geodesy

- No changes

## geographic_info

- No changes

## geographic_msgs

```
* Fix merge error in GeoPath message.
```
