### PR TITLE
Revert "gdown: 3.2.6-0 in 'lunar/distribution.yaml' [bloom]"

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -401,13 +401,6 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: lunar-devel
     status: developed
-  gdown:
-    release:
-      tags:
-        release: release/lunar/{package}/{version}
-      url: https://github.com/wkentaro/gdown-release.git
-      version: 3.2.6-0
-    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#14935

Sorry, I found https://github.com/ros-infrastructure/ros_release_python and think it must be used for releasing python-gdown.