### PR TITLE
rqt_web: 0.4.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6255,6 +6255,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_topic.git
       version: master
     status: maintained
+  rqt_web:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_web.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_web-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_web.git
+      version: master
+    status: maintained
   rsv_balance:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_web` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_web.git
- release repository: https://github.com/ros-gbp/rqt_web-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_web

```
* add missing WebKit dependency (#449 <https://github.com/ros-visualization/rqt_common_plugins/pull/449>)
```
