### PR TITLE
gdown: 3.2.6-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -401,6 +401,13 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: lunar-devel
     status: developed
+  gdown:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/wkentaro/gdown-release.git
+      version: 3.2.6-0
+    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gdown` to `3.2.6-0`:

- upstream repository: https://github.com/wkentaro/gdown.git
- release repository: https://github.com/wkentaro/gdown-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## gdown

```
* Add CMakeLists.txt and package.xml to release with bloom
* Contributors: Kentaro Wada
```
