### PR TITLE
rtt_geometry: 2.9.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7850,7 +7850,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_geometry-release.git
-      version: 2.9.0-0
+      version: 2.9.1-0
     source:
       type: git
       url: https://github.com/orocos/rtt_geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_geometry` to `2.9.1-0`:

- upstream repository: https://github.com/orocos/rtt_geometry.git
- release repository: https://github.com/orocos-gbp/rtt_geometry-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.9.0-0`

## eigen_typekit

```
* eigen_typekit: only find_package(cmake_modules) if EIGEN3 was not found
  cmake_modules is provided by ROS indigo, but the Eigen module has been deprecated since
  ROS jade (see http://wiki.ros.org/jade/Migration#Eigen_CMake_Module_in_cmake_modules).
* Contributors: Johannes Meyer
```

## kdl_typekit

```
* Contributors: Johannes Meyer
```

## rtt_geometry

```
* Contributors: Johannes Meyer
```
