### PR TITLE
rviz: 1.12.6-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2218,7 +2218,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.12.6-0
+      version: 1.12.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.12.6-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.12.6-0`

## rviz

```
* Added and updated displays to visualize covariance matrices (#1096 <https://github.com/ros-visualization/rviz/issues/1096>)
  * Added display for PoseWithCovariance.
  * Update OdometryDisplay to optionally show covariances.
* Fixed regression in previous release which was a type error that happened with newer versions of urdf (#1098 <https://github.com/ros-visualization/rviz/issues/1098>)
* Contributors: William Woodall
```
