### PR TITLE
gazebo_ros_pkgs: 2.5.12-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1406,7 +1406,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.5.11-0
+      version: 2.5.12-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.5.12-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.5.11-0`

## gazebo_msgs

- No changes

## gazebo_plugins

```
* Revert catkin warning fix (#567 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/567>)
  Many regressions in third party software (see https://github.com/yujinrobot/kobuki_desktop/issues/50)
* Contributors: Jose Luis Rivero
```

## gazebo_ros

- No changes

## gazebo_ros_control

```
* Fixed broken gazebo_ros_control tutorial link (#566 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/566>)
* Contributors: Ian McMahon
```

## gazebo_ros_pkgs

- No changes
