### PR TITLE
Revert "gdown: 3.2.6-1 in 'jade/distribution.yaml' [bloom]"

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1328,13 +1328,6 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: jade-devel
     status: maintained
-  gdown:
-    release:
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/wkentaro/gdown-release.git
-      version: 3.2.6-1
-    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#14930

Sorry, I found https://github.com/ros-infrastructure/ros_release_python and think it must be used for releasing python-gdown.