### PR TITLE
gscam: 1.0.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -699,7 +699,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-drivers-gbp/gscam-release.git
-      version: 0.2.0-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/gscam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gscam` to `1.0.0-0`:

- upstream repository: git://github.com/ros-drivers/gscam.git
- release repository: https://github.com/ros-drivers-gbp/gscam-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.0-0`

## gscam

```
* Gstreamer 1 0 support (#36 <https://github.com/ros-drivers/gscam/issues/36> )
  * delete unused manifest.xml, rosdep.yaml
  * use libgstreamer1.0 for lunar
  * Fixing preproc switches so that the 1.0 branch still builds against 0.1 without the switch flags
  * Preliminary GStreamer-1.0 support see README for more info
* Contributors: Jonathan Bohren, Kei Okada
```
