### PR TITLE
p2os: 2.0.6-2 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1339,7 +1339,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
-      version: 2.0.6-0
+      version: 2.0.6-2
     source:
       type: git
       url: https://github.com/allenh1/p2os.git


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `2.0.6-2`:

- upstream repository: https://github.com/allenh1/p2os
- release repository: https://github.com/allenh1/p2os-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.0.6-0`

## p2os_doc

```
* Updated p2os_doc email address.
* Contributors: Hunter L. Allen
```

## p2os_driver

- No changes

## p2os_launch

```
* Added an enable motors launch file.
* Contributors: Hunter L. Allen
```

## p2os_msgs

- No changes

## p2os_teleop

- No changes

## p2os_urdf

```
* Change mass to more reasonable value.
* Clean up indentation.
* Clean up obsolete xml-schema namespaces.
* Remove obsolete files.
* Fix swivel joint.
* Add plugin for publishing ground truth odometry (position and velocity).
* Add and configure differential drive plugin.
  Seems to behave reasonably.
  There is an issue with the swivel which seems to break off randomly.
* Clean up and simplify collisions.
* Remove deprecated elem tag.
  Promote its attributes mu1, mu2, kp, kd to tags.
* Fix xacro deprecation warnings.
* Fix xacro deprecated warnings.
* Remove visual names in wheel descriptions...
  ...due to SDF bug https://bitbucket.org/osrf/sdformat/issues/132/parser-does-not-handle-urdf-material
* Use wheel descriptions from pioneer3dx_wheel.xacro.
  Remove invalid collision element from wheel definition.
  Comment out transmission element for now.
* Remove visual names.
  Visual names prevented Gazebo from rendering material colors, as per this issue: https://bitbucket.org/osrf/sdformat/issues/132/parser-does-not-handle-urdf-material
* Fix crash on model spawn in Gazebo.
  Remove zero-sized collision elements, as per this thread: http://answers.gazebosim.org/question/15816/gazebo-crashes-when-spawning-robot-from-urdf/
* Contributors: Damjan Miklic
```
