### PR TITLE
nav_pcontroller: 0.1.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -3576,7 +3576,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/code-iai-release/nav_pcontroller-release.git
-      version: 0.1.2-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/code-iai/nav_pcontroller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nav_pcontroller` to `0.1.4-0`:

- upstream repository: https://github.com/code-iai/nav_pcontroller.git
- release repository: https://github.com/code-iai-release/nav_pcontroller-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.2-0`

## nav_pcontroller

```
* Adapted the maintainer
* Contributors: Alexis Maldonado
```
