### PR TITLE
rviz_visual_tools: 3.4.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7452,7 +7452,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/davetcoleman/rviz_visual_tools-release.git
-      version: 3.4.0-0
+      version: 3.4.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `3.4.1-0`:

- upstream repository: https://github.com/davetcoleman/rviz_visual_tools.git
- release repository: https://github.com/davetcoleman/rviz_visual_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `3.4.0-0`

## rviz_visual_tools

```
* Add dependency on QT5 for Ubuntu Zesty/Lunar support
* Allow publishPath with std_msgs::ColorRGBA
* Make INFO msg DEBUG
* Contributors: Dave Coleman, Victor Lamoine
```
