### PR TITLE
gazebo_ros_pkgs: 2.5.13-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1711,6 +1711,7 @@ repositories:
       version: kinetic-devel
     release:
       packages:
+      - gazebo_dev
       - gazebo_msgs
       - gazebo_plugins
       - gazebo_ros
@@ -1719,7 +1720,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.5.12-0
+      version: 2.5.13-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.5.13-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.5.12-0`

## gazebo_dev

```
* Add catkin package(s) to provide the default version of Gazebo - take II (kinetic-devel) (#571 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/571>)
  * Added catkin package gazebo_dev which provides the cmake config of the installed Gazebo version
  * gazebo_dev: added execution dependency gazebo
* Contributors: Jose Luis Rivero
```

## gazebo_msgs

```
* Add catkin package(s) to provide the default version of Gazebo (#571 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/571>)
  * Added catkin package gazebo_dev which provides the cmake config of the installed Gazebo version
* Contributors: Jose Luis Rivero
```

## gazebo_plugins

```
* Fix inverted height in block laser plugin (#582 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/582>)
* Allow disabling distorted camera border crop (and associated tests) (#572 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/572>)
* Add an IMU sensor plugin that inherits from SensorPlugin (#363 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/363>)
  * now the plugin works with multiple robots
  * using GetParentName name instead of GetScopedName
  * added comments to highlight the differents between GazeboRosImuSensor and GazeboRosIMU
  * now the message header is properly handled, using bodyName parameter as frame_id
  * added check on gazebo version
  * added check for sensor null pointer
  * changed deprecated functions for gazebo version >= 6
  * fixed version check
  * added missing sensor variable for LastUpdateTime() function call
  * considering '/' included in the robotNamespace
  * replaced "bodyFrame" with "frameName"
* Less exciting console output (#561 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/561>)
* Add catkin package(s) to provide the default version of Gazebo (#571 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/571>)
  * gazebo_dev: added execution dependency gazebo
* Contributors: Adam Allevato, Alessandro Settimi, Dave Coleman, Jose Luis Rivero, Shohei Fujii
```

## gazebo_ros

```
* Quote arguments to echo in libcommon.sh (#590 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/590>)
* Add catkin package(s) to provide the default version of Gazebo (#571 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/571>)
  * Added catkin package gazebo_dev which provides the cmake config of the installed Gazebo version
* Contributors: Jose Luis Rivero, daewok
```

## gazebo_ros_control

```
* Less exciting console output (#561 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/561>)
* Add catkin package(s) to provide the default version of Gazebo (#571 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/571>)
  * Added catkin package gazebo_dev which provides the cmake config of the installed Gazebo version
* Contributors: Dave Coleman, Jose Luis Rivero
```

## gazebo_ros_pkgs

```
* Add catkin package(s) to provide the default version of Gazebo (#571 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/571>)
  * Added catkin package gazebo_dev which provides the cmake config of the installed Gazebo version
* Contributors: Jose Luis Rivero
```
