### PR TITLE
ubiquity_motor: 0.5.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7922,7 +7922,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
-      version: 0.5.1-1
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/ubiquity_motor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ubiquity_motor` to `0.5.2-0`:

- upstream repository: https://github.com/UbiquityRobotics/ubiquity_motor.git
- release repository: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.5.1-1`

## ubiquity_motor

```
* Remove debug topics (#25 <https://github.com/UbiquityRobotics/ubiquity_motor/issues/25>)
  * Remove debug topics
  * Remove tests of debug registers
* Merge pull request #22 <https://github.com/UbiquityRobotics/ubiquity_motor/issues/22> from UbiquityRobotics/suppresserrorsatstartup
  Supress some potentially confusing warnings
* Increase error_threshold
* Merge pull request #23 <https://github.com/UbiquityRobotics/ubiquity_motor/issues/23> from UbiquityRobotics/fix_acceleration_limits
  Fix computaion of elapsed time so that it is +ve
* Fix computaion of elapsed time so that it is +ve
* Supress some potentially confusing warnings
* Clean out serial loop (#20 <https://github.com/UbiquityRobotics/ubiquity_motor/issues/20>)
  * Transmit the the same thread caller, not in serial thread
  * go back to debug on tranmissions
  * Use smarter waits and reads in reading thread
  * Get rid of serial loop rate
  * Reformat
* Contributors: Jim Vaughan, Rohan Agrawal
```
