### PR TITLE
jsk_apc: 3.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5000,7 +5000,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_apc-release.git
-      version: 3.0.1-0
+      version: 3.0.2-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_apc` to `3.0.2-0`:

- upstream repository: https://github.com/start-jsk/jsk_apc.git
- release repository: https://github.com/tork-a/jsk_apc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `3.0.1-0`

## jsk_2015_05_baxter_apc

```
* Put in order tags in CHANGELOG.rst
* Contributors: Kentaro Wada
```

## jsk_2016_01_baxter_apc

```
* Put in order tags in CHANGELOG.rst
* Fix torque limit of prismatic joint in gripper (#2094 <https://github.com/start-jsk/jsk_apc/issues/2094>)
* Move astra_hand_rgv5.launch into baxterrgv5.launch
* Contributors: Kentaro Wada, Shun Hasegawa
```

## jsk_apc

```
* Put in order tags in CHANGELOG.rst
* Contributors: Kentaro Wada
```

## jsk_apc2015_common

```
* Put in order tags in CHANGELOG.rst
* Contributors: Kentaro Wada
```

## jsk_apc2016_common

```
* Put in order tags in CHANGELOG.rst
* Contributors: Kentaro Wada
```

## jsk_arc2017_baxter

- No changes

## jsk_arc2017_common

```
* Fix missing build depend on jsk_data
  - because install_data.py is run in Cmake
* Contributors: Kentaro Wada
```
