### PR TITLE
rostune: 1.0.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6849,7 +6849,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/roboskel/rostune-release.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     status: developed
   roswww:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rostune` to `1.0.5-0`:

- upstream repository: https://github.com/roboskel/rostune.git
- release repository: https://github.com/roboskel/rostune-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.4-0`

## rostune

```
* Hopefully fixed dependency issues for all platforms
* Contributors: George Stavrinos
```
