### PR TITLE
qb_chain: 1.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5344,7 +5344,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
-      version: 1.0.1-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbchain-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_chain` to `1.0.3-0`:

- upstream repository: https://bitbucket.org/qbrobotics/qbchain-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.1-0`

## qb_chain

- No changes

## qb_chain_control

```
* Update cmake version to match Kinetic standards
```

## qb_chain_description

```
* Update cmake version to match Kinetic standards
```
