### PR TITLE
qb_move: 1.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5408,7 +5408,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
-      version: 1.0.1-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbmove-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_move` to `1.0.4-0`:

- upstream repository: https://bitbucket.org/qbrobotics/qbmove-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.1-0`

## qb_move

- No changes

## qb_move_control

```
* Update cmake version to match Kinetic standards
```

## qb_move_description

```
* Update cmake version to match Kinetic standards
```

## qb_move_hardware_interface

```
* Update cmake version to match Kinetic standards
```
