### PR TITLE
thormang3_common: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7531,7 +7531,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Common-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_common` to `0.1.3-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Common.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.2-0`

## thormang3_common

```
* updated the URDF file of Thormang3
* Contributors: SCH-
```

## thormang3_description

```
* updated the URDF file of Thormang3
* Contributors: SCH
```

## thormang3_gazebo

```
* updated the URDF file of Thormang3
* Contributors: SCH
```
