### PR TITLE
cob_manipulation: 0.6.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1815,16 +1815,14 @@ repositories:
       - cob_kinematics
       - cob_lookat_action
       - cob_manipulation
-      - cob_moveit_config
+      - cob_moveit_bringup
       - cob_moveit_interface
       - cob_obstacle_distance_moveit
       - cob_pick_place_action
-      - cob_tactiletools
-      - cob_tray_monitor
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_manipulation-release.git
-      version: 0.6.4-0
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/ipa320/cob_manipulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_manipulation` to `0.6.5-1`:

- upstream repository: https://github.com/ipa320/cob_manipulation.git
- release repository: https://github.com/ipa320/cob_manipulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.6.4-0`

## cob_collision_monitor

```
* parameters via launch file
* default verbosity set to false
* catch runtime exception
* add debug info to collision_monitor
* restructure moveit config
* do not load robot_description in cob_moveit_config/upload_config.launch
* minor launch adjustments
* update cob_collision_monitor
* add remaps for cob4 as comments
* Contributors: ipa-fxm, ipa-nhg
```

## cob_grasp_generation

```
* make pick and grasp more robot-agnostic
* Contributors: ipa-fxm
```

## cob_kinematics

```
* Fix ikfast cmake
  * do not write plugins.xml in source space
  * added install tags
* use xacro --inorder
* Contributors: Mathias Lüdtke, ipa-fxm
```

## cob_lookat_action

```
* fix install tags
* rework package: now using virtual KDL chain and FJT action client
* Contributors: Felix Messmer, ipa-fxm
```

## cob_manipulation

```
* Revert "Adding chomp planning pipeline"
* added exec_depend to chomp
* remove obsolete packages due to unsupported robots
* moved cob_moveit_config
* new package cob_moveit_bringup
* Contributors: Felix Messmer, fau-mjp, ipa-fxm
```

## cob_moveit_bringup

```
* remove stomp configuration
* Revert "Adding chomp planning pipeline"
* chomp planning pipeline file added robot argument
* restructure moveit config
* Update planning_context.xml
* Stomp planner (#104 <https://github.com/ipa320/cob_manipulation/issues/104>)
  * moveit setup with UR arm
  * Arm moveit configuration
  * Controller corrected
  * Arm with gripper moveit config
  * solver options tunned
  * moveit whole body configuration planning for raw3-1
  * whole body configuration with virtual joint working
  * Stomp configuration files created for mailto:rob@work arm
  * stomp configuration for raw3-1 created and tested
  * changes from pull request
  * new change from pull request
  * added travis rosinstall dependencies for industrial_moveit
  * identation fixed in travis.rosinstall
  * NEW FIX TO INDENTATION
  * proper rosdep key for occupancy grid  monitor
  * rosinstall chnaged to my local fork to test install tags
  * stomp moveit link change to original github browser after pull request being accepted
  * version updated
  * pull request changes
* add xacro-args --inorder
* fix moveit deprecation warning
* scripts for updating collisions in moveit_config
* move setup_assistant launch file
* do not load robot_description in cob_moveit_config/upload_config.launch
* minor launch adjustments
* fix database location
* split, move and adjust launch files
* new package cob_moveit_bringup
* Contributors: Bruno Brito, Felix Messmer, Mayank_Patel, ipa-fxm
```

## cob_moveit_interface

- No changes

## cob_obstacle_distance_moveit

```
* Merge pull request #110 <https://github.com/ipa320/cob_manipulation/issues/110> from ipa320/ipa-fxm-refactor_configuration_structure
  Refactor configuration structure
* restructure moveit config
* ;)
* deleted some whitespaces
* Added SRDF for AllowedCollisionMatrix computation
* Changed launchfile accourding to new cob structure
* do not load robot_description in cob_moveit_config/upload_config.launch
* minor launch adjustments
* add remaps for cob4 as comments
* move scripts to proper folder
* add install tags
* Contributors: Christoph Mark, Felix Messmer, ipa-fxm, ipa-nhg
```

## cob_pick_place_action

```
* fix script - missing import and assimp error
* make pick and grasp more robot-agnostic
* Contributors: ipa-fxm
```
