### PR TITLE
Add smbclient to rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3853,6 +3853,8 @@ smartmontools:
   debian: [smartmontools]
   fedora: [smartmontools]
   ubuntu: [smartmontools]
+smbclient:
+  ubuntu: [smbclient]
 snappy:
   arch: [snappy]
   fedora: [snappy]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3854,6 +3854,9 @@ smartmontools:
   fedora: [smartmontools]
   ubuntu: [smartmontools]
 smbclient:
+  arch: [smbclient]
+  debian: [smbclient]
+  fedora: [samba-client]
   ubuntu: [smbclient]
 snappy:
   arch: [snappy]


### PR DESCRIPTION
**What, the Swiss army knife of the Samba suit is missing?**

We are using this in a project, so it would be great to have it here.
Initially we wanted to use pysmb but had not the best results on some devices.
smbclient just worked where pysmb failed. You might find this self-claimed "ugly hack" useful: https://bitbucket.org/nosklo/pysmbclient/overview

