### PR TITLE
opencv_apps: 1.12.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4117,7 +4117,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-perception/opencv_apps-release.git
-      version: 1.11.15-0
+      version: 1.12.0-0
     source:
       type: git
       url: https://github.com/ros-perception/opencv_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `opencv_apps` to `1.12.0-0`:

- upstream repository: https://github.com/ros-perception/opencv_apps.git
- release repository: https://github.com/ros-perception/opencv_apps-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.11.15-0`

## opencv_apps

```
* [src/node/standalone_nodelet_exec.cpp.in] workaround for freezing imshow on kinetic (#67 <https://github.com/ros-perception/opencv_apps/issues/67>)
  * use ros::param::set instead of ros::NodeHandle("~"), that did not output NODELET_INFO
  * workaround for freezing imshow on kinetic
* [launch/hough_circles.launch] Corrected a typo and applied the node_name argument (#69 <https://github.com/ros-perception/opencv_apps/issues/69> )
* [face_recognition] add nodelet / script / message files for face recognition (new) #63 <https://github.com/ros-perception/opencv_apps/issues/63> from furushchev/face-recognition-new
  
    * add face_recognition nodelet / test
      cfg/FaceRecognition.cfg
      launch/face_recognition.launch
      scripts/face_recognition_trainer.py
      src/nodelet/face_recognition_nodelet.cpp
    * [Face.msg] add label / confidence for face recognition
    * [CMakeLists.txt] remove duplicate msg: RectArrayStamped.msg
  
* cfg/*.cfg : Set useless use_camera_info flag to false in default (#58 <https://github.com/ros-perception/opencv_apps/issues/58> )
* Contributors: Kei Okada, Kentaro Wada, Yuki Furuta, wangl5
```
