### PR TITLE
Adding python-opencv for xenial ubuntu version

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1641,6 +1641,7 @@ python-opencv:
   ubuntu:
     saucy: [python-opencv]
     trusty: [python-opencv]
+    xenial: [python-opencv]
 python-opengl:
   arch: [python2-opengl]
   debian: [python-opengl]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1638,10 +1638,7 @@ python-opencv:
   gentoo: [media-libs/opencv]
   opensuse: [python-opencv]
   slackware: [opencv]
-  ubuntu:
-    saucy: [python-opencv]
-    trusty: [python-opencv]
-    xenial: [python-opencv]
+  ubuntu: [python-opencv]
 python-opengl:
   arch: [python2-opengl]
   debian: [python-opengl]


### PR DESCRIPTION
python-opencv currently not available for xenial ubuntu version. This PR fixes the problem.