### PR TITLE
stage: 4.3.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2038,11 +2038,12 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/stage-release.git
-      version: 4.1.1-2
+      version: 4.3.0-0
     source:
       type: git
       url: https://github.com/ros-gbp/stage-release.git
       version: release/kinetic/stage
+    status: maintained
   std_capabilities:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stage` to `4.3.0-0`:

- upstream repository: https://github.com/rtv/Stage.git
- release repository: https://github.com/ros-gbp/stage-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `4.1.1-2`
