### PR TITLE
libsegwayrmp: 0.2.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3185,6 +3185,21 @@ repositories:
       url: https://github.com/IntelRealSense/librealsense.git
       version: master
     status: maintained
+  libsegwayrmp:
+    doc:
+      type: git
+      url: https://github.com/segwayrmp/libsegwayrmp.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/segwayrmp/libsegwayrmp-release.git
+      version: 0.2.10-0
+    source:
+      type: git
+      url: https://github.com/segwayrmp/libsegwayrmp.git
+      version: master
+    status: maintained
   libsick_ldmrs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libsegwayrmp` to `0.2.10-0`:

- upstream repository: https://github.com/segwayrmp/libsegwayrmp.git
- release repository: https://github.com/segwayrmp/libsegwayrmp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## libsegwayrmp

```
* The segwayrmp_gui is now installed so it is available from binaries
```
