### PR TITLE
plotjuggler: 1.1.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4567,7 +4567,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 1.1.1-0
+      version: 1.1.3-0
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `1.1.3-0`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.1.1-0`

## plotjuggler

```
* fixed few issues with DataStreamROS
* Update README.md
* improvement #43 <https://github.com/facontidavide/PlotJuggler/issues/43>. Use F10 to hide/show controls
* Contributors: Davide Faconti
```
