### PR TITLE
phidgets_drivers: 0.7.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1433,6 +1433,27 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: lunar-devel
     status: maintained
+  phidgets_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: lunar
+    release:
+      packages:
+      - libphidget21
+      - phidgets_api
+      - phidgets_drivers
+      - phidgets_imu
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
+      version: 0.7.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: lunar
+    status: developed
   pid:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `0.7.2-0`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## libphidget21

- No changes

## phidgets_api

- No changes

## phidgets_drivers

- No changes

## phidgets_imu

```
* First release into Lunar
* phidgets_imu: Add use_magnetic_field_msg to launch
  This is required in Jade: Since Jade, phidgets_imu publishes
  MagneticField messages, but imu_filter_madgwick still subscribes by
  default to Vector3Stamped messages. When running as nodelets, this can
  produce a silent error.
  In Kinetic, this is optional: imu_filter_madgwick now defaults to
  MagneticField.
  From Lunar on, it should be removed, because the use_magnetic_field_msg
  param was removed from imu_filter_madgwick.
* Contributors: Martin Günther
```
