### PR TITLE
Remove teraranger packages from Indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14524,23 +14524,7 @@ repositories:
       url: https://github.com/zlt1991/tensor_field_nav.git
       version: master
     status: maintained
-  terarangerduo-ros:
-    release:
-      packages:
-      - terarangerduo
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/Terabee/terarangerduo-ros-release.git
-      version: 0.1.1-0
-    status: maintained
   terarangerone-ros:
-    release:
-      packages:
-      - terarangerone
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/Terabee/terarangerone-ros-release.git
-      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/Terabee/terarangerone-ros.git


### PR DESCRIPTION
Removes packages `terarangerduo` and `terarangerone` from ROS Indigo. Their release repositories no longer exist.

@Terabee fyi