### PR TITLE
phidgets_drivers: 0.7.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4392,7 +4392,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 0.7.0-0
+      version: 0.7.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `0.7.1-0`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.7.0-0`

## libphidget21

```
* libphidget21: disable warnings from upstream lib
  We can't do anything about the upstream bugs, and this caused the build
  to become "unstable" on the Kinetic build farm.
* Migrate libphidget21 to catkin-native wrapping
* Contributors: Martin Günther
```

## phidgets_api

```
* Set event handlers for motor + encoder APIs
* Added basic motor api
* Added basic encoder board api
* Contributors: Zach Anderson, Martin Günther
```

## phidgets_drivers

- No changes

## phidgets_imu

```
* phidgets_imu: add optional serial number parameter (#7 <https://github.com/ros-drivers/phidgets_drivers/issues/7>)
* phidgets_imu: Add imu_filter_madgwick dependency
  Closes #9 <https://github.com/ros-drivers/phidgets_drivers/issues/9>.
* Contributors: Johan M. von Behren, Martin Günther
```
