### PR TITLE
cob_extern: 0.6.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1750,15 +1750,17 @@ repositories:
     release:
       packages:
       - cob_extern
+      - libconcorde_tsp_solver
       - libdlib
       - libntcan
-      - libopengm
       - libpcan
       - libphidgets
+      - libqsopt
+      - opengm
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_extern-release.git
-      version: 0.6.10-0
+      version: 0.6.11-0
     source:
       type: git
       url: https://github.com/ipa320/cob_extern.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_extern` to `0.6.11-0`:

- upstream repository: https://github.com/ipa320/cob_extern.git
- release repository: https://github.com/ipa320/cob_extern-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.6.10-0`

## cob_extern

```
* corrected spelling mistake
* minor changes
* Contributors: ipa-rmb-fj
```

## libconcorde_tsp_solver

```
* fix include_dirs in cmake_extras
* use EXPORTED_TARGETS
* migrated libconcorde_tsp_solver to catkin-native wrapping
* license workarounds
* style check
* updated install tags for bins in libconcorde_tsp_solver
* minor bugfix in libconcorde_tsp_solver regarding installation of executable
* changed libopengm to opengm, because of internal includes of opengm-library that expect headers to be in include/opengm
* continued workaround before merge with ipa320
* catkin workaround before merge with ipa320
* updated package.xml for libqsopt and libconcorde-tsp-solver
* concorde tests if architecture is supported for qsopt
* absolut path to qsopt found by cmake
* working on libconcorde_tsp_solver to find libqsopt
* separated Qsopt and Concorde into two packages
* Contributors: ipa-fxm, ipa-rmb-fj
```

## libdlib

```
* fix include_dirs in cmake_extras
* use EXPORTED_TARGETS
* migrated libdlib to catkin-native wrapping
* license workarounds
* minor changes
* changed libopengm to opengm, because of internal includes of opengm-library that expect headers to be in include/opengm
* continued workaround before merge with ipa320
* catkin workaround before merge with ipa320
* changed libdlib and libqsopt to provide the static library right
* Contributors: ipa-fxm, ipa-rmb-fj
```

## libntcan

```
* copy header and libs into devel space
* use EXPORTED_TARGETS
* final consistency
* migrated libntcan to catkin-native wrapping
* Contributors: ipa-fxm
```

## libpcan

```
* fix include_dirs in cmake_extras
* use EXPORTED_TARGETS
* final consistency
* migrated libpcan to catkin-native wrapping
* kernel source is not needed for building libpcan
* update to newest peak driver version 8.3
* Contributors: Benjamin Maidel, Mathias Lüdtke, ipa-fxm
```

## libphidgets

```
* fix libphidgets download url
* fix include_dirs in cmake_extras
* use EXPORTED_TARGETS
* final consistency
* migrated libphidgets to catkin-native wrapping
* Contributors: Matthias Gruhler, ipa-fxm
```

## libqsopt

```
* fix include_dirs in cmake_extras
* final consistency
* migrated libqsopt to catkin-native wrapping
* license workarounds
* added authors of Qsopt
* style check
* minor changes
* continued workaround before merge with ipa320
* catkin workaround before merge with ipa320
* changed libdlib and libqsopt to provide the static library right
* updated package.xml for libqsopt and libconcorde-tsp-solver
* concorde tests if architecture is supported for qsopt
* absolut path to qsopt found by cmake
* separated Qsopt and Concorde into two packages
* Contributors: ipa-fxm, ipa-rmb-fj
```

## opengm

```
* fix include_dirs in cmake_extras
* use EXPORTED_TARGETS
* migrated opengm to catkin-native wrapping
* license workarounds
* style check
* minor changes
* changed libopengm to opengm, because of internal includes of opengm-library that expect headers to be in include/opengm
* changed libopengm to opengm, because of internal includes of opengm-library that expect headers to be in include/opengm
* Contributors: ipa-fxm, ipa-rmb-fj
```
