### PR TITLE
Add python-pathtools to indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9557,6 +9557,13 @@ repositories:
       url: https://github.com/andreasBihlmaier/pysdf.git
       version: master
     status: developed
+  python-pathtools:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/yotabits/python-pathtools-release.git
+      version: 0.1.2-0
+    status: maintained
   python_ethernet_rmp:
     doc:
       type: git


### PR DESCRIPTION
Releasing python-pathtools for ROS Indigo.