### PR TITLE
Ds4drv rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3356,6 +3356,11 @@ python-werkzeug:
   fedora: [python-werkzeug]
   gentoo: [dev-python/werkzeug]
   ubuntu: [python-werkzeug]
+python-wheel:
+  debian: [python-wheel]
+  fedora: [python-wheel]
+  gentoo: [dev-python/wheel]
+  ubuntu: [python-wheel]
 python-ws4py-pip:
   ubuntu:
     pip:
@@ -3469,11 +3474,6 @@ python3-pep8:
   ubuntu: [python3-pep8]
 python3-setuptools:
   ubuntu: [python3-setuptools]
-wheel:
-  debian: [python-wheel]
-  fedora: [python-wheel]
-  gentoo: [dev-python/wheel]
-  ubuntu: [python-wheel]
 xdot:
   debian: [xdot]
   fedora: [python-xdot]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8,7 +8,7 @@ adafruit-pca9685-pip:
   ubuntu:
     pip:
       packages: [adafruit-pca9685]
-ds4drv:
+ds4drv-pip:
   ubuntu:
     pip:
       packages: [ds4drv]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3470,9 +3470,10 @@ python3-pep8:
 python3-setuptools:
   ubuntu: [python3-setuptools]
 wheel:
-  ubuntu:
-    pip:
-      packages: [wheel]
+  debian: [python-wheel]
+  fedora: [python-wheel]
+  gentoo: [dev-python/wheel]
+  ubuntu: [python-wheel]
 xdot:
   debian: [xdot]
   fedora: [python-xdot]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3469,6 +3469,10 @@ python3-pep8:
   ubuntu: [python3-pep8]
 python3-setuptools:
   ubuntu: [python3-setuptools]
+wheel:
+  ubuntu:
+    pip:
+      packages: [wheel]
 xdot:
   debian: [xdot]
   fedora: [python-xdot]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8,6 +8,10 @@ adafruit-pca9685-pip:
   ubuntu:
     pip:
       packages: [adafruit-pca9685]
+ds4drv:
+  ubuntu:
+    pip:
+      packages: [ds4drv]
 gunicorn:
   fedora: [python-gunicorn]
   gentoo: [www-servers/gunicorn]


### PR DESCRIPTION
Adding a ds4drv rule to rosdep.  The wheel rule is included in this pull request as ds4drv does not install without wheel being installed too.  
I'm using ds4drv to control a robot from a Sony controller and need to be able to install these dependencies.


ds4drv
A Sony DualShock 4 userspace driver for Linux
https://pypi.python.org/pypi/ds4drv/0.5.1

wheel
A built-package format for Python
https://pypi.python.org/pypi/wheel/0.30.0a0