### PR TITLE
abb: 1.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16,6 +16,27 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/abb.git
       version: kinetic-devel
+    release:
+      packages:
+      - abb
+      - abb_driver
+      - abb_irb2400_moveit_config
+      - abb_irb2400_moveit_plugins
+      - abb_irb2400_support
+      - abb_irb4400_support
+      - abb_irb5400_support
+      - abb_irb6600_support
+      - abb_irb6640_moveit_config
+      - abb_irb6640_support
+      - abb_resources
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/abb-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/abb.git
+      version: kinetic
     status: developed
   abb_experimental:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `abb` to `1.3.0-1`:

- upstream repository: https://github.com/ros-industrial/abb.git
- release repository: https://github.com/ros-industrial-release/abb-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## abb

```
* Added 4400 support package to meta-package manifest of abb.
* fix comments from PR #126 <https://github.com/ros-industrial/abb/issues/126>.
* kinetic-devel release of ros-industrial/abb
* Contributors: AustinDeric, Jonathan Meyer
```

## abb_driver

```
* kinetic-devel release of ros-industrial/abb
* Contributors: AustinDeric
```

## abb_irb2400_moveit_config

```
* remove reference to source build and rebase to indigo devel.
* kinetic-devel release of ros-industrial/abb
* Contributors: Austin Deric
```

## abb_irb2400_moveit_plugins

```
* kinetic-devel release of ros-industrial/abb
* Contributors: AustinDeric
```

## abb_irb2400_support

```
* remove reference to source build and rebase to indigo devel.
* kinetic-devel release of ros-industrial/abb
* Contributors: Austin Deric
```

## abb_irb4400_support

```
* Removed urdf file from 4400 support package.
* Copied the irb4400 support package from the experimental repo.
* Contributors: Jonathan Meyer
```

## abb_irb5400_support

```
* remove reference to source build and rebase to indigo devel.
* kinetic-devel release of ros-industrial/abb
* Contributors: Austin Deric
```

## abb_irb6600_support

```
* remove reference to source build and rebase to indigo devel.
* kinetic-devel release of ros-industrial/abb
* Contributors: Austin Deric
```

## abb_irb6640_moveit_config

```
* kinetic-devel release of ros-industrial/abb
* Contributors: AustinDeric
```

## abb_irb6640_support

```
* remove reference to source build and rebase to indigo devel.
* kinetic-devel release of ros-industrial/abb
* Contributors: Austin Deric
```

## abb_resources

```
* remove reference to source build and rebase to indigo devel.
* kinetic-devel release of ros-industrial/abb
* Contributors: Austin Deric
```
