### PR TITLE
pointgrey_camera_driver: 0.13.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4552,7 +4552,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
-      version: 0.13.0-0
+      version: 0.13.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointgrey_camera_driver` to `0.13.1-0`:

- upstream repository: https://github.com/ros-drivers/pointgrey_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.13.0-0`

## image_exposure_msgs

- No changes

## pointgrey_camera_description

- No changes

## pointgrey_camera_driver

```
* Add flycapture2 lib download rule for aarch64(e.g. Jetson TX1) (#93 <https://github.com/ros-drivers/pointgrey_camera_driver/issues/93>)
* Make flycap d/l logic work on re-build. (#109 <https://github.com/ros-drivers/pointgrey_camera_driver/issues/109>)
* Fix missing roslaunch dep, package format 2.
```

## statistics_msgs

- No changes

## wfov_camera_msgs

- No changes
