### PR TITLE
rqt_srv: 0.4.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6372,6 +6372,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_shell.git
       version: master
     status: maintained
+  rqt_srv:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_srv.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_srv-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_srv.git
+      version: master
+    status: maintained
   rqt_top:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_srv` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_srv.git
- release repository: https://github.com/ros-gbp/rqt_srv-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_srv

- No changes
