### PR TITLE
turtlebot3_simulations: 0.1.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8001,7 +8001,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
-      version: 0.1.4-1
+      version: 0.1.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_simulations` to `0.1.5-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.4-1`

## turtlebot3_fake

```
* none
```

## turtlebot3_gazebo

```
* modified make files for dependencies
* updated turtlebot3 sim
* updated world config
* Contributors: Darby Lim
```

## turtlebot3_simulations

```
* modified make files for dependencies
* updated turtlebot3 sim
* updated world config
* Contributors: Darby Lim
```
