### PR TITLE
Adding tensor_field_nav to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13664,6 +13664,16 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  tensor_field_nav:
+    doc:
+      type: git
+      url: https://github.com/zlt1991/tensor_field_nav.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/zlt1991/tensor_field_nav.git
+      version: master
+    status: maintained
   terarangerduo-ros:
     release:
       packages:


### PR DESCRIPTION
I'd like tensor_field_nav to be indexed and documented on ros.org.