### PR TITLE
rqt_tf_tree: 0.5.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7639,7 +7639,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_tf_tree-release.git
-      version: 0.5.7-0
+      version: 0.5.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_tf_tree` to `0.5.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_tf_tree.git
- release repository: https://github.com/ros-gbp/rqt_tf_tree-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.5.7-0`

## rqt_tf_tree

```
* [fix] child_frame_id format #6 <https://github.com/ros-visualization/rqt_tf_tree/issues/6>
* Update maintainer
* Contributors: Dirk Thomas, Isaac I.Y. Saito, Peter Han
```
