### PR TITLE
genpy: 0.6.6-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -618,7 +618,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.6.5-0
+      version: 0.6.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.6.6-0`:

- upstream repository: git@github.com:ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.6.5-0`

## genpy

```
* add escaping for strings which is valid in YAML (#79 <https://github.com/ros/genpy/issues/79>)
* fix inefficient canon method in rostime (#77 <https://github.com/ros/genpy/issues/77>)
```
