### PR TITLE
ps4eye: 0.0.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4571,6 +4571,21 @@ repositories:
       url: https://github.com/pr2/pr2_mechanism_msgs.git
       version: master
     status: maintained
+  ps4eye:
+    doc:
+      type: git
+      url: https://github.com/longjie/ps4eye.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/ps4eye-release.git
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/longjie/ps4eye.git
+      version: master
+    status: developed
   pugixml:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ps4eye` to `0.0.4-0`:

- upstream repository: https://github.com/longjie/ps4eye.git
- release repository: https://github.com/tork-a/ps4eye-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`

## ps4eye

```
* Fix create_udev_rules option. Change README.md.
* Add udev install script.
* Automatically loading firmware.
* all need is to run create_udev_rules script.
* add viewer argment to stereo.launch. Set true to bring up stereo viewer.
* Add ps4eye/ps4eye files and update README.md contents.
* using  to nodelet manager name
* use gscam nodelet instead of gscam node
* use load_driver, instead of setting DEVICE false to check use real camera
* Contributors: Hiroaki Yaguchi, Ron Tajima
```
