### PR TITLE
gdown: 3.2.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3328,6 +3328,13 @@ repositories:
       url: https://github.com/JenniferBuehler/gazebo-pkgs.git
       version: master
     status: developed
+  gdown:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wkentaro/gdown-release.git
+      version: 3.2.6-0
+    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gdown` to `3.2.6-0`:

- upstream repository: https://github.com/wkentaro/gdown.git
- release repository: https://github.com/wkentaro/gdown-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## gdown

```
* Add CMakeLists.txt and package.xml to release with bloom
* Contributors: Kentaro Wada
```
