### PR TITLE
robot_model: 1.12.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5773,7 +5773,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
-      version: 1.12.8-0
+      version: 1.12.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_model` to `1.12.11-0`:

- upstream repository: https://github.com/ros/robot_model.git
- release repository: https://github.com/ros-gbp/robot_model-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.12.8-0`

## joint_state_publisher

- No changes

## robot_model

- No changes

## urdf

```
* Shared ptr yakkety (#207 <https://github.com/ros/robot_model/issues/207>)
  * Forward declare urdf::Model when urdfdom version is > 0.4
  * Add test for upcasting from urdf::ModelSharedPtr to urdf::ModelInterfaceSharedPtr
* Contributors: Shane Loretz
```

## urdf_parser_plugin

- No changes
