### PR TITLE
robotis_framework: 0.2.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5577,7 +5577,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
-      version: 0.2.4-0
+      version: 0.2.5-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_framework` to `0.2.5-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.4-0`

## robotis_controller

```
* updated for yaml-cpp dependencies
* Contributors: SCH
```

## robotis_device

```
* none
```

## robotis_framework

```
* updated for yaml-cpp dependencies (robotis_controller)
* Contributors: SCH
```

## robotis_framework_common

```
* none
```
