### PR TITLE
pcl_conversions: 0.2.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -902,6 +902,21 @@ repositories:
       url: https://github.com/orocos/orocos_kinematics_dynamics.git
       version: master
     status: maintained
+  pcl_conversions:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/pcl_conversions.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/pcl_conversions-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/pcl_conversions.git
+      version: indigo-devel
+    status: maintained
   pcl_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_conversions` to `0.2.1-0`:

- upstream repository: https://github.com/ros-perception/pcl_conversions.git
- release repository: https://github.com/ros-gbp/pcl_conversions-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## pcl_conversions

```
* Added a test for rounding errors in stamp conversion
  for some values the test fails.
* add pcl::PointCloud to Image msg converter for extracting the rgb component of a cloud
* Contributors: Brice Rebsamen, Lucid One, Michael Ferguson, Paul Bovbel
```
