### PR TITLE
py_trees: 0.5.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5149,7 +5149,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 0.5.9-0
+      version: 0.5.10-0
     source:
       type: git
       url: https://github.com/stonier/py_trees.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `0.5.10-0`:

- upstream repository: https://github.com/stonier/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.5.9-0`

## py_trees

```
* [meta] add children monkeypatching for composite imposters
* [blackboard] check for nested variables in WaitForBlackboard
```
