### PR TITLE
ros_peerjs: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5633,6 +5633,13 @@ repositories:
       url: https://github.com/iirob/ros_opcua_communication.git
       version: kinetic-devel
     status: developed
+  ros_peerjs:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/easymov/ros_peerjs-release.git
+      version: 0.1.1-0
+    status: developed
   ros_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_peerjs` to `0.1.1-0`:

- upstream repository: https://gitlab.com/easymov/ros_peerjs.git
- release repository: https://github.com/easymov/ros_peerjs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## ros_peerjs

```
* add dependencies
* install with cmake
* test page and script
* small edit
* fix ws install
* gitignore + name on CMakeLists.txt
* first
* Contributors: Gérald Lelong, nmartignoni
```
