### PR TITLE
oros_tools: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4221,6 +4221,13 @@ repositories:
       url: https://github.com/orocos/orocos_kinematics_dynamics.git
       version: master
     status: maintained
+  oros_tools:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/easymov/oros_tools-release.git
+      version: 0.1.1-0
+    status: developed
   osrf_gear:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `oros_tools` to `0.1.1-0`:

- upstream repository: https://lelongg@gitlab.com/easymov/oros_tools.git
- release repository: https://github.com/easymov/oros_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## oros_tools

```
* prepare for release
* dev.oros.io in defaul.launch
* first
* Contributors: Gérald Lelong, nmartignoni
```
