### PR TITLE
ar_track_alvar: 0.7.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -58,6 +58,26 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  ar_track_alvar:
+    doc:
+      type: git
+      url: https://github.com/sniekum/ar_track_alvar.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ar_track_alvar
+      - ar_track_alvar_metapkg
+      - ar_track_alvar_msgs
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/ar_track_alvar-release.git
+      version: 0.7.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/sniekum/ar_track_alvar.git
+      version: kinetic-devel
+    status: maintained
   bfl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar` to `0.7.0-0`:

- upstream repository: https://github.com/sniekum/ar_track_alvar
- release repository: https://github.com/ros-gbp/ar_track_alvar-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## ar_track_alvar

```
* Consolidate ar_track_alvar* packages into a single repo (#120 <https://github.com/sniekum/ar_track_alvar/issues/120>)
* Contributors: Isaac I.Y. Saito
```

## ar_track_alvar_metapkg

```
* Consolidate ar_track_alvar* packages into a single repo (#120 <https://github.com/sniekum/ar_track_alvar/issues/120>)
* Contributors: Isaac I.Y. Saito
```

## ar_track_alvar_msgs

```
* Consolidate ar_track_alvar* packages into a single repo (#120 <https://github.com/sniekum/ar_track_alvar/issues/120>)
* Contributors: Isaac I.Y. Saito
```
