### PR TITLE
rviz: 1.12.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1320,6 +1320,22 @@ repositories:
       url: https://github.com/orocos/rtt_ros_integration.git
       version: toolchain-2.9
     status: maintained
+  rviz:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rviz.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/rviz-release.git
+      version: 1.12.4-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rviz.git
+      version: kinetic-devel
+    status: maintained
   srdfdom:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.12.4-0`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rviz

```
* Restored "Use ``urdf::*ShredPtr`` instead of ``boost::shared_ptr``" (#1064 <https://github.com/ros-visualization/rviz/issues/1064>)
  Now supports ``urdfdom`` 0.3 and 0.4 through a compatibility header in ``urdf``.
* You can now visualize joint axis and display type and limits (#1029 <https://github.com/ros-visualization/rviz/issues/1029>)
* Contributors: Lucas Walter, Robert Haschke, William Woodall
```
