### PR TITLE
gscam: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1734,6 +1734,21 @@ repositories:
       url: https://github.com/ethz-asl/grid_map.git
       version: master
     status: developed
+  gscam:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/gscam.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/gscam-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/gscam.git
+      version: master
+    status: developed
   haf_grasping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gscam` to `0.2.0-0`:

- upstream repository: https://github.com/tork-a/gscam.git
- release repository: https://github.com/tork-a/gscam-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`

## gscam

```
* Merge remote-tracking branch 'dhood/master'
* Merge remote-tracking branch 'blutack/master'
* gscam_nodelet.h: include scoped_ptr.hpp to compile with boost 1.57
  When compiling gscam with the currently latest boost version 1.57,
  it fails with:
  In file included from [...]/src/gscam_nodelet.cpp:5:0:
  [...]/include/gscam/gscam_nodelet.h:20:12: error: 'scoped_ptr' in namespace 'boost' does not name a template type
  boost::scoped_ptr<GSCam> gscam_driver_;
  ^
  [...]/include/gscam/gscam_nodelet.h:21:12: error: 'scoped_ptr' in namespace 'boost' does not name a template type
  boost::scoped_ptr<boost::thread> stream_thread_;
  ^
  It seems that the dependencies of boost/thread.hpp have changed
  and boost/scoped_ptr.hpp is not included anymore with
  boost/thread.hpp. Hence, the scoped_ptr is not defined in the
  gscam_nodelet header. After scanning quickly through the release
  notes of version 1.57, the boost bug tracker and a few changesets,
  I could not find not a hint what has changed in the thread library
  that gscam must include scoped_ptr itself.
  This commit simply addresses the compiler error by explicitly
  adding boost's scoped_ptr header in the gscam_nodelet header.
  As this commit also compiles with boost version 1.56, the commit
  is not expected to cause any problems with other build
  configurations.
  Signed-off-by: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
* Remove dependency on opencv2 to fix under indigo
  Packages can no longer depend on opencv2 as of indigo.
  I've updated the package to depend instead on cv_bridge as suggested by http://wiki.ros.org/indigo/Migration#OpenCV.
* Install the parameters file refered to in v4l.launch
* Update package.xml
* Merge pull request #15 <https://github.com/tork-a/gscam/issues/15> from kubark42/osx_camera_launch
  Examples: Added standard launch file for OSX
* Examples: Added example for OSX
  Add a simple launch configuration for OSX. The camera can be selected by
  changing the default="0" to the appropriate integer.
* Adding libraries to gscam target
  Fixes #13 <https://github.com/tork-a/gscam/issues/13>, now builds on stricter linkers
* adding proper depends to catkin package call
* Update minoru.launch
* Contributors: CHILI Demo Corner, Jonathan Bohren, Kenn Sebesta, Lukas Bulwahn, Russell Toris, blutack
```
