### PR TITLE
Remove dependency of fcn-pip on libhdf5-dev

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -871,19 +871,19 @@ python-falcon:
 python-fcn-pip:
   debian:
     pip:
-      depends: [libhdf5-dev, liblapack-dev]
+      depends: [liblapack-dev]
       packages: [fcn]
   fedora:
     pip:
-      depends: [libhdf5-dev, liblapack-dev]
+      depends: [liblapack-dev]
       packages: [fcn]
   osx:
     pip:
-      depends: [hdf5, gfortran]
+      depends: [gfortran]
       packages: [fcn]
   ubuntu:
     pip:
-      depends: [libhdf5-dev, liblapack-dev]
+      depends: [liblapack-dev]
       packages: [fcn]
 python-fixtures:
   debian: [python-fixtures]


### PR DESCRIPTION
it is no longer used in fcn-pip v6.3.0 (latest): https://github.com/wkentaro/fcn/blob/v6.0.3/requirements.txt