### PR TITLE
rosdoc_lite: 0.2.7-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1948,6 +1948,21 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: kinetic-devel
     status: maintained
+  rosdoc_lite:
+    doc:
+      type: git
+      url: https://github.com/ros-infrastructure/rosdoc_lite.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/rosdoc_lite-release.git
+      version: 0.2.7-0
+    source:
+      type: git
+      url: https://github.com/ros-infrastructure/rosdoc_lite.git
+      version: master
+    status: maintained
   roslint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosdoc_lite` to `0.2.7-0`:

- upstream repository: https://github.com/ros-infrastructure/rosdoc_lite.git
- release repository: https://github.com/ros-gbp/rosdoc_lite-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rosdoc_lite

```
* fix import (#74 <https://github.com/ros-infrastructure/rosdoc_lite/issues/74>)
* add ability to configure the doxygen parameter EXTRACT_ALL (#72 <https://github.com/ros-infrastructure/rosdoc_lite/issues/72>)
* more correct reference to the package website url (#68 <https://github.com/ros-infrastructure/rosdoc_lite/issues/68>)
* get rid of HTML static path, so build farm quits complaining
* Contributors: Daniel Stonier, Dirk Thomas, Jack O'Quin, Levi Armstrong
```
