### PR TITLE
[dep][ubuntu/debian] Add geographiclib-tools/libgeographiclib-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -826,6 +826,7 @@ geographiclib:
     xenial: [libgeographic-dev]
 geographiclib-tools:
   debian: [geographiclib-tools]
+  fedora: [GeographicLib]
   ubuntu: [geographiclib-tools]
 geos:
   arch: [geos]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -812,6 +812,7 @@ gdal-bin:
   gentoo: [sci-libs/gdal]
   ubuntu: [gdal-bin]
 geographiclib:
+  debian: [libgeographiclib-dev]
   fedora: [GeographicLib-devel]
   ubuntu:
     precise: [libgeographiclib-dev]
@@ -823,6 +824,9 @@ geographiclib:
     vivid: [libgeographic-dev]
     wily: [libgeographic-dev]
     xenial: [libgeographic-dev]
+geographiclib-tools:
+  debian: [geographiclib-tools]
+  ubuntu: [geographiclib-tools]
 geos:
   arch: [geos]
   fedora: [geos-devel]


### PR DESCRIPTION
```bash
$rosdep resolve geographiclib-tools
#apt
geographiclib-tools

$rosdep resolve geographiclib-tools --os=ubuntu:xenial
#apt
geographiclib-tools
```
Main purpose is allowing integration of datasets of GeographicLib to be used by [mavros](http://wiki.ros.org/mavros).