### PR TITLE
remove expiringdict rosdep key for fedora

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -758,9 +758,6 @@ python-evdev:
     xenial: [python-evdev]
 python-expiringdict:
   debian: [python-expiringdict]
-  fedora:
-    pip:
-      packages: [expiringdict]
   ubuntu: [python-expiringdict]
 python-falcon:
   debian: [python-falcon]


### PR DESCRIPTION
Remove expiringdict rosdep key for fedora since fedora doesn't support pip installer apparently.

When trying to release a package depending on *expiringdict* with *bloom-release*:

```
==> git-bloom-generate -y rosrpm --prefix release/kinetic kinetic -i 0
Generating source RPMs for the packages: ['log_server']
RPM Incremental Version: 0
RPM Distributions: ['23', '24']
Releasing for rosdistro: kinetic

Pre-verifying RPM dependency keys...
Running 'rosdep update'...
Key 'python-expiringdict' resolved to '['expiringdict']' with installer 'pip', which does not match the default installer 'yum'.
Failed to resolve python-expiringdict on fedora:23 with: Error running generator: The RPM generator does not support dependencies which are installed with the 'pip' installer.
python-expiringdict is depended on by these packages: ['log_server']
<== Failed
Key 'python-expiringdict' resolved to '['expiringdict']' with installer 'pip', which does not match the default installer 'yum'.
Failed to resolve python-expiringdict on fedora:24 with: Error running generator: The RPM generator does not support dependencies which are installed with the 'pip' installer.
python-expiringdict is depended on by these packages: ['log_server']
<== Failed
Some of the dependencies for packages in this repository could not be resolved by rosdep.
You can try to address the issues which appear above and try again if you wish, or continue without releasing into RPM-based distributions (e.g. Fedora 24).
```