### PR TITLE
marti_common: 0.3.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2885,6 +2885,7 @@ repositories:
       - swri_opencv_util
       - swri_prefix_tools
       - swri_roscpp
+      - swri_rospy
       - swri_route_util
       - swri_serial_util
       - swri_string_util
@@ -2894,7 +2895,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 0.1.7-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -2873,7 +2873,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/marti_common.git
-      version: jade-devel
+      version: master
     release:
       packages:
       - marti_data_structures
@@ -2899,7 +2899,7 @@ repositories:
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git
-      version: jade-devel
+      version: master
     status: developed
   marti_messages:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `0.3.0-0`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.7-0`

## marti_data_structures

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_console_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_geometry_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Add OpenCV dependency
* Contributors: P. J. Reed
```

## swri_image_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Enable blending with transparency mask (#439 <https://github.com/pjreed/marti_common/issues/439>)
* Contributors: Jerry Towler, P. J. Reed
```

## swri_math_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_nodelet

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_opencv_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_prefix_tools

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_roscpp

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_rospy

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_route_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_serial_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_string_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_system_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```

## swri_transform_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Fix dynamic reconfigure in dynamic_publisher (closes issue #448 <https://github.com/pjreed/marti_common/issues/448>).
* Contributors: Elliot Johnson, P. J. Reed
```

## swri_yaml_util

```
* Merge together the indigo, jade, and kinetic branches (#443 <https://github.com/pjreed/marti_common/issues/443>)
* Contributors: P. J. Reed
```
