### PR TITLE
geometry2: 0.5.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3699,7 +3699,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.5.15-0
+      version: 0.5.16-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.5.16-0`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.5.15-0`

## geometry2

- No changes

## geometry_experimental

- No changes

## tf2

```
* remove explicit templating to standardize on overloading. But provide backwards compatibility with deprecation.
* Merge pull request #144 <https://github.com/ros/geometry2/issues/144> from clearpathrobotics/dead_lock_fix
  Solve a bug that causes a deadlock in MessageFilter
* Resolve 2 places where the error_msg would not be propogated.
  Fixes #198 <https://github.com/ros/geometry2/issues/198>
* Remove generate_rand_vectors() from a number of tests. (#227 <https://github.com/ros/geometry2/issues/227>)
* fixing include directory order to support overlays (#231 <https://github.com/ros/geometry2/issues/231>)
* replaced dependencies on tf2_msgs_gencpp by exported dependencies
* Document the lifetime of the returned reference for getFrameId getTimestamp
* relax normalization tolerance. #196 <https://github.com/ros/geometry2/issues/196> was too strict for some use cases. (#220 <https://github.com/ros/geometry2/issues/220>)
* Solve a bug that causes a deadlock in MessageFilter
* Contributors: Adel Fakih, Chris Lalancette, Christopher Wecht, Tully Foote, dhood
```

## tf2_bullet

```
* store gtest return value as int (#229 <https://github.com/ros/geometry2/issues/229>)
* Contributors: dhood
```

## tf2_eigen

```
* fix return value to prevent warnings on windows (#237 <https://github.com/ros/geometry2/issues/237>)
* fixing include directory order to support overlays (#231 <https://github.com/ros/geometry2/issues/231>)
* tf2_eigen: added support for Quaternion and QuaternionStamped (#230 <https://github.com/ros/geometry2/issues/230>)
* Remove an unused variable from the tf2_eigen test. (#215 <https://github.com/ros/geometry2/issues/215>)
* Find eigen in a much nicer way.
* Switch tf2_eigen to use package.xml format 2. (#216 <https://github.com/ros/geometry2/issues/216>)
* Contributors: Chris Lalancette, Mikael Arguedas, Tully Foote, cwecht
```

## tf2_geometry_msgs

```
* remove explicit templating to standardize on overloading. But provide backwards compatibility with deprecation.
* adding unit tests for conversions
* Copy transform before altering it in do_transform_vector3 [issue 233] (#235 <https://github.com/ros/geometry2/issues/235>)
* store gtest return value as int (#229 <https://github.com/ros/geometry2/issues/229>)
* Document the lifetime of the returned reference for getFrameId and getTimestamp
* tf2_geometry_msgs: using tf2::Transform in doTransform-functions, marked gmTransformToKDL as deprecated
* Switch tf2_geometry_msgs to use package.xml format 2 (#217 <https://github.com/ros/geometry2/issues/217>)
* tf2_geometry_msgs: added missing conversion functions
* Contributors: Christopher Wecht, Sebastian Wagner, Tully Foote, dhood, pAIgn10
```

## tf2_kdl

```
* store gtest return value as int (#229 <https://github.com/ros/geometry2/issues/229>)
* Find eigen in a much nicer way.
* Switch tf2_kdl over to package.xml format 2.
* Contributors: Chris Lalancette, dhood
```

## tf2_msgs

- No changes

## tf2_py

```
* fix memory leak calling Py_DECREF for all created PyObject
* replaced dependencies on tf2_msgs_gencpp by exported dependencies
* Relax strict type checks at setTransform to only check for members (#221 <https://github.com/ros/geometry2/issues/221>)
* expose deprecated methods in tf2_py API to support better backwards compatibility. Fixes #206 <https://github.com/ros/geometry2/issues/206>
* Contributors: Christopher Wecht, Sergio Ramos, Tully Foote, alex
```

## tf2_ros

```
* Merge pull request #144 <https://github.com/ros/geometry2/issues/144> from clearpathrobotics/dead_lock_fix
  Solve a bug that causes a deadlock in MessageFilter
* Clear error string if it exists from the external entry points.
  Fixes #117 <https://github.com/ros/geometry2/issues/117>
* Make buff_size and tcp_nodelay and subscriber queue size mutable.
* Remove generate_rand_vectors() from a number of tests. (#227 <https://github.com/ros/geometry2/issues/227>)
  * Remove generate_rand_vectors() from a number of tests.
* Log jump duration on backwards time jump detection. (#234 <https://github.com/ros/geometry2/issues/234>)
* replaced dependencies on tf2_msgs_gencpp by exported dependencies
* Use new-style objects in python 2
* Solve a bug that causes a deadlock in MessageFilter
* Contributors: Adel Fakih, Chris Lalancette, Christopher Wecht, Eric Wieser, Koji Terada, Stephan, Tully Foote, koji_terada
```

## tf2_sensor_msgs

```
* Fix do_transform_cloud for multi-channelled pointcloud2. (#241 <https://github.com/ros/geometry2/issues/241>)
* store gtest return value as int (#229 <https://github.com/ros/geometry2/issues/229>)
* Document the lifetime of the returned reference for getFrameId and getTimestamp
* Find eigen in a much nicer way.
* Switch tf2_sensor_msgs over to package format 2.
* Contributors: Atsushi Watanabe, Chris Lalancette, dhood
```

## tf2_tools

- No changes
