### PR TITLE
add omp dep key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1675,6 +1675,9 @@ libglw1-mesa:
 libgmp:
   fedora: [gmp-devel]
   ubuntu: [libgmp-dev]
+libgomp1:
+  debian: [libgomp1]
+  ubuntu: [libgomp1]
 libgoogle-glog-dev:
   debian: [libgoogle-glog-dev]
   fedora: [glog-devel]


### PR DESCRIPTION
although omp is installed with gcc compiler, this key is needed to be explicit in deps