### PR TITLE
camera_umd: 0.2.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -427,6 +427,17 @@ repositories:
       url: https://github.com/ros-perception/camera_info_manager_py.git
       version: master
     status: maintained
+  camera_umd:
+    release:
+      packages:
+      - camera_umd
+      - jpeg_streamer
+      - uvc_camera
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/camera_umd-release.git
+      version: 0.2.4-0
+    status: developed
   capabilities:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_umd` to `0.2.4-0`:

- upstream repository: https://github.com/ktossell/camera_umd.git
- release repository: https://github.com/tork-a/camera_umd-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## camera_umd

- No changes

## jpeg_streamer

- No changes

## uvc_camera

```
* Added new parameters: auto_focus (bool), focus_absolute (int), auto_exposure (bool),
  exposure_absolute (int), power_line_frequency (int: 0/50/60)
* Contributors: Andreas Bihlmaier
```
