### PR TITLE
rostune: 1.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6844,6 +6844,13 @@ repositories:
       url: https://github.com/ros-drivers/rosserial.git
       version: jade-devel
     status: maintained
+  rostune:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/roboskel/rostune-release.git
+      version: 1.0.4-0
+    status: developed
   roswww:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rostune` to `1.0.4-0`:

- upstream repository: https://github.com/roboskel/rostune.git
- release repository: https://github.com/roboskel/rostune-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
