### PR TITLE
fanuc: 0.4.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2897,7 +2897,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/fanuc-release.git
-      version: 0.4.1-0
+      version: 0.4.2-0
     source:
       type: git
       url: https://github.com/ros-industrial/fanuc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fanuc` to `0.4.2-0`:

- upstream repository: https://github.com/ros-industrial/fanuc.git
- release repository: https://github.com/ros-industrial-release/fanuc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.4.1-0`

## fanuc

```
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_driver

```
* add readme to explain that low-level launch files should probably not be used directly.
* increase default Karel loop rate to 42 Hz (ref: #203 <https://github.com/ros-industrial/fanuc/issues/203>).
* minor: remove 'irs_in_mtn' prototype from Karel library.
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_lrmate200ic5h_moveit_config

```
* push trajectory execution parameters down into namespace (#211 <https://github.com/ros-industrial/fanuc/issues/211>).
* switch to Jade+ xacro processing.
* load top-level xacros instead of urdfs (#169 <https://github.com/ros-industrial/fanuc/issues/169>).
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_lrmate200ic5l_moveit_config

```
* push trajectory execution parameters down into namespace (#211 <https://github.com/ros-industrial/fanuc/issues/211>).
* switch to Jade+ xacro processing.
* load top-level xacros instead of urdfs (#169 <https://github.com/ros-industrial/fanuc/issues/169>).
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_lrmate200ic_moveit_config

```
* push trajectory execution parameters down into namespace (#211 <https://github.com/ros-industrial/fanuc/issues/211>).
* switch to Jade+ xacro processing.
* load top-level xacros instead of urdfs (#169 <https://github.com/ros-industrial/fanuc/issues/169>).
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_lrmate200ic_moveit_plugins

```
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_lrmate200ic_support

```
* add 'flange' frame: attachment point for EEF xacro models (#213 <https://github.com/ros-industrial/fanuc/pull/213>).
* use Jade+ xacro 'pi' constant instead of our own.
* remove redundant urdfs, consumers should use xacro macros or top-level xacros.
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* migrate to in-order processing of xacros (supported on Indigo and up).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_m10ia_moveit_config

```
* push trajectory execution parameters down into namespace (#211 <https://github.com/ros-industrial/fanuc/issues/211>).
* switch to Jade+ xacro processing.
* load top-level xacros instead of urdfs (#169 <https://github.com/ros-industrial/fanuc/issues/169>).
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_m10ia_moveit_plugins

```
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_m10ia_support

```
* add 'flange' frame: attachment point for EEF xacro models (#213 <https://github.com/ros-industrial/fanuc/pull/213>).
* use Jade+ xacro 'pi' constant instead of our own.
* remove redundant urdfs, consumers should use xacro macros or top-level xacros.
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* migrate to in-order processing of xacros (supported on Indigo and up).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_m16ib20_moveit_config

```
* push trajectory execution parameters down into namespace (#211 <https://github.com/ros-industrial/fanuc/issues/211>).
* switch to Jade+ xacro processing.
* load top-level xacros instead of urdfs (#169 <https://github.com/ros-industrial/fanuc/issues/169>).
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_m16ib_moveit_plugins

```
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_m16ib_support

```
* add 'flange' frame: attachment point for EEF xacro models (#213 <https://github.com/ros-industrial/fanuc/pull/213>).
* use Jade+ xacro 'pi' constant instead of our own.
* remove redundant urdfs, consumers should use xacro macros or top-level xacros.
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* migrate to in-order processing of xacros (supported on Indigo and up).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_m20ia10l_moveit_config

```
* push trajectory execution parameters down into namespace (#211 <https://github.com/ros-industrial/fanuc/issues/211>).
* switch to Jade+ xacro processing.
* load top-level xacros instead of urdfs (#169 <https://github.com/ros-industrial/fanuc/issues/169>).
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_m20ia_moveit_config

```
* push trajectory execution parameters down into namespace (#211 <https://github.com/ros-industrial/fanuc/issues/211>).
* switch to Jade+ xacro processing.
* load top-level xacros instead of urdfs (#169 <https://github.com/ros-industrial/fanuc/issues/169>).
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_m20ia_moveit_plugins

```
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_m20ia_support

```
* add 'flange' frame: attachment point for EEF xacro models (#213 <https://github.com/ros-industrial/fanuc/pull/213>).
* use Jade+ xacro 'pi' constant instead of our own.
* remove redundant urdfs, consumers should use xacro macros or top-level xacros.
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* migrate to in-order processing of xacros (supported on Indigo and up).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_m430ia2f_moveit_config

```
* push trajectory execution parameters down into namespace (#211 <https://github.com/ros-industrial/fanuc/issues/211>).
* switch to Jade+ xacro processing.
* load top-level xacros instead of urdfs (#169 <https://github.com/ros-industrial/fanuc/issues/169>).
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_m430ia2p_moveit_config

```
* push trajectory execution parameters down into namespace (#211 <https://github.com/ros-industrial/fanuc/issues/211>).
* switch to Jade+ xacro processing.
* load top-level xacros instead of urdfs (#169 <https://github.com/ros-industrial/fanuc/issues/169>).
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_m430ia_moveit_plugins

```
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_m430ia_support

```
* add 'flange' frame: attachment point for EEF xacro models (#213 <https://github.com/ros-industrial/fanuc/pull/213>).
* support: we use xacro pi now, so remove unneeded include.
  As of 7d1457fd5a905229da533381a9f1c9e0264f7860 we don't use our own 'pi'
  anymore, so the constants xacro is no longer needed.
* remove redundant urdfs, consumers should use xacro macros or top-level xacros.
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* migrate to in-order processing of xacros (supported on Indigo and up).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```

## fanuc_resources

```
* deprecate 'common_constants' utility xacro.
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* for a complete list of changes see the commit log for 0.4.2 <https://github.com/ros-industrial/fanuc/compare/0.4.1...0.4.2>.
```
