### PR TITLE
rosauth: 0.1.7-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2238,6 +2238,21 @@ repositories:
       url: https://github.com/amor-ros-pkg/rosaria.git
       version: master
     status: maintained
+  rosauth:
+    doc:
+      type: git
+      url: https://github.com/GT-RAIL/rosauth.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/gt-rail-release/rosauth-release.git
+      version: 0.1.7-1
+    source:
+      type: git
+      url: https://github.com/GT-RAIL/rosauth.git
+      version: develop
+    status: maintained
   rosbag_direct_write:
     source:
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rosauth` to `0.1.7-1`:

- upstream repository: https://github.com/GT-RAIL/rosauth.git
- release repository: https://github.com/gt-rail-release/rosauth-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`
