### PR TITLE
Adding rrt_exploration to documentation index for indigo and kinetic

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12836,6 +12836,16 @@ repositories:
       url: https://github.com/stonier/rqt_wrapper.git
       version: devel
     status: developed
+  rrt_exploration:
+    doc:
+      type: git
+      url: https://github.com/hasauino/rrt_exploration.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/hasauino/rrt_exploration.git
+      version: indigo-devel
+    status: maintained
   rtabmap:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7756,6 +7756,16 @@ repositories:
       url: https://github.com/stonier/rqt_wrapper.git
       version: devel
     status: developed
+  rrt_exploration:
+    doc:
+      type: git
+      url: https://github.com/hasauino/rrt_exploration.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/hasauino/rrt_exploration.git
+      version: kinetic-devel
+    status: maintained
   rtabmap:
     doc:
       type: git


### PR DESCRIPTION
I'd like rrt_exploration to be indexed and documented on ros.org.