### PR TITLE
jekyll dependency - gentoo

### DIFF
--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -26,6 +26,7 @@ hoe:
   gentoo: [dev-ruby/hoe]
   ubuntu: [ruby-hoe]
 jekyll:
+  gentoo: [www-apps/jekyll]
   ubuntu:
     precise:
       gem:


### PR DESCRIPTION
```
* www-apps/jekyll
     Available versions:  ~3.1.6-r1 ~3.2.1-r2 {doc test ELIBC="FreeBSD" RUBY_TARGETS="ruby21 ruby22"}
     Homepage:            http://jekyllrb.com https://github.com/jekyll/jekyll
     Description:         A simple, blog aware, static site generator
```