### PR TITLE
phidgets_drivers: 0.7.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4511,7 +4511,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 0.7.2-0
+      version: 0.7.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `0.7.3-0`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.7.2-0`

## libphidget21

```
* fixed broken url to phidgets library (#12 <https://github.com/ros-drivers/phidgets_drivers/issues/12>)
* Contributors: imitschke
```

## phidgets_api

- No changes

## phidgets_drivers

- No changes

## phidgets_imu

- No changes
