### PR TITLE
Clean Up Gentoo Deps

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -20,33 +20,25 @@ alsa-oss:
   arch: [alsa-oss]
   debian: [alsa-oss]
   fedora: [alsa-oss]
-  gentoo:
-    portage:
-      packages: [media-libs/alsa-oss]
+  gentoo: [media-libs/alsa-oss]
   ubuntu: [alsa-oss]
 alsa-utils:
   arch: [alsa-utils]
   debian: [alsa-utils]
   fedora: [alsa-utils]
-  gentoo:
-    portage:
-      packages: [media-sound/alsa-utils]
+  gentoo: [media-sound/alsa-utils]
   ubuntu: [alsa-utils]
 ant:
   arch: [apache-ant]
   debian: [ant]
   fedora: [ant]
-  gentoo:
-    portage:
-      packages: [dev-java/ant]
+  gentoo: [dev-java/ant]
   ubuntu: [ant]
 antlr:
   arch: [antlr]
   debian: [antlr, libantlr-dev]
   fedora: [antlr3-C, antlr-C++]
-  gentoo:
-    portage:
-      packages: [dev-java/antlr]
+  gentoo: [dev-java/antlr]
   ubuntu: [antlr, libantlr-dev]
 apache2-mpm-prefork:
   debian: [apache2-mpm-prefork]
@@ -80,9 +72,7 @@ armadillo:
   arch: [armadillo]
   debian: [libarmadillo-dev]
   fedora: [armadillo-devel]
-  gentoo:
-    portage:
-      packages: [sci-libs/armadillo]
+  gentoo: [sci-libs/armadillo]
   ubuntu: [libarmadillo-dev]
 asio:
   arch: [asio]
@@ -98,9 +88,7 @@ assimp:
     stretch: [libassimp-dev]
     wheezy: [libassimp-dev]
   fedora: [assimp]
-  gentoo:
-    portage:
-      packages: [media-libs/assimp]
+  gentoo: [media-libs/assimp]
   macports: [assimp]
   opensuse: [libassimp3]
   rhel: [assimp-devel]
@@ -129,9 +117,7 @@ assimp-dev:
     stretch: [libassimp-dev]
     wheezy: [libassimp-dev]
   fedora: [assimp-devel]
-  gentoo:
-    portage:
-      packages: [media-libs/assimp]
+  gentoo: [media-libs/assimp]
   opensuse: [libassimp3]
   rhel: [assimp-devel]
   slackware: [assimp]
@@ -155,9 +141,7 @@ atlas:
   arch: [atlas-lapack]
   debian: [libatlas-base-dev]
   fedora: [atlas-devel]
-  gentoo:
-    portage:
-      packages: [sci-libs/atlas]
+  gentoo: [sci-libs/atlas]
   macports: [atlas]
   ubuntu: [libatlas-base-dev]
 autoconf:
@@ -165,9 +149,7 @@ autoconf:
   debian: [autoconf]
   fedora: [autoconf]
   freebsd: [autoconf213, autoconf268]
-  gentoo:
-    portage:
-      packages: [sys-devel/autoconf]
+  gentoo: [sys-devel/autoconf]
   macports: [autoconf]
   opensuse: [autoconf]
   rhel: [autoconf]
@@ -177,9 +159,7 @@ automake:
   debian: [automake]
   fedora: [automake]
   freebsd: [automake14, automake111]
-  gentoo:
-    portage:
-      packages: [sys-devel/automake]
+  gentoo: [sys-devel/automake]
   macports: [automake]
   opensuse: [automake]
   rhel: [automake]
@@ -193,9 +173,7 @@ avahi-daemon:
   arch: [avahi]
   debian: [avahi-daemon]
   fedora: [avahi]
-  gentoo:
-    portage:
-      packages: [net-dns/avahi]
+  gentoo: [net-dns/avahi]
   ubuntu: [avahi-daemon]
 avahi-utils:
   arch: [avahi]
@@ -207,16 +185,12 @@ avr-libc:
   arch: [avr-libc]
   debian: [avr-libc]
   fedora: [avr-libc]
-  gentoo:
-    portage:
-      packages: [dev-embedded/avr-libc]
+  gentoo: [dev-embedded/avr-libc]
   ubuntu: [avr-libc]
 avrdude:
   arch: [avrdude]
   fedora: [avrdude]
-  gentoo:
-    portage:
-      packages: [dev-embedded/avrdude]
+  gentoo: [dev-embedded/avrdude]
   ubuntu: [avrdude]
 babeltrace:
   debian: [babeltrace]
@@ -228,9 +202,7 @@ bazaar:
   debian: [bzr]
   fedora: [bazaar]
   freebsd: [bazaar]
-  gentoo:
-    portage:
-      packages: [dev-vcs/bzr]
+  gentoo: [dev-vcs/bzr]
   macports: [bazaar]
   opensuse: [bzr]
   ubuntu: [bzr]
@@ -238,25 +210,19 @@ beep:
   arch: [beep]
   debian: [beep]
   fedora: [beep]
-  gentoo:
-    portage:
-      packages: [app-misc/beep]
+  gentoo: [app-misc/beep]
   ubuntu: [beep]
 binutils:
   arch: [binutils]
   debian: [binutils-dev]
   fedora: [binutils-devel]
-  gentoo:
-    portage:
-      packages: [sys-devel/binutils]
+  gentoo: [sys-devel/binutils]
   ubuntu: [binutils-dev]
 bison:
   arch: [bison]
   debian: [bison]
   fedora: [bison]
-  gentoo:
-    portage:
-      packages: [sys-devel/bison]
+  gentoo: [sys-devel/bison]
   macports: [bison]
   ubuntu: [bison]
 blender:
@@ -322,9 +288,7 @@ bullet:
   arch: [bullet]
   debian: [libbullet-dev]
   fedora: [bullet-devel]
-  gentoo:
-    portage:
-      packages: [sci-physics/bullet]
+  gentoo: [sci-physics/bullet]
   macports: [bullet]
   opensuse: [libbullet]
   ubuntu:
@@ -346,9 +310,7 @@ bzip2:
   debian: [libbz2-dev]
   fedora: [bzip2-devel]
   freebsd: [bzip2]
-  gentoo:
-    portage:
-      packages: [app-arch/bzip2]
+  gentoo: [app-arch/bzip2]
   macports: [bzip2]
   opensuse: [libbz2-devel]
   rhel: [bzip2-devel]
@@ -367,9 +329,7 @@ can-utils:
   fedora: [can-utils]
   ubuntu: [can-utils]
 catkin_pkg:
-  gentoo:
-    portage:
-      packages: [dev-python/catkin_pkg]
+  gentoo: [dev-python/catkin_pkg]
 cdk:
   fedora: [cdk]
   gentoo: [dev-libs/cdk]
@@ -382,9 +342,7 @@ cgal:
   arch: [cgal]
   debian: [libcgal-dev]
   fedora: [CGAL-devel]
-  gentoo:
-    portage:
-      packages: [sci-mathematics/cgal]
+  gentoo: [sci-mathematics/cgal]
   ubuntu: [libcgal-dev]
 checkinstall:
   arch: [checkinstall]
@@ -433,9 +391,7 @@ collada-dom:
   arch: [collada-dom]
   debian: [libcollada-dom2.4-dp-dev]
   fedora: [collada-dom-devel]
-  gentoo:
-    portage:
-      packages: [dev-libs/collada-dom]
+  gentoo: [dev-libs/collada-dom]
   macports: [collada-dom]
   slackware: [collada-dom]
   ubuntu:
@@ -467,18 +423,14 @@ couchdb:
   arch: [couchdb]
   debian: [couchdb]
   fedora: [couchdb]
-  gentoo:
-    portage:
-      packages: [dev-db/couchdb]
+  gentoo: [dev-db/couchdb]
   ubuntu: [couchdb]
 cppunit:
   arch: [cppunit]
   debian: [libcppunit-dev]
   fedora: [cppunit-devel]
   freebsd: [cppunit]
-  gentoo:
-    portage:
-      packages: [dev-util/cppunit]
+  gentoo: [dev-util/cppunit]
   macports: [cppunit]
   opensuse: [libcppunit-devel]
   rhel: [cppunit-devel]
