### PR TITLE
ocl: 2.9.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3994,7 +3994,10 @@ repositories:
       url: https://github.com/orocos-toolchain/ocl.git
       version: toolchain-2.9
     release:
+      tags:
+        release: release/kinetic/{package}/{version}
       url: https://github.com/orocos-gbp/ocl-release.git
+      version: 2.9.0-0
     source:
       type: git
       url: https://github.com/orocos-toolchain/ocl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ocl` to `2.9.0-0`:

- upstream repository: https://github.com/orocos-toolchain/ocl.git
- release repository: https://github.com/orocos-gbp/ocl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
