### PR TITLE
remove rosdep entries removed from Homebrew

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -287,26 +287,10 @@ libpq-dev:
   osx:
     homebrew:
       packages: [postgresql]
-libqglviewer-qt4-dev:
-  osx:
-    homebrew:
-      packages: [libqglviewer]
 libqhull:
   osx:
     homebrew:
       packages: [qhull]
-libqt4:
-  osx:
-    homebrew:
-      packages: [qt]
-libqt4-dev:
-  osx:
-    homebrew:
-      packages: [qt]
-libqt4-opengl-dev:
-  osx:
-    homebrew:
-      packages: [qt]
 libqt5-core:
   osx:
     homebrew:
@@ -608,18 +592,6 @@ python-pyproj:
   osx:
     pip:
       packages: [pyproj]
-python-qt-bindings:
-  osx:
-    homebrew:
-      packages: [pyside, shiboken, pyqt, sip]
-python-qt-bindings-gl:
-  osx:
-    homebrew:
-      packages: [pyqt]
-python-qt-bindings-qwt5:
-  osx:
-    homebrew:
-      packages: [pyqwt]
 python-qt5-bindings:
   osx:
     homebrew:
@@ -666,10 +638,6 @@ python-yaml:
     pip:
       depends: [yaml]
       packages: [PyYAML]
-qt4-qmake:
-  osx:
-    homebrew:
-      packages: [qt]
 qt5-qmake:
   osx:
     homebrew:


### PR DESCRIPTION
Unfortunately Homebrew has removed many of the older qt4 related formula. I tried to resurrect them in https://github.com/ros/homebrew-deps/pull/31 and https://github.com/ros/rosdistro/pull/14459 but I was unable to do so.

See prs which removed each formula (note that the "boneyard" also no longer remains):

- qt (https://github.com/Homebrew/homebrew-core/pull/8306) (now aliased to qt5)
- pyqt (https://github.com/Homebrew/homebrew-core/pull/6817) (now aliased to pyqt5)
- pyside (https://github.com/Homebrew/homebrew-core/pull/5725)
- shiboken (https://github.com/Homebrew/homebrew-core/pull/5726)
- pyqwt (https://github.com/Homebrew/homebrew-core/issues/4850)
- libqglviewer (https://github.com/Homebrew/homebrew-core/pull/6827)