@@ -493,9 +445,7 @@ curl:
   debian: [libcurl4-openssl-dev, curl]
   fedora: [libcurl-devel, curl]
   freebsd: [curl]
-  gentoo:
-    portage:
-      packages: [net-misc/curl]
+  gentoo: [net-misc/curl]
   macports: [curl]
   opensuse: [libcurl-devel, curl]
   rhel: [libcurl-devel, curl]
@@ -510,9 +460,7 @@ curlpp-dev:
 cvs:
   arch: [cvs]
   fedora: [cvs]
-  gentoo:
-    portage:
-      packages: [dev-vcs/cvs]
+  gentoo: [dev-vcs/cvs]
   ubuntu: [cvs]
 cwiid:
   arch: [cwiid]
@@ -536,9 +484,7 @@ cython:
 daemontools:
   arch: [daemontools]
   debian: [daemontools]
-  gentoo:
-    portage:
-      packages: [virtual/daemontools]
+  gentoo: [virtual/daemontools]
   ubuntu: [daemontools]
 dfu-util:
   debian: [dfu-util]
@@ -583,9 +529,7 @@ eclipse:
   arch: [eclipse, eclipse-rcp, eclipse-emf, eclipse-pde]
   debian: [eclipse, eclipse-rcp, eclipse-xsd, eclipse-pde]
   fedora: [eclipse-pde, eclipse-emf]
-  gentoo:
-    portage:
-      packages: [dev-java/ant-eclipse-ecj, dev-java/eclipse-ecj]
+  gentoo: [dev-java/ant-eclipse-ecj, dev-java/eclipse-ecj]
   ubuntu:
     karmic: [eclipse, eclipse-platform, eclipse-rcp, eclipse-pde]
     lucid: [eclipse, eclipse-platform, eclipse-rcp, eclipse-pde]
@@ -603,9 +547,7 @@ eigen:
     stretch: [libeigen3-dev]
     wheezy: [libeigen3-dev]
   fedora: [eigen3-devel]
-  gentoo:
-    portage:
-      packages: [dev-cpp/eigen]
+  gentoo: [dev-cpp/eigen]
   macports: [eigen3]
   opensuse: [libeigen3-devel]
   rhel: [eigen3-devel]
@@ -645,9 +587,7 @@ f2c:
   arch: [f2c]
   debian: [f2c, libf2c2, libf2c2-dev]
   fedora: [f2c, f2c-libs]
-  gentoo:
-    portage:
-      packages: [dev-lang/f2c]
+  gentoo: [dev-lang/f2c]
   ubuntu: [f2c, libf2c2, libf2c2-dev]
 fakeroot:
   debian: [fakeroot]
@@ -657,17 +597,13 @@ fcgi:
   arch: [fcgi, mod_fcgid, spawn-fcgi]
   debian: [libfcgi-dev, libapache2-mod-fastcgi, spawn-fcgi]
   fedora: [fcgi, mod_fcgid, spawn-fcgi]
-  gentoo:
-    portage:
-      packages: [dev-ruby/fcgi]
+  gentoo: [dev-ruby/fcgi]
   ubuntu: [libfcgi-dev, libapache2-mod-fastcgi, spawn-fcgi]
 festival:
   arch: [festival, festival-english]
   debian: [festival, festvox-kallpc16k]
   fedora: [festival, festvox-kal-diphone]
-  gentoo:
-    portage:
-      packages: [app-accessibility/festival]
+  gentoo: [app-accessibility/festival]
   ubuntu: [festival, festvox-kallpc16k]
 festival-dev:
   debian: [festival-dev]
@@ -837,9 +773,7 @@ gccxml:
   arch: [gccxml-git]
   debian: [gccxml]
   fedora: [gccxml]
-  gentoo:
-    portage:
-      packages: [dev-cpp/gccxml]
+  gentoo: [dev-cpp/gccxml]
   macports: [gccxml-devel]
   ubuntu: [gccxml]
 gdal-bin:
@@ -880,17 +814,13 @@ gfortran:
   arch: [gcc-fortran]
   debian: [gfortran]
   fedora: [gcc-fortran]
-  gentoo:
-    portage:
-      packages: [sys-devel/gcc]
+  gentoo: [sys-devel/gcc]
   ubuntu: [gfortran]
 gifsicle:
   arch: [gifsicle]
   debian: [gifsicle]
   fedora: [gifsicle]
-  gentoo:
-    portage:
-      packages: [media-gfx/gifsicle]
+  gentoo: [media-gfx/gifsicle]
   ubuntu: [gifsicle]
 gimp:
   fedora: [gimp]
@@ -914,9 +844,7 @@ gksu:
   ubuntu: [gksu]
 glc:
   arch: [glc]
-  gentoo:
-    portage:
-      packages: [media-libs/quesoglc]
+  gentoo: [media-libs/quesoglc]
 glut:
   arch: [freeglut]
   debian: [freeglut3-dev]
@@ -928,9 +856,7 @@ glut:
 gnuplot:
   arch: [gnuplot]
   fedora: [gnuplot]
-  gentoo:
-    portage:
-      packages: [sci-visualization/gnuplot]
+  gentoo: [sci-visualization/gnuplot]
   ubuntu: [gnuplot]
 golang-go:
   debian: [golang-go]
@@ -984,17 +910,13 @@ gstreamer0.10-plugins-good:
   arch: [gstreamer0.10-good-plugins]
   debian: [gstreamer0.10-plugins-good]
   fedora: [gstreamer-plugins-good]
-  gentoo:
-    portage:
-      packages: ['=media-libs/gst-plugins-good:0.10']
+  gentoo: ['media-libs/gst-plugins-good:0.10']
   ubuntu: [gstreamer0.10-plugins-good]
 gstreamer0.10-plugins-ugly:
   arch: [gstreamer0.10-ugly-plugins]
   debian: [gstreamer0.10-plugins-ugly]
   fedora: [gstreamer-plugins-ugly]
-  gentoo:
-    portage:
-      packages: ['=media-libs/gst-plugins-ugly:0.10']
+  gentoo: ['media-libs/gst-plugins-ugly:0.10']
   ubuntu:
     lucid: [gstreamer0.10-plugins-ugly-multiverse]
     maverick: [gstreamer0.10-plugins-ugly-multiverse]
@@ -1015,7 +937,7 @@ gstreamer1.0:
   arch: [gstreamer]
   debian: [gstreamer1.0-tools, libgstreamer1.0-0, gir1.2-gstreamer-1.0]
   fedora: [gstreamer1]
-  gentoo: ['=media-libs/gstreamer:1.0']
+  gentoo: ['media-libs/gstreamer:1.0']
   ubuntu: [gstreamer1.0-tools, libgstreamer1.0-0, gir1.2-gstreamer-1.0]
 gstreamer1.0-libav:
   arch: [gst-libav]
@@ -1026,25 +948,25 @@ gstreamer1.0-plugins-bad:
   arch: [gst-plugins-bad]
   debian: [gstreamer1.0-plugins-bad]
   fedora: [gstreamer1-plugins-bad-free]
-  gentoo: ['=media-libs/gst-plugins-bad:1.0']
+  gentoo: ['media-libs/gst-plugins-bad:1.0']
   ubuntu: [gstreamer1.0-plugins-bad]
 gstreamer1.0-plugins-base:
   arch: [gst-plugins-base]
   debian: [gstreamer1.0-plugins-base, libgstreamer-plugins-base1.0-0, gir1.2-gst-plugins-base-1.0]
   fedora: [gstreamer1-plugins-base]
-  gentoo: ['=media-libs/gst-plugins-base:1.0']
+  gentoo: ['media-libs/gst-plugins-base:1.0']
   ubuntu: [gstreamer1.0-plugins-base, libgstreamer-plugins-base1.0-0, gir1.2-gst-plugins-base-1.0]
 gstreamer1.0-plugins-good:
   arch: [gst-plugins-good]
   debian: [gstreamer1.0-plugins-good]
   fedora: [gstreamer1-plugins-good]
