### PR TITLE
libuvc: 0.0.5-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2578,6 +2578,13 @@ repositories:
       type: git
       url: https://github.com/SICKAG/libsick_ldmrs.git
       version: master
+  libuvc:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/libuvc-release.git
+      version: 0.0.5-0
+    status: developed
   lms1xx:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc` to `0.0.5-0`:

- upstream repository: https://github.com/ktossell/libuvc.git
- release repository: https://github.com/tork-a/libuvc-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
