### PR TITLE
jsk_pr2eus: 0.3.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5350,7 +5350,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_pr2eus-release.git
-      version: 0.3.12-0
+      version: 0.3.13-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.3.13-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_pr2eus
- release repository: https://github.com/tork-a/jsk_pr2eus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.3.12-0`

## jsk_pr2eus

- No changes

## pr2eus

```
* [pr2eus] enable controller-type in :cancel-angle-vector (#313 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/313>)
  * fix typo in robot-interface ( doc string of :cancel-angle-vector method)
  * cancel angle-vector by controller-type
* Contributors: Kei Okada, Shingo Kitagawa
```

## pr2eus_moveit

```
* [pr2eus_moveit] add 0.5 seconds sleep after collision object pub (#315 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/315>)
  * add comment why we need unix:sleep
  * add 0.5 seconds sleep after collision object pub
* add test for https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/310#issuecomment-314694668 (#312 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/312> )
  * test/test-pr2eus-moveit.l, add test-moveit-fastest-trajectory, ensure that :angle-vector-motion-plan will not send faster motion then moveit planned motion
  * display both scaled trajectory time and actual time_to_start time
  * robot-moveit.l : set default start-offset-time to 0, not to skip :trajectory-filter
  * robot-moveit.l, fix debug info (/ total-time 1000) -> (/ total-time 1000.0)
* Revert #310 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/310> "[pr2eus_moveit] fix typo in total-time condition" (#314 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/314> )
* Contributors: Kei Okada, Shingo Kitagawa
```

## pr2eus_tutorials

- No changes
