### PR TITLE
[IJK] Move some release repos to ros-gbp org.

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2060,7 +2060,7 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/tork-a/csm-release.git
+      url: https://github.com/ros-gbp/csm-release.git
       version: 1.0.2-2
     source:
       type: git
@@ -3124,7 +3124,7 @@ repositories:
       - gravity_compensation
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/tork-a/force_torque_tools-release.git
+      url: https://github.com/ros-gbp/force_torque_tools-release.git
       version: 1.0.2-0
     source:
       type: git
@@ -6773,7 +6773,7 @@ repositories:
       - r2_moveit_generated
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/tork-a/moveit_robots-release.git
+      url: https://github.com/ros-gbp/moveit_robots-release.git
       version: 1.0.7-0
     source:
       type: git
@@ -11815,7 +11815,7 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/tork-a/roswww-release.git
+      url: https://github.com/ros-gbp/roswww-release.git
       version: 0.1.10-1
     source:
       type: git
@@ -12855,7 +12855,7 @@ repositories:
       - scan_tools
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/tork-a/scan_tools-release.git
+      url: https://github.com/ros-gbp/scan_tools-release.git
       version: 0.3.2-0
     source:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -701,7 +701,7 @@ repositories:
     release:
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/tork-a/csm-release.git
+      url: https://github.com/ros-gbp/csm-release.git
       version: 1.0.2-1
     source:
       type: git
@@ -1225,7 +1225,7 @@ repositories:
       - gravity_compensation
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/tork-a/force_torque_tools-release.git
+      url: https://github.com/ros-gbp/force_torque_tools-release.git
       version: 1.1.0-0
     source:
       type: git
@@ -5890,7 +5890,7 @@ repositories:
     release:
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/tork-a/roswww-release.git
+      url: https://github.com/ros-gbp/roswww-release.git
       version: 0.1.10-0
     source:
       type: git
@@ -6729,7 +6729,7 @@ repositories:
       - scan_tools
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/tork-a/scan_tools-release.git
+      url: https://github.com/ros-gbp/scan_tools-release.git
       version: 0.3.1-0
     source:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -769,7 +769,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/tork-a/csm-release.git
+      url: https://github.com/ros-gbp/csm-release.git
       version: 1.0.2-1
     source:
       type: git
@@ -6219,7 +6219,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/tork-a/roswww-release.git
+      url: https://github.com/ros-gbp/roswww-release.git
       version: 0.1.10-0
     source:
       test_pull_requests: true
@@ -6993,7 +6993,7 @@ repositories:
       - scan_tools
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/tork-a/scan_tools-release.git
+      url: https://github.com/ros-gbp/scan_tools-release.git
       version: 0.3.2-0
     source:
       type: git


### PR DESCRIPTION
These repos are already transfered to `ros-gbp`.