### PR TITLE
jsk_roseus: 1.6.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5408,7 +5408,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.6.1-0
+      version: 1.6.2-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_roseus.git
+      version: master
     status: maintained
   jsk_smart_apps:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.6.2-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.6.1-0`

## jsk_roseus

- No changes

## roseus

```
* CMakeLists.txt: find_package jskeus and add euslisp/jskeus to DEPENDS in CMakeLists.txt to get euslisp/jskeus version (#514 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/514>)
* [roseus_utils.l] fix make-camera-from-ros-camera-info-aux (#526 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/526>)
* skip test/test-genmsg.catkin.test (#518 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/518>)
* if goal is overridden from different instance in same roseus process, actionlib do not return from :wait-for-result. (updated
  version of #519) (#521 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/521>)
  * actinlib.l : add :name-space method to simple-action-server
  * print warn if :wait-for-result ends with preempted
  * add test-simple-client-cancel.test for https://github.com/start-jsk/jsk_apc/issues/2106
  * set queue of status/result/feedback cb from 1 to 8, to get old results, also keep action-client to global list and if result is not yours, look client from list
  * actionlib.l : fix error when (send comm-state :action-goal) do not exists
  * use gentemp to bound object, to find from do-symbols
  * add test-client-dispose
* roseus/euslisp/roseus-utils.l: update make-camera-from-ros-camera-info (#517 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/517>)
* CMakeLists.txt: use grep package.xml when git --tags did not retun any message (it happens in build farm) (#516 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/516>)
* tell full path of roseus diretory when load roseus.l ... (#515 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/515>)
* CMakeLists.txt: find_package jskeus and add euslisp/jskeus to DEPENDS in CMakeLists.txt to get euslisp/jskeus version (#514 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/514>)
* Contributors: Kei Okada, YoheiKakiuchi
```

## roseus_mongo

- No changes

## roseus_smach

```
* replace ros-info by ros-debug in state-machine.l (#523 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/523>)
* add root-name key in exec-state-machine (#523 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/523>)
  * use exex-state-machine in sample programexec-smach-with-spin is deprecated.
  
    * add exec-state-machine with :root-name key test
    * add root-name key in exec-state-machine
  
* Contributors: Shingo Kitagawa
```

## roseus_tutorials

- No changes
