### PR TITLE
gazebo_ros_pkgs: 2.7.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -363,6 +363,29 @@ repositories:
       url: https://github.com/ros/filters.git
       version: hydro-devel
     status: maintained
+  gazebo_ros_pkgs:
+    doc:
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+      version: lunar-devel
+    release:
+      packages:
+      - gazebo_dev
+      - gazebo_msgs
+      - gazebo_plugins
+      - gazebo_ros
+      - gazebo_ros_control
+      - gazebo_ros_pkgs
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
+      version: 2.7.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+      version: lunar-devel
+    status: developed
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.7.1-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## gazebo_dev

```
* Use gazeob8 as exec_depend
* Use 2.7.0 as starting version
* Depend on gazebo8 instead of gazebo7
* Add catkin package(s) to provide the default version of Gazebo - take II (kinetic-devel) (#571 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/571>)
  * Added catkin package gazebo_dev which provides the cmake config of the installed Gazebo version
  Conflicts:
  gazebo_plugins/package.xml
  gazebo_ros/package.xml
  gazebo_ros_control/package.xml
  * gazebo_plugins/gazebo_ros: removed dependency SDF from CMakeLists.txt
  The sdformat library is an indirect dependency of Gazebo and does not need to be linked explicitly.
  * gazebo_dev: added execution dependency gazebo
* Contributors: Jose Luis Rivero
* Use gazeob8 as exec_depend
* Use 2.7.0 as starting version
* Depend on gazebo8 instead of gazebo7
* Add catkin package(s) to provide the default version of Gazebo - take II (kinetic-devel) (#571 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/571>)
  * Added catkin package gazebo_dev which provides the cmake config of the installed Gazebo version
  Conflicts:
  gazebo_plugins/package.xml
  gazebo_ros/package.xml
  gazebo_ros_control/package.xml
  * gazebo_plugins/gazebo_ros: removed dependency SDF from CMakeLists.txt
  The sdformat library is an indirect dependency of Gazebo and does not need to be linked explicitly.
  * gazebo_dev: added execution dependency gazebo
* Contributors: Jose Luis Rivero
```

## gazebo_msgs

```
* Add catkin package(s) to provide the default version of Gazebo - take II (kinetic-devel) (#571 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/571>)
* Contributors: Jose Luis Rivero
```

## gazebo_plugins

```
* Fixes for compilation and warnings in Lunar-devel  (#573 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/573>)
  Multiple fixes for compilation and warnings coming from Gazebo8 and ignition-math3
* Add an IMU sensor plugin that inherits from SensorPlugin (#363 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/363>)
* Less exciting console output (#561 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/561>)
* Add catkin package(s) to provide the default version of Gazebo - take II (kinetic-devel) (#571 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/571>)
* Contributors: Alessandro Settimi, Dave Coleman, Jose Luis Rivero
```

## gazebo_ros

```
* Fixes for compilation and warnings in Lunar-devel  (#573 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/573>)
  Multiple fixes for compilation and warnings coming from Gazebo8 and ignition-math3
* Add catkin package(s) to provide the default version of Gazebo - take II (kinetic-devel) (#571 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/571>)
* Contributors: Jose Luis Rivero
```

## gazebo_ros_control

```
* Fixes for compilation and warnings in Lunar-devel  (#573 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/573>)
  Multiple fixes for compilation and warnings coming from Gazebo8 and ignition-math3
* Less exciting console output (#561 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/561>)
* Add catkin package(s) to provide the default version of Gazebo - take II (kinetic-devel) (#571 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/571>)
* Contributors: Dave Coleman, Jose Luis Rivero
```

## gazebo_ros_pkgs

```
* Add catkin package(s) to provide the default version of Gazebo (kinetic-devel) (#571 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/571>)
* Contributors: Jose Luis Rivero
```
