### PR TITLE
rqt_dep: 0.4.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11902,6 +11902,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_console.git
       version: master
     status: maintained
+  rqt_dep:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_dep.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_dep-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_dep.git
+      version: master
+    status: maintained
   rqt_ez_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_dep` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_dep.git
- release repository: https://github.com/ros-gbp/rqt_dep-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_dep

- No changes
