### PR TITLE
cob_gazebo_plugins: 0.7.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -810,6 +810,24 @@ repositories:
       url: https://github.com/ipa320/cob_extern.git
       version: indigo_dev
     status: developed
+  cob_gazebo_plugins:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_gazebo_plugins.git
+      version: kinetic_release_candidate
+    release:
+      packages:
+      - cob_gazebo_plugins
+      - cob_gazebo_ros_control
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_gazebo_plugins-release.git
+      version: 0.7.1-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_gazebo_plugins.git
+      version: kinetic_dev
+    status: developed
   collada_urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_gazebo_plugins` to `0.7.1-0`:

- upstream repository: https://github.com/ipa320/cob_gazebo_plugins.git
- release repository: https://github.com/ipa320/cob_gazebo_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cob_gazebo_plugins

- No changes

## cob_gazebo_ros_control

```
* fix dependencies
* Contributors: Richard Bormann
```
