### PR TITLE
stage_ros: 1.8.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2189,6 +2189,22 @@ repositories:
       url: https://github.com/ros-gbp/stage-release.git
       version: release/kinetic/stage
     status: maintained
+  stage_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-simulation/stage_ros.git
+      version: lunar-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/stage_ros-release.git
+      version: 1.8.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-simulation/stage_ros.git
+      version: lunar-devel
+    status: maintained
   std_capabilities:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stage_ros` to `1.8.0-0`:

- upstream repository: https://github.com/ros-simulation/stage_ros.git
- release repository: https://github.com/ros-gbp/stage_ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## stage_ros

```
* Now uses Stage's native event loop properly and added reassuring startup output.
* Added a GUI section so that the world starts in a good place.
* Fixed issue such that ranger intensity values are no longer clipped to 256
  See: #31 <https://github.com/ros-simulation/stage_ros/issues/31>
* Contributors: Richard Vaughan, Shane Loretz, William Woodall, gerkey
```
