### PR TITLE
fiducials: 0.7.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1311,13 +1311,14 @@ repositories:
       - aruco_detect
       - fiducial_detect
       - fiducial_lib
+      - fiducial_msgs
       - fiducial_pose
       - fiducial_slam
       - fiducials
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/fiducials-release.git
-      version: 0.6.1-0
+      version: 0.7.0-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/fiducials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fiducials` to `0.7.0-0`:

- upstream repository: https://github.com/UbiquityRobotics/fiducials
- release repository: https://github.com/UbiquityRobotics-release/fiducials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.6.1-0`

## aruco_detect

```
* Fix dependencies
* Added image and object error calculation. Renamed K and dist
* Moved all service and message definitions to fiducial_msgs
* Update copyright on aruco detect C++
* Contributors: Jim Vaughan, Rohan Agrawal
```

## fiducial_detect

```
* Fix dependencies
* Moved all service and message definitions to fiducial_msgs
* Contributors: Jim Vaughan
```

## fiducial_lib

- No changes

## fiducial_msgs

```
* Moved all service and message definitions to fiducial_msgs
* Contributors: Jim Vaughan, Rohan Agrawal
```

## fiducial_pose

```
* Fix dependencies
* Fiducial transforms are always camera->fiducial
* Moved all service and message definitions to fiducial_msgs
* Contributors: Jim Vaughan
```

## fiducial_slam

```
* Fix dependencies
* Make sure that the variance sent to rviz doesn't truncate to 0
* Rewrite the code in C++, kill the python
* Fiducial transforms are always camera->fiducial
* Moved all service and message definitions to fiducial_msgs
* Contributors: Jim Vaughan, Rohan Agrawal
```

## fiducials

```
* Update package.xml
  Remove fiducial_slam2
* Added fiducial_slam2 - c++ slam node
* Moved all service and message definitions to fiducial_msgs (#56 <https://github.com/UbiquityRobotics/fiducials/issues/56>)
  * Moved msg and srv to fidicial_msg
  * Moved msg and srv to fidicial_msg
  * Fixed import of srv
  * Fixed import of msg
* Added fiducial_slam2 - c++ slam node
* Moved msg and srv to fidicial_msg
* Contributors: Jim Vaughan
```
