### PR TITLE
grid_map: 1.5.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2279,11 +2279,13 @@ repositories:
       packages:
       - grid_map
       - grid_map_core
+      - grid_map_costmap_2d
       - grid_map_cv
       - grid_map_demos
       - grid_map_filters
       - grid_map_loader
       - grid_map_msgs
+      - grid_map_octomap
       - grid_map_pcl
       - grid_map_ros
       - grid_map_rviz_plugin
@@ -2291,7 +2293,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ethz-asl/grid_map-release.git
-      version: 1.4.2-0
+      version: 1.5.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `1.5.1-0`:

- upstream repository: https://github.com/ethz-asl/grid_map.git
- release repository: https://github.com/ethz-asl/grid_map-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.4.2-0`

## grid_map

- No changes

## grid_map_core

- No changes

## grid_map_costmap_2d

- No changes

## grid_map_cv

- No changes

## grid_map_demos

- No changes

## grid_map_filters

- No changes

## grid_map_loader

- No changes

## grid_map_msgs

- No changes

## grid_map_octomap

- No changes

## grid_map_pcl

- No changes

## grid_map_ros

```
* Added backwards compatibility for costmap_2d conversion in grid_map_ros (#111 <https://github.com/ethz-asl/grid_map/issues/111>).
* Contributors: Peter Fankhauser
```

## grid_map_rviz_plugin

- No changes

## grid_map_visualization

- No changes
