### PR TITLE
ar_track_alvar: 0.7.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -126,6 +126,25 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  ar_track_alvar:
+    doc:
+      type: git
+      url: https://github.com/sniekum/ar_track_alvar.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ar_track_alvar
+      - ar_track_alvar_metapkg
+      - ar_track_alvar_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/ar_track_alvar-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/sniekum/ar_track_alvar.git
+      version: kinetic-devel
+    status: maintained
   ardrone_autonomy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar` to `0.7.0-1`:

- upstream repository: https://github.com/sniekum/ar_track_alvar
- release repository: https://github.com/ros-gbp/ar_track_alvar-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## ar_track_alvar

```
* Consolidate ar_track_alvar* packages into a single repo (#120 <https://github.com/sniekum/ar_track_alvar/issues/120>)
* Contributors: Isaac I.Y. Saito
```

## ar_track_alvar_metapkg

```
* Consolidate ar_track_alvar* packages into a single repo (#120 <https://github.com/sniekum/ar_track_alvar/issues/120>)
* Contributors: Isaac I.Y. Saito
```

## ar_track_alvar_msgs

```
* Consolidate ar_track_alvar* packages into a single repo (#120 <https://github.com/sniekum/ar_track_alvar/issues/120>)
* Contributors: Isaac I.Y. Saito
```
