### PR TITLE
household_objects_database_msgs: 0.1.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -528,6 +528,21 @@ repositories:
       url: https://github.com/ros-visualization/gl_dependency.git
       version: kinetic-devel
     status: maintained
+  household_objects_database_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-interactive-manipulation/household_objects_database_msgs.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/household_objects_database_msgs-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/ros-interactive-manipulation/household_objects_database_msgs.git
+      version: hydro-devel
+    status: maintained
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `household_objects_database_msgs` to `0.1.2-0`:

- upstream repository: https://github.com/ros-interactive-manipulation/household_objects_database_msgs.git
- release repository: https://github.com/ros-gbp/household_objects_database_msgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## household_objects_database_msgs

```
* [feat] added ORK type field in DatabaseModelPose #1 <https://github.com/ros-interactive-manipulation/household_objects_database_msgs/issues/1>
* Updated maintainers
* Contributors: Matei Ciocarlie, Dave Coleman, Isaac I.Y. Saito
```