-  gentoo: ['=media-libs/gst-plugins-good:1.0']
+  gentoo: ['media-libs/gst-plugins-good:1.0']
   ubuntu: [gstreamer1.0-plugins-good, libgstreamer-plugins-good1.0-0]
 gstreamer1.0-plugins-ugly:
   arch: [gst-plugins-ugly]
   debian: [gstreamer1.0-plugins-ugly]
   fedora: [gstreamer1-plugins-ugly]
-  gentoo: ['=media-libs/gst-plugins-ugly:1.0']
+  gentoo: ['media-libs/gst-plugins-ugly:1.0']
   ubuntu: [gstreamer1.0-plugins-ugly]
 gstreamer1.0-tools:
   debian: [gstreamer1.0-tools]
@@ -1060,9 +982,7 @@ gtest:
   debian: [libgtest-dev]
   fedora: [gtest-devel]
   freebsd: [googletest]
-  gentoo:
-    portage:
-      packages: [dev-cpp/gtest]
+  gentoo: [dev-cpp/gtest]
   macports: [ros-gtest]
   opensuse: [googletest-devel]
   rhel: [gtest-devel]
@@ -1072,16 +992,14 @@ gtk-doc-tools:
   arch: [gtk-doc]
   debian: [gtk-doc-tools]
   fedora: [gtk-doc]
-  gentoo:
-    portage:
-      packages: [dev-util/gtk-doc]
+  gentoo: [dev-util/gtk-doc]
   ubuntu: [gtk-doc-tools]
 gtk2:
   arch: [gtk2]
   debian: [libgtk2.0-dev]
   fedora: [gtk2-devel]
   freebsd: [gtk20]
-  gentoo: ['=x11-libs/gtk+:2']
+  gentoo: ['x11-libs/gtk+:2']
   macports: [gtk2]
   opensuse: [gtk2-devel]
   rhel: [gtk2-devel]
@@ -1093,17 +1011,13 @@ gv:
   arch: [gv]
   debian: [gv]
   fedora: [gv]
-  gentoo:
-    portage:
-      packages: [app-text/gv]
+  gentoo: [app-text/gv]
   ubuntu: [gv]
 hddtemp:
   arch: [hddtemp]
   debian: [hddtemp]
   fedora: [hddtemp]
-  gentoo:
-    portage:
-      packages: [app-admin/hddtemp]
+  gentoo: [app-admin/hddtemp]
   macports: [python27]
   opensuse: [hddtemp]
   slackware: [hddtemp]
@@ -1119,9 +1033,7 @@ hostapd:
   arch: [hostapd]
   debian: [hostapd]
   fedora: [hostapd]
-  gentoo:
-    portage:
-      packages: [net-wireless/hostapd]
+  gentoo: [net-wireless/hostapd]
   ubuntu: [hostapd]
 hostname:
   arch: [inetutils]
@@ -1150,9 +1062,7 @@ imagemagick:
   arch: [imagemagick]
   debian: [imagemagick]
   fedora: [ImageMagick]
-  gentoo:
-    portage:
-      packages: [virtual/imagemagick-tools]
+  gentoo: [virtual/imagemagick-tools]
   ubuntu: [imagemagick]
 intltool:
   arch: [intltool]
@@ -1170,9 +1080,7 @@ ipmitool:
   arch: [ipmitool]
   debian: [ipmitool]
   fedora: [ipmitool]
-  gentoo:
-    portage:
-      packages: [sys-apps/ipmitool]
+  gentoo: [sys-apps/ipmitool]
   ubuntu: [ipmitool]
 iproute2:
   arch: [iproute2]
@@ -1233,17 +1141,13 @@ jython:
   arch: [jython]
   debian: [jython]
   fedora: [jython]
-  gentoo:
-    portage:
-      packages: [dev-java/jython]
+  gentoo: [dev-java/jython]
   ubuntu: [jython]
 kakasi:
   arch: [kakasi]
   debian: [kakasi]
   fedora: [kakasi]
-  gentoo:
-    portage:
-      packages: [app-i18n/kakasi]
+  gentoo: [app-i18n/kakasi]
   ubuntu: [kakasi]
 kate:
   debian: [kate]
@@ -1254,9 +1158,7 @@ kgraphviewer:
   arch: [kgraphviewer]
   debian: [kgraphviewer]
   fedora: [kgraphviewer]
-  gentoo:
-    portage:
-      packages: [media-gfx/kgraphviewer]
+  gentoo: [media-gfx/kgraphviewer]
   ubuntu: [kgraphviewer]
 konsole:
   debian: [konsole]
@@ -1298,17 +1200,13 @@ libapache2-mod-python:
   arch: [mod_python]
   debian: [libapache2-mod-python]
   fedora: [mod_python]
-  gentoo:
-    portage:
-      packages: [www-apache/mod_python]
+  gentoo: [www-apache/mod_python]
   ubuntu: [libapache2-mod-python]
 libargtable2-dev:
   arch: [argtable]
   debian: [libargtable2-dev]
   fedora: [argtable2-devel]
-  gentoo:
-    portage:
-      packages: [dev-libs/argtable]
+  gentoo: [dev-libs/argtable]
   ubuntu: [libargtable2-dev]
 libaria:
   debian:
@@ -1338,9 +1236,7 @@ libav:
   arch: [libav-git]
   debian: [libav-tools]
   fedora: []
-  gentoo:
-    portage:
-      packages: [virtual/ffmpeg]
+  gentoo: [virtual/ffmpeg]
   ubuntu: [libav-tools]
 libavahi-client-dev:
   arch: [avahi]
@@ -1386,9 +1282,7 @@ libboost-random-dev:
 libcairo2-dev:
   arch: [cairo]
   fedora: [cairo-devel]
-  gentoo:
-    portage:
-      packages: [x11-libs/cairo]
+  gentoo: [x11-libs/cairo]
   ubuntu: [libcairo2-dev]
 libcap-dev:
   arch: [libcap]
@@ -1410,23 +1304,17 @@ libcegui-mk2-dev:
   arch: [cegui]
   debian: [libcegui-mk2-dev]
   fedora: [cegui]
-  gentoo:
-    portage:
-      packages: [dev-games/cegui]
+  gentoo: [dev-games/cegui]
   ubuntu: [libcegui-mk2-dev]
 libceres-dev:
   fedora: [ceres-solver-devel]
-  gentoo:
-    portage:
-      packages: [sci-libs/ceres-solver]
+  gentoo: [sci-libs/ceres-solver]
   ubuntu: [libceres-dev]
 libcoin60-dev:
   arch: [coin]
   debian: [libcoin60-dev]
   fedora: [Coin2-devel]
-  gentoo:
-    portage:
-      packages: [media-libs/coin]
+  gentoo: [media-libs/coin]
   ubuntu: [libcoin60-dev]
 libcoin80-dev:
   debian: [libcoin80-dev]
@@ -1453,9 +1341,7 @@ libdbus-dev:
   arch: [dbus-core]
   debian: [libdbus-1-dev]
   fedora: [dbus-devel]
-  gentoo:
-    portage:
-      packages: [sys-apps/dbus]
+  gentoo: [sys-apps/dbus]
   ubuntu: [libdbus-1-dev]
 libdc1394-dev:
   arch:
@@ -1472,9 +1358,7 @@ libdevil-dev:
   arch: [devil]
   debian: [libdevil-dev]
   fedora: [DevIL-devel]
-  gentoo:
-    portage:
-      packages: [media-libs/devil]
+  gentoo: [media-libs/devil]
   ubuntu: [libdevil-dev]
 libdmtx-dev:
   arch: [libdmtx]
@@ -1486,9 +1370,7 @@ libdrm-dev:
   arch: [libdrm]
   debian: [libdrm-dev]
   fedora: [libdrm-devel]
-  gentoo:
-    portage:
-      packages: [x11-libs/libdrm]
+  gentoo: [x11-libs/libdrm]
   ubuntu: [libdrm-dev]
 libesd0-dev:
   debian: [libesd0-dev]
@@ -1522,9 +1404,7 @@ libexpat1-dev:
   arch: [expat]
   debian: [libexpat1-dev]
   fedora: [expat-devel]
-  gentoo:
-    portage:
-      packages: [dev-libs/expat]
+  gentoo: [dev-libs/expat]
   ubuntu: [libexpat1-dev]
 libfcl-dev:
   arch: [fcl]
