### PR TITLE
velodyne_simulator: 1.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7604,7 +7604,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_simulator` to `1.0.4-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
- release repository: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.3-0`

## velodyne_description

```
* Updated package.xml format to version 2
* Contributors: Kevin Hallenbeck
```

## velodyne_gazebo_plugins

```
* Updated package.xml format to version 2
* Removed gazebo_plugins dependency
* Contributors: Kevin Hallenbeck
```

## velodyne_simulator

```
* Updated package.xml format to version 2
* Contributors: Kevin Hallenbeck
```
