### PR TITLE
webkit_dependency: 1.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -7298,6 +7298,21 @@ repositories:
       url: https://github.com/asmodehn/webargs-rosrelease.git
       version: 1.3.4-3
     status: maintained
+  webkit_dependency:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/webkit_dependency.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/webkit_dependency-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/webkit_dependency.git
+      version: indigo-devel
+    status: maintained
   webtest:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webkit_dependency` to `1.0.0-0`:

- upstream repository: https://github.com/ros-visualization/webkit_dependency.git
- release repository: https://github.com/ros-gbp/webkit_dependency-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
