### PR TITLE
jsk_common_msgs: 4.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -937,6 +937,28 @@ repositories:
       url: https://github.com/ros/ivcon.git
       version: kinetic-devel
     status: maintained
+  jsk_common_msgs:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
+      version: master
+    release:
+      packages:
+      - jsk_common_msgs
+      - jsk_footstep_msgs
+      - jsk_gui_msgs
+      - jsk_hark_msgs
+      - posedetection_msgs
+      - speech_recognition_msgs
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/tork-a/jsk_common_msgs-release.git
+      version: 4.2.0-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
+      version: master
+    status: developed
   katana_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common_msgs` to `4.2.0-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common_msgs
- release repository: https://github.com/tork-a/jsk_common_msgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## jsk_common_msgs

- No changes

## jsk_footstep_msgs

- No changes

## jsk_gui_msgs

- No changes

## jsk_hark_msgs

- No changes

## posedetection_msgs

- No changes

## speech_recognition_msgs

```
* [speech_recognition_msgs] add messages for grammar recognition #17 <https://github.com/jsk-ros-pkg/jsk_common_msgs/pull/17>
  * [speech_recognition_msgs] update srv/SpeechRecognition.srv to support both isolated word, grammar, THIS BREAKS SRV API
  * [speech_recognition_msgs] remove deprecated mainpage.dox
  * [speech_recognition_msgs] add grammar messages (msg/Grammar.msg, msg/PhraseRule.msg)
* Contributors: Yuki Furuta
```
