### PR TITLE
libuvc: 0.0.5-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2597,6 +2597,17 @@ repositories:
       type: git
       url: https://github.com/SICKAG/libsick_ldmrs.git
       version: master
+  libuvc:
+    doc:
+      type: git
+      url: https://github.com/ktossell/libuvc.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/ktossell/libuvc-release.git
+      version: 0.0.5-1
+    status: unmaintained
   lms1xx:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc` to `0.0.5-1`:

- upstream repository: https://github.com/ktossell/libuvc.git
- release repository: https://github.com/ktossell/libuvc-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
