### PR TITLE
magni_robot 0.1.0 kinetic release

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3252,6 +3252,24 @@ repositories:
       url: https://github.com/hrnr/m-explore.git
       version: kinetic-devel
     status: developed
+  magni_robot:
+    doc:
+      type: git
+      url: https://github.com/UbiquityRobotics/magni_robot.git
+      version: indigo-devel
+    release:
+      packages:
+      - magni_bringup
+      - magni_demos
+      - magni_description
+      - magni_nav
+      - magni_robot
+      - magni_teleop
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/UbiquityRobotics-release/magni_robot-release.git
+      version: 0.1.0-0
+    status: developed
   manipulation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Manually releasing magni_robot 0.1.0 (initial release)
Contains:

- magni_bringup
- magni_demos
- magni_description
- magni_nav
- magni_teleop