### PR TITLE
Use gazebo7 instead of gazebo8 in Lunar

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -779,20 +779,13 @@ gazebo:
     trusty: [gazebo2]
     wily: [gazebo7]
     xenial: [gazebo7]
-    yakkety: [gazebo8]
-    zesty: [gazebo8]
+    yakkety: [gazebo7]
+    zesty: [gazebo7]
 gazebo5:
   arch: [gazebo]
   fedora: [gazebo]
   gentoo: [sci-electronics/gazebo]
   ubuntu: [gazebo5]
-gazebo8:
-  arch: [gazebo]
-  debian: [gazebo8]
-  fedora: [gazebo-devel]
-  gentoo: [sci-electronics/gazebo]
-  slackware: [gazebo]
-  ubuntu: [gazebo8]
 gcc-arm-none-eabi:
   arch: [gcc-arm-none-eabi]
   debian: [gcc-arm-none-eabi]
@@ -1600,14 +1593,6 @@ libgazebo7-dev:
   opensuse: [gazebo-devel]
   slackware: [gazebo]
   ubuntu: [libgazebo7-dev]
-libgazebo8-dev:
-  arch: [gazebo]
-  debian: [libgazebo8-dev]
-  fedora: [gazebo-devel]
-  gentoo: [sci-electronics/gazebo]
-  opensuse: [gazebo-devel]
-  slackware: [gazebo]
-  ubuntu: [libgazebo8-dev]
 libgconf2:
   arch: [gconf]
   debian: [libgconf-2-4]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -115,10 +115,6 @@ gazebo7:
   osx:
     homebrew:
       packages: [gazebo7]
-gazebo8:
-  osx:
-    homebrew:
-      packages: [gazebo8]
 gccxml:
   osx:
     homebrew:
@@ -215,10 +211,6 @@ libgazebo7-dev:
   osx:
     homebrew:
       depends: [gazebo7]
-libgazebo8-dev:
-  osx:
-    homebrew:
-      depends: [gazebo8]
 libglew-dev:
   osx:
     homebrew:


### PR DESCRIPTION
Revert pull request #14564 and use gazebo7 for ROS Lunar. Details: https://discourse.ros.org/t/lunar-to-target-gazebo-7/1840/1