### PR TITLE
rqt_rviz: 0.5.8-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1992,7 +1992,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rqt_rviz-release.git
-      version: 0.5.7-0
+      version: 0.5.8-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_rviz` to `0.5.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_rviz.git
- release repository: https://github.com/ros-gbp/rqt_rviz-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.5.7-0`

## rqt_rviz

```
* Qt5 widgets bugfix (#4 <https://github.com/ros-visualization/rqt_rviz/issues/4>)
  * add qtbase to dependency list
  * find widgets as components rather than package
* Contributors: Mikael Arguedas
```
