### PR TITLE
perception_pcl: 1.5.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1080,7 +1080,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/perception_pcl-release.git
-      version: 1.5.1-3
+      version: 1.5.2-0
     source:
       type: git
       url: https://github.com/ros-perception/perception_pcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.5.2-0`:

- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.5.1-3`

## pcl_ros

```
* Find Qt5Widgets to fix -lQt5::Widgets error
* Contributors: Kentaro Wada
```

## perception_pcl

- No changes
