### PR TITLE
jsk_apc: 3.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4981,10 +4981,12 @@ repositories:
       - jsk_apc
       - jsk_apc2015_common
       - jsk_apc2016_common
+      - jsk_arc2017_baxter
+      - jsk_arc2017_common
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_apc-release.git
-      version: 2.0.0-0
+      version: 3.0.0-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_apc` to `3.0.0-0`:

- upstream repository: https://github.com/start-jsk/jsk_apc.git
- release repository: https://github.com/tork-a/jsk_apc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.0.0-0`

## jsk_2015_05_baxter_apc

```
* Fix rosdep key for gdown: python-gdown-pip
* Add link to wiki
* use alist to avoid segmentation fault (#1997 <https://github.com/start-jsk/jsk_apc/issues/1997>)
* Contributors: Kentaro Wada, Shingo Kitagawa
```

## jsk_2016_01_baxter_apc

```
* fix syntax in euslint
* improve euslint to accept path
* fix too long line in baxter-interface
* modify min-pressure threshold
* rename movable-region_ and set it in slots
* add head-controller in rarm-controller
* rename jsk_2016_01_baxter_apc slots name
* modify object_segmentation_3d to accept args
* Fix rosdep key for gdown: python-gdown-pip
* Include astra_hand in astra_hand_rgv5
* Add main launch for baxterrgv5
* Add lisp main and examples for baxterrgv5
* Add baxter-interface of baxterrgv5
* Calibrate Astra for gripper-v5
* Add launch for baxterrgv5
* Add ros_control system for gripper-v5
* Add launch for gripper-v5 dynamixel controllers
* Add a dynamixel controller for gripper-v5
* Add hose_connector_manager firmware
* Add models of baxterrgv5 (baxter with right gripper-v5)
* Add gripper-v5 meshes
* merge baxter_sim.launch and include/baxter_sim.xml
* Use rqt_yn_btn instead of rviz plugin
  In order to avoid the blocking of topic update on rviz.
* Add link to wiki
* Merge pull request #2030 <https://github.com/start-jsk/jsk_apc/issues/2030> from pazeshun/fix-dup-def
  Fix duplicate definition of variables
* Enable test_move_arm_to_bin
* Fix duplicate definition of variables
* Skip bin_B for which ik is difficult to be solved
* Faster scale for data collection
* update CMakelists to simplify euslint test
* fix typo in baxter_pick_sim and baxter_stow_sim
* add baxter_sim launch
* disable collision between head and gripper
* disable collision between pedestal and gripper
* disable collision between display and screen
* remove unused rosinstall
* Fix tf rate of camera 10 -> 100
* Use - instead of _ to define variable further
* Use - instead of _ to define variable
* Use let instead of let* as much as possible
* euslint escape ; in quotation
* Visualize objects in bin on Euslisp
* add left_first args to setup_for_stow
* Merge pull request #1994 <https://github.com/start-jsk/jsk_apc/issues/1994> from pazeshun/add-rotate-wrist-ik
  Add :rotate-wrist-ik
* Add :rotate-wrist-ik
* Fix long and bad variable name
* Fix :ik->nearest-pose not to move arms unintendedly
* Merge pull request #1999 <https://github.com/start-jsk/jsk_apc/issues/1999> from knorth55/ik-check-improve
  fix ik-check to work proper with gripper-v2
* fix codes in ik-check
* use gripper and set rotation axis in ik-check
* use alist to avoid segmentation fault (#1997 <https://github.com/start-jsk/jsk_apc/issues/1997>)
* consider object bounding box to pick from tote
* Enable to set ik-prepared-poses
* Merge pull request #1985 <https://github.com/start-jsk/jsk_apc/issues/1985> from pazeshun/not-move-gripper
  Don't move gripper while carrying object in picking-with-sib
* Don't move gripper while carrying object in picking-with-sib
* Add no-gripper-controller
* Enable move-arm-body->order-bin to set controller type
* Enable send-av to set controller type
* Adjust picking-with-sib to current object segmentation
* Add method to get the work order of certain bin
* add gazebo material tag for gripper
* add inertia tag in both gripper.urdf.xacro
* fix trajectory_execution namespace
  see https://github.com/ros-planning/moveit/issues/61
* mv LICENSE and add kiva_pod stl model
* add ompl_planning and update param
  longest_valid_segment_fraction: 0.05 -> 0.01
  this solves moveit path simplification error.
* specify to use av-seq-raw in spin-off-by-wrist
* add moveit group "both_arms" as :arms
* refine pick-object-in-order-bin motion
* fix movable-region warning
  current: this warning always shows up
* remove wait-interpolation from :hold-opposite-hand-object
* add dy key in :view-opposite-hand-pose
* add distance :move-arm-body->bin-with-support-arm
* remove place-object-pose when picking from tote
* modify view-hand-pose because we don't use kinect2
* add data_collection launch
* add moveit-environment in baxter-interface
  default key :moveit nil
  if you want to enable moveit, you need to set key :moveit t.
  (jsk_2016_01_baxter_apc::baxter-init :moveit t)
* add baxter_moveit launch for moveit usage
* add jskbaxter2 moveit_config
* add gazebo tag in vacuum_gripper.xacro
* set nil not to initialize default moveit config
* add gripper_trajectory_server for simulator
* update xacro wiki url
* Fix position of arduino firmware
* Add urdf checking launch
* comment out vgg object verification node
* Fix for not working :interpolatingp on simulation
  - See :wait-interpolation on pr2eus/robot-interface.l also.
* add :move-arm-body->bin-with-support-arm in baxter-interface
* add :hold-opposite-hand-object in baxter-interface
* add :approaching-from-downside-pose in baxter-robot
* add :view-opposite-hand-pose in baxter-robot
* Fix typo in tmuxinator config
* add wait-interpolation-until-grasp method
* add option in euslint and remove indent check
* Add config for tmuxinator
* Add missing run_depend
* Adjust right hand mounted astra camera
* Fix KeyError for bin without target object
* Support no target in rqt_select_target
* modify debug-view nil not to show debug log
* comment out drawing irtviewer line
* Move images under jsk_apc2016_common to use it in launch correctly
* Remove check_baxter_pkg_version.sh that is not used
  You can just run in shell:
  ```
  rospack list | awk '{print $1}' | grep baxter | xargs -t -n1 rosversion
  ```
* Remove old README from jsk_2016_01_baxter_apc
  See https://github.com/start-jsk/jsk_apc#install
* Move srv to common package to fix dependency graph
  - dependency graph should be jsk_2016_01_baxter_apc -> jsk_apc2016_common
* Contributors: Kentaro Wada, Shingo Kitagawa, Shun Hasegawa, pazeshun
```

