### PR TITLE
calibration: 0.10.14-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -124,6 +124,34 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: master
     status: maintained
+  calibration:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/calibration.git
+      version: hydro
+    release:
+      packages:
+      - calibration
+      - calibration_estimation
+      - calibration_launch
+      - calibration_msgs
+      - calibration_setup_helper
+      - image_cb_detector
+      - interval_intersection
+      - joint_states_settler
+      - laser_cb_detector
+      - monocam_settler
+      - settlerlib
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/calibration-release.git
+      version: 0.10.14-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/calibration.git
+      version: hydro
+    status: maintained
   camera_info_manager_py:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `calibration` to `0.10.14-0`:

- upstream repository: http://github.com/ros-perception/calibration.git
- release repository: https://github.com/ros-gbp/calibration-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## calibration

- No changes

## calibration_estimation

```
* remove useless dependency
* fix bad PyKDL usage
  fixes #39 <https://github.com/ros-perception/calibration/issues/39>
* get rid of the tf dependency
* Contributors: Vincent Rabaud
```

## calibration_launch

- No changes

## calibration_msgs

- No changes

## calibration_setup_helper

- No changes

## image_cb_detector

```
* simplify OpenCV3 dependency
* Contributors: Vincent Rabaud
```

## interval_intersection

- No changes

## joint_states_settler

- No changes

## laser_cb_detector

- No changes

## monocam_settler

- No changes

## settlerlib

- No changes
