### PR TITLE
log_server: 0.1.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2771,7 +2771,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/easymov/log_server-release.git
-      version: 0.1.1-1
+      version: 0.1.4-0
     status: developed
   lpms_imu:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `log_server` to `0.1.4-0`:

- upstream repository: https://lelongg@gitlab.com/easymov/log_server.git
- release repository: https://github.com/easymov/log_server-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.1-1`

## log_server

```
* add missing build depend
* Contributors: Gérald Lelong
```
