### PR TITLE
perception_pcl: 1.5.1-2 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -984,7 +984,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/perception_pcl-release.git
-      version: 1.5.1-1
+      version: 1.5.1-2
     source:
       type: git
       url: https://github.com/ros-perception/perception_pcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.5.1-2`:

- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.5.1-1`

## pcl_ros

```
* Add my name as a maintainer
* Contributors: Kentaro Wada
```

## perception_pcl

```
* Add my name as a maintainer
* Contributors: Kentaro Wada
```
