### PR TITLE
Move collada_urdf to new repo (lunar)

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -267,6 +267,23 @@ repositories:
       type: git
       url: https://github.com/ros/cmake_modules.git
       version: 0.4-devel
+  collada_urdf:
+    doc:
+      type: git
+      url: https://github.com/ros/collada_urdf.git
+      version: kinetic-devel
+    release:
+      packages:
+      - collada_parser
+      - collada_urdf
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/collada_urdf-release.git
+      version: 1.12.10-2
+    source:
+      type: git
+      url: https://github.com/ros/collada_urdf.git
+      version: kinetic-devel
     status: maintained
   common_msgs:
     doc:
@@ -1918,8 +1935,6 @@ repositories:
       version: kinetic-devel
     release:
       packages:
-      - collada_parser
-      - collada_urdf
       - joint_state_publisher
       - robot_model
       - urdf


### PR DESCRIPTION
This moves collada_urdf to a new repository in lunar. This has already been done for indigo/jade/kinetic. `bloom-release` was run up to the point where it automatically creates a rosdistro pull request. This is a manual pull request because bloom aborts when it sees the packages `collada_parser` and `collada_urdf` already exist in `robot_model`.