### PR TITLE
robotis_framework: 0.2.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5369,13 +5369,14 @@ repositories:
       version: kinetic-devel
     release:
       packages:
+      - robotis_controller
       - robotis_device
       - robotis_framework
       - robotis_framework_common
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
-      version: 0.2.1-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_framework` to `0.2.3-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.1-0`

## robotis_controller

```
* updated the cmake file for ros install
* Contributors: SCH
```

## robotis_device

```
* updated the cmake file for ros install
* Contributors: SCH
```

## robotis_framework

```
* updated the cmake file for ros install
* Contributors: SCH
```

## robotis_framework_common

```
* updated the cmake file for ros install
* Contributors: SCH
```
