### PR TITLE
rosdep: add polyclipping and python-{genshi, tinydb, xmltodict} deps

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3463,10 +3463,12 @@ pocketsphinx:
     xenial: [pocketsphinx]
     yakkety: [pocketsphinx]
     zesty: [pocketsphinx]
-polyclipping:
-  ubuntu:
-    trusty: [libpolyclipping-dev]
-    xenial: [libpolyclipping-dev]
+polyclipping-dev:
+  debian:
+    jessie: [libpolyclipping-dev]
+    stretch: [libpolyclipping-dev]
+    sid: [libpolyclipping-dev]
+  ubuntu: [libpolyclipping-dev]
 portaudio:
   arch: [portaudio]
   debian: [libportaudio-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3463,6 +3463,10 @@ pocketsphinx:
     xenial: [pocketsphinx]
     yakkety: [pocketsphinx]
     zesty: [pocketsphinx]
+polyclipping:
+  ubuntu:
+    trusty: [libpolyclipping-dev]
+    xenial: [libpolyclipping-dev]
 portaudio:
   arch: [portaudio]
   debian: [libportaudio-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3467,7 +3467,6 @@ polyclipping-dev:
   debian:
     jessie: [libpolyclipping-dev]
     stretch: [libpolyclipping-dev]
-    sid: [libpolyclipping-dev]
   ubuntu: [libpolyclipping-dev]
 portaudio:
   arch: [portaudio]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -965,6 +965,10 @@ python-gdown-pip:
     pip:
       packages: [gdown]
 python-genshi:
+  debian:
+    wheezy: [python-genshi]
+    jessie: [python-genshi]
+    stretch: [python-genshi]
   ubuntu: [python-genshi]
 python-geographiclib:
   debian: [python-geographiclib]
@@ -3353,7 +3357,6 @@ python-xmltodict:
   debian:
     jessie: [python-xmltodict]
     stretch: [python-xmltodict]
-    sid: [python-xmltodict]
   ubuntu:
     xenial: [python-xmltodict]
     yakkety: [python-xmltodict]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3355,10 +3355,10 @@ python-xmltodict:
     jessie: [python-xmltodict]
     stretch: [python-xmltodict]
   ubuntu:
+    artful: [python-xmltodict]
     xenial: [python-xmltodict]
     yakkety: [python-xmltodict]
     zesty: [python-xmltodict]
-    artful: [python-xmltodict]
 python-yaml:
   arch: [python2-yaml]
   centos: [PyYAML]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -965,10 +965,7 @@ python-gdown-pip:
     pip:
       packages: [gdown]
 python-genshi:
-  debian:
-    wheezy: [python-genshi]
-    jessie: [python-genshi]
-    stretch: [python-genshi]
+  debian: [python-genshi]
   ubuntu: [python-genshi]
 python-geographiclib:
   debian: [python-geographiclib]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -964,6 +964,10 @@ python-gdown-pip:
   ubuntu:
     pip:
       packages: [gdown]
+python-genshi:
+  ubuntu:
+    trusty: [python-genshi]
+    xenial: [python-genshi]
 python-geographiclib:
   debian: [python-geographiclib]
   fedora: [python-GeographicLib]
@@ -3057,6 +3061,13 @@ python-tilestache:
     heisenbug: [python-tilestache]
     schrödinger’s: [python-tilestache]
   ubuntu: [tilestache]
+python-tinydb:
+  debian:
+    pip:
+      packages: [tinydb]
+  ubuntu:
+    pip:
+      packages: [tinydb]
 python-tk:
   arch: [python2, tk]
   debian: [python-tk]
@@ -3340,6 +3351,9 @@ python-xlib:
   fedora: [python-xlib]
   gentoo: [dev-python/python-xlib]
   ubuntu: [python-xlib]
+python-xmltodict:
+  ubuntu:
+    xenial: [python-xmltodict]
 python-yaml:
   arch: [python2-yaml]
   centos: [PyYAML]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -965,9 +965,7 @@ python-gdown-pip:
     pip:
       packages: [gdown]
 python-genshi:
-  ubuntu:
-    trusty: [python-genshi]
-    xenial: [python-genshi]
+  ubuntu: [python-genshi]
 python-geographiclib:
   debian: [python-geographiclib]
   fedora: [python-GeographicLib]
@@ -3061,7 +3059,7 @@ python-tilestache:
     heisenbug: [python-tilestache]
     schrödinger’s: [python-tilestache]
   ubuntu: [tilestache]
-python-tinydb:
+python-tinydb-pip:
   debian:
     pip:
       packages: [tinydb]
@@ -3352,8 +3350,15 @@ python-xlib:
   gentoo: [dev-python/python-xlib]
   ubuntu: [python-xlib]
 python-xmltodict:
+  debian:
+    jessie: [python-xmltodict]
+    stretch: [python-xmltodict]
+    sid: [python-xmltodict]
   ubuntu:
     xenial: [python-xmltodict]
+    yakkety: [python-xmltodict]
+    zesty: [python-xmltodict]
+    artful: [python-xmltodict]
 python-yaml:
   arch: [python2-yaml]
   centos: [PyYAML]


### PR DESCRIPTION
I would like to add the following package dependencies:
- polyclipping: https://packages.ubuntu.com/xenial/libpolyclipping-dev
- python-genshi: https://packages.ubuntu.com/xenial/python-genshi
- python-xmltodict: https://packages.ubuntu.com/xenial/python-xmltodict
- python-tinydb: https://pypi.python.org/pypi/tinydb

I am using these packages for working on paths polygon as well as XML processing in Python.

Please note that I've followed the guidelines [here](https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md) and [here](http://docs.ros.org/independent/api/rosdep/html/contributing_rules.html), and tested my changes accordingly.