### PR TITLE
gdown: 3.2.6-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1328,6 +1328,13 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: jade-devel
     status: maintained
+  gdown:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wkentaro/gdown-release.git
+      version: 3.2.6-0
+    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gdown` to `3.2.6-0`:

- upstream repository: https://github.com/wkentaro/gdown.git
- release repository: https://github.com/wkentaro/gdown-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## gdown

```
* Add CMakeLists.txt and package.xml to release with bloom
* Contributors: Kentaro Wada
```
