### PR TITLE
plotjuggler: 1.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8879,7 +8879,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 1.0.7-0
+      version: 1.0.8-0
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `1.0.8-0`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.7-0`

## plotjuggler

```
* update to be compatible with ros_type_introspection 0.6
* setting uninitialized variable (thanks valgrind)
* improvement #48 <https://github.com/facontidavide/PlotJuggler/issues/48>
* fix for issue #46 <https://github.com/facontidavide/PlotJuggler/issues/46> (load csv files)
* more intuitive ordering of strings. Based on PR #45 <https://github.com/facontidavide/PlotJuggler/issues/45>. Fixes #27 <https://github.com/facontidavide/PlotJuggler/issues/27>
* Correct the string being searched for to find the header stamp field (#44 <https://github.com/facontidavide/PlotJuggler/issues/44>)
* Contributors: Davide Faconti, Kartik Mohta
```
