### PR TITLE
urdf_tutorial: 0.2.5-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2252,6 +2252,21 @@ repositories:
       url: https://github.com/ros-geographic-info/unique_identifier.git
       version: master
     status: maintained
+  urdf_tutorial:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_tutorial.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/urdf_tutorial-release.git
+      version: 0.2.5-0
+    source:
+      type: git
+      url: https://github.com/ros/urdf_tutorial.git
+      version: master
+    status: maintained
   urdfdom_py:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tutorial` to `0.2.5-0`:

- upstream repository: https://github.com/ros/urdf_tutorial.git
- release repository: https://github.com/ros-gbp/urdf_tutorial-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## urdf_tutorial

```
* New ROS Control Tutorial
* Remove dependency on pr2_description (uses local meshes instead)
* General cleanup, bug fixes and reorganization
* Contributors: David V. Lu!!, Felix Duvallet, Paul Bovbel, Thibault Kruse
```
