### PR TITLE
Adding packages to documentation index for indigo and kinetic

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -495,6 +495,11 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_rapidxml.git
       version: master
+  asr_ros_uri:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ros_uri.git
+      version: master
   astra_camera:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -490,6 +490,11 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_navfn.git
       version: master
+  asr_rapidxml:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_rapidxml.git
+      version: master
   astra_camera:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -455,6 +455,16 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_ftc_local_planner.git
       version: master
+  asr_ivt:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ivt.git
+      version: master
+  asr_ivt_bridge:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ivt_bridge.git
+      version: master
   asr_mild_base_driving:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -510,6 +510,11 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_ros_uri.git
       version: master
+  asr_xsd2cpp:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_xsd2cpp.git
+      version: master
   astra_camera:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -219,6 +219,11 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_ros_uri.git
       version: master
+  asr_xsd2cpp:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_xsd2cpp.git
+      version: master
   astra_camera:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -204,6 +204,11 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_rapidxml.git
       version: master
+  asr_ros_uri:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ros_uri.git
+      version: master
   astra_camera:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -199,6 +199,11 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_navfn.git
       version: master
+  asr_rapidxml:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_rapidxml.git
+      version: master
   astra_camera:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -164,6 +164,16 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_ftc_local_planner.git
       version: master
+  asr_ivt:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ivt.git
+      version: master
+  asr_ivt_bridge:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ivt_bridge.git
+      version: master
   asr_mild_base_driving:
     doc:
       type: git


### PR DESCRIPTION
I would like our packages asr_ivt, asr_ivt_bridge, asr_rapidxml, asr_ros_uri and asr_xsd2cpp to be documented