### PR TITLE
urdf_geometry_parser: 0.0.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3124,6 +3124,11 @@ repositories:
       type: git
       url: https://github.com/ros-controls/urdf_geometry_parser.git
       version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/urdf_geometry_parser-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/ros-controls/urdf_geometry_parser.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_geometry_parser` to `0.0.1-0`:

- upstream repository: https://github.com/ros-controls/urdf_geometry_parser.git
- release repository: https://github.com/ros-gbp/urdf_geometry_parser-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## urdf_geometry_parser

```
* First release of urdf_geometry_parser
* Contributors: Vincent Rousseau
```
