### PR TITLE
jsk_apc: 3.3.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5212,7 +5212,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_apc-release.git
-      version: 3.2.0-0
+      version: 3.3.0-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_apc` to `3.3.0-1`:

- upstream repository: https://github.com/start-jsk/jsk_apc.git
- release repository: https://github.com/tork-a/jsk_apc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `3.2.0-0`

## jsk_2015_05_baxter_apc

- No changes

## jsk_2016_01_baxter_apc

```
* disable test to pass travis
* Contributors: Kei Okada
```

## jsk_apc

- No changes

## jsk_apc2015_common

```
* Fix fcn model_file param name
* Contributors: Kentaro Wada
```

## jsk_apc2016_common

```
* add use_topic and input_candidates args
* replace bg_label by ignore_labels
* ad ignore_labels in label_to_cpi
* Fix fcn model_file param name
* add USE_PCA argment in object_segmentation_3d.launch
* Contributors: Kentaro Wada, Naoya Yamaguchi, Shingo Kitagawa
```

## jsk_arc2017_baxter

```
* Add look_around_bins experiment
* Update hand action state in :hand-interpolatingp
* Clean up :graspingp
* Always set graspingp of pinching as true
* Detect serial blocked and restart
* Re-calibrate left vacuum pad joint
* Move gripper upward in :return-object to prevent collision
* Add initialization of left hand
* Fix for slow tf_to_transform
* Rotate head monitor before collect_data_in_shelf
* Use transformable_markers_client in collect_data_in_shelf
* Disable moveit to see in shelf
* add sleep after publishing moveit scene msg
* Fix :get-arm-controller for larm (#2271 <https://github.com/start-jsk/jsk_apc/issues/2271>)
* Program to test hand-eye coordination (#2265 <https://github.com/start-jsk/jsk_apc/issues/2265>)
  * Test hand eye coordination
  * Add test_hand_eye_coordination example
* add controller-type in cancel-angle-vector (#2266 <https://github.com/start-jsk/jsk_apc/issues/2266>)
* Make @pazeshun happy by hand-eye calibration (#2264 <https://github.com/start-jsk/jsk_apc/issues/2264>)
  * Make @pazeshun happy by hand-eye calibration
  * Remove initial pose setting in stereo_astra_hand.launch
* fix indent in baxter-interface.l
* add arm-head-controller, exclude head from arm-controller
* Fix topic of republish_gripper_sensor_states.py
* Fix typo in :finger-closep
* Fix line length
* vacuum_gripper.srdf.xacro -> gripper_v6.srdf.xacro
* Adjust pick and stow to left gripper-v6
* Adjust moveit config to left gripper-v6
* Adjust baxter interface to left gripper-v6
* Adjust baxter.launch to left gripper-v6
* Add left gripper-v6 to gripper launch
* Add udev rule for left gripper-v6
* Add Arduino firm for left gripper-v6
* Add config for left gripper-v6
* Add left gripper-v6 to robot model
* Add mesh of left gripper-v6
* loosen weight error limit
* Enable to change offset of flex threshold in :wait-interpolation-until
* Improve logging of :wait-interpolation-until
* Fix for euslint
* divide too long lines into several lines
* add check pinch graspability program
* add midpoint when returning from place object
* remove duplicated file
* add unix::sleep in while loop
* change error to ros::ros-error
* wait for :interpolatingp
* use proximity in :start-grasp
* rotate gripper according to BoundingBox pose before pinching
* check if angle-vector length is 0 or 2
* add scale methods in arc-interface
* refine weight_candidates_refiner node
* add scale node in setup launch
* add scale.launch
* add use_topic and input_candidates args
* update place motion
* make cardboard bbox bigger to avoid collision
* disable moveit and add fixme
* escape when both arm waiting other arm
* fix typo in main program
* try twice when grasp-stye is :suction
* change head_pan angle to suppress warning message
* add moveit debug arg in baxter.launch
* add midpoint for place object
* Fix encoding of depth: use 32FC1
* Stop using right side depth sensor to avoid ir conflicts
* Calibrate intrinsic parameters
* Use software registration for depth registration
* Revert #2235 <https://github.com/start-jsk/jsk_apc/issues/2235> 'Grasp using proximity'
  Because
  - We cannot use left hand with this change.
  - Has typo.
* update pick.rviz
* Add test for :recognize-bboxes
* update add-cardboard-scene method
* fix typo in arc-interface
* update transformable_markers_client node name
* modify to set offset in world coords
* update ik->cardboard-center to use subscribed bbox
* add recognize-cardboard-boxes method
* add cardboard markers
* order depends of jsk_arc2017_baxter alphabetically
* add smach_viewer args in main launch
* add smach_viewer as run_depend
* apply stereo to setup_for_pick/stow.launch (fixed 3e91e84)
* Fix topic name in euslisp
* Replace publish_boxes to transformable_markers_client/output/boxes
* Use transformable_markers_client to adjust scene
* fix typo  :rarm -> arm
* correct open/close parenthesises
* add exit after ros::ros-error
* add unix::sleep in while loop
* change error to ros::ros-error
* correct indent 3
* wait for :interpolatingp
* correct indent 2
* correct indent
* use proximity in :start-grasp
* rotate gripper according to BoundingBox pose before pinching
* check if angle-vector length is 0 or 2
* Add sleep in :wait-interpolation-until loop
* replace bg_label by ignore_labels
* use arc2017 object_segmentation_3d in stow task
* return nil when largest box is not found
* Show FCN results in stow.rviz
* Improve stow.rviz with transparent moveit scene
* Resolve dependency on position_controller/joint_trajectory_controller
* Revert "Apply stereo camera to setup_for_pick/stow.launch"
* do not use fused RGB as FCN input
* apply stereo camera to setup_for_pick/stow.launch
* Contributors: Kentaro Wada, Naoya Yamaguchi, Shingo Kitagawa, Shun Hasegawa, Yuto Uchimi
```

## jsk_arc2017_common

```
* Add script to visualize annotated 2d dataset
* fix E271 multiple spaces after keyword ERROR....
* Detect serial blocked and restart
* Update to support multi shelf bins
* Add README to annotate_2d_dataset
* Rename to annotate_2d_dataset.py
* Publish scenes and view frame of DatasetV3 in ROS
* merge json_generator into one program (#2270 <https://github.com/start-jsk/jsk_apc/issues/2270>)
* Fix for flake8
* Memoize result of visualize_json
* refine weight_candidates_refiner node
* publish -1 when scale is disabled
* remove unused launch
* rename to weight_candidates_refiner node
* add use_topic and input_candidates args
* sub candidates in scale object estimation node
* publish WeightStamped from scale node
* add Weight and WeightStamped msg
* replace bg_label by ignore_labels
* use arc2017 object_segmentation_3d in stow task
* ad ignore_labels in label_to_cpi
* add USE_PCA argment in object_segmentation_3d.launch
* Contributors: Kei Okada, Kentaro Wada, Naoya Yamaguchi, Shingo Kitagawa, Shun Hasegawa
```
