### PR TITLE
Adding velo2cam_calibration and velo2cam_gazebo to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7626,6 +7626,16 @@ repositories:
       url: https://github.com/ethz-asl/variant.git
       version: master
     status: developed
+  velo2cam_gazebo:
+    doc:
+      type: git
+      url: https://github.com/beltransen/velo2cam_gazebo.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/beltransen/velo2cam_gazebo.git
+      version: master
+    status: maintained
   velodyne_simulator:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7626,6 +7626,16 @@ repositories:
       url: https://github.com/ethz-asl/variant.git
       version: master
     status: developed
+  velo2cam_calibration:
+    doc:
+      type: git
+      url: https://github.com/beltransen/velo2cam_calibration.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/beltransen/velo2cam_calibration.git
+      version: master
+    status: maintained
   velo2cam_gazebo:
     doc:
       type: git


### PR DESCRIPTION
I'd like velo2cam_calibration and velo2cam_gazebo to be indexed and documented on ros.org