### PR TITLE
jsk_recognition: 1.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2775,7 +2775,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.1.1-0
+      version: 1.1.3-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_recognition.git
+      version: master
     status: developed
   jsk_roseus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `1.1.3-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.1.1-0`

## checkerboard_detector

- No changes

## imagesift

- No changes

## jsk_pcl_ros

```
* Filter invalid centroid in centroid_publisher (#2150 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2150>)
  * Add sample and test for CentroidPublisher
* Support PCA even without input planes but with only ground frame (#2149 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2149>)
* Add nodelet for computing & comparing color histogram (#2101 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2101>)
  * [jsk_pcl_ros] add color_histogram_classifier and visualizer
* Generate Kinfu texture model with attention (BoundingBox) and Ground frame to fix occluded surface (#2135 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2135>)
  * Refactor slicing of textures_ and cameras_
  * Use save_mesh_server.py in example
  * Remove no need print debug
  * Create save_dir when necessary
  * Refactoring texture_file for occluded.jpg
  * Fix to use size_t for indexing
  * Set texture file with relative path to mesh file
  * Save kinfu mesh model with bbox and ground frame id
  * Create polygon mesh with bbox request in kinfu
  * Create function to crop point cloud by bounding box
  * Add dynamic_reconfigure for kinfu to change save_dir in dynamic
* Various sort options for cluster point indices decomposer (#2133 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2133>)
  * Check bounding box's size to make it valid
  * Add ref for std::sort with lambda function
  * use std::sort in ClusterPointIndicesDecomposer
  * Use argsort to add label to bounding box correctlyThe box label is the index of input indices.
  Index_{output_indices} = argsort(Index_{input_indices})
  
    * Add test for ClusterPointIndicesDecomposer with sort_by option
    * Add capability to sort indices with cloud size
    * Refactor ClusterPointIndicesDecomposer with ~sort_by param
  
* [jsk_pcl_ros] use smaller rosbag data for ppf registration (#2123 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2123>)
  * use nodelet in sample octree voxel grid
  * use smaller rosbag data for ppf registration
* [jsk_pcl_ros/OctomapServerContact] Supress octomap debug message (#2122 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2122>)
  * [jsk_pcl_ros/src/octomap_server_contact_nodelet.cpp] fix log output function.
  * [jsk_pcl_ros/src/octomap_server_contact_nodelet.cpp] add NDEBUG definition for octomap log.
* src/supervoxel_segmentation_nodelet.cpp: check size of PointCloud data size (#2120 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2120>)
* Following change of #2103 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2103> (#2111 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2111>)
  * Use max_pub_queue_size, max_sub_queue_size
* Rewrite KinfuNodelet with some enhancements and new features (#2129 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2129>)
  * Create jsk_recognition_msgs/TrackingStatus.msg and use it in Kinfu
  * Add sample of kinfu for hrp2_apc
  * Remove no longer required rotate90_x
  * Check number of subscribers for each topic to publish
  * Hanle mutex correctly for kinfu_ and cameras_
  * Reset cameras_ when kinfu is reset
  * Use boost shared_ptr to avoid resource leak by kinfu instance
  * Improve topic name: generated_depth -> depth
  * Publish kinfu tracking status
  * Parameterize odom_init (fixed_frame_id)
  * Remove no need scoped lock
  * Add hint comment for slam by kinfu
  * Remove unused Kinfu.cfg
  * Disable slam in default
  * Support kinfu as slam and publish tf map -> odom_init
  * Improve comment
  * Support kinfu as slam with making fixed frame as child
  * Fix kinfu.launch ~input/info -> ~input/camera_info
  * Preserve default behavior of auto_reset=true
  * Test kinfu output topics
  * Preserve kinfu ~output (camera pose)
  * Preserve previous kinfu ~output/cloud
  * Support texture mesh generated using kinfu
  * Support colorized cloud output by kinfu
  * Refactoring: use enc::
  * Support publishing depth image generated by kinfu
  * Fix missing header for rendered image msg
  * Support colorized rendered image
  * Support color integration
  * Refactoring seeing kinfuLS_app.cpp
  * Save mesh model with service request
  * Rewrite KinfuNodelet with some enhancementsStable tracking
  
  Publish rendered image
* [docs][color_histogram_classifier] add tutorials #2147 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2147>
  * [jsk_pcl_ros][color_histogram] update docs / rviz config
  * [jsk_pcl_ros][sample_color_histogram.launch] update launch file
  * [jsk_pcl_ros][color_histogram_visualizer] change bg color to gray
* Various sort options for cluster point indices decomposer (#2133 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2133>)
* Contributors: Kei Okada, Kentaro Wada, Masaki Murooka, Shingo Kitagawa, Yuki Furuta
```

## jsk_pcl_ros_utils

