### PR TITLE
ntpd_driver: 1.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1512,6 +1512,21 @@ repositories:
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel
     status: maintained
+  ntpd_driver:
+    doc:
+      type: git
+      url: https://github.com/vooon/ntpd_driver.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/vooon/ntpd_driver-release.git
+      version: 1.2.0-0
+    source:
+      type: git
+      url: https://github.com/vooon/ntpd_driver.git
+      version: master
+    status: maintained
   object_recognition_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ntpd_driver` to `1.2.0-0`:

- upstream repository: https://github.com/vooon/ntpd_driver.git
- release repository: https://github.com/vooon/ntpd_driver-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## ntpd_driver

```
* #2 <https://github.com/vooon/ntpd_driver/issues/2>: allow both UDPROS and TCPROS
* Contributors: Vladimir Ermakov
```
