### PR TITLE
ivcon: 0.1.6-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -643,6 +643,17 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: indigo-devel
     status: maintained
+  ivcon:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/ivcon-release.git
+      version: 0.1.6-0
+    source:
+      type: git
+      url: https://github.com/ros/ivcon.git
+      version: kinetic-devel
+    status: maintained
   laser_assembler:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ivcon` to `0.1.6-0`:

- upstream repository: https://github.com/ros/ivcon.git
- release repository: https://github.com/ros-gbp/ivcon-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
