### PR TITLE
moveit: 0.9.8-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1272,7 +1272,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.9.7-0
+      version: 0.9.8-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.9.8-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.9.7-0`

## moveit

```
* [fix][moveit_ros_visualization] TrajectoryVisualization crash if no window_context exists (#523 <https://github.com/ros-planning/moveit/issues/523>, #525 <https://github.com/ros-planning/moveit/issues/525>)
* [fix][moveit_ros_visualization]  robot display: Don't reload robot model upon topic change (Fixes #528 <https://github.com/ros-planning/moveit/issues/528>)
* [fix][moveit_ros_planning] Include callback of execution status if trajectory is invalid. (#524 <https://github.com/ros-planning/moveit/issues/524>)
* [fix][simple_controller_manager] include order (#529 <https://github.com/ros-planning/moveit/issues/529>)
* [enhance][moveit_ros_visualization]  rviz display: stop trajectory visualization on new plan. Fixes #526 <https://github.com/ros-planning/moveit/issues/526> (#531 <https://github.com/ros-planning/moveit/issues/531>, #510 <https://github.com/ros-planning/moveit/issues/510>).
* [enhance][moveit_setup_assistant] setup assistant: add use_gui param to demo.launch (#532 <https://github.com/ros-planning/moveit/issues/532>)
* [build][moveit_kinematics] adjust cmake_minimum_required for add_compile_options (#521 <https://github.com/ros-planning/moveit/issues/521>)
* [build][moveit_kinematics] ikfast_kinematics_plugin: Add c++11 compile option. This is required for Kinetic.
* [build][moveit_kinematics] ikfast_kinematics_plugin: Write XML files as UTF-8 (#514 <https://github.com/ros-planning/moveit/issues/514>)
* [build][moveit_ros_visualization] add Qt-moc guards for boost 1.64 compatibility (#534 <https://github.com/ros-planning/moveit/issues/534>)
* Contributors: dougsm, Martin Guenther, Michael Goerner, Isaac I.Y. Saito, Simon Schmeisser, Yannick Jonetzko, henhenhen
```

## moveit_commander

- No changes

## moveit_controller_manager_example

- No changes

## moveit_core

- No changes

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

```
* [build] ikfast_kinematics_plugin: Write XML files as UTF-8 (#514 <https://github.com/ros-planning/moveit/issues/514>)
* [build] adjust cmake_minimum_required for add_compile_options (#521 <https://github.com/ros-planning/moveit/issues/521>)
* [build] ikfast_kinematics_plugin: Add c++11 compile option. This is required for Kinetic.
* Contributors: Martin Guenther, Michael Goerner
```

## moveit_planners

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* [fix] Include callback of execution status if trajectory is invalid. (#524 <https://github.com/ros-planning/moveit/issues/524>)
+* Contributors: dougsm
```

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* [fix] TrajectoryVisualization crash if no window_context exists (#523 <https://github.com/ros-planning/moveit/issues/523>, #525 <https://github.com/ros-planning/moveit/issues/525>)
* [fix] robot display: Don't reload robot model upon topic change (Fixes #528 <https://github.com/ros-planning/moveit/issues/528>)
* [build] add Qt-moc guards for boost 1.64 compatibility (#534 <https://github.com/ros-planning/moveit/issues/534>)
* [enhance] rviz display: stop trajectory visualization on new plan. Fixes #526 <https://github.com/ros-planning/moveit/issues/526> (#531 <https://github.com/ros-planning/moveit/issues/531>, #510 <https://github.com/ros-planning/moveit/issues/510>).
* Contributors: Isaac I.Y. Saito, Simon Schmeisser, Yannick Jonetzko, henhenhen, v4hn
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_setup_assistant

```
* [enhance] setup assistant: add use_gui param to demo.launch (#532 <https://github.com/ros-planning/moveit/issues/532>)
* [build] add Qt-moc guards for boost 1.64 compatibility (#534 <https://github.com/ros-planning/moveit/issues/534>)
* Contributors: Michael Goerner
```

## moveit_simple_controller_manager

```
* [fix] include order (#529 <https://github.com/ros-planning/moveit/issues/529>)
* Contributors: Michael Goerner
```
