### PR TITLE
log4cpp: 2.9.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2815,7 +2815,10 @@ repositories:
       url: https://github.com/orocos-toolchain/log4cpp.git
       version: toolchain-2.9
     release:
+      tags:
+        release: release/kinetic/{package}/{version}
       url: https://github.com/orocos-gbp/log4cpp-release.git
+      version: 2.9.0-0
     source:
       type: git
       url: https://github.com/orocos-toolchain/log4cpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `log4cpp` to `2.9.0-0`:

- upstream repository: https://github.com/orocos-toolchain/log4cpp.git
- release repository: https://github.com/orocos-gbp/log4cpp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
