### PR TITLE
py_trees_ros: 0.5.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4634,7 +4634,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 0.5.8-0
+      version: 0.5.9-0
     source:
       type: git
       url: https://github.com/stonier/py_trees_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `0.5.9-0`:

- upstream repository: https://github.com/stonier/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.5.8-0`

## py_trees_ros

```
* [doc] add missing rqt-py-trees image
* [infra] bugfix missing install rule for mock sensors script
```
