### PR TITLE
ar_track_alvar: 0.7.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -154,12 +154,11 @@ repositories:
     release:
       packages:
       - ar_track_alvar
-      - ar_track_alvar_metapkg
       - ar_track_alvar_msgs
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ar_track_alvar-release.git
-      version: 0.7.0-1
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/ros-perception/ar_track_alvar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar` to `0.7.1-0`:

- upstream repository: https://github.com/ros-perception/ar_track_alvar
- release repository: https://github.com/ros-gbp/ar_track_alvar-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.7.0-1`

## ar_track_alvar

```
* [maintenance] Remove unnecessary metapkg.
* [fix][build][CMakeLists] Prevent rosdep errors that only occur when running tests with catkin_make_isolated. See http://answers.ros.org/question/262558/buildfarm-missing-package-dependencies-pkg_namepackagexml/
* [test] Relax tf test criteria #39 <https://github.com/ros-perception/ar_track_alvar/pull/39>
* Contributors: Isaac I.Y. Saito
```

## ar_track_alvar_msgs

```
* [maintenance] Remove unnecessary metapkg.
```
