### PR TITLE
diagnostics: 1.9.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -245,6 +245,30 @@ repositories:
       url: https://github.com/ros-controls/control_toolbox.git
       version: kinetic-devel
     status: maintained
+  diagnostics:
+    doc:
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: indigo-devel
+    release:
+      packages:
+      - diagnostic_aggregator
+      - diagnostic_analysis
+      - diagnostic_common_diagnostics
+      - diagnostic_updater
+      - diagnostics
+      - rosdiagnostic
+      - self_test
+      - test_diagnostic_aggregator
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/diagnostics-release.git
+      version: 1.9.0-0
+    source:
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: indigo-devel
+    status: maintained
   dynamic_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `1.9.0-0`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros-gbp/diagnostics-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## diagnostic_aggregator

```
* Longer settling time
* Fix race condition in unload
* Fix cmake warnings
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* Changed all deprecated PLUGINLIB_DECLARE_CLASS to PLUGINLIB_EXPORT_CLASS macros
* Contributors: Aris Synodinos, Lukas Bulwahn, trainman419
```

## diagnostic_analysis

```
* Install diagnostic_analysis nodes
  Fixes #51 <https://github.com/ros/diagnostics/issues/51>
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* Contributors: Lukas Bulwahn, trainman419
```

## diagnostic_common_diagnostics

```
* Remove warning for missing queue size specification
* Contributors: sandeep
```

## diagnostic_updater

```
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* Fixed bug with merge summary in status wrapper
* Contributors: Lukas Bulwahn, pAIgn10
```

## diagnostics

- No changes

## rosdiagnostic

```
* Initial release
* Created a command to print rosdiagnostics to the console.
  Works very much like rostopic echo but instead automatically connects to the aggregated diagnostics and output in a friendly format the content of the diagnostic report.
  Issue: https://github.com/ros/diagnostics/issues/57
* Contributors: Guillaume Autran
```

## self_test

- No changes

## test_diagnostic_aggregator

```
* Fix cmake warnings
* Changed all deprecated PLUGINLIB_DECLARE_CLASS to PLUGINLIB_EXPORT_CLASS macros
* Contributors: Aris Synodinos, trainman419
```
