### PR TITLE
rqt_logger_level: 0.4.8-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1372,6 +1372,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: kinetic-devel
     status: maintained
+  rqt_logger_level:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_logger_level.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_logger_level-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_logger_level.git
+      version: master
+    status: maintained
   rqt_plot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_logger_level` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_logger_level.git
- release repository: https://github.com/ros-gbp/rqt_logger_level-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_logger_level

- No changes
