### PR TITLE
Add librdkafka-dev to rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2620,6 +2620,10 @@ libraw1394-dev:
     portage:
       packages: [sys-libs/libraw1394]
   ubuntu: [libraw1394-dev]
+librdkafka-dev:
+  debian: [librdkafka-dev]
+  gentoo: [dev-libs/librdkafka]
+  ubuntu: [librdkafka-dev]
 libreadline:
   arch: [readline]
   debian: [libreadline-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2622,6 +2622,7 @@ libraw1394-dev:
   ubuntu: [libraw1394-dev]
 librdkafka-dev:
   debian: [librdkafka-dev]
+  fedora: [librdkafka-devel]
   gentoo: [dev-libs/librdkafka]
   ubuntu: [librdkafka-dev]
 libreadline:


### PR DESCRIPTION
Add key for [librdkafka](https://github.com/edenhill/librdkafka), a C/C++ library for the [Kafka](https://kafka.apache.org/) project.

debian: https://packages.debian.org/jessie/librdkafka-dev
gentoo: https://packages.gentoo.org/packages/dev-libs/librdkafka
ubuntu: https://packages.ubuntu.com/xenial/librdkafka-dev