### PR TITLE
Add brunel_hand_ros to documentation index for distro kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -598,6 +598,12 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: master
     status: maintained
+  brunel_hand_ros:
+    doc:
+      type: git
+      url: https://github.com/rerobots/brunel_hand_ros.git
+      version: kinetic-devel
+    status: maintained
   bta_tof_driver:
     doc:
       type: git


### PR DESCRIPTION
The package provides a ROS wrapper around a serial interface to the [Brunel Hand](https://www.openbionics.com/shop/brunel-hand) by [Open Bionics](https://www.openbionics.com).