### PR TITLE
add rosdep for cpuburn and lm-sensors

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3153,6 +3153,7 @@ lm-sensors:
   arch: [lm_sensors]
   debian: [lm-sensors]
   fedora: [lm_sensors]
+  gentoo: [sys-apps/lm_sensors]
   ubuntu: [lm-sensors]
 log4cxx:
   arch: [log4cxx]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -469,6 +469,11 @@ cppunit:
   rhel: [cppunit-devel]
   slackware: [cppunit]
   ubuntu: [libcppunit-dev]
+cpuburn:
+  arch: [cpuburn]
+  debian: [cpuburn]
+  fedora: [cpuburn]
+  ubuntu: [cpuburn]
 crypto++:
   fedora: [cryptopp-devel]
   gentoo: [dev-libs/crypto++]
@@ -3144,6 +3149,11 @@ linux-headers-generic:
     wheezy: [linux-headers-3.2.0-4-all]
   fedora: [kernel-headers]
   ubuntu: [linux-headers-generic]
+lm-sensors:
+  arch: [lm_sensors]
+  debian: [lm-sensors]
+  fedora: [lm_sensors]
+  ubuntu: [lm-sensors]
 log4cxx:
   arch: [log4cxx]
   cygwin: [liblog4cxx-devel]


### PR DESCRIPTION
Adds two rosdeps for commonly used tools for heat/stress testing robot computers.

This might look like a small bit of duplication as there is a key for libsensors4-dev, which happens to use lm_sensors on arch/fedora, but if you want the command line tools, you really need the full lm_sensors for ubuntu/debian.