### PR TITLE
gdown: 3.2.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1442,6 +1442,13 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: kinetic-devel
     status: maintained
+  gdown:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/wkentaro/gdown-release.git
+      version: 3.2.6-0
+    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gdown` to `3.2.6-0`:

- upstream repository: https://github.com/wkentaro/gdown.git
- release repository: https://github.com/wkentaro/gdown-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## gdown

```
* Add CMakeLists.txt and package.xml to release with bloom
* Contributors: Kentaro Wada
```
