### PR TITLE
mavros: 0.19.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3096,7 +3096,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.18.7-0
+      version: 0.19.0-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.19.0-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.18.7-0`

## libmavconn

- No changes

## mavros

```
* launch: remove setpoint-attitude from apm blacklist
* lib: cleanup in enum_to_string
* extras: Add ADSB plugin
* plugin: home_position: Log poll
* plugin: home_position: Log report
* plugin #695 <https://github.com/mavlink/mavros/issues/695>: Fix plugin
* plugin: Add home_position
* Added SAFETY_ALLOWED_AREA rx handler (#689 <https://github.com/mavlink/mavros/issues/689>)
  * Added SAFETY_ALLOWED_AREA rx handler and publish PolygonStamped msg with the 2 points
  * add resize to array to avoid sigfault
* lib: Fix millis timesync passthrough
* Plugin: Add unstamped Twist subscriber for setpoint_velocity
* uas: Move timesync_mode enum to utils.h + fixes
  That enum are used for utils too, but forward declaration of class
  internal enum is impossible.
* sys_time: Add timesync mode selection parameter.
* sys_time : add multi-mode timesync
* uas : add multi-mode timesync
* uas : add multi-mode timesync
* launch fix #670 <https://github.com/mavlink/mavros/issues/670>: Add configuration of distance_sensor plugin for APM
* Contributors: Kabir Mohammed, Nuno Marques, Pierre Kancir, Randy Mackay, Vladimir Ermakov
```

## mavros_extras

```
* extras: fix package link
* extras: Fix adsb plugin
* extras: Add ADSB plugin
* Add frame transform for vibration levels (#690 <https://github.com/mavlink/mavros/issues/690>)
  * add frame transform for accel vibration levels
  * use vectorEigenToMsg
  * unscrustify
* Contributors: Nuno Marques, Vladimir Ermakov
```

## mavros_msgs

```
* msgs: Add cog script to finish ADSBVehicle.msg
* extras: Add ADSB plugin
* plugin #695 <https://github.com/mavlink/mavros/issues/695>: Fix plugin
* plugin: Add home_position
* Contributors: Nuno Marques, Vladimir Ermakov
```

## test_mavros

```
* cmake: remove Eigen warning
* Contributors: Vladimir Ermakov
```
