### PR TITLE
rqt_image_view: 0.4.9-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2593,7 +2593,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rqt_image_view-release.git
-      version: 0.4.8-0
+      version: 0.4.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_view` to `0.4.9-0`:

- upstream repository: https://github.com/ros-visualization/rqt_image_view.git
- release repository: https://github.com/ros-gbp/rqt_image_view-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.4.8-0`

## rqt_image_view

```
* reduce the size of the image border on the left and right side (#5 <https://github.com/ros-visualization/rqt_image_view/issues/5>)
* avoid shrinking the image when the aspect ratio changes (#4 <https://github.com/ros-visualization/rqt_image_view/issues/4>)
```
