### PR TITLE
sick_tim: 0.0.10-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2454,6 +2454,22 @@ repositories:
       url: https://github.com/ros-visualization/rviz.git
       version: kinetic-devel
     status: maintained
+  sick_tim:
+    doc:
+      type: git
+      url: https://github.com/uos/sick_tim.git
+      version: lunar
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/uos-gbp/sick_tim-release.git
+      version: 0.0.10-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/uos/sick_tim.git
+      version: lunar
+    status: developed
   srdfdom:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_tim` to `0.0.10-0`:

- upstream repository: https://github.com/uos/sick_tim
- release repository: https://github.com/uos-gbp/sick_tim-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## sick_tim

```
* Automatically reboot scanner if it reports an error code. (#44 <https://github.com/uos/sick_tim/issues/44>)
* Update strtok logic. Fixes #42 <https://github.com/uos/sick_tim/issues/42> (#43 <https://github.com/uos/sick_tim/issues/43>)
* Contributors: Derek King, Jochen Sprickerhof, Martin Guenther
```
