### PR TITLE
actionlib: 1.11.10-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -36,7 +36,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.11.9-0
+      version: 1.11.10-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.11.10-0`:

- upstream repository: https://github.com/ros/actionlib.git
- release repository: https://github.com/ros-gbp/actionlib-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.11.9-0`

## actionlib

```
* Clang tidy fixes (#86 <https://github.com/ros/actionlib/issues/86>)
* C++ style (#72 <https://github.com/ros/actionlib/issues/72>)
* Proper return value after assert (#83 <https://github.com/ros/actionlib/issues/83>)
* switch to package format 2 (#82 <https://github.com/ros/actionlib/issues/82>)
* remove trailing whitespaces (#81 <https://github.com/ros/actionlib/issues/81>)
* lock listhandle earlier in getCommState in client_goal_handle_imp. active bool critical (#77 <https://github.com/ros/actionlib/issues/77>)
* add missing runtime dependencies (#79 <https://github.com/ros/actionlib/issues/79>)
* Contributors: Esteve Fernandez, Mikael Arguedas, johaq
```
