### PR TITLE
shared_autonomy_manipulation: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7662,6 +7662,24 @@ repositories:
       url: https://github.com/wjwwood/serial.git
       version: master
     status: maintained
+  shared_autonomy_manipulation:
+    doc:
+      type: git
+      url: https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation.git
+      version: hydro-devel
+    release:
+      packages:
+      - safe_teleop_base
+      - safe_teleop_stage
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/shared_autonomy_manipulation-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation.git
+      version: hydro-devel
+    status: unmaintained
   sick_ldmrs_laser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `shared_autonomy_manipulation` to `0.0.2-0`:

- upstream repository: https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation.git
- release repository: https://github.com/ros-gbp/shared_autonomy_manipulation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## safe_teleop_base

- No changes

## safe_teleop_stage

```
* change catkin_package() (#9 <https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation/issues/9>)
* Contributors: Kei Okada
```
