### PR TITLE
rosdep key for userspace linux kernel headers

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3162,6 +3162,11 @@ linux-headers-generic:
     wheezy: [linux-headers-3.2.0-4-all]
   fedora: [kernel-headers]
   ubuntu: [linux-headers-generic]
+linux-kernel-headers:
+  arch: [linux-api-headers]
+  debian: [linux-kernel-headers]
+  fedora: [kernel-headers]
+  ubuntu: [linux-kernel-headers]
 log4cxx:
   arch: [log4cxx]
   cygwin: [liblog4cxx-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3160,7 +3160,7 @@ linux-headers-generic:
     jessie: [linux-headers-3.16.0-4-all]
     stretch: [linux-headers-4.9.0-2-all]
     wheezy: [linux-headers-3.2.0-4-all]
-  fedora: [kernel-headers]
+  fedora: [kernel-headers, kernel-devel]
   ubuntu: [linux-headers-generic]
 linux-kernel-headers:
   arch: [linux-api-headers]


### PR DESCRIPTION
(follow-up of https://github.com/ros/rosdistro/pull/15050)

On Ubuntu `linux-headers-generic` [pulls in files](https://packages.ubuntu.com/de/trusty/amd64/linux-headers-3.13.0-24-generic/filelist) under `/usr/src`, mainly for buiding kernel modules.
The header files in `/usr/include/linux/` are provided via `linux-kernel-headers` ([debian](https://packages.debian.org/jessie/linux-kernel-headers), [ubuntu](https://packages.ubuntu.com/xenial/linux-kernel-headers)).

On Arch Linux [linux-headers](https://www.archlinux.org/packages/core/x86_64/linux-headers/) provides the kernel headers for modules and [linux-api-headers](https://www.archlinux.org/packages/core/x86_64/linux-api-headers/) provides userspace headers.

On Fedora `kernel-headers` provides the userspace headers, and `kernel-devel` provides the headers for building modules.
For compatibility reasons I have included both for the `linux-headers-generic` key.
I was not able to find the packages in the package DB, I had do verify it in the docker images.