### PR TITLE
rosdep python: Add setuptools and future for Ubuntu yakkety & zesty

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -856,6 +856,7 @@ python-future:
     wily: [python-future]
     xenial: [python-future]
     yakkety: [python-future]
+    zesty: [python-future]
 python-fysom:
   debian:
     pip:
@@ -2449,6 +2450,8 @@ python-setuptools:
     wily_python3: [python3-setuptools]
     xenial: [python-setuptools]
     xenial_python3: [python3-setuptools]
+    yakkety: [python-setuptools]
+    zesty: [python-setuptools]
 python-shapely:
   debian: [python-shapely]
   fedora: [python-shapely]


### PR DESCRIPTION
That should fix lunar mavlink release https://github.com/ros/rosdistro/pull/15062