### PR TITLE
moveit: 0.9.6-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -920,6 +920,45 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: kinetic-devel
     status: maintained
+  moveit:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit.git
+      version: kinetic-devel
+    release:
+      packages:
+      - moveit
+      - moveit_commander
+      - moveit_controller_manager_example
+      - moveit_core
+      - moveit_fake_controller_manager
+      - moveit_kinematics
+      - moveit_planners
+      - moveit_planners_ompl
+      - moveit_plugins
+      - moveit_ros
+      - moveit_ros_benchmarks
+      - moveit_ros_control_interface
+      - moveit_ros_manipulation
+      - moveit_ros_move_group
+      - moveit_ros_perception
+      - moveit_ros_planning
+      - moveit_ros_planning_interface
+      - moveit_ros_robot_interaction
+      - moveit_ros_visualization
+      - moveit_ros_warehouse
+      - moveit_runtime
+      - moveit_setup_assistant
+      - moveit_simple_controller_manager
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/moveit-release.git
+      version: 0.9.6-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit.git
+      version: kinetic-devel
+    status: developed
   moveit_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.9.6-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## moveit

```
* [fix] warehouse services (#474 <https://github.com/ros-planning/moveit/issues/474>)
* [fix][moveit_ros_visualization] RViz plugin some cosmetics and minor refactoring #482 <https://github.com/ros-planning/moveit/issues/482>
* [fix][moveit_ros_visualization] rviz panel: Don't add object marker if the wrong tab is selected #454 <https://github.com/ros-planning/moveit/pull/454>
* [fix][moveit_ros_robot_interaction] catkin_make -DCMAKE_ENABLE_TESTING=0 failure (#478 <https://github.com/ros-planning/moveit/issues/478>)
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* [fix][moveit_ros_manipulation] Set planning frame correctly in evaluation of reachable and valid pose filter (#476 <https://github.com/ros-planning/moveit/issues/476>)
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* [fix] undefined symbol in planning_scene_monitor (#463 <https://github.com/ros-planning/moveit/issues/463>)
* [fix][moveit_planners_ompl] Always update initial robot state to prevent dirty robot state error. #448 <https://github.com/ros-planning/moveit/pull/448>
* [fix][moveit_core] PlanarJointModel::getVariableRandomPositionsNearBy (#464 <https://github.com/ros-planning/moveit/issues/464>)
* [improve][moveit_ros_visualization] RobotState display [kinetic] (#465 <https://github.com/ros-planning/moveit/issues/465>)
* [improve][moveit_ros_planning_interface] MoveGroupInterface: add public interface to construct the MotionPlanRequest (#461 <https://github.com/ros-planning/moveit/issues/461>)
* [improve][moveit_ros_benchmarks] Add install rule for examples, statistics script
* [improve] Add warning if no IK solvers found (#485 <https://github.com/ros-planning/moveit/issues/485>)
* Contributors: Ruben Burger, Dave Coleman, Yannick Jonetzko, Henning Kayser, Beatriz Leon, Bence Magyar, Jorge Nicho, Tamaki Nishino, Michael Goerner, Dmitry Rozhkov, Isaac I.Y. Saito
```

## moveit_commander

- No changes

## moveit_controller_manager_example

- No changes

## moveit_core

```
* [fix] PlanarJointModel::getVariableRandomPositionsNearBy (#464 <https://github.com/ros-planning/moveit/issues/464>)
* Contributors: Tamaki Nishino
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_ompl

```
* Always update initial robot state to prevent dirty robot state error.
* Contributors: Henning Kayser
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* [improve] Add install rule for examples, statistics script
* Contributors: Bence Magyar
```

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

```
* [fix] Set planning frame correctly in evaluation of reachable and valid pose filter (#476 <https://github.com/ros-planning/moveit/issues/476>)
* Contributors: Yannick Jonetzko
```

## moveit_ros_move_group

- No changes

## moveit_ros_perception

```
* [fix][moveit_ros_robot_interaction] catkin_make -DCMAKE_ENABLE_TESTING=0 failure (#478 <https://github.com/ros-planning/moveit/issues/478>)
* Contributors: Michael Goerner
```

## moveit_ros_planning

```
* [fix] gcc6 build error (#471 <https://github.com/ros-planning/moveit/issues/471>, #458 <https://github.com/ros-planning/moveit/issues/458>)
* [fix] undefined symbol in planning_scene_monitor (#463 <https://github.com/ros-planning/moveit/issues/463>)
* Contributors: Dmitry Rozhkov, Ruben Burger
```

## moveit_ros_planning_interface

```
* [improve] MoveGroupInterface: add public interface to construct the MotionPlanRequest (#461 <https://github.com/ros-planning/moveit/issues/461>)
* Contributors: Michael Goerner
```

## moveit_ros_robot_interaction

```
* [fix] catkin_make -DCMAKE_ENABLE_TESTING=0 failure (#478 <https://github.com/ros-planning/moveit/issues/478>)
* Contributors: Michael Goerner
```

## moveit_ros_visualization

```
* [fix] RViz plugin some cosmetics and minor refactoring #482 <https://github.com/ros-planning/moveit/issues/482>
* [fix] rviz panel: Don't add object marker if the wrong tab is selected #454 <https://github.com/ros-planning/moveit/pull/454>
* [improve] RobotState display [kinetic] (#465 <https://github.com/ros-planning/moveit/issues/465>)
* Contributors: Jorge Nicho, Michael Goerner, Yannick Jonetzko
```

## moveit_ros_warehouse

```
* [fix] warehouse services (#474 <https://github.com/ros-planning/moveit/issues/474>)
* Contributors: Beatriz Leon
```

## moveit_runtime

- No changes

## moveit_setup_assistant

```
* [improve] Add warning if no IK solvers found (#485 <https://github.com/ros-planning/moveit/issues/485>)
* Contributors: Dave Coleman
```

## moveit_simple_controller_manager

- No changes
