### PR TITLE
robotis_math: 0.2.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5205,7 +5205,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Math-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Math.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_math` to `0.2.3-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Math.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Math-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.2.2-0`

## robotis_math

```
* changed matrices to fixed size matrix
* changed dynamic size mat to fixed size mat for performence
* Contributors: Jay Song
```
