### PR TITLE
laser_odometry: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 141: http://ros.org/reps/rep-0141.html
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   fedora:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -5788,7 +5788,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/artivis/laser_odometry-release.git
-      version: 0.0.1-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/artivis/laser_odometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_odometry` to `0.1.0-0`:

- upstream repository: https://github.com/artivis/laser_odometry.git
- release repository: https://github.com/artivis/laser_odometry-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.0.1-0`

## laser_odometry

- No changes

## laser_odometry_core

```
* add fillIncrementMsg
* fix msg_ptr z oups
* rename twist_cov -> inc_cov
* rename correction_ -> increment_ & :lipstick:
* fix macro
* fix macro
* Contributors: Jeremie Deray
```

## laser_odometry_node

```
* add pose increment publication in node
* Contributors: Jeremie Deray
```
