### PR TITLE
Modified pathtools to python-pathtools

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8484,6 +8484,13 @@ repositories:
       url: https://github.com/AutonomyLab/parrot_arsdk.git
       version: indigo-devel
     status: developed
+  pathtools:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yotabits/pathtools-release.git
+      version: 0.1.2-0
+    status: maintained
   patrolling_sim:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8484,13 +8484,6 @@ repositories:
       url: https://github.com/AutonomyLab/parrot_arsdk.git
       version: indigo-devel
     status: developed
-  pathtools:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/yotabits/pathtools-release.git
-      version: 0.1.2-0
-    status: maintained
   patrolling_sim:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4214,13 +4214,6 @@ repositories:
       url: https://github.com/AutonomyLab/parrot_arsdk.git
       version: indigo-devel
     status: developed
-  pathtools:
-    release:
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/yotabits/pathtools-release.git
-      version: 0.1.2-0
-    status: maintained
   patrolling_sim:
     doc:
       type: git
@@ -4737,6 +4730,13 @@ repositories:
       url: https://github.com/asmodehn/pyros-utils.git
       version: jade
     status: developed
+  python-pathtools:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/yotabits/python-pathtools-release.git
+      version: 0.1.2-0
+    status: maintained
   python_ethernet_rmp:
     doc:
       type: git


### PR DESCRIPTION
The name of the package has to be changed according to [this](https://github.com/ros/rosdistro/pull/15152) and [this](https://github.com/ros/rosdistro/pull/15095) discussion.