### PR TITLE
cob_gazebo_plugins: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1776,7 +1776,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_gazebo_plugins-release.git
-      version: 0.6.4-0
+      version: 0.6.6-0
     source:
       type: git
       url: https://github.com/ipa320/cob_gazebo_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_gazebo_plugins` to `0.6.6-0`:

- upstream repository: https://github.com/ipa320/cob_gazebo_plugins.git
- release repository: https://github.com/ipa320/cob_gazebo_plugins-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.6.4-0`

## cob_gazebo_plugins

```
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_gazebo_ros_control

```
* add state_valid behavior
* add estop behavior
* manually fix changelog
* Contributors: ipa-fxm
```
