### PR TITLE
diagnostics: 1.9.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -798,7 +798,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/diagnostics-release.git
-      version: 1.9.0-0
+      version: 1.9.1-0
     source:
       type: git
       url: https://github.com/ros/diagnostics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `1.9.1-0`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros-gbp/diagnostics-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.9.0-0`

## diagnostic_aggregator

```
* Add queue size parameters on Publishers
* add_analyzers improvements
  * Warning message when bond is broken
  * Per-bond topics to avoid queue length issues
* Option to make diagnostics in Other an error
* Contributors: trainman419
```

## diagnostic_analysis

- No changes

## diagnostic_common_diagnostics

```
* Add queue size parameters on Publishers
* Minor python updates
* Added CPU percentage monitor
  CPU monitor that outputs the average CPU percentage and a percentage per
  CPU. The user can specify the warning CPU percentage. When one CPU exceeds
  this percentage, the diagnostics status is set to WARN.
* Contributors: Rein Appeldoorn, trainman419
```

## diagnostic_updater

```
* Add queue size parameters on Publishers
* Minor python updates
* Contributors: trainman419
```

## diagnostics

- No changes

## rosdiagnostic

- No changes

## self_test

- No changes

## test_diagnostic_aggregator

```
* Add queue size parameters on Publishers
* Contributors: trainman419
```
