### PR TITLE
use non-virtual package for linux-kernel-headers

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3164,9 +3164,9 @@ linux-headers-generic:
   ubuntu: [linux-headers-generic]
 linux-kernel-headers:
   arch: [linux-api-headers]
-  debian: [linux-kernel-headers]
+  debian: [linux-libc-dev]
   fedora: [kernel-headers]
-  ubuntu: [linux-kernel-headers]
+  ubuntu: [linux-libc-dev]
 log4cxx:
   arch: [log4cxx]
   cygwin: [liblog4cxx-devel]


### PR DESCRIPTION
should be reverted as soon as new rosdep version (with support for virtual packages) was released.
(as discussed in https://github.com/ros/rosdistro/pull/15064#issuecomment-304127344)