### PR TITLE
fix wrong package name for python-vlc

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3291,16 +3291,16 @@ python-visual:
 python-vlc-pip:
   debian:
     pip:
-      packages: [vlc]
+      packages: [python-vlc]
   fedora:
     pip:
-      packages: [vlc]
+      packages: [python-vlc]
   osx:
     pip:
-      packages: [vlc]
+      packages: [python-vlc]
   ubuntu:
     pip:
-      packages: [vlc]
+      packages: [python-vlc]
 python-vtk:
   arch: [vtk]
   debian: [python-vtk]


### PR DESCRIPTION
did not make it to https://github.com/ros/rosdistro/pull/15366