### PR TITLE
rqt: 0.4.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11830,10 +11830,11 @@ repositories:
       - rqt_gui
       - rqt_gui_cpp
       - rqt_gui_py
+      - rqt_py_common
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt-release.git
-      version: 0.2.14-1
+      version: 0.4.8-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros-gbp/rqt-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.14-1`

## rqt_gui

```
* version bump to match version of migrated package rqt_py_common
```

## rqt_gui_cpp

```
* version bump to match version of migrated package rqt_py_common
```

## rqt_gui_py

```
* version bump to match version of migrated package rqt_py_common
```

## rqt_py_common

```
* migrated from rqt_common_plugins repo
```
