### PR TITLE
jsk_apc: 3.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5055,7 +5055,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_apc-release.git
-      version: 3.0.2-0
+      version: 3.0.3-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_apc` to `3.0.3-0`:

- upstream repository: https://github.com/start-jsk/jsk_apc.git
- release repository: https://github.com/tork-a/jsk_apc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `3.0.2-0`

## jsk_2015_05_baxter_apc

- No changes

## jsk_2016_01_baxter_apc

```
* fix default-controller not to set head twice (#2097 <https://github.com/start-jsk/jsk_apc/issues/2097>)
* add roseus_mongo as run_depend (#2099 <https://github.com/start-jsk/jsk_apc/issues/2099>)
* Contributors: Shingo Kitagawa
```

## jsk_apc

- No changes

## jsk_apc2015_common

- No changes

## jsk_apc2016_common

- No changes

## jsk_arc2017_baxter

```
* Add roseus as build_depend
* update midpose to go back fold-pose-back (#2093 <https://github.com/start-jsk/jsk_apc/issues/2093>)
* Contributors: Kentaro Wada, Shingo Kitagawa
```

## jsk_arc2017_common

- No changes
