### PR TITLE
ridgeback_simulator: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10106,7 +10106,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback_simulator-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_simulator` to `0.0.2-0`:

- upstream repository: https://github.com/ridgeback/ridgeback_simulator.git
- release repository: https://github.com/clearpath-gbp/ridgeback_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.1-0`

## mecanum_gazebo_plugin

```
* Disabled tests for mecanum_gazebo_plugin.
* Contributors: Tony Baltovski
```

## ridgeback_gazebo

```
* Changed Ridgeback config to environment variable and minor clean-up of ForceBasedPlugin.
* Updated default world to a wider and less constrained version.
* Contributors: Tony Baltovski
```

## ridgeback_gazebo_plugins

```
* Changed Ridgeback config to environment variable and minor clean-up of ForceBasedPlugin.
* Contributors: Tony Baltovski
```

## ridgeback_simulator

- No changes
