### PR TITLE
turtlebot3: 0.1.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7780,7 +7780,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3` to `0.1.5-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.4-0`

## turtlebot3

```
* updated turtlebot3 waffle URDF
* changed the node name from hlds_laser_publisher to turtlebot3_lds
* modified bag and map files
* added SLAM bag file
* Contributors: Darby Lim, Pyo
```

## turtlebot3_bringup

```
* changed the node name from hlds_laser_publisher to turtlebot3_lds
* Contributors: Pyo
```

## turtlebot3_description

```
* updated turtlebot3 waffle URDF
* Contributors: Darby Lim
```

## turtlebot3_navigation

```
* modified bag and map files
* Contributors: Darby Lim, Pyo
```

## turtlebot3_slam

```
* modified bag and map files
* added SLAM bag files
* Contributors: Darby Lim, Pyo
```

## turtlebot3_teleop

```
* none
```
