### PR TITLE
rqt_reconfigure: 0.4.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6135,6 +6135,22 @@ repositories:
       url: https://github.com/ros-visualization/rqt_py_console.git
       version: master
     status: maintained
+  rqt_reconfigure:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_reconfigure.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_reconfigure-release.git
+      version: 0.4.8-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_reconfigure.git
+      version: master
+    status: maintained
   rqt_robot_plugins:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros-gbp/rqt_reconfigure-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_reconfigure

- No changes
