### PR TITLE
thormang3_common: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6903,7 +6903,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Common-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_common` to `0.1.2-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Common.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.1.1-0`

## thormang3_common

```
* modified rviz config file
* updated simulation
* updated config files
* Contributors: Kayman, SCH
```

## thormang3_description

```
* modified rviz config file
* updated simulation
* updated config files
* Contributors: Kayman, SCH
```

## thormang3_gazebo

```
* updated the simulation
* Contributors: SCH
```
