### PR TITLE
catkin: 0.7.7-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -230,7 +230,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.6-0
+      version: 0.7.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.7-0`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.7.6-0`

## catkin

```
* fix warning in case devel space is nested in the build space (#880 <https://github.com/ros/catkin/pull/880>)
* remove workaround using -l:<libpath> necessary for older pkg-config versions (#879 <https://github.com/ros/catkin/issues/879>)
* replace exec call with runpy.run_path (#873 <https://github.com/ros/catkin/issues/873>)
* use environment variable to extend environment in plain shell (#862 <https://github.com/ros/catkin/issues/862>)
* prefer reporting problems to bugtracker / website before maintainer (#861 <https://github.com/ros/catkin/issues/861>)
```
