### PR TITLE
update fcl for Y,Z and Stretch

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1463,9 +1463,15 @@ libexpat1-dev:
   ubuntu: [libexpat1-dev]
 libfcl-dev:
   arch: [fcl]
-  debian: [libfcl-0.5-dev]
+  debian:
+    jessie: [libfcl-0.5-dev]
+    stretch: [libfcl-dev]
   fedora: [fcl-devel]
-  ubuntu: [libfcl-0.5-dev]
+  ubuntu:
+    wily: [libfcl-0.5-dev]
+    xenial: [libfcl-0.5-dev]
+    yakkety: [libfcl-dev]
+    zesty: [libfcl-dev]
 libffi-dev:
   debian: [libffi-dev]
   fedora: [libffi-devel]


### PR DESCRIPTION
`libfcl-0.5-dev` is hosted on repositories.ros.org for  Wily, Xenial and Jessie
We use upstream for:
Yakkety: http://packages.ubuntu.com/yakkety/libfcl-dev
Zesty: http://packages.ubuntu.com/zesty/libfcl-dev
Stretch: https://packages.debian.org/stretch/libfcl-dev

@130s FYI 