### PR TITLE
rosjava_core: 0.3.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6702,7 +6702,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_core-release.git
-      version: 0.3.4-1
+      version: 0.3.5-0
     source:
       type: git
       url: https://github.com/rosjava/rosjava_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_core` to `0.3.5-0`:

- upstream repository: https://github.com/rosjava/rosjava_core
- release repository: https://github.com/rosjava-release/rosjava_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.3.4-1`

## rosjava_core

```
* Fix remapping member variable not set if argument is not null
* Adding the capability to remove a messageListener from a subscriber.
* Avoid flooding log with error messages on NTP sync failure
* Fix to avoid logging the same error multiple times for NtpTimeProvider.
* Fix: avoid exceptions on node shutdown
* Fix to avoid spurious exceptions on node shutdown if there's an active topic.
* Contributors: Juan Ignacio Ubeira, Julian Cerruti, Perrine Aguiar
```
