### PR TITLE
Updated ogre dep to 1.9 for arch.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2069,7 +2069,7 @@ libogg:
   slackware: [libogg]
   ubuntu: [libogg-dev]
 libogre-dev:
-  arch: [ogre]
+  arch: [ogre-1.9]
   debian:
     jessie: [libogre-1.9-dev]
     sid: [libogre-1.9-dev]


### PR DESCRIPTION
Simple fix here. The official ogre package on arch has moved to 1.10, which breaks things. Updates the arch libogre-dev alias to ogre-1.9, an AUR package that builds the supported version of ogre.