### PR TITLE
bump linux-headers version for debian stretch

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3158,7 +3158,7 @@ linux-headers-generic:
   arch: [linux-headers]
   debian:
     jessie: [linux-headers-3.16.0-4-all]
-    stretch: [linux-headers-4.9.0-2-all]
+    stretch: [linux-headers-4.9.0-3-all]
     wheezy: [linux-headers-3.2.0-4-all]
   fedora: [kernel-headers]
   ubuntu: [linux-headers-generic]


### PR DESCRIPTION
https://packages.debian.org/stretch/linux-headers-4.9.0-3-all