### PR TITLE
schunk_svh_driver: 0.2.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6294,6 +6294,21 @@ repositories:
       url: https://github.com/SmartRoboticSystems/schunk_grippers.git
       version: master
     status: maintained
+  schunk_svh_driver:
+    doc:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git
+      version: master
+    status: developed
   screen_grab:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_svh_driver` to `0.2.0-0`:

- upstream repository: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## schunk_svh_driver

```
* Added hardware support for the 2nd hardware version of the Schunk SVH
* Added dynamic parameter switcher for automatically setting parameters
* Improved sine test with increased movement range, thumb movement and possibility to change the speed
* Extracted ``fzi_icl_core`` and ``fzi_icl_comm``
* Fixed xacro warnings
* Contributors: Felix Mauch, Pascal Becker, Johannes Mangler
```
