### PR TITLE
jsk_robot: 1.1.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5398,6 +5398,7 @@ repositories:
       - jsk_nao_startup
       - jsk_pepper_startup
       - jsk_pr2_calibration
+      - jsk_pr2_desktop
       - jsk_pr2_startup
       - jsk_robot
       - jsk_robot_startup
@@ -5410,7 +5411,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_robot-release.git
-      version: 1.0.6-2
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_robot.git
+      version: master
     status: developed
   jsk_roseus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_robot` to `1.1.0-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_robot.git
- release repository: https://github.com/tork-a/jsk_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.6-2`

## baxtereus

```
* baxtereus: test/*.test: time-limit=100000 is too large need to set 300-600 (`#802 <https://github.com/jsk-ros-pkg/jsk_robot/issues/802>`_)
  * test/*.test: time-limit=100000 is too large need to set 300-600
* [baxtereus] Fix run_depend to pr2eus_moveit (#798 <https://github.com/jsk-ros-pkg/jsk_robot/issues/798>)
  * Fix run_depend to pr2eus_moveit
* [baxtereus] support tm :fast in moveit angle-vector methods (#789 <https://github.com/jsk-ros-pkg/jsk_robot/issues/789>)
  * angle-vector-sequence accept tms as list of timerelated to https://github.com/jsk-ros-pkg/jsk_robot/pull/791#pullrequestreview-45324124
  
    * test tm :fast angle-vector methods and av-sequence
    * update doc for :angle-vecor methods
    * support tm :fast in moveit angle-vector methods
  
* [baxtereus] add key :robot in baxter-interface :init (#784 <https://github.com/jsk-ros-pkg/jsk_robot/issues/784>)
  * add key :robot in baxter-interface :init
* [baxtereus] Use end-coords-interpolation (#747 <https://github.com/jsk-ros-pkg/jsk_robot/issues/747>)
  * Use end-coords-interpolation in baxter-interface
* [baxtereus][jsk_baxter_startup] add baxter moveit test (#779 <https://github.com/jsk-ros-pkg/jsk_robot/issues/779>)
  * add baxter_sim_controllers as test_depend
  * add gazebo moveit starting time assertion
  * add joint_state_controller as test_depend
  * update cmake and package for baxter moveit test
  * add baxter moveit test
* [baxtereus] set wait key default as t (#769 <https://github.com/jsk-ros-pkg/jsk_robot/issues/769>)
  * set wait key default as t
* [baxtereus] add wait key in :start-grasp (#768 <https://github.com/jsk-ros-pkg/jsk_robot/issues/768>)
* [baxtereus] remove unused baxter-moveit.l (#764 <https://github.com/jsk-ros-pkg/jsk_robot/issues/764>)
  * remove baxter-moveit.l from CMakeLists.txt
  * remove unused baxter-moveit.l, it is replaced in baxter-interface.l
* [baxtereus] fix bug in :command-grasp and :calib-grasp (#762 <https://github.com/jsk-ros-pkg/jsk_robot/issues/762>)
  * pass pos in :calib-grasp
  * pass arm as symbol to :command-grasp
* add ik-prepared-poses in baxter class (#748 <https://github.com/jsk-ros-pkg/jsk_robot/issues/748>)
  * baxter-util.l : :ik-prepared-poses, enable to set nil
  * baxter-util.l : self-collision-check, fix symbol  symbol expected for function argument error on compile
  * define :ik-prepared-poses in baxter-robot.l
* [baxtereus] pass args to angle-vector-motion-plan (#737 <https://github.com/jsk-ros-pkg/jsk_robot/issues/737>)
  * add moveit option in baxter-init
  * pass args to angle-vector-motion-plan in baxtereus
* [baxtereus] execute raw angle-vector methods in case tm is not number (#734 <https://github.com/jsk-ros-pkg/jsk_robot/issues/734>)
  * execute raw angle-vector in case tm is not numbercommon case is
  (send ri :angle-vector-sequnce avs :fast)
* [baxtereus] add ctype in angle-vector methods for moveit (#730 <https://github.com/jsk-ros-pkg/jsk_robot/issues/730>)
  * use &key instead of &rest in baxter angle-vectoruse &key instead of &rest args in :angle-vector methods in baxtereus and
  refine codes.
  
    * add ctype in angle-vector-sequence for moveit
    * add ctype in angle-vector for moveit
  
* [baxtereus] add :angle-vector-sequence for moveit (#728 <https://github.com/jsk-ros-pkg/jsk_robot/issues/728>)
  * fix typo in baxter-util.l
  * add :angle-vector-sequence for moveit:angle-vector-sequence -> :angle-vector-sequence-motion-plan
* [baxtereus] add :arms for baxter_moveit_config "both_arms" (#731 <https://github.com/jsk-ros-pkg/jsk_robot/issues/731>)
  * add :arms for baxter_moveit_config "both_arms"
* [baxtereus] Fix bug to pass args in :angle-vector (#729 <https://github.com/jsk-ros-pkg/jsk_robot/issues/729>)
  * fix bug in :angle-vectoruse :move-arm as key and pass other args to other methods
  currently args passing was not proper
  
    * fix typo in baxter-interface
    * remove tab and use space in baxter-interface
    * refine warning message in baxter-interface
  
* [baxtereus] override :angle-vector and rename existing methods (#721 <https://github.com/jsk-ros-pkg/jsk_robot/issues/721>)
  * override :angle-vector and rename existing methodsBefore                       After
  :angle-vector-motion-plan -> :angle-vector
  :angle-vector             -> :angle-vector-raw
  :angle-vector-sequence    -> :angle-vector-sequence-raw
* [baxtereus] add moveit init option in baxter-interface (#719 <https://github.com/jsk-ros-pkg/jsk_robot/issues/719>)
  * add moveit config init option in baxter-interfacethis option is needed for customize baxter like jsk_baxter_apc
  
    * add SRDF description in baxter-interface.l
  
* [baxtereus] add moveit in baxter-interface (#716 <https://github.com/jsk-ros-pkg/jsk_robot/issues/716>)
  * add moveit in baxter-interface
* Contributors: Kei Okada, Kentaro Wada, Shingo Kitagawa, Shun Hasegawa
```

## fetcheus

```
* fetcheus/CMakeLists.txt : add install rule (#763 <https://github.com/jsk-ros-pkg/jsk_robot/issues/763>)
* [Fetch] jsk_fetch_robot/fetcheus/fetch-interface.l :angle-vector,
  :angle-vector-sequence supports old API (#795 <https://github.com/jsk-ros-pkg/jsk_robot/issues/795> )
  * pass start-time to start-offset-time and support :start-time key
  * support :start-time key in angle-vector methods
  * pass start-time in start-offset-time
  * support old API
  * :angle-vector-sequence accept tms in list of time
  * add :angle-vector-sequence with moveit in fetcheus
  * update :angle-vector in fetch-interface
* [fetcheus] disable gui in fetch-moveit.test (#778 <https://github.com/jsk-ros-pkg/jsk_robot/issues/778> )
  * disable gui in fetch-moveit.test
  * use simulation.launch instead of playground.launch
* [fetch] Correct head orientation for look-at #771 <https://github.com/jsk-ros-pkg/jsk_robot/issues/771> (#773 <https://github.com/jsk-ros-pkg/jsk_robot/issues/773>)
  * Correct fetch head orientation
  * test/test-fetcheus.l: add test to check #771 <https://github.com/jsk-ros-pkg/jsk_robot/issues/771>
  * package.xml: add depends to pr2eus_moveit
* [fetcheus] modify :reset-pose (#742 <https://github.com/jsk-ros-pkg/jsk_robot/issues/742>)
  * send *fetch* :torso :waist-z :joint-angle 20moveit need more space between base and elbow_flex_link
* [fetch-robot] set effort to 40 in :go-grasp (#727 <https://github.com/jsk-ros-pkg/jsk_robot/issues/727> )
  * set effort to 40 in :go-grasp
* fetch-interface.l : add args for :speak methods (#723 <https://github.com/jsk-ros-pkg/jsk_robot/issues/723>)
* test/test-fetcheus.l: add test to check :angle-vector on kinematics simulator (#717 <https://github.com/jsk-ros-pkg/jsk_robot/issues/717> )
  * use :angle-vector-raw for simulation mode
  * test/test-fetcheus.l: add euslisp test to check :angle-vector on kinematics simulator
* Contributors: Noya Yamaguchi, Guilherme-Affonso, Yuki Furuta, Kei Okada, Shingo Kitagawa
```

## jsk_201504_miraikan

- No changes

## jsk_baxter_desktop

- No changes

## jsk_baxter_startup

```
* [baxtereus][jsk_baxter_startup] add baxter moveit test (#779 <https://github.com/jsk-ros-pkg/jsk_robot/issues/779>)
  * add initialize_baxter in jsk_baxter_toolsoriginally from jsk_2015_01_baxter_apc
  modify to launch moveit launch
* [jsk_baxter_moveit] modify jsk_baxter_moveit moveit.launch (#765 <https://github.com/jsk-ros-pkg/jsk_robot/issues/765>)
  * enable gripper in moveit when its action launched
  * modify jsk_baxter_moveit moveit.launch
* Contributors: Kei Okada, Shingo Kitagawa
```

## jsk_baxter_web

- No changes

## jsk_fetch_startup

```
* Enable safe teleop for fetch (#801 <https://github.com/jsk-ros-pkg/jsk_robot/issues/801>)
  * fetch_gazebo_bringup.launch and fetch_teleop.xml both starts cmd_vel_mux, add roslaunch_add_file_check  fetch_gazebo_bringup.launch
  * add roslaunch_depends.py from https://github.com/ros/ros_comm/pull/998 to support if, https://github.com/ros/ros_comm/issues/953 could not load launch file with args directory
  * jsk_fetch_startup/package.xml: missing joy, topic_tools, fetch_teleop depends
  * launch/fetch_teleop.xml run unsafe_warning.l directory, not by roseus package
  * jsk_fetch_startup/package.xml: missing fetch_moveit_config depends
  * [jsk_fetch_startup] exclude fetch_bringup.launch from check
  * [jsk_fetch_startup] move unsafe_warning.l to jsk_robot_startup / enable unsafe_warning on fetch
  * [jsk_fetch_startup] add launch for safe teleop
* [jsk_pr2_startup] fix: init pose parameter typo for gazebo (#753 <https://github.com/jsk-ros-pkg/jsk_robot/issues/753>)
  * [jsk_fetch_startup][fetch_gazebo_73b2.launch] fix: param name typo
* [jsk_fetch_startup][fetch_bringup.launch] fix: robot/type robot/name (#752 <https://github.com/jsk-ros-pkg/jsk_robot/issues/752>)
* [jsk_fetch_startup][warning.py] fix: suppress warning: 'self.robot_state_msgs is not initialized' (#750 <https://github.com/jsk-ros-pkg/jsk_robot/issues/750> )
* Contributors: Kei Okada, Yuki Furuta
```

## jsk_nao_startup

- No changes

## jsk_pepper_startup

- No changes

## jsk_pr2_calibration

- No changes

## jsk_pr2_desktop

```
* [jsk_pr2_desktop] change install destination to ~/.local/share/applications (#788 <https://github.com/jsk-ros-pkg/jsk_robot/issues/788> )
* catkinize jsk_pr2_desktop (#781 <https://github.com/jsk-ros-pkg/jsk_robot/issues/781>)
* Contributors: Yuki Furuta, Kei Okada
```

## jsk_pr2_startup

```
* Enable safe teleop for fetch (#801 <https://github.com/jsk-ros-pkg/jsk_robot/issues/801>)
  * [jsk_fetch_startup] move unsafe_warning.l to jsk_robot_startup / enable unsafe_warning on fetch
  * [jsk_pr2_startup] move mux_selector.py to jsk_robot_startup
* [jsk_pr2_startup][pr2.launch] update voice_text launch (#796 <https://github.com/jsk-ros-pkg/jsk_robot/issues/796>)
* [jsk_pr2_startup] fix: pr2 move_base local cost map does not work on gazebo (#736 <https://github.com/jsk-ros-pkg/jsk_robot/issues/736>)
* [jsk_pr2_startup] fix: init pose parameter typo for gazebo (#753 <https://github.com/jsk-ros-pkg/jsk_robot/issues/753>)
  * [jsk_pr2_startup] fix param for initialpose_publisher.l
* [jsk_pr2_startup] IAI kitchen gazebo startup launch (#695 <https://github.com/jsk-ros-pkg/jsk_robot/issues/695> )
  * [jsk_pr2_startup] add iai_kitchen gazebo startup launch
  * [jsk_pr2_startup/pr2.launch] add launch_map option
* Contributors: Kei Okada, Yuki Furuta
```

## jsk_robot

- No changes

## jsk_robot_startup

```
* Enable safe teleop for fetch (#801 <https://github.com/jsk-ros-pkg/jsk_robot/issues/801> )
  * [jsk_fetch_startup] move unsafe_warning.l to jsk_robot_startup / enable unsafe_warning on fetch
  * [jsk_pr2_startup] move mux_selector.py to jsk_robot_startup
* run active_user.l with 1hz (#787 <https://github.com/jsk-ros-pkg/jsk_robot/issues/787> )
* [jsk_robot_startup, multisense_local.launch] add USE_HEIGHTMAP parameter (#783 <https://github.com/jsk-ros-pkg/jsk_robot/issues/783> )
* [jsk_robot_startup] add record launch files for SLAM (#760 <https://github.com/jsk-ros-pkg/jsk_robot/issues/760>)
* [jsk_robot_startup][mongodb.launch] pass through arg test_mode (#755 <https://github.com/jsk-ros-pkg/jsk_robot/issues/755>)
* [jsk_robot_startup] Tuned odometry params for jaxon (#732 <https://github.com/jsk-ros-pkg/jsk_robot/issues/732>)
* Contributors: Kei Okada, Yohei Kakiuchi, Yuki Furuta, Iori Kumagai
```

## jsk_robot_utils

- No changes

## naoeus

- No changes

## naoqieus

- No changes

## peppereus

- No changes

## pr2_base_trajectory_action

- No changes

## roseus_remote

- No changes
