### PR TITLE
image_overlay_scale_and_compass: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2531,6 +2531,21 @@ repositories:
       url: https://github.com/ros-perception/image_common.git
       version: hydro-devel
     status: maintained
+  image_overlay_scale_and_compass:
+    doc:
+      type: git
+      url: https://github.com/danielsnider/image_overlay_scale_and_compass.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/danielsnider/image_overlay_scale_and_compass-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/danielsnider/image_overlay_scale_and_compass.git
+      version: master
+    status: maintained
   image_pipeline:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_overlay_scale_and_compass` to `0.2.1-0`:

- upstream repository: https://github.com/danielsnider/image_overlay_scale_and_compass.git
- release repository: https://github.com/danielsnider/image_overlay_scale_and_compass-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## image_overlay_scale_and_compass

```
* Dependency name fix for click
```
