### PR TITLE
urdf_tutorial: 0.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8746,10 +8746,13 @@ repositories:
       url: https://github.com/ros/urdf_tutorial.git
       version: master
     release:
+      packages:
+      - urdf_sim_tutorial
+      - urdf_tutorial
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/urdf_tutorial-release.git
-      version: 0.2.5-0
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ros/urdf_tutorial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tutorial` to `0.3.0-1`:

- upstream repository: https://github.com/ros/urdf_tutorial.git
- release repository: https://github.com/ros-gbp/urdf_tutorial-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.5-0`
