### PR TITLE
jsk_common_msgs: 4.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2654,7 +2654,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_common_msgs-release.git
-      version: 4.1.1-0
+      version: 4.2.0-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common_msgs` to `4.2.0-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common_msgs
- release repository: https://github.com/tork-a/jsk_common_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `4.1.1-0`

## jsk_common_msgs

- No changes

## jsk_footstep_msgs

- No changes

## jsk_gui_msgs

- No changes

## jsk_hark_msgs

- No changes

## posedetection_msgs

- No changes

## speech_recognition_msgs

```
* [speech_recognition_msgs] add messages for grammar recognition #17 <https://github.com/jsk-ros-pkg/jsk_common_msgs/pull/17>
  * [speech_recognition_msgs] update srv/SpeechRecognition.srv to support both isolated word, grammar, THIS BREAKS SRV API
  * [speech_recognition_msgs] remove deprecated mainpage.dox
  * [speech_recognition_msgs] add grammar messages (msg/Grammar.msg, msg/PhraseRule.msg)
* Contributors: Yuki Furuta
```
