### PR TITLE
robotis_framework: 0.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5184,13 +5184,14 @@ repositories:
       version: kinetic-devel
     release:
       packages:
+      - robotis_controller
       - robotis_device
       - robotis_framework
       - robotis_framework_common
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_framework` to `0.2.2-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.2.1-0`

## robotis_controller

```
* updated robotis_controller.cpp
* changed to read control cycle from .robot file
* Contributors: Zerom
```

## robotis_device

```
* added a deivce: OpenCR
* changed to read control cycle from .robot file
* Contributors: Zerom, Kayman
```

## robotis_framework

```
* added a deivce: OpenCR
* updated robotis_controller.cpp
* changed to read control cycle from .robot file
* Contributors: Zerom, Kayman
```

## robotis_framework_common

```
* updated for other packages
* Contributors: Zerom, Kayman
```
