### PR TITLE
Revert "gdown: 3.2.6-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1442,13 +1442,6 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: kinetic-devel
     status: maintained
-  gdown:
-    release:
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/wkentaro/gdown-release.git
-      version: 3.2.6-0
-    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#14932

Sorry, I found https://github.com/ros-infrastructure/ros_release_python and think it must be used for releasing python-gdown.