### PR TITLE
laser_odometry: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 141: http://ros.org/reps/rep-0141.html
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   fedora:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -5754,6 +5754,21 @@ repositories:
       url: https://github.com/ros-perception/laser_geometry.git
       version: indigo-devel
     status: maintained
+  laser_odometry:
+    release:
+      packages:
+      - laser_odometry
+      - laser_odometry_core
+      - laser_odometry_node
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/artivis/laser_odometry-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/artivis/laser_odometry.git
+      version: 0.0.1
+    status: developed
   laser_pipeline:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5767,7 +5767,7 @@ repositories:
     source:
       type: git
       url: https://github.com/artivis/laser_odometry.git
-      version: 0.0.1
+      version: master
     status: developed
   laser_pipeline:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_odometry` to `0.0.1-0`:

- upstream repository: https://github.com/artivis/laser_odometry.git
- release repository: https://github.com/artivis/laser_odometry-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## laser_odometry

```
* added metapkg, renamed laser_odometry to laser_odometry_node
* node add missing global frame for origin init
* replace kword world->fixed
* node doc
* Fix installation rules
* fix origin frame retrieval
* fix topic in and default world = map
* reduce default getTf duration
* node default pub odom & not tf & topic_in
* laser_odometry add simple launch file and update conf file
* fix setLaserFromTf
* add node default yaml
* node pub kframe
* clean laser_odom launch
* laser_odometry install rule
* node add timer on process()
* add cheap throttling
* made publish template
* node :lipstick:
* use proper singleton scheme
* rename instantiater
* protect a bunch of functions
* throw if no laser odometry type specified
* setLaserFromTf with optional stamp
* add possibility of a not fixed sensor<->base frame
* fix node launch
* hacky easy sub to either laser_scan or pcl2 & fix include
* add laser_odometry to hold the main node
* Contributors: Jeremie Deray, Procópio Stein, artivis, davidfernandez
```

## laser_odometry_core

```
* LICENSE pkg.xml
* cov is twist cov, comment pose cov
* lipstick
  
  
* replace kword world->fixed
* base rm usuless bool
* node doc
* ProcessReport doc
* lipstick
  
  
* add twist_covariance_
* delete usuless func
* base doc
* readme
* fix topic in and default world = map
* reduce default getTf duration
* fix warning unused
* core add getKeyFrame
* add hasNewKeyFrame
* Base:process no more virtual
* core install rule
* add isNotKeyFrame & fixes
* base::odomType do not throw but warn and return unknown
* reset correction
* isKeyFrame(correction_) && confImpl returns true && doc
* getTf do not set tf if it couldn't get it
* add isKeyFrame() && comments && :lipstick:
* wip toward Base handling common comp
* message filling made template
* wip toward Base handling the common comp
* add pre/postProcessing
* use Covariance type rather than vector
* fix warning
* add isKeyFrame in base & func reordering
* mv Base class decl to base.h -> core.h simple includer
* process returns ProcessReport rather than bool
* add ProcessReport pimpl
* use fillOdomMsg & fix child_frame_id
* return by const ref
* add odomType
* getTf add opt duration & fix err msg
* use proper singleton scheme
* rename instantiater
* getTf with optional stamp
* fix core build
* fillOdomMsg uses current_time_ & add expressFromLaserToBase
* rm reference_scan & :lipstick:
* rm main node from core
* core cmake
* process() aint pur virtual anymore but throws & add process(pcl2)
* node init origin
* rename get/set FrameWorld -> FrameFixed
* fix getTf uninitialized
* core CMake add node
* add node launch file
* core add Node class
* replace class LaserOdometry -> LaserOdometryInstantiater
* core getter/setter & fillPose*Msg & odom frame = odom
* one-liner tfFromXYTheta
* fix tf pub
* yup changed core api again
* utils getTf from msg
* comments
* tf init I
* lipstick
  
  
* core api retrieve relative_tf & setInitialGuess
* new process api & mv common stuff to base class
* getTf setIdentity
* core friend loader
* core add loader/holder class
* laser_odometry_core fix deps
* core lib
* Base configure & predict & broadcast
* add utils
* _core fix constructor & process(PoseWithCovarianceStampedPtr)
* upload laser_odometry_core
* Contributors: Jeremie Deray, artivis
```

## laser_odometry_node

```
* added metapkg, renamed laser_odometry to laser_odometry_node
* Contributors: Procópio Stein
```
