### PR TITLE
gps_umd: 0.1.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3560,6 +3560,10 @@ repositories:
       version: 2.1.0-1
     status: maintained
   gps_umd:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: master
     release:
       packages:
       - gps_common
@@ -3567,8 +3571,13 @@ repositories:
       - gpsd_client
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ktossell/gps_umd-release.git
-      version: 0.1.7-0
+      url: https://github.com/swri-robotics-gbp/gps_umd-release.git
+      version: 0.1.9-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: master
+    status: maintained
   graft:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `0.1.9-0`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/swri-robotics-gbp/gps_umd-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.7-0`

## gps_common

```
* removed unused variables
* Contributors: Frank Hoeller
```

## gps_umd

- No changes

## gpsd_client

- No changes
