### PR TITLE
Add rosdep keys for some ROS 2 dependencies.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -351,6 +351,9 @@ checkinstall:
 chromium-browser:
   gentoo: [www-client/chromium]
   ubuntu: [chromium-browser]
+clang-format:
+  ubuntu:
+    xenial: [clang-format]
 cmake:
   arch: [cmake]
   debian: [cmake]
@@ -425,6 +428,9 @@ couchdb:
   fedora: [couchdb]
   gentoo: [dev-db/couchdb]
   ubuntu: [couchdb]
+cppcheck:
+  ubuntu:
+    xenial: [cppcheck]
 cppunit:
   arch: [cppunit]
   debian: [libcppunit-dev]
@@ -3552,6 +3558,12 @@ pstoedit:
   fedora: [pstoedit]
   gentoo: [media-gfx/pstoedit]
   ubuntu: [pstoedit]
+pydocstyle:
+  ubuntu:
+    xenial: [pydocstyle]
+pyflakes3:
+  ubuntu:
+    xenial: [pyflakes3]
 pyqt4-dev-tools:
   arch: [python2-pyqt4]
   debian: [pyqt4-dev-tools]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -429,8 +429,7 @@ couchdb:
   gentoo: [dev-db/couchdb]
   ubuntu: [couchdb]
 cppcheck:
-  ubuntu:
-    xenial: [cppcheck]
+  ubuntu: [cppcheck]
 cppunit:
   arch: [cppunit]
   debian: [libcppunit-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3558,12 +3558,6 @@ pstoedit:
   fedora: [pstoedit]
   gentoo: [media-gfx/pstoedit]
   ubuntu: [pstoedit]
-pydocstyle:
-  ubuntu:
-    xenial: [pydocstyle]
-pyflakes3:
-  ubuntu:
-    xenial: [pyflakes3]
 pyqt4-dev-tools:
   arch: [python2-pyqt4]
   debian: [pyqt4-dev-tools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3415,20 +3415,15 @@ python3-babeltrace:
     wily: [python3-babeltrace]
     xenial: [python3-babeltrace]
 python3-empy:
-  ubuntu:
-    xenial: [python3-empy]
+  ubuntu: [python3-empy]
 python3-flake8:
-  ubuntu:
-    xenial: [python3-flake8]
+  ubuntu: [python3-flake8]
 python3-nose:
-  ubuntu:
-    xenial: [python3-nose]
+  ubuntu: [python3-nose]
 python3-pep8:
-  ubuntu:
-    xenial: [python3-pep8]
+  ubuntu: [python3-pep8]
 python3-setuptools:
-  ubuntu:
-    xenial: [python3-setuptools]
+  ubuntu: [python3-setuptools]
 xdot:
   debian: [xdot]
   fedora: [python-xdot]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -122,8 +122,6 @@ python:
     yakkety_python3: [python3-dev]
     zesty: [python-dev]
     zesty_python3: [python3-dev]
-python3:
-  ubuntu: [python3-dev]
 python-adafruit-bno055-pip:
   debian:
     pip:
@@ -3406,6 +3404,8 @@ python-zmq:
     wily: [python-zmq]
     xenial: [python-zmq]
     yakkety: [python-zmq]
+python3:
+  ubuntu: [python3-dev]
 python3-babeltrace:
   debian:
     jessie: [python3-babeltrace]
@@ -3420,12 +3420,12 @@ python3-empy:
 python3-flake8:
   ubuntu:
     xenial: [python3-flake8]
-python3-pep8:
-  ubuntu:
-    xenial: [python3-pep8]
 python3-nose:
   ubuntu:
     xenial: [python3-nose]
+python3-pep8:
+  ubuntu:
+    xenial: [python3-pep8]
 python3-setuptools:
   ubuntu:
     xenial: [python3-setuptools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -58,6 +58,12 @@ pika:
     pip:
       packages: [pika]
   ubuntu: [python-pika]
+pydocstyle:
+  ubuntu:
+    xenial: [pydocstyle]
+pyflakes3:
+  ubuntu:
+    xenial: [pyflakes3]
 pyper-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -116,6 +116,8 @@ python:
     yakkety_python3: [python3-dev]
     zesty: [python-dev]
     zesty_python3: [python3-dev]
+python3:
+  ubuntu: [python3-dev]
 python-adafruit-bno055-pip:
   debian:
     pip:
@@ -3406,6 +3408,21 @@ python3-babeltrace:
   ubuntu:
     wily: [python3-babeltrace]
     xenial: [python3-babeltrace]
+python3-empy:
+  ubuntu:
+    xenial: [python3-empy]
+python3-flake8:
+  ubuntu:
+    xenial: [python3-flake8]
+python3-pep8:
+  ubuntu:
+    xenial: [python3-pep8]
+python3-nose:
+  ubuntu:
+    xenial: [python3-nose]
+python3-setuptools:
+  ubuntu:
+    xenial: [python3-setuptools]
 xdot:
   debian: [xdot]
   fedora: [python-xdot]


### PR DESCRIPTION
These keys were added during the packaging of ROS 2 in advance of the beta 2 release. I don't believe any introduce conflicts with existing rosdep keys.

Right now keys have only been added for Ubuntu Xenial since that's the only distro supported by the ROS 2 binaries and I didn't want to add keys that I didn't test for satisfaction.