### PR TITLE
cob_command_tools: 0.6.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1630,7 +1630,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.5-0
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.5-1`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.6.5-0`

## cob_command_gui

```
* 0.6.4
* update changelog
* undo pop-up related changes
* only show MessagDialog for init and recover
* calling sss.commands in thread with MessageDialog
* 0.6.3
* update changelog
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```

## cob_command_tools

```
* 0.6.4
* update changelog
* 0.6.3
* update changelog
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```

## cob_dashboard

```
* 0.6.4
* update changelog
* use aggregated power message
* 0.6.3
* update changelog
* remove trailing whitespaces
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fmw, ipa-fxm
```

## cob_interactive_teleop

```
* 0.6.4
* update changelog
* 0.6.3
* update changelog
* boost revision
* do not install headers in executable-only packages
* explicit dependency for boost
* remove obsolete autogenerated mainpage.dox files
* remove FILES_MATCHING
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: ipa-fxm
```

## cob_monitoring

```
* fix diagnostics output
* 
  
    * Made changes to handle HZ monitoring for multiple topics.
  
* 
  
    * Minor fix for publishing multiple topics.
  
* 
  
    * Made changes for handling multiple hz topics.
  
* 
  
    * Completely commented out the code segments for HDD temperature statistics.
    * Added cla for providing directory name, default is root directory.
  
* use reasonable default window size and fix status level
* fix code style
* add hz monitor
* simplify emergency_stop monitor
* fix emergency_stop monitor for enable_light set to false
* enable cpu warnings in diagnostics
* increased battery_monitors led prio
* check if light is enabled
* init light mode object
* 0.6.4
* update changelog
* stop charging mode if no more power_state msgs received
* fix node and class name
* fix emergency_stop_monitor
* parameter name consistency
* fix script
* configurable battery thresholds
* parameter for enabling sound and light
* combine battery_light_monitor and battery_monitor
* add say output to battery_light_monitor
* added actionlib exec dep and install tag
* fixes
* fix
* fix
* use cob_lights track_id in battery light monitor
* adapted em stop monitor to new cob_light
* fixes due to cob_light changes
* changes due to cob_lights refactor
* implemented compatibility for non addressable led bands
* switched from info to debug message
* switched from action to service
* added monitor to switch cobs light if charging
* set queue size to 1
* Update emergency_stop_monitor.py
* fixed em stop monitor
* removed configuration files
* fixes type conversion in ddwrt
* 0.6.3
* update changelog
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* critically review dependencies
* Contributors: Benjamin Maidel, Florian Weisshardt, fmw-hb, fmw-ss, ipa-bnm, ipa-cob4-2, ipa-cob4-5, ipa-fxm, ipa-nhg, msh
```

## cob_script_server

```
* use joint_states instead of controller_state
* Removed an extra space
* Removed a comma
* fixed more concatenate messages errors
* Update log message
* Fix concatenate error
* fix error message for move_base_rel
* 0.6.4
* update changelog
* undo pop-up related changes
* indentation fixes
* more verbose action_handle (takes an additional string in set_failed())
  more consistent usage of action_handle throughout code
* cleanup action_handle
* parameter for enabling sound and light
* allow passing of component_name to sss.say
* use modes definition instead of magic numbers
* Merge branch 'indigo_dev' into fix/refactor_light
  Conflicts:
  cob_teleop/ros/src/cob_teleop.cpp
* reduce timeout for all wait_for_server calls
* fixes due to cob_light changes
* shorten timeout
* fix CMakeLists.txt
* add dependency to actionlib
* fix ScriptAction include in cob_teleop
* fix sss error handling for light
* Merge branch 'fix_teleop' into fix_sss
* set zero velocity and acceleration for all trajectory points
* fix actionhandle for trigger
* deleted script_server tests from launch file
* 0.6.3
* update changelog
* do not install headers in executable-only packages
* more cleanup
* remove obsolete autogenerated mainpage.dox files
* remove trailing whitespaces
* remove trailing whitespaces
* migrate to package format 2
* Merge pull request #105 <https://github.com/ipa320/cob_command_tools/issues/105> from ipa-nhg/play_sound
  minor changes
* minor changes
* Merge pull request #103 <https://github.com/ipa320/cob_command_tools/issues/103> from ipa-nhg/play_sound
  play sound
* log error
* cob_sound
* sort dependencies
* critically review dependencies
* play sound
* Contributors: Benjamin Maidel, Florian Köhler, Florian Weisshardt, Nadia Hammoudeh García, ipa-cob4-2, ipa-cob4-5, ipa-fmw, ipa-fxm, ipa-nhg
```

## cob_teleop

```
* add safe mode for teleop
* 0.6.4
* fix version
* update changelog
* reduce terminal output
* changes for new message structure and concurrent mode
* compile fixes because of changes in cob_light
* swap say-setLight execution order2
* introduce enable params, styling, consistency, beautifying
* add catkin include dirs
* adapt twist_mux topic names according to https://github.com/ipa320/orga/pull/1#issuecomment-159195427
* added apply_ramp parameter to switch velocity smoothing on teleop side on and off (if velocity_smoother is active teleop do not need to smooth)
* changed keyboard default topic to twist_mux input
* Merge branch 'fix_teleop' of https://github.com/ipa-fmw/cob_command_tools into fix_teleop
* announce 'go' after init all
* tabs vs. spaces
* replace string before passing to say
* change speach output
* enable speach for default position mode
* cob_teleop: disable light, encapsulate say and use deadman button to enable mode switch
* Fix typo
* added tag exported targets
* deleted config folder
* change frequencies
* removed configuration files
* use light action server
* first robot test
* global ns for actions
* cob_teleop review
* updated package.axml and CMakeLists
* fisrt testable version
* adapt the node for other robots
* beautify
* update
* update
* new node
* 0.6.3
* update changelog
* boost revision
* do not install headers in executable-only packages
* explicit dependency for boost
* more cleanup
* remove obsolete autogenerated mainpage.dox files
* remove FILES_MATCHING
* remove trailing whitespaces
* migrate to package format 2
* sort dependencies
* Contributors: Benjamin Maidel, Florian Weisshardt, Marco Bezzon, ipa-fmw, ipa-fxm, ipa-nhg
```
