### PR TITLE
ros_canopen: 0.7.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5271,7 +5271,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_canopen-release.git
-      version: 0.7.2-0
+      version: 0.7.4-0
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.7.4-0`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.7.2-0`

## can_msgs

- No changes

## canopen_402

```
* use portable boost::math::isnan
* Contributors: Mathias Lüdtke
```

## canopen_chain_node

- No changes

## canopen_master

- No changes

## canopen_motor_node

```
* use portable boost::math::isnan
* Contributors: Mathias Lüdtke
```

## ros_canopen

- No changes

## socketcan_bridge

- No changes

## socketcan_interface

- No changes
