### PR TITLE
rodi_robot: 0.0.1-0 in 'kinetic/distribution.yaml'

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6040,6 +6040,21 @@ repositories:
       url: https://github.com/robotics-in-concert/rocon_tools.git
       version: release/0.3-kinetic
     status: developed
+  rodi_robot:
+    doc:
+      type: git
+      url: https://github.com/rodibot/rodi_robot.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/benjayah/rodi_robot-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/rodibot/rodi_robot.git
+      version: master
+    status: maintained
   romeo_robot:
     doc:
       type: git


### PR DESCRIPTION
- Fixed previous problems with the package #15185. It now passes pre-release test.