### PR TITLE
marti_messages: 0.0.9-0 in 'kinetic/distribution.yaml'

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3033,7 +3033,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/marti_messages.git
-      version: indigo-devel
+      version: master
     release:
       packages:
       - marti_can_msgs
@@ -3045,11 +3045,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_messages-release.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_messages.git
-      version: indigo-devel
+      version: master
     status: developed
   marvelmind_nav:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `0.0.9-0`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.8-0`

## marti_can_msgs

- No changes

## marti_common_msgs

- No changes

## marti_nav_msgs

```
* Add Wgs84Sample message type. (#82 <https://github.com/swri-robotics/marti_messages/issues/82>)
  Wgs84Sample is a new message type that contains a sensor measurement in WGS-84 (e.g. GPS sample)
  and the corresponding sensor location in relative coordinates (e.g. antenna position).
* Contributors: Elliot Johnson
```

## marti_perception_msgs

- No changes

## marti_sensor_msgs

- No changes

## marti_visualization_msgs

- No changes