### PR TITLE
usb_cam: 0.3.5-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2794,6 +2794,21 @@ repositories:
       url: https://github.com/ros/urdf_parser_py.git
       version: indigo-devel
     status: maintained
+  usb_cam:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/usb_cam.git
+      version: develop
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/usb_cam-release.git
+      version: 0.3.5-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/usb_cam.git
+      version: develop
+    status: unmaintained
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam` to `0.3.5-0`:

- upstream repository: https://github.com/ros-drivers/usb_cam.git
- release repository: https://github.com/ros-gbp/usb_cam-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## usb_cam

```
* add ROS Orphaned Package Maintainers to maintainer tag (#69 <https://github.com/ros-drivers/usb_cam/issues/69>)
* support for Kinetic / Ubuntu 16.04 (#58 <https://github.com/ros-drivers/usb_cam/issues/58>)
  * replace use of deprecated functions in newer ffmpeg/libav versionsffmpeg/libav 55.x (used in ROS Kinetic) deprecated the avcodec_alloc_frame.
* Add grey scale pixel format. (#45 <https://github.com/ros-drivers/usb_cam/issues/45>)
* add start/stop capture services (#44 <https://github.com/ros-drivers/usb_cam/issues/44> )
  * better management of start/stop
  * up package.xml
  * add capture service
* fix bug for byte count in a pixel (3 bytes not 24 bytes) (#40 <https://github.com/ros-drivers/usb_cam/issues/40> )
* Contributors: Daniel Seifert, Eric Zavesky, Kei Okada, Ludovico Russo, Russell Toris, honeytrap15
```
