### PR TITLE
rfsm: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5081,7 +5081,10 @@ repositories:
       url: https://github.com/orocos/rFSM.git
       version: master
     release:
+      tags:
+        release: release/kinetic/{package}/{version}
       url: https://github.com/orocos-gbp/rfsm-release.git
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/orocos/rFSM.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rfsm` to `1.0.1-0`:

- upstream repository: https://github.com/orocos/rFSM.git
- release repository: https://github.com/orocos-gbp/rfsm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rfsm

```
* Merge pull request #1 <https://github.com/orocos/rFSM/issues/1> from meyerj/added-print-fcn-argument-to-gen_dbgcolor
  Added optional print_fcn argument to rfsmpp.gen_dbgcolor
* Readded manifest.xml file to not break rFSM for fuerte and earlier
* Contributors: Johannes Meyer
```
