### PR TITLE
ros_type_introspection: 0.6.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5643,7 +5643,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/facontidavide/ros_type_introspection-release.git
-      version: 0.5.1-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/facontidavide/ros_type_introspection.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_type_introspection` to `0.6.0-0`:

- upstream repository: https://github.com/facontidavide/ros_type_introspection.git
- release repository: https://github.com/facontidavide/ros_type_introspection-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.5.1-0`

## ros_type_introspection

```
* moved the deserializing code
* new API
* fixing issue in resize (to be tested)
* fixed osx compilation failure due to implicit_instantiation of std::array
* Fix formating and typos
* Contributors: Bo Li, Davide Faconti, Sam Pfeiffer
```
