### PR TITLE
move_basic: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3287,7 +3287,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/UbiquityRobotics/move_basic.git
-      version: kinetic-devek
+      version: kinetic-devel
     status: developed
   moveit:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3273,6 +3273,22 @@ repositories:
       url: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip.git
       version: kinetic
     status: maintained
+  move_basic:
+    doc:
+      type: git
+      url: https://github.com/UbiquityRobotics/move_basic.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/UbiquityRobotics-release/move_basic-release.git
+      version: 0.1.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/UbiquityRobotics/move_basic.git
+      version: kinetic-devek
+    status: developed
   moveit:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_basic` to `0.1.0-0`:

- upstream repository: https://github.com/UbiquityRobotics/move_basic.git
- release repository: https://github.com/UbiquityRobotics-release/move_basic-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## move_basic

```
* Initial Release of a package for very basic navigation. The path planning consists of rotating in place to face the goal and then driving straight toward it. It is designed to provide the same interfaces as move_base.
* Contributors: Jim Vaughan, Rohan Agrawal
```
