### PR TITLE
oculusprime: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7998,7 +7998,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/xaxxontech/oculusprime_ros-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/xaxxontech/oculusprime_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `oculusprime` to `0.1.2-0`:

- upstream repository: https://github.com/xaxxontech/oculusprime_ros.git
- release repository: https://github.com/xaxxontech/oculusprime_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.1-0`

## oculusprime

```
* add empty param folder
* package.xml updated
* Contributors: xaxxontech
```
