### PR TITLE
rqt_plot: 0.4.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11949,6 +11949,21 @@ repositories:
       url: https://github.com/dornhege/rqt_paramedit.git
       version: indigo-devel
     status: maintained
+  rqt_plot:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_plot-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: master
+    status: maintained
   rqt_pr2_dashboard:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros-gbp/rqt_plot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_plot

```
* add scroll area when showing images with 1-to-1 mapping (#433 <https://github.com/ros-visualization/rqt_common_plugins/issues/433>)
```
