### PR TITLE
Add rosdep for adafruit-pca9685

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -116,6 +116,16 @@ python:
     yakkety_python3: [python3-dev]
     zesty: [python-dev]
     zesty_python3: [python3-dev]
+adafruit-pca9685:
+  debian:
+    pip:
+      packages: [adafruit-pca9685]
+  fedora:
+    pip:
+      packages: [adafruit-pca9685]
+  ubuntu:
+    pip:
+      packages: [adafruit-pca9685]
 python-adafruit-bno055-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1,4 +1,4 @@
-adafruit-pca9685:
+adafruit-pca9685-pip:
   debian:
     pip:
       packages: [adafruit-pca9685]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1,3 +1,13 @@
+adafruit-pca9685:
+  debian:
+    pip:
+      packages: [adafruit-pca9685]
+  fedora:
+    pip:
+      packages: [adafruit-pca9685]
+  ubuntu:
+    pip:
+      packages: [adafruit-pca9685]
 gunicorn:
   fedora: [python-gunicorn]
   gentoo: [www-servers/gunicorn]
@@ -116,16 +126,6 @@ python:
     yakkety_python3: [python3-dev]
     zesty: [python-dev]
     zesty_python3: [python3-dev]
-adafruit-pca9685:
-  debian:
-    pip:
-      packages: [adafruit-pca9685]
-  fedora:
-    pip:
-      packages: [adafruit-pca9685]
-  ubuntu:
-    pip:
-      packages: [adafruit-pca9685]
 python-adafruit-bno055-pip:
   debian:
     pip:


### PR DESCRIPTION
This is to add a rosdep key for the Adafruit-PCA9685 raspberry pi controller. Source for the controller is here:

https://github.com/adafruit/Adafruit_Python_PCA9685

PIP package is here:

https://pypi.python.org/pypi/Adafruit-PCA9685/1.0.1