### PR TITLE
rotors_simulator: 3.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5836,6 +5836,23 @@ repositories:
       url: https://github.com/tork-a/roswww.git
       version: develop
     status: maintained
+  rotors_simulator:
+    release:
+      packages:
+      - rotors_comm
+      - rotors_control
+      - rotors_description
+      - rotors_evaluation
+      - rotors_gazebo
+      - rotors_gazebo_plugins
+      - rotors_hil_interface
+      - rotors_joy_interface
+      - rotors_simulator
+      - rqt_rotors
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ethz-asl/rotors_simulator-release.git
+      version: 3.0.0-0
   rplidar_python:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rotors_simulator` to `3.0.0-0`:

- upstream repository: https://github.com/ethz-asl/rotors_simulator.git
- release repository: https://github.com/ethz-asl/rotors_simulator-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rotors_comm

```
* Jade release
```

## rotors_control

```
* Jade release
```

## rotors_description

```
* Jade release
```

## rotors_evaluation

```
* Jade release
```

## rotors_gazebo

```
* Jade release
```

## rotors_gazebo_plugins

- No changes

## rotors_hil_interface

```
* Jade release
```

## rotors_joy_interface

```
* Jade release
```

## rotors_simulator

```
* Jade release
```

## rqt_rotors

```
* Jade release
```
