### PR TITLE
thormang3_tools: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7014,10 +7014,14 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Tools.git
       version: kinetic-devel
     release:
+      packages:
+      - thormang3_action_editor
+      - thormang3_offset_tuner_server
+      - thormang3_tools
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Tools-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_tools` to `0.1.1-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Tools.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.1.0-0`

## thormang3_action_editor

```
* added dependencies for action_editor
* uploaded action_editor v 1.00
* uploaded working files : thormang3_action_editor
* Contributors: Jay Song, Zerom
```

## thormang3_offset_tuner_server

```
* added dependencies
* Contributors: Jay Song, Zerom
```

## thormang3_tools

```
* added dependencies for action_editor
* uploaded action_editor v 1.00
* uploaded working files : thormang3_action_editor
* Contributors: Jay Song, Zerom
```
