### PR TITLE
rtmros_hironx: 1.1.25-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12720,7 +12720,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.24-0
+      version: 1.1.25-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `1.1.25-0`:

- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.1.24-0`

## hironx_calibration

- No changes

## hironx_moveit_config

- No changes

## hironx_ros_bridge

```
* [QNX log fetch] Fix to get it working again.
* [QNX log fetch] Add a feature to remove existing .log files on QNX to save disk space. #508 <https://github.com/start-jsk/rtmros_hironx/pull/508>
* Contributors: Isaac I.Y. Saito
```

## rtmros_hironx

```
* [QNX log fetch] Fix to get it working again.
* [QNX log fetch] Add a feature to remove existing .log files on QNX to save disk space. #508 <https://github.com/start-jsk/rtmros_hironx/pull/508>
* Contributors: Isaac I.Y. Saito
```
