### PR TITLE
Add nbtscan to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3853,6 +3853,8 @@ smartmontools:
   debian: [smartmontools]
   fedora: [smartmontools]
   ubuntu: [smartmontools]
+smbclient:
+  ubuntu: [smbclient]
 snappy:
   arch: [snappy]
   fedora: [snappy]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3854,6 +3854,9 @@ smartmontools:
   fedora: [smartmontools]
   ubuntu: [smartmontools]
 smbclient:
+  arch: [smbclient]
+  debian: [smbclient]
+  fedora: [samba-client]
   ubuntu: [smbclient]
 snappy:
   arch: [snappy]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3271,6 +3271,12 @@ nasm:
   macports: [nasm]
   opensuse: [nasm]
   ubuntu: [nasm]
+nbtscan:
+  arch: [nbtscan]
+  debian: [nbtscan]
+  fedora: [nbtscan]
+  gentoo: [net-analyzer/nbtscan]
+  ubuntu: [nbtscan]
 net-tools:
   arch: [net-tools]
   debian: [net-tools]


### PR DESCRIPTION
nbtscan (a netbios scanning tool) is used in one of our projects. Would be great to have it in the dependencies.

Package List (I only tested ubuntu).
https://www.archlinux.de/?page=Packages&search=nbtscan
https://packages.debian.org/search?keywords=nbtscan
https://admin.fedoraproject.org/pkgdb/package/rpms/nbtscan/
https://packages.gentoo.org/packages/net-analyzer/nbtscan
https://packages.ubuntu.com/xenial/net/nbtscan