### PR TITLE
qb_device: 1.0.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5394,7 +5394,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
-      version: 1.0.7-0
+      version: 1.0.8-0
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbdevice-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_device` to `1.0.8-0`:

- upstream repository: https://bitbucket.org/qbrobotics/qbdevice-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.7-0`

## qb_device

- No changes

## qb_device_bringup

- No changes

## qb_device_control

```
* Fix C++11 support for cmake version less than 3.1
```

## qb_device_description

- No changes

## qb_device_driver

```
* Fix C++11 support for cmake version less than 3.1
```

## qb_device_hardware_interface

```
* Fix C++11 support for cmake version less than 3.1
```

## qb_device_msgs

- No changes

## qb_device_srvs

- No changes
