### PR TITLE
rosdoc_lite: 0.2.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5671,7 +5671,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rosdoc_lite-release.git
-      version: 0.2.6-0
+      version: 0.2.7-0
     source:
       type: git
       url: https://github.com/ros-infrastructure/rosdoc_lite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosdoc_lite` to `0.2.7-0`:

- upstream repository: https://github.com/ros-infrastructure/rosdoc_lite.git
- release repository: https://github.com/ros-gbp/rosdoc_lite-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.6-0`

## rosdoc_lite

```
* fix import (#74 <https://github.com/ros-infrastructure/rosdoc_lite/issues/74>)
* add ability to configure the doxygen parameter EXTRACT_ALL (#72 <https://github.com/ros-infrastructure/rosdoc_lite/issues/72>)
* more correct reference to the package website url (#68 <https://github.com/ros-infrastructure/rosdoc_lite/issues/68>)
* get rid of HTML static path, so build farm quits complaining
* Contributors: Daniel Stonier, Dirk Thomas, Jack O'Quin, Levi Armstrong
```
