### PR TITLE
jsk_control: 0.1.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5031,7 +5031,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_control-release.git
-      version: 0.1.11-0
+      version: 0.1.13-0
     status: developed
   jsk_demos:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_control` to `0.1.13-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_control.git
- release repository: https://github.com/tork-a/jsk_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.1.11-0`

## contact_states_observer

- No changes

## eus_nlopt

- No changes

## eus_qp

- No changes

## eus_qpoases

- No changes

## joy_mouse

- No changes

## jsk_calibration

- No changes

## jsk_control

- No changes

## jsk_footstep_controller

```
* CMakeLists.txt : fix typo on install DESTINATION
* [jsk_footstep_controller] prevent too large footstep refine
* [jsk_footstep_controller] add utilitiy functions and update for footstep_planner
* [jsk_footstep_controller] add keyword for sample footstep client
* [jsk_footstep_contorller] Do not publish odom tf when publish_odom_tf param is false
* [jsk_footstep_contorller] Update footstep params for JAXON
* Contributors: Kei Okada, Yohei Kakiuchi, Iori Kumagai
```

## jsk_footstep_planner

```
* [jsk_footstep_planner, jsk_teleop_joy] add stack mode to footstep_marker
* [jsk_footstep_planner] add pass through filter for creating heightmap (remove points of a ceiling)
* [jsk_footstep_planner] Make initial map_origin_pointcloud smaller
* Contributors: Yohei Kakiuchi
```

## jsk_ik_server

- No changes

## jsk_teleop_joy

```
* [jsk_footstep_planner, jsk_teleop_joy] add stack mode to footstep_marker
* [jsk_teleop_joy] Remove / from default frame_id in pose6d plugin
* [jsk_teleop_joy] update view control in rviz using teleop_joy
* Contributors: Yohei Kakiuchi
```
