### PR TITLE
gazebo_ros_pkgs: 2.4.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3489,7 +3489,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.4.13-0
+      version: 2.4.14-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.4.14-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.4.13-0`

## gazebo_msgs

- No changes

## gazebo_plugins

```
* Fix distortion coefficients order (#503 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/503>)
* Contributors: Enrique Fernández Perdomo
```

## gazebo_ros

```
* fixed conflicts
* Contributors: Jose Luis Rivero
```

## gazebo_ros_control

- No changes

## gazebo_ros_pkgs

- No changes
