### PR TITLE
cob_substitute: 0.6.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -906,6 +906,26 @@ repositories:
       url: https://github.com/ipa320/cob_perception_common.git
       version: indigo_dev
     status: developed
+  cob_substitute:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_substitute.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_docker_control
+      - cob_reflector_referencing
+      - cob_safety_controller
+      - cob_substitute
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_substitute-release.git
+      version: 0.6.6-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_substitute.git
+      version: indigo_dev
+    status: developed
   cob_supported_robots:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_substitute` to `0.6.6-0`:

- upstream repository: https://github.com/ipa320/cob_substitute.git
- release repository: https://github.com/ipa320/cob_substitute-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cob_docker_control

```
* added fake_docking executable
  removed unused docker_control
* manually fix changelog
* Contributors: fmw-ss, ipa-fxm
```

## cob_reflector_referencing

```
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_safety_controller

```
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_substitute

```
* remove obsolete packages due to unsupported robots
* manually fix changelog
* Contributors: ipa-fxm
```