## jsk_apc

```
* add jsk_arc2017 package in jsk_apc
* Update package.xml
* Add link to wiki
* Contributors: Kentaro Wada, Shingo Kitagawa
```

## jsk_apc2015_common

```
* Add link to wiki
* use better pod_lowres.stl model
  original repos: https://github.com/mDibyo/apc
* Contributors: Kentaro Wada, Shingo Kitagawa
```

## jsk_apc2016_common

```
* add arg default for object_segmentation_3d launch
* modify object_segmentation_3d to accept args
* Add json for pick task by baxterrgv5
* Add main launch for baxterrgv5
* Add link to wiki
* Install sample data with a script
* add table plane removal node
* Use compressed images to get them in 30Hz
* Add apc recognition samples with Fetch
* Add script to list object names
* FCN32s-V2: Update fcn32s trained model
  - Trained with dataset v2 (JSK + MIT)
  - 148000 iterations
* Fix 404 of trained data vgg16_rotation_translation_brightness_372000...
* Fix for migrated srv of UpdateTarget
* Support no target in rqt_select_target
* Merge pull request #1910 <https://github.com/start-jsk/jsk_apc/issues/1910> from start-jsk/mv-srv-to-common
  Move srv to common package to fix dependency graph
* Place yaml file for object data in right place
* Move images under jsk_apc2016_common to use it in launch correctly
* Place node script in right place
* Move srv to common package to fix dependency graph
  - dependency graph should be jsk_2016_01_baxter_apc -> jsk_apc2016_common
* Contributors: Kentaro Wada, Naoya Yamaguchi, Shingo Kitagawa, Shun Hasegawa
```

## jsk_arc2017_baxter

