### PR TITLE
robot_controllers: 0.5.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10461,7 +10461,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
-      version: 0.5.2-0
+      version: 0.5.3-0
     source:
       type: git
       url: https://github.com/fetchrobotics/robot_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_controllers` to `0.5.3-0`:

- upstream repository: https://github.com/fetchrobotics/robot_controllers.git
- release repository: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.5.2-0`

## robot_controllers

```
* remove limiter
* Improve cartesian twist controller (#26 <https://github.com/fetchrobotics/robot_controllers/issues/26>)
* Contributors: Hanjun Song, Michael Ferguson
```

## robot_controllers_interface

```
* add error message when pluginlib fails
* fix cmake warnings on kinetic (#28 <https://github.com/fetchrobotics/robot_controllers/issues/28>)
* Contributors: Michael Ferguson
```

## robot_controllers_msgs

- No changes
