### PR TITLE
mastering_ros_demo_pkg: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3531,6 +3531,12 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
       version: 1.0.6-0
+  mastering_ros_demo_pkg:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/jocacace/mastering_ros_demo_pkg.git
+      version: 0.0.3-0
   mav_comm:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `mastering_ros_demo_pkg` to `0.0.3-0`:

- upstream repository: https://github.com/jocacace/mastering_ros_demo_pkg.git
- release repository: https://github.com/jocacace/mastering_ros_demo_pkg.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
