### PR TITLE
qb_hand: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5301,6 +5301,26 @@ repositories:
       url: https://bitbucket.org/qbrobotics/qbdevice-ros.git
       version: production-kinetic
     status: developed
+  qb_hand:
+    doc:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbhand-ros.git
+      version: production-kinetic
+    release:
+      packages:
+      - qb_hand
+      - qb_hand_control
+      - qb_hand_description
+      - qb_hand_hardware_interface
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://bitbucket.org/qbrobotics/qbhand-ros-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbhand-ros.git
+      version: production-kinetic
+    status: developed
   qt_gui_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_hand` to `1.0.1-0`:

- upstream repository: https://bitbucket.org/qbrobotics/qbhand-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbhand-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
