### PR TITLE
convex_decomposition: 0.1.11-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -265,6 +265,17 @@ repositories:
       url: https://github.com/ros-controls/control_toolbox.git
       version: kinetic-devel
     status: maintained
+  convex_decomposition:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/convex_decomposition-release.git
+      version: 0.1.11-0
+    source:
+      type: git
+      url: https://github.com/ros/convex_decomposition.git
+      version: kinetic-devel
+    status: maintained
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `convex_decomposition` to `0.1.11-0`:

- upstream repository: https://github.com/ros/convex_decomposition.git
- release repository: https://github.com/ros-gbp/convex_decomposition-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
