### PR TITLE
thormang3_msgs: 0.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6938,16 +6938,15 @@ repositories:
       packages:
       - thormang3_action_module_msgs
       - thormang3_feet_ft_module_msgs
-      - thormang3_gripper_module_msgs
+      - thormang3_head_control_module_msgs
       - thormang3_manipulation_module_msgs
       - thormang3_msgs
       - thormang3_offset_tuner_msgs
       - thormang3_walking_module_msgs
-      - thormang3_wholebody_module_msgs
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-msgs-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_msgs` to `0.2.2-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.2.1-0`

## thormang3_action_module_msgs

```
* none
```

## thormang3_feet_ft_module_msgs

```
* none
```

## thormang3_head_control_module_msgs

```
* add head_control_module_msgs
* Contributors: Kayman
```

## thormang3_manipulation_module_msgs

```
* added jointgrouppose
* deleted gripper msg & modified manipulation msg
* added manipulation module msgs
* Contributors: SCH
```

## thormang3_msgs

```
* none
```

## thormang3_offset_tuner_msgs

```
* none
```

## thormang3_walking_module_msgs

```
* modified SetBalanceParam.srv
* added some msg and sev for compile
* modified walking msgs for new balance control
* Contributors: Zerom
```
