### PR TITLE
updated linux-headers-generic for debian stretch

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3125,7 +3125,7 @@ linux-headers-generic:
   arch: [linux-headers]
   debian:
     jessie: [linux-headers-3.16.0-4-all]
-    stretch: [linux-headers-4.6.0-1-all]
+    stretch: [linux-headers-4.9.0-2-all]
     wheezy: [linux-headers-3.2.0-4-all]
   fedora: [kernel-headers]
   ubuntu: [linux-headers-generic]


### PR DESCRIPTION
Debian stretch now uses kernel 4.9.0-2: https://packages.debian.org/testing/kernel/linux-headers-4.9.0-2-all