### PR TITLE
ompl: 1.3.1-2 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1215,7 +1215,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/ompl-release.git
-      version: 1.3.0-1
+      version: 1.3.1-2
     status: maintained
   opencv3:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.3.1-2`:

- upstream repository: https://bitbucket.org/ompl/ompl
- release repository: https://github.com/ros-gbp/ompl-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.3.0-1`
