### PR TITLE
rviz: 1.12.8-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2233,7 +2233,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.12.7-0
+      version: 1.12.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.12.8-0`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.12.7-0`

## rviz

```
* Fixed bug where generated material names were not unique (#1102 <https://github.com/ros-visualization/rviz/issues/1102>)
  * This was a regression of #1079 <https://github.com/ros-visualization/rviz/issues/1079>
* Contributors: Maarten de Vries
```
