### PR TITLE
libfreenect: 0.5.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -586,6 +586,17 @@ repositories:
       url: https://github.com/ros-perception/laser_pipeline.git
       version: hydro-devel
     status: maintained
+  libfreenect:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/libfreenect.git
+      version: ros-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/libfreenect-ros-release.git
+      version: 0.5.1-0
+    status: maintained
   libg2o:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libfreenect` to `0.5.1-0`:

- upstream repository: https://github.com/ros-drivers/libfreenect.git
- release repository: https://github.com/ros-drivers-gbp/libfreenect-ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
