### PR TITLE
jsk_recognition: 1.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5394,7 +5394,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.2.1-0
+      version: 1.2.2-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `1.2.2-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.2.1-0`

## checkerboard_detector

- No changes

## imagesift

- No changes

## jsk_pcl_ros

- No changes

## jsk_pcl_ros_utils

- No changes

## jsk_perception

```
* add bg_label in apply_context_to_label_probability (#2175 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2175>)
  * Remove no need ~use_topic flag
  * Refactor to handle fixed candidates in ApplyContextToLabelProbability
  * add bg_label in apply_context_to_label_probability
* fix bug in label_image_classifier (#2174 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2174>)
  * Update label_image_classifier.py
  * fix bug in label_image_classifier
* Contributors: Kentaro Wada, Shingo Kitagawa
```

## jsk_recognition

- No changes

## jsk_recognition_msgs

- No changes

## jsk_recognition_utils

- No changes

## resized_image_transport

```
* current source code needs jsk_topic_tools >= 2.2.4 (#2173 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2173>)
* Contributors: Kei Okada
```
