### PR TITLE
rqt_launch: 0.4.8-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1451,6 +1451,22 @@ repositories:
       url: https://github.com/ros-visualization/rqt_image_view.git
       version: master
     status: maintained
+  rqt_launch:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_launch.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_launch-release.git
+      version: 0.4.8-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_launch.git
+      version: master
+    status: maintained
   rqt_logger_level:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_launch` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_launch.git
- release repository: https://github.com/ros-gbp/rqt_launch-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_launch

- No changes
