### PR TITLE
roscpp_core: 0.6.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1941,7 +1941,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.6.4-0`:

- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.6.3-0`

## cpp_common

- No changes

## roscpp_serialization

- No changes

## roscpp_traits

- No changes

## rostime

```
* add logic to support steady time on macOS (regression of 0.6.3) (#59 <https://github.com/ros/roscpp_core/pull/59>)
```
