### PR TITLE
rqt_common_plugins: 0.4.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6184,6 +6184,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
+      version: 0.4.8-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/ros-gbp/rqt_common_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_common_plugins

- No changes
