### PR TITLE
imu_tools: 1.1.5-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -712,6 +712,26 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: indigo-devel
     status: maintained
+  imu_tools:
+    doc:
+      type: git
+      url: https://github.com/ccny-ros-pkg/imu_tools.git
+      version: lunar
+    release:
+      packages:
+      - imu_complementary_filter
+      - imu_filter_madgwick
+      - imu_tools
+      - rviz_imu_plugin
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/uos-gbp/imu_tools-release.git
+      version: 1.1.5-0
+    source:
+      type: git
+      url: https://github.com/ccny-ros-pkg/imu_tools.git
+      version: lunar
+    status: developed
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.1.5-0`:

- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## imu_complementary_filter

- No changes

## imu_filter_madgwick

```
* Initial release into Lunar
* Remove support for Vector3 mag messages
* Change default world_frame = enu
* Rewrite rosbags: Use MagneticField for magnetometer
* Contributors: Martin Günther
```

## imu_tools

- No changes

## rviz_imu_plugin

- No changes
