### PR TITLE
gazebo_ros_pkgs: 2.7.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -409,7 +409,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.7.1-0
+      version: 2.7.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.7.2-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.7.1-0`

## gazebo_dev

```
* Revert gazebo8 changes in Lunar and back to use gazebo7 (#583 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/583>)
* Contributors: Jose Luis Rivero
```

## gazebo_msgs

- No changes

## gazebo_plugins

```
* Revert gazebo8 changes in Lunar and back to use gazebo7 (#583 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/583>)
* Contributors: Jose Luis Rivero
```

## gazebo_ros

```
* Revert gazebo8 changes in Lunar and back to use gazebo7 (#583 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/583>)
* Contributors: Jose Luis Rivero
```

## gazebo_ros_control

```
* Revert gazebo8 changes in Lunar and back to use gazebo7 (#583 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/583>)
* Contributors: Jose Luis Rivero
```

## gazebo_ros_pkgs

- No changes
