### PR TITLE
rqt_nav_view: 0.5.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6343,6 +6343,21 @@ repositories:
       url: https://github.com/ethz-asl/rqt_multiplot_plugin.git
       version: master
     status: developed
+  rqt_nav_view:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_nav_view.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_nav_view.git
+      version: 0.5.7-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_nav_view.git
+      version: master
+    status: maintained
   rqt_plot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_nav_view` to `0.5.7-0`:

- upstream repository: https://github.com/ros-visualization/rqt_nav_view.git
- release repository: https://github.com/ros-gbp/rqt_nav_view.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_nav_view

- No changes
