### PR TITLE
fiducials: 0.7.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1318,7 +1318,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/fiducials-release.git
-      version: 0.7.0-0
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/fiducials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fiducials` to `0.7.1-0`:

- upstream repository: https://github.com/UbiquityRobotics/fiducials
- release repository: https://github.com/UbiquityRobotics-release/fiducials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.7.0-0`

## aruco_detect

- No changes

## fiducial_detect

- No changes

## fiducial_lib

- No changes

## fiducial_msgs

```
* Remove opencv dep from fiducial_msgs; add fiducial_msgs dep to fiducial_pose
* Contributors: Jim Vaughan
```

## fiducial_pose

```
* Remove opencv dep from fiducial_msgs; add fiducial_msgs dep to fiducial_pose
* Contributors: Jim Vaughan
```

## fiducial_slam

- No changes

## fiducials

- No changes
