### PR TITLE
multiwii: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3972,6 +3972,11 @@ repositories:
       type: git
       url: https://github.com/christianrauch/ros-multiwii.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/christianrauch/ros-multiwii-release.git
+      version: 2.0.0-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `multiwii` to `2.0.0-0`:

- upstream repository: https://github.com/christianrauch/ros-multiwii.git
- release repository: https://github.com/christianrauch/ros-multiwii-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
