### PR TITLE
remove never building Jade repos from release

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -194,24 +194,6 @@ repositories:
       type: git
       url: https://github.com/auboliuxin/aubo_robot.git
       version: jade-devel
-    release:
-      packages:
-      - aubo_control
-      - aubo_description
-      - aubo_driver
-      - aubo_gazebo
-      - aubo_i5_moveit_config
-      - aubo_kinematics
-      - aubo_msgs
-      - aubo_new_driver
-      - aubo_panel
-      - aubo_robot
-      - aubo_trajectory
-      - aubo_trajectory_filters
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/auboliuxin/aubo_robot-release.git
-      version: 0.3.16-0
     source:
       type: git
       url: https://github.com/auboliuxin/aubo_robot.git
@@ -7370,11 +7352,6 @@ repositories:
       type: git
       url: https://github.com/OSLL/tiny-slam-ros-cpp.git
       version: master
-    release:
-      tags:
-        release: release/jade/{package}/{version}
-      url: https://github.com/OSLL/tiny-slam-ros-release.git
-      version: 0.1.2-3
     source:
       type: git
       url: https://github.com/OSLL/tiny-slam-ros-cpp.git


### PR DESCRIPTION
I'm removing the release section of two repos because some or all of their packages never built for Jade:

- `aubo_robot` via https://github.com/ros/rosdistro/pull/13293
  - @auboliuxin FYI
  - example job: http://build.ros.org/job/Jbin_arm_uThf__aubo_control__ubuntu_trusty_armhf__binary/116/
- `tiny_slam` via https://github.com/ros/rosdistro/pull/12170
  - @krinkin FYI
  - example job: http://build.ros.org/job/Jbin_arm_uThf__tiny_slam__ubuntu_trusty_armhf__binary/386/