### PR TITLE
python-ftputil: 3.3.0-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5334,6 +5334,13 @@ repositories:
       url: https://github.com/asmodehn/pyros-utils.git
       version: devel
     status: developed
+  python-ftputil:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/asmodehn/ftputil-rosrelease.git
+      version: 3.3.0-3
+    status: developed
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python-ftputil` to `3.3.0-3`:

- upstream repository: http://hg.sschwarzer.net/ftputil
- release repository: https://github.com/asmodehn/ftputil-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
