### PR TITLE
segway_rmp: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7670,6 +7670,21 @@ repositories:
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git
       version: master
     status: developed
+  segway_rmp:
+    doc:
+      type: git
+      url: https://github.com/segwayrmp/segway-rmp-ros-pkg.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/segwayrmp/segway_rmp-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/segwayrmp/segway_rmp.git
+      version: master
+    status: maintained
   serial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `segway_rmp` to `0.1.2-0`:

- upstream repository: https://github.com/segwayrmp/segway-rmp-ros-pkg.git
- release repository: https://github.com/segwayrmp/segway_rmp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## segway_rmp

```
* Merge pull request #24 <https://github.com/segwayrmp/segway_rmp/issues/24> from segwayrmp/piyushk/parametrize_frame_ids
  allow parametrizing odometry frame id as well (useful for multiple robots)
* Contributors: Piyush Khandelwal
```
