### PR TITLE
pr2_common: 1.12.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1064,6 +1064,27 @@ repositories:
       url: https://github.com/ros-perception/pointcloud_to_laserscan.git
       version: indigo-devel
     status: maintained
+  pr2_common:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_common.git
+      version: kinetic-devel
+    release:
+      packages:
+      - pr2_common
+      - pr2_dashboard_aggregator
+      - pr2_description
+      - pr2_machine
+      - pr2_msgs
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/pr2_common-release.git
+      version: 1.12.0-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_common.git
+      version: kinetic-devel
+    status: maintained
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common` to `1.12.0-0`:

- upstream repository: https://github.com/PR2/pr2_common.git
- release repository: https://github.com/ros-gbp/pr2_common-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
