### PR TITLE
camera_umd: 0.2.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -642,6 +642,25 @@ repositories:
       url: https://github.com/ros-perception/camera_info_manager_py.git
       version: master
     status: maintained
+  camera_umd:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/camera_umd.git
+      version: master
+    release:
+      packages:
+      - camera_umd
+      - jpeg_streamer
+      - uvc_camera
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/camera_umd-release.git
+      version: 0.2.5-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/camera_umd.git
+      version: master
+    status: unmaintained
   capabilities:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_umd` to `0.2.5-0`:

- upstream repository: https://github.com/ros-drivers/camera_umd.git
- release repository: https://github.com/ros-drivers-gbp/camera_umd-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## camera_umd

```
* add ROS Orphaned Package Maintainers to maintainer tag
* Contributors: Kei Okada
```

## jpeg_streamer

```
* add ROS Orphaned Package Maintainers to maintainer tag
* Contributors: Kei Okada
```

## uvc_camera

```
* add ROS Orphaned Package Maintainers to maintainer tag (#18 <https://github.com/ros-drivers/camera_umd/pull/18>)
* important property: focus_absolute ; add because here example == documentation
* Added exposure, gain, horizontal flip and vertical flip controls (#15 <https://github.com/ros-drivers/camera_umd/pull/15>)
* Added support for some camera controls in ROS .launch files.  (#14 <https://github.com/ros-drivers/camera_umd/pull/14>)
  * Added exposure, gain, horizontal flip and vertical flip controls
  * Added support for camera controls in ROS .launch files. Also added example.launch
* Support MJPEG format direct streaming (#13 <https://github.com/ros-drivers/camera_umd/pull/13>)
* Add comment in launchfiles. (#12 <https://github.com/ros-drivers/camera_umd/pull/12>)
* Add brightness control parameter. (#12 <https://github.com/ros-drivers/camera_umd/pull/12>)
* Contributors: Adrian Yuen, Glass Bot, Kei Okada, Lingzhu Xiang, Toni Oliver
```
