### PR TITLE
roslisp_common: 0.2.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11886,7 +11886,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/roslisp_common-release.git
-      version: 0.2.8-1
+      version: 0.2.9-0
     source:
       type: git
       url: https://github.com/ros/roslisp_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp_common` to `0.2.9-0`:

- upstream repository: https://github.com/ros/roslisp_common.git
- release repository: https://github.com/ros-gbp/roslisp_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.8-1`
