### PR TITLE
simple_drive: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8105,6 +8105,21 @@ repositories:
       url: https://github.com/uos/sick_tim.git
       version: kinetic
     status: developed
+  simple_drive:
+    doc:
+      type: git
+      url: https://github.com/danielsnider/simple_drive.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/danielsnider/simple_drive-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/danielsnider/simple_drive.git
+      version: master
+    status: maintained
   simple_grasping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_drive` to `0.1.0-0`:

- upstream repository: https://github.com/danielsnider/simple_drive.git
- release repository: https://github.com/danielsnider/simple_drive-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## simple_drive

```
* First release
```
