### PR TITLE
remove rqt plugins releases for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6147,33 +6147,9 @@ repositories:
       url: https://github.com/ros-visualization/rqt_common_plugins.git
       version: master
     release:
-      packages:
-      - rqt_action
-      - rqt_bag
-      - rqt_bag_plugins
-      - rqt_common_plugins
-      - rqt_console
-      - rqt_dep
-      - rqt_graph
-      - rqt_image_view
-      - rqt_launch
-      - rqt_logger_level
-      - rqt_msg
-      - rqt_plot
-      - rqt_publisher
-      - rqt_py_common
-      - rqt_py_console
-      - rqt_reconfigure
-      - rqt_service_caller
-      - rqt_shell
-      - rqt_srv
-      - rqt_top
-      - rqt_topic
-      - rqt_web
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.4.7-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
@@ -6247,21 +6223,9 @@ repositories:
       url: https://github.com/ros-visualization/rqt_robot_plugins.git
       version: master
     release:
-      packages:
-      - rqt_moveit
-      - rqt_nav_view
-      - rqt_pose_view
-      - rqt_robot_dashboard
-      - rqt_robot_monitor
-      - rqt_robot_plugins
-      - rqt_robot_steering
-      - rqt_runtime_monitor
-      - rqt_rviz
-      - rqt_tf_tree
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_plugins-release.git
-      version: 0.5.6-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_plugins.git


### PR DESCRIPTION
In order to release them again from the separate repositories (see #14652).