### PR TITLE
gdown: 3.2.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3328,6 +3328,15 @@ repositories:
       url: https://github.com/JenniferBuehler/gazebo-pkgs.git
       version: master
     status: developed
+  gdown:
+    release:
+      packages:
+      - python_gdown
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wkentaro/python_gdown-release.git
+      version: 3.2.5-1
+    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gdown` to `3.2.5-1`:

- upstream repository: https://github.com/wkentaro/gdown.git
- release repository: https://github.com/wkentaro/python_gdown-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## python_gdown

```
* 3.2.5
* Update README.rst
* Update README.rst
* Update README
* Update README.rst
* Contributors: Kentaro Wada
```
