### PR TITLE
pluginlib: 1.11.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1832,7 +1832,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.10.5-0
+      version: 1.11.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.11.0-0`:

- upstream repository: https://github.com/ros/pluginlib
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.10.5-0`

## pluginlib

```
* Switch to Tinyxml2 (#59 <https://github.com/ros/pluginlib/issues/59>)
* do not use popen to solve catkin_path. (#49 <https://github.com/ros/pluginlib/issues/49>)
* switch to package format 2 (#55 <https://github.com/ros/pluginlib/issues/55>)
* remove trailing whitespaces (#54 <https://github.com/ros/pluginlib/issues/54>)
* Contributors: Dmitry Rozhkov, Koji Terada, Mikael Arguedas
```
