### PR TITLE
Changed link for ublox distros to maintained & runnable repo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15037,8 +15037,9 @@ repositories:
   ublox:
     doc:
       type: git
-      url: https://github.com/tu-darmstadt-ros-pkg/ublox.git
-      version: catkin
+      url: https://github.com/KumarRobotics/ublox.git
+      version: master
+    status: maintained
   ucl_drone:
     doc:
       type: git

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -7460,8 +7460,8 @@ repositories:
   ublox:
     doc:
       type: git
-      url: https://github.com/tu-darmstadt-ros-pkg/ublox.git
-      version: catkin
+      url: https://github.com/KumarRobotics/ublox.git
+      version: master
   ueye:
     doc:
       type: hg

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8819,8 +8819,9 @@ repositories:
   ublox:
     doc:
       type: git
-      url: https://github.com/tu-darmstadt-ros-pkg/ublox.git
-      version: catkin
+      url: https://github.com/KumarRobotics/ublox.git
+      version: master
+    status: maintained
   ueye:
     doc:
       type: hg

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -604,6 +604,10 @@ python-qt5-bindings-gl:
   osx:
     homebrew:
       packages: [pyqt5, sip]
+python-qt5-bindings-webkit:
+  osx:
+    homebrew:
+      packages: [pyqt5, sip]
 python-rospkg:
   osx:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3741,3 +3741,31 @@ wxpython:
     xenial: [python-wxgtk3.0]
     yakkety: [python-wxgtk3.0]
     zesty: [python-wxgtk3.0]
+yapf:
+  debian:
+    buster: [yapf]
+    stretch: [yapf]
+  ubuntu:
+    artful: [yapf]
+    saucy:
+      pip:
+        packages: [yapf]
+    trusty:
+      pip:
+        packages: [yapf]
+    utopic:
+      pip:
+        packages: [yapf]
+    vivid:
+      pip:
+        packages: [yapf]
+    wily:
+      pip:
+        packages: [yapf]
+    xenial:
+      pip:
+        packages: [yapf]
+    yakkety:
+      pip:
+        packages: [yapf]
+    zesty: [yapf]


### PR DESCRIPTION
The new ublox link is to a maintained repo which also runs properly.  The original linked repo does not run due to build file issues and is no longer maintained.