### PR TITLE
rtt_geometry: 2.9.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6790,7 +6790,10 @@ repositories:
       - eigen_typekit
       - kdl_typekit
       - rtt_geometry
+      tags:
+        release: release/kinetic/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_geometry-release.git
+      version: 2.9.0-0
     source:
       type: git
       url: https://github.com/orocos/rtt_geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_geometry` to `2.9.0-0`:

- upstream repository: https://github.com/orocos/rtt_geometry.git
- release repository: https://github.com/orocos-gbp/rtt_geometry-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## eigen_typekit

```
* Fixed extra semicolon warnings when compiling in pedantic mode
* Merge pull request #24 <https://github.com/orocos/rtt_geometry/issues/24> from meyerj/fix/eigen3-cmake into toolchain-2.9
* Use FindEigen3.cmake config shipped with Eigen starting from version 3.3
* Refactored eigen_typekit and kdl_typekit to allow compilation in catkin devel-space
* Merged pull request #17 <https://github.com/orocos/rtt_geometry/pull/17> from kuka-isir/eigen-corba-support into indigo-devel
  Corba / MQueue support
* Updated changelogs and bumped version number to 2.9.0
* Contributors: Antoine Hoarau, Johannes Meyer
```

## kdl_typekit

```
* Fixed extra semicolon warnings when compiling in pedantic mode
* Merge pull request #24 <https://github.com/orocos/rtt_geometry/issues/24> from meyerj/fix/eigen3-cmake into toolchain-2.9
* Use FindEigen3.cmake config shipped with Eigen starting from version 3.3
* kdl_typekit: fixed test compilation errors
* Refactored eigen_typekit and kdl_typekit to allow compilation in catkin devel-space
* kdl_typekit: add CArrayTypeInfo variants to the typekit to support fixed-size arrays
* Merged pull request #17 <https://github.com/orocos/rtt_geometry/pull/17> from kuka-isir/eigen-corba-support into indigo-devel
  Corba / MQueue support
* kdl_typekit: Add angle/axis constructor for Rotation
* Updated changelogs and bumped version number to 2.9.0
* Contributors: Antoine Hoarau, Johannes Meyer, Stephen Roderick
```

## rtt_geometry

```
* Updated changelogs and bumped version number to 2.9.0
* Contributors: Johannes Meyer
```
