### PR TITLE
nav_pcontroller: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7584,7 +7584,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/code-iai-release/nav_pcontroller-release.git
-      version: 0.1.2-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/code-iai/nav_pcontroller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nav_pcontroller` to `0.1.4-0`:

- upstream repository: https://github.com/code-iai/nav_pcontroller.git
- release repository: https://github.com/code-iai-release/nav_pcontroller-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.2-0`

## nav_pcontroller

```
* Adapted the maintainer
* Contributors: Alexis Maldonado
```