@@ -1547,17 +1427,13 @@ libfftw3:
   arch: [fftw]
   debian: [libfftw3-3, libfftw3-dev]
   fedora: [fftw, fftw-devel]
-  gentoo:
-    portage:
-      packages: [sci-libs/fftw]
+  gentoo: [sci-libs/fftw]
   ubuntu: [libfftw3-3, libfftw3-dev]
 libflann:
   arch: [flann]
   debian: [libflann1.7]
   fedora: [flann]
-  gentoo:
-    portage:
-      packages: [sci-libs/flann]
+  gentoo: [sci-libs/flann]
   macports: [flann]
   ubuntu:
     precise: [libflann1]
@@ -1573,9 +1449,7 @@ libflann-dev:
   arch: [flann]
   debian: [libflann-dev]
   fedora: [flann-devel]
-  gentoo:
-    portage:
-      packages: [sci-libs/flann]
+  gentoo: [sci-libs/flann]
   macports: [flann]
   ubuntu: [libflann-dev]
 libfltk-dev:
@@ -1627,9 +1501,7 @@ libftdi-dev:
   arch: [libftdi]
   debian: [libftdi-dev]
   fedora: [libftdi-devel]
-  gentoo:
-    portage:
-      packages: [dev-embedded/libftdi]
+  gentoo: [dev-embedded/libftdi]
   ubuntu: [libftdi-dev]
 libftdipp-dev:
   debian:
@@ -1648,9 +1520,7 @@ libftgl-dev:
   arch: [ftgl]
   debian: [libftgl-dev]
   fedora: [ftgl-devel]
-  gentoo:
-    portage:
-      packages: [media-libs/ftgl]
+  gentoo: [media-libs/ftgl]
   ubuntu: [libftgl-dev]
 libgazebo5-dev:
   arch: [gazebo]
@@ -1686,9 +1556,7 @@ libgflags-dev:
   arch: [gflags]
   debian: [libgflags-dev]
   fedora: [gflags-devel]
-  gentoo:
-    portage:
-      packages: [dev-cpp/gflags]
+  gentoo: [dev-cpp/gflags]
   ubuntu: [libgflags-dev]
 libgfortran3:
   arch: [gcc-libs]
@@ -1705,9 +1573,7 @@ libglew-dev:
   arch: [glew]
   debian: [libglew-dev]
   fedora: [glew-devel]
-  gentoo:
-    portage:
-      packages: [media-libs/glew]
+  gentoo: [media-libs/glew]
   ubuntu:
     oneiric: [libglew1.5-dev]
     precise: [libglew1.6-dev]
@@ -1725,9 +1591,7 @@ libglib-dev:
   arch: [glib2]
   debian: [libglib2.0-dev]
   fedora: [glib2-devel]
-  gentoo:
-    portage:
-      packages: [dev-libs/glib]
+  gentoo: [dev-libs/glib]
   ubuntu: [libglib2.0-dev]
 libglm-dev:
   arch: [glm]
@@ -1744,9 +1608,7 @@ libglw1-mesa:
   arch: [glw]
   debian: [libglw1-mesa]
   fedora: [mesa-libGlw]
-  gentoo:
-    portage:
-      packages: [x11-libs/libGLw]
+  gentoo: [x11-libs/libGLw]
   ubuntu: [libglw1-mesa]
 libgmp:
   fedora: [gmp-devel]
@@ -1759,17 +1621,13 @@ libgomp1:
 libgoogle-glog-dev:
   debian: [libgoogle-glog-dev]
   fedora: [glog-devel]
-  gentoo:
-    portage:
-      packages: [dev-cpp/glog]
+  gentoo: [dev-cpp/glog]
   ubuntu: [libgoogle-glog-dev]
 libgphoto-dev:
   arch: [libgphoto2]
   debian: [libgphoto2-2-dev]
   fedora: [libgphoto2-devel]
-  gentoo:
-    portage:
-      packages: [media-gfx/gphoto2]
+  gentoo: [media-gfx/gphoto2]
   ubuntu:
     lucid: [libgphoto2-dev]
     precise: [libgphoto2-2-dev]
@@ -1784,9 +1642,7 @@ libgps:
   arch: [gpsd]
   debian: [libgps-dev]
   fedora: [gpsd-devel]
-  gentoo:
-    portage:
-      packages: [sci-geosciences/gpsd]
+  gentoo: [sci-geosciences/gpsd]
   opensuse: [gpsd-devel]
   ubuntu: [libgps-dev]
 libgsl:
@@ -1796,9 +1652,7 @@ libgsl:
     stretch: [libgsl-dev]
     wheezy: [libgsl0-dev]
   fedora: [gsl]
-  gentoo:
-    portage:
-      packages: [sci-libs/gsl]
+  gentoo: [sci-libs/gsl]
   macports: [gsl]
   ubuntu:
     precise: [libgsl0-dev]
@@ -1814,53 +1668,49 @@ libgstreamer-plugins-base0.10-0:
   arch: [gstreamer0.10-base-plugins]
   debian: [libgstreamer-plugins-base0.10-0]
   fedora: [gstreamer-plugins-base]
-  gentoo: ['=media-libs/gst-plugins-base:0.10']
+  gentoo: ['media-libs/gst-plugins-base:0.10']
   ubuntu: [libgstreamer-plugins-base0.10-0]
 libgstreamer-plugins-base0.10-dev:
   arch: [gstreamer0.10-base-plugins]
   debian: [libgstreamer-plugins-base0.10-dev]
   fedora: [gstreamer-plugins-base-devel]
-  gentoo: ['=media-libs/gst-plugins-base:0.10']
+  gentoo: ['media-libs/gst-plugins-base:0.10']
   ubuntu: [libgstreamer-plugins-base0.10-dev]
 libgstreamer-plugins-base1.0-dev:
   arch: [gst-plugins-base]
   debian: [libgstreamer-plugins-base1.0-dev]
   fedora: [gstreamer1-plugins-base-devel]
-  gentoo: ['=media-libs/gst-plugins-base:1.0']
+  gentoo: ['media-libs/gst-plugins-base:1.0']
   ubuntu: [libgstreamer-plugins-base1.0-dev]
 libgstreamer0.10-0:
   arch: [gstreamer0.10]
   debian: [libgstreamer0.10-0]
   fedora: [gstreamer]
-  gentoo: ['=media-libs/gstreamer:0.10']
+  gentoo: ['media-libs/gstreamer:0.10']
   ubuntu: [libgstreamer0.10-0]
 libgstreamer0.10-dev:
   arch: [gstreamer0.10]
   debian: [libgstreamer0.10-dev]
   fedora: [gstreamer-devel]
-  gentoo: ['=media-libs/gstreamer:0.10']
+  gentoo: ['media-libs/gstreamer:0.10']
   ubuntu: [libgstreamer0.10-dev]
 libgstreamer1.0-dev:
   arch: [gstreamer]
   debian: [libgstreamer1.0-dev]
   fedora: [gstreamer1-devel]
-  gentoo: ['=media-libs/gstreamer:1.0']
+  gentoo: ['media-libs/gstreamer:1.0']
   ubuntu: [libgstreamer1.0-dev]
 libgtkmm:
   arch: [gtkmm]
   debian: [libgtkmm-dev]
   fedora: [gtkmm24]
-  gentoo:
-    portage:
-      packages: [dev-cpp/gtkmm]
+  gentoo: [dev-cpp/gtkmm]
   ubuntu: [libgtkmm-dev]
 libgts:
   arch: [gts]
   debian: [libgts-dev]
   fedora: [gts]
-  gentoo:
-    portage:
-      packages: [sci-libs/gts]
+  gentoo: [sci-libs/gts]
   ubuntu: [libgts-dev]
 libhal-dev:
   arch:
@@ -1886,22 +1736,16 @@ libirrlicht-dev:
   arch: [irrlicht]
   debian: [libirrlicht-dev]
   fedora: [irrlicht-devel]
-  gentoo:
-    portage:
-      packages: [dev-games/irrlicht]
+  gentoo: [dev-games/irrlicht]
   ubuntu: [libirrlicht-dev]
 libiw-dev:
   debian: [libiw-dev]
   fedora: [wireless-tools-devel]
