### PR TITLE
jsk_3rdparty: 2.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2600,6 +2600,7 @@ repositories:
       - ffha
       - jsk_3rdparty
       - julius
+      - julius_ros
       - libcmt
       - libsiftfast
       - lpg_planner
@@ -2614,7 +2615,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.0.20-0
+      version: 2.1.0-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
+      version: master
     status: developed
   jsk_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.1.0-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.0.20-0`

## assimp_devel

- No changes

## bayesian_belief_networks

- No changes

## downward

- No changes

## ff

- No changes

## ffha

- No changes

## jsk_3rdparty

- No changes

## julius

```
* [julius] update to use julius v4.4.2 (#99 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/99>)
* Contributors: Yuki Furuta
```

## julius_ros

```
* [julius_ros] support grammatical recognition (#102 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/102>)
  * [julius_ros] fix: initial vocabulary
  * [julius_ros][julius_client.py] advertise service on grammar mode
  * [julius_ros][julius.test] delay play audio 10 seconds
  * [julius_ros] add missing deps
  * [julius_ros] split grammar test
  * [julius_ros] support grammar
  * [julius_ros] update conf for grammar recognition[julius_ros] escape xml value before parse
  [julius_ros] update launch files
  [julius_ros] use machine tag by default
  [julius_ros] support respawn; minor fix
  [julius_ros][julius_grammar.launch] add argument for topic name of 'speech_to_text'
  [julius_ros] add command line tools to add grammar / vocabulary to julius engine
  [julius_ros][julius_client.py] add service to show julius engine status
  [julius_ros][julius_client.py] bugfix: INPUTONCHANGE WAIT
  [julius_ros][julius_client.py] cleanup change gram
* [julius_ros] Update julius to 4.4.2 / add ROS interface (#99 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/99>)
  * add julius_ros package
  * [julius_ros] add test
* Contributors: Furushchev, Yuki Furuta
```

## libcmt

- No changes

## libsiftfast

```
* [libsiftfast] find python 2 (#106 <https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/106>)
  * libsiftfast is written for python2 and can be successfully installed with python2.
  * However this package finds and uses python3 (not 2) first on environment where both python2 and 3 are installed. (In new travis environment both python2 and 3 seems to be installed)
  * This issue is fixed in this PR by setting version 2 on find_package python.
* Contributors: Yuki Furuta
```

## lpg_planner

- No changes

## mini_maxwell

- No changes

## nlopt

- No changes

## opt_camera

- No changes

## pgm_learner

- No changes

## rospatlite

- No changes

## rosping

- No changes

## slic

- No changes

## voice_text

```
* [voice_text] Refactor API (#101 <https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/101>)
  * Cleanup directory (remove rosbuild related files.)
  * Rewrote VoiceText server node as ROS friendly.
  * text2wave calls rosservice internally (This enables running VoiceText
  * engine on remote machine easily)
  * Create sample launch file
  * Create README
  * WARNING : This breaks API (we need to run voice_text node in addition to sound_play), so existing users will have to change launch file for using voice text.
* Contributors: Yuki Furuta
```
