### PR TITLE
qb_chain: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5277,6 +5277,25 @@ repositories:
       url: https://github.com/asmodehn/pyzmp.git
       version: master
     status: developed
+  qb_chain:
+    doc:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbchain-ros.git
+      version: production-kinetic
+    release:
+      packages:
+      - qb_chain
+      - qb_chain_control
+      - qb_chain_description
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbchain-ros.git
+      version: production-kinetic
+    status: developed
   qb_device:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_chain` to `1.0.1-0`:

- upstream repository: https://bitbucket.org/qbrobotics/qbchain-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
