### PR TITLE
rosparam_handler: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6424,6 +6424,21 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: jade-devel
     status: maintained
+  rosparam_handler:
+    doc:
+      type: git
+      url: https://github.com/cbandera/rosparam_handler.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/cbandera/rosparam_handler-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/cbandera/rosparam_handler.git
+      version: master
+    status: maintained
   rosparam_shortcuts:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_handler` to `0.1.1-0`:

- upstream repository: https://github.com/cbandera/rosparam_handler.git
- release repository: https://github.com/cbandera/rosparam_handler-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## rosparam_handler

```
* Initial release of rosparam_handler
* Contributors: Claudio Bandera, Fabian Poggenhans, Jeremie Deray, Matthias Füller, Nikolaus Demmel, Sascha Wirges, artivis
```
