### PR TITLE
Revert "grid_map: 1.5.0-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2279,13 +2279,11 @@ repositories:
       packages:
       - grid_map
       - grid_map_core
-      - grid_map_costmap_2d
       - grid_map_cv
       - grid_map_demos
       - grid_map_filters
       - grid_map_loader
       - grid_map_msgs
-      - grid_map_octomap
       - grid_map_pcl
       - grid_map_ros
       - grid_map_rviz_plugin
@@ -2293,7 +2291,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ethz-asl/grid_map-release.git
-      version: 1.5.0-0
+      version: 1.4.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#15553

@pfankhauser FYI 

Re: 
- https://github.com/ethz-asl/grid_map/issues/111
- https://github.com/stonier/cost_map/issues/44
- https://discourse.ros.org/t/preparing-for-kinetic-sync-2017-07-24/2287