### PR TITLE
libuvc_ros: 0.0.7-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -768,6 +768,16 @@ repositories:
       url: https://github.com/ros-gbp/libg2o-release.git
       version: 2017.4.2-1
     status: maintained
+  libuvc_ros:
+    release:
+      packages:
+      - libuvc_camera
+      - libuvc_ros
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/tork-a/libuvc_ros-release.git
+      version: 0.0.7-0
+    status: developed
   log4cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc_ros` to `0.0.7-0`:

- upstream repository: https://github.com/ktossell/libuvc_ros.git
- release repository: https://github.com/tork-a/libuvc_ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## libuvc_camera

```
* Removed dependency on the deprecated driver_base package.
* Added more informative error messages in the case of uvc_open() failure
```

## libuvc_ros

- No changes
