### PR TITLE
Updated name of python-catkin-pkg for Arch.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -393,7 +393,7 @@ python-catkin-lint:
   fedora: [python-catkin_lint]
   ubuntu: [python-catkin-lint]
 python-catkin-pkg:
-  arch: [python2-catkin-pkg]
+  arch: [python2-catkin_pkg]
   debian: [python-catkin-pkg]
   fedora: [python-catkin_pkg]
   gentoo: [dev-python/catkin_pkg]


### PR DESCRIPTION
A bit of minor package renaming is happening for Arch.