### PR TITLE
Moved collada_parser and collada_urdf to a new repo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1771,6 +1771,25 @@ repositories:
       url: https://github.com/ipa320/cob_substitute.git
       version: indigo_dev
     status: maintained
+  collada_urdf:
+    doc:
+      type: git
+      url: https://github.com/ros/collada_urdf.git
+      version: indigo-devel
+    release:
+      packages:
+      - collada_parser
+      - collada_urdf
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/collada-urdf-release.git
+      version: 1.11.13-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/collada_urdf.git
+      version: indigo-devel
+    status: maintained
   common_msgs:
     doc:
       type: git
@@ -10239,8 +10258,6 @@ repositories:
       version: indigo-devel
     release:
       packages:
-      - collada_parser
-      - collada_urdf
       - joint_state_publisher
       - kdl_parser
       - kdl_parser_py

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1782,7 +1782,7 @@ repositories:
       - collada_urdf
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/collada-urdf-release.git
+      url: https://github.com/ros-gbp/collada_urdf-release.git
       version: 1.11.13-0
     source:
       test_pull_requests: true


### PR DESCRIPTION
This is a manual pull request because collada_parser and collada_urdf have been moved to a new repository.

I ran bloom up to the point where it warned `Failed to open pull request: AssertionError - Duplicate package name 'collada_parser' exists in repository 'robot_model' as well as in re
pository 'collada_urdf'`