### PR TITLE
openni_launch: 1.9.8-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -867,6 +867,22 @@ repositories:
       url: https://github.com/ros-drivers/openni_camera.git
       version: indigo-devel
     status: maintained
+  openni_launch:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni_launch.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/openni_launch-release.git
+      version: 1.9.8-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/openni_launch.git
+      version: indigo-devel
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_launch` to `1.9.8-0`:

- upstream repository: https://github.com/ros-drivers/openni_launch.git
- release repository: https://github.com/ros-gbp/openni_launch-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## openni_launch

```
* [feat] adding depth_registered_filtered injection #26 <https://github.com/ros-drivers/openni_launch/issues/26>
* [sys][Travis CI] Update config to using industrial_ci with Prerelease Test. #28 <https://github.com/ros-drivers/openni_launch/issues/28>
* Contributors: Jonathan Bohren, Isaac I.Y. Saito
```
