### PR TITLE
cob_command_tools: 0.6.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -807,6 +807,32 @@ repositories:
       url: https://github.com/ipa320/cob_calibration_data.git
       version: indigo_dev
     status: developed
+  cob_command_tools:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_command_tools.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_command_gui
+      - cob_command_tools
+      - cob_dashboard
+      - cob_helper_tools
+      - cob_interactive_teleop
+      - cob_monitoring
+      - cob_script_server
+      - cob_teleop
+      - generic_throttle
+      - service_tools
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_command_tools-release.git
+      version: 0.6.6-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_command_tools.git
+      version: indigo_dev
+    status: developed
   cob_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.6-0`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cob_command_gui

```
* 'trigger_action' is blocking
* add buttons for 'trigger_action'
* fix python import
* add proper print_functions import
* some python3 print fixes
* manually fix changelog
* Contributors: ipa-fxm, robot
```

## cob_command_tools

```
* add auto_recover to new cob_helper_tools pkg
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_dashboard

```
* dual distro compatibility for qt
* rospy.sleep exception handling
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_helper_tools

```
* move visualize navigation goals to cob_helper_tools
* retry init on failure
* only store timestamp for last recover on success
* add fake_diagnostics
* add fake_driver
* added license header
* evaluate handle and better output
* add auto_init
* add auto_recover to new cob_helper_tools pkg
* Contributors: Florian Weisshardt, ipa-fxm, robot
```

## cob_interactive_teleop

```
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_monitoring

```
* fix parameter name
* use desired frequency as default windows size for the topic freq monitor
* adjust tolerance, window_size
* allow to monitor multiple topics
* adjust to hz_monitor yaml layout
* generic topic status monitor based on diagnostic updater
* [hotfix] python syntax
* remove useless code (#173 <https://github.com/ipa320/cob_command_tools/issues/173>)
* update psutil api
* add fake_diagnostics
* get num_cores from psutils
* add proper print_functions import
* some python3 print fixes
* rospy.sleep exception handling
* manually fix changelog
* make smapling rate configurable and add warning
* Contributors: Benjamin Maidel, Felix Messmer, Sourav Senapati, ipa-fxm, msh
```

## cob_script_server

```
* move visualize navigation goals to cob_helper_tools
* add node for visualization of script server navigation goals
* handle uninitielized action clients
* add trigger_action function to sss
* fix Trigger unittests
* increased min point time
* minimal trajectory point_time
* catch ValueError during point time calculation when using mimic joints
* manually fix changelog
* fixed cob_console script
* Contributors: Benjamin Maidel, Florian Weisshardt, Mathias Lüdtke, ipa-fxm
```

## cob_teleop

```
* manually fix changelog
* Contributors: ipa-fxm
```

## generic_throttle

```
* Change resolution factor to be a multiplicative factor and not a division.
  Handle resize to factor 0 as OpenCV error.
* Change misleading resolution with resolution_factor
* Add rostopic exec_depend
* Remove cv_bridge build dependency
* Update manifest and cmake list
* Update README.md to resolution throttle.
* Implement resolution throttle for sensor_msgs/Image.
* Add @ipa-fmw as maintainer.
* Add install tags for the executable node
* Move throttle_node to script folder. Fix typos in README.
* Update README
* Rewrite lazy and latched behavior implementation
* Adapt to new parameter definition layout. Parameters are now set in the node namespace.
  Throttled topics have "_throttled" appended to original topic name.
* Add ROS node for the throttle separated from the GenericThrottle implementation
* Implement lazy behavior. Lazy and Latched behavior are disabled by default
* Remove delay feature. Add latched behaviour (True/False).
* Remove build dependency on rospy
* Remove CMakeLists.txt not needed depedencies.
* Change package to format "2" and remove not needed dependencies
* Update README
* Moving the python package inside src/generic_throttle. Modifying accordingly CMakeLists.txt and package.xml.
* remove testing files
* introduce directory layer
* Contributors: MattiaRacca
```

## service_tools

```
* implemented service_relay
* Contributors: Mathias Lüdtke
```