-  gentoo:
-    portage:
-      packages: [net-wireless/wireless-tools]
+  gentoo: [net-wireless/wireless-tools]
   ubuntu: [libiw-dev]
 libjackson-json-java:
   fedora: [jackson]
-  gentoo:
-    portage:
-      packages: [dev-java/jackson]
+  gentoo: [dev-java/jackson]
   ubuntu: [libjackson-json-java]
 libjansson-dev:
   debian: [libjansson-dev]
@@ -1946,24 +1790,18 @@ libjson-glib:
   arch: [json-glib]
   debian: [libjson-glib-dev]
   fedora: [json-glib]
-  gentoo:
-    portage:
-      packages: [dev-libs/json-glib]
+  gentoo: [dev-libs/json-glib]
   ubuntu: [libjson-glib-dev]
 libjson-java:
   debian: [libjson-java]
   fedora: [json-lib]
-  gentoo:
-    portage:
-      packages: [dev-java/json]
+  gentoo: [dev-java/json]
   ubuntu: [libjson-java]
 libjson0-dev:
   arch: [json-c]
   debian: [libjson0-dev]
   fedora: [json-c-devel]
-  gentoo:
-    portage:
-      packages: [dev-libs/json-c]
+  gentoo: [dev-libs/json-c]
   ubuntu: [libjson0-dev]
 libjsoncpp:
   debian: [libjsoncpp1]
@@ -1983,9 +1821,7 @@ libjsoncpp-dev:
   arch: [jsoncpp]
   debian: [libjsoncpp-dev]
   fedora: [jsoncpp-devel]
-  gentoo:
-    portage:
-      packages: [dev-libs/jsoncpp]
+  gentoo: [dev-libs/jsoncpp]
   ubuntu: [libjsoncpp-dev]
 libkdtree++-dev:
   fedora: [libkdtree++-devel]
@@ -1994,17 +1830,13 @@ liblapack-dev:
   arch: [lapack]
   debian: [liblapack-dev]
   fedora: [lapack-devel]
-  gentoo:
-    portage:
-      packages: [virtual/lapack]
+  gentoo: [virtual/lapack]
   ubuntu: [liblapack-dev]
 libleptonica-dev:
   arch: [leptonica]
   debian: [libleptonica-dev]
   fedora: [leptonica-devel]
-  gentoo:
-    portage:
-      packages: [media-libs/leptonica]
+  gentoo: [media-libs/leptonica]
   ubuntu: [libleptonica-dev]
 liblinear-dev:
   fedora: [liblinear-devel]
@@ -2031,9 +1863,7 @@ libmarble-dev:
   arch: [kdeedu-marble]
   debian: [libmarble-dev]
   fedora: [marble-devel]
-  gentoo:
-    portage:
-      packages: [kde-base/marble]
+  gentoo: [kde-base/marble]
   ubuntu: [libmarble-dev]
 libmicrohttpd:
   debian: [libmicrohttpd-dev]
@@ -2047,17 +1877,13 @@ libmotif-dev:
   arch: [lesstif]
   debian: [libmotif-dev]
   fedora: [lesstif-devel]
-  gentoo:
-    portage:
-      packages: [x11-libs/motif]
+  gentoo: [x11-libs/motif]
   ubuntu: [libmotif-dev]
 libmp3lame-dev:
   arch: [lame]
   debian: [libmp3lame-dev]
   fedora: [lame-devel]
-  gentoo:
-    portage:
-      packages: [media-sound/lame]
+  gentoo: [media-sound/lame]
   ubuntu: [libmp3lame-dev]
 libmpich-dev:
   debian: [libmpich-dev]
@@ -2079,9 +1905,7 @@ libmysqlclient-dev:
     heisenbug: [mariadb-devel]
     schrödinger’s: [mariadb-devel]
     spherical: [mysql-devel]
-  gentoo:
-    portage:
-      packages: [virtual/libmysqlclient]
+  gentoo: [virtual/libmysqlclient]
   macports: [mysql5]
   opensuse: [libmysqlclient-devel]
   ubuntu: [libmysqlclient-dev]
@@ -2090,43 +1914,33 @@ libmysqlcppconn-dev:
     aur: [mysql-connector-c++]
   debian: [libmysqlcppconn-dev]
   fedora: [libmysqlcppconn-devel]
-  gentoo:
-    portage:
-      packages: [dev-db/mysql-connector-c++]
+  gentoo: [dev-db/mysql-connector-c++]
   opensuse: [libmysqlcppconn-devel]
   ubuntu: [libmysqlcppconn-dev]
 libncurses-dev:
   arch: [ncurses]
   debian: [libncurses5-dev]
   fedora: [ncurses-devel]
-  gentoo:
-    portage:
-      packages: [sys-libs/ncurses]
+  gentoo: [sys-libs/ncurses]
   macports: [ncurses]
   ubuntu: [libncurses5-dev]
 libnl-3:
   arch: [libnl]
   debian: [libnl-3-200, libnl-genl-3-200]
   fedora: [libnl3]
-  gentoo:
-    portage:
-      packages: [dev-libs/libnl]
+  gentoo: [dev-libs/libnl]
   ubuntu: [libnl-3-200, libnl-genl-3-200]
 libnl-3-dev:
   arch: [libnl]
   debian: [libnl-3-dev, libnl-genl-3-dev]
   fedora: [libnl3-devel]
-  gentoo:
-    portage:
-      packages: [dev-libs/libnl]
+  gentoo: [dev-libs/libnl]
   ubuntu: [libnl-3-dev, libnl-genl-3-dev]
 libnl-dev:
   arch: [libnl1]
   debian: [libnl-dev]
   fedora: [libnl-devel]
-  gentoo:
-    portage:
-      packages: [dev-libs/libnl]
+  gentoo: [dev-libs/libnl]
   ubuntu: [libnl-dev]
 libnlopt-dev:
   debian: [libnlopt-dev]
@@ -2189,9 +2003,7 @@ libois-dev:
   arch: [ois]
   debian: [libois-dev]
   fedora: [ois-devel]
-  gentoo:
-    portage:
-      packages: [dev-games/ois]
+  gentoo: [dev-games/ois]
   ubuntu: [libois-dev]
 libopal-dev:
   debian: [libopal-dev]
@@ -2243,18 +2055,14 @@ libopenscenegraph:
   arch: [openscenegraph]
   debian: [openscenegraph, libopenscenegraph-dev, libopenscenegraph80, libopenthreads-dev, libopenthreads14]
   fedora: [OpenSceneGraph, OpenSceneGraph-devel, OpenThreads, OpenThreads-devel]
-  gentoo:
-    portage:
-      packages: [dev-games/openscenegraph]
+  gentoo: [dev-games/openscenegraph]
   ubuntu: [openscenegraph, libopenscenegraph-dev]
 libopenvdb:
   arch: [openvdb]
   debian:
     jessie: [libopenvdb2.3]
     stretch: [libopenvdb3.2]
-  gentoo:
-    portage:
-      packages: [media-gfx/openvdb]
+  gentoo: [media-gfx/openvdb]
   ubuntu:
     saucy: [libopenvdb1.1]
     trusty: [libopenvdb2.1]
@@ -2267,17 +2075,13 @@ libopenvdb:
 libopenvdb-dev:
   arch: [openvdb]
   debian: [libopenvdb-dev]
-  gentoo:
-    portage:
-      packages: [media-gfx/openvdb]
+  gentoo: [media-gfx/openvdb]
   ubuntu: [libopenvdb-dev]
 libosmesa6-dev:
   arch: [mesa]
   debian: [libosmesa6-dev]
   fedora: [mesa-libOSMesa-devel]
-  gentoo:
-    portage:
-      packages: [media-libs/mesa]
+  gentoo: [media-libs/mesa]
   ubuntu: [libosmesa6-dev]
 libpcap:
   arch:
@@ -2285,9 +2089,7 @@ libpcap:
       packages: [libpcap]
   debian: [libpcap0.8-dev]
   fedora: [libpcap-devel]
-  gentoo:
-    portage:
-      packages: [net-libs/libpcap]
+  gentoo: [net-libs/libpcap]
   macports: [libpcap]
   ubuntu: [libpcap0.8-dev]
 libpcl-all:
