### PR TITLE
urdf_tutorial: 0.2.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14793,7 +14793,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/urdf_tutorial-release.git
-      version: 0.2.4-0
+      version: 0.2.5-0
     source:
       type: git
       url: https://github.com/ros/urdf_tutorial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tutorial` to `0.2.5-0`:

- upstream repository: https://github.com/ros/urdf_tutorial.git
- release repository: https://github.com/ros-gbp/urdf_tutorial-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.4-0`

## urdf_tutorial

```
* New ROS Control Tutorial
* Remove dependency on pr2_description (uses local meshes instead)
* General cleanup, bug fixes and reorganization
* Contributors: David V. Lu!!, Felix Duvallet, Paul Bovbel, Thibault Kruse
```
