### PR TITLE
python-opencv for ubuntu > trusty

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1638,9 +1638,7 @@ python-opencv:
   gentoo: [media-libs/opencv]
   opensuse: [python-opencv]
   slackware: [opencv]
-  ubuntu:
-    saucy: [python-opencv]
-    trusty: [python-opencv]
+  ubuntu: [python-opencv]
 python-opengl:
   arch: [python2-opengl]
   debian: [python-opengl]


### PR DESCRIPTION
python-opencv is currently not resolvable for xenial. This PR simplifies the mapping as the package name it's identical for saucy, trusty and xenial.