### PR TITLE
interactive_marker_twist_server: 1.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2505,7 +2505,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
-      version: 1.1.0-0
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/ros-visualization/interactive_marker_twist_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_marker_twist_server` to `1.2.0-0`:

- upstream repository: https://github.com/ros-visualization/interactive_marker_twist_server.git
- release repository: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.1.0-0`

## interactive_marker_twist_server

```
* Fixed CMake warning and updated to package format 2. (#11 <https://github.com/ros-visualization/interactive_marker_twist_server/issues/11>)
* Install the default config files. (#10 <https://github.com/ros-visualization/interactive_marker_twist_server/issues/10>)
* Contributors: Tony Baltovski
```
