### PR TITLE
mongodb_store: 0.1.29-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6783,7 +6783,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.1.28-1
+      version: 0.1.29-1
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.29-1`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.28-1`

## mongodb_log

- No changes

## mongodb_store

```
* Support local datacentre timeout
  The timeout for the datacentre was hardcoded to 10 seconds. However, in
  some environments, for example in a cloud setup, this may not be enough.
  Make this configurable and just default to the previous 10 seconds.
* Fixed updateClient assignment on copy.
* The projection tests are changed
* Revert back to original mongodb cmd
* [mongodb_store/stests/message_store_cpp_test.cpp] fix test for non-wait insert
* Fixed projection error happening when exclude and include field directives are mixed
* [mongodb_store] add test for non-wait insert
* [mongodb_store] add non-wait insert functionality
* Mongo C++ header location not exposed.
  Implemented fix from @ronwalf closes #176 <https://github.com/strands-project/mongodb_store/issues/176>
* Fixed missing return value
* Fixing the compatibility issues of messagestore cpp client with old SOMA versions
* Fixed issue with projection query including fields instead of excluding
* [mongodb_store/scripts/mongodb_server.py] connect with localhost when shutdown server
* Fixed if statement
* geotype of ROI has been added
* The geospatial indexing of SOMA ROI objects is added
* Contributors: Hakan, Justin Huang, Nick Hawes, Tim Niemueller, Yuki Furuta
```

## mongodb_store_msgs

```
* [mongodb_store_msgs] add Insert.msg
* Contributors: Nick Hawes, Yuki Furuta
```
