### PR TITLE
hls-lfcd-lds-driver: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1865,7 +1865,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release.git
-      version: 0.1.1-1
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hls-lfcd-lds-driver` to `0.1.2-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
- release repository: https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.1.1-1`

## hls_lfcd_lds_driver

```
* modified the timing to take a timestamp for sync the scan and odom
* added a hlds_laser_segment_publisher node
* Contributors: Pyo
```
