### PR TITLE
octomap: 1.9.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -956,7 +956,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/octomap-release.git
-      version: 1.8.0-2
+      version: 1.9.0-0
     source:
       type: git
       url: https://github.com/OctoMap/octomap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap` to `1.9.0-0`:

- upstream repository: https://github.com/OctoMap/octomap.git
- release repository: https://github.com/ros-gbp/octomap-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.8.0-2`
