### PR TITLE
Revert "robotis_framework: 0.2.2-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5237,14 +5237,13 @@ repositories:
       version: kinetic-devel
     release:
       packages:
-      - robotis_controller
       - robotis_device
       - robotis_framework
       - robotis_framework_common
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
-      version: 0.2.2-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git


### PR DESCRIPTION
Reverts ros/rosdistro#14607

FYI @robotpilot  re: https://discourse.ros.org/t/preparing-for-kinetic-sync-2017-04-22/1711/1

https://github.com/ROBOTIS-GIT/ROBOTIS-Framework/issues/40