### PR TITLE
remove python-* in base.yaml, which already defined in python.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3568,48 +3568,14 @@ pyqt5-dev-tools:
   fedora: [python-qt5-devel]
   gentoo: [dev-python/PyQt5]
   ubuntu: [pyqt5-dev-tools]
-python-cairo:
-  fedora: [pycairo]
-  gentoo: [dev-python/pycairo]
-python-nose:
-  fedora: [python-nose]
-  gentoo: [dev-python/nose]
-python-opencv:
-  fedora: [opencv-python]
-  gentoo: [media-libs/opencv]
-  ubuntu: [python-opencv]
-python-pyaudio:
-  debian: [python-pyaudio]
-  fedora: [pyaudio]
-  gentoo: [dev-python/pyaudio]
-  ubuntu: [python-pyaudio]
-python-pydot:
-  fedora: [pydot]
-  gentoo: [media-gfx/pydot]
 python-pyftpdlib:
   debian: [python-pyftpdlib]
   gentoo: [dev-python/pyftpdlib]
   ubuntu: [python-pyftpdlib]
-python-pygraphviz:
-  fedora: [python-pygraphviz]
-  gentoo: [dev-python/pygraphviz]
-  opensuse: [python-pygraphviz]
 python-qrencode:
   debian: [python-qrencode]
   gentoo: [media-gfx/qrencode-python]
   ubuntu: [python-qrencode]
-python-sphinx:
-  fedora: [python-sphinx]
-  gentoo: [dev-python/sphinx]
-python-tornado:
-  arch: [python-tornado]
-  debian: [python-tornado]
-  fedora: [python-tornado]
-  gentoo: [www-servers/tornado]
-  ubuntu: [python-tornado]
-python-vtk:
-  fedora: [vtk-python]
-  gentoo: [dev-python/pyvtk]
 qhull-bin:
   arch: [qhull]
   debian: [qhull-bin]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3108,6 +3108,7 @@ python-tk:
     xenial: [python-tk]
     xenial_python3: [python3-tk]
 python-tornado:
+  arch: [python-tornado]
   debian: [python-tornado]
   fedora: [python-tornado]
   gentoo: [www-servers/tornado]


### PR DESCRIPTION
rewrited version of https://github.com/ros/rosdistro/pull/15257

some of rosdep keys is multiply defined, and that sometime confuse users.

- This just to remove duplicates entry from base.yaml, no regressions.
