### PR TITLE
cob_calibration_data: 0.6.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -786,6 +786,21 @@ repositories:
       url: https://github.com/ros/cmake_modules.git
       version: 0.4-devel
     status: maintained
+  cob_calibration_data:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_calibration_data.git
+      version: indigo_release_candidate
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_calibration_data-release.git
+      version: 0.6.7-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_calibration_data.git
+      version: indigo_dev
+    status: developed
   cob_extern:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_calibration_data` to `0.6.7-0`:

- upstream repository: https://github.com/ipa320/cob_calibration_data.git
- release repository: https://github.com/ipa320/cob_calibration_data-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cob_calibration_data

```
* Merge pull request #132 <https://github.com/ipa320/cob_calibration_data/issues/132> from ipa-cob4-8/cob4-8
  [Cob4-8] Recalibrate head camera
* minor beautifying whitespace
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_calibration_data into cob4-8
* Recalibrate the head camera
* Merge pull request #131 <https://github.com/ipa320/cob_calibration_data/issues/131> from ipa-nhg/cob4-8
  setup cob4-8
* renamed sensorring camera
* setup cob4-8
* Merge pull request #130 <https://github.com/ipa320/cob_calibration_data/issues/130> from ipa-nhg/cob4-9
  Setup cob4-9
* Merge pull request #129 <https://github.com/ipa320/cob_calibration_data/issues/129> from ipa-bnm/head_cam_calibration
  recalibrated cob4-7 head cam
* Setup cob4-9
* new calibration for lower resolution
* recalibrated cob4-7 head cam
* Merge pull request #122 <https://github.com/ipa320/cob_calibration_data/issues/122> from ipa-fxm/multi_distro_travis
  Multi distro travis
* add xacro-test as AFTER_SCRIPT
* fix allow_failures
* document distro support in README
* setup travis matrix for multiple distros
* Merge pull request #128 <https://github.com/ipa320/cob_calibration_data/issues/128> from ipa-nhg/cob4-paul-stuttgart
  Setup cob4 paul stuttgart
* Merge pull request #127 <https://github.com/ipa320/cob_calibration_data/issues/127> from ipa-nhg/HeadCamCalib
  cob4-7 - calibrated head cam
* remove cob4-10 config
* update cob4-7 setup , cob4-paul-stuttgart
* clean spaces
* cob4-7 - calibrated head cam
* Merge pull request #126 <https://github.com/ipa320/cob_calibration_data/issues/126> from ipa-cob4-5/indigo_dev
  Re-calibrate cob4-5 head camera
* Merge branch 'indigo_dev' of github.com:ipa-cob4-5/cob_calibration_data into indigo_dev
* cob4-5 recalibrate head camera
* Merge pull request #123 <https://github.com/ipa320/cob_calibration_data/issues/123> from ipa-cob4-5/indigo_dev
  calibrate head camera
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_calibration_data into indigo_dev
* Merge github.com:ipa320/cob_calibration_data into indigo_dev
* Merge pull request #124 <https://github.com/ipa320/cob_calibration_data/issues/124> from ipa-fxm/fix_travis
  Fix travis
* add cob_supported_robots to rosinstall
* Revert "use cob_supported_robots in travis underlay"
  This reverts commit b99fdc64d2289f7d8397f446b826fcb7995fd5b2.
* calibrate head camera
* use default ipa320 .gitignore
* Merge pull request #120 <https://github.com/ipa320/cob_calibration_data/issues/120> from ipa-fmw/indigo_dev
  update calibratin for new cob4-2 head cam
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_calibration_data into indigo_dev
* update calibratin for new cob4-2 head cam
* Merge pull request #119 <https://github.com/ipa320/cob_calibration_data/issues/119> from ipa-fxm/remove_cob4-1
  Remove cob4 1
* remove cob4-1
* remove cob4-2 leftover
* Merge pull request #117 <https://github.com/ipa320/cob_calibration_data/issues/117> from ipa-fxm/remove_unupported_robots
  remove unsupported robots
* remove unsupported robots
* Merge pull request #116 <https://github.com/ipa320/cob_calibration_data/issues/116> from ipa-mdl/patch-1
  use cob_supported_robots in travis underlay
* print file names that get tested
* fixed path to env.sh
* simple xacro test (#114 <https://github.com/ipa320/cob_calibration_data/issues/114>)
* use cob_supported_robots in travis underlay
* Merge pull request #115 <https://github.com/ipa320/cob_calibration_data/issues/115> from ipa-fxm/export-robotlist
  use exported robotlist
* use exported robotlist
* Merge pull request #113 <https://github.com/ipa320/cob_calibration_data/issues/113> from ipa-mdl/fix-xacro
  [hotfix] added missing xmlns
* added missing xmlns
* Merge pull request #112 <https://github.com/ipa320/cob_calibration_data/issues/112> from ipa-fxm/use_latest_xacro_syntax
  use latest xacro syntax
* Merge pull request #111 <https://github.com/ipa320/cob_calibration_data/issues/111> from ipa-fxm/harmonize_calibration_structure
  move camera calibration files into sub-folders
* Merge pull request #110 <https://github.com/ipa320/cob_calibration_data/issues/110> from ipa320/indigo_release_candidate
  Indigo release candidate
* use latest xacro syntax
* move camera calibration files into sub-folders
* Merge pull request #108 <https://github.com/ipa320/cob_calibration_data/issues/108> from ipa-cob4-7/cob4-10
  usb camera calibration
* camera calibration
* Merge pull request #107 <https://github.com/ipa320/cob_calibration_data/issues/107> from ipa-cob4-7/cob4-10
  Setup cob4-10
* setup cob4-10
* Merge pull request #106 <https://github.com/ipa320/cob_calibration_data/issues/106> from ipa-cob4-7/indigo_dev
  [cob4-7] added head usb camera
* add arms
* added head usb camera
* Contributors: Benjamin Maidel, Felix Messmer, Florian Weisshardt, Mathias Lüdtke, Matthias Gruhler, Nadia Hammoudeh García, ipa-cob4-5, ipa-cob4-8, ipa-fxm, ipa-nhg, robot
```
