### PR TITLE
jsk_pr2eus: 0.3.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5335,7 +5335,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_pr2eus-release.git
-      version: 0.3.10-0
+      version: 0.3.11-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
+      version: master
     status: developed
   jsk_recognition:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.3.11-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_pr2eus
- release repository: https://github.com/tork-a/jsk_pr2eus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.3.10-0`

## jsk_pr2eus

- No changes

## pr2eus

```
* use make-caemra-from-ros-camera-info-aux inroseus, in order to generate pr2 model corresponding to jsk-ros-pkg/jsk_roseus/pulls/#526 <https://github.com/jsk-ros-pkg/jsk-ros-pkg/jsk_roseus/pulls/526> (#301 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/301>)
  * [pr2eus/pr2.l] update make-camera-from-ros-camera-info-aux
  * add comment to why we redefine make-camera-from-ros-camera-info-aux in robot model
  * skip position test in test-cameras on hydro
* [robot_interface.l] add tms comment to :angle-vector-sequence c.f. https://github.com/jsk-ros-pkg/jsk_robot/pull/791#pullrequestreview-45324124 (#299 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/299>)
* [robot_interface.l] add :stamp method for reading latest stamp (#298 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/298>)
* .travis.yml: re-enable pr2-ri-test (using gazebo) for indigo (#296 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/296>
  * pr2-ri-test.l: add test to check :wait-for-interpolation, see (https://github.com/start-jsk/jsk_apc/issues/2106 <https://github.com/start-jsk/jsk_apc/issues/2106>)
  * when unknown goal is received, we assume the original goal is canceled and set time-to-finish to 0.0
  * test-start-grasp: send move-gripper with more gain
  * .travis.yml: re-enable pr2-ri-test (using gazebo) for indigo
* [pr2eus][pr2-interface.l] add switch-controller methods  (#295 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/295>
  * [pr2eus] add pr2_mechanism_msgs to depend
* [pr2eus][pr2eus_moveit] use ctype in :send-trajectory and pass ctype in angle-vector-motion-plan (#295 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/295>)
  * use only controller-type in send-trajectory
* [pr2eus] fix some funcs that break behaviors written at docs (#289 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/289>)
  * [pr2eus][default-ri-test.l] fix: load path for passing test on local machine
  * [pr2eus][pr2-ri-test-simple.l] assert return values of robot-interface methods
  * [pr2eus][robot-interface.l] implement :go-waitp when simulation-modep is t
  * [pr2eus][robot-interface.l] :move-to-wait returns t when simulation-modep
  * [pr2eus][robot-interface.l] implement :interpolatingp when :simulation-modep is t
* use link-list instead of (car link-list) in use-base condition(#272 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/272>)
* Contributors: Yuki Furuta, Kei Okada, Shingo Kitagawa, Yohei Kakiuchi, Chi Wun Au
```

## pr2eus_moveit

```
* pr2eus_moveit/euslisp/robot-moveit.l: support tm :fast in :angle-vector-motion-plan (#297 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/297> )
  * add :scale for :fast in :angle-vector-motion-plan
  * add trajectory_constraints commentouttrajectory_constraints is not used in motion planning.
  see https://github.com/ros-planning/moveit_msgs/issues/2
  
    * add max_velocity/acceleration_scaling_factor
    * support tm :fast in :angle-vector-motion-plan
  
* pr2eus_moveit/euslisp/robot-moveit.l: add angle-vector-sequence-motion-plan test (#293 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/293> )
  * set longer time-limit for moveit test
* pass ctype in angle-vector-motion-plan (#292 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/292> )
* advertise CollisionObject with latch=t (#290 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/290> )
* Contributors: Kei Okada, Shingo Kitagawa
```

## pr2eus_tutorials

```
* add test code for pr2 dual arm IK (#272 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/272> )
* Contributors: Chi Wun Au
```
