### PR TITLE
surface_perception: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14225,7 +14225,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/jstnhuang-release/surface_perception-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/jstnhuang/surface_perception.git


### PR DESCRIPTION
Increasing version of package(s) in repository `surface_perception` to `0.1.1-0`:

- upstream repository: https://github.com/jstnhuang/surface_perception.git
- release repository: https://github.com/jstnhuang-release/surface_perception-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.0-0`

## surface_perception

```
* Added missing dependency.
* Contributors: Justin Huang
```
