### PR TITLE
[IJKL] Enable test_pull_requests for rqt plugin repos that are recently split from meta repos.

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11996,6 +11996,7 @@ repositories:
       url: https://github.com/ros-gbp/rqt_image_view-release.git
       version: 0.4.8-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_image_view.git
       version: master
@@ -12057,6 +12058,7 @@ repositories:
       url: https://github.com/ros-gbp/rqt_moveit.git
       version: 0.5.7-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_moveit.git
       version: master

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6024,6 +6024,7 @@ repositories:
       url: https://github.com/ros-gbp/rqt_image_view-release.git
       version: 0.4.8-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_image_view.git
       version: master
@@ -6085,6 +6086,7 @@ repositories:
       url: https://github.com/ros-gbp/rqt_moveit.git
       version: 0.5.7-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_moveit.git
       version: master

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6261,6 +6261,7 @@ repositories:
       url: https://github.com/ros-gbp/rqt_image_view-release.git
       version: 0.4.8-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_image_view.git
       version: master
@@ -6322,6 +6323,7 @@ repositories:
       url: https://github.com/ros-gbp/rqt_moveit.git
       version: 0.5.7-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_moveit.git
       version: master

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1749,6 +1749,7 @@ repositories:
       url: https://github.com/ros-gbp/rqt_image_view-release.git
       version: 0.4.8-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_image_view.git
       version: master
@@ -1795,6 +1796,7 @@ repositories:
       url: https://github.com/ros-gbp/rqt_moveit.git
       version: 0.5.7-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_moveit.git
       version: master


### PR DESCRIPTION
CI choice should be up to the maintainer of each repository but since these packages are split from unified repos, it makes to me to recommend the default, generic CI option (hopefully most of maintainers will appreciate if CI is already setup).

Jade? Sorry I slacked off there :/