### PR TITLE
roomblock: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5535,6 +5535,27 @@ repositories:
       url: https://github.com/ros-aldebaran/romeo_virtual.git
       version: master
     status: developed
+  roomblock:
+    doc:
+      type: git
+      url: https://github.com/tork-a/roomblock.git
+      version: master
+    release:
+      packages:
+      - roomblock
+      - roomblock_bringup
+      - roomblock_description
+      - roomblock_mapping
+      - roomblock_navigation
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/roomblock-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/tork-a/roomblock.git
+      version: master
+    status: developed
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roomblock` to `0.0.2-0`:

- upstream repository: https://github.com/tork-a/roomblock.git
- release repository: https://github.com/tork-a/roomblock-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## roomblock

```
* add metapackage
* Contributors: Tokyo Opensource Robotics Developer 534
```
