### PR TITLE
dynamixel_sdk: 3.4.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -948,7 +948,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
-      version: 3.4.3-1
+      version: 3.4.4-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.4.4-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `3.4.3-1`

## dynamixel_sdk

```
* hotfix - return delay time is changed from 4 into 8 due to the Ubuntu update 16.04.2
* Contributors: Leon
```
