### PR TITLE
image_pipeline: 1.12.20-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -637,11 +637,12 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/image_pipeline-release.git
-      version: 1.12.19-0
+      version: 1.12.20-0
     source:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git
       version: indigo
+    status: maintained
   image_transport_plugins:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `1.12.20-0`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros-gbp/image_pipeline-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.12.19-0`

## camera_calibration

```
* properly save bytes buffer as such
  This is useful for Python 3 and fixes #256 <https://github.com/ros-perception/image_pipeline/issues/256>.
* Get tests slightly looser.
  OpenCV 3.2 gives slightly different results apparently.
* Use floor division where necessary. (#247 <https://github.com/ros-perception/image_pipeline/issues/247>)
* Fix and Improve Camera Calibration Checker Node (#254 <https://github.com/ros-perception/image_pipeline/issues/254>)
  * Fix according to calibrator.py API
  * Add approximate to cameracheck
* Force first corner off chessboard to be uppler left.
  Fixes #140 <https://github.com/ros-perception/image_pipeline/issues/140>
* fix doc jobs
  This is a proper fix for #233 <https://github.com/ros-perception/image_pipeline/issues/233>
* During stereo calibration check that the number of corners detected in the left and right images are the same. This fixes ros-perception/image_pipeline#225 <https://github.com/ros-perception/image_pipeline/issues/225>
* Contributors: Léonard Gérard, Martin Peris, Vincent Rabaud, hgaiser
```

## depth_image_proc

```
* Fix CMake warnings about Eigen.
* Convert depth image metric from [m] to [mm]
* address gcc6 build error
  With gcc6, compiling fails with stdlib.h: No such file or directory,
  as including '-isystem /usr/include' breaks with gcc6, cf.,
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.
  This commit addresses this issue for this package in the same way
  it was addressed in various other ROS packages. A list of related
  commits and pull requests is at:
  https://github.com/ros/rosdistro/issues/12783
  Signed-off-by: Lukas Bulwahn <mailto:lukas.bulwahn@oss.bmw-carit.de>
* Contributors: Kentaro Wada, Lukas Bulwahn, Vincent Rabaud
```

## image_pipeline

```
* Update package.xml (#263 <https://github.com/ros-perception/image_pipeline/issues/263>)
* Contributors: Kei Okada
```

## image_proc

```
* Add nodelet to resize image and camera_info (#273 <https://github.com/ros-perception/image_pipeline/issues/273>)
  * Add nodelet to resize image and camera_info
  * Depends on nodelet_topic_tools
  * Use recursive_mutex for mutex guard for dynamic reconfiguring
* Fix nodelet name: crop_nonZero ->  crop_non_zero (#269 <https://github.com/ros-perception/image_pipeline/issues/269>)
  Fix https://github.com/ros-perception/image_pipeline/issues/217
* Fix permission of executable files unexpectedly (#260 <https://github.com/ros-perception/image_pipeline/issues/260>)
* address gcc6 build error
  With gcc6, compiling fails with stdlib.h: No such file or directory,
  as including '-isystem /usr/include' breaks with gcc6, cf.,
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.
  This commit addresses this issue for this package in the same way
  it was addressed in various other ROS packages. A list of related
  commits and pull requests is at:
  https://github.com/ros/rosdistro/issues/12783
  Signed-off-by: Lukas Bulwahn <mailto:lukas.bulwahn@oss.bmw-carit.de>
* Contributors: Kentaro Wada, Lukas Bulwahn
```

## image_publisher

```
* explicitly cast to std::vector<double> to make gcc6 happy
  With gcc6, compiling image_publisher fails with this error:
  ```
  /[...]/image_publisher/src/nodelet/image_publisher_nodelet.cpp: In member function 'virtual void image_publisher::ImagePublisherNodelet::onInit()':
  /[...]/image_publisher/src/nodelet/image_publisher_nodelet.cpp:180:43: error: ambiguous overload for 'operator=' (operand types are 'sensor_msgs::CameraInfo\_<std::allocator<void> >::_D_type {aka std::vector<double>}' and 'boost::assign_detail::generic_list<int>')
  camera_info\_.D = list_of(0)(0)(0)(0)(0);
  ```
  After adding an initial explicit type cast for the assignment,
  compiling fails further with:
  ```
  | /[...]/image_publisher/src/nodelet/image_publisher_nodelet.cpp: In member function 'virtual void image_publisher::ImagePublisherNodelet::onInit()':
  | /[...]/image_publisher/src/nodelet/image_publisher_nodelet.cpp:180:65: error: call of overloaded 'vector(boost::assign_detail::generic_list<int>&)' is ambiguous
  |      camera_info\_.D = std::vector<double> (list_of(0)(0)(0)(0)(0));
  ```
  Various sources on the internet [1, 2, 3] point to use the
  convert_to_container method; hence, this commit follows those
  suggestions and with that image_publisher compiles with gcc6.
  [1] http://stackoverflow.com/questions/16211410/ambiguity-when-using-boostassignlist-of-to-construct-a-stdvector
  [2] http://stackoverflow.com/questions/12352692/ambiguous-call-with-list-of-in-vs2010/12362548#12362548 <https://github.com/ambiguous-call-with-list-of-in-vs2010/12362548/issues/12362548>
  [3] http://stackoverflow.com/questions/13285272/using-boostassignlist-of?rq=1
  Signed-off-by: Lukas Bulwahn <mailto:lukas.bulwahn@oss.bmw-carit.de>
* address gcc6 build error
  With gcc6, compiling fails with stdlib.h: No such file or directory,
  as including '-isystem /usr/include' breaks with gcc6, cf.,
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.
  This commit addresses this issue for this package in the same way
  it was addressed in various other ROS packages. A list of related
  commits and pull requests is at:
  https://github.com/ros/rosdistro/issues/12783
  Signed-off-by: Lukas Bulwahn <mailto:lukas.bulwahn@oss.bmw-carit.de>
* Contributors: Lukas Bulwahn
```

## image_rotate

```
* Fix CMake warnings about Eigen.
* address gcc6 build error
  With gcc6, compiling fails with stdlib.h: No such file or directory,
  as including '-isystem /usr/include' breaks with gcc6, cf.,
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.
  This commit addresses this issue for this package in the same way
  it was addressed in various other ROS packages. A list of related
  commits and pull requests is at:
  https://github.com/ros/rosdistro/issues/12783
  Signed-off-by: Lukas Bulwahn <mailto:lukas.bulwahn@oss.bmw-carit.de>
* Contributors: Lukas Bulwahn, Vincent Rabaud
```

## image_view

```
* DisparityViewNodelet: fixed freeze (#244 <https://github.com/ros-perception/image_pipeline/issues/244>)
* launch image view with a predefined window size (#257 <https://github.com/ros-perception/image_pipeline/issues/257>)
* Remove python-opencv run_depend for image_view (#270 <https://github.com/ros-perception/image_pipeline/issues/270>)
  The python-opencv dependency pulls in the system OpenCV v2.4 which is
  not required since the image_view package depends on cv_bridge which
  pulls in opencv3 and opencv3 provides the python library that
  image_view can use.
* Fix encoding error message (#253 <https://github.com/ros-perception/image_pipeline/issues/253>)
  * Fix encoding error message
  * Update image_saver.cpp
  Allow compilation on older compilers
* Including stereo_msgs dep fixes #248 <https://github.com/ros-perception/image_pipeline/issues/248> (#249 <https://github.com/ros-perception/image_pipeline/issues/249>)
* Add no gui mode to just visualize & publish with image_view (#241 <https://github.com/ros-perception/image_pipeline/issues/241>)
* stere_view: fixed empty left, right, disparity windows with opencv3
* Apply value scaling to depth/float image with min/max image value
  If min/max image value is specified we just use it, and if not,
  - 32FC1: we assume depth image with meter metric, and 10[m] as the max range.
  - 16UC1: we assume depth image with milimeter metric, and 10 * 1000[mm] as the max range.
* Depends on cv_bridge 1.11.13 for CvtColorForDisplayOptions
  Close #238 <https://github.com/ros-perception/image_pipeline/issues/238>
* fix doc jobs
  This is a proper fix for #233 <https://github.com/ros-perception/image_pipeline/issues/233>
* address gcc6 build error
  With gcc6, compiling fails with stdlib.h: No such file or directory,
  as including '-isystem /usr/include' breaks with gcc6, cf.,
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.
  This commit addresses this issue for this package in the same way
  it was addressed in various other ROS packages. A list of related
  commits and pull requests is at:
  https://github.com/ros/rosdistro/issues/12783
  Signed-off-by: Lukas Bulwahn <mailto:lukas.bulwahn@oss.bmw-carit.de>
* Contributors: Christopher Wecht, Kartik Mohta, Kei Okada, Kentaro Wada, Lukas Bulwahn, Léonard Gérard, Vincent Rabaud, cwecht, mryellow
```

## stereo_image_proc

```
* fix doc jobs
  This is a proper fix for #233 <https://github.com/ros-perception/image_pipeline/issues/233>
* address gcc6 build error
  With gcc6, compiling fails with stdlib.h: No such file or directory,
  as including '-isystem /usr/include' breaks with gcc6, cf.,
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.
  This commit addresses this issue for this package in the same way
  it was addressed in various other ROS packages. A list of related
  commits and pull requests is at:
  https://github.com/ros/rosdistro/issues/12783
  Signed-off-by: Lukas Bulwahn <mailto:lukas.bulwahn@oss.bmw-carit.de>
* Contributors: Lukas Bulwahn, Vincent Rabaud
```
