### PR TITLE
jsk_pr2eus: 0.3.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5350,7 +5350,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_pr2eus-release.git
-      version: 0.3.11-0
+      version: 0.3.12-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.3.12-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_pr2eus
- release repository: https://github.com/tork-a/jsk_pr2eus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.3.11-0`

## jsk_pr2eus

- No changes

## pr2eus

```
* [robot-interface.l] :angle-vector-duration add document to how we use :max-joint-velocity (#305 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/305> )
* Contributors: Kei Okada
```

## pr2eus_moveit

```
* robot-interface.l: send angle-vector only once, some controller-table had multiple definition for one method, we ignore them (#308 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/308>)
  * test/test-pr2eus-moveit.test only runs on indigo
  * fix when two controller has same action instance
  * add dummy controller for #308 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/308>
  * send angle-vector only once, some controller-table had multiple definition for one method, we ignore them
* [pr2eus_moveit] fix bug in angle-vector-motion-plan (#309 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/309>)
  * fix bug in angle-vector-motion-plan error occur when (length controller-actions) != (length (send self ctype))this case happens when you init robot-interface with :default-controller, but send av with :rarm-controller.
* [pr2eus_moveit] fix typo in total-time condition (#310 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/310>)
* [pr2eus_moveit] fix typo in robot-moveit.l (#306 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/306> )
  * [(:angle-vector-motion-plan] controller-type -> ctype
* Contributors: Kei Okada, Shingo Kitagawa
```

## pr2eus_tutorials

- No changes
