### PR TITLE
camera_info_manager_py: 0.2.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -89,6 +89,21 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: master
     status: maintained
+  camera_info_manager_py:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/camera_info_manager_py.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/camera_info_manager_py-release.git
+      version: 0.2.3-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/camera_info_manager_py.git
+      version: master
+    status: maintained
   capabilities:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_info_manager_py` to `0.2.3-0`:

- upstream repository: https://github.com/ros-perception/camera_info_manager_py.git
- release repository: https://github.com/ros-gbp/camera_info_manager_py-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## camera_info_manager_py

- No changes
