### PR TITLE
filters: 1.8.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -309,7 +309,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/filters-release.git
-      version: 1.8.0-0
+      version: 1.8.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `1.8.1-0`:

- upstream repository: https://github.com/ros/filters.git
- release repository: https://github.com/ros-gbp/filters-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.8.0-0`

## filters

```
* Fix warning about string type
* Contributors: Jon Binney
```
