### PR TITLE
multimaster_fkie: 0.7.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6908,7 +6908,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.7.2-0
+      version: 0.7.3-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.7.3-0`:

- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.7.2-0`

## default_cfg_fkie

```
* default_cfg_fkie: fixed problem with "pass_all_args" attribute
* fixed warnings in API documentation
* Contributors: Alexander Tiderko
```

## master_discovery_fkie

```
* fixed warnings in API documentation
* Contributors: Alexander Tiderko
```

## master_sync_fkie

```
* fixed warnings in API documentation
* Contributors: Alexander Tiderko
```

## multimaster_fkie

```
* default_cfg_fkie: fixed problem with "pass_all_args" attribute
* node_manager_fkie: fix crash on start master_discovery
* node_manager_fkie: fixed network discovery dialog
* node_manager_fkie: added "pass_all_args" for highlighter
* node_manager_fkie: fixed crash while stop or start a lot of nodes
* node_manager_fkie: changed font color in echo dialog
* node_manager_fkie: changed default color in description widget
* node_manager_fkie: added a workaround for "CTR mode needs counter parameter, not IV"
* node_manager_fkie: reverted url changes
* fixed warnings in API documentation
* node_manager_fkie: fixed url handling in host control
* Contributors: Alexander Tiderko
```

## multimaster_msgs_fkie

- No changes

## node_manager_fkie

```
* node_manager_fkie: fix crash on start master_discovery
* node_manager_fkie: fixed network discovery dialog
* node_manager_fkie: added "pass_all_args" for highlighter
* node_manager_fkie: fixed crash while stop or start a lot of nodes
* node_manager_fkie: changed font color in echo dialog
* node_manager_fkie: changed default color in description widget
* node_manager_fkie: added a workaround for "CTR mode needs counter parameter, not IV"
* node_manager_fkie: reverted url changes
* fixed warnings in API documentation
* node_manager_fkie: fixed url handling in host control
* Contributors: Alexander Tiderko
```
