### PR TITLE
jsk_common: 2.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5215,7 +5215,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.2.3-0
+      version: 2.2.4-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.2.4-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.2.3-0`

## dynamic_tf_publisher

```
* add ROSIntrupptException, not to show strage message on shutting down (#1522 <https://github.com/jsk-ros-pkg/jsk_common/pull/1522>)
* Contributors: Kei Okada
```

## image_view2

- No changes

## jsk_common

- No changes

## jsk_data

```
* [jsk_data][pr2_play.launch] replace doc to comment (#1526 <https://github.com/jsk-ros-pkg/jsk_common/issues/1526>)
  * [jsk_data][pr2_play.launch] remove relay to c2 ns
  * [jsk_data][pr2_play.sh] support other rosbag arguments
* Fix bug for initialization of service server of data_collection_server (#1525 <https://github.com/jsk-ros-pkg/jsk_common/issues/1525>)
  * Mode to save topics without requestModified:
  - jsk_data/node_scripts/data_collection_server.py
* Contributors: Kentaro Wada, Yuki Furuta
```

## jsk_network_tools

- No changes

## jsk_tilt_laser

```
* [multisense_laser_pipeline] fix from inside the JAXON (#1528 <https://github.com/jsk-ros-pkg/jsk_common/pull/1528>)
* Contributors: Yohei Kakiuchi
```

## jsk_tools

```
* CMakeLists.txt : fix install process, bin is already installed to /opt/ros/indigo/lib/jsk_tools/ directory (#1518 <https://github.com/jsk-ros-pkg/jsk_common/issues/1518>)
* Remove import error message in ros_console.py, Because python-colorama is installed via apt (#1517 <https://github.com/jsk-ros-pkg/jsk_common/issues/1517>)
* Contributors: Kei Okada, Kentaro Wada
```

## jsk_topic_tools

```
* [jsk_topic_tools][LightweightThrottle] dynamic change update_rate (#1514 <https://github.com/jsk-ros-pkg/jsk_common/pull/1514>)
  *  [jsk_topic_tools][lightweight_throttle] support jump back in time
* [jsk_topic_tools][connection_based_nodelet] add isSubscribed method (#1523 <https://github.com/jsk-ros-pkg/jsk_common/pull/1523>)
* Test disconnection in test_connection.py (#1520 <https://github.com/jsk-ros-pkg/jsk_common/pull/1520>)
  - modified:   test/test_connection.py
  - https://github.com/jsk-ros-pkg/jsk_common/pull/1520#issuecomment-298151270
* [jsk_topic_tools][connection_based_nodelet] warn if onInitPostProcess is not called (#1513 <https://github.com/jsk-ros-pkg/jsk_common/pull/1513>)
* Contributors: Kentaro Wada, Yuki Furuta
```

## multi_map_server

- No changes

## virtual_force_publisher

- No changes
