### PR TITLE
oros_tools_examples: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4337,7 +4337,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/easymov/oros_tools_examples-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     status: developed
   osrf_gear:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `oros_tools_examples` to `0.1.3-0`:

- upstream repository: https://gitlab.com/easymov/oros_tools_examples.git
- release repository: https://github.com/easymov/oros_tools_examples-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.2-0`

## oros_tools_examples

```
* switch to stage simulator & add dependencies
* Contributors: Gérald Lelong
```
