### PR TITLE
OMPL: 1.3.0-1 in 'lunar/distribution.yaml' [non-bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1060,6 +1060,17 @@ repositories:
       url: https://github.com/OctoMap/octomap_msgs.git
       version: lunar-devel
     status: maintained
+  ompl:
+    doc:
+      type: hg
+      url: https://bitbucket.org/ompl/ompl.git
+      version: default
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/ompl-release.git
+      version: 1.3.0-1
+    status: maintained
   opencv3:
     release:
       tags:


### PR DESCRIPTION
Artifact at the release repo is ready ([discussion at bitbucket.org/ompl/#318](https://bitbucket.org/ompl/ompl/issues/318/release-into-ros-lunar)).