### PR TITLE
[dep][ubuntu] Add gstreamer0.10-gconf

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -906,6 +906,16 @@ graphviz:
 gringo:
   fedora: [gringo]
   ubuntu: [gringo]
+gstreamer0.10-gconf:
+  debian:
+    jessie: [gstreamer0.10-gconf]
+  ubuntu:
+    precise: [gstreamer0.10-gconf]
+    trusty: [gstreamer0.10-gconf]
+    utopic: [gstreamer0.10-gconf]
+    vivid: [gstreamer0.10-gconf]
+    wily: [gstreamer0.10-gconf]
+    xenial: [gstreamer0.10-gconf]
 gstreamer0.10-plugins-good:
   arch: [gstreamer0.10-good-plugins]
   debian: [gstreamer0.10-plugins-good]


### PR DESCRIPTION
Trusty: https://packages.ubuntu.com/trusty/gstreamer0.10-gconf
xenial: https://packages.ubuntu.com/xenial/gstreamer0.10-gconf

On packages.ubuntu.com only two distros above are found, which is why I'm adding those two only.
Some other sites I found may state it's been available on other distros, but I'm not confident the credibility of those sites.

Cc @7675t 