### PR TITLE
Add julius-voxforge key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1144,6 +1144,7 @@ joystick:
   ubuntu: [joystick]
 julius-voxforge:
   arch: [voxforge-am-julius]
+  fedora: [julius-voxforge]
   ubuntu: [julius-voxforge]
 jython:
   arch: [jython]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1142,6 +1142,9 @@ joystick:
   opensuse: [input-utils]
   rhel: [joystick]
   ubuntu: [joystick]
+julius-voxforge:
+  arch: [voxforge-am-julius]
+  ubuntu: [julius-voxforge]
 jython:
   arch: [jython]
   debian: [jython]


### PR DESCRIPTION
This package provides acoustic model for speech recognition software Julius.
Also found similar package on Arch linux but could not found on others.