### PR TITLE
rtt_ros_integration: 2.9.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6794,7 +6794,10 @@ repositories:
       - rtt_tf
       - rtt_trajectory_msgs
       - rtt_visualization_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_ros_integration-release.git
+      version: 2.9.0-0
     source:
       type: git
       url: https://github.com/orocos/rtt_ros_integration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_ros_integration` to `2.9.0-0`:

- upstream repository: https://github.com/orocos/rtt_ros_integration.git
- release repository: https://github.com/orocos-gbp/rtt_ros_integration-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rtt_actionlib

```
* Added deprecation warning for header rtt_roscomm/rtt_rostopic.h and updated some include directives within rtt_ros_integration
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_actionlib_msgs

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_common_msgs

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_diagnostic_msgs

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_dynamic_reconfigure

```
* rtt_dynamic_reconfigure: create a partially filled PropertyBag from a Config message that only has a subset of fields
* rtt_dynamic_reconfigure: support both, non-const and const updateProperties callback signatures
  This is an improved version of https://github.com/orocos/rtt_ros_integration/pull/81 that is backwards-compatible
  to existing components that provide the const-variant of the callback.
* rtt_dynamic_reconfigure: allow the update callback to change the values in the propertybag
  This fixes a thread-safety issue with the previous commit b603585e9f74b3a553347301b44c73b0249856a1.
  But the user-defined update callback has to update the referenced bag manually in case it modified
  some property values.
* rtt_dynamic_reconfigure: publish updated property values in setConfigCallback() instead of desired once
  Rebuild new_config ConfigType from owner's PropertyBag before serializing and publishing dynamic_reconfigure msg from PropertyBag.
  The user might have modified the property values in one of the callbacks.
* rtt_dynamic_reconfigure: fixed potential deadlock in refresh() for RTT prior to 2.9
  We do not know for sure which thread is calling this method/operation, but we can check if the current
  thread is the same as the thread that will process the update/notify operation. If yes, we clone the
  underlying OperationCaller implementation and set the caller to the processing engine. In this case
  RTT <2.9 should always call the operation directly as if it would be a ClientThread operation:
  https://github.com/orocos-toolchain/rtt/blob/toolchain-2.8/rtt/base/OperationCallerInterface.hpp#L79
  RTT 2.9 and above already checks the caller thread internally and therefore does not require this hack.
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer, Viktor Kunovski
```

## rtt_geometry_msgs

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_kdl_conversions

```
* rtt_kdl_conversions: removed operations for deprecated functions
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_nav_msgs

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_ros

```
* rtt_std_msgs: added a transport plugin for ROS primitive types
* Contributors: Johannes Meyer
```

## rtt_ros_comm

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_ros_integration

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_ros_msgs

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_rosclock

```
* fix xenomai rtt_now() fix PR`#41 <https://github.com/orocos/rtt_ros_integration/issues/41>`_
* Added individual changelogs and bumped versions to 2.9.0
* rtt_rosclock: adapted SimClockActivity to the updated ActivityInterface with the master-update-hook-vs-callback-queue patch (orocos-toolchain/rtt#91 <https://github.com/orocos-toolchain/rtt/issues/91>)
  Signed-off-by: Johannes Meyer <mailto:johannes@intermodalics.eu>
* Contributors: Antoine Hoarau, Johannes Meyer
```

## rtt_roscomm

```
* rtt_roscomm: find templates and create_boost_header.py script directly in the source-space
* rtt_roscomm: fixed missing package headers include directories for service proxies (fix #87 <https://github.com/orocos/rtt_ros_integration/issues/87>)
* rtt_roscomm: remove using namespace directive from rtt_rostopic_ros_msg_transporter.hpp header
* Added deprecation warning for header rtt_roscomm/rtt_rostopic.h and updated some include directives within rtt_ros_integration
* rtt_roscomm: remove using namespace directive from rtt_rostopic_ros_msg_transporter.hpp header
* rtt_roscomm: renamed header rtt_rostopic.h to rostopic.h and changed namespace for the ROSService service requester for consistency
* rtt_roscomm: added new operations to the documentation in README.md
* rtt_roscomm: get rid of custom IDL
* rtt_roscomm: use @ROSMSGTYPE@ variable in ros_msg_corba_conversion.hpp.in to allow reuse for custom types
* rtt_roscomm: do not include boost header from Types.hpp
* rtt_roscomm: avoid unnecessary copy during conversion of ROS types to CORBA sequence and catch StreamOverrunException
* rtt_roscomm: do not generate unused source files for per-message typekit
* rtt_roscomm: avoid mismatched-tags warning in clang by removing the extern template declaration and instantiation for RTT::internal::DataSourceTypeInfo<T>
* rtt_roscomm: introduced cmake options ENABLE_MQ and ENABLE_CORBA and disable additional transport plugins by default
* Added individual changelogs and bumped versions to 2.9.0
* Also add a virtual destructor to the base class of the ROS Service Proxy
* Added an explicit destructor to shutdown services servers, and cleanup the registered proxies
* Added CORBA and mqueue transport for ROS typekits
* rtt_roscomm: added support for updated dataflow semantics (RTT version >= 2.8.99)
* Contributors: Antoine Hoarau, Guillaume Walck, Johannes Meyer
```

## rtt_rosdeployment

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_rosgraph_msgs

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_rosnode

```
* rtt_rosnode: fixed corruption of RTT's argv vector when loading the rosnode plugin (fix #54 <https://github.com/orocos/rtt_ros_integration/issues/54>)
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_rospack

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_rosparam

```
* rtt_rosparam: removed cmake_modules dependency and fixed export of eigen3 dependency
* rtt_rosparam: fixed retrieval of Eigen::VectorXf properties from the parameter server
* rtt_rosparam: added missing operations and operation callers
* rtt_rosparam: moved ResolutionPolicy enum to the service requester header
* rtt_rosparam: enabled Eigen-based operation callers in rosparam.h and added build_export_depend
* sync service with new functions
* add vectorXd/Xf methods
* add Component private/relative/absolute methods
* add template instead of macros
* add missing comma
* only ops supported types
* add ros param getter and setters operations
* add Component private/Relative resolution
* Added individual changelogs and bumped versions to 2.9.0
* cast enum to int to avoid warning
* Contributors: Antoine Hoarau, Johannes Meyer
```

## rtt_sensor_msgs

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_shape_msgs

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_std_msgs

```
* Added deprecation warning for header rtt_roscomm/rtt_rostopic.h and updated some include directives within rtt_ros_integration
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_std_srvs

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_stereo_msgs

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_tf

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_trajectory_msgs

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```

## rtt_visualization_msgs

```
* Added individual changelogs and bumped versions to 2.9.0
* Contributors: Johannes Meyer
```
