### PR TITLE
jsk_3rdparty: 2.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2630,7 +2630,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.1.0-0
+      version: 2.1.1-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.1.1-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.1.0-0`

## assimp_devel

- No changes

## bayesian_belief_networks

- No changes

## downward

- No changes

## ff

- No changes

## ffha

- No changes

## jsk_3rdparty

- No changes

## julius

```
* [julius] fix: failure on buildfirm (#109 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/109>)
* Contributors: Yuki Furuta
```

## julius_ros

```
* [julius_ros] fix: missing deps julius-voxforge (#109 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/109>)
* Contributors: Furushchev
```

## libcmt

- No changes

## libsiftfast

- No changes

## lpg_planner

- No changes

## mini_maxwell

- No changes

## nlopt

- No changes

## opt_camera

- No changes

## pgm_learner

- No changes

## rospatlite

- No changes

## rosping

- No changes

## slic

- No changes

## voice_text

```
* add dynamic_reconfigure to run/build depends  (#110 <https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/110>)
* Contributors: Kei Okada
```
