### PR TITLE
rqt_logger_level: 0.4.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6202,6 +6202,21 @@ repositories:
       url: https://github.com/pschillinger/rqt_launchtree.git
       version: kinetic
     status: maintained
+  rqt_logger_level:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_logger_level.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_logger_level-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_logger_level.git
+      version: master
+    status: maintained
   rqt_multiplot_plugin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_logger_level` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_logger_level.git
- release repository: https://github.com/ros-gbp/rqt_logger_level-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_logger_level

- No changes