@@ -2296,9 +2098,7 @@ libpcl-all:
     jessie: [libpcl1.7]
     stretch: [libpcl-apps1.8, libpcl-common1.8, libpcl-features1.8, libpcl-filters1.8, libpcl-io1.8, libpcl-kdtree1.8, libpcl-keypoints1.8, libpcl-ml1.8, libpcl-octree1.8, libpcl-outofcore1.8, libpcl-people1.8, libpcl-recognition1.8, libpcl-registration1.8, libpcl-sample-consensus1.8, libpcl-search1.8, libpcl-segmentation1.8, libpcl-stereo1.8, libpcl-surface1.8, libpcl-tracking1.8, libpcl-visualization1.8]
   fedora: [pcl, pcl-tools]
-  gentoo:
-    portage:
-      packages: [sci-libs/pcl]
+  gentoo: [sci-libs/pcl]
   macports: [libpcl]
   opensuse: [pcl]
   slackware: [pcl]
@@ -2318,9 +2118,7 @@ libpcl-all-dev:
   arch: [pcl]
   debian: [libpcl-dev]
   fedora: [pcl-devel]
-  gentoo:
-    portage:
-      packages: [sci-libs/pcl]
+  gentoo: [sci-libs/pcl]
   macports: [libpcl]
   opensuse: [pcl]
   slackware: [pcl]
@@ -2340,9 +2138,7 @@ libpcsclite-dev:
   arch: [pcsclite]
   debian: [libpcsclite-dev]
   fedora: [pcsc-lite-devel]
-  gentoo:
-    portage:
-      packages: [sys-apps/pcsc-lite]
+  gentoo: [sys-apps/pcsc-lite]
   ubuntu: [libpcsclite-dev]
 libphonon:
   debian: [libphonon4]
@@ -2364,9 +2160,7 @@ libpng-dev:
     stretch: [libpng-dev]
     wheezy: [libpng12-dev]
   fedora: [libpng-devel]
-  gentoo:
-    portage:
-      packages: [media-libs/libpng]
+  gentoo: [media-libs/libpng]
   macports: [libpng]
   opensuse: [libpng12-devel]
   slackware: [libpng]
@@ -2386,9 +2180,7 @@ libpng12-dev:
   arch: [libpng]
   debian: [libpng12-dev]
   fedora: [libpng12-devel]
-  gentoo:
-    portage:
-      packages: [media-libs/libpng]
+  gentoo: [media-libs/libpng]
   macports: [libpng]
   opensuse: [libpng12-devel]
   slackware: [libpng]
@@ -2397,9 +2189,7 @@ libpoco-dev:
   arch: [poco]
   debian: [libpoco-dev]
   fedora: [poco-devel]
-  gentoo:
-    portage:
-      packages: [dev-libs/poco]
+  gentoo: [dev-libs/poco]
   macports: [poco]
   opensuse: [poco-devel]
   slackware: [poco]
@@ -2412,9 +2202,7 @@ libpopt-dev:
   arch: [popt]
   debian: [libpopt-dev]
   fedora: [popt-devel]
-  gentoo:
-    portage:
-      packages: [dev-libs/popt]
+  gentoo: [dev-libs/popt]
   ubuntu: [libpopt-dev]
 libpq-dev:
   arch: [postgresql-libs]
@@ -2428,9 +2216,7 @@ libpq-dev:
     heisenbug: [derelict-postgresql-devel, postgresql-devel]
     schrödinger’s: [derelict-postgresql-devel, postgresql-devel]
     spherical: [derelict-postgresql-devel, postgresql-devel]
-  gentoo:
-    portage:
-      packages: [dev-db/postgresql]
+  gentoo: [dev-db/postgresql]
   ubuntu: [libpq-dev]
 libpqxx:
   fedora: [libpqxx]
@@ -2479,9 +2265,7 @@ libqcustomplot-dev:
 libqd-dev:
   debian: [libqd-dev]
   fedora: [qd-devel]
-  gentoo:
-    portage:
-      packages: [sci-libs/qd]
+  gentoo: [sci-libs/qd]
   macports: [qd]
   ubuntu: [libqd-dev]
 libqglviewer-qt4:
@@ -2555,9 +2339,7 @@ libqt4:
   debian: [libqt4-core]
   fedora: [qt]
   freebsd: [qt4-corelib]
-  gentoo:
-    portage:
-      packages: ['=dev-qt/qtcore:4']
+  gentoo: ['dev-qt/qtcore:4']
   macports: [qt4-mac]
   opensuse: [libqt4]
   rhel: [qt]
@@ -2567,9 +2349,7 @@ libqt4-dev:
   debian: [libqt4-dev]
   fedora: [qt-devel]
   freebsd: [qt4-corelib]
-  gentoo:
-    portage:
-      packages: ['=dev-qt/qtcore:4']
+  gentoo: ['dev-qt/qtcore:4']
   macports: [qt4-mac]
   opensuse: [libqt4-devel]
   rhel: [qt-devel]
@@ -2578,18 +2358,14 @@ libqt4-opengl:
   arch: [qt4]
   debian: [libqt4-opengl]
   fedora: [qt]
-  gentoo:
-    portage:
-      packages: ['=dev-qt/qtopengl:4']
+  gentoo: ['dev-qt/qtopengl:4']
   rhel: [qt]
   ubuntu: [libqt4-opengl]
 libqt4-opengl-dev:
   arch: [qt4]
   debian: [libqt4-opengl-dev]
   fedora: [qt-devel]
-  gentoo:
-    portage:
-      packages: ['=dev-qt/qtopengl:4']
+  gentoo: ['dev-qt/qtopengl:4']
   macports: [qt4-mac]
   opensuse: [libqt4-devel]
   rhel: [qt-devel]
@@ -2598,16 +2374,14 @@ libqt4-sql-psql:
   arch: [qt4]
   debian: [libqt4-sql-psql]
   fedora: [qt-postgresql]
-  gentoo:
-    portage:
-      packages: ['=dev-qt/qtsql:4']
+  gentoo: ['dev-qt/qtsql:4']
   macports: [qt4-mac]
   ubuntu: [libqt4-sql-psql]
 libqt5-core:
   arch:   [qt5-base]
   debian: [libqt5core5a]
   fedora: [qt5-qtbase]
-  gentoo: ['=dev-qt/qtcore:5']
+  gentoo: ['dev-qt/qtcore:5']
   opensuse: [libQt5Core5]
   slackware: [qt5]
   ubuntu: [libqt5core5a]
@@ -2615,7 +2389,7 @@ libqt5-gui:
   arch:   [qt5-base]
   debian: [libqt5gui5]
   fedora: [qt5-qtbase-gui]
-  gentoo: ['=dev-qt/qtgui:5']
+  gentoo: ['dev-qt/qtgui:5']
   opensuse: [libQt5Gui5]
   slackware: [qt5]
   ubuntu: [libqt5gui5]
@@ -2623,13 +2397,13 @@ libqt5-network:
   arch:   [qt5-base]
   debian: [libqt5network5]
   fedora: [qt5-qtbase]
-  gentoo: ['=dev-qt/qtnetwork:5']
+  gentoo: ['dev-qt/qtnetwork:5']
   ubuntu: [libqt5network5]
 libqt5-opengl:
   arch:   [qt5-base]
   debian: [libqt5opengl5]
   fedora: [qt5-qtbase]
-  gentoo: ['=dev-qt/qtopengl:5']
+  gentoo: ['dev-qt/qtopengl:5']
   opensuse: [libQt5OpenGL5]
   slackware: [qt5]
   ubuntu: [libqt5opengl5]
@@ -2637,13 +2411,13 @@ libqt5-opengl-dev:
   arch:   [qt5-base]
   debian: [libqt5opengl5-dev]
   fedora: [qt5-qtbase]
-  gentoo: ['=dev-qt/qtopengl:5']
+  gentoo: ['dev-qt/qtopengl:5']
   slackware: [qt5]
   ubuntu: [libqt5opengl5-dev]
 libqt5-sql:
   arch:   [qt5-base]
   fedora: [qt5-qtbase]
