### PR TITLE
rqt_service_caller: 0.4.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6089,6 +6089,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_robot_plugins.git
       version: master
     status: developed
+  rqt_service_caller:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_service_caller.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_service_caller-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_service_caller.git
+      version: master
+    status: maintained
   rqt_shell:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_service_caller` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_service_caller.git
- release repository: https://github.com/ros-gbp/rqt_service_caller-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_service_caller

- No changes
