### PR TITLE
interactive_marker_twist_server: 1.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -863,6 +863,21 @@ repositories:
       url: https://github.com/innokrobotics/innok_heros_driver.git
       version: lunar
     status: maintained
+  interactive_marker_twist_server:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
+      version: 1.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
+      version: kinetic-devel
+    status: maintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_marker_twist_server` to `1.2.0-0`:

- upstream repository: https://github.com/ros-visualization/interactive_marker_twist_server.git
- release repository: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`

## interactive_marker_twist_server

```
* Fixed CMake warning and updated to package format 2. (#11 <https://github.com/ros-visualization/interactive_marker_twist_server/issues/11>)
* Install the default config files. (#10 <https://github.com/ros-visualization/interactive_marker_twist_server/issues/10>)
* Contributors: Tony Baltovski
```
