### PR TITLE
rqt_web: 0.4.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6492,6 +6492,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_topic.git
       version: master
     status: maintained
+  rqt_web:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_web.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_web-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_web.git
+      version: master
+    status: maintained
   rqt_wrapper:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_web` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_web.git
- release repository: https://github.com/ros-gbp/rqt_web-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_web

```
* add missing WebKit dependency (#449 <https://github.com/ros-visualization/rqt_common_plugins/pull/449>)
```
