### PR TITLE
pocketsphinx is already taken by ros package(http://wiki.ros.org/pock…

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3645,7 +3645,7 @@ pkg-config:
     slackpkg:
       packages: [pkg-config]
   ubuntu: [pkg-config]
-pocketsphinx:
+pocketsphinx-bin:
   debian:
     buster: [pocketsphinx]
     jessie: [pocketsphinx]


### PR DESCRIPTION
…etsphinx) and that different from pocketsphinx system package, libshphinxbase is library and pocketsphinx installs some application binaries, so they are differnet too

rewrited version of #15257

some of rosdep keys is multiply defined, and that sometime confuse users.

pocketsphinx is already taken by ros package(http://wiki.ros.org/pocketsphinx)
and that different from pocketsphinx system package,
libshphinxbase is library and pocketsphinx installs some application binaries, so they are different too
this changes pocketsphinx key in base.yaml to pocketsphinx-bin, this also breaks compatibility, but that was added just a few month ago

~~~
ubuntu-14:~$ dpkg -L libsphinxbase1
/.
/usr
/usr/share
/usr/share/doc
/usr/share/doc/libsphinxbase1
/usr/share/doc/libsphinxbase1/copyright
/usr/share/doc/libsphinxbase1/changelog.Debian.gz
/usr/lib
/usr/lib/libsphinxbase.so.1.1.1
/usr/lib/libsphinxad.so.0.0.1
/usr/lib/libsphinxbase.so.1
/usr/lib/libsphinxad.so.0
ubuntu-14:~$ dpkg -L libpocketsphinx1/.
/usr
/usr/lib
/usr/lib/libpocketsphinx.so.1.1.0
/usr/share
/usr/share/doc
/usr/share/doc/libpocketsphinx1
/usr/share/doc/libpocketsphinx1/copyright
/usr/share/doc/libpocketsphinx1/changelog.Debian.gz
/usr/lib/libpocketsphinx.so.1


ubuntu-16:~$ dpkg -L pocketsphinx
/.
/usr
/usr/bin
/usr/bin/pocketsphinx_mdef_convert
/usr/bin/pocketsphinx_continuous
/usr/bin/pocketsphinx_batch
/usr/share
/usr/share/doc
/usr/share/doc/pocketsphinx
/usr/share/doc/pocketsphinx/copyright
/usr/share/man
/usr/share/man/man1
/usr/share/man/man1/pocketsphinx_batch.1.gz
/usr/share/man/man1/pocketsphinx_continuous.1.gz
/usr/share/man/man1/pocketsphinx_mdef_convert.1.gz
/usr/share/doc/pocketsphinx/changelog.Debian.gz

ubuntu-16:~$ dpkg -L libpocketsphinx3
/.
/usr
/usr/lib
/usr/lib/x86_64-linux-gnu
/usr/lib/x86_64-linux-gnu/libpocketsphinx.so.3.0.0
/usr/share
/usr/share/doc
/usr/share/doc/libpocketsphinx3
/usr/share/doc/libpocketsphinx3/copyright
/usr/share/doc/libpocketsphinx3/changelog.Debian.gz
/usr/lib/x86_64-linux-gnu/libpocketsphinx.so.3
```
