### PR TITLE
ros_canopen: 0.7.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1167,6 +1167,30 @@ repositories:
       url: https://github.com/ros/ros.git
       version: lunar-devel
     status: maintained
+  ros_canopen:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/ros_canopen.git
+      version: jade-devel
+    release:
+      packages:
+      - can_msgs
+      - canopen_402
+      - canopen_chain_node
+      - canopen_master
+      - canopen_motor_node
+      - ros_canopen
+      - socketcan_bridge
+      - socketcan_interface
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-industrial-release/ros_canopen-release.git
+      version: 0.7.2-0
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ros_canopen.git
+      version: jade-devel
+    status: maintained
   ros_comm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.7.2-0`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`

## can_msgs

- No changes

## canopen_402

- No changes

## canopen_chain_node

- No changes

## canopen_master

```
* fix: handle EMCY as error, not as warning
* Contributors: Mathias Lüdtke
```

## canopen_motor_node

- No changes

## ros_canopen

- No changes

## socketcan_bridge

- No changes

## socketcan_interface

- No changes
