### PR TITLE
manipulator_h: 0.2.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3204,7 +3204,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-MANIPULATOR-H-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-MANIPULATOR-H.git


### PR DESCRIPTION
Increasing version of package(s) in repository `manipulator_h` to `0.2.3-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-MANIPULATOR-H.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-MANIPULATOR-H-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.2-0`

## manipulator_h

```
* updated CMakeLists.txt & package.yaml to release binary packages
* Contributors: SCH
```

## manipulator_h_base_module

```
* updated CMakeLists.txt & package.yaml to release binary packages
* Contributors: SCH
```

## manipulator_h_base_module_msgs

```
* none
```

## manipulator_h_bringup

```
* none
```

## manipulator_h_description

```
* none
```

## manipulator_h_gazebo

```
* none
```

## manipulator_h_gui

```
* none
```

## manipulator_h_kinematics_dynamics

```
* none
```

## manipulator_h_manager

```
* none
```
