### PR TITLE
vision_visp: 0.10.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3107,6 +3107,29 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: kinetic
     status: maintained
+  vision_visp:
+    doc:
+      type: git
+      url: https://github.com/lagadic/vision_visp.git
+      version: lunar
+    release:
+      packages:
+      - vision_visp
+      - visp_auto_tracker
+      - visp_bridge
+      - visp_camera_calibration
+      - visp_hand2eye_calibration
+      - visp_tracker
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/lagadic/vision_visp-release.git
+      version: 0.10.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/lagadic/vision_visp.git
+      version: lunar-devel
+    status: maintained
   visualization_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.10.0-0`:

- upstream repository: https://github.com/lagadic/vision_visp.git
- release repository: https://github.com/lagadic/vision_visp-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## vision_visp

```
* kinetic-0.9.3
* Prepare changelogs
* Contributors: Fabien Spindler
```

## visp_auto_tracker

```
* Fix catkin_lint warnings level 2
* kinetic-0.9.3
* Prepare changelogs
* Contributors: Fabien Spindler
```

## visp_bridge

```
* Fix catkin_lint warnings level 2
* kinetic-0.9.3
* Prepare changelogs
* Contributors: Fabien Spindler
* tool for converting visp camera parameter files to/from ros camera  parameter files
* 0.7.3
* Prepare changelogs
* Prepare changelogs
* Contributors: Fabien Spindler, Riccardo Spica
```

## visp_camera_calibration

```
* Fix compilation on 17.04 by adding missing boost/format.hpp inclusion (#63 <https://github.com/lagadic/vision_visp/issues/63>)
* Fix catkin_lint warnings level 2
* kinetic-0.9.3
* Prepare changelogs
* Contributors: Fabien Spindler, Marco Esposito
```

## visp_hand2eye_calibration

```
* Fix catkin_lint warnings level 2
* kinetic-0.9.3
* Prepare changelogs
* Contributors: Fabien Spindler
```
