### PR TITLE
Adding lidar_camera_calibration to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2793,6 +2793,20 @@ repositories:
       type: git
       url: https://github.com/SICKAG/libsick_ldmrs.git
       version: master
+  lidar_camera_calibration:
+    doc:
+      type: git
+      url: https://github.com/ankitdhall/lidar_camera_calibration.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ankitdhall/lidar_camera_calibration.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/ankitdhall/lidar_camera_calibration.git
+      version: master
   linux_peripheral_interfaces:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2798,11 +2798,6 @@ repositories:
       type: git
       url: https://github.com/ankitdhall/lidar_camera_calibration.git
       version: master
-    release:
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/ankitdhall/lidar_camera_calibration.git
-      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/ankitdhall/lidar_camera_calibration.git


### PR DESCRIPTION
I would like to have my ROS package lidar_camera_calibration indexed and documented on ros.org.