### PR TITLE
dynamixel-workbench: 0.1.5-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -954,7 +954,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
-      version: 0.1.3-0
+      version: 0.1.5-2
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel-workbench` to `0.1.5-2`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
- release repository: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.3-0`

## dynamixel_workbench

```
* modified the cmake of toolbox
* Contributors: Darby Lim
```

## dynamixel_workbench_controllers

```
* modified the cmake of toolbox
* Contributors: Darby Lim
```

## dynamixel_workbench_msgs

```
* modified the cmake of toolbox
* Contributors: Darby Lim
```

## dynamixel_workbench_single_manager

```
* modified the cmake of toolbox
* Contributors: Darby Lim
```

## dynamixel_workbench_single_manager_gui

```
* modified the cmake of toolbox
* Contributors: Darby Lim
```

## dynamixel_workbench_toolbox

```
* modified the cmake of toolbox
* Contributors: Darby Lim
```

## dynamixel_workbench_tutorials

```
* modified the cmake of toolbox
* Contributors: Darby Lim
```
