### PR TITLE
fixed wrong scipy category on gentoo

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2539,7 +2539,7 @@ python-scipy:
   debian: [python-scipy]
   fedora: [scipy]
   freebsd: [py-scipy]
-  gentoo: [dev-libs/scipy]
+  gentoo: [sci-libs/scipy]
   macports: [py27-scipy]
   opensuse: [python-scipy]
   ubuntu:


### PR DESCRIPTION
closes https://github.com/ros/ros-overlay/issues/102