### PR TITLE
rtt_geometry: 2.8.1-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6742,7 +6742,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_geometry-release.git
-      version: 2.8.1-0
+      version: 2.8.1-1
     source:
       type: git
       url: https://github.com/orocos/rtt_geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_geometry` to `2.8.1-1`:

- upstream repository: https://github.com/orocos/rtt_geometry.git
- release repository: https://github.com/orocos-gbp/rtt_geometry-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.8.1-0`
