### PR TITLE
katana_driver: 1.0.7-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -739,6 +739,33 @@ repositories:
       url: https://github.com/ros/ivcon.git
       version: kinetic-devel
     status: maintained
+  katana_driver:
+    doc:
+      type: git
+      url: https://github.com/uos/katana_driver.git
+      version: lunar
+    release:
+      packages:
+      - katana
+      - katana_arm_gazebo
+      - katana_description
+      - katana_driver
+      - katana_gazebo_plugins
+      - katana_moveit_ikfast_plugin
+      - katana_msgs
+      - katana_teleop
+      - katana_tutorials
+      - kni
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/uos-gbp/katana_driver-release.git
+      version: 1.0.7-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/uos/katana_driver.git
+      version: lunar
+    status: developed
   kdl_parser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `katana_driver` to `1.0.7-0`:

- upstream repository: https://github.com/uos/katana_driver.git
- release repository: https://github.com/uos-gbp/katana_driver-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## katana

```
* KNIKinematics: Remove GetKinematicSolverInfo service
  The service definition was removed from moveit_msgs on Kinetic in commit 2f3f97b9.
* Contributors: Martin Guenther
```

## katana_arm_gazebo

- No changes

## katana_description

- No changes

## katana_driver

- No changes

## katana_gazebo_plugins

- No changes

## katana_moveit_ikfast_plugin

- No changes

## katana_msgs

- No changes

## katana_teleop

- No changes

## katana_tutorials

- No changes

## kni

- No changes
