### PR TITLE
Miss gazebo7 rosdep key for debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -788,6 +788,7 @@ gazebo5:
   ubuntu: [gazebo5]
 gazebo7:
   arch: [gazebo]
+  debian: [gazebo7]
   fedora: [gazebo]
   gentoo: [sci-electronics/gazebo]
   slackware: [gazebo]


### PR DESCRIPTION
Bloom is complaining about the lack of gazebo7 rosdep key for debian. And it is right.