### PR TITLE
jsk_common_msgs: 4.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2314,6 +2314,10 @@ repositories:
       version: 2.2.2-0
     status: developed
   jsk_common_msgs:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
+      version: master
     release:
       packages:
       - jsk_common_msgs
@@ -2325,7 +2329,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_common_msgs-release.git
-      version: 4.1.0-0
+      version: 4.1.1-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
+      version: master
     status: developed
   jsk_control:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common_msgs` to `4.1.1-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common_msgs
- release repository: https://github.com/tork-a/jsk_common_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `4.1.0-0`

## jsk_common_msgs

- No changes

## jsk_footstep_msgs

- No changes

## jsk_gui_msgs

- No changes

## jsk_hark_msgs

- No changes

## posedetection_msgs

- No changes

## speech_recognition_msgs

```
* [speech_recognition_msgs] add Vocabulary.msg / SpeechRecognition.srv
* Contributors: Yuki Furuta
```
