### PR TITLE
Removing packages that are failing to build from Kinetic rosdistro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3198,7 +3198,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/segwayrmp/libsegwayrmp-release.git
-      version: 0.2.10-0
     source:
       type: git
       url: https://github.com/segwayrmp/libsegwayrmp.git
@@ -3417,15 +3416,12 @@ repositories:
       version: kinetic-devel
     release:
       packages:
-      - manipulator_h
-      - manipulator_h_base_module
       - manipulator_h_base_module_msgs
       - manipulator_h_bringup
       - manipulator_h_description
       - manipulator_h_gazebo
       - manipulator_h_gui
       - manipulator_h_kinematics_dynamics
-      - manipulator_h_manager
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-MANIPULATOR-H-release.git
@@ -7702,7 +7698,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/segwayrmp/segway_rmp-release.git
-      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/segwayrmp/segway_rmp.git
@@ -8230,20 +8225,12 @@ repositories:
       version: kinetic-devel
     release:
       packages:
-      - ati_ft_sensor
       - motion_module_tutorial
       - sensor_module_tutorial
       - thormang3_action_module
       - thormang3_balance_control
-      - thormang3_base_module
-      - thormang3_feet_ft_module
-      - thormang3_gripper_module
-      - thormang3_head_control_module
       - thormang3_imu_3dm_gx4
       - thormang3_kinematics_dynamics
-      - thormang3_manager
-      - thormang3_manipulation_module
-      - thormang3_mpc
       - thormang3_walking_module
       tags:
         release: release/kinetic/{package}/{version}
@@ -8300,9 +8287,7 @@ repositories:
     release:
       packages:
       - thormang3_manipulation_demo
-      - thormang3_ppc
       - thormang3_sensors
-      - thormang3_walking_demo
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-PPC-release.git
@@ -8319,8 +8304,6 @@ repositories:
       version: kinetic-devel
     release:
       packages:
-      - thormang3_action_editor
-      - thormang3_offset_tuner_server
       - thormang3_tools
       tags:
         release: release/kinetic/{package}/{version}
@@ -8785,7 +8768,6 @@ repositories:
       packages:
       - underwater_sensor_msgs
       - underwater_vehicle_dynamics
-      - uwsim
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uji-ros-pkg/underwater_simulation-release.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8303,8 +8303,6 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Tools.git
       version: kinetic-devel
     release:
-      packages:
-      - thormang3_tools
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Tools-release.git


### PR DESCRIPTION
@pyo @wjwwood @marioprats @perezsolerj  FYI

These packages are failing to build repeatedly so I'm removing them from the rosdistro. When you have a moment please consider updating and rereleasing.

Partially reverts: 
 * #15044 
 * #15045 
 * #13689
 * #15478 
 * #15479 

Also related #15504 

![image](https://user-images.githubusercontent.com/447804/28235209-33b70a8c-68be-11e7-8325-a417717192ad.png)
