### PR TITLE
rqt_top: 0.4.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12020,6 +12020,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_shell.git
       version: master
     status: maintained
+  rqt_top:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_top.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_top-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_top.git
+      version: master
+    status: maintained
   rqt_wrapper:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_top` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_top.git
- release repository: https://github.com/ros-gbp/rqt_top-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_top

- No changes
