### PR TITLE
Include the gazebo7 rosdep key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -786,6 +786,12 @@ gazebo5:
   fedora: [gazebo]
   gentoo: [sci-electronics/gazebo]
   ubuntu: [gazebo5]
+gazebo7:
+  arch: [gazebo]
+  fedora: [gazebo]
+  gentoo: [sci-electronics/gazebo]
+  slackware: [gazebo]
+  ubuntu: [gazebo7]
 gcc-arm-none-eabi:
   arch: [gcc-arm-none-eabi]
   debian: [gcc-arm-none-eabi]


### PR DESCRIPTION
After the change of using gazebo7 for ROS Lunar instead of gazebo8, I'm including here a rosdep key definition for `gazebo7` in the same way we did for `gazebo5`.