### PR TITLE
rosauth: 0.1.7-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11611,7 +11611,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/rosauth-release.git
-      version: 0.1.7-0
+      version: 0.1.7-1
     source:
       type: git
       url: https://github.com/GT-RAIL/rosauth.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosauth` to `0.1.7-1`:

- upstream repository: https://github.com/GT-RAIL/rosauth.git
- release repository: https://github.com/gt-rail-release/rosauth-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `0.1.7-0`

## rosauth

```
* Merge pull request #8 from ckrooss/develop
  Added gencpp-dependency for test target
* Added gencpp-dependency for test target
* Contributors: Russell Toris, ckrooss
```
