### PR TITLE
Depend on generic libcurl-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -447,7 +447,7 @@ crypto++:
   ubuntu: [libcrypto++-dev]
 curl:
   arch: [curl]
-  debian: [libcurl4-openssl-dev, curl]
+  debian: [libcurl-dev, curl]
   fedora: [libcurl-devel, curl]
   freebsd: [curl]
   gentoo: [net-misc/curl]
@@ -457,7 +457,7 @@ curl:
   slackware:
     slackpkg:
       packages: [curl]
-  ubuntu: [libcurl4-openssl-dev, curl]
+  ubuntu: [libcurl-dev, curl]
 curlpp-dev:
   debian: [libcurlpp-dev]
   fedora: [curlpp-devel]


### PR DESCRIPTION
Don't depend on specific openssl version, as this could conflict with an
already installed gnutls version.