### PR TITLE
follow_waypoints: 0.3.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1626,7 +1626,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/danielsnider/follow_waypoints-release.git
-      version: 0.2.0-0
+      version: 0.3.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `follow_waypoints` to `0.3.0-2`:

- upstream repository: https://github.com/danielsnider/follow_waypoints.git
- release repository: https://github.com/danielsnider/follow_waypoints-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.0-0`

## follow_waypoints

```
* Added support for emptying the waypoint queue
* Update package.xml
* Update README.md
```
