### PR TITLE
moveit: 0.7.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6835,7 +6835,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.7.9-0
+      version: 0.7.10-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.7.10-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.7.9-0`

## moveit

```
* [fix][moveit_core] checks for empty name arrays messages before parsing the robot state message data (#499 <https://github.com/ros-planning/moveit/issues/499>) (#518 <https://github.com/ros-planning/moveit/issues/518>)
* [fix] moveit rviz panel name #482 <https://github.com/ros-planning/moveit/pull/482>
* [fix] Build for Ubuntu YZ by adding BOOST_MATH_DISABLE_FLOAT128 (#505 <https://github.com/ros-planning/moveit/issues/505>)
* [fix][moveit_ros/visualization] Tentative encoding workaround (https://github.com/ros-infrastructure/catkin_pkg/issues/181).
* [capability][vizualization] New panel with a slider to control the visualized trajectory (#491 <https://github.com/ros-planning/moveit/issues/491>) (#508 <https://github.com/ros-planning/moveit/issues/508>)
* Contributors: Dave Coleman, Mikael Arguedas, Isaac I.Y. Saito, Yannick Jonetzko
* Contributors: Jorge Nicho, Isaac I.Y. Saito
```

## moveit_commander

- No changes

## moveit_controller_manager_example

- No changes

## moveit_core

```
* [fix] checks for empty name arrays messages before parsing the robot state message data (#499 <https://github.com/ros-planning/moveit/issues/499>) (#518 <https://github.com/ros-planning/moveit/issues/518>)
* Contributors: Jorge Nicho, Isaac I.Y. Saito
```

## moveit_fake_controller_manager

- No changes

## moveit_full

- No changes

## moveit_full_pr2

- No changes

## moveit_kinematics

```
* [fix][Indigo] moveit_kinematics Eigen3 dependency (#470 <https://github.com/ros-planning/moveit/issues/470>)
* Contributors: YuehChuan
```

## moveit_planners

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_benchmarks_gui

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

- No changes

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* [fix] moveit rviz panel name #482 <https://github.com/ros-planning/moveit/pull/482>
* [fix] Build for Ubuntu YZ by adding BOOST_MATH_DISABLE_FLOAT128 (#505 <https://github.com/ros-planning/moveit/issues/505>)
* [fix][moveit_ros/visualization] Tentative encoding workaround (https://github.com/ros-infrastructure/catkin_pkg/issues/181).
* [capability] New panel with a slider to control the visualized trajectory (#491 <https://github.com/ros-planning/moveit/issues/491>) (#508 <https://github.com/ros-planning/moveit/issues/508>)
* Contributors: Dave Coleman, Mikael Arguedas, Isaac I.Y. Saito, Yannick Jonetzko
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_setup_assistant

```
* [fix] Build for Ubuntu YZ by adding BOOST_MATH_DISABLE_FLOAT128 (#505 <https://github.com/ros-planning/moveit/issues/505>)
* [improve][MSA] Open a directory where setup_assistant.launch was started. (#509 <https://github.com/ros-planning/moveit/issues/509>)
* Contributors: Isaac I.Y. Saito, Mikael Arguedas
```

## moveit_simple_controller_manager

- No changes
