### PR TITLE
mav_comm: 3.2.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3036,6 +3036,15 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
       version: 1.0.6-0
+  mav_comm:
+    release:
+      packages:
+      - mav_comm
+      - mav_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ethz-asl/mav_comm-release.git
+      version: 3.2.0-1
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mav_comm` to `3.2.0-1`:

- upstream repository: https://github.com/ethz-asl/mav_comm.git
- release repository: https://github.com/ethz-asl/mav_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## mav_comm

```
* See mav_msgs changelog for details.
```

## mav_msgs

```
* Access covariance in eigen odometry
* External force default topic
* External wind speed default topic
```
