### PR TITLE
rqt_action: 0.4.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5904,6 +5904,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: groovy-devel
     status: maintained
+  rqt_action:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_action.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_action-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_action.git
+      version: master
+    status: maintained
   rqt_bag:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_action` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_action.git
- release repository: https://github.com/ros-gbp/rqt_action-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_action

- No changes
