### PR TITLE
executive_smach_visualization: 2.0.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -458,6 +458,24 @@ repositories:
       url: https://github.com/ros/executive_smach.git
       version: indigo-devel
     status: maintained
+  executive_smach_visualization:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/executive_smach_visualization.git
+      version: indigo-devel
+    release:
+      packages:
+      - executive_smach_visualization
+      - smach_viewer
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/jbohren/executive_smach_visualization-release.git
+      version: 2.0.1-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/executive_smach_visualization.git
+      version: indigo-devel
+    status: unmaintained
   filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `executive_smach_visualization` to `2.0.1-0`:

- upstream repository: https://github.com/ros-visualization/executive_smach_visualization.git
- release repository: https://github.com/jbohren/executive_smach_visualization-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## executive_smach_visualization

```
* add ROS Orphaned Package Maintainers to maintainer tag (#15 <https://github.com/ros-visualization/executive_smach_visualization/issues/15>)
* Contributors: Kei Okada
```

## smach_viewer

```
* add ROS Orphaned Package Maintainers to maintainer tag (#15 <https://github.com/ros-visualization/executive_smach_visualization/issues/15>)
* copy xdot from https://github.com/jbohren/xdot, (#14 <https://github.com/ros-visualization/executive_smach_visualization/issues/14>)
  
    * support for Qt5 (Kinetic)
    * update CMakeLists.txt, package.xml, setup.py, smach_viewer.py for new xdot structure
    * add necessary lines in xdot/__init__.py https://github.com/jbohren/xdot/pull/14
    * copy xdot from https://github.com/jbohren/xdot, since system xdot is released in rosdep key https://github.com/ros/rosdistro/pull/4976
  
* add auto focus to subgraph mode button (#11 <https://github.com/ros-visualization/executive_smach_visualization/issues/11>)
  
    * add launch option for 'auto focus to subgraph' mode as default
    * add auto focus to subgraph mode button
  
* feature: Add ability to save the dot graph for further processing (#8 <https://github.com/ros-visualization/executive_smach_visualization/issues/8>)
  
    * forgot two imports
    * Add option to save dot graph to file
      Add a icon which enables the user to save the currently displayed
      graph as a .dot file in the currently hardcoded ros_home/dotfiles,
      which should normaly be $HOME/.ros/dotfiles
      From there it can be converted with the dot commandline tool into
      png, pdf or others without the problem of quality loss.
  
* wx viewer: checking to make sure item urls are strings to prevent crash (#1 <https://github.com/jbohren/executive_smach_visualization/pull/1>)
* Contributors: Yuki Furuta, Jonathan Bohren, Kei Okada, Markus Bajones
```
