### PR TITLE
executive_smach: 2.0.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -401,6 +401,10 @@ repositories:
       version: master
     status: maintained
   executive_smach:
+    doc:
+      type: git
+      url: https://github.com/ros/executive_smach.git
+      version: indigo-devel
     release:
       packages:
       - executive_smach
@@ -410,7 +414,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/executive_smach-release.git
-      version: 2.0.0-0
+      version: 2.0.1-0
     source:
       type: git
       url: https://github.com/ros/executive_smach.git


### PR DESCRIPTION
Increasing version of package(s) in repository `executive_smach` to `2.0.1-0`:

- upstream repository: https://github.com/ros/executive_smach.git
- release repository: https://github.com/ros-gbp/executive_smach-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.0.0-0`

## executive_smach

```
* [fix] SimpleActionState will wait forever for a missing ActionServer #41 <https://github.com/ros/executive_smach/pull/41>
* [fix] monitor state callback args and adding unit test for monitor state that modifies userdata
* [improve] Specify queue sizes for introspection publishers #31 <https://github.com/ros/executive_smach/pull/31>
* [improve] make ServiceState more robust to termination while waiting for service #32 <https://github.com/ros/executive_smach/pull/32>
* [build] make rostest in CMakeLists optional #45 <https://github.com/ros/executive_smach/pull/45>
* change MonitorState and document its behavior
* increment n_checks only *after* checking
  otherwise, setting max_checks=1 results in a MonitorState that returns the 'valid' outcome for any message
* [test] adding test for actionlib timeout
* [maintenance] Update maintainer. switching to package.xml format 2
* Contributors: Isaac I.Y. Saito, Jonathan Bohren, Loy, Lukas Bulwahn, Nils Berg, contradict
```

## smach

```
* [maintenance] Update maintainer. switching to package.xml format 2
* Contributors: Isaac I.Y. Saito
```

## smach_msgs

```
* [maintenance] Update maintainer. switching to package.xml format 2
* Contributors: Isaac I.Y. Saito, Jonathan Bohren
```

## smach_ros

```
* [fix] SimpleActionState will wait forever for a missing ActionServer #41 <https://github.com/ros/executive_smach/pull/41>
* [fix] monitor state callback args and adding unit test for monitor state that modifies userdata
* [improve] Specify queue sizes for introspection publishers #31 <https://github.com/ros/executive_smach/pull/31>
* [improve] make ServiceState more robust to termination while waiting for service #32 <https://github.com/ros/executive_smach/pull/32>
* [build] make rostest in CMakeLists optional #45 <https://github.com/ros/executive_smach/pull/45>
* change MonitorState and document its behavior
* increment n_checks only *after* checking
  otherwise, setting max_checks=1 results in a MonitorState that returns the 'valid' outcome for any message
* [test] adding test for actionlib timeout
* [maintenance] Update maintainer. switching to package.xml format 2
* Contributors: Isaac I.Y. Saito, Jonathan Bohren, Loy, Lukas Bulwahn, Nils Berg, contradict
```
