### PR TITLE
qt_gui_core: 0.3.5-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1892,7 +1892,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.3.4-2
+      version: 0.3.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.3.5-0`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.3.4-2`

## qt_dotgraph

```
* avoid collision of topic nodes with / and _ (#95 <https://github.com/ros-visualization/qt_gui_core/pull/95>)
* small fixes for Python3 compatibility (#88 <https://github.com/ros-visualization/qt_gui_core/pull/88>)
* remove color item added unintentionally (#86 <https://github.com/ros-visualization/qt_gui_core/pull/86>)
* fix missing label coloring on hover (#85 <https://github.com/ros-visualization/qt_gui_core/pull/85>)
* parse subgraphs recursively (#72 <https://github.com/ros-visualization/qt_gui_core/issues/72>)
```

## qt_gui

```
* remove trailing spaces from exported perspective files (#92 <https://github.com/ros-visualization/qt_gui_core/issues/92>)
* fix perspective export with Python3 (#91 <https://github.com/ros-visualization/qt_gui_core/pull/91>)
* hide the remaining title bar elements not disabled by -l and -f (#90 <https://github.com/ros-visualization/qt_gui_core/issues/90>)
* use file name for rqt window title when loading a .perspective (#84 <https://github.com/ros-visualization/qt_gui_core/pull/84>)
```

## qt_gui_app

- No changes

## qt_gui_cpp

```
* find and depend on tinyxml, add missing tinyxml include (#96 <https://github.com/ros-visualization/qt_gui_core/issues/96>, #97 <https://github.com/ros-visualization/qt_gui_core/issues/97>)
* fix relative import for Python3 (#89 <https://github.com/ros-visualization/qt_gui_core/pull/89>)
```

## qt_gui_py_common

- No changes
