### PR TITLE
shared_autonomy_manipulation: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13412,6 +13412,25 @@ repositories:
       url: https://github.com/ros-planning/shape_tools.git
       version: master
     status: maintained
+  shared_autonomy_manipulation:
+    doc:
+      type: git
+      url: https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation.git
+      version: hydro-devel
+    release:
+      packages:
+      - safe_teleop_base
+      - safe_teleop_pr2
+      - safe_teleop_stage
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/shared_autonomy_manipulation-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation.git
+      version: hydro-devel
+    status: unmaintained
   shared_serial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `shared_autonomy_manipulation` to `0.0.1-0`:

- upstream repository: https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation.git
- release repository: https://github.com/ros-gbp/shared_autonomy_manipulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## safe_teleop_base

```
* add 'ROS Orphaned Package Maintainers' as maintainer (#6 <https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation/pull/6>)
* changed branch and fixed launch file
* catkinize the packages to work on hydro (#1 <https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation/pull/1>)
* fixed authors/maintainers in manifest files
* bug fix in safe_teleop_base
* fixed scope of topics published by safe_teleop_base
* bug fix in safe_teleop_base for holonomic robots
* added safe_teleop_base along with demos
* Contributors: Benjamin Pitzer, Charles Duhadway, Ryohei Ueda, Sarah Osentoski, Yuki Furuta
```

## safe_teleop_pr2

```
* add 'ROS Orphaned Package Maintainers' as maintainer (#6 <https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation/pull/6>)
* safe_teleop_pr2 and safe_teleop_stage do not require safe_teleop_base at
  build time (#3 <https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation/pull/3>)
* changed branch and fixed launch file
* catkinize the packages to work on hydro (#1 <https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation/pull/1>)
* fixed authors/maintainers in manifest files
* moved to shared_autonomy
* Contributors: Benjamin Pitzer, Ryohei Ueda, Sarah Osentoski, Yuki Furuta
```

## safe_teleop_stage

```
* add 'ROS Orphaned Package Maintainers' as maintainer (#6 <https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation/pull/6>)
* safe_teleop_pr2 and safe_teleop_stage do not require safe_teleop_base at
  build time (#3 <https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation/pull/3>)
* catkinize the packages to work on hydro (#1 <https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation/pull/1>)
* fixed authors/maintainers in manifest files
* moved to shared_autonomy
* Contributors: Benjamin Pitzer, Ryohei Ueda, Yuki Furuta
```
