### PR TITLE
robot_markers: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10360,6 +10360,21 @@ repositories:
       url: https://github.com/cra-ros-pkg/robot_localization.git
       version: indigo-devel
     status: maintained
+  robot_markers:
+    doc:
+      type: git
+      url: https://github.com/jstnhuang/robot_markers.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/jstnhuang-release/robot_markers-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/jstnhuang/robot_markers.git
+      version: indigo-devel
+    status: developed
   robot_model:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_markers` to `0.1.0-0`:

- upstream repository: https://github.com/jstnhuang/robot_markers.git
- release repository: https://github.com/jstnhuang-release/robot_markers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## robot_markers

```
* Initial package creation.
* Contributors: Justin Huang
```
