### PR TITLE
rviz_visual_tools: 3.4.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2714,6 +2714,21 @@ repositories:
       url: https://github.com/ros-visualization/rviz.git
       version: kinetic-devel
     status: maintained
+  rviz_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/rviz_visual_tools.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/davetcoleman/rviz_visual_tools-release.git
+      version: 3.4.0-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/rviz_visual_tools.git
+      version: kinetic-devel
+    status: developed
   sick_ldmrs_laser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `3.4.0-0`:

- upstream repository: https://github.com/davetcoleman/rviz_visual_tools.git
- release repository: https://github.com/davetcoleman/rviz_visual_tools-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rviz_visual_tools

```
* Consolidated publishing into RemoteReciever class
* Improve console output
* Add RvizGui and KeyTool
* Enable remote control from withing rviz_visual_tools
* New publishPath() function
* Shorten number of lines printTranslation() requires
* Contributors: Dave Coleman
```
