### PR TITLE
fiducials: 0.7.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1564,7 +1564,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/fiducials-release.git
-      version: 0.7.2-0
+      version: 0.7.3-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/fiducials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fiducials` to `0.7.3-0`:

- upstream repository: https://github.com/UbiquityRobotics/fiducials
- release repository: https://github.com/UbiquityRobotics-release/fiducials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.7.2-0`

## aruco_detect

- No changes

## fiducial_detect

- No changes

## fiducial_lib

- No changes

## fiducial_msgs

- No changes

## fiducial_pose

- No changes

## fiducial_slam

```
* Install launch files and fiducials.rviz
* add test of auto init
* Print out 6DOF camera pose
* Fix multiplication order bug in autoInit()
* Renamed some variables to be more clear
* Add publish_6dof_pose param to disable squashing of estimated robot pose
* Contributors: Jim Vaughan
```

## fiducials

- No changes
