### PR TITLE
Add a rosdep key for python3-dev.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3455,6 +3455,8 @@ python3-babeltrace:
   ubuntu:
     wily: [python3-babeltrace]
     xenial: [python3-babeltrace]
+python3-dev:
+  ubuntu: [python3-dev]
 python3-empy:
   ubuntu: [python3-empy]
 python3-flake8:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3445,8 +3445,6 @@ python-zmq:
     wily: [python-zmq]
     xenial: [python-zmq]
     yakkety: [python-zmq]
-python3:
-  ubuntu: [python3-dev]
 python3-babeltrace:
   debian:
     jessie: [python3-babeltrace]


### PR DESCRIPTION
This adds a key for python3-dev that is explicitly called python3-dev at @dirk-thomas's [suggestion](https://github.com/ros2/rosidl/pull/218#issuecomment-310226840).

He also recommends against changing the existing `python3` -> `python3-dev` key to avoid affecting packages using that key, but the key was added in https://github.com/ros/rosdistro/pull/15239 by me under the assumption that `python3` was the prefered name because ament_package [specified python3](https://github.com/ament/ament_package/blob/769c4ab87dbf4d7e0d47f0cdfc56f57f8562832b/package.xml#L10-L12) but needed python3-dev in order to build.

I don't know how much effort is made to standardize or de-duplicate keys but if we wanted to actually remove the `python3`->`python3-dev` key there isn't a better time than before it becomes more generally applied.