### PR TITLE
catkin_pip: 0.2.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -451,7 +451,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/catkin_pip-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pip.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pip` to `0.2.1-0`:

- upstream repository: https://github.com/asmodehn/catkin_pip.git
- release repository: https://github.com/asmodehn/catkin_pip-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.0-0`

## catkin_pip

```
* Merge pull request #115 <https://github.com/asmodehn/catkin_pip/issues/115> from asmodehn/distutils
  Implementing distutils support
* refining tests on install flow, to confirm which test framework is used.
  upgrading catkin package format to advised format 2.
* fixes to support distutils as well as setuptools.
* adding setuptools_setup test project and tests to validate package structure after installation.
* adding test to make sure "make install" does not trigger errors.
* adding a basic package to test distutils based setup.py
* Contributors: AlexV, yotabits
```
