### PR TITLE
turtlebot3: 0.1.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7725,14 +7725,13 @@ repositories:
       - turtlebot3
       - turtlebot3_bringup
       - turtlebot3_description
-      - turtlebot3_fake
-      - turtlebot3_gazebo
       - turtlebot3_navigation
       - turtlebot3_slam
+      - turtlebot3_teleop
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3` to `0.1.4-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.3-0`

## turtlebot3

```
* modified launch file name
* added teleop package
* Contributors: Darby Lim
```

## turtlebot3_bringup

```
* modified launch file name
* added teleop package
* Contributors: Darby Lim
```

## turtlebot3_description

```
* modified launch file name
* added teleop package
* Contributors: Darby Lim
```

## turtlebot3_navigation

```
* modified launch file name
* added teleop package
* Contributors: Darby Lim
```

## turtlebot3_slam

```
* modified launch file name
* added teleop package
* Contributors: Darby Lim
```

## turtlebot3_teleop

```
* modified launch file name
* added teleop package
* Contributors: Darby Lim
```
