### PR TITLE
rtmros_hironx: 1.1.24-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12533,7 +12533,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.23-0
+      version: 1.1.24-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.24-0`:

- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.1.23-0`

## hironx_calibration

- No changes

## hironx_moveit_config

- No changes

## hironx_ros_bridge

```
* [py] Better error msg, better doc about impedance control. #496 <https://github.com/start-jsk/rtmros_hironx/pull/496>, #499 <https://github.com/start-jsk/rtmros_hironx/pull/499>
* Contributors: Isaac I.Y. Saito
```

## rtmros_hironx

```
* [py] Better error msg, better doc about impedance control. #496 <https://github.com/start-jsk/rtmros_hironx/pull/496>, #499 <https://github.com/start-jsk/rtmros_hironx/pull/499>
* Contributors: Isaac I.Y. Saito
```
