### PR TITLE
rgbd_launch: 2.2.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1029,6 +1029,22 @@ repositories:
       url: https://github.com/orocos/rFSM.git
       version: master
     status: maintained
+  rgbd_launch:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/rgbd_launch.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/rgbd_launch-release.git
+      version: 2.2.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/rgbd_launch.git
+      version: jade-devel
+    status: maintained
   robot_model:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rgbd_launch` to `2.2.2-0`:

- upstream repository: https://github.com/ros-drivers/rgbd_launch.git
- release repository: https://github.com/ros-gbp/rgbd_launch-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rgbd_launch

```
* [capability] add rgb prefix, rectify_ir to node name
* [maintenance] enable rostest upon build.
* [maintenance] Remove Indigo. Enable Kinetic from Travis conf. #32 <https://github.com/ros-drivers/rgbd_launch/issues/32>
* Contributors: Yuki Furuta, Isaac I.Y. Saito
```
