### PR TITLE
rqt_top: 0.4.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6025,6 +6025,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_shell.git
       version: master
     status: maintained
+  rqt_top:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_top.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_top-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_top.git
+      version: master
+    status: maintained
   rsv_balance:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_top` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_top.git
- release repository: https://github.com/ros-gbp/rqt_top-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_top

- No changes
