### PR TITLE
move release repository from jbohren to tork-a

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2794,8 +2794,8 @@ repositories:
       - smach_viewer
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/jbohren/executive_smach_visualization-release.git
-      version: 2.0.0-0
+      url: https://github.com/tork-a/executive_smach_visualization-release.git
+      version: 2.1.0-0
     source:
       type: git
       url: https://github.com/ros-visualization/executive_smach_visualization.git


### PR DESCRIPTION

- ros-indigo-xdot is overriden by https://github.com/ros/rosdistro/pull/4978#issuecomment-298829906, 
- So if we want to continue using smach_viwer, we have to switch to system xdot or find other means.
- ros-indigo-xdot and system xdot is very different, my solution is to copy ros-indigo-xdot within smach_viewer directory https://github.com/ros-visualization/executive_smach_visualization/pull/14
- seems original maintainer is so busy, we haven't released this more than a year https://github.com/ros-visualization/executive_smach_visualization/issues/13 https://github.com/jbohren/executive_smach_visualization-release/issues/1

I understand receiving maintainer jobs is too much responsibility for everyone, but for releasing existing software is not a big deal and I think there might be good way not to drop existing software just because we have new ros distro.

- **[bloom release maintainer level]** packages already prepared (already ran `catkin_prepare_release`) and just forget to run `bloom-release`, specially for new distro => put release repo to community level organization (ex. https://github.com/ros-gbp/) give access to everyone who asked for release. If one have familiar with `Ubuntu` and `Github`, they can run `bloom-release`. Ex. https://github.com/ros/rosdistro/pull/14862 (usb_cam), https://github.com/ros/rosdistro/pull/14867 (libuvc_ros), https://github.com/ros/rosdistro/pull/14870 (camera_umd)t 

- **[package release maintainer level]** packages is ready to run `catkin_prepare_release`, but maintainers did not run `catkin_prepare_release`, not sure why this happens, may be maintainer merged, but forget to run `catkin_prepare_release` before they stop maintain it. Currently if original maintainer stop maintaining , we have to send mail / issue many times for transfer or add access to that repository  (this is time consuming) or we have to force take over it (this confuse users, which we should look into ?). So if we should control this type of software under community level control and give access to everyone who have familiar with `catkin_prepare_release`. Ex https://github.com/ros/rosdistro/pull/14878 (gscam), 

- **[package migration maintainer level]** packages need to be fixed before run `catkin_prepare_release`. You do not have to have algorithm level knowledge or think about software design, mostly just to fix migration level, such as `opencv2` -> `opencv3` or `qt4` -> `qt5`. So not as heavy as full-software level maintainer. May be potential solution is equal to package release maintainer level situation. Ex. https://github.com/ros/rosdistro/pull/14890 (smach_viewer)