### PR TITLE
qb_hand: 1.0.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5414,7 +5414,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbhand-ros-release.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbhand-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_hand` to `1.0.5-0`:

- upstream repository: https://bitbucket.org/qbrobotics/qbhand-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbhand-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.4-0`

## qb_hand

- No changes

## qb_hand_control

```
* Fix C++11 support for cmake version less than 3.1
```

## qb_hand_description

- No changes

## qb_hand_hardware_interface

```
* Fix C++11 support for cmake version less than 3.1
```
