### PR TITLE
rostune: 1.0.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12116,7 +12116,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/roboskel/rostune-release.git
-      version: 1.0.5-0
+      version: 1.0.5-1
+    source:
+      type: git
+      url: https://github.com/roboskel/rostune.git
+      version: master
     status: developed
   roswww:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rostune` to `1.0.5-1`:

- upstream repository: https://github.com/roboskel/rostune.git
- release repository: https://github.com/roboskel/rostune-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.5-0`

## rostune

```
* Hopefully fixed dependency issues for all platforms
* Contributors: George Stavrinos
```
