### PR TITLE
Add dependency for python-qt5-bindings-webkit (#15117)

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -604,6 +604,10 @@ python-qt5-bindings-gl:
   osx:
     homebrew:
       packages: [pyqt5, sip]
+python-qt5-bindings-webkit:
+  osx:
+    homebrew:
+      packages: [pyqt5, sip]
 python-rospkg:
   osx:
     pip:


### PR DESCRIPTION
Without this the webkit dependency will always fail to resolve.

fixes #15117 