### PR TITLE
ros_comm: 1.13.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2125,7 +2125,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.13.0-0
+      version: 1.13.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.13.1-0`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.13.0-0`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

```
* fix handling connections without indices (#1109 <https://github.com/ros/ros_comm/pull/1109>)
* improve message of check command (#1067 <https://github.com/ros/ros_comm/pull/1067>)
* fix BZip2 inclusion (#1016 <https://github.com/ros/ros_comm/pull/1016>)
* expose rate-control-topic and rate-control-max-delay args to command line tool (#1015 <https://github.com/ros/ros_comm/pull/1015>)
* improve migration rule generation (#1009 <https://github.com/ros/ros_comm/pull/1009>, #1010 <https://github.com/ros/ros_comm/pull/1010>, #1011 <https://github.com/ros/ros_comm/pull/1011>)
```

## rosbag_storage

```
* fix buffer overflow vulnerability (#1092 <https://github.com/ros/ros_comm/issues/1092>)
* fix rosbag::View::iterator copy assignment operator (#1017 <https://github.com/ros/ros_comm/issues/1017>)
* fix open mode on Windows (#1005 <https://github.com/ros/ros_comm/pull/1005>)
* add swap function instead of copy constructor / assignment operator for rosbag::Bag (#1000 <https://github.com/ros/ros_comm/issues/1000>)
```

## rosconsole

```
* remove extra semicolon in definition of macro ROSCONSOLE_PRINTF_ATTRIBUTE(a, b) (#1056 <https://github.com/ros/ros_comm/pull/1056>)
* add ROSCONSOLE_STDOUT_LINE_BUFFERED env var to force flushing stdout in Formatter::print (#1012 <https://github.com/ros/ros_comm/issues/1012>)
```

## roscpp

```
* add SteadyTimer, used in TimerManager (#1014 <https://github.com/ros/ros_comm/issues/1014>)
* include missing header for writev() (#1105 <https://github.com/ros/ros_comm/pull/1105>)
* clean the namespace to get rid of double or trailing forward slashes (#1100 <https://github.com/ros/ros_comm/issues/1100>)
* add missing mutex lock for publisher links (#1090 <https://github.com/ros/ros_comm/pull/1090>)
* fix race condition that lead to miss first message (#1058 <https://github.com/ros/ros_comm/issues/1058>)
* fix bug in transport_tcp on Windows (#1050 <https://github.com/ros/ros_comm/issues/1050>)
* add subscriber to connection log messages (#1023 <https://github.com/ros/ros_comm/issues/1023>)
* avoid deleting XmlRpcClient while being used in another thread (#1013 <https://github.com/ros/ros_comm/issues/1013>)
```

## rosgraph

```
* improve message when roslogging cannot change permissions (#1068 <https://github.com/ros/ros_comm/issues/1068>)
* allow python_logging.yaml for logging configuration (#1061 <https://github.com/ros/ros_comm/issues/1061>)
* write log for class method with class name (#1043 <https://github.com/ros/ros_comm/issues/1043>)
```

## roslaunch

```
* add $(dirname) to get directory of current launch file (#1103 <https://github.com/ros/ros_comm/pull/1103>)
* clean the namespace to get rid of double or trailing forward slashes (#1100 <https://github.com/ros/ros_comm/issues/1100>)
* only launch core nodes if master was launched by roslaunch (#1098 <https://github.com/ros/ros_comm/pull/1098>)
* ensure pid file is removed on exit (#1057 <https://github.com/ros/ros_comm/pull/1057>, #1084 <https://github.com/ros/ros_comm/pull/1084>)
* add yaml type for param tag (#1045 <https://github.com/ros/ros_comm/issues/1045>)
* ensure cwd exists (#1031 <https://github.com/ros/ros_comm/pull/1031>)
* respect if/unless for roslaunch-check (#998 <https://github.com/ros/ros_comm/pull/998>)
```

## roslz4

```
* add XXH_NAMESPACE, for namespace emulation in C (#1065 <https://github.com/ros/ros_comm/pull/1065>)
```

## rosmaster

```
* close CLOSE_WAIT sockets by default (#1104 <https://github.com/ros/ros_comm/issues/1104>)
```

## rosmsg

```
* fix rosmsg show from bag (#1006 <https://github.com/ros/ros_comm/pull/1006>)
```

## rosnode

- No changes

## rosout

```
* move code from init to initializer (#990 <https://github.com/ros/ros_comm/issues/990>)
```

## rosparam

- No changes

## rospy

```
* improve rospy.logXXX_throttle performance (#1091 <https://github.com/ros/ros_comm/pull/1091>)
* add option to reset timer when time moved backwards (#1083 <https://github.com/ros/ros_comm/issues/1083>)
* abort topic lookup on connection refused (#1044 <https://github.com/ros/ros_comm/pull/1044>)
* add rospy.logXXX_once (#1041 <https://github.com/ros/ros_comm/issues/1041>)
* remove "ROS time moved backwards" log message (#1027 <https://github.com/ros/ros_comm/pull/1027>)
* sleep in rospy wait_for_service even if exceptions raised (#1025 <https://github.com/ros/ros_comm/pull/1025>)
* add named loggers (#948 <https://github.com/ros/ros_comm/pull/948>)
```

## rosservice

- No changes

## rostest

```
* check clock publication neatly in publishtest (#973 <https://github.com/ros/ros_comm/issues/973>)
```

## rostopic

```
* fix rostopic prining long integers (#1110 <https://github.com/ros/ros_comm/pull/1110>)
```

## roswtf

```
* improve roswtf tests (#1101 <https://github.com/ros/ros_comm/pull/1101>, #1102 <https://github.com/ros/ros_comm/pull/1102>)
```

## topic_tools

- No changes

## xmlrpcpp

```
* switch to libb64 for base64 encoding/decoding (#1046 <https://github.com/ros/ros_comm/issues/1046>)
```
