### PR TITLE
usb_cam: 0.3.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8027,6 +8027,13 @@ repositories:
       url: https://github.com/ros-drivers/urg_node.git
       version: indigo-devel
     status: maintained
+  usb_cam:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/usb_cam-release.git
+      version: 0.3.4-0
+    status: developed
   uwsim_bullet:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam` to `0.3.4-0`:

- upstream repository: https://github.com/bosch-ros-pkg/usb_cam.git
- release repository: https://github.com/tork-a/usb_cam-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## usb_cam

```
* Installs launch files
* Merge pull request #37 from tzutalin/develop
  Add a launch file for easy test
* Add a launch file for easy test
* Contributors: Russell Toris, tzu.ta.lin
```
