### PR TITLE
rostune: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12111,6 +12111,13 @@ repositories:
       url: https://gitlab.com/OvGU-ESS/rosshell.git
       version: master
     status: maintained
+  rostune:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/roboskel/rostune-release.git
+      version: 1.0.1-0
+    status: developed
   roswww:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rostune` to `1.0.1-0`:

- upstream repository: https://github.com/roboskel/rostune.git
- release repository: https://github.com/roboskel/rostune-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rostune

```
* Release 1.0.0
* Fixed the mighty python nodes bug! yay!
* Fixed topic stats
* Each machine checks only for its own nodes, nodestats includes percentages.
* Added information about overall stats
* Statistics for all topics working. Now we need to filter them, based on the publisher.
* CPU usage and memory stats
  Unix-related code to get CPU usage and memory stats.
  Checking with master node to update list of nodes.
  Sample logger that just writes to ROSINFO.
* Contributors: George Stavrinos, Stasinos Konstantopoulos
```
