### PR TITLE
cob_perception_common: 0.6.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -882,6 +882,30 @@ repositories:
       url: https://github.com/ipa320/cob_hand.git
       version: indigo_dev
     status: developed
+  cob_perception_common:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_perception_common.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_3d_mapping_msgs
+      - cob_cam3d_throttle
+      - cob_image_flip
+      - cob_object_detection_msgs
+      - cob_object_detection_visualizer
+      - cob_perception_common
+      - cob_perception_msgs
+      - cob_vision_utils
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_perception_common-release.git
+      version: 0.6.9-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_perception_common.git
+      version: indigo_dev
+    status: developed
   cob_supported_robots:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_perception_common` to `0.6.9-0`:

- upstream repository: https://github.com/ipa320/cob_perception_common.git
- release repository: https://github.com/ipa320/cob_perception_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cob_3d_mapping_msgs

```
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_cam3d_throttle

```
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_image_flip

```
* remove obsolete dependencies to cmake_modules
* manually fix changelog
* reduce console logs
* comment std out
* fixed a direction sign bug with sin() in gravity mode
* fixed upside down rotation bug in gravity mode
* 180deg flip for gravity mode
* fixed image flip rotation against gravity
* Contributors: Richard Bormann, ipa-cob4-1, ipa-fxm, msh
```

## cob_object_detection_msgs

```
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_object_detection_visualizer

```
* remove obsolete dependencies to cmake_modules
* opencv3 compatibility
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_perception_common

```
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_perception_msgs

```
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_vision_utils

```
* Softkinetic DS 325 integration (#77 <https://github.com/ipa320/cob_perception_common/issues/77>)
* Update CMakeLists.txt
* manually fix changelog
* Contributors: Felix Messmer, Richard Bormann, ipa-fxm
```
