### PR TITLE
ros_type_introspection: 0.6.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2059,6 +2059,20 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: lunar-devel
     status: maintained
+  ros_type_introspection:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/ros_type_introspection.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/facontidavide/ros_type_introspection-release.git
+      version: 0.6.0-0
+    source:
+      type: git
+      url: https://github.com/facontidavide/ros_type_introspection.git
+      version: master
   rosaria:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2073,6 +2073,7 @@ repositories:
       type: git
       url: https://github.com/facontidavide/ros_type_introspection.git
       version: master
+    status: developed
   rosaria:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_type_introspection` to `0.6.0-0`:

- upstream repository: https://github.com/facontidavide/ros_type_introspection.git
- release repository: https://github.com/facontidavide/ros_type_introspection-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## ros_type_introspection

```
* moved the deserializing code
* new API
* fixing issue in resize (to be tested)
* fixed osx compilation failure due to implicit_instantiation of std::array
* Fix formating and typos
* Contributors: Bo Li, Davide Faconti, Sam Pfeiffer
```
