### PR TITLE
moveit_visual_tools: 3.3.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1278,6 +1278,21 @@ repositories:
       url: https://github.com/ros-planning/moveit_resources.git
       version: master
     status: developed
+  moveit_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_visual_tools.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/davetcoleman/moveit_visual_tools-release.git
+      version: 3.3.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_visual_tools.git
+      version: kinetic-devel
+    status: developed
   mrpt_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `3.3.0-0`:

- upstream repository: https://github.com/ros-planning/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## moveit_visual_tools

```
* Change error message to warning
* Make planning scene monitor publicly exposed
* Remove label from imarkers
* Ability to move a collision object without removing it first
* IMarkerRobotState: update imarkers location when setting robot state
* IMarkerRobotState: Added setRobotState()
* IMarkerRobotState: Renamed function publishRobotState()
* MoveItVisualTools: renamed variable to psm_
* Expose verbose collision checking
* Contributors: Dave Coleman
```
