### PR TITLE
imu_tools: 1.0.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4546,7 +4546,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.0.14-0
+      version: 1.0.15-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/imu_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.0.15-0`:

- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.14-0`

## imu_complementary_filter

- No changes

## imu_filter_madgwick

```
* Print warning if waiting for topic
  Closes #61 <https://github.com/ccny-ros-pkg/imu_tools/issues/61>.
* Fix boost::lock_error on shutdown
* Contributors: Martin Günther
```

## imu_tools

- No changes

## rviz_imu_plugin

```
* Add option to display orientation in world frame (#69 <https://github.com/ccny-ros-pkg/imu_tools/issues/69>)
  Per REP 145 IMU orientation is in the world frame. Rotating the
  orientation data to transform into the sensor frame results in strange
  behavior, such as double-rotation of orientation on a robot. Provide an
  option to display orientation in the world frame, and enable it by
  default. Continue to translate the position of the data to the sensor
  frame.
* Contributors: C. Andy Martin
```
