### PR TITLE
ros_controllers: 0.12.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1184,6 +1184,24 @@ repositories:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git
       version: kinetic-devel
+    release:
+      packages:
+      - diff_drive_controller
+      - effort_controllers
+      - force_torque_sensor_controller
+      - forward_command_controller
+      - gripper_action_controller
+      - imu_sensor_controller
+      - joint_state_controller
+      - joint_trajectory_controller
+      - position_controllers
+      - ros_controllers
+      - rqt_joint_trajectory_controller
+      - velocity_controllers
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/ros_controllers-release.git
+      version: 0.12.2-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.12.2-0`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_controller

- No changes

## forward_command_controller

- No changes

## gripper_action_controller

- No changes

## imu_sensor_controller

- No changes

## joint_state_controller

- No changes

## joint_trajectory_controller

```
* Remove rqt_plot test_depend & make plots optional
* Contributors: Bence Magyar
```

## position_controllers

- No changes

## ros_controllers

- No changes

## rqt_joint_trajectory_controller

- No changes

## velocity_controllers

- No changes
