### PR TITLE
Build failed due to misconfigured python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2122,6 +2122,7 @@ python-qt-bindings-webkit:
     trusty: [python-qt4]
     utopic: [python-qt4]
     vivid: [python-qt4]
+    xenial: [python-qt4]
 python-qt4-gl:
   debian: [python-qt4-gl]
   fedora: [PyQt4]


### PR DESCRIPTION
A bunch of users noticed that ROS won't build on their systems. On my laptop, the rosdep fails on
`webkit_dependency: No definition of [python-qt-bindings-webkit] for OS version [xenial]`
I think this is an acceptable fix for my lapotp (ubuntu 16.04). But we need more lines for other environments.