### PR TITLE
Adding tango_ros_streamer to documentation index for indigo and kinetic

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14196,6 +14196,11 @@ repositories:
       url: https://github.com/openrobotics/talos_description.git
       version: indigo-devel
     status: developed
+  tango_ros_streamer:
+    doc:
+      type: git
+      url: https://github.com/Intermodalics/tango_ros.git
+      version: master
   tblib:
     release:
       tags:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7539,6 +7539,11 @@ repositories:
       url: https://github.com/swri-robotics/swri_console.git
       version: master
     status: developed
+  tango_ros_streamer:
+    doc:
+      type: git
+      url: https://github.com/Intermodalics/tango_ros.git
+      version: master
   tblib:
     release:
       tags:


### PR DESCRIPTION
I would like [tango_ros_streamer](http://wiki.ros.org/tango_ros_streamer) to be indexed and documented on ros.org.