### PR TITLE
katana_driver: 1.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5387,7 +5387,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uos-gbp/katana_driver-release.git
-      version: 1.0.7-0
+      version: 1.1.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `katana_driver` to `1.1.2-0`:

- upstream repository: https://github.com/uos/katana_driver.git
- release repository: https://github.com/uos-gbp/katana_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.7-0`

## katana

- No changes

## katana_arm_gazebo

- No changes

## katana_description

- No changes

## katana_driver

- No changes

## katana_gazebo_plugins

- No changes

## katana_moveit_ikfast_plugin

```
* ikfast plugin: regenerated with newest moveit_ikfast
* Update update_ikfast_plugin.sh
* Contributors: Martin Günther
```

## katana_msgs

- No changes

## katana_teleop

- No changes

## katana_tutorials

- No changes

## kni

```
* kni: Build with c++11, fix warnings
* Contributors: Martin Günther
```
