### PR TITLE
cob_hand: 0.6.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -843,6 +843,24 @@ repositories:
       url: https://github.com/ipa320/cob_gazebo_plugins.git
       version: kinetic_dev
     status: developed
+  cob_hand:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_hand.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_hand
+      - cob_hand_bridge
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_hand-release.git
+      version: 0.6.2-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_hand.git
+      version: indigo_dev
+    status: developed
   cob_supported_robots:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_hand` to `0.6.2-0`:

- upstream repository: https://github.com/ipa320/cob_hand.git
- release repository: https://github.com/ipa320/cob_hand-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cob_hand

- No changes

## cob_hand_bridge

```
* properly handle re-init after restart
  tested on cob4-5
* Contributors: Mathias Lüdtke
```
