### PR TITLE
pyros_common: 0.4.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4596,6 +4596,13 @@ repositories:
       url: https://github.com/asmodehn/pyros.git
       version: indigo
     status: developed
+  pyros_common:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/asmodehn/pyros-common-rosrelease.git
+      version: 0.4.2-0
+    status: developed
   pyros_config:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_common` to `0.4.2-0`:

- upstream repository: https://github.com/asmodehn/pyros-common.git
- release repository: https://github.com/asmodehn/pyros-common-rosrelease.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## pyros_common

```
* Fixing setup.py to point to normal pyros-common package. [AlexV]
* V0.4.2. [AlexV]
* Fixing setup.py commands after pacakge structure change. [AlexV]
* Dropping the namespace idea, since we cant make a working deb pkg out
  of it. [AlexV]
* Preparing ros release... [AlexV]
```
