### PR TITLE
remove duplicates keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3568,48 +3568,14 @@ pyqt5-dev-tools:
   fedora: [python-qt5-devel]
   gentoo: [dev-python/PyQt5]
   ubuntu: [pyqt5-dev-tools]
-python-cairo:
-  fedora: [pycairo]
-  gentoo: [dev-python/pycairo]
-python-nose:
-  fedora: [python-nose]
-  gentoo: [dev-python/nose]
-python-opencv:
-  fedora: [opencv-python]
-  gentoo: [media-libs/opencv]
-  ubuntu: [python-opencv]
-python-pyaudio:
-  debian: [python-pyaudio]
-  fedora: [pyaudio]
-  gentoo: [dev-python/pyaudio]
-  ubuntu: [python-pyaudio]
-python-pydot:
-  fedora: [pydot]
-  gentoo: [media-gfx/pydot]
 python-pyftpdlib:
   debian: [python-pyftpdlib]
   gentoo: [dev-python/pyftpdlib]
   ubuntu: [python-pyftpdlib]
-python-pygraphviz:
-  fedora: [python-pygraphviz]
-  gentoo: [dev-python/pygraphviz]
-  opensuse: [python-pygraphviz]
 python-qrencode:
   debian: [python-qrencode]
   gentoo: [media-gfx/qrencode-python]
   ubuntu: [python-qrencode]
-python-sphinx:
-  fedora: [python-sphinx]
-  gentoo: [dev-python/sphinx]
-python-tornado:
-  arch: [python-tornado]
-  debian: [python-tornado]
-  fedora: [python-tornado]
-  gentoo: [www-servers/tornado]
-  ubuntu: [python-tornado]
-python-vtk:
-  fedora: [vtk-python]
-  gentoo: [dev-python/pyvtk]
 qhull-bin:
   arch: [qhull]
   debian: [qhull-bin]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3448,18 +3448,10 @@ pkg-config:
     slackpkg:
       packages: [pkg-config]
   ubuntu: [pkg-config]
-pocketsphinx:
+pocketsphinx-bin:
   fedora: [pocketsphinx]
   gentoo: [app-accessibility/pocketsphinx]
   ubuntu:
-    precise: [libsphinxbase1]
-    quantal: [libsphinxbase1]
-    raring: [libsphinxbase1]
-    saucy: [libsphinxbase1]
-    trusty: [libsphinxbase1]
-    utopic: [libsphinxbase1]
-    vivid: [libsphinxbase1]
-    wily: [libsphinxbase1]
     xenial: [pocketsphinx]
     yakkety: [pocketsphinx]
     zesty: [pocketsphinx]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3442,7 +3442,7 @@ python3-babeltrace:
   ubuntu:
     wily: [python3-babeltrace]
     xenial: [python3-babeltrace]
-xdot:
+python-xdot:
   debian: [xdot]
   fedora: [python-xdot]
   gentoo: [media-gfx/xdot]


### PR DESCRIPTION
c.f. https://github.com/ros-infrastructure/rosdep/pull/520

some of rosdep keys is multiply defined, and that sometime confuse users.

- rename xdot in python.yaml to python-xdot, because xdot is already taken by  ros package, at least until indigo http://wiki.ros.org/xdot

change xdot to python-xdot, this will break backward compatibility....

-  pocketsphinx is already taken by ros  package(http://wiki.ros.org/pocketsphinx) 
    and that different from pocketsphinx system package,
    libshphinxbase is library and pocketsphinx installs some application binaries, so they are different too

  this changes pocketsphinx key in base.yaml to pocketsphinx-bin, this also breaks compatibility, but that was added just a few month ago

   ```

ubuntu-14:~$ dpkg -L libsphinxbase1
/.
/usr
/usr/share
/usr/share/doc
/usr/share/doc/libsphinxbase1
/usr/share/doc/libsphinxbase1/copyright
/usr/share/doc/libsphinxbase1/changelog.Debian.gz
/usr/lib
/usr/lib/libsphinxbase.so.1.1.1
/usr/lib/libsphinxad.so.0.0.1
/usr/lib/libsphinxbase.so.1
/usr/lib/libsphinxad.so.0
ubuntu-14:~$ dpkg -L libpocketsphinx1/.
/usr
/usr/lib
/usr/lib/libpocketsphinx.so.1.1.0
/usr/share
/usr/share/doc
/usr/share/doc/libpocketsphinx1
/usr/share/doc/libpocketsphinx1/copyright
/usr/share/doc/libpocketsphinx1/changelog.Debian.gz
/usr/lib/libpocketsphinx.so.1


ubuntu-16:~$ dpkg -L pocketsphinx
/.
/usr
/usr/bin
/usr/bin/pocketsphinx_mdef_convert
/usr/bin/pocketsphinx_continuous
/usr/bin/pocketsphinx_batch
/usr/share
/usr/share/doc
/usr/share/doc/pocketsphinx
/usr/share/doc/pocketsphinx/copyright
/usr/share/man
/usr/share/man/man1
/usr/share/man/man1/pocketsphinx_batch.1.gz
/usr/share/man/man1/pocketsphinx_continuous.1.gz
/usr/share/man/man1/pocketsphinx_mdef_convert.1.gz
/usr/share/doc/pocketsphinx/changelog.Debian.gz

ubuntu-16:~$ dpkg -L libpocketsphinx3
/.
/usr
/usr/lib
/usr/lib/x86_64-linux-gnu
/usr/lib/x86_64-linux-gnu/libpocketsphinx.so.3.0.0
/usr/share
/usr/share/doc
/usr/share/doc/libpocketsphinx3
/usr/share/doc/libpocketsphinx3/copyright
/usr/share/doc/libpocketsphinx3/changelog.Debian.gz
/usr/lib/x86_64-linux-gnu/libpocketsphinx.so.3

   ```

-  remove python-* in base.yaml, which already defined in python.yaml

This just to remove duplicates entry from base.yaml, no regressions.