### PR TITLE
rosflight: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6065,6 +6065,26 @@ repositories:
       url: https://github.com/ros-infrastructure/rosdoc_lite.git
       version: master
     status: maintained
+  rosflight:
+    doc:
+      type: git
+      url: https://github.com/rosflight/rosflight.git
+      version: master
+    release:
+      packages:
+      - rosflight
+      - rosflight_msgs
+      - rosflight_pkgs
+      - rosflight_utils
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/rosflight/rosflight-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/rosflight/rosflight.git
+      version: master
+    status: developed
   rosjava:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosflight` to `0.1.0-1`:

- upstream repository: https://github.com/rosflight/rosflight.git
- release repository: https://github.com/rosflight/rosflight-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
