### PR TITLE
rqt_console: 0.4.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5918,6 +5918,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_common_plugins.git
       version: master
     status: developed
+  rqt_console:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_console.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_console-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_console.git
+      version: master
+    status: maintained
   rqt_ez_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_console` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_console.git
- release repository: https://github.com/ros-gbp/rqt_console-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_console

- No changes
