### PR TITLE
rosparam_handler: 0.1.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5796,6 +5796,17 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: jade-devel
     status: maintained
+  rosparam_handler:
+    doc:
+      type: git
+      url: https://github.com/cbandera/rosparam_handler.git
+      version: 0.1.1
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/cbandera/rosparam_handler-release.git
+      version: 0.1.1-0
+    status: maintained
   rosparam_shortcuts:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5800,12 +5800,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/cbandera/rosparam_handler.git
-      version: 0.1.1
+      version: master
     release:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/cbandera/rosparam_handler-release.git
       version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/cbandera/rosparam_handler.git
+      version: master
     status: maintained
   rosparam_shortcuts:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_handler` to `0.1.1-0`:

- upstream repository: https://github.com/cbandera/rosparam_handler.git
- release repository: https://github.com/cbandera/rosparam_handler-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## rosparam_handler

```
* Initial release of rosparam_handler
* Contributors: Claudio Bandera, Fabian Poggenhans, Jeremie Deray, Matthias Füller, Nikolaus Demmel, Sascha Wirges, artivis
```
