### PR TITLE
Adding packages to documentation index for kinetic and indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -450,6 +450,11 @@ repositories:
       type: git
       url: https://github.com/ethz-asl/asctec_mav_framework.git
       version: master
+  asr_fake_object_recognition:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_fake_object_recognition.git
+      version: master
   asr_flir_ptu_controller:
     doc:
       type: git
@@ -469,6 +474,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/asr-ros/asr_gazebo_models.git
+      version: master
+  asr_halcon_bridge:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_halcon_bridge.git
       version: master
   asr_ivt:
     doc:
@@ -525,10 +535,20 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_navfn.git
       version: master
+  asr_object_database:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_object_database.git
+      version: master
   asr_rapidxml:
     doc:
       type: git
       url: https://github.com/asr-ros/asr_rapidxml.git
+      version: master
+  asr_resources_for_vision:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_resources_for_vision.git
       version: master
   asr_robot_model_services:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -495,6 +495,11 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_rapidxml.git
       version: master
+  asr_ros_uri:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ros_uri.git
+      version: master
   astra_camera:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -490,6 +490,11 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_navfn.git
       version: master
+  asr_rapidxml:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_rapidxml.git
+      version: master
   astra_camera:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -455,6 +455,16 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_ftc_local_planner.git
       version: master
+  asr_ivt:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ivt.git
+      version: master
+  asr_ivt_bridge:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ivt_bridge.git
+      version: master
   asr_mild_base_driving:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -510,6 +510,11 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_ros_uri.git
       version: master
+  asr_xsd2cpp:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_xsd2cpp.git
+      version: master
   astra_camera:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -180,6 +180,11 @@ repositories:
       url: https://github.com/AutonomyLab/ardrone_autonomy.git
       version: indigo-devel
     status: developed
+  asr_fake_object_recognition:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_fake_object_recognition.git
+      version: master
   asr_flir_ptu_controller:
     doc:
       type: git
@@ -199,6 +204,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/asr-ros/asr_gazebo_models.git
+      version: master
+  asr_halcon_bridge:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_halcon_bridge.git
       version: master
   asr_ivt:
     doc:
@@ -255,10 +265,20 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_navfn.git
       version: master
+  asr_object_database:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_object_database.git
+      version: master
   asr_rapidxml:
     doc:
       type: git
       url: https://github.com/asr-ros/asr_rapidxml.git
+      version: master
+  asr_resources_for_vision:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_resources_for_vision.git
       version: master
   asr_robot_model_services:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -219,6 +219,11 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_ros_uri.git
       version: master
+  asr_xsd2cpp:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_xsd2cpp.git
+      version: master
   astra_camera:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -204,6 +204,11 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_rapidxml.git
       version: master
+  asr_ros_uri:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ros_uri.git
+      version: master
   astra_camera:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -199,6 +199,11 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_navfn.git
       version: master
+  asr_rapidxml:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_rapidxml.git
+      version: master
   astra_camera:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -164,6 +164,16 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_ftc_local_planner.git
       version: master
+  asr_ivt:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ivt.git
+      version: master
+  asr_ivt_bridge:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ivt_bridge.git
+      version: master
   asr_mild_base_driving:
     doc:
       type: git


### PR DESCRIPTION
I would like our packages asr_fake_object_recognition, asr_halcon_bridge, asr_object_database and asr_resources_for_vision to be documented