### PR TITLE
roslisp_common: 0.2.9-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2257,6 +2257,31 @@ repositories:
       url: https://github.com/ros/roslisp.git
       version: master
     status: maintained
+  roslisp_common:
+    doc:
+      type: git
+      url: https://github.com/ros/roslisp_common.git
+      version: master
+    release:
+      packages:
+      - actionlib_lisp
+      - cl_tf
+      - cl_tf2
+      - cl_transforms
+      - cl_transforms_stamped
+      - cl_urdf
+      - cl_utils
+      - roslisp_common
+      - roslisp_utilities
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/roslisp_common-release.git
+      version: 0.2.9-0
+    source:
+      type: git
+      url: https://github.com/ros/roslisp_common.git
+      version: master
+    status: developed
   rospack:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp_common` to `0.2.9-0`:

- upstream repository: https://github.com/ros/roslisp_common.git
- release repository: https://github.com/ros-gbp/roslisp_common-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
