### PR TITLE
executive_smach_visualization: 2.1.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1076,6 +1076,24 @@ repositories:
       url: https://github.com/ros/executive_smach.git
       version: indigo-devel
     status: maintained
+  executive_smach_visualization:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/executive_smach_visualization.git
+      version: indigo-devel
+    release:
+      packages:
+      - executive_smach_visualization
+      - smach_viewer
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/tork-a/executive_smach_visualization-release.git
+      version: 2.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/executive_smach_visualization.git
+      version: indigo-devel
+    status: developed
   fanuc:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `executive_smach_visualization` to `2.1.0-0`:

- upstream repository: https://github.com/tork-a/executive_smach_visualization.git
- release repository: https://github.com/tork-a/executive_smach_visualization-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## executive_smach_visualization

- No changes

## smach_viewer

```
* support for Qt5 (Kinetic)
* update CMakeLists.txt, package.xml, setup.py, smach_viewer.py for new xdot structure
* add necessary lines in xdot/__init__.py https://github.com/jbohren/xdot/pull/14
* copy xdot from https://github.com/jbohren/xdot, since system xdot is released in rosdep key https://github.com/ros/rosdistro/pull/4976
* wx viewer: checking to make sure item urls are strings to prevent crash
* Contributors: Jonathan Bohren, Kei Okada
```
