### PR TITLE
perception_pcl: 1.5.1-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -972,6 +972,24 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: indigo-devel
     status: maintained
+  perception_pcl:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: lunar-devel
+    release:
+      packages:
+      - pcl_ros
+      - perception_pcl
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/perception_pcl-release.git
+      version: 1.5.1-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: lunar-devel
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.5.1-1`:

- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## pcl_ros

```
* Add my name as a maintainer
* Contributors: Kentaro Wada
```

## perception_pcl

```
* Add my name as a maintainer
* Contributors: Kentaro Wada
```
