### PR TITLE
cob_android: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1592,7 +1592,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_android-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/ipa320/cob_android.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_android` to `0.1.3-0`:

- upstream repository: https://github.com/ipa320/cob_android.git
- release repository: https://github.com/ipa320/cob_android-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.2-0`

## cob_android

- No changes

## cob_android_msgs

- No changes

## cob_android_resource_server

- No changes

## cob_android_script_server

```
* removed scripts and requires tag from setup.py
* do not use sub folder for installed scripts
* Create CMakeLists.txt
* remove duplicate install_tag
* refactor config structure
* removed planning parameter for trigger service
* Contributors: Benjamin Maidel, Florian Weisshardt, ipa-cob4-2, ipa-fxm
```

## cob_android_settings

```
* refactor config structure
* Contributors: ipa-fxm
```
