### PR TITLE
ros_controllers: 0.9.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11364,7 +11364,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.9.3-0
+      version: 0.9.4-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.9.4-0`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.9.3-0`

## diff_drive_controller

```
* Publish executed velocity if publish_cmd
* Contributors: Bence Magyar, Jeremie Deray
```

## effort_controllers

```
* Included angles in dependencies
* Contributors: Mr-Yellow
```

## force_torque_sensor_controller

- No changes

## forward_command_controller

- No changes

## gripper_action_controller

- No changes

## imu_sensor_controller

- No changes

## joint_state_controller

- No changes

## joint_trajectory_controller

```
* Fix for issue #275 <https://github.com/ros-controls/roscontrollers/issues/275> (State error calculation not accounting for wrapping joint positions)
* Contributors: bponsler
```

## position_controllers

- No changes

## ros_controllers

- No changes

## rqt_joint_trajectory_controller

- No changes

## velocity_controllers

- No changes
