### PR TITLE
rosjava_bootstrap: 0.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5956,7 +5956,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_bootstrap-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/rosjava/rosjava_bootstrap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_bootstrap` to `0.3.2-0`:

- upstream repository: https://github.com/rosjava/rosjava_bootstrap
- release repository: https://github.com/rosjava-release/rosjava_bootstrap-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.3.1-0`

## rosjava_bootstrap

```
* Bumping message_generation version to kinetic range in CatkinPlugin script for generating new message artifacts properly.
* Contributors: Juan Ignacio Ubeira, Julian Cerruti
```
