### PR TITLE
moveit_pr2: 0.6.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6981,7 +6981,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_pr2-release.git
-      version: 0.6.5-0
+      version: 0.6.6-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_pr2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_pr2` to `0.6.6-0`:

- upstream repository: https://github.com/ros-planning/moveit_pr2.git
- release repository: https://github.com/ros-gbp/moveit_pr2-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.6.5-0`

## moveit_pr2

```
* [fix] Remove obsolete dependency on moveit-tutorials #92 <https://github.com/ros-planning/moveit_pr2/issues/92>
* Contributors: Dave Coleman
```

## pr2_moveit_config

- No changes

## pr2_moveit_plugins

- No changes
