### PR TITLE
katana_driver: 1.1.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -779,7 +779,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/uos-gbp/katana_driver-release.git
-      version: 1.1.0-0
+      version: 1.1.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `katana_driver` to `1.1.1-0`:

- upstream repository: https://github.com/uos/katana_driver.git
- release repository: https://github.com/uos-gbp/katana_driver-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.1.0-0`

## katana

```
* Compile katana package with c++11
  This fixes the following warning introduced in adf463b6:
  katana_driver/katana/include/katana/Katana300.h:64:47: warning: non-static data member initializers only available with -std=c++11 or -std=gnu++11 [enabled by default]
  const double JOINTS_STOPPED_POS_TOLERANCE = 0.01;
* Contributors: Martin Günther
```

## katana_arm_gazebo

- No changes

## katana_description

- No changes

## katana_driver

- No changes

## katana_gazebo_plugins

- No changes

## katana_moveit_ikfast_plugin

- No changes

## katana_msgs

- No changes

## katana_teleop

- No changes

## katana_tutorials

- No changes

## kni

- No changes
