### PR TITLE
jsk_apc: 3.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5000,7 +5000,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_apc-release.git
-      version: 3.0.0-0
+      version: 3.0.1-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_apc` to `3.0.1-0`:

- upstream repository: https://github.com/start-jsk/jsk_apc.git
- release repository: https://github.com/tork-a/jsk_apc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `3.0.0-0`

## jsk_2015_05_baxter_apc

```
* [jsk_2015_05_baxter_apc] remove gazebo_ros_vacuum_gripper plugin because it is already merged to upstream gazebo_plugins package.
* Contributors: Masaki Murooka
```

## jsk_2016_01_baxter_apc

```
* Find automatically astra device_id
* mv euslint to jsk_apc2016_common package
* Contributors: Kentaro Wada, Shingo Kitagawa
```

## jsk_apc

- No changes

## jsk_apc2015_common

- No changes

## jsk_apc2016_common

```
* Merge pull request #2077 <https://github.com/start-jsk/jsk_apc/issues/2077> from knorth55/move-euslint-to-common
  Check euslisp format for jsk_apc2016_common
* fix format for euslint check
* euslint check for samples euslisp file
* mv euslint to jsk_apc2016_common package
* Contributors: Kei Okada, Shingo Kitagawa
```

## jsk_arc2017_baxter

```
* Move astra_hand.launch from setup_for_pick.launch to baxter.launch
* fix typo in CMakeLists
* Fix for moved euslint to jsk_apc2016_common
* Depends at test time on jsk_2016_01_baxter_apc
* add wait condition for wait_for_user_input
* got to wait_for_opposite_arm first
* update waiting condition
* fix typo in arc-interface
* mv euslint to jsk_apc2016_common package
* Contributors: Kentaro Wada, Shingo Kitagawa, YutoUchimi
```

## jsk_arc2017_common

```
* Fix missing dependency on jsk_data
* fix typo in WorkOrderPublisher
* sort cardboard by box size and give ABC name
* Contributors: Kentaro Wada, Shingo Kitagawa
```