-  gentoo: ['=dev-qt/qtsql:5']
+  gentoo: ['dev-qt/qtsql:5']
   ubuntu: [libqt5sql5]
 libqt5-svg-dev:
   debian: [libqt5svg5-dev]
@@ -2654,22 +2428,20 @@ libqt5-widgets:
   arch:   [qt5-base]
   debian: [libqt5widgets5]
   fedora: [qt5-qtbase]
-  gentoo: ['=dev-qt/qtwidgets:5']
+  gentoo: ['dev-qt/qtwidgets:5']
   opensuse: [libQt5Widgets5]
   slackware: [qt5]
   ubuntu: [libqt5widgets5]
 libqt5x11extras5-dev:
   debian: [libqt5x11extras5-dev]
   fedora: [qt5-qtx11extras-devel]
-  gentoo: ['=dev-qt/qtx11extras:5']
+  gentoo: ['dev-qt/qtx11extras:5']
   ubuntu: [libqt5x11extras5-dev]
 libqtgui4:
   arch: [qt4]
   debian: [libqtgui4]
   fedora: [qt-x11]
-  gentoo:
-    portage:
-      packages: ['=dev-qt/qtgui:4']
+  gentoo: ['dev-qt/qtgui:4']
   ubuntu: [libqtgui4]
 libqtwebkit-dev:
   fedora: [qtwebkit-devel]
@@ -2679,14 +2451,12 @@ libqwt5-qt4-dev:
   arch: [qwt5]
   debian: [libqwt5-qt4-dev]
   fedora: [qwt-devel]
-  gentoo:
-    portage:
-      packages: [x11-libs/qwt]
+  gentoo: [x11-libs/qwt]
   ubuntu: [libqwt5-qt4-dev]
 libqwt6:
   arch: [qwt]
   fedora: [qwt-devel]
-  gentoo: ['=x11-libs/qwt:6']
+  gentoo: ['x11-libs/qwt:6']
   ubuntu:
     precise: [libqwt-dev]
     quantal: [libqwt-dev]
@@ -2701,9 +2471,7 @@ libqwtplot3d-qt4-dev:
   arch: [qwtplot3d]
   debian: [libqwtplot3d-qt4-dev]
   fedora: [qwtplot3d-qt4-devel]
-  gentoo:
-    portage:
-      packages: [x11-libs/qwtplot3d]
+  gentoo: [x11-libs/qwtplot3d]
   ubuntu: [libqwtplot3d-qt4-dev]
 libraw1394:
   arch:
@@ -2711,9 +2479,7 @@ libraw1394:
       packages: [libraw1394]
   debian: [libraw1394-11]
   fedora: [libraw1394]
-  gentoo:
-    portage:
-      packages: [sys-libs/libraw1394]
+  gentoo: [sys-libs/libraw1394]
   ubuntu: [libraw1394-11]
 libraw1394-dev:
   arch:
@@ -2721,9 +2487,7 @@ libraw1394-dev:
       packages: [libraw1394]
   debian: [libraw1394-dev]
   fedora: [libraw1394-devel]
-  gentoo:
-    portage:
-      packages: [sys-libs/libraw1394]
+  gentoo: [sys-libs/libraw1394]
   ubuntu: [libraw1394-dev]
 librdkafka-dev:
   debian: [librdkafka-dev]
@@ -2734,27 +2498,21 @@ libreadline:
   arch: [readline]
   debian: [libreadline-dev]
   fedora: [readline]
-  gentoo:
-    portage:
-      packages: [sys-libs/readline]
+  gentoo: [sys-libs/readline]
   macports: [readline]
   ubuntu: [libreadline-dev]
 libreadline-dev:
   arch: [readline]
   debian: [libreadline-dev]
   fedora: [readline-devel]
-  gentoo:
-    portage:
-      packages: [sys-libs/readline]
+  gentoo: [sys-libs/readline]
   macports: [readline]
   ubuntu: [libreadline-dev]
 libreadline-java:
   arch: [java-readline]
   debian: [libreadline-java]
   fedora: [libreadline-java]
-  gentoo:
-    portage:
-      packages: [dev-java/libreadline-java]
+  gentoo: [dev-java/libreadline-java]
   ubuntu: [libreadline-java]
 libsensors4-dev:
   arch: [lm_sensors]
@@ -2768,9 +2526,7 @@ libserial-dev:
 libsimage-dev:
   arch: [simage]
   debian: [libsimage-dev]
-  gentoo:
-    portage:
-      packages: [media-libs/simage]
+  gentoo: [media-libs/simage]
   ubuntu: [libsimage-dev]
 libsndfile1-dev:
   fedora: [libsndfile-devel]
@@ -2780,29 +2536,23 @@ libsoqt4-dev:
   arch: [soqt]
   debian: [libsoqt4-dev]
   fedora: [SoQt-devel]
-  gentoo:
-    portage:
-      packages: [media-libs/SoQt]
+  gentoo: [media-libs/SoQt]
   ubuntu: [libsoqt4-dev]
 libspnav-dev:
   arch: [libspnav]
   debian: [libspnav-dev]
   fedora: [libspnav-devel]
-  gentoo:
-    portage:
-      packages: [dev-libs/libspnav]
+  gentoo: [dev-libs/libspnav]
   ubuntu: [libspnav-dev]
 libsqlite3-dev:
   arch: [sqlite]
   debian: [libsqlite3-dev]
   fedora: [libsq3-devel]
-  gentoo:
-    portage:
-      packages: [dev-db/sqlite]
+  gentoo: [dev-db/sqlite]
   ubuntu: [libsqlite3-dev]
 libsrtp0-dev:
   fedora: [libsrtp-devel]
-  gentoo: ['=net-libs/libsrtp:0']
+  gentoo: ['net-libs/libsrtp:0']
   ubuntu: [libsrtp0-dev]
 libssh2:
   fedora: [libssh2]
@@ -2816,18 +2566,14 @@ libssl-dev:
   arch: [openssl]
   debian: [libssl-dev]
   fedora: [openssl-devel]
-  gentoo:
-    portage:
-      packages: [dev-libs/openssl]
+  gentoo: [dev-libs/openssl]
   ubuntu: [libssl-dev]
 libstdc++5:
   arch: [libstdc++5]
   debian: [libstdc++5]
   fedora: [libstdc++]
   freebsd: [builtin]
-  gentoo:
-    portage:
-      packages: [virtual/libstdc++]
+  gentoo: [virtual/libstdc++]
   opensuse: [libstdc++33]
   ubuntu: [libstdc++5]
 libsvm-dev:
@@ -2847,9 +2593,7 @@ libswscale-dev:
   arch: [ffmpeg]
   debian: [libswscale-dev]
   fedora: [ffmpeg-devel]
-  gentoo:
-    portage:
-      packages: [virtual/ffmpeg]
+  gentoo: [virtual/ffmpeg]
   ubuntu: [libswscale-dev]
 libtesseract:
   fedora: [tesseract-devel]
@@ -2874,9 +2618,7 @@ libtiff-dev:
     stretch: [libtiff5-dev]
     wheezy: [libtiff5-alt-dev]
   fedora: [libtiff]
-  gentoo:
-    portage:
-      packages: [media-libs/tiff]
+  gentoo: [media-libs/tiff]
   macports: [tiff]
   opensuse: [libtiff-devel]
   slackware:
@@ -2903,9 +2645,7 @@ libtiff4-dev:
   arch: [libtiff]
   debian: [libtiff4-dev]
   fedora: [libtiff-devel]
-  gentoo:
-    portage:
-      packages: ['=media-libs/tiff:0']
+  gentoo: ['media-libs/tiff:0']
   macports: [tiff]
   ubuntu: [libtiff4-dev]
 libtool:
@@ -2952,9 +2692,7 @@ libudev-dev:
   arch: [systemd]
   debian: [libudev-dev]
   fedora: [libudev-devel]
-  gentoo:
-    portage:
-      packages: [virtual/libudev]
+  gentoo: [virtual/libudev]
   ubuntu: [libudev-dev]
 libunittest++:
   arch: [unittestpp]
@@ -3023,7 +2761,7 @@ libusb-1.0:
     heisenbug: [libusbx]
     schrödinger’s: [libusbx]
     spherical: [libusbx]
