### PR TITLE
binpicking_utils: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -557,7 +557,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/durovsky/binpicking_utils.git
-      version: git
+      version: master
     release:
       packages:
       - bin_pose_emulator
@@ -570,7 +570,8 @@ repositories:
     source:
       type: git
       url: https://github.com/durovsky/binpicking_utils.git
-      version: git
+      version: master
+    status: maintained
   bond_core:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -553,6 +553,24 @@ repositories:
       url: https://github.com/ros-gbp/bfl-release.git
       version: upstream
     status: maintained
+  binpicking_utils:
+    doc:
+      type: git
+      url: https://github.com/durovsky/binpicking_utils.git
+      version: git
+    release:
+      packages:
+      - bin_pose_emulator
+      - bin_pose_msgs
+      - binpicking_utils
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/durovsky/binpicking_utils-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/durovsky/binpicking_utils.git
+      version: git
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `binpicking_utils` to `0.1.1-0`:

- upstream repository: https://github.com/durovsky/binpicking_utils.git
- release repository: https://github.com/durovsky/binpicking_utils-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## bin_pose_emulator

```
* moving .travis.yml
* initial commit
* initial commit
* Contributors: Frantisek Durovsky
```

## bin_pose_msgs

```
* initial commit
* Contributors: Frantisek Durovsky
```

## binpicking_utils

```
* initial commit
* Contributors: Frantisek Durovsky
```
