### PR TITLE
Added pathtools to jade/distribution.yaml

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4204,11 +4204,11 @@ repositories:
       url: https://github.com/AutonomyLab/parrot_arsdk.git
       version: indigo-devel
     status: developed
-  pathtools:                                                                                                                                                                                                                                                                  
-    release:                                                                                                                                                                                                                                                                  
-      tags:                                                                                                                                                                                                                                                                   
-        release: release/jade/{package}/{version}                                                                                                                                                                                                                             
-      url: https://github.com/yotabits/pathtools-release.git                                                                                                                                                                                                                  
+  pathtools:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/yotabits/pathtools-release.git
       version: 0.1.2-0
       status: maintained
   patrolling_sim:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4204,6 +4204,13 @@ repositories:
       url: https://github.com/AutonomyLab/parrot_arsdk.git
       version: indigo-devel
     status: developed
+  pathtools:                                                                                                                                                                                                                                                                  
+    release:                                                                                                                                                                                                                                                                  
+      tags:                                                                                                                                                                                                                                                                   
+        release: release/jade/{package}/{version}                                                                                                                                                                                                                             
+      url: https://github.com/yotabits/pathtools-release.git                                                                                                                                                                                                                  
+      version: 0.1.2-0
+      status:maintained
   patrolling_sim:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4210,7 +4210,7 @@ repositories:
         release: release/jade/{package}/{version}
       url: https://github.com/yotabits/pathtools-release.git
       version: 0.1.2-0
-      status: maintained
+    status: maintained
   patrolling_sim:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4210,7 +4210,7 @@ repositories:
         release: release/jade/{package}/{version}                                                                                                                                                                                                                             
       url: https://github.com/yotabits/pathtools-release.git                                                                                                                                                                                                                  
       version: 0.1.2-0
-      status:maintained
+      status: maintained
   patrolling_sim:
     doc:
       type: git


### PR DESCRIPTION
Having some issues on bloom while doing release PR for pathtools package so doing it by hand.