-  gentoo: ['=virtual/libusb:1']
+  gentoo: ['virtual/libusb:1']
   opensuse: [libusb-1_0-0]
   ubuntu: [libusb-1.0-0]
 libusb-1.0-dev:
@@ -3040,7 +2778,7 @@ libusb-1.0-dev:
     heisenbug: [libusbx-devel]
     schrödinger’s: [libusbx-devel]
     spherical: [libusbx-devel]
-  gentoo: ['=virtual/libusb:1']
+  gentoo: ['virtual/libusb:1']
   macports: [libusb]
   opensuse: [libusb-1_0-devel]
   ubuntu: [libusb-1.0-0-dev]
@@ -3510,9 +3248,7 @@ nasm:
   debian: [nasm]
   fedora: [nasm]
   freebsd: [nasm]
-  gentoo:
-    portage:
-      packages: [dev-lang/nasm]
+  gentoo: [dev-lang/nasm]
   macports: [nasm]
   opensuse: [nasm]
   ubuntu: [nasm]
@@ -3818,9 +3554,7 @@ pyqt4-dev-tools:
   arch: [python2-pyqt4]
   debian: [pyqt4-dev-tools]
   fedora: [PyQt4-devel]
-  gentoo:
-    portage:
-      packages: [dev-python/PyQt4]
+  gentoo: [dev-python/PyQt4]
   ubuntu: [pyqt4-dev-tools]
 pyqt5-dev-tools:
   debian: [pyqt5-dev-tools]
@@ -3829,14 +3563,10 @@ pyqt5-dev-tools:
   ubuntu: [pyqt5-dev-tools]
 python-cairo:
   fedora: [pycairo]
-  gentoo:
-    portage:
-      packages: [dev-python/pycairo]
+  gentoo: [dev-python/pycairo]
 python-nose:
   fedora: [python-nose]
-  gentoo:
-    portage:
-      packages: [dev-python/nose]
+  gentoo: [dev-python/nose]
 python-opencv:
   fedora: [opencv-python]
   gentoo: [media-libs/opencv]
@@ -3848,18 +3578,14 @@ python-pyaudio:
   ubuntu: [python-pyaudio]
 python-pydot:
   fedora: [pydot]
-  gentoo:
-    portage:
-      packages: [media-gfx/pydot]
+  gentoo: [media-gfx/pydot]
 python-pyftpdlib:
   debian: [python-pyftpdlib]
   gentoo: [dev-python/pyftpdlib]
   ubuntu: [python-pyftpdlib]
 python-pygraphviz:
   fedora: [python-pygraphviz]
-  gentoo:
-    portage:
-      packages: [dev-python/pygraphviz]
+  gentoo: [dev-python/pygraphviz]
   opensuse: [python-pygraphviz]
 python-qrencode:
   debian: [python-qrencode]
@@ -3899,7 +3625,7 @@ qt4-qmake:
   arch: [qt4]
   debian: [qt4-qmake]
   fedora: [qt-devel]
-  gentoo: ['=dev-qt/qtcore:4']
+  gentoo: ['dev-qt/qtcore:4']
   macports: [qt4-mac]
   opensuse: [libqt4-devel]
   rhel: [qt-devel]
@@ -3908,7 +3634,7 @@ qt5-qmake:
   arch:   [qt5-base]
   debian: [qt5-qmake]
   fedora: [qt5-qtbase-devel]
-  gentoo: ['=dev-qt/qtcore:5']
+  gentoo: ['dev-qt/qtcore:5']
   opensuse: [libqt5-qtbase-common-devel]
   slackware: [qt5]
   ubuntu: [qt5-qmake]
@@ -3916,7 +3642,7 @@ qtbase5-dev:
   arch:   [qt5-base]
   debian: [qtbase5-dev]
   fedora: [qt5-qtbase-devel]
-  gentoo: ['=dev-qt/qtcore:5']
+  gentoo: ['dev-qt/qtcore:5']
   opensuse: [libqt5-qtbase-common-devel, libqt5-qtbase-devel]
   slackware: [qt5]
   ubuntu: [qtbase5-dev]
@@ -3984,9 +3710,7 @@ sbcl:
   arch: [sbcl]
   debian: [sbcl]
   fedora: [sbcl]
-  gentoo:
-    portage:
-      packages: [dev-lisp/sbcl]
+  gentoo: [dev-lisp/sbcl]
   macports: [sbcl]
   opensuse: [sbcl]
   slackware: [sbcl]
@@ -4004,9 +3728,7 @@ screen:
   arch: [screen]
   debian: [screen]
   fedora: [screen]
-  gentoo:
-    portage:
-      packages: [app-misc/screen]
+  gentoo: [app-misc/screen]
   ubuntu: [screen]
 sdformat:
   arch: [sdformat-hg]
@@ -4031,9 +3753,7 @@ sdl-gfx:
   arch: [sdl_gfx]
   debian: [libsdl-gfx1.2-dev]
   fedora: [SDL_gfx]
-  gentoo:
-    portage:
-      packages: [media-libs/sdl-gfx]
+  gentoo: [media-libs/sdl-gfx]
   ubuntu: [libsdl-gfx1.2-dev]
 sdl-image:
   arch: [sdl_image]
@@ -4366,9 +4086,7 @@ tinyxml:
   arch: [tinyxml]
   debian: [libtinyxml-dev]
   fedora: [tinyxml-devel]
-  gentoo:
-    portage:
-      packages: [dev-libs/tinyxml]
+  gentoo: [dev-libs/tinyxml]
   macports: [tinyxml]
   opensuse: [tinyxml-devel]
   rhel: [tinyxml-devel]
@@ -4508,9 +4226,7 @@ wget:
   debian: [wget]
   fedora: [wget]
   freebsd: [wget]
-  gentoo:
-    portage:
-      packages: [net-misc/wget]
+  gentoo: [net-misc/wget]
   macports: [wget]
   opensuse: [wget]
   ubuntu: [wget]
@@ -4701,9 +4417,7 @@ yaml-cpp:
     stretch: [libyaml-cpp-dev]
     wheezy: [libyaml-cpp-dev]
   fedora: [yaml-cpp-devel]
-  gentoo:
-    portage:
-      packages: [dev-cpp/yaml-cpp]
+  gentoo: [dev-cpp/yaml-cpp]
   macports: [yaml-cpp]
   opensuse: [yaml-cpp-devel]
   rhel: [yaml-cpp-devel]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1452,9 +1452,7 @@ python-nose:
   arch: [python2-nose]
   debian: [python-nose]
   fedora: [python-nose]
-  gentoo:
-    portage:
-      packages: [dev-python/nose]
+  gentoo: [dev-python/nose]
   macports: [py27-nose]
   opensuse: [python-nose]
   slackware: [nose]
@@ -1832,9 +1830,7 @@ python-pydot:
   arch: [python2-pydot]
   debian: [python-pydot]
   fedora: [pydot]
-  gentoo:
-    portage:
-      packages: [media-gfx/pydot]
+  gentoo: [media-gfx/pydot]
   macports: [py27-pydot]
   opensuse: [python-pydot]
   osx:
@@ -2713,9 +2709,7 @@ python-sphinx:
   debian: [python-sphinx]
   fedora: [python-sphinx]
   freebsd: [py27-sphinx]
-  gentoo:
-    portage:
-      packages: [dev-python/sphinx]
+  gentoo: [dev-python/sphinx]
   macports: [py27-sphinx]
   opensuse: [python-Sphinx]
   ubuntu:

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -63,9 +63,7 @@ ruby:
   arch: [ruby]
   debian: [ruby, ruby-dev]
   fedora: [ruby, ruby-devel, openssl-devel, rubygems]
-  gentoo:
-    portage:
-      packages: [dev-lang/ruby]
+  gentoo: [dev-lang/ruby]
   macports: [ruby]
   ubuntu:
     lucid: [ruby1.8-dev, libopenssl-ruby1.8, rubygems1.8]


### PR DESCRIPTION
We currently have both

```
gentoo:
  portage:
    packages: [ blah ]
```

and

```
gentoo: [ blah ]
```

which I have removed in this PR.

I also fixed the slotting of the ebuilds,
as it made portage unhappy.

(@tfoote this fixes one of the issues I had earlier).