### PR TITLE
urdf_tutorial: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15185,10 +15185,13 @@ repositories:
       url: https://github.com/ros/urdf_tutorial.git
       version: master
     release:
+      packages:
+      - urdf_sim_tutorial
+      - urdf_tutorial
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/urdf_tutorial-release.git
-      version: 0.2.5-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/ros/urdf_tutorial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tutorial` to `0.3.0-0`:

- upstream repository: https://github.com/ros/urdf_tutorial.git
- release repository: https://github.com/ros-gbp/urdf_tutorial-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.5-0`
