### PR TITLE
rosflight: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6165,7 +6165,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosflight/rosflight-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/rosflight/rosflight.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosflight` to `0.1.3-0`:

- upstream repository: https://github.com/rosflight/rosflight.git
- release repository: https://github.com/rosflight/rosflight-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.2-0`

## rosflight

```
* Temporarily removed magnetometer calibration
* Updated package.xml files
* Renamed sonar/data topic to sonar
* Changed yaml-cpp dependency to a PkgConfig module
* Contributors: Daniel Koch
```

## rosflight_msgs

```
* Updated package.xml files
* Contributors: Daniel Koch
```

## rosflight_pkgs

```
* Updated package.xml files
* Contributors: Daniel Koch
```

## rosflight_utils

```
* Updated package.xml files
* Contributors: Daniel Koch
```
