### PR TITLE
rqt_multiplot_plugin: 0.0.7-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6389,7 +6389,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ethz-asl/rqt_multiplot_plugin-release.git
-      version: 0.0.6-0
+      version: 0.0.7-2
     source:
       type: git
       url: https://github.com/ethz-asl/rqt_multiplot_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_multiplot_plugin` to `0.0.7-2`:

- upstream repository: https://github.com/ethz-asl/rqt_multiplot_plugin.git
- release repository: https://github.com/ethz-asl/rqt_multiplot_plugin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.6-0`

## rqt_multiplot

```
* fix issues when plotting constant values
* fix plotting with receipt time
* Contributors: Samuel Bachmann
```
