### PR TITLE
arbotix: 0.10.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -164,6 +164,23 @@ repositories:
       url: https://github.com/ros-perception/ar_track_alvar.git
       version: kinetic-devel
     status: maintained
+  arbotix:
+    doc:
+      type: git
+      url: https://github.com/vanadiumlabs/arbotix_ros.git
+      version: indigo-devel
+    release:
+      packages:
+      - arbotix
+      - arbotix_controllers
+      - arbotix_firmware
+      - arbotix_msgs
+      - arbotix_python
+      - arbotix_sensors
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/vanadiumlabs/arbotix_ros-release.git
+      version: 0.10.0-0
   ardrone_autonomy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `arbotix` to `0.10.0-0`:

- upstream repository: https://github.com/vanadiumlabs/arbotix_ros.git
- release repository: https://github.com/vanadiumlabs/arbotix_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## arbotix

- No changes

## arbotix_controllers

```
* Set queue_size=5 on all publishers
* Check if command exceeds opening limits
* Contributors: Jorge Santos
```

## arbotix_firmware

- No changes

## arbotix_msgs

- No changes

## arbotix_python

```
* Set queue_size=5 on all publishers
* Contributors: Jorge Santos
```

## arbotix_sensors

```
* Set queue_size=5 on all publishers
* Contributors: Jorge Santos
```
