### PR TITLE
oros_tools_examples: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4252,6 +4252,13 @@ repositories:
       url: https://github.com/easymov/oros_tools-release.git
       version: 0.1.1-0
     status: developed
+  oros_tools_examples:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/easymov/oros_tools_examples-release.git
+      version: 0.1.2-0
+    status: developed
   osrf_gear:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `oros_tools_examples` to `0.1.2-0`:

- upstream repository: https://gitlab.com/easymov/oros_tools_examples.git
- release repository: https://github.com/easymov/oros_tools_examples-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
