### PR TITLE
Revert "Updating distribution.yaml"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5777,21 +5777,6 @@ repositories:
       url: https://github.com/robotics-in-concert/rocon_tools.git
       version: release/0.3-kinetic
     status: developed
-  rodi_robot:
-    doc:
-      type: git
-      url: https://github.com/benjayah/rodi_robot.git
-      version: master
-    release:
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/benjayah/rodi_robot-release.git
-      version: 0.0.1-0
-    source:
-      type: git
-      url: https://github.com/benjayah/rodi_robot.git
-      version: master
-    status: maintained
   romeo_robot:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#15180

This is failing to build on all platforms. I'm reverting it.

Also @benjayah you are not listed as the maintainer, @martinezjavier is listed as the maintainer and he just pinged me about why he's getting emails. Did you talk to him before forking and releasing the package?