### PR TITLE
Adding tr_hub_parser to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -14645,6 +14645,17 @@ repositories:
       url: https://github.com/asmodehn/tornado-rosrelease.git
       version: 4.2.1-3
     status: maintained
+  tr_hub_parser:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/Terabee/tr_hub_parser.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/Terabee/tr_hub_parser.git
+      version: master
+    status: developed
   trac_ik:
     doc:
       type: git


### PR DESCRIPTION
I'd like tr_hub_parser to be indexed and documented on ros.org.