### PR TITLE
rename xdot in python.yaml to python-xdot, becase xdot is already tak…

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3500,6 +3500,11 @@ python-wxtools:
   fedora: [wxPython]
   gentoo: [dev-python/wxpython]
   ubuntu: [python-wxtools]
+python-xdot:
+  debian: [xdot]
+  fedora: [python-xdot]
+  gentoo: [media-gfx/xdot]
+  ubuntu: [xdot]
 python-xlib:
   debian: [python-xlib]
   fedora: [python-xlib]
@@ -3615,8 +3620,3 @@ python3-setuptools:
   ubuntu: [python3-setuptools]
 python3-yaml:
   ubuntu: [python3-yaml]
-xdot:
-  debian: [xdot]
-  fedora: [python-xdot]
-  gentoo: [media-gfx/xdot]
-  ubuntu: [xdot]


### PR DESCRIPTION
…en by ros package, atleast until indigo http://wiki.ros.org/xdot

rewrited version of #15257


some of rosdep keys are multiply defined, and that sometime confuse users.

rename xdot in python.yaml to python-xdot, becase xdot is already taken by ros package, atleast until indigo http://wiki.ros.org/xdot
change xdot to python-xdot, this will break backword compatibility....