### PR TITLE
webkit_dependency: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14934,6 +14934,21 @@ repositories:
       url: https://github.com/asmodehn/webargs-rosrelease.git
       version: 1.3.4-8
     status: maintained
+  webkit_dependency:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/webkit_dependency.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/webkit_dependency-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/webkit_dependency.git
+      version: indigo-devel
+    status: maintained
   webtest:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webkit_dependency` to `1.0.0-0`:

- upstream repository: https://github.com/ros-visualization/webkit_dependency.git
- release repository: https://github.com/ros-gbp/webkit_dependency-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
