### PR TITLE
kobuki_desktop: 0.5.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2535,7 +2535,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki_desktop-release.git
-      version: 0.5.6-0
+      version: 0.5.7-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_desktop` to `0.5.7-0`:

- upstream repository: https://github.com/yujinrobot/kobuki_desktop.git
- release repository: https://github.com/yujinrobot-release/kobuki_desktop-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.5.6-0`

## kobuki_qtestsuite

```
* bugfix for pyqt4->pyqt5 pyrrc tools rosdep
```
