### PR TITLE
remove rqt plugins releases for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11860,33 +11860,9 @@ repositories:
       url: https://github.com/ros-visualization/rqt_common_plugins.git
       version: master
     release:
-      packages:
-      - rqt_action
-      - rqt_bag
-      - rqt_bag_plugins
-      - rqt_common_plugins
-      - rqt_console
-      - rqt_dep
-      - rqt_graph
-      - rqt_image_view
-      - rqt_launch
-      - rqt_logger_level
-      - rqt_msg
-      - rqt_plot
-      - rqt_publisher
-      - rqt_py_common
-      - rqt_py_console
-      - rqt_reconfigure
-      - rqt_service_caller
-      - rqt_shell
-      - rqt_srv
-      - rqt_top
-      - rqt_topic
-      - rqt_web
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.4.7-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
@@ -11989,21 +11965,9 @@ repositories:
       url: https://github.com/ros-visualization/rqt_robot_plugins.git
       version: master
     release:
-      packages:
-      - rqt_moveit
-      - rqt_nav_view
-      - rqt_pose_view
-      - rqt_robot_dashboard
-      - rqt_robot_monitor
-      - rqt_robot_plugins
-      - rqt_robot_steering
-      - rqt_runtime_monitor
-      - rqt_rviz
-      - rqt_tf_tree
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-      version: 0.5.6-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git


### PR DESCRIPTION
In order to release them again from the separate repositories (see #14652).