### PR TITLE
ros_control_boilerplate: 0.4.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1983,7 +1983,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/davetcoleman/ros_control_boilerplate-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/davetcoleman/ros_control_boilerplate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control_boilerplate` to `0.4.1-0`:

- upstream repository: https://github.com/davetcoleman/ros_control_boilerplate.git
- release repository: https://github.com/davetcoleman/ros_control_boilerplate-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.4.0-0`

## ros_control_boilerplate

```
* Changed boost::shared_ptr to typedef for Lunar support
* Implemented simulated velocity control
* Contributors: Dave Coleman
```
