### PR TITLE
moveit_sim_controller: 0.1.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1278,6 +1278,21 @@ repositories:
       url: https://github.com/ros-planning/moveit_resources.git
       version: master
     status: developed
+  moveit_sim_controller:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/moveit_sim_controller.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/davetcoleman/moveit_sim_controller-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/moveit_sim_controller.git
+      version: kinetic-devel
+    status: maintained
   moveit_visual_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_sim_controller` to `0.1.0-0`:

- upstream repository: https://github.com/davetcoleman/moveit_sim_controller.git
- release repository: https://github.com/davetcoleman/moveit_sim_controller-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## moveit_sim_controller

```
* Add C++11 support
* Fixed occational Nan
* Minor formatting
* added roslint and roslint changes
* Contributors: Dave Coleman
```
