### PR TITLE
Added Python-argh to available packages

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3198,8 +3198,6 @@ xdot:
   fedora: [python-xdot]
   ubuntu: [xdot]
 python-argh:
-  ubuntu:
-    trusty:[python-argh]
-    xenial:[python-argh]
-    yakkety:[python-argh]
-    zesty:[python-argh]
+  debian: [python-argh]
+  fedora: [python-argh]
+  ubuntu:[python-argh]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3197,3 +3197,9 @@ xdot:
   debian: [xdot]
   fedora: [python-xdot]
   ubuntu: [xdot]
+python-argh:
+  ubuntu:
+    trusty:[python-argh]
+    xenial:[python-argh]
+    yakkety:[python-argh]
+    zesty:[python-argh]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -148,6 +148,10 @@ python-apparmor:
 python-argcomplete:
   fedora: [python-argcomplete]
   ubuntu: [python-argcomplete]
+python-argh:
+  debian: [python-argh]
+  fedora: [python-argh]
+  ubuntu: [python-argh]
 python-argparse:
   arch: [python2]
   debian:
@@ -3197,7 +3201,3 @@ xdot:
   debian: [xdot]
   fedora: [python-xdot]
   ubuntu: [xdot]
-python-argh:
-  debian: [python-argh]
-  fedora: [python-argh]
-  ubuntu: [python-argh]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3200,4 +3200,4 @@ xdot:
 python-argh:
   debian: [python-argh]
   fedora: [python-argh]
-  ubuntu:[python-argh]
+  ubuntu: [python-argh]


### PR DESCRIPTION
This package is needed for the further release of python-watchdog R.O.S. package