### PR TITLE
cob_substitute: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1940,17 +1940,13 @@ repositories:
     release:
       packages:
       - cob_docker_control
-      - cob_lbr
       - cob_reflector_referencing
       - cob_safety_controller
       - cob_substitute
-      - frida_driver
-      - prace_common
-      - prace_gripper_driver
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_substitute-release.git
-      version: 0.6.5-0
+      version: 0.6.6-0
     source:
       type: git
       url: https://github.com/ipa320/cob_substitute.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_substitute` to `0.6.6-0`:

- upstream repository: https://github.com/ipa320/cob_substitute.git
- release repository: https://github.com/ipa320/cob_substitute-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.6.5-0`

## cob_docker_control

```
* added fake_docking executable
  removed unused docker_control
* manually fix changelog
* Contributors: fmw-ss, ipa-fxm
```

## cob_reflector_referencing

```
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_safety_controller

```
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_substitute

```
* remove obsolete packages due to unsupported robots
* manually fix changelog
* Contributors: ipa-fxm
```
