### PR TITLE
[dep][fedora] Add libusb-1.0-dev for 25, 26.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2853,6 +2853,8 @@ libusb-1.0-dev:
     '22': [libusbx-devel]
     '23': [libusbx-devel]
     '24': [libusbx-devel]
+    '25': [libusbx-devel]
+    '26': [libusbx-devel]
     beefy: [libusb1-devel]
     heisenbug: [libusbx-devel]
     schrödinger’s: [libusbx-devel]


### PR DESCRIPTION
https://admin.fedoraproject.org/pkgdb/package/rpms/libusbx :
```
Fedora 26	Approved -- critpath
Fedora 25 	Approved -- critpath
```