### PR TITLE
pointcloud_to_laserscan: 1.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4607,7 +4607,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/pointcloud_to_laserscan-release.git
-      version: 1.3.0-1
+      version: 1.3.1-0
     source:
       type: git
       url: https://github.com/ros-perception/pointcloud_to_laserscan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointcloud_to_laserscan` to `1.3.1-0`:

- upstream repository: https://github.com/ros-perception/pointcloud_to_laserscan.git
- release repository: https://github.com/ros-gbp/pointcloud_to_laserscan-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.3.0-1`

## pointcloud_to_laserscan

```
* Merge pull request #4 <https://github.com/ros-perception/pointcloud_to_laserscan/issues/4> from yoshimalucky/fix-miscalculation-in-angle-increment
  Fixed miscalculation in angle_increment in the launch files.
* fixed miscalculation in angle_increment in the launchfiles.
* Contributors: Paul Bovbel, yoshimalucky
```
