### PR TITLE
fzi_icl_comm: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1360,6 +1360,12 @@ repositories:
       url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can.git
       version: master
     status: maintained
+  fzi_icl_comm:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_comm-release.git
+      version: 0.0.2-0
   fzi_icl_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fzi_icl_comm` to `0.0.2-0`:

- upstream repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_comm.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## fzi_icl_comm

```
* corrected maintainer's email address
* moved fzi prefix from roscpp to icl_core
  this error was introduced before
* Contributors: Felix Mauch
```
