### PR TITLE
cob_supported_robots: 0.6.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -828,6 +828,21 @@ repositories:
       url: https://github.com/ipa320/cob_gazebo_plugins.git
       version: kinetic_dev
     status: developed
+  cob_supported_robots:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_supported_robots.git
+      version: indigo_release_candidate
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_supported_robots-release.git
+      version: 0.6.7-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_supported_robots.git
+      version: indigo_dev
+    status: developed
   collada_urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_supported_robots` to `0.6.7-0`:

- upstream repository: https://github.com/ipa320/cob_supported_robots.git
- release repository: https://github.com/ipa320/cob_supported_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cob_supported_robots

```
* Merge pull request #5 <https://github.com/ipa320/cob_supported_robots/issues/5> from ipa-nhg/cob4-8
  setup cob4-8
* setup cob4-8
* Merge pull request #4 <https://github.com/ipa320/cob_supported_robots/issues/4> from ipa-nhg/cob4-9
  Setup cob4-9
* Setup cob4-9
* Merge pull request #3 <https://github.com/ipa320/cob_supported_robots/issues/3> from ipa-nhg/cob4-paul-stuttgart
  Remove cob4-10 config
* remove cob4-10 config
* Merge pull request #2 <https://github.com/ipa320/cob_supported_robots/issues/2> from ipa-fxm/multi_distro_travis
  Multi distro travis
* fix allow_failures
* document distro support in README
* update .rosinstall files
* setup travis matrix for multiple distros
* Update README.md
* Merge pull request #1 <https://github.com/ipa320/cob_supported_robots/issues/1> from ipa-fxm/indigo_dev
  moved cob_supported_robots to separate repo
* remove cob4-1
* update robotlist
* added cob_supported_robots package
* Initial commit
* Contributors: Felix Messmer, Florian Weisshardt, Mathias Lüdtke, Nadia Hammoudeh García, ipa-cob4-8, ipa-fxm, ipa-nhg
```
