### PR TITLE
rotors_simulator: 2.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11783,7 +11783,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-asl/rotors_simulator-release.git
-      version: 2.1.0-4
+      version: 2.1.1-0
     source:
       type: git
       url: https://github.com/ethz-asl/rotors_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rotors_simulator` to `2.1.1-0`:

- upstream repository: https://github.com/ethz-asl/rotors_simulator.git
- release repository: https://github.com/ethz-asl/rotors_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.1.0-4`

## rotors_comm

```
* update maintainers
* Contributors: fmina
```

## rotors_control

```
* update maintainers
* Contributors: fmina
```

## rotors_description

```
* update maintainers
* Adding pressure plugin to urdf description
* Contributors: fmina, pvechersky
```

## rotors_evaluation

```
* update maintainers
* Contributors: fmina
```

## rotors_gazebo

```
* update maintainers
* Contributors: fmina
```

## rotors_gazebo_plugins

```
* Merge pull request #377 <https://github.com/ethz-asl/rotors_simulator/issues/377> from ethz-asl/feature/pressure-plugin
  Feature/pressure-plugin
* More verbose variable names in pressure calculations.
* update maintainers
* Giving more verbose names to the constants
* Adapting the pressure plugin to work with Gazebo transport interface
* Adding Gazebo interface for fluid pressure message
* Initial commit for pressure plugin.
* Contributors: Timo Hinzmann, fmina, pvechersky
```

## rotors_hil_interface

```
* Update maintainers.
* Contributors: Timo Hinzmann
```

## rotors_joy_interface

```
* update maintainers
* Contributors: fmina
```

## rotors_simulator

```
* update maintainers
* Contributors: fmina
```

## rqt_rotors

```
* Update maintainers.
* Contributors: Timo Hinzmann
```
