### PR TITLE
dynamixel-workbench: 0.1.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -911,7 +911,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel-workbench` to `0.1.4-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
- release repository: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.1.3-0`

## dynamixel_workbench

```
* toolbox bug fixed
* added dynamixel new model: XL430_W250
* added dynamixel new model: XH
* renamed current controller -> torque controller
* Contributors: Darby Lim
```

## dynamixel_workbench_controllers

```
* added dynamixel new model: XL430_W250
* added dynamixel new model: XH
* renamed current controller -> torque controller
* Contributors: Darby Lim, Dardy Lim
```

## dynamixel_workbench_msgs

```
* added dynamixel new model: XL430_W250
* added dynamixel new model: XH
* Contributors: Darby Lim
```

## dynamixel_workbench_single_manager

```
* added dynamixel new model: XL430_W250
* added dynamixel new model: XH
* Contributors: Darby Lim
```

## dynamixel_workbench_single_manager_gui

```
* added dynamixel new model: XL430_W250
* added dynamixel new model: XH
* Contributors: Darby Lim
```

## dynamixel_workbench_toolbox

```
* toolbox bug fixed
* added dynamixel new model: XL430_W250
* added dynamixel new model: XH
* renamed current controller -> torque controller
* Contributors: Darby Lim
```

## dynamixel_workbench_tutorials

```
* updated for other packages
* Contributors: Darby Lim
```
