### PR TITLE
Move collada_urdf to new repository

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -502,6 +502,25 @@ repositories:
       url: https://github.com/ros/cmake_modules.git
       version: 0.4-devel
     status: maintained
+  collada_urdf:
+    doc:
+      type: git
+      url: https://github.com/ros/collada_urdf.git
+      version: indigo-devel
+    release:
+      packages:
+      - collada_parser
+      - collada_urdf
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ros-gbp/collada_urdf-release.git
+      version: 1.11.14-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/collada_urdf.git
+      version: indigo-devel
+    status: maintained
   common_msgs:
     doc:
       type: git
@@ -5067,8 +5086,6 @@ repositories:
       version: indigo-devel
     release:
       packages:
-      - collada_parser
-      - collada_urdf
       - joint_state_publisher
       - kdl_parser
       - kdl_parser_py


### PR DESCRIPTION
`collada_urdf` and `collada_parser` have been moved to a new repository. This is the same as #14859 and #14897 but for jade.