### PR TITLE
rqt_publisher: 0.4.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6282,6 +6282,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_plot.git
       version: master
     status: maintained
+  rqt_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_publisher.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_publisher-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_publisher.git
+      version: master
+    status: maintained
   rqt_py_console:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_publisher` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_publisher.git
- release repository: https://github.com/ros-gbp/rqt_publisher-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_publisher

- No changes
