### PR TITLE
Revert "dynamixel-workbench: 0.1.4-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -901,7 +901,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
-      version: 0.1.4-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git


### PR DESCRIPTION
Reverts ros/rosdistro#14599

Re: https://discourse.ros.org/t/preparing-for-kinetic-sync-2017-04-22/1711

