### PR TITLE
ros_canopen: 0.7.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5783,7 +5783,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_canopen-release.git
-      version: 0.7.4-0
+      version: 0.7.5-0
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.7.5-0`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.7.4-0`

## can_msgs

- No changes

## canopen_402

- No changes

## canopen_chain_node

```
* added reset_errors_before_recover option
* Contributors: Mathias Lüdtke
```

## canopen_master

```
* added EMCYHandler::resetErrors
* added VectorHelper::callFunc
  generalized call templates
* Contributors: Mathias Lüdtke
```

## canopen_motor_node

- No changes

## ros_canopen

- No changes

## socketcan_bridge

- No changes

## socketcan_interface

```
* fix rosdep dependency on kernel headers
* Contributors: Mathias Lüdtke
```
