### PR TITLE
libuvc_ros: 0.0.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2578,6 +2578,16 @@ repositories:
       type: git
       url: https://github.com/SICKAG/libsick_ldmrs.git
       version: master
+  libuvc_ros:
+    release:
+      packages:
+      - libuvc_camera
+      - libuvc_ros
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/libuvc_ros-release.git
+      version: 0.0.7-0
+    status: developed
   lms1xx:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc_ros` to `0.0.7-0`:

- upstream repository: https://github.com/ktossell/libuvc_ros.git
- release repository: https://github.com/tork-a/libuvc_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## libuvc_camera

```
* Removed dependency on the deprecated driver_base package.
* Added more informative error messages in the case of uvc_open() failure
```

## libuvc_ros

- No changes
