### PR TITLE
Adding innok_heros_driver to documentation index for Jade

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2080,6 +2080,16 @@ repositories:
       url: https://github.com/ros-industrial/industrial_core.git
       version: jade
     status: maintained
+  innok_heros_driver:
+    doc:
+      type: git
+      url: https://github.com/innok-robotics/innok_heros_driver.git
+      version: jade
+    source:
+      type: git
+      url: https://github.com/innok-robotics/innok_heros_driver.git
+      version: jade
+    status: maintained
   interactive_marker_proxy:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2083,11 +2083,11 @@ repositories:
   innok_heros_driver:
     doc:
       type: git
-      url: https://github.com/innok-robotics/innok_heros_driver.git
+      url: https://github.com/innokrobotics/innok_heros_driver.git
       version: jade
     source:
       type: git
-      url: https://github.com/innok-robotics/innok_heros_driver.git
+      url: https://github.com/innokrobotics/innok_heros_driver.git
       version: jade
     status: maintained
   interactive_marker_proxy:


### PR DESCRIPTION
I'd like to add innok_heros_driver to documentation index for Jade