### PR TITLE
Corrects ubuntu name of portaudio19-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3665,7 +3665,7 @@ portaudio19-dev:
   debian: [libportaudio19-dev]
   fedora: [libportaudio-devel]
   gentoo: ['=media-libs/portaudio-19*']
-  ubuntu: [libportaudio19-dev]
+  ubuntu: [portaudio19-dev]
 postgresql:
   debian: [postgresql, postgresql-contrib]
   fedora: [postgresql-server, postgresql-contrib]


### PR DESCRIPTION
Did searches from Precise onwards and looks like it should just be portaudio19-dev