### PR TITLE
ros_control_boilerplate: 0.4.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1956,6 +1956,21 @@ repositories:
       url: https://github.com/ros-controls/ros_control.git
       version: kinetic-devel
     status: maintained
+  ros_control_boilerplate:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/ros_control_boilerplate.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/davetcoleman/ros_control_boilerplate-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/ros_control_boilerplate.git
+      version: kinetic-devel
+    status: maintained
   ros_controllers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control_boilerplate` to `0.4.0-0`:

- upstream repository: https://github.com/davetcoleman/ros_control_boilerplate.git
- release repository: https://github.com/davetcoleman/ros_control_boilerplate-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## ros_control_boilerplate

```
* Depend on Eigen3
* Remove dependency on meta package
* Fixed var name
* Contributors: Dave Coleman
```
