### PR TITLE
rosflight: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6079,7 +6079,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosflight/rosflight-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/rosflight/rosflight.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosflight` to `0.1.2-0`:

- upstream repository: https://github.com/rosflight/rosflight.git
- release repository: https://github.com/rosflight/rosflight-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.1-0`

## rosflight

```
* Removed OpenMP compile flag for now
* Added missing tf dependency
* Contributors: Daniel Koch
```

## rosflight_msgs

- No changes

## rosflight_pkgs

- No changes

## rosflight_utils

- No changes
