### PR TITLE
gazebo_ros_pkgs: 2.5.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1382,7 +1382,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.5.10-0
+      version: 2.5.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.5.11-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.5.10-0`

## gazebo_msgs

```
* Changed the spawn model methods to spawn also lights. (#511 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/511>)
* Contributors: Alessandro Ambrosano
```

## gazebo_plugins

```
* Change build system to set DEPEND on Gazebo/SDFormat (fix catkin warning)
  Added missing DEPEND clauses to catkin_package to fix gazebo catkin warning.
  Note that after the change problems could appear related to -lpthreads
  errors. This is an known issue related to catkin:
  https://github.com/ros/catkin/issues/856
* Fix: add gazebo_ros_range to catkin package libraries (#558 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/558>)
* Contributors: Christoph Rist, Dave Coleman
```

## gazebo_ros

```
* Changed the spawn model methods to spawn also lights. (#511 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/511>)
* Change build system to set DEPEND on Gazebo/SDFormat (fix catkin warning)
  Added missing DEPEND clauses to catkin_package to fix gazebo catkin warning.
  Note that after the change problems could appear related to -lpthreads
  errors. This is an known issue related to catkin:
  https://github.com/ros/catkin/issues/856.
* Use correct logerr method (#557 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/557>)
* Contributors: Alessandro Ambrosano, Dave Coleman, Gary Servin
```

## gazebo_ros_control

```
* Change build system to set DEPEND on Gazebo/SDFormat (fix catkin warning)
  Added missing DEPEND clauses to catkin_package to fix gazebo catkin warning. Note that after the change problems could appear related to -lpthreads errors. This is an known issue related to catkin: https://github.com/ros/catkin/issues/856.
* Make gazebo_ros_control compatible with ros_control with respect to <hardwareInterface> tag (#550 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/550>)
  * ros_control expects "<hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>", i.e. "hardware_interface/" prefix
  * add deprecation warning
  * improve warning
  * fix warning message fix
* Contributors: Andreas Bihlmaier, Dave Coleman
```

## gazebo_ros_pkgs

- No changes
