### PR TITLE
jsk_visualization: 2.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5454,7 +5454,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 2.1.0-0
+      version: 2.1.2-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_visualization.git
+      version: master
     status: developed
   jskeus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `2.1.2-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.1.0-0`

## jsk_interactive

- No changes

## jsk_interactive_marker

```
* [jsk_rviz_plugins][classification_result_visualizer] minor bugfix (#669 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/669>)
* [jsk_interactive_marker] Install scripts in jsk_interactive_marker (#670 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/670>)
* Contributors: Kei Okada, Kentaro Wada
```

## jsk_interactive_test

- No changes

## jsk_rqt_plugins

- No changes

## jsk_rviz_plugins

```
* [jsk_rviz_plugins][classification_result_visualizer] minor bugfix (#669 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/669> )
* [jsk_rviz_plugins] add marker publisher for classification result (#667 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/667>)
  * [jsk_rviz_plugins] add visualizer for classification result
* Contributors: Yuki Furuta
```

## jsk_visualization

- No changes
