### PR TITLE
lost_comms_recovery: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3618,6 +3618,21 @@ repositories:
       url: https://github.com/UTNuclearRoboticsPublic/look_at_pose.git
       version: kinetic
     status: maintained
+  lost_comms_recovery:
+    doc:
+      type: git
+      url: https://github.com/danielsnider/lost_comms_recovery.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/danielsnider/lost_comms_recovery-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/danielsnider/lost_comms_recovery.git
+      version: master
+    status: maintained
   lpms_imu:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lost_comms_recovery` to `0.1.0-0`:

- upstream repository: https://github.com/danielsnider/lost_comms_recovery.git
- release repository: https://github.com/danielsnider/lost_comms_recovery-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## lost_comms_recovery

```
* First release
```