```
* add TODO in util.l
* rename opposite-arm -> get-opposite-arm
* move get-bin-contents to arc-interface
* format apc -> arc for ARC2017
* remove unused package and sort alphabetically
* add find_package jsk_2016_01_baxter_apc in test
* refer related issue in TODO
* move some util func in apc-interface
* add TODO: make apc-inteface and pick-interface class properly
* make tf->pose-coords as a method of apc-interface
* rename arg launch_main -> main
* set myself as a author
* mv pick_work_order_server -> work_order_publisher
* replace publish_shelf_bin_bbox to existing node
* improve euslint to accept path
* remove unnecessary lines in CMakeLists
* update pytorch fcn model file
* place manager in ns
* fix and improve let variables
* use arm2str instead of arm-symbol2str
* improve picking motion
* when object is not recognized, wait opposite arm
* rename get-movable-region -> set-movable-region
* modify pick object motion
* angle-vector use :fast and :scale
* update overlook-pose to avoid aggresive motion
* rename baxter-interface -> apc-interface
* fix typo and improve euslisp codes
* fix typo in pick.launch for jsk_arc2017_baxter
* add pick.launch for arc2017
* add euslint in jsk_arc2017_baxter
* add euslisp codes for arc2017
* add myself as a maintainer
* update CMakelists.txt and package.xml for roseus
* move baxter.launch to setup
* add setup_for_pick.launch for arc2017
* add baxter.launch for arc2017
* move collect_data_in_bin in launch/main
* add run_depend in jsk_arc2017_baxter
* Add link to wiki
* Fix typo in collect_data_in_bin.launch
* Save tf and bin_name also
* Save tf also
* Save data with compression
* Update save dir
* Add data_collection program in bin
* Contributors: Kentaro Wada, Shingo Kitagawa
```

## jsk_arc2017_common

```
* Fix style of nodes in roslaunch files
* Add sample for work_order_publisher
* Fix name of sample_set_location_in_rosparam
* Fix for move of data/objects -> config/objects
* Don't use ROS in training script
* add sample launch for set_location_in_rosparam
* print stdout in set_location_in_rosparam
* fix typo in set_location_in_rosparam
* remove unused package and sort alphabetically
* use label_names.yaml instead of objects.txt
* set myself as a author
* update json generator script
* mv pick_work_order_server -> work_order_publisher
* replace publish_shelf_bin_bbox to existing node
* remove unnecessary lines in CMakeLists
* move json -> data/json
* switch cardboard place
  cardboard a: left upper
  cardboard b: left lower
  cardboard c: right
* add abandon items for work_order_server
* fix typo in package.xml in jsk_arc2017_common
* update shelf_bin position config
* set cardboard id as A,B,C in work_order
* add pick_work_order_server test
* fix typo in arc2017 json item_location_file.json
* add myself as a maintainer
* update CMakelists.txt and package.xml for roseus
* add set_location_in_rosparam node
* format bin_name as capital alphabet
* update pick_work_order_server for new json format
* update json generator and sample in correct format
* add example json and box size config
* add pick_work_order_server for arc2017
* introduce new WorkOrder&WorkOrderArray msg
* add sample_pick.json and json generate script
* add setup_for_pick.launch for arc2017
* add shelf_interactive_marker.yaml
* add publish_shelf_bin_bbox for new shelf
* Add python-serial to run_depends
* Fix typo
* Read weight data from AND scale
  - new file:   and_scale_rosserial.py
* Ignore AR20170331
* Update model file with stacking data augmentation
* Add data augmentation method with stacking
* Update api of torchfcn
* Improve imgaug
* Simplify config
* Update data with AR_20170331 dataset
* Add link to wiki
* Neat config & log handling
* Add ROS sample of FCNObjectSegmentation
* Add sample data of JSKV1 dataset
* Fix path of data
* Change path of JSKV1
* Add option to skip dataset with stamp
* Show datetime in annotation
* Improve view_jsk_v1
  - p for back
  - show timestamp
* Training experiments
* Update config
* Check label.npz existence
* Sort dirs for annotation
* Fix locking
* Show stamp_dir
* Lock for parallel annotation
* Augument image using imgaug
* Fix data field name
* 002_fcn32s_dataset_v1.yaml
* Fix for flake8
* Add requirements.txt
* Training script of FCN32s
* Add dataset class for JSKARC2017From16
* Add script to convert JSKAPC2016 to ARC2017
* Split dataset for train and valid
* Remove underscore for consistent names
* Add dataset.py
* Neat visualization of dataset
  - Show size of All and Annotated
  - Show label names
* Script to view dataset before/after annotated
* Update data using Training_items_20170320_fixed.zip
* Save data with compression
* Save label as npz file with compression
* Smaller size of object list
* Annotation script for JSK_V1 dataset
* Add script to list objects
* Visualize object list
* Parse AR_20170224 dataset
* Contributors: Kentaro Wada, Shingo Kitagawa
```
