### PR TITLE
cob_environments: 0.6.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -858,6 +858,24 @@ repositories:
       url: https://github.com/ipa320/cob_control.git
       version: kinetic_dev
     status: developed
+  cob_environments:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_environments.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_default_env_config
+      - cob_environments
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_environments-release.git
+      version: 0.6.5-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_environments.git
+      version: indigo_dev
+    status: developed
   cob_extern:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_environments` to `0.6.5-0`:

- upstream repository: https://github.com/ipa320/cob_environments.git
- release repository: https://github.com/ipa320/cob_environments-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cob_default_env_config

```
* refactor config structure
* update apartment map
* export envlist
* manually fix changelog
* Contributors: ipa-fmw, ipa-fxm
```

## cob_environments

```
* manually fix changelog
* Contributors: ipa-fxm
```
