### PR TITLE
rosjava_core: 0.3.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6075,7 +6075,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_core-release.git
-      version: 0.3.3-0
+      version: 0.3.4-1
     source:
       type: git
       url: https://github.com/rosjava/rosjava_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_core` to `0.3.4-1`:

- upstream repository: https://github.com/rosjava/rosjava_core
- release repository: https://github.com/rosjava-release/rosjava_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.3.3-0`

## rosjava_core

```
* Implement parameter server's searchParam
* fixed nullptr triggered by default node factory
* Contributors: Julian Cerruti, Leroy Ruegemer
```
