### PR TITLE
libuvc: 0.0.5-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2793,6 +2793,17 @@ repositories:
       type: git
       url: https://github.com/SICKAG/libsick_ldmrs.git
       version: master
+  libuvc:
+    doc:
+      type: git
+      url: https://github.com/ktossell/libuvc.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ktossell/libuvc-release.git
+      version: 0.0.5-2
+    status: unmaintained
   lidar_camera_calibration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc` to `0.0.5-2`:

- upstream repository: https://github.com/ktossell/libuvc.git
- release repository: https://github.com/ktossell/libuvc-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
