### PR TITLE
rqt_pose_view: 0.5.7-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1590,6 +1590,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_plot.git
       version: master
     status: maintained
+  rqt_pose_view:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_pose_view.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_pose_view.git
+      version: 0.5.7-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_pose_view.git
+      version: master
+    status: maintained
   rqt_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_pose_view` to `0.5.7-0`:

- upstream repository: https://github.com/ros-visualization/rqt_pose_view.git
- release repository: https://github.com/ros-gbp/rqt_pose_view.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_pose_view

- No changes
