### PR TITLE
robot_controllers: 0.5.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5641,7 +5641,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
-      version: 0.5.2-0
+      version: 0.5.3-0
     status: maintained
   robot_localization:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_controllers` to `0.5.3-0`:

- upstream repository: https://github.com/fetchrobotics/robot_controllers.git
- release repository: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.5.2-0`

## robot_controllers

```
* remove limiter
* Improve cartesian twist controller (#26 <https://github.com/fetchrobotics/robot_controllers/issues/26>)
* Contributors: Hanjun Song, Michael Ferguson
```

## robot_controllers_interface

```
* add error message when pluginlib fails
* fix cmake warnings on kinetic (#28 <https://github.com/fetchrobotics/robot_controllers/issues/28>)
* Contributors: Michael Ferguson
```

## robot_controllers_msgs

- No changes
