### PR TITLE
libuvc: 0.0.5-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -768,6 +768,13 @@ repositories:
       url: https://github.com/ros-gbp/libg2o-release.git
       version: 2017.4.2-1
     status: maintained
+  libuvc:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/tork-a/libuvc-release.git
+      version: 0.0.5-0
+    status: developed
   log4cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc` to `0.0.5-0`:

- upstream repository: https://github.com/ktossell/libuvc.git
- release repository: https://github.com/tork-a/libuvc-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
