### PR TITLE
rqt_image_view: 0.4.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11948,6 +11948,21 @@ repositories:
       url: https://github.com/osrf/rqt_graphprofiler.git
       version: master
     status: developed
+  rqt_image_view:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_image_view.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_image_view-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_image_view.git
+      version: master
+    status: maintained
   rqt_launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_view` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_image_view.git
- release repository: https://github.com/ros-gbp/rqt_image_view-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_image_view

- No changes
