### PR TITLE
lms1xx: 0.1.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2606,7 +2606,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/clearpath-gbp/lms1xx-release.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/lms1xx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lms1xx` to `0.1.6-0`:

- upstream repository: https://github.com/clearpathrobotics/LMS1xx.git
- release repository: https://github.com/clearpath-gbp/lms1xx-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.5-0`

## lms1xx

```
* Added max/min angle to gazebo plugin.
* [ros params] Adding 'port' parameter. (#35 <https://github.com/clearpathrobotics/LMS1xx/issues/35>)
* Add robot namespace to lidar plugin
* Exposed parameters min_range and max_range
* add parameters 'sample_size' and 'update_rate' for gazebo's ray plugin
* Contributors: Achim, CyrillePierre, Mike Purvis, Paul Bovbel, Tony Baltovski, mailto:bikramak@aandkrobotics.com
```
