### PR TITLE
multimaster_fkie: 0.7.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3457,7 +3457,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.7.3-0
+      version: 0.7.4-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.7.4-0`:

- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.7.3-0`

## default_cfg_fkie

- No changes

## master_discovery_fkie

```
* master_discovery_fkie: improved filter logging
* fixed read parameter with host filter
* Contributors: Alexander Tiderko
```

## master_sync_fkie

```
* master_sync_fkie: fixed sync_hosts parameter
* added description how to filter for specific hosts
* Contributors: Alexander Tiderko
```

## multimaster_fkie

```
* node_manager_fkie: updated highlightning in sync dialog
* node_manager_fkie: add tooltip to a filter in echo dialog
* node_manager_fkie: fixed problems with ampersand.
  The ampersand is automatically set in QPushButton or QCheckbx by
  KDEPlatformTheme plugin in Qt5
  [https://bugs.kde.org/show_bug.cgi?id=337491]
  A workaroud is to add
  [Development]
  AutoCheckAccelerators=false
  to ~/.config/kdeglobals
  This fix removes the ampersand manually.
* master_discovery_fkie: improved filter logging
* master_snyc_fkie: fixed sync_hosts parameter
* master_snyc_fkie: fixed filter for specific hosts
* added description how to filter for specific hosts
* Contributors: Alexander Tiderko
```

## multimaster_msgs_fkie

- No changes

## node_manager_fkie

```
* node_manager_fkie: updated highlightning in sync dialog
* node_manager_fkie: add tooltip to a filter in echo dialog
* node_manager_fkie: fixed problems with ampersand.
  The ampersand is automatically set in QPushButton or QCheckbx by
  KDEPlatformTheme plugin in Qt5
  [https://bugs.kde.org/show_bug.cgi?id=337491]
  A workaroud is to add
  [Development]
  AutoCheckAccelerators=false
  to ~/.config/kdeglobals
  This fix removes the ampersand manually.
* Contributors: Alexander Tiderko
```
