### PR TITLE
nodelet_core: 1.9.11-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1520,7 +1520,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.9.10-0
+      version: 1.9.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.11-0`:

- upstream repository: https://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.9.10-0`

## nodelet

```
* Add getRemappingArgs method to nodelet to reuse it in subclass (#61 <https://github.com/ros/nodelet_core/issues/61>)
* remove trailing whitespaces (#62 <https://github.com/ros/nodelet_core/issues/62>)
* switch to package format 2 (#63 <https://github.com/ros/nodelet_core/issues/63>)
* Show pkg and manifest file with verbose option (#59 <https://github.com/ros/nodelet_core/issues/59>)
* Contributors: Kentaro Wada, Mikael Arguedas
```

## nodelet_core

```
* remove trailing whitespaces (#62 <https://github.com/ros/nodelet_core/issues/62>)
* switch to package format 2 (#63 <https://github.com/ros/nodelet_core/issues/63>)
* Contributors: Mikael Arguedas
```

## nodelet_topic_tools

```
* remove trailing whitespaces (#62 <https://github.com/ros/nodelet_core/issues/62>)
* switch to package format 2 (#63 <https://github.com/ros/nodelet_core/issues/63>)
* Contributors: Mikael Arguedas
```
