### PR TITLE
rospeex: 3.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5747,7 +5747,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://bitbucket.org/rospeex/rospeex-release.git
-      version: 3.0.0-0
+      version: 3.0.1-0
     source:
       type: git
       url: https://bitbucket.org/rospeex/rospeex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospeex` to `3.0.1-0`:

- upstream repository: https://bitbucket.org/rospeex/rospeex.git
- release repository: https://bitbucket.org/rospeex/rospeex-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `3.0.0-0`

## rospeex

- No changes

## rospeex_audiomonitor

- No changes

## rospeex_core

```
* Mod VAD parameters
* Mod microphone gain and VAD parameters
```

## rospeex_if

- No changes

## rospeex_launch

```
* Mod microphone gain and VAD parameters
```

## rospeex_msgs

- No changes

## rospeex_samples

- No changes

## rospeex_webaudiomonitor

- No changes
