### PR TITLE
Move kdl_parser and kdl_parser_py to a new repo (indigo)

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5274,6 +5274,25 @@ repositories:
       url: https://github.com/uos/katana_driver.git
       version: indigo_catkin
     status: developed
+  kdl_parser:
+    doc:
+      type: git
+      url: https://github.com/ros/kdl_parser.git
+      version: indigo-devel
+    release:
+      packages:
+      - kdl_parser
+      - kdl_parser_py
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/kdl_parser-release.git
+      version: 1.11.14-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/kdl_parser.git
+      version: indigo-devel
+    status: maintained
   keyboard:
     release:
       tags:
@@ -10279,8 +10298,6 @@ repositories:
     release:
       packages:
       - joint_state_publisher
-      - kdl_parser
-      - kdl_parser_py
       - robot_model
       - urdf
       - urdf_parser_plugin


### PR DESCRIPTION
This moves kdl_parser and kdl_parser_py from the repo ros/robot_model to ros/kdl_parser. Bloom-release was used up to the point of making the rosdistro PR. 

part of ros/robot_model#195 
