### PR TITLE
Add key for pip package cppcheck-junit

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8,6 +8,13 @@ adafruit-pca9685-pip:
   ubuntu:
     pip:
       packages: [adafruit-pca9685]
+cppcheck-junit-pip:
+  debian:
+    pip:
+      packages: [cppcheck-junit]  
+  ubuntu:
+    pip:
+      packages: [cppcheck-junit]
 ds4drv-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -11,7 +11,7 @@ adafruit-pca9685-pip:
 cppcheck-junit-pip:
   debian:
     pip:
-      packages: [cppcheck-junit]  
+      packages: [cppcheck-junit]
   ubuntu:
     pip:
       packages: [cppcheck-junit]


### PR DESCRIPTION
Just add a key for the pip package `cppcheck-junit`. Wasn't able to find a debian for it.