### PR TITLE
binpicking_utils: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -587,7 +587,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/durovsky/binpicking_utils-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/durovsky/binpicking_utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `binpicking_utils` to `0.1.3-0`:

- upstream repository: https://github.com/durovsky/binpicking_utils.git
- release repository: https://github.com/durovsky/binpicking_utils-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.2-0`

## bin_pose_emulator

```
* Disable loading default yaml config
* adding examle yaml config install
* typo fix
* Contributors: Frantisek Durovsky
* Disable loading default yaml config
* adding examle yaml config install
* typo fix
* Contributors: Frantisek Durovsky
```

## bin_pose_msgs

```
* Contributors: Frantisek Durovsky
```

## binpicking_utils

```
* Contributors: Frantisek Durovsky
```
