### PR TITLE
pyros_common: 0.4.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5286,6 +5286,13 @@ repositories:
       url: https://github.com/asmodehn/pyros.git
       version: master
     status: developed
+  pyros_common:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/asmodehn/pyros-common-rosrelease.git
+      version: 0.4.2-1
+    status: developed
   pyros_config:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_common` to `0.4.2-1`:

- upstream repository: https://github.com/asmodehn/pyros-common.git
- release repository: https://github.com/asmodehn/pyros-common-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## pyros_common

```
* Fixing setup.py to point to normal pyros-common package. [AlexV]
* V0.4.2. [AlexV]
* Fixing setup.py commands after pacakge structure change. [AlexV]
* Dropping the namespace idea, since we cant make a working deb pkg out
  of it. [AlexV]
* Preparing ros release... [AlexV]
```
