### PR TITLE
marti_messages: 0.0.9-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -814,6 +814,28 @@ repositories:
       url: https://github.com/orocos-toolchain/log4cpp.git
       version: toolchain-2.9
     status: maintained
+  marti_messages:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: master
+    release:
+      packages:
+      - marti_can_msgs
+      - marti_common_msgs
+      - marti_nav_msgs
+      - marti_perception_msgs
+      - marti_sensor_msgs
+      - marti_visualization_msgs
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_messages-release.git
+      version: 0.0.9-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: master
+    status: developed
   media_export:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `0.0.9-0`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## marti_can_msgs

- No changes

## marti_common_msgs

- No changes

## marti_nav_msgs

```
* Add Wgs84Sample message type. (#82 <https://github.com/swri-robotics/marti_messages/issues/82>)
  Wgs84Sample is a new message type that contains a sensor measurement in WGS-84 (e.g. GPS sample)
  and the corresponding sensor location in relative coordinates (e.g. antenna position).
* Contributors: Elliot Johnson
```

## marti_perception_msgs

- No changes

## marti_sensor_msgs

- No changes

## marti_visualization_msgs

- No changes
