### PR TITLE
robotis_utility: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5219,11 +5219,12 @@ repositories:
     release:
       packages:
       - robotis_utility
+      - ros_madplay_player
       - ros_mpg321_player
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Utility-release.git
-      version: 0.1.1-2
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Utility.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_utility` to `0.1.2-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Utility.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Utility-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.1.1-2`

## robotis_utility

```
* added ros_madplay_player pkg
* added movement done msg
* Contributors: Jay Song
```

## ros_madplay_player

```
* added ros_madplay_player pkg
* Contributors: Jay Song
```

## ros_mpg321_player

```
* added movement done msg
* Contributors: Jay Song
```
