### PR TITLE
dynamixel_sdk: 3.4.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -947,7 +947,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
-      version: 3.4.1-0
+      version: 3.4.3-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.4.3-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `3.4.1-0`

## dynamixel_sdk

```
* DynamixelSDK C++ ver. and ROS ver. in Windows platform now can use the port number of over then 10 #45
* Contributors: leon
```
