### PR TITLE
ros_peerjs: 0.1.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5686,7 +5686,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/easymov/ros_peerjs-release.git
-      version: 0.1.2-0
+      version: 0.1.6-0
     status: developed
   ros_tutorials:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_peerjs` to `0.1.6-0`:

- upstream repository: https://gitlab.com/easymov/ros_peerjs.git
- release repository: https://github.com/easymov/ros_peerjs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.2-0`

## ros_peerjs

```
* remove node_modules
* Contributors: Gérald Lelong
```
