### PR TITLE
diagnostics: 1.9.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2238,12 +2238,13 @@ repositories:
       - diagnostic_common_diagnostics
       - diagnostic_updater
       - diagnostics
+      - rosdiagnostic
       - self_test
       - test_diagnostic_aggregator
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/diagnostics-release.git
-      version: 1.8.10-0
+      version: 1.9.0-0
     source:
       type: git
       url: https://github.com/ros/diagnostics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `1.9.0-0`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros-gbp/diagnostics-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.8.10-0`

## diagnostic_aggregator

```
* Longer settling time
* Fix race condition in unload
* Fix cmake warnings
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* Changed all deprecated PLUGINLIB_DECLARE_CLASS to PLUGINLIB_EXPORT_CLASS macros
* Contributors: Aris Synodinos, Lukas Bulwahn, trainman419
```

## diagnostic_analysis

```
* Install diagnostic_analysis nodes
  Fixes #51 <https://github.com/ros/diagnostics/issues/51>
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* Contributors: Lukas Bulwahn, trainman419
```

## diagnostic_common_diagnostics

```
* Remove warning for missing queue size specification
* Contributors: sandeep
```

## diagnostic_updater

```
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* Fixed bug with merge summary in status wrapper
* Contributors: Lukas Bulwahn, pAIgn10
```

## diagnostics

- No changes

## rosdiagnostic

```
* Initial release
* Created a command to print rosdiagnostics to the console.
  Works very much like rostopic echo but instead automatically connects to the aggregated diagnostics and output in a friendly format the content of the diagnostic report.
  Issue: https://github.com/ros/diagnostics/issues/57
* Contributors: Guillaume Autran
```

## self_test

- No changes

## test_diagnostic_aggregator

```
* Fix cmake warnings
* Changed all deprecated PLUGINLIB_DECLARE_CLASS to PLUGINLIB_EXPORT_CLASS macros
* Contributors: Aris Synodinos, trainman419
```
