### PR TITLE
[kinetic][ar_track_alvar*] Remove temporarily

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -126,36 +126,6 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
-  ar_track_alvar:
-    doc:
-      type: git
-      url: https://github.com/sniekum/ar_track_alvar.git
-      version: kinetic-devel
-    release:
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-gbp/ar_track_alvar-release.git
-      version: 0.6.3-0
-    source:
-      type: git
-      url: https://github.com/sniekum/ar_track_alvar.git
-      version: kinetic-devel
-    status: maintained
-  ar_track_alvar_msgs:
-    doc:
-      type: git
-      url: https://github.com/sniekum/ar_track_alvar_msgs.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-gbp/ar_track_alvar_msgs-release.git
-      version: 0.5.1-0
-    source:
-      type: git
-      url: https://github.com/sniekum/ar_track_alvar_msgs.git
-      version: indigo-devel
-    status: maintained
   ardrone_autonomy:
     doc:
       type: git


### PR DESCRIPTION
As discussed in https://github.com/sniekum/ar_track_alvar/issues/121, `ar_track_alvar*` packages are consolidated into a single repo. I (@130s) am afraid that in order to run `bloom` the existing rosdistro entries should be removed in advance, which can break the downstream packages build.

Once this commit gets merged in @130s will run bloom to release these packages back in to keep the glitch the minimum hopefully.