### PR TITLE
rosparam_shortcuts: 0.2.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2133,6 +2133,21 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: lunar-devel
     status: maintained
+  rosparam_shortcuts:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/rosparam_shortcuts.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/davetcoleman/rosparam_shortcuts-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/rosparam_shortcuts.git
+      version: kinetic-devel
+    status: maintained
   rqt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_shortcuts` to `0.2.1-0`:

- upstream repository: https://github.com/davetcoleman/rosparam_shortcuts.git
- release repository: https://github.com/davetcoleman/rosparam_shortcuts-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rosparam_shortcuts

```
* Fix Eigen3 include
* Fix C++11 compiling method
* Update Travis for Kinetic
* Updated README
* Contributors: Dave Coleman
```
