### PR TITLE
abb: 1.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16,6 +16,27 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/abb.git
       version: kinetic-devel
+    release:
+      packages:
+      - abb
+      - abb_driver
+      - abb_irb2400_moveit_config
+      - abb_irb2400_moveit_plugins
+      - abb_irb2400_support
+      - abb_irb4400_support
+      - abb_irb5400_support
+      - abb_irb6600_support
+      - abb_irb6640_moveit_config
+      - abb_irb6640_support
+      - abb_resources
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/abb-release.git
+      version: 1.3.0-0
+    source:
+      type: git
+      url: https://github.com/ros-industrial/abb.git
+      version: 1.3.0
     status: developed
   abb_experimental:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `abb` to `1.3.0-0`:

- upstream repository: https://github.com/ros-industrial/abb.git
- release repository: https://github.com/ros-industrial-release/abb-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## abb

```
* No changes
```

## abb_driver

```
* No changes
```

## abb_irb2400_moveit_config

```
* No changes
```

## abb_irb2400_moveit_plugins

```
* No changes
```

## abb_irb2400_support

```
* No changes
```

## abb_irb4400_support

```
* Removed urdf file
* Copied the irb4400 support package from the abb_experimental repo.
```

## abb_irb5400_support

```
* No changes
```

## abb_irb6600_support

```
* No changes
```

## abb_irb6640_moveit_config

```
* No changes
```

## abb_irb6640_support

```
* No changes
```

## abb_resources

```
* No change
```
