### PR TITLE
schunk_svh_driver: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12480,7 +12480,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver-release.git
-      version: 0.1.5-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_svh_driver` to `0.2.0-0`:

- upstream repository: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.5-0`

## schunk_svh_driver

```
* Added hardware support for the 2nd hardware version of the Schunk SVH
* Added dynamic parameter switcher for automatically setting parameters
* Improved sine test with increased movement range, thumb movement and possibility to change the speed
* Extracted ``fzi_icl_core`` and ``fzi_icl_comm``
* Fixed xacro warnings
* Contributors: Felix Mauch, Pascal Becker, Johannes Mangler
```
