### PR TITLE
cartesian_msgs: 0.0.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -206,6 +206,21 @@ repositories:
       url: https://github.com/osrf/capabilities.git
       version: master
     status: maintained
+  cartesian_msgs:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/cartesian_msgs.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/davetcoleman/cartesian_msgs-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/cartesian_msgs.git
+      version: jade-devel
+    status: maintained
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartesian_msgs` to `0.0.3-0`:

- upstream repository: https://github.com/davetcoleman/cartesian_msgs.git
- release repository: https://github.com/davetcoleman/cartesian_msgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cartesian_msgs

```
* catkin lint cleanup
* Contributors: Dave Coleman
```
