### PR TITLE
Adding wire repo to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8491,6 +8491,11 @@ repositories:
       url: https://github.com/asmodehn/webtest-rosrelease.git
       version: 2.0.18-1
     status: maintained
+  wire:
+    doc:
+      type: git
+      url: https://github.com/tue-robotics/wire.git
+      version: master
   wireless:
     doc:
       type: git


### PR DESCRIPTION
I like wire to be indexed and documented on ros.org!