### PR TITLE
libuvc_ros: 0.0.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3106,7 +3106,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/libuvc_ros-release.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/ros-drivers/libuvc_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc_ros` to `0.0.9-0`:

- upstream repository: https://github.com/ros-drivers/libuvc_ros.git
- release repository: https://github.com/ros-drivers-gbp/libuvc_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.8-0`

## libuvc_camera

```
* enable to compile with libuvc <= v0.0.5
* Contributors: Kei Okada
```

## libuvc_ros

- No changes
