### PR TITLE
rqt_robot_plugins: 0.5.7-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1858,6 +1858,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_robot_monitor.git
       version: master
     status: maintained
+  rqt_robot_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_plugins.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
+      version: 0.5.7-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_plugins.git
+      version: master
+    status: maintained
   rqt_robot_steering:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_plugins` to `0.5.7-0`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_plugins.git
- release repository: https://github.com/ros-gbp/rqt_robot_plugins-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_robot_plugins

- No changes
