### PR TITLE
rqt_ez_publisher: 0.4.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1758,6 +1758,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_dep.git
       version: master
     status: maintained
+  rqt_ez_publisher:
+    doc:
+      type: git
+      url: https://github.com/OTL/rqt_ez_publisher.git
+      version: lunar-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/OTL/rqt_ez_publisher-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/OTL/rqt_ez_publisher.git
+      version: lunar-devel
+    status: maintained
   rqt_graph:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_ez_publisher` to `0.4.0-0`:

- upstream repository: https://github.com/OTL/rqt_ez_publisher.git
- release repository: https://github.com/OTL/rqt_ez_publisher-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rqt_ez_publisher

```
* Update config dialog for Qt5
* Migrate to Qt5
* Merge pull request #23 <https://github.com/OTL/rqt_ez_publisher/issues/23> from felixduvallet/travis_fix
  Fix travis script
* Fix python import path by sourcing devel/setup.bash.
* Contributors: Felix Duvallet, Takashi Ogura
```
