### PR TITLE
roslisp_common: 0.2.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6657,7 +6657,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/roslisp_common-release.git
-      version: 0.2.8-0
+      version: 0.2.9-0
     source:
       type: git
       url: https://github.com/ros/roslisp_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp_common` to `0.2.9-0`:

- upstream repository: https://github.com/ros/roslisp_common.git
- release repository: https://github.com/ros-gbp/roslisp_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.8-0`
