### PR TITLE
thormang3_tools: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7665,7 +7665,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Tools-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_tools` to `0.1.2-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Tools.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.1-0`

## thormang3_action_editor

```
* updated cmake file for ros install
* Contributors: SCH
```

## thormang3_offset_tuner_server

```
* updated cmake file for ros install
* Contributors: SCH
```

## thormang3_tools

```
* updated cmake file for ros install
* Contributors: SCH
```
