### PR TITLE
cob_driver: 0.6.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -858,6 +858,43 @@ repositories:
       url: https://github.com/ipa320/cob_control.git
       version: kinetic_dev
     status: developed
+  cob_driver:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_driver.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_base_drive_chain
+      - cob_bms_driver
+      - cob_camera_sensors
+      - cob_canopen_motor
+      - cob_driver
+      - cob_elmo_homing
+      - cob_generic_can
+      - cob_head_axis
+      - cob_light
+      - cob_mimic
+      - cob_phidget_em_state
+      - cob_phidget_power_state
+      - cob_phidgets
+      - cob_relayboard
+      - cob_scan_unifier
+      - cob_sick_lms1xx
+      - cob_sick_s300
+      - cob_sound
+      - cob_undercarriage_ctrl
+      - cob_utilities
+      - cob_voltage_control
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_driver-release.git
+      version: 0.6.10-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_driver.git
+      version: indigo_dev
+    status: developed
   cob_environments:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.6.10-0`:

- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cob_base_drive_chain

- No changes

## cob_bms_driver

- No changes

## cob_camera_sensors

- No changes

## cob_canopen_motor

- No changes

## cob_driver

- No changes

## cob_elmo_homing

- No changes

## cob_generic_can

- No changes

## cob_head_axis

- No changes

## cob_light

```
* fixed function return value
* Contributors: Benjamin Maidel
```

## cob_mimic

```
* Merge branch 'indigo_dev' into indigo_release_candidate
* added apache header
* ported mimic from python to c++
* Contributors: Benjamin Maidel, flg-pb
```

## cob_phidget_em_state

- No changes

## cob_phidget_power_state

- No changes

## cob_phidgets

- No changes

## cob_relayboard

- No changes

## cob_scan_unifier

- No changes

## cob_sick_lms1xx

- No changes

## cob_sick_s300

- No changes

## cob_sound

- No changes

## cob_undercarriage_ctrl

- No changes

## cob_utilities

- No changes

## cob_voltage_control

- No changes
