### PR TITLE
rqt_py_console: 0.4.8-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1834,6 +1834,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_publisher.git
       version: master
     status: maintained
+  rqt_py_console:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_py_console.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_py_console-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_py_console.git
+      version: master
+    status: maintained
   rqt_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_py_console` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_py_console.git
- release repository: https://github.com/ros-gbp/rqt_py_console-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_py_console

- No changes
