### PR TITLE
move_base_to_manip: 1.0.17-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3463,7 +3463,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip-release.git
-      version: 1.0.15-0
+      version: 1.0.17-0
     source:
       type: git
       url: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_to_manip` to `1.0.17-0`:

- upstream repository: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip.git
- release repository: https://github.com/UTNuclearRoboticsPublic/move_base_to_manip-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.15-0`
