### PR TITLE
move_basic: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3307,7 +3307,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/move_basic-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_basic` to `0.1.1-0`:

- upstream repository: https://github.com/UbiquityRobotics/move_basic.git
- release repository: https://github.com/UbiquityRobotics-release/move_basic-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.0-0`

## move_basic

```
* Add URL to wiki page to README.md (#15 <https://github.com/UbiquityRobotics/move_basic/issues/15>)
* added all deps in the package xml (#14 <https://github.com/UbiquityRobotics/move_basic/issues/14>)
* Contributors: Jim Vaughan, Rohan Agrawal
```
