### PR TITLE
moveit_goal_builder: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6919,6 +6919,21 @@ repositories:
       url: https://github.com/ros-planning/moveit.git
       version: indigo-devel
     status: developed
+  moveit_goal_builder:
+    doc:
+      type: git
+      url: https://github.com/jstnhuang/moveit_goal_builder.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/jstnhuang-release/moveit_goal_builder-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/jstnhuang/moveit_goal_builder.git
+      version: indigo-devel
+    status: developed
   moveit_helpers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_goal_builder` to `0.1.0-0`:

- upstream repository: https://github.com/jstnhuang/moveit_goal_builder.git
- release repository: https://github.com/jstnhuang-release/moveit_goal_builder-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## moveit_goal_builder

```
* Initial package release.
* Contributors: Justin Huang
```
