### PR TITLE
executive_smach_tutorials: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2787,6 +2787,15 @@ repositories:
       url: https://github.com/ros/executive_smach.git
       version: indigo-devel
     status: maintained
+  executive_smach_tutorials:
+    release:
+      packages:
+      - smach_tutorials
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/executive_smach_tutorials-release.git
+      version: 0.1.0-0
+    status: developed
   executive_smach_visualization:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `executive_smach_tutorials` to `0.1.0-0`:

- upstream repository: https://github.com/rhaschke/executive_smach_tutorials.git
- release repository: https://github.com/tork-a/executive_smach_tutorials-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
