### PR TITLE
follow_waypoints: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1617,6 +1617,22 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: kinetic-devel
     status: maintained
+  follow_waypoints:
+    doc:
+      type: git
+      url: https://github.com/danielsnider/follow_waypoints.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/danielsnider/follow_waypoints-release.git
+      version: 0.2.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/danielsnider/follow_waypoints.git
+      version: master
+    status: maintained
   four_wheel_steering_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `follow_waypoints` to `0.2.0-0`:

- upstream repository: https://github.com/danielsnider/follow_waypoints.git
- release repository: https://github.com/danielsnider/follow_waypoints-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## follow_waypoints

```
* Update README.md
* Major update
```
