### PR TITLE
rail_manipulation_msgs: 0.0.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9930,7 +9930,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/rail_manipulation_msgs-release.git
-      version: 0.0.9-0
+      version: 0.0.10-0
     source:
       type: git
       url: https://github.com/GT-RAIL/rail_manipulation_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_manipulation_msgs` to `0.0.10-0`:

- upstream repository: https://github.com/GT-RAIL/rail_manipulation_msgs.git
- release repository: https://github.com/gt-rail-release/rail_manipulation_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.0.9-0`

## rail_manipulation_msgs

```
* Merge pull request #2 <https://github.com/GT-RAIL/rail_manipulation_msgs/issues/2> from velveteenrobot/develop
  Added new msg and srv to facilitate grasp suggestion
* Added new msg and srv to facilitate grasp suggestion
* Contributors: David Kent, Sarah Elliott
```
