### PR TITLE
jsk_3rdparty: 2.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5189,7 +5189,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.1.1-0
+      version: 2.1.2-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.1.2-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.1.1-0`

## assimp_devel

- No changes

## bayesian_belief_networks

- No changes

## collada_urdf_jsk_patch

- No changes

## downward

- No changes

## ff

- No changes

## ffha

- No changes

## jsk_3rdparty

```
* add julius_ros to meta package (#111 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/111>)
* Contributors: Kei Okada
```

## julius

```
* [julius][package.xml] add rsync to run_depend (#112 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/112>)
* Contributors: Yui Furuta
```

## julius_ros

- No changes

## laser_filters_jsk_patch

- No changes

## libcmt

- No changes

## libsiftfast

- No changes

## lpg_planner

- No changes

## mini_maxwell

- No changes

## nlopt

- No changes

## opt_camera

- No changes

## pgm_learner

- No changes

## rospatlite

- No changes

## rosping

- No changes

## rostwitter

- No changes

## slic

- No changes

## voice_text

- No changes
