### PR TITLE
mavros: 0.19.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -943,6 +943,28 @@ repositories:
       url: https://github.com/mavlink/mavlink-gbp-release.git
       version: release/lunar/mavlink
     status: maintained
+  mavros:
+    doc:
+      type: git
+      url: https://github.com/mavlink/mavros.git
+      version: master
+    release:
+      packages:
+      - libmavconn
+      - mavros
+      - mavros_extras
+      - mavros_msgs
+      - test_mavros
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/mavlink/mavros-release.git
+      version: 0.19.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/mavlink/mavros.git
+      version: master
+    status: developed
   media_export:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.19.0-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## libmavconn

- No changes

## mavros

```
* launch: remove setpoint-attitude from apm blacklist
* lib: cleanup in enum_to_string
* extras: Add ADSB plugin
* plugin: home_position: Log poll
* plugin: home_position: Log report
* plugin #695 <https://github.com/mavlink/mavros/issues/695>: Fix plugin
* plugin: Add home_position
* Added SAFETY_ALLOWED_AREA rx handler (#689 <https://github.com/mavlink/mavros/issues/689>)
  * Added SAFETY_ALLOWED_AREA rx handler and publish PolygonStamped msg with the 2 points
  * add resize to array to avoid sigfault
* lib: Fix millis timesync passthrough
* Plugin: Add unstamped Twist subscriber for setpoint_velocity
* uas: Move timesync_mode enum to utils.h + fixes
  That enum are used for utils too, but forward declaration of class
  internal enum is impossible.
* sys_time: Add timesync mode selection parameter.
* sys_time : add multi-mode timesync
* uas : add multi-mode timesync
* uas : add multi-mode timesync
* launch fix #670 <https://github.com/mavlink/mavros/issues/670>: Add configuration of distance_sensor plugin for APM
* Contributors: Kabir Mohammed, Nuno Marques, Pierre Kancir, Randy Mackay, Vladimir Ermakov
```

## mavros_extras

```
* extras: fix package link
* extras: Fix adsb plugin
* extras: Add ADSB plugin
* Add frame transform for vibration levels (#690 <https://github.com/mavlink/mavros/issues/690>)
  * add frame transform for accel vibration levels
  * use vectorEigenToMsg
  * unscrustify
* Contributors: Nuno Marques, Vladimir Ermakov
```

## mavros_msgs

```
* msgs: Add cog script to finish ADSBVehicle.msg
* extras: Add ADSB plugin
* plugin #695 <https://github.com/mavlink/mavros/issues/695>: Fix plugin
* plugin: Add home_position
* Contributors: Nuno Marques, Vladimir Ermakov
```

## test_mavros

```
* cmake: remove Eigen warning
* Contributors: Vladimir Ermakov
```
