### PR TITLE
marti_common: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3444,6 +3444,7 @@ repositories:
       - swri_opencv_util
       - swri_prefix_tools
       - swri_roscpp
+      - swri_rospy
       - swri_route_util
       - swri_serial_util
       - swri_string_util
@@ -3453,7 +3454,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 0.2.4-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3432,7 +3432,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/marti_common.git
-      version: kinetic-devel
+      version: master
     release:
       packages:
       - marti_data_structures
@@ -3458,7 +3458,7 @@ repositories:
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git
-      version: kinetic-devel
+      version: master
     status: developed
   marti_messages:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.3.0-0`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.4-0`

## marti_data_structures

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_console_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_geometry_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Add OpenCV dependency
* Contributors: P. J. Reed
```

## swri_image_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Enable blending with transparency mask (#439 <https://github.com/pjreed/marti_common/issues/439>)
* Contributors: Jerry Towler, P. J. Reed
```

## swri_math_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_nodelet

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_opencv_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_prefix_tools

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_roscpp

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_rospy

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_route_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_serial_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_string_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_system_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_transform_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Fix dynamic reconfigure in dynamic_publisher (closes issue #448 <https://github.com/pjreed/marti_common/issues/448>).
* Contributors: Elliot Johnson, P. J. Reed
```

## swri_yaml_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```
