### PR TITLE
nav_pcontroller: 0.1.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1429,6 +1429,21 @@ repositories:
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
       version: master
     status: maintained
+  nav_pcontroller:
+    doc:
+      type: git
+      url: https://github.com/code-iai/nav_pcontroller.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/code-iai-release/nav_pcontroller-release.git
+      version: 0.1.4-0
+    source:
+      type: git
+      url: https://github.com/code-iai/nav_pcontroller.git
+      version: master
+    status: maintained
   navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nav_pcontroller` to `0.1.4-0`:

- upstream repository: https://github.com/code-iai/nav_pcontroller.git
- release repository: https://github.com/code-iai-release/nav_pcontroller-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## nav_pcontroller

```
* Adapted the maintainer
* Contributors: Alexis Maldonado
```
