### PR TITLE
cob_common: 0.6.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -801,6 +801,27 @@ repositories:
       url: https://github.com/ipa320/cob_calibration_data.git
       version: indigo_dev
     status: developed
+  cob_common:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_common.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_common
+      - cob_description
+      - cob_msgs
+      - cob_srvs
+      - raw_description
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_common-release.git
+      version: 0.6.7-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_common.git
+      version: indigo_dev
+    status: developed
   cob_extern:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.6.7-0`:

- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cob_common

```
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_description

```
* use asus xtion default values
* usb_cam default values
* use realsense default values
* separate laser scanner from base
* remove static tf frames
* raise effort limit. fixes https://github.com/ipa320/cob_robots/issues/641
* change back mean value of noise (caused troubles for close by obstacles)
* set proper velocity limits for cob4 drive_wheel
* adjusted laserscan-sensors in simulation
* proper conditions
* move gazebo_ros_control plugin
* use xacro --inorder
* fix collision mesh for cob4 torso
* remove obsolete components due to unsupported robots
* Merge pull request #200 <https://github.com/ipa320/cob_common/issues/200> from ipa-fxm/latest_xacro_syntax
  use latest xacro syntax
* allow static sensorring
* fix syntax error
* use latest xacro syntax
* manually fix changelog
* unify torso xacros, use default transmission macro
* move sensors from torso xacro to robot xacro
* remove unused torso_3dof
* use default transmission macro
* unify sensorring xacros
* move sensors from sensorring xacro to robot xacro
* remove unused sensorring_3dcs
* unify head xacros
* introduce default transmission
* move sensors from head xacro to robot xacro
* removed softkinetic description
* updated resolution for usb camera
* updated resolution for usb camera
* renamed xacro and files(head_cam -> usb_cam)
* check camera resolution
* added head_cam frame to urdf
* Contributors: Felix Messmer, Florian Weisshardt, Mathias Lüdtke, fmw-hb, ipa-fxm, ipa-nhg
```

## cob_msgs

```
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_srvs

```
* manually fix changelog
* Contributors: ipa-fxm
```

## raw_description

```
* Current config gripper (#221 <https://github.com/ipa320/cob_common/issues/221>)
  * added vacuum gripper
  * New STL file for the vacuum gripper
  * Vacuum Gripper file description updated
  * torso and gripper updates
  * removed obsolete files
  * orient_gripper
* fix the wheel radius to meet with the actual hardware radii
* separate laser scanner from base
* finalizing
* changes acoording to pull request
* origin of the colision mesh corrected according with visual values
* origin of the colision mesh corrected
* gripper mesh simplified
* stable behavior by tweaking the base mass/inertia achieved
* stable behavior by tweaking the base mass/inertia achieved
* get a stable behavior by tweaking the base mass/inertia
* use scalable primitive meshes
* use the properties at the top for the collision properties
* file name and suffix all small letters.
* gripper macro name changed and prefix removed as argument
* tabs vs spaces solved
* requested changes
* torso and gripper updates
* Vacuum Gripper file description updated
* New STL file for the vacuum gripper
* added vacuum gripper
* move gazebo_ros_control plugin
* use latest xacro syntax
* manually fix changelog
* Contributors: Bruno Brito, Richard Bormann, ipa-bfb-sc, ipa-fxm, ipa-mjp, ipa-raw3-3
```
