### PR TITLE
added pyusb via pip for debian and ubuntu

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2180,6 +2180,11 @@ python-pyudev:
     wily: [python-pyudev]
     xenial: [python-pyudev]
     yakkety: [python-pyudev]
+python-pyusb-pip:
+  debian:
+    pip: [pyusb]
+  ubuntu:
+    pip: [pyusb]
 python-pyuserinput:
   ubuntu:
     pip:


### PR DESCRIPTION
[pyusb 1.0.0](https://pypi.python.org/pypi/pyusb/1.0.0)