### PR TITLE
libuvc_ros: 0.0.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3076,6 +3076,24 @@ repositories:
       url: https://github.com/ktossell/libuvc-release.git
       version: 0.0.5-2
     status: unmaintained
+  libuvc_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/libuvc_ros.git
+      version: master
+    release:
+      packages:
+      - libuvc_camera
+      - libuvc_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/libuvc_ros-release.git
+      version: 0.0.8-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/libuvc_ros.git
+      version: master
+    status: unmaintained
   lidar_camera_calibration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc_ros` to `0.0.8-0`:

- upstream repository: https://github.com/ros-drivers/libuvc_ros.git
- release repository: https://github.com/ros-drivers-gbp/libuvc_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## libuvc_camera

```
* add ROS Orphaned Package Maintainers to maintainer tag (#40 <https://github.com/ros-drivers/libuvc_ros/issues/40>)
* Implement missing index select behavior (#27 <https://github.com/ros-drivers/libuvc_ros/issues/27>)
* Enable mjpeg support despite uvs_any2bgr shortcoming (#26 <https://github.com/ros-drivers/libuvc_ros/issues/26>)
* [libuvc_camera/src/camera_driver.cpp] use frame's capture time for   timestamp of ros message instead of callback time (#24 <https://github.com/ros-drivers/libuvc_ros/issues/24>)
* [libuvc_camera] support multiple video mode (#22 <https://github.com/ros-drivers/libuvc_ros/issues/22>)
  * [libuvc_camera] add detail error message if no image format support
  * [libuvc_camera] support multiple video_mode
* add new parameters in cfg (#21 <https://github.com/ros-drivers/libuvc_ros/issues/21>)
* Changed defaults: auto_exposure=True, auto_focus=aperture_priority
* Implemented AE priority, abs exposure/focus, autofocus, pantilt controls
* Contributors: Yuki Furuta, Josh Villbrandt, Kei Okada, Ken Tossell
```

## libuvc_ros

```
* add ROS Orphaned Package Maintainers to maintainer tag
* Contributors: Kei Okada
```
