### PR TITLE
ros_control: 0.11.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6301,7 +6301,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.11.4-0
+      version: 0.11.5-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.11.5-0`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.11.4-0`

## combined_robot_hw

```
* Fix typo in architecture.svg
* Contributors: Martin Günther
```

## combined_robot_hw_tests

- No changes

## controller_interface

- No changes

## controller_manager

```
* Fix misspelling revise message
* Contributors: Dave Coleman
```

## controller_manager_msgs

- No changes

## controller_manager_tests

- No changes

## hardware_interface

- No changes

## joint_limits_interface

```
* Throw error if EffortJointSaturationHandle is missing effort or velocity limits
* Contributors: Bence Magyar, Dave Coleman
```

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
