### PR TITLE
iot_bridge: 0.9.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -839,6 +839,21 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: indigo-devel
     status: maintained
+  iot_bridge:
+    doc:
+      type: git
+      url: https://github.com/corb555/iot_bridge.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/iot_bridge-release.git
+      version: 0.9.0-0
+    source:
+      type: git
+      url: https://github.com/corb555/iot_bridge.git
+      version: kinetic-devel
+    status: developed
   ivcon:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `iot_bridge` to `0.9.0-0`:

- upstream repository: https://github.com/corb555/iot_bridge.git
- release repository: https://github.com/ros-gbp/iot_bridge-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## iot_bridge

```
* Initial release to ROS
* [test] Add unit test.
* [maintenance] Add CI config.
* Contributors: corb555, Isaac I.Y. Saito
```
