### PR TITLE
Fix broken pyassimp regression

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2025,7 +2025,11 @@ python-pyassimp:
     utopic: [python-pyassimp]
     vivid: [python-pyassimp]
     wily: [python-pyassimp]
-    xenial: [python-pyassimp]
+    xenial:
+      apt:
+        packages: [libassimp-dev]
+      pip:
+        packages: [pyassimp]
     yakkety: [python-pyassimp]
     zesty: [python-pyassimp]
 python-pyaudio:


### PR DESCRIPTION
This is a follow up to comments on the [thread](https://github.com/ros-planning/moveit/issues/86). There is also a separate issue created [here](https://github.com/assimp/assimp/issues/1209). It fixes the broken pyassimp regression by installing libassimp-dev from apt and pyassimp from pip instead of directly installing pyassimp from apt.