### PR TITLE
rviz: 1.12.7-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2218,7 +2218,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.12.6-1
+      version: 1.12.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.12.7-0`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.12.6-1`

## rviz

```
* Fix render system regression (#1101 <https://github.com/ros-visualization/rviz/issues/1101>)
  * Also updated the render system code to follow latest recommendations for integrating Qt5 and Ogre3D, see: http://www.ogre3d.org/tikiwiki/tiki-index.php?page=Integrating+Ogre+into+QT5
  * Restored conditional code for Qt5 versus Qt4, which fixed #1100 <https://github.com/ros-visualization/rviz/issues/1100>
* Imported several updates to the covariance related displays (#1099 <https://github.com/ros-visualization/rviz/issues/1099>)
  * Added offset to covariance properties
  * Refactored CovarianceVisual
  * Fixed tolerance test at angular discontinuity
  * Renamed PoseWithCovarianceDisplay::Shape enums
* Contributors: Ellon Paiva Mendes, William Woodall
```
