### PR TITLE
octomap_ros: 0.4.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -979,6 +979,21 @@ repositories:
       url: https://github.com/OctoMap/octomap_msgs.git
       version: lunar-devel
     status: maintained
+  octomap_ros:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_ros.git
+      version: lunar-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_ros-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_ros.git
+      version: lunar-devel
+    status: maintained
   opencv3:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_ros` to `0.4.0-0`:

- upstream repository: https://github.com/OctoMap/octomap_ros.git
- release repository: https://github.com/ros-gbp/octomap_ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## octomap_ros

```
* Dropped PCL support in favor of sensor_msgs::PointCloud2.
```
