### PR TITLE
[WIP][test] Check if wiki.ros.org/PKG_NAME exists.

### DIFF
--- a/test/test_build_caches.py
+++ b/test/test_build_caches.py
@@ -1,5 +1,7 @@
 from collections import OrderedDict
+import httplib
 import os
+from urlparse import urlparse
 
 from catkin_pkg.package import parse_package_string
 from ros_buildfarm.common import topological_order_packages
@@ -11,6 +13,24 @@ from scripts import eol_distro_names
 from .fold_block import Fold
 
 INDEX_YAML = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'index.yaml'))
+
+
+def exists_webpage(pkg_name, pkgweb_root='http://wiki.ros.org/'):
+    '''
+    @summary: Returns false if a wiki page of the given package does not exist.
+    @type pkg_name: str
+    @rtype: bool
+    @raise RuntimeError: When the webpage not existent.
+    '''
+    url = pkgweb_root + pkg_name
+    p = urlparse(url)
+    conn = httplib.HTTPConnection(p.netloc)
+    conn.request('HEAD', p.path)
+    resp = conn.getresponse()
+    print('[DEBUG] {}: http response: {}'.format(pkg_name, resp.status))
+    if 200 < resp.status:
+        raise RuntimeError('{}: pkg does not exist. Open the URL, create one now.'.format(url))
+    return True
 
 
 def test_build_caches():
@@ -33,6 +53,12 @@ If this fails you can run 'rosdistro_build_cache index.yaml' to perform the same
                     errors.append(str(e))
                 else:
                     caches[dist_name] = cache
+
+                #for pkg_name, pkg_xml in cache.release_package_xmls.items():
+                #    try:
+                #        exists_webpage(pkg_name)
+                #    except RuntimeError as e:
+                #        errors.append('%s' % (e))
 
         # also check topological order to prevent circular dependencies
         for dist_name, cache in caches.items():


### PR DESCRIPTION
**Background**
Currently AFAIK there's no mechanism to check if a page on wiki.ros.org for the packages listed on rosdistro exist. Some/many of them are missing because of that.

**Approach**
Check if the corresponding wiki page exists (i.e. not "does not exist").

**Limitation**
At the time of this commit, the added check is commented out, as it does NOT work as intended
(with the commented-out code, test checks all listed packages and accesses wiki.ros.org, most of which result in http status code 503, probably due to web server's regulation).

Checking the packages that are ONLY included in the pull request should improve the situation, but the author couldn't implement a way to do so.

Question-1. Is this feature something we might want to add?
Question-2. Is there already way existing to get package names from the pull request diff?