### PR TITLE
perception_pcl: 1.5.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1105,7 +1105,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/perception_pcl-release.git
-      version: 1.5.2-0
+      version: 1.5.3-0
     source:
       type: git
       url: https://github.com/ros-perception/perception_pcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.5.3-0`:

- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.5.2-0`

## pcl_ros

```
* Add dependency on qtbase5-dev for find_package(Qt5Widgets)
  See https://github.com/ros-perception/perception_pcl/pull/117#issuecomment-298158272 for detail.
* Contributors: Kentaro Wada
```

## perception_pcl

- No changes
