### PR TITLE
robot_model: 1.12.9-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1156,7 +1156,10 @@ repositories:
       type: git
       url: https://github.com/ros/robot_model.git
       version: kinetic-devel
-    status: maintained
+    status: end-of-life
+    status_description: The robot_model metapackage is deprecated and will be removed
+      in ROS M. The packages it includes will continue to be maintained, but will be 
+      moved to new repositories.
   robot_state_publisher:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1157,9 +1157,9 @@ repositories:
       url: https://github.com/ros/robot_model.git
       version: kinetic-devel
     status: end-of-life
-    status_description: The robot_model metapackage is deprecated and will be removed
-      in ROS M. The packages it includes will continue to be maintained, but will be 
-      moved to new repositories.
+    status_description: The robot_model metapackage is deprecated and will be
+      removed in ROS M. The packages it includes will continue to be maintained,
+      but will be moved to new repositories.
   robot_state_publisher:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1157,9 +1157,9 @@ repositories:
       url: https://github.com/ros/robot_model.git
       version: kinetic-devel
     status: end-of-life
-    status_description: The robot_model metapackage is deprecated and will be
-      removed in ROS M. The packages it includes will continue to be maintained,
-      but will be moved to new repositories.
+    status_description: The robot_model metapackage is deprecated and will be removed
+      in ROS M. The packages it includes will continue to be maintained, but will
+      be moved to new repositories.
   robot_state_publisher:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1151,7 +1151,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.12.8-2
+      version: 1.12.9-0
     source:
       type: git
       url: https://github.com/ros/robot_model.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.12.9-0`:

- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.12.8-2`

## collada_parser

- No changes

## collada_urdf

- No changes

## joint_state_publisher

- No changes

## kdl_parser

- No changes

## kdl_parser_py

```
* Unset origin xyz or rpy is now properly interpreted as zero vector (#187 <https://github.com/ros/robot_model/issues/187>)
* Contributors: eugene-katsevman
```

## robot_model

```
* Adds deprecation message to robot_model package.xml (#196 <https://github.com/ros/robot_model/issues/196>)
* Contributors: Shane Loretz
```

## urdf

- No changes

## urdf_parser_plugin

- No changes
