### PR TITLE
Revert "gazebo_ros_pkgs: 2.4.14-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3489,7 +3489,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.4.14-0
+      version: 2.4.13-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#15351

FYI @j-rivero 

This is failing due to a compile error

Here's an excerpt of http://build.ros.org/view/Ibin_uT64/job/Ibin_uT64__gazebo_ros__ubuntu_trusty_amd64__binary/16/console
```
11:44:49 /usr/bin/x86_64-linux-gnu-g++   -DROSCONSOLE_BACKEND_LOG4CXX -DROS_PACKAGE_NAME=\"gazebo_ros\" -Dgazebo_ros_api_plugin_EXPORTS -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -D_FORTIFY_SOURCE=2    -fPIC -I/tmp/binarydeb/ros-indigo-gazebo-ros-2.4.14/obj-x86_64-linux-gnu/devel/include -I/tmp/binarydeb/ros-indigo-gazebo-ros-2.4.14/include -I/opt/ros/indigo/include -I/usr/include/gazebo-2.2 -I/usr/include/sdformat-1.4     -I/usr/include -I/usr/include/gazebo-2.2 -o CMakeFiles/gazebo_ros_api_plugin.dir/src/gazebo_ros_api_plugin.cpp.o -c /tmp/binarydeb/ros-indigo-gazebo-ros-2.4.14/src/gazebo_ros_api_plugin.cpp
11:44:56 /tmp/binarydeb/ros-indigo-gazebo-ros-2.4.14/src/gazebo_ros_api_plugin.cpp: In constructor ‘gazebo::GazeboRosApiPlugin::GazeboRosApiPlugin()’:
11:44:56 /tmp/binarydeb/ros-indigo-gazebo-ros-2.4.14/src/gazebo_ros_api_plugin.cpp:37:3: warning: extended initializer lists only available with -std=c++11 or -std=gnu++11 [enabled by default]
11:44:56    enable_ros_network_
11:44:56    ^
11:44:56 /tmp/binarydeb/ros-indigo-gazebo-ros-2.4.14/src/gazebo_ros_api_plugin.cpp:39:27: error: expected ‘}’ before ‘;’ token
11:44:56    robot_namespace_.clear();
11:44:56                            ^
11:44:56 /tmp/binarydeb/ros-indigo-gazebo-ros-2.4.14/src/gazebo_ros_api_plugin.cpp:39:27: error: cannot convert ‘<brace-enclosed initializer list>’ to ‘bool’ in initialization
11:44:56 /tmp/binarydeb/ros-indigo-gazebo-ros-2.4.14/src/gazebo_ros_api_plugin.cpp:39:27: error: expected ‘{’ before ‘;’ token
11:44:56 /tmp/binarydeb/ros-indigo-gazebo-ros-2.4.14/src/gazebo_ros_api_plugin.cpp: At global scope:
11:44:56 /tmp/binarydeb/ros-indigo-gazebo-ros-2.4.14/src/gazebo_ros_api_plugin.cpp:42:1: error: ‘GazeboRosApiPlugin’ does not name a type
11:44:56  GazeboRosApiPlugin::~GazeboRosApiPlugin()
```
