### PR TITLE
urdf_geometry_parser: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8730,6 +8730,11 @@ repositories:
       type: git
       url: https://github.com/ros-controls/urdf_geometry_parser.git
       version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/urdf_geometry_parser-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/ros-controls/urdf_geometry_parser.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_geometry_parser` to `0.0.1-0`:

- upstream repository: https://github.com/ros-controls/urdf_geometry_parser.git
- release repository: https://github.com/ros-gbp/urdf_geometry_parser-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## urdf_geometry_parser

```
* First release of urdf_geometry_parser
* Contributors: Vincent Rousseau
```
