### PR TITLE
metapackages: 1.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3191,7 +3191,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/metapackages-release.git
-      version: 1.3.0-0
+      version: 1.3.1-0
     source:
       type: git
       url: https://github.com/ros/metapackages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metapackages` to `1.3.1-0`:

- upstream repository: https://github.com/ros/metapackages.git
- release repository: https://github.com/ros-gbp/metapackages-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.3.0-0`
