### PR TITLE
plotjuggler: 1.1.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1753,7 +1753,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 1.1.1-0
+      version: 1.1.3-0
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `1.1.3-0`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.1.1-0`

## plotjuggler

```
* fixed few issues with DataStreamROS
* Update README.md
* improvement #43 <https://github.com/facontidavide/PlotJuggler/issues/43>. Use F10 to hide/show controls
* Contributors: Davide Faconti
```
