### PR TITLE
thormang3_ppc: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7616,10 +7616,11 @@ repositories:
       - thormang3_manipulation_demo
       - thormang3_ppc
       - thormang3_sensors
+      - thormang3_walking_demo
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-PPC-release.git
-      version: 0.1.0-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-PPC.git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_ppc` to `0.1.2-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-PPC.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-PPC-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.0-0`

## thormang3_manipulation_demo

```
* updated cmake file for ros install
* Contributors: SCH
```

## thormang3_ppc

```
* updated cmake file for ros install
* Contributors: SCH
```

## thormang3_sensors

```
* updated cmake file for ros install
* Contributors: SCH
```

## thormang3_walking_demo

```
* updated cmake file for ros install
* Contributors: SCH
```
