### PR TITLE
grid_map: 1.5.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3896,7 +3896,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-asl/grid_map-release.git
-      version: 1.5.0-0
+      version: 1.5.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `1.5.1-0`:

- upstream repository: https://github.com/ethz-asl/grid_map.git
- release repository: https://github.com/ethz-asl/grid_map-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.5.0-0`

## grid_map

- No changes

## grid_map_core

- No changes

## grid_map_costmap_2d

- No changes

## grid_map_cv

- No changes

## grid_map_demos

- No changes

## grid_map_filters

- No changes

## grid_map_loader

- No changes

## grid_map_msgs

- No changes

## grid_map_octomap

- No changes

## grid_map_pcl

- No changes

## grid_map_ros

```
* Added backwards compatibility for costmap_2d conversion in grid_map_ros (#111 <https://github.com/ethz-asl/grid_map/issues/111>).
* Contributors: Peter Fankhauser
```

## grid_map_rviz_plugin

- No changes

## grid_map_visualization

- No changes
