### PR TITLE
Revert "tele_dir: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14519,7 +14519,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rdelgadov/tele_dir-release.git
-      version: 0.0.4-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/rdelgadov/tele_dir.git


### PR DESCRIPTION
Reverts ros/rosdistro#13517

Ticketed upstream at: https://github.com/rdelgadov/tele_dir/issues/2