### PR TITLE
add asio library as header-only alternative to boost::asio

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -85,6 +85,11 @@ armadillo:
     portage:
       packages: [sci-libs/armadillo]
   ubuntu: [libarmadillo-dev]
+asio:
+  arch: [asio]
+  debian: [libasio-dev]
+  fedora: [asio-devel]
+  ubuntu: [libasio-dev]
 assimp:
   arch: [assimp]
   debian:


### PR DESCRIPTION
asio library for ubuntu, debian, fedora, arch