### PR TITLE
jsk_3rdparty: 2.0.20-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2206,7 +2206,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.0.19-0
+      version: 2.0.20-0
     status: developed
   jsk_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.0.20-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.0.19-0`

## assimp_devel

- No changes

## bayesian_belief_networks

- No changes

## collada_urdf_jsk_patch

```
* use indigo-devel before changing hydro-devel package structure
* Contributors: Kei Okada
```

## downward

- No changes

## ff

- No changes

## ffha

- No changes

## jsk_3rdparty

- No changes

## julius

- No changes

## libcmt

- No changes

## libsiftfast

- No changes

## lpg_planner

- No changes

## mini_maxwell

- No changes

## nlopt

- No changes

## opt_camera

```
* Revert "[opt_camera][OptNM33Camera.cfg] param "4view" does not follow ROS convention"
* [opt_camera][OptNM33Camera.cfg] param "4view" does not follow ROS convention
* Contributors: Kei Okada, Yuki Furuta
```

## pgm_learner

- No changes

## rospatlite

- No changes

## rosping

- No changes

## rostwitter

- No changes

## slic

- No changes

## voice_text

- No changes
