### PR TITLE
look_at_pose: 0.7.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3178,6 +3178,22 @@ repositories:
       url: https://github.com/easymov/log_server-release.git
       version: 0.1.4-1
     status: developed
+  look_at_pose:
+    doc:
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/look_at_pose.git
+      version: kinetic
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/UTNuclearRoboticsPublic/look_at_pose-release.git
+      version: 0.7.4-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/look_at_pose.git
+      version: kinetic
+    status: maintained
   lpms_imu:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `look_at_pose` to `0.7.4-0`:

- upstream repository: https://github.com/UTNuclearRoboticsPublic/look_at_pose.git
- release repository: https://github.com/UTNuclearRoboticsPublic/look_at_pose-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
