### PR TITLE
robot_model: 1.12.10-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1908,8 +1908,6 @@ repositories:
       version: kinetic-devel
     release:
       packages:
-      - collada_parser
-      - collada_urdf
       - joint_state_publisher
       - robot_model
       - urdf
@@ -1917,7 +1915,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.12.9-0
+      version: 1.12.10-1
     source:
       type: git
       url: https://github.com/ros/robot_model.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.12.10-1`:

- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.12.9-0`

## joint_state_publisher

- No changes

## robot_model

- No changes

## urdf

```
* Change urdf::Model to use std::shared_ptrs in urdfdom > v0.4 (#206 <https://github.com/ros/robot_model/issues/206>)
* Contributors: Dave Coleman
```

## urdf_parser_plugin

- No changes
