### PR TITLE
class_loader: 0.3.7-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -246,7 +246,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/class_loader-release.git
-      version: 0.3.6-0
+      version: 0.3.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `0.3.7-0`:

- upstream repository: https://github.com/ros/class_loader
- release repository: https://github.com/ros-gbp/class_loader-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.3.6-0`

## class_loader

```
* switch to package format 2 (#56 <https://github.com/ros/class_loader/issues/56>)
* remove trailing whitespaces (#55 <https://github.com/ros/class_loader/issues/55>)
* use CONSOLE_BRIDGE_X logging macros (#52 <https://github.com/ros/class_loader/issues/52>)
* Contributors: Mikael Arguedas, jmachowinski
```
