### PR TITLE
Moved collada_urdf and collada_parser to new repository (kinetic)

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -548,6 +548,25 @@ repositories:
       url: https://github.com/ros/cmake_modules.git
       version: 0.4-devel
     status: maintained
+  collada_urdf:
+    doc:
+      type: git
+      url: https://github.com/ros/collada_urdf.git
+      version: kinetic-devel
+    release:
+      packages:
+      - collada_parser
+      - collada_urdf
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/collada_urdf-release.git
+      version: 1.12.10-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/collada_urdf.git
+      version: kinetic-devel
+    status: maintained
   common_msgs:
     doc:
       type: git
@@ -5158,8 +5177,6 @@ repositories:
       version: kinetic-devel
     release:
       packages:
-      - collada_parser
-      - collada_urdf
       - joint_state_publisher
       - kdl_parser
       - kdl_parser_py


### PR DESCRIPTION
`collada_urdf` and `collada_parser` have been moved to a new repository. This releases a new version into kinetic

Related

* Indigo #14859 and #14897 
* Jade #14898 
