### PR TITLE
Revert Opencv3 debian increments

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8160,7 +8160,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/opencv3-release.git
-      version: 3.1.0-2
+      version: 3.1.0-1
     status: maintained
   opencv_apps:
     doc:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4012,7 +4012,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/opencv3-release.git
-      version: 3.2.0-5
+      version: 3.2.0-4
     status: maintained
   opencv_apps:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4446,7 +4446,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/opencv3-release.git
-      version: 3.2.0-5
+      version: 3.2.0-4
     status: maintained
   opencv_apps:
     doc:

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1322,7 +1322,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/opencv3-release.git
-      version: 3.2.0-9
+      version: 3.2.0-6
     status: maintained
   openni_camera:
     doc:


### PR DESCRIPTION
This is rolling back the OpenCV3 changes that are failing to build. The binary changes(to pngs) could not go though the sourcedeb debian diff generation.

Talking with @vrabaud OpenCV 3.2.1 is coming out in a week. We will roll back and then we can push the new version in a week or so. 