### PR TITLE
fetch_pbd: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2914,11 +2914,12 @@ repositories:
     release:
       packages:
       - fetch_arm_control
+      - fetch_pbd_interaction
       - fetch_social_gaze
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics/fetch_pbd-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_pbd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_pbd` to `0.0.7-0`:

- upstream repository: https://github.com/fetchrobotics/fetch_pbd.git
- release repository: https://github.com/fetchrobotics/fetch_pbd-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.0.6-0`

## fetch_arm_control

```
* Make the gripper open all the way
* Contributors: Sarah Elliott
```

## fetch_pbd_interaction

```
* Built frontend and now serve pre-built frontend directly
* add couchdb as run_depend, fix #6 <https://github.com/fetchrobotics/fetch_pbd/issues/6>
* Custom ros3d.js to use unsubscribeTf and show mesh colours. Use local copies of Robot Web Tools libraries.
* Contributors: Sarah Elliott
```

## fetch_social_gaze

- No changes
