### PR TITLE
look_at_pose: 0.7.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3261,7 +3261,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UTNuclearRoboticsPublic/look_at_pose-release.git
-      version: 0.7.6-0
+      version: 0.7.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `look_at_pose` to `0.7.7-0`:

- upstream repository: https://github.com/UTNuclearRoboticsPublic/look_at_pose.git
- release repository: https://github.com/UTNuclearRoboticsPublic/look_at_pose-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.7.6-0`
