### PR TITLE
shared_autonomy_manipulation: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13425,7 +13425,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/shared_autonomy_manipulation-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `shared_autonomy_manipulation` to `0.0.2-0`:

- upstream repository: https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation.git
- release repository: https://github.com/ros-gbp/shared_autonomy_manipulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.1-0`

## safe_teleop_base

- No changes

## safe_teleop_pr2

```
* CMakeLists.txt : change catkin_package() (#9 <https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation/issues/9> )
* CMakeLists.txt : fix install error (#8 <https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation/issues/8>)
* Contributors: Kei Okada
```

## safe_teleop_stage

```
* change catkin_package() (#9 <https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation/issues/9>)
* Contributors: Kei Okada
```
