### PR TITLE
Add rosdep for msgpack

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3317,6 +3317,16 @@ mrpt:
     wily: [libmrpt-dev]
     xenial: [libmrpt-dev]
     yakkety: [libmrpt-dev]
+msgpack:
+  arch: [msgpack-c]
+  debian: [libmsgpack-dev]
+  fedora: [msgpack-devel]
+  ubuntu:
+    artful: [libmsgpack-dev]
+    trusty: [libmsgpack-dev]
+    xenial: [libmsgpack-dev]
+    yakkety: [libmsgpack-dev]
+    zesty: [libmsgpack-dev]
 muparser:
   debian: [libmuparser-dev]
   fedora: [muParser-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3321,12 +3321,7 @@ msgpack:
   arch: [msgpack-c]
   debian: [libmsgpack-dev]
   fedora: [msgpack-devel]
-  ubuntu:
-    artful: [libmsgpack-dev]
-    trusty: [libmsgpack-dev]
-    xenial: [libmsgpack-dev]
-    yakkety: [libmsgpack-dev]
-    zesty: [libmsgpack-dev]
+  ubuntu: [libmsgpack-dev]
 muparser:
   debian: [libmuparser-dev]
   fedora: [muParser-devel]


### PR DESCRIPTION
This adds [MessagePack](http://msgpack.org/) library package.
MessagePack is a efficient binary serialization format.