### PR TITLE
rviz: 1.11.16-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6695,7 +6695,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.11.15-0
+      version: 1.11.16-0
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.11.16-0`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.11.15-0`

## rviz

```
* indigo-devel backports from kinetic-devel (1.12.9) (#1110 <https://github.com/ros-visualization/rviz/issues/1110>)
  * Add fullscreen option (#1017 <https://github.com/ros-visualization/rviz/issues/1017>)
  * Added compatibility with newer urdfdom versions (#1064 <https://github.com/ros-visualization/rviz/issues/1064>)
  * Display is now updated if an empty pointcloud2 is published (#1073 <https://github.com/ros-visualization/rviz/issues/1073>)
  * The render panel is now scaled correctly on high resolution displays (#1078 <https://github.com/ros-visualization/rviz/issues/1078>)
  * Now supports multiple materials per link in robot display (urdf) (fixed) (#1079 <https://github.com/ros-visualization/rviz/issues/1079>)
  * Fixed duplicate property name for Path colors which prevent saving correctly to the config file (#1089 <https://github.com/ros-visualization/rviz/issues/1089>)
* Now supports multiple materials for one link in robot display (urdf) (#1080 <https://github.com/ros-visualization/rviz/issues/1080>)
* Fixed visualization of collada textures in markers (#1084 <https://github.com/ros-visualization/rviz/issues/1084>)
* Contributors: Kei Okada, Marieke Copejans, William Woodall
```