```
* Filter invalid centroid in centroid_publisher (#2150 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2150>)
  * Looser timeout for centroid_publisher.test
  * Add sample and test for CentroidPublisher
  * Filter invalid centroid in centroid_publisher
* Capability of specifying background label for LabelToClusterPointIndices (#2134 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2134>)
  * fix bug in label_to_cluster_point_indices_nodelet
  * Capability of specifying background label for LabelToClusterPointIndices
* add ignore_labels in label_to_cluster_point_indices (#2151 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2151>)
  * Fix style of code of LabelToClusterPointIndices
* [jsk_pcl_ros_utils/src] add onInitPostProcess forStaticPolygonArrayPublisher, PolygonArrayTransformer (#2126 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2126>)
  * [jsk_pcl_ros_utils] add onInitPostProcess to static_polygon_array_publisher_nodelet.cpp, polygon_array_transformer_nodelet.cpp
* Contributors: Kanae Kochigami, Kentaro Wada, Shingo Kitagawa
```

## jsk_perception

```
* [jsk_perception] add FCN-based classifiers (#2142 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2142>)
  * make FCN-based classifiers pass test
  * mask_image_generator run only when use_mask=true
  * add voc_target_names yaml
  * FCN-based classifiers publish full result
  * add sample and test of fcn-based classifiers
  * add probability_image_classifier node
  * add label_image_classifier node
* [jsk_perception] squeeze mask to image dim=2 in fcn segmentation (#2144 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2144>)
  * check mask ndim before squeeze
  * add use_mask sample and test for FCN segmentation
  * fix typo in fcn segmentation
  * squeeze mask to image dim=2 in fcn segmentation
* [jsk_perception/polygon_to_mask] add error message of frame_id (#2125 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2125>)
  * [jsk_perception/polygon_to_mask_image] add error message when frame_id is not correct.
* [jsk_perception] apply candidates node supports topic update (#2143 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2143>)
  * node_scripts/apply_context_to_label_probability: update Label msg API
  * node_scripts/apply_context_to_label_probability: apply candiates support topic update
* [jsk_perception] PeoplePoseEstimation2D (#2115 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2115>)
  * [jsk_perception][people_pose_estimation_2d.py] keep compatibility chainer v1
  * [jsk_perception/people_pose_estimation_2d] Fixed missed numpy/cupy type
  * [jsk_perception/people_pose_estimation_2d] Changed sample bag file
  * [jsk_perception/people_pose_estimation_2d] Add people_mask_publisher
  * [jsk_perception/people_pose_estimation_2d] Publishe 2d image pose
  * [jsk_recogntion_msgs/PoseArray] Add score
  * [jsk_perception/people_pose_estimation_2d] Fixed install sample bag
  * [jsk_perception/people_pose_estimation_2d] Delete duplicated code
  * [jsk_perception/people_pose_estimation_2d] Modified type of PeoplePose.msg
  * [jsk_perception/people_pose_estimation_2d] Fiexed publish img encodings
  * [jsk_perception/people_pose_estimation_2d] Add test
* [jsk_perception/people_pose] Fixed typo and publish rect images. (#2146 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2146> )
  * [jsk_perception/people_pose] Refactor. Delete unnecessary code
  * [jsk_perception/people_pose] Bug fix. Publish rectified image
  * [jsk_perception/people_pose] Fix typo
  * [jsk_perception/people_pose] Delete pcl dependencies
* [jsk_perception/draw_rect_array.py] check polygon_msg list size (#2114 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2114> )
* [jsk_perception/mask_image_to_rect.cpp] check indices size before execute boundingRect (#2113 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2113> )
  * [jsk_perception] check indices size before execute boundingRect
  * jsk_perception/src/mask_image_to_rect.cpp: publish topic even if list is empty
* Contributors: Yuki Furuta, Kanae Kochigami, Masaki Murooka, Shingo Kitagawa, Iori Yanokura
```

## jsk_recognition

- No changes

## jsk_recognition_msgs

```
* [jsk_perception] apply candidates node supports topic update (#2143 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2143>)
  * update Label msg API
  * add Label and LabelArray msg
* Rewrite KinfuNodelet with some enhancements and new features (#2129 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2129>)
  * Save kinfu mesh model with bbox and ground frame id
  * Create polygon mesh with bbox request in kinfu
  * Create jsk_recognition_msgs/TrackingStatus.msg and use it in  Kinfue
* [jsk_perception] PeoplePoseEstimation2D (#2115 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2115>)
  * [jsk_recogntion_msgs/PoseArray] Add score
  * [jsk_perception/people_pose_estimation_2d] Modified type of PeoplePose.msg
  * [jsk_recognition_msgs] Add people_pose msgs
* Contributors: Kei Okada, Kentaro Wada, Shingo Kitagawa, Iori Yanokura
```

## jsk_recognition_utils

```
* [jsk_pcl_ros_utils] Add nodelet for computing & comparing color  histogram (#2101 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2101> )
  * jsk_recognition_utils/include/jsk_recognition_utils/pcl/color_histogram.h: add color_histogram_classifier and visualizer
* Generate Kinfu texture model with attention (BoundingBox) and Groundframe to fix occluded surface  (#2135 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2135> )
  * Create function to crop point cloud by bounding box #2118 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2118> )
* install node_scripts in jsk_recognition_utils
* Contributors: Kentaro Wada, Shingo Kitagawa, Yuki Furuta
```

## resized_image_transport

- No changes
