### PR TITLE
gscam: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3923,6 +3923,20 @@ repositories:
       url: https://github.com/g/grizzly_simulator.git
       version: indigo-devel
     status: maintained
+  gscam:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/gscam.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/gscam-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/gscam.git
+      version: master
   h4r_thermapp_camera:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `gscam` to `0.2.0-0`:

- upstream repository: git://github.com/ros-drivers/gscam.git
- release repository: https://github.com/ros-drivers-gbp/gscam-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## gscam

```
* add ROS Orphaned Package Maintainers to maintainer tag (#35 <https://github.com/ros-drivers/gscam/issues/35> )
* gscam_nodelet.h: include scoped_ptr.hpp to compile with boost 1.57
  When compiling gscam with the currently latest boost version 1.57,
  it fails with:
  In file included from [...]/src/gscam_nodelet.cpp:5:0:
  [...]/include/gscam/gscam_nodelet.h:20:12: error: 'scoped_ptr' in namespace 'boost' does not name a template type
  boost::scoped_ptr<GSCam> gscam_driver_;
  ^
  [...]/include/gscam/gscam_nodelet.h:21:12: error: 'scoped_ptr' in namespace 'boost' does not name a template type
  boost::scoped_ptr<boost::thread> stream_thread_;
  ^
  It seems that the dependencies of boost/thread.hpp have changed
  and boost/scoped_ptr.hpp is not included anymore with
  boost/thread.hpp. Hence, the scoped_ptr is not defined in the
  gscam_nodelet header. After scanning quickly through the release
  notes of version 1.57, the boost bug tracker and a few changesets,
  I could not find not a hint what has changed in the thread library
  that gscam must include scoped_ptr itself.
  This commit simply addresses the compiler error by explicitly
  adding boost's scoped_ptr header in the gscam_nodelet header.
  As this commit also compiles with boost version 1.56, the commit
  is not expected to cause any problems with other build
  configurations.
  Signed-off-by: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
* Remove dependency on opencv2 to fix under indigo
  Packages can no longer depend on opencv2 as of indigo.
  I've updated the package to depend instead on cv_bridge as suggested by http://wiki.ros.org/indigo/Migration#OpenCV.
* Install the parameters file refered to in v4l.launch
* Update package.xml
* Examples: Added example for OSX (#15 <https://github.com/ros-drivers/gscam/issues/15>)
  Add a simple launch configuration for OSX. The camera can be selected by
  changing the default="0" to the appropriate integer.
* Adding libraries to gscam target
  Fixes #13 <https://github.com/ros-drivers/gscam/issues/13>, now builds on stricter linkers
* adding proper depends to catkin package call
* Update minoru.launch
* Contributors: CHILI Demo Corner, Jonathan Bohren, Kei Okada, Kenn Sebesta, Lukas Bulwahn, Russell Toris, Lukas Bulwahn
```
