### PR TITLE
add python-pathtools, python-watchdog on xenial

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1869,8 +1869,12 @@ python-path.py:
     pip:
       packages: [path.py]
 python-pathtools:
+  debian: [python-pathtools]
   ubuntu:
     xenial: [python-pathtools]
+    yakkety: [python-pathtools]
+    zesty: [python-pathtools]
+    artful: [python-pathtools]
 python-pcapy:
   arch: [python2-pcapy]
   debian: [python-pcapy]
@@ -3555,8 +3559,12 @@ python-walrus-pip:
     pip:
       packages: [walrus]
 python-watchdog:
+  debian: [python-watchdog]
   ubuntu:
     xenial: [python-watchdog]
+    yakkety: [python-watchdog]
+    zesty: [python-watchdog]
+    artful: [python-watchdog]
 python-webob:
   debian: [python-webob]
   fedora: [python-webob]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1868,6 +1868,9 @@ python-path.py:
   ubuntu:
     pip:
       packages: [path.py]
+python-pathtools:
+  ubuntu:
+    xenial: [python-pathtools]
 python-pcapy:
   arch: [python2-pcapy]
   debian: [python-pcapy]
@@ -3551,6 +3554,9 @@ python-walrus-pip:
   ubuntu:
     pip:
       packages: [walrus]
+python-watchdog:
+  ubuntu:
+    xenial: [python-watchdog]
 python-webob:
   debian: [python-webob]
   fedora: [python-webob]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1871,10 +1871,10 @@ python-path.py:
 python-pathtools:
   debian: [python-pathtools]
   ubuntu:
+    artful: [python-pathtools]
     xenial: [python-pathtools]
     yakkety: [python-pathtools]
     zesty: [python-pathtools]
-    artful: [python-pathtools]
 python-pcapy:
   arch: [python2-pcapy]
   debian: [python-pcapy]
@@ -3561,10 +3561,10 @@ python-walrus-pip:
 python-watchdog:
   debian: [python-watchdog]
   ubuntu:
+    artful: [python-watchdog]
     xenial: [python-watchdog]
     yakkety: [python-watchdog]
     zesty: [python-watchdog]
-    artful: [python-watchdog]
 python-webob:
   debian: [python-webob]
   fedora: [python-webob]


### PR DESCRIPTION
Only adding ubuntu for now to validate switching from trusty ros-package to kinetic xenial packages.