### PR TITLE
Revert "arbotix: 0.10.0-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -164,23 +164,6 @@ repositories:
       url: https://github.com/ros-perception/ar_track_alvar.git
       version: kinetic-devel
     status: maintained
-  arbotix:
-    doc:
-      type: git
-      url: https://github.com/vanadiumlabs/arbotix_ros.git
-      version: indigo-devel
-    release:
-      packages:
-      - arbotix
-      - arbotix_controllers
-      - arbotix_firmware
-      - arbotix_msgs
-      - arbotix_python
-      - arbotix_sensors
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/vanadiumlabs/arbotix_ros-release.git
-      version: 0.10.0-0
   ardrone_autonomy:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#15284

Like: #15285 this has indigo dependencies in the generated metadata.