### PR TITLE
moveit_visual_tools: 3.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3828,7 +3828,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 3.2.1-0
+      version: 3.3.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `3.3.0-0`:

- upstream repository: https://github.com/ros-planning/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `3.2.1-0`

## moveit_visual_tools

```
* Change error message to warning
* Make planning scene monitor publicly exposed
* Remove label from imarkers
* Ability to move a collision object without removing it first
* IMarkerRobotState: update imarkers location when setting robot state
* IMarkerRobotState: Added setRobotState()
* IMarkerRobotState: Renamed function publishRobotState()
* MoveItVisualTools: renamed variable to psm_
* Expose verbose collision checking
* Contributors: Dave Coleman
```
