### PR TITLE
add w1thermsensor for debian

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3081,6 +3081,9 @@ python-w1thermsensor-pip:
   debian:
     pip:
       packages: [w1thermsensor]
+  ubuntu:
+    pip:
+      packages: [w1thermsensor]
 python-waitress:
   debian: [python-waitress]
   fedora: [python-waitress]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3077,6 +3077,10 @@ python-vtk:
     vivid: [python-vtk]
     wily: [python-vtk]
     xenial: [python-vtk6]
+python-w1thermsensor-pip:
+  debian:
+    pip:
+      packages: [w1thermsensor]
 python-waitress:
   debian: [python-waitress]
   fedora: [python-waitress]


### PR DESCRIPTION
[w1thermsensor](https://pypi.python.org/pypi/w1thermsensor) is useful for interfacing with a [ds18b20 temperature sensor](https://www.adafruit.com/product/381) on a raspberry pi