### PR TITLE
catkin_pip: 0.2.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -451,7 +451,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/asmodehn/catkin_pip-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pip.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pip` to `0.2.2-0`:

- upstream repository: https://github.com/asmodehn/catkin_pip.git
- release repository: https://github.com/asmodehn/catkin_pip-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.1-0`

## catkin_pip

```
* Merge pull request #123 <https://github.com/asmodehn/catkin_pip/issues/123> from yotabits/devel
  Added option NOSE_OPT to catkin_add_nosetests func
* Added option NOSE_OPT to catkin_add_nosetests func
  In order to use some specific option for nosetests we now have a NOSE_OPT
  parameter that allow to use some customs options for launching nosetests
  The same has been done for pytests with the param PYTEST_OPT
* Contributors: AlexV, Thomas
```
