### PR TITLE
metapackages: 1.2.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2952,7 +2952,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/metapackages-release.git
-      version: 1.2.0-0
+      version: 1.2.1-0
     source:
       type: git
       url: https://github.com/ros/metapackages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metapackages` to `1.2.1-0`:

- upstream repository: https://github.com/ros/metapackages.git
- release repository: https://github.com/ros-gbp/metapackages-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.2.0-0`
