### PR TITLE
Adding additional rosdep rules for Python packages

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -138,6 +138,10 @@ python-amqp:
     vivid: [python-amqp]
     wily: [python-amqp]
     xenial: [python-amqp]
+python-annoy-pip:
+  ubuntu:
+    pip:
+      packages: [annoy]
 python-anyjson:
   debian: [python-anyjson]
   fedora: [python-anyjson]
@@ -767,6 +771,8 @@ python-fcn-pip:
     pip:
       depends: [libhdf5-dev, liblapack-dev]
       packages: [fcn]
+python-fixtures:
+  ubuntu: [python-fixtures]
 python-flake8:
   fedora:
     '21': [python-flake8]
@@ -858,6 +864,10 @@ python-future:
     xenial: [python-future]
     yakkety: [python-future]
     zesty: [python-future]
+python-fuzzywuzzy-pip:
+  ubuntu:
+    pip:
+      packages: [fuzzywuzzy]
 python-fysom:
   debian:
     pip:
@@ -922,6 +932,10 @@ python-gitpython-pip:
   ubuntu:
     pip:
       packages: [gitpython]
+python-google-cloud-vision-pip:
+  ubuntu:
+    pip:
+      packages: [google-cloud-vision]
 python-googleapi:
   debian: [python-googleapi]
   fedora: [google-api-python-client]
@@ -1144,6 +1158,8 @@ python-kombu-pip:
   ubuntu:
     pip:
       packages: [kombu]
+python-levenshtein:
+  ubuntu: [python-levenshtein]
 python-libpcap:
   debian: [python-libpcap]
   fedora: [pylibpcap]
@@ -1705,6 +1721,10 @@ python-progressbar:
     vivid: [python-progressbar]
     wily: [python-progressbar]
     xenial: [python-progressbar]
+python-progressbar2-pip:
+  ubuntu:
+    pip:
+      packages: [progressbar2]    
 python-psutil:
   arch: [python2-psutil]
   debian: [python-psutil]
@@ -2820,6 +2840,10 @@ python-termcolor:
     wily: [python-termcolor]
     xenial: [python-termcolor]
     xenial_python3: [python3-termcolor]
+python-testscenarios:
+  ubuntu: [python-testscenarios]
+python-testtools:
+  ubuntu: [python-testtools]    
 python-texttable:
   arch: [python2-texttable]
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1724,7 +1724,7 @@ python-progressbar:
 python-progressbar2-pip:
   ubuntu:
     pip:
-      packages: [progressbar2]    
+      packages: [progressbar2]
 python-psutil:
   arch: [python2-psutil]
   debian: [python-psutil]
@@ -2843,7 +2843,7 @@ python-termcolor:
 python-testscenarios:
   ubuntu: [python-testscenarios]
 python-testtools:
-  ubuntu: [python-testtools]    
+  ubuntu: [python-testtools]
 python-texttable:
   arch: [python2-texttable]
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -139,6 +139,12 @@ python-amqp:
     wily: [python-amqp]
     xenial: [python-amqp]
 python-annoy-pip:
+  debian:
+    pip:
+      packages: [annoy]
+  fedora:
+    pip:
+      packages: [annoy]
   ubuntu:
     pip:
       packages: [annoy]
@@ -772,6 +778,8 @@ python-fcn-pip:
       depends: [libhdf5-dev, liblapack-dev]
       packages: [fcn]
 python-fixtures:
+  debian: [python-fixtures]
+  fedora: [python-fixtures]
   ubuntu: [python-fixtures]
 python-flake8:
   fedora:
@@ -865,6 +873,12 @@ python-future:
     yakkety: [python-future]
     zesty: [python-future]
 python-fuzzywuzzy-pip:
+  debian:
+    pip:
+      packages: [fuzzywuzzy]
+  fedora:
+    pip:
+      packages: [fuzzywuzzy]
   ubuntu:
     pip:
       packages: [fuzzywuzzy]
@@ -933,6 +947,12 @@ python-gitpython-pip:
     pip:
       packages: [gitpython]
 python-google-cloud-vision-pip:
+  debian:
+    pip:
+      packages: [google-cloud-vision]
+  fedora:
+    pip:
+      packages: [google-cloud-vision]
   ubuntu:
     pip:
       packages: [google-cloud-vision]
@@ -1159,6 +1179,8 @@ python-kombu-pip:
     pip:
       packages: [kombu]
 python-levenshtein:
+  debian: [python-levenshtein]
+  fedora: [python-Levenshtein]
   ubuntu: [python-levenshtein]
 python-libpcap:
   debian: [python-libpcap]
@@ -1722,6 +1744,12 @@ python-progressbar:
     wily: [python-progressbar]
     xenial: [python-progressbar]
 python-progressbar2-pip:
+  debian:
+    pip:
+      packages: [progressbar2]
+  fedora:
+    pip:
+      packages: [progressbar2]
   ubuntu:
     pip:
       packages: [progressbar2]
@@ -2841,8 +2869,12 @@ python-termcolor:
     xenial: [python-termcolor]
     xenial_python3: [python3-termcolor]
 python-testscenarios:
+  debian: [python-testscenarios]
+  fedora: [python-testscenarios]
   ubuntu: [python-testscenarios]
 python-testtools:
+  debian: [python-testtools]
+  fedora: [python-testtools]
   ubuntu: [python-testtools]
 python-texttable:
   arch: [python2-texttable]


### PR DESCRIPTION
apt: ```python-fixtures, python-testscenarios, python-testtools, python-levenshtein```
pip: ```annoy, google-cloud-vision, progressbar2, fuzzywuzzy```

All have been tested locally.

