### PR TITLE
moveit: 0.9.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3548,7 +3548,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.9.6-0
+      version: 0.9.7-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.9.7-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.9.6-0`

## moveit

```
* [fix][ikfast_kinematics_plugin][Kinetic+] Add c++11 compile option #515 <https://github.com/ros-planning/moveit/pull/515>
* [fix][moveit_kinematics][Indigo] Eigen3 dependency (#470 <https://github.com/ros-planning/moveit/issues/470>)
* [fix][moveit_ros] Build for Ubuntu YZ by adding BOOST_MATH_DISABLE_FLOAT128 (#505 <https://github.com/ros-planning/moveit/issues/505>)
* [fix][moveit_core] checks for empty name arrays messages before parsing the robot state message data (#499 <https://github.com/ros-planning/moveit/issues/499>)
* [capability][visualization] New panel with a slider to control the visualized trajectory (#491 <https://github.com/ros-planning/moveit/issues/491>) (#508 <https://github.com/ros-planning/moveit/issues/508>)
* [improve][MSA] Open a directory where setup_assistant.launch was started. (#509 <https://github.com/ros-planning/moveit/issues/509>)
* Contributors: Jorge Nicho, Michael Goerner, Martin Guenther, YuehChuan, Dave Coleman, Isaac I.Y. Saito, Mikael Arguedas
```

## moveit_commander

- No changes

## moveit_controller_manager_example

- No changes

## moveit_core

```
* [fix] checks for empty name arrays messages before parsing the robot state message data (#499 <https://github.com/ros-planning/moveit/issues/499>)
* Contributors: Jorge Nicho, Michael Goerner
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

```
* [fix][Kinetic+] ikfast_kinematics_plugin: Add c++11 compile option #515 <https://github.com/ros-planning/moveit/pull/515>
* [fix][Indigo] moveit_kinematics Eigen3 dependency (#470 <https://github.com/ros-planning/moveit/issues/470>)
* Contributors: Martin Guenther, YuehChuan
```

## moveit_planners

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

- No changes

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* [capability] New panel with a slider to control the visualized trajectory (#491 <https://github.com/ros-planning/moveit/issues/491>) (#508 <https://github.com/ros-planning/moveit/issues/508>)
* [fix] Build for Ubuntu YZ by adding BOOST_MATH_DISABLE_FLOAT128 (#505 <https://github.com/ros-planning/moveit/issues/505>)
* Contributors: Dave Coleman, Mikael Arguedas
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_setup_assistant

```
* [fix] Build for Ubuntu YZ by adding BOOST_MATH_DISABLE_FLOAT128 (#505 <https://github.com/ros-planning/moveit/issues/505>)
* [improve][MSA] Open a directory where setup_assistant.launch was started. (#509 <https://github.com/ros-planning/moveit/issues/509>)
* Contributors: Isaac I.Y. Saito, Mikael Arguedas
```

## moveit_simple_controller_manager

- No changes
