### PR TITLE
rqt_rviz: 0.5.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6493,6 +6493,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_runtime_monitor.git
       version: master
     status: maintained
+  rqt_rviz:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_rviz.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_rviz.git
+      version: 0.5.7-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_rviz.git
+      version: master
+    status: maintained
   rqt_service_caller:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_rviz` to `0.5.7-0`:

- upstream repository: https://github.com/ros-visualization/rqt_rviz.git
- release repository: https://github.com/ros-gbp/rqt_rviz.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_rviz

- No changes
