### PR TITLE
cob_navigation: 0.6.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -973,6 +973,30 @@ repositories:
       url: https://github.com/ipa320/cob_hand.git
       version: indigo_dev
     status: developed
+  cob_navigation:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_navigation.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_linear_nav
+      - cob_map_accessibility_analysis
+      - cob_mapping_slam
+      - cob_navigation
+      - cob_navigation_config
+      - cob_navigation_global
+      - cob_navigation_local
+      - cob_navigation_slam
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_navigation-release.git
+      version: 0.6.5-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_navigation.git
+      version: indigo_dev
+    status: developed
   cob_perception_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_navigation` to `0.6.5-0`:

- upstream repository: https://github.com/ipa320/cob_navigation.git
- release repository: https://github.com/ipa320/cob_navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cob_linear_nav

```
* add c++11 definitions
* adjusted look up time stamps and durations of wait for transform
* added server to set base_frame, included some wait for transfrom and error handling
* Contributors: ipa-fxm, ipa-srd
```

## cob_map_accessibility_analysis

```
* remove obsolete dependencies to cmake_modules
* added comment
* disabled the output
* bugfix
* moved two functions to the public section in class
* added missing dependency
* code review
* restructuring map_accessibility_analysis so that it can be used as lib and as ROS service
* Fixed headers and output
* Fix compile warning
* Reformatted source files with ipa_code_refactoring
* Fixed headers and replaced std::cout with ROS logging services
* Moved files into folder
* Contributors: Benjamin Maidel, Elias Marks, Richard Bormann, ipa-fxm
```

## cob_mapping_slam

- No changes

## cob_navigation

```
* added cob_map_accessibility_analysis to metapackage
* Contributors: Benjamin Maidel
```

## cob_navigation_config

```
* remove nav config for unsupported bases
* refactoring env config
* restructure nav config
* remove cob4-10
* add configs for missing supported robots
* remove cob4-1
* remove obsolete configs due to unsupported robots
* nav config for raw3-6
* use new costmap param layout
* cob4-5 setup
* Adapted config file for cob3-2
* Adapted config file for cob3-6
* Added map types to changed configs
* Adapted config file for cob4-2
* Adapted config file for cob4-1
* Adapted config file for raw3-6
* Adapted config file for raw3-5
* Adapted config file for raw3-4
* Adapted config file for raw3-1
* Adapted costmap config file for raw3-3
* first adaption of costmap parameters
* Contributors: Benjamin Maidel, Florian Weisshardt, ipa-cob4-5, ipa-fxm, ipa-mig, mig-em, teddy
```

## cob_navigation_global

```
* remove nav config for unsupported bases
* arg pkg_nav_config
* refactoring env config
* restructure nav config
* use exported robotlist and envlist
* remove dependency to eband_local_planner
* remove cob4-1
* remove obsolete configs due to unsupported robots
* remove relays
* cob4-5 setup
* enable roslaunch checks (requires ros_comm #814 <https://github.com/ipa320/cob_navigation/issues/814> to be merged and released)
* add dependency to dwa_local_planner (was not automatically installed using apt-get)
* adapt global rviz config
* put specific launch files in correct namespaces
* first adaption of costmap parameters
* remove eband planner launch and config files
* Contributors: Felix Messmer, Florian Weisshardt, ipa-cob4-5, ipa-fxm, ipa-mig
```

## cob_navigation_local

```
* remove nav config for unsupported bases
* arg pkg_nav_config
* restructure nav config
* use exported robotlist and envlist
* remove cob4-1
* remove obsolete configs due to unsupported robots
* enable roslaunch checks (requires ros_comm #814 <https://github.com/ipa320/cob_navigation/issues/814> to be merged and released)
* add dependency to dwa_local_planner (was not automatically installed using apt-get)
* Added namespace to parameter loading
* Adapted config for cob_navigation_local
* adapt local rviz config
* Contributors: Florian Weisshardt, ipa-fxm, teddy
```

## cob_navigation_slam

```
* remove nav config for unsupported bases
* arg pkg_nav_config
* use exported robotlist and envlist
* remove obsolete configs due to unsupported robots
* Contributors: ipa-fxm
```
