### PR TITLE
magni_robot: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3358,7 +3358,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/magni_robot-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     status: developed
   manipulation_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `magni_robot` to `0.1.1-0`:

- upstream repository: https://github.com/UbiquityRobotics/magni_robot.git
- release repository: https://github.com/UbiquityRobotics-release/magni_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.0-0`

## magni_bringup

```
* Install launch/param dirs
* Contributors: Rohan Agrawal
```

## magni_demos

```
* Install launch/param dirs
* Contributors: Rohan Agrawal
```

## magni_description

```
* Install launch/param dirs
* Contributors: Rohan Agrawal
```

## magni_nav

```
* Install launch/param dirs
* Contributors: Rohan Agrawal
```

## magni_robot

- No changes

## magni_teleop

```
* Install launch/param dirs
* Contributors: Rohan Agrawal
```
