### PR TITLE
binpicking_utils: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -566,7 +566,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/durovsky/binpicking_utils-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/durovsky/binpicking_utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `binpicking_utils` to `0.1.2-0`:

- upstream repository: https://github.com/durovsky/binpicking_utils.git
- release repository: https://github.com/durovsky/binpicking_utils-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.1-0`

## bin_pose_emulator

```
* added install targets
* Update Readme.md
* Create README.md
* Contributors: Frantisek Durovsky
```

## bin_pose_msgs

- No changes

## binpicking_utils

- No changes
