### PR TITLE
debian does not have libgstreamer-plugins-good1.0-0

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -998,7 +998,7 @@ gstreamer1.0-plugins-base:
   ubuntu: [gstreamer1.0-plugins-base, libgstreamer-plugins-base1.0-0, gir1.2-gst-plugins-base-1.0]
 gstreamer1.0-plugins-good:
   arch: [gst-plugins-good]
-  debian: [gstreamer1.0-plugins-good, libgstreamer-plugins-good1.0-0]
+  debian: [gstreamer1.0-plugins-good]
   fedora: [gstreamer1-plugins-good]
   ubuntu: [gstreamer1.0-plugins-good, libgstreamer-plugins-good1.0-0]
 gstreamer1.0-plugins-ugly:


### PR DESCRIPTION
it seems libgstreamer-plugins-good1.0-0 never released on debian, see https://packages.debian.org/search?suite=all&section=all&arch=amd64&searchon=names&keywords=streamer-plugins
, http://snapshot.debian.org/binary/?cat=libg
this is the cause of building some packages on debian

http://build.ros.org/job/Kbin_dj_dJ64__pr2eus__debian_jessie_amd64__binary/82/console
```
10:36:03   112 'Done'
10:36:03   113 'Some packages could not be installed. This may mean that you have'
10:36:03   114 'requested an impossible situation or if you are using the unstable'
10:36:03   115 'distribution that some required packages have not yet been created'
10:36:03   116 'or been moved out of Incoming.'
10:36:03   117 'The following information may help to resolve the situation:'
10:36:03   118 ''
10:36:03   119 'The following packages have unmet dependencies:'
10:36:03   120 ' ros-kinetic-sound-play : Depends: libgstreamer-plugins-good1.0-0 but it is not installable'
10:36:03   121 'E: Unable to correct problems, you have held broken packages.'
10:36:03 None of the following known errors were detected:
```

c.f. https://github.com/ros/rosdistro/pull/12356