### PR TITLE
Add gpsd (with the gpsd daemon) to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -949,6 +949,11 @@ gperftools:
   fedora: [gperftools, gperftools-devel]
   gentoo: [dev-util/gperf]
   ubuntu: [google-perftools, libgoogle-perftools-dev]
+gpsd:
+  debian: [gpsd]
+  fedora: [gpsd]
+  gentoo: [sci-geosciences/gpsd]
+  ubuntu: [gpsd]
 gradle:
   arch: [gradle]
   fedora: [gradle]


### PR DESCRIPTION
This counters https://github.com/ros/rosdistro/commit/8a0122e41849e469f926ed54bda24cd8907c4b37 from 2012, which removed gpsd in favor of libgps-dev but libgps-dev (currently) only *suggests* the installation of gpsd and does not actually install that daemon