### PR TITLE
manipulator_h: 0.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3034,16 +3034,18 @@ repositories:
     release:
       packages:
       - manipulator_h
+      - manipulator_h_base_module
       - manipulator_h_base_module_msgs
       - manipulator_h_bringup
       - manipulator_h_description
       - manipulator_h_gazebo
       - manipulator_h_gui
       - manipulator_h_kinematics_dynamics
+      - manipulator_h_manager
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-MANIPULATOR-H-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-MANIPULATOR-H.git


### PR DESCRIPTION
Increasing version of package(s) in repository `manipulator_h` to `0.2.2-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-MANIPULATOR-H.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-MANIPULATOR-H-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.1-0`

## manipulator_h

```
* updated cmake file for ros install
* Contributors: SCH
```

## manipulator_h_base_module

```
* updated cmake file for ros install
* Contributors: SCH
```

## manipulator_h_base_module_msgs

```
* updated cmake file for ros install
* Contributors: SCH
```

## manipulator_h_bringup

```
* updated cmake file for ros install
* Contributors: SCH
```

## manipulator_h_description

```
* updated cmake file for ros install
* Contributors: SCHch
```

## manipulator_h_gazebo

```
* updated cmake file for ros install
* Contributors: SCH
```

## manipulator_h_gui

```
* updated cmake file for ros install
* deleted logs
* Contributors: SCH
```

## manipulator_h_kinematics_dynamics

```
* updated cmake file for ros install
* Contributors: SCH
```

## manipulator_h_manager

```
* updated cmake file for ros install
* added a control cycle in robot file
* Contributors: SCH
```
