### PR TITLE
rviz: 1.12.5-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2181,7 +2181,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.12.4-0
+      version: 1.12.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.12.5-0`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.12.4-0`

## rviz

```
* Renamed duplicated pass_depth.vert in nogp program to avoid Ogre 1.10 runtime error (#1063 <https://github.com/ros-visualization/rviz/issues/1063>)
* Fixed some handling of Window ID's for OS X and ogre 1.9 (#1093 <https://github.com/ros-visualization/rviz/issues/1093>)
* Added support for maps larger than video memory using swatches (#1095 <https://github.com/ros-visualization/rviz/issues/1095>)
* Added fullscreen option (f11) (#1017 <https://github.com/ros-visualization/rviz/issues/1017>)
* Added an option to transform map based on header timestamp (#1066 <https://github.com/ros-visualization/rviz/issues/1066>)
* Now updates the display if empty a pointcloud2 message is recieved (#1073 <https://github.com/ros-visualization/rviz/issues/1073>)
  Previously the old point cloud would continue to be rendered.
* Now correctly scales the render panel on high resolution displays (#1078 <https://github.com/ros-visualization/rviz/issues/1078>)
* Added support for multiple materials in a single link of a robot model (#1079 <https://github.com/ros-visualization/rviz/issues/1079>)
* Now includes missing headers necessary for ogre 1.10 (#1092 <https://github.com/ros-visualization/rviz/issues/1092>)
* Fixed duplicate property name for Path colors which caused it to not be restored from saved configs (#1089 <https://github.com/ros-visualization/rviz/issues/1089>)
  See issue #1087 <https://github.com/ros-visualization/rviz/issues/1087>.
* Contributors: Hidde Wieringa, Kei Okada, Maarten de Vries, Phil Osteen, Timo Röhling, Tom Moore, William Woodall, axelschroth
```
