### PR TITLE
rosjava_extras: 0.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6155,7 +6155,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_extras-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/rosjava/rosjava_extras.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_extras` to `0.3.2-0`:

- upstream repository: https://github.com/rosjava/rosjava_extras.git
- release repository: https://github.com/rosjava-release/rosjava_extras-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.3.1-0`

## rosjava_extras

```
* add cv_bridge_javacv (java library).
* Contributors: talregev
```
