### PR TITLE
thormang3_mpc: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7588,7 +7588,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-MPC-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-MPC.git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_mpc` to `0.1.3-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-MPC.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-MPC-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.2-0`

## ati_ft_sensor

```
* updated cmake file for ros install
* Contributors: SCH
```

## motion_module_tutorial

```
* updated cmake file for ros install
* Contributors: SCH
```

## sensor_module_tutorial

```
* updated cmake file for ros install
* Contributors: SCH
```

## thormang3_action_module

```
* updated cmake file for ros install
* Contributors: SCH
```

## thormang3_balance_control

```
* updated cmake file for ros install
* Contributors: SCH
```

## thormang3_base_module

```
* updated cmake file for ros install
* Contributors: SCH
```

## thormang3_feet_ft_module

```
* updated cmake file for ros install
* Contributors: SCH
```

## thormang3_gripper_module

```
* updated cmake file for ros install
* Contributors: SCH
```

## thormang3_head_control_module

```
* updated cmake file for ros install
* Contributors: SCH
```

## thormang3_imu_3dm_gx4

```
* updated cmake file for ros install
* Contributors: SCH
```

## thormang3_kinematics_dynamics

```
* updated cmake file for ros install
* Contributors: SCH
```

## thormang3_manager

```
* updated cmake file for ros install
* Contributors: SCH
```

## thormang3_manipulation_module

```
* updated cmake file for ros install
* Contributors: SCH
```

## thormang3_mpc

```
* updated cmake file for ros install
* Contributors: SCH
```

## thormang3_walking_module

```
* updated cmake file for ros install
* Contributors: SCH
```
