### PR TITLE
geographic_info: 0.5.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1520,7 +1520,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-geographic-info/geographic_info-release.git
-      version: 0.4.0-0
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/ros-geographic-info/geographic_info.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geographic_info` to `0.5.2-0`:

- upstream repository: https://github.com/ros-geographic-info/geographic_info.git
- release repository: https://github.com/ros-geographic-info/geographic_info-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.4.0-0`

## geodesy

- No changes

## geographic_info

- No changes

## geographic_msgs

```
* Fix merge error in GeoPath message.
```
