### PR TITLE
rqt: 0.4.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5894,10 +5894,11 @@ repositories:
       - rqt_gui
       - rqt_gui_cpp
       - rqt_gui_py
+      - rqt_py_common
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rqt-release.git
-      version: 0.2.14-0
+      version: 0.4.8-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros-gbp/rqt-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.14-0`

## rqt_gui

```
* version bump to match version of migrated package rqt_py_common
```

## rqt_gui_cpp

```
* version bump to match version of migrated package rqt_py_common
```

## rqt_gui_py

```
* version bump to match version of migrated package rqt_py_common
```

## rqt_py_common

```
* migrated from rqt_common_plugins repo
```
