### PR TITLE
auv_msgs: 0.0.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -83,6 +83,11 @@ repositories:
       type: git
       url: https://github.com/oceansystemslab/auv_msgs.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/oceansystemslab/auv_msgs-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/oceansystemslab/auv_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `auv_msgs` to `0.0.1-0`:

- upstream repository: https://github.com/oceansystemslab/auv_msgs.git
- release repository: https://github.com/oceansystemslab/auv_msgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## auv_msgs

```
* Initial commit
* Contributors: Bence Magyar
```
