### PR TITLE
oculusprime: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4403,6 +4403,21 @@ repositories:
       url: https://github.com/OctoMap/octomap_rviz_plugins.git
       version: kinetic-devel
     status: maintained
+  oculusprime:
+    doc:
+      type: git
+      url: https://github.com/xaxxontech/oculusprime_ros.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/xaxxontech/oculusprime_ros-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/xaxxontech/oculusprime_ros.git
+      version: master
+    status: developed
   omip:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `oculusprime` to `0.1.3-0`:

- upstream repository: https://github.com/xaxxontech/oculusprime_ros.git
- release repository: https://github.com/xaxxontech/oculusprime_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
