### PR TITLE
rostune: 1.0.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6864,7 +6864,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/roboskel/rostune-release.git
-      version: 1.0.5-0
+      version: 1.0.5-1
+    source:
+      type: git
+      url: https://github.com/roboskel/rostune.git
+      version: master
     status: developed
   roswww:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rostune` to `1.0.5-1`:

- upstream repository: https://github.com/roboskel/rostune.git
- release repository: https://github.com/roboskel/rostune-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.5-0`

## rostune

```
* Hopefully fixed dependency issues for all platforms
* Contributors: George Stavrinos
```
