### PR TITLE
ecto: 0.6.12-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -346,6 +346,17 @@ repositories:
       url: https://github.com/ros/dynamic_reconfigure.git
       version: master
     status: maintained
+  ecto:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/ecto-release.git
+      version: 0.6.12-0
+    source:
+      type: git
+      url: https://github.com/plasmodic/ecto.git
+      version: master
+    status: maintained
   eigen_stl_containers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto` to `0.6.12-0`:

- upstream repository: https://github.com/plasmodic/ecto.git
- release repository: https://github.com/ros-gbp/ecto-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## ecto

```
* fix tests on Kinetic
* fix PySide dependency
* add missing implementation for executing
  That fixes #233 <https://github.com/plasmodic/ecto/issues/233>
* install the ecto library of test cells for users to utilise in their own tests.
* checking for ecto-test target existence
* Contributors: Daniel Stonier, Vincent Rabaud, edgarriba
```
