### PR TITLE
fix rqt robot plugins release repo names

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12054,7 +12054,7 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_moveit.git
+      url: https://github.com/ros-gbp/rqt_moveit-release.git
       version: 0.5.7-0
     source:
       test_pull_requests: true
@@ -12102,7 +12102,7 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_nav_view.git
+      url: https://github.com/ros-gbp/rqt_nav_view-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -12150,7 +12150,7 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_pose_view.git
+      url: https://github.com/ros-gbp/rqt_pose_view-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -12222,7 +12222,7 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_robot_dashboard.git
+      url: https://github.com/ros-gbp/rqt_robot_dashboard-release.git
       version: 0.5.7-0
     source:
       test_pull_requests: true
@@ -12238,7 +12238,7 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_robot_monitor.git
+      url: https://github.com/ros-gbp/rqt_robot_monitor-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -12268,7 +12268,7 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_robot_steering.git
+      url: https://github.com/ros-gbp/rqt_robot_steering-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -12283,7 +12283,7 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_runtime_monitor.git
+      url: https://github.com/ros-gbp/rqt_runtime_monitor-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -12298,7 +12298,7 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_rviz.git
+      url: https://github.com/ros-gbp/rqt_rviz-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -12358,7 +12358,7 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_tf_tree.git
+      url: https://github.com/ros-gbp/rqt_tf_tree-release.git
       version: 0.5.7-0
     source:
       test_pull_requests: true

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6081,7 +6081,7 @@ repositories:
     release:
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_moveit.git
+      url: https://github.com/ros-gbp/rqt_moveit-release.git
       version: 0.5.7-0
     source:
       test_pull_requests: true
@@ -6129,7 +6129,7 @@ repositories:
     release:
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_nav_view.git
+      url: https://github.com/ros-gbp/rqt_nav_view-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -6159,7 +6159,7 @@ repositories:
     release:
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_pose_view.git
+      url: https://github.com/ros-gbp/rqt_pose_view-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -6220,7 +6220,7 @@ repositories:
     release:
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_robot_dashboard.git
+      url: https://github.com/ros-gbp/rqt_robot_dashboard-release.git
       version: 0.5.7-0
     source:
       test_pull_requests: true
@@ -6236,7 +6236,7 @@ repositories:
     release:
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_robot_monitor.git
+      url: https://github.com/ros-gbp/rqt_robot_monitor-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -6266,7 +6266,7 @@ repositories:
     release:
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_robot_steering.git
+      url: https://github.com/ros-gbp/rqt_robot_steering-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -6281,7 +6281,7 @@ repositories:
     release:
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_runtime_monitor.git
+      url: https://github.com/ros-gbp/rqt_runtime_monitor-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -6296,7 +6296,7 @@ repositories:
     release:
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_rviz.git
+      url: https://github.com/ros-gbp/rqt_rviz-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -6356,7 +6356,7 @@ repositories:
     release:
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_tf_tree.git
+      url: https://github.com/ros-gbp/rqt_tf_tree-release.git
       version: 0.5.7-0
     source:
       test_pull_requests: true

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6322,7 +6322,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_moveit.git
+      url: https://github.com/ros-gbp/rqt_moveit-release.git
       version: 0.5.7-0
     source:
       test_pull_requests: true
@@ -6370,7 +6370,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_nav_view.git
+      url: https://github.com/ros-gbp/rqt_nav_view-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -6400,7 +6400,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_pose_view.git
+      url: https://github.com/ros-gbp/rqt_pose_view-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -6476,7 +6476,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_robot_dashboard.git
+      url: https://github.com/ros-gbp/rqt_robot_dashboard-release.git
       version: 0.5.7-0
     source:
       test_pull_requests: true
@@ -6492,7 +6492,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_robot_monitor.git
+      url: https://github.com/ros-gbp/rqt_robot_monitor-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -6522,7 +6522,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_robot_steering.git
+      url: https://github.com/ros-gbp/rqt_robot_steering-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -6537,7 +6537,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_runtime_monitor.git
+      url: https://github.com/ros-gbp/rqt_runtime_monitor-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -6552,7 +6552,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_rviz.git
+      url: https://github.com/ros-gbp/rqt_rviz-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -6612,7 +6612,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_tf_tree.git
+      url: https://github.com/ros-gbp/rqt_tf_tree-release.git
       version: 0.5.7-0
     source:
       test_pull_requests: true

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1793,7 +1793,7 @@ repositories:
     release:
       tags:
         release: release/lunar/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_moveit.git
+      url: https://github.com/ros-gbp/rqt_moveit-release.git
       version: 0.5.7-0
     source:
       test_pull_requests: true
@@ -1824,7 +1824,7 @@ repositories:
     release:
       tags:
         release: release/lunar/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_nav_view.git
+      url: https://github.com/ros-gbp/rqt_nav_view-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -1854,7 +1854,7 @@ repositories:
     release:
       tags:
         release: release/lunar/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_pose_view.git
+      url: https://github.com/ros-gbp/rqt_pose_view-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -1915,7 +1915,7 @@ repositories:
     release:
       tags:
         release: release/lunar/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_robot_dashboard.git
+      url: https://github.com/ros-gbp/rqt_robot_dashboard-release.git
       version: 0.5.7-0
     source:
       test_pull_requests: true
@@ -1931,7 +1931,7 @@ repositories:
     release:
       tags:
         release: release/lunar/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_robot_monitor.git
+      url: https://github.com/ros-gbp/rqt_robot_monitor-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -1961,7 +1961,7 @@ repositories:
     release:
       tags:
         release: release/lunar/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_robot_steering.git
+      url: https://github.com/ros-gbp/rqt_robot_steering-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -1976,7 +1976,7 @@ repositories:
     release:
       tags:
         release: release/lunar/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_runtime_monitor.git
+      url: https://github.com/ros-gbp/rqt_runtime_monitor-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -1991,7 +1991,7 @@ repositories:
     release:
       tags:
         release: release/lunar/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_rviz.git
+      url: https://github.com/ros-gbp/rqt_rviz-release.git
       version: 0.5.7-0
     source:
       type: git
@@ -2051,7 +2051,7 @@ repositories:
     release:
       tags:
         release: release/lunar/{package}/{version}
-      url: https://github.com/ros-gbp/rqt_tf_tree.git
+      url: https://github.com/ros-gbp/rqt_tf_tree-release.git
       version: 0.5.7-0
     source:
       test_pull_requests: true


### PR DESCRIPTION
Adding the missing `-release` suffix to be consistent with other gbp repos.