### PR TITLE
moveit_goal_builder: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6928,7 +6928,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/jstnhuang-release/moveit_goal_builder-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/jstnhuang/moveit_goal_builder.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_goal_builder` to `0.1.1-0`:

- upstream repository: https://github.com/jstnhuang/moveit_goal_builder.git
- release repository: https://github.com/jstnhuang-release/moveit_goal_builder-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.0-0`

## moveit_goal_builder

```
* Added dependency on TF.
* Updated documentation.
* Contributors: Justin Huang
```
