### PR TITLE
openni_camera: 1.9.5-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -782,6 +782,22 @@ repositories:
       url: https://github.com/ros-gbp/opencv3-release.git
       version: 3.2.0-6
     status: maintained
+  openni_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni_camera.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/openni_camera-release.git
+      version: 1.9.5-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/openni_camera.git
+      version: indigo-devel
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_camera` to `1.9.5-0`:

- upstream repository: https://github.com/ros-drivers/openni_camera.git
- release repository: https://github.com/ros-gbp/openni_camera-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## openni_camera

```
* [feat] Updated max drop rate
* [sys] Added log4cxx missing explicit linkage #44 <https://github.com/ros-drivers/openni_camera/issues/44>
* Contributors: Francois-Michel De Rainville, Isaac IY Saito, Leopold Palomo-Avellaneda, Isaac I.Y. Saito
```
