### PR TITLE
rqt_robot_dashboard: 0.5.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12206,6 +12206,22 @@ repositories:
       url: https://github.com/ros-visualization/rqt_reconfigure.git
       version: master
     status: maintained
+  rqt_robot_dashboard:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_dashboard.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_robot_dashboard.git
+      version: 0.5.7-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_dashboard.git
+      version: master
+    status: maintained
   rqt_robot_monitor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_dashboard` to `0.5.7-0`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_dashboard.git
- release repository: https://github.com/ros-gbp/rqt_robot_dashboard.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_robot_dashboard

- No changes
