### PR TITLE
cob_control: 0.7.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -822,6 +822,36 @@ repositories:
       url: https://github.com/ipa320/cob_common.git
       version: indigo_dev
     status: developed
+  cob_control:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_control.git
+      version: kinetic_release_candidate
+    release:
+      packages:
+      - cob_base_velocity_smoother
+      - cob_cartesian_controller
+      - cob_collision_velocity_filter
+      - cob_control
+      - cob_control_mode_adapter
+      - cob_control_msgs
+      - cob_footprint_observer
+      - cob_frame_tracker
+      - cob_model_identifier
+      - cob_obstacle_distance
+      - cob_omni_drive_controller
+      - cob_trajectory_controller
+      - cob_twist_controller
+      - cob_undercarriage_ctrl_node
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_control-release.git
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_control.git
+      version: kinetic_dev
+    status: developed
   cob_extern:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.7.0-0`:

- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cob_base_velocity_smoother

- No changes

## cob_cartesian_controller

- No changes

## cob_collision_velocity_filter

- No changes

## cob_control

- No changes

## cob_control_mode_adapter

- No changes

## cob_control_msgs

- No changes

## cob_footprint_observer

- No changes

## cob_frame_tracker

- No changes

## cob_model_identifier

```
* Merge branch 'indigo_dev' of github.com:ipa320/cob_control into multi_distro_travis_kinetic
  Conflicts:
  .travis.yml
  README.md
* Added Eigen3 Indigo/Kinetic compatibility
* Contributors: Denis Štogl, ipa-fxm
```

## cob_obstacle_distance

```
* Merge branch 'indigo_release_candidate' into kinetic_release_candidate
* Merge branch 'indigo_dev' of github.com:ipa320/cob_control into multi_distro_travis_kinetic
  Conflicts:
  .travis.yml
  README.md
* [kinetic] migration (#115 <https://github.com/ipa320/cob_control/issues/115>)
  * [kinetic] find package Eigen3 instead of Eigen
  * [kinetic] switched from fcl to libfcl-dev dependency
  * ignore cob_obstacle_distance for now
  * [kinetic] use industrial_ci for travis
  * [kinetic] use industrial_cis ipa320 fork & notify on_success only on change
  * fixed fcl dependency
  * new fcl version switched from boost::shared to std::shared
  * whitelist package
  * use ros-industrials fork
  * cleaned up travis.yml
* Added Eigen3 Indigo/Kinetic compatibility
* Contributors: Benjamin Maidel, Denis Štogl, Richard Bormann, ipa-fxm
```

## cob_omni_drive_controller

- No changes

## cob_trajectory_controller

- No changes

## cob_twist_controller

```
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_control into kinetic_dev
* [kinetic] migration (#115 <https://github.com/ipa320/cob_control/issues/115>)
  * [kinetic] find package Eigen3 instead of Eigen
  * [kinetic] switched from fcl to libfcl-dev dependency
  * ignore cob_obstacle_distance for now
  * [kinetic] use industrial_ci for travis
  * [kinetic] use industrial_cis ipa320 fork & notify on_success only on change
  * fixed fcl dependency
  * new fcl version switched from boost::shared to std::shared
  * whitelist package
  * use ros-industrials fork
  * cleaned up travis.yml
* Contributors: Benjamin Maidel, ipa-fxm
```

## cob_undercarriage_ctrl_node

- No changes
