### PR TITLE
Added PyYAML to available packages

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3197,3 +3197,7 @@ xdot:
   debian: [xdot]
   fedora: [python-xdot]
   ubuntu: [xdot]
+py-yaml-pip:
+  ubuntu:
+    pip:
+      packages: [PyYAML]


### PR DESCRIPTION
This package is needed for the further release of [python-watchdog](https://github.com/gorakhargosh/watchdog) package 
