### PR TITLE
four_wheel_steering_msgs: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1311,6 +1311,21 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: kinetic-devel
     status: maintained
+  four_wheel_steering_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/four_wheel_steering_msgs-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
+      version: master
+    status: developed
   freenect_stack:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `four_wheel_steering_msgs` to `1.0.0-0`:

- upstream repository: https://github.com/ros-drivers/four_wheel_steering_msgs.git
- release repository: https://github.com/ros-drivers-gbp/four_wheel_steering_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`

## four_wheel_steering_msgs

```
* Update url path
* Initial commit from https://github.com/Romea/romea_controllers
* Contributors: Vincent Rousseau
```
