### PR TITLE
qb_device: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5277,6 +5277,30 @@ repositories:
       url: https://github.com/asmodehn/pyzmp.git
       version: master
     status: developed
+  qb_device:
+    doc:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbdevice-ros.git
+      version: production-kinetic
+    release:
+      packages:
+      - qb_device
+      - qb_device_bringup
+      - qb_device_control
+      - qb_device_description
+      - qb_device_driver
+      - qb_device_hardware_interface
+      - qb_device_msgs
+      - qb_device_srvs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: ssh://git@bitbucket.org/qbrobotics/qbdevice-ros-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbdevice-ros.git
+      version: production-kinetic
+    status: developed
   qt_gui_core:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5294,7 +5294,7 @@ repositories:
       - qb_device_srvs
       tags:
         release: release/kinetic/{package}/{version}
-      url: ssh://git@bitbucket.org/qbrobotics/qbdevice-ros-release.git
+      url: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
       version: 1.0.1-0
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_device` to `1.0.1-0`:

- upstream repository: https://bitbucket.org/qbrobotics/qbdevice-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
