### PR TITLE
tele_dir: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14517,7 +14517,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rdelgadov/tele_dir-release.git
-      version: 0.0.3-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/rdelgadov/tele_dir.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tele_dir` to `0.0.5-0`:

- upstream repository: https://github.com/rdelgadov/tele_dir
- release repository: https://github.com/rdelgadov/tele_dir-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.3-0`

## tele_dir

```
* Delete setup.py
* Rebase cmake because have errors
  begin new branch to resolved
* Contributors: Rodrigo Alexis Delgado Vega
```
