### PR TITLE
pyros_common: 0.4.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9223,7 +9223,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/pyros-common-rosrelease.git
-      version: 0.4.0-3
+      version: 0.4.2-0
     status: developed
   pyros_config:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_common` to `0.4.2-0`:

- upstream repository: https://github.com/asmodehn/pyros-common.git
- release repository: https://github.com/asmodehn/pyros-common-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.4.0-3`

## pyros_common

```
* Fixing setup.py to point to normal pyros-common package. [AlexV]
* V0.4.2. [AlexV]
* Fixing setup.py commands after pacakge structure change. [AlexV]
* Dropping the namespace idea, since we cant make a working deb pkg out
  of it. [AlexV]
* Preparing ros release... [AlexV]
```
