### PR TITLE
visualization_tutorials: 0.10.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2068,6 +2068,29 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: kinetic
     status: maintained
+  visualization_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/visualization_tutorials.git
+      version: kinetic-devel
+    release:
+      packages:
+      - interactive_marker_tutorials
+      - librviz_tutorial
+      - rviz_plugin_tutorials
+      - rviz_python_tutorial
+      - visualization_marker_tutorials
+      - visualization_tutorials
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/visualization_tutorials-release.git
+      version: 0.10.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/visualization_tutorials.git
+      version: kinetic-devel
+    status: maintained
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_tutorials` to `0.10.1-0`:

- upstream repository: https://github.com/ros-visualization/visualization_tutorials.git
- release repository: https://github.com/ros-gbp/visualization_tutorials-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## interactive_marker_tutorials

- No changes

## librviz_tutorial

```
* Added qt5 dependencies to the package.xml.
* Contributors: William Woodall
```

## rviz_plugin_tutorials

```
* Added qt5 dependencies to the package.xml.
* Contributors: William Woodall
```

## rviz_python_tutorial

- No changes

## visualization_marker_tutorials

- No changes

## visualization_tutorials

- No changes
