### PR TITLE
Add Voluptuous, a python data validation library

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3056,6 +3056,15 @@ python-vcstool:
 python-visual:
   fedora: [python-visual]
   ubuntu: [python-visual]
+python-voluptuous-pip:
+  debian:
+    pip: [voluptuous]
+  fedora:
+    pip: [voluptuous]
+  osx:
+    pip: [voluptuous]
+  ubuntu:
+    pip: [voluptuous]
 python-vtk:
   arch: [vtk]
   debian: [python-vtk]


### PR DESCRIPTION
This adds [Voluptuous](https://pypi.python.org/pypi/voluptuous) pip package. Voluptuous is a Python data validation library for deeply validating JSON and YAML structures according to strict schemas.