### PR TITLE
ros_controllers: 0.12.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5619,7 +5619,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.12.1-0
+      version: 0.12.3-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.12.3-0`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.12.1-0`

## diff_drive_controller

- No changes

## effort_controllers

```
* Supply NodeHandle to urdf::Model. Closes #244 <https://github.com/ros-controls/ros_controllers/issues/244>
* Contributors: Piyush Khandelwal
```

## force_torque_sensor_controller

- No changes

## forward_command_controller

- No changes

## gripper_action_controller

- No changes

## imu_sensor_controller

- No changes

## joint_state_controller

- No changes

## joint_trajectory_controller

- No changes

## position_controllers

- No changes

## ros_controllers

- No changes

## rqt_joint_trajectory_controller

- No changes

## velocity_controllers

```
* Supply NodeHandle to urdf::Model. Closes #244 <https://github.com/ros-controls/ros_controllers/issues/244>
* Contributors: Piyush Khandelwal
```
