### PR TITLE
[rosdep] added mongodb-dev for wily/xenial

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3192,6 +3192,8 @@ mongodb-dev:
     trusty: [libmongo-client-dev, mongodb-dev]
     utopic: [libmongo-client-dev]
     vivid: [libmongo-client-dev]
+    wily: [libmongo-client-dev]
+    xenial: [libmongo-client-dev]
 mono-complete:
   debian: [mono-complete]
   gentoo: [dev-lang/mono]


### PR DESCRIPTION
this was missing, I believe.