### PR TITLE
cob_robots: 0.6.7-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1894,15 +1894,15 @@ repositories:
     release:
       packages:
       - cob_bringup
-      - cob_controller_configuration_gazebo
       - cob_default_robot_behavior
       - cob_default_robot_config
       - cob_hardware_config
+      - cob_moveit_config
       - cob_robots
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.6.6-0
+      version: 0.6.7-1
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.6.7-1`:

- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.6.6-0`

## cob_bringup

```
* add missing bringup launch file for cob4-11
* add missing bringup launch file for cob4-10
* switch to mimic cpp implementation
* export display number to get mimic working
* use scan unified for docking
* renamed sensorring camera
* setup cob4-8
* switch back to python version of hz monitor
* Merge pull request #667 <https://github.com/ipa320/cob_robots/issues/667> from ipa-bnm/feature/local_changes
  local changes from cob4-7
* use sim arg for bms
* local changes from cob4-7
* space vs tabs
* integrate arg sim
* rename sick visionary launch file
* update cob4-5 setup
* merge
* finalize
* invert right wheels and change ordering of config (needed after retuning and UM=2)
* added reset_errors_before_recovery_parameter from ros_canopen
* steer_ctrl param handling
* final cleanup
* canopen config for raw3-3 base
* finalize cob4-9
* Setup cob4-9
* finalizing configs
* added head for cob4-7
* added head for cob4-5
* topic relays for additional sensor topics not available in simulation
* harmonize robots
* use diagnostic_updater base topic_status_monitor, fake simulation
* proper namespace for static_transform_broadcaster
* use mimic in simulation
* cleanup phidget launch
* adjust pc_monitor
* tested the update with the robot - it works
* fxm change requests
* merge with 320 and bugfix for raw3-1
* fix roslaunch_checks
* arg pkg_hardware_config
* refactoring env config
* restructure cob_hardware_config
* restructure cob_default_robot_config
* configuration via yaml file
* Stomp planner (#631 <https://github.com/ipa320/cob_robots/issues/631>)
  * merged stomp configuration with actual indigo_dev
  * controllers for moveit namespace corrected
  * stomp configuration for raw3-1 created and tested
  * few corrections before pull request
  * twist controller config for raw3-1
  * changes from pull request
  * new change from pull request
  * whole-body planning group: robot
  * stomp configuration for robot group
  * pull request changes
  * stomp plannning yaml file correct group names
  * twist controller config file updated to include input limits parameters
  * finalizing PR
* harmonize cob4-2 and cob4-7
* lower resolution for head camera
* add realsense static frames for simulation
* cob4-7 hardware updates
* unified ros control base driver and controller config
* added stuck_detector node for all cob4 bases
* update cob4-paul-stuttgart
* remove cob4-10
* Revert "added stuck_detector to bringup"
  This reverts commit 8c06a19ff64510837c9f127e3dc2d121c143972e.
* Merge branch 'tmp/disable_head' into indigo_dev
* added dependency to the camera plugins for the compressed topics
* Raw3 5 config for ros_canopen (#609 <https://github.com/ipa320/cob_robots/issues/609>)
  * Updated raw3-5 launch and description
  * changes for test raw3-5
  * config for raw 3-5 with ros_canopen
  * uncommenting code and optimizing neutral positions
  * delete .dae and .urdf for raw3-5
  * Cleanded files
  * changed diagnostics_analyzers to match with cob4 config
* missed ns group
* changes as per review.
  removed the unused docker_control node.
* changes as per review.
  modified to the single line notation for fake_docking node.
* changes for using fake docking and power usage
* comment ur_modern_driver
* fix diagnostics
* payload default vaues added in the ur launch driver file
* fake_bms driver is publishing diagnostics
* harmonize namespaces of fake_bms
* made changes to keep the parameters under the bms namspace for the fake_bms node
* bms parameters is now being used by fake_bms driver for simulation
* incorporated changes to handle fake_bms and simulation
* make simulation work preliminarily
* Ur Modern Driver configuration
* add fake_diagnostics to all robots
* add fake_diagnostics again
* Merge branch 'stuck_detector' into tmp/disable_head
* added stuck_detector to bringup
* beautify naming of pc monitor
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_robots into tmp/disable_head
* disabled head and sensorring
* remove trailing whitespaces
* image_proc for usb_cam in component
* replace fake_driver
* fix indentation
* fix for indentation issues
* fixes as per requested changes
* added fake power state publisher in order to support simulation
* adapt flexisoft sim for all cob4
* use simulated/fake components
* remove cob4-1
* upgrade cob4-2
* remove obsolete components and dependencies
* remove unsupported robots - launch and config
* framerate explanation comment
* do not use joystick in simulation
* head and sensorring on one bus
* use external and shared sync mode on cob4-10
* overwrite sync interval only in external sync mode
* added external sync mode, generate CAN config on-the-fly
* new bms config
* missing install tag
* [WIP] Use grouped low level components for simulation (#583 <https://github.com/ipa320/cob_robots/issues/583>)
  * refactored generic canopen&config into canopen_generic.launch
  * refactored base driver+config into canopen_base.launch
  * added components/cob4_head_camera.launch
  * added components/cam3d_openni2.launch
  * added components/cam3d_r200_rgbd.launch
  * introduce sim arg for components
  * use sim arg in robot.xml
  * remove nodes started within robot.xml from default_controllers_robot.launch
  * introducing legacy components
  * reorganize and sim toggle for more components
  * adjust cob4-1 to latest changes
  * use new structure for cob3-2
  * use new structure for cob3-6
  * use new structure for cob3-9
  * use new structure for cob4-2
  * use new structure for remaining cob4s
  * travis fixes
  * syntax styling
  * use new structure for raws
  * more travis fixes
  * harmonize old vs. new behavior cob4-1
  * guarantee same hw behavior as before
  * add flip argument
* use test_depends where applicable
* use cob_supported_robots_ROBOTLIST in dependent packages
* Merge pull request #567 <https://github.com/ipa320/cob_robots/issues/567> from ipa-fxm/restructure_moveit_config
  Restructure moveit config
* remove obsolete envlist from tests
* use mimic rotation
* move camera calibration files into sub-folders
* upload semantic description using new moveit_config structure
* manually fix changelog
* tabs vs spaces
* mimic support the rotation of the face
* unify xml robot files
* cleanup
* android required robot name as argument
* android requires the robot argument
* setup cob4-10
* cob4-7 setup: final test
* fake monitoring for simulation to work with msh scenario
* added phidgets
* Ur Modern Driver configuration
* added arm in bringup, corrected torso mounting angle
* switch cameras
* twist controller launch for bringup
* missing payload parameters for the arm controller
* Added controller for gazebo. Arm gripper removed
* realsense as default torso down camera
* build torso with arms
* add heartbeat for android gui
* rename fliped camear topic
* Merge github.com:ipa320/cob_robots into indigo_dev
  Conflicts:
  cob_default_robot_behavior/CMakeLists.txt
* update cob4-2.xml
* setup cob4-7
* update for raw3-1 torso driver configuration
* Contributors: Benjamin Maidel, Bruno Brito, Felix Messmer, Florian Weisshardt, Mathias Lüdtke, Nadia Hammoudeh García, Richard Bormann, andreeatulbure, cob4-7, fmw-ss, hannes, ipa-cob4-5, ipa-cob4-8, ipa-fxm, ipa-nhg, ipa-raw3-3, ipa-rmb, ipa-uhr-mk, msh, robot
```

## cob_default_robot_behavior

```
* missed install tag
* setup cob4-8
* unify default behaviors
* remove pick behavior
* remove cob4-10 behavior
* update cob4-paul-stuttgart
* remove cob4-10
* remove cob4-1
* cob4-7 - update behavior script to move the arms
* manually fix changelog
* setup cob4-10
* Merge github.com:ipa320/cob_robots into indigo_dev
  Conflicts:
  cob_default_robot_behavior/CMakeLists.txt
* setup cob4-7
* Contributors: ipa-cob4-8, ipa-fxm, ipa-nhg, robot
```

## cob_default_robot_config

```
* add initial config for cob4-10
* add initial cob4-11 serodi config
* cob4-8 setup
* setup cob4-8
* removed unsafed positions
* update cob4-5 setup
* final cleanup
* finalize cob4-9
* Setup cob4-9
* added head for cob4-7
* update cob4-5 configs
* added head for cob4-5
* fxm change requests
* restructure cob_default_robot_config
* cob4-7 hardware updates
* update cob4-paul-stuttgart
* remove cob4-10
* remove sound buttons
* arm speed
* added vacuum gripper
* updated the arm configuration (topics, default vel) in cob_default_hardware_config
* remove cob4-1
* upgrade cob4-2
* remove unsupported robots - launch and config
* harmonize default robot config
* remove home button for head
* remove home button for head
* activate 3dof head
* use test_depends where applicable
* use cob_supported_robots_ROBOTLIST in dependent packages
* manually fix changelog
* setup cob4-10
* cob4-7 setup: final test
* added back_left and back_right
* arm speed
* added vacuum gripper
* updated the arm configuration (topics, default vel) in cob_default_hardware_config
* build torso with arms
* Merge github.com:ipa320/cob_robots into indigo_dev
  Conflicts:
  cob_default_robot_behavior/CMakeLists.txt
* setup cob4-7
* Contributors: Mathias Lüdtke, Richard Bormann, cob4-10, cob4-11, cob4-7, hannes, ipa-cob4-5, ipa-cob4-8, ipa-fxm, ipa-nhg, robot
```

## cob_hardware_config

```
* Update teleop.yaml
* add initial config for cob4-10
* add initial cob4-11 serodi config
* use cob4-b12 for paul-stuttgart
* use cob4-b2 instead of cob4-b7 for paul-ingolstadt
* cob4-8 setup
* renamed sensorring camera
* renamed sensorring camera
* setup cob4-8
* tune sensorring parameters for cob4-5 (kinect+sick sensor)
* revert docking distance_tolerance introduced in https://github.com/ipa320/cob_robots/commit/814d3947bd4c01098f509db98e92acd9fb40aea3
* update teleop config to init the head
* reset pc monitors
* reset hz monitor for cam3d
* local changes from cob4-7
* update cob4-5 setup
* merge
* invert right wheels and change ordering of config (needed after retuning and UM=2)
* steer_ctrl param handling
* final cleanup
* canopen config for raw3-3 base
* cleanup files
* finalize cob4-9
* remove obsolete scan_unifier parameter
* Setup cob4-9
* finalizing configs
* added head for cob4-7
* update cob4-5 configs
* added joint_states for the head
* added head for cob4-5
* larger data_skip for simulation
* pass camera settings to gazebo plugins
* parameterizable usb_cam
* added 10 Hz heartbeat to Schunk DCF
* adjust pc_monitor
* fxm change requests
* fixed path
* copy the rviz config file
* fix identantion
* rename display launch file
* added a launch file to display a urdf.xacro model
* remove obsolete files raw3-5
* remove obsolete rviz displays
* remove obsolete laser config files
* separate laser scanner from base
* fix typo
* restructure cob_hardware_config
* configuration via yaml file
* Stomp planner (#631 <https://github.com/ipa320/cob_robots/issues/631>)
  * merged stomp configuration with actual indigo_dev
  * controllers for moveit namespace corrected
  * stomp configuration for raw3-1 created and tested
  * few corrections before pull request
  * twist controller config for raw3-1
  * changes from pull request
  * new change from pull request
  * whole-body planning group: robot
  * stomp configuration for robot group
  * pull request changes
  * stomp plannning yaml file correct group names
  * twist controller config file updated to include input limits parameters
  * finalizing PR
* harmonize cob4-2 and cob4-7
* unify tests
* reduce station tolerance
* cob4-7 hardware updates
* renamed voltage_max to voltage_divider_factor
* update cartesian controller parameters
* disable head and sensorring for cob4-2
* read current from Elmos, add it to base joint states
* unified ros control base driver and controller config
* update cob4-paul-stuttgart
* remove cob4-10
* speedup docking process
* changed docker position
* Revert "added stuck_detector to bringup"
  This reverts commit 8c06a19ff64510837c9f127e3dc2d121c143972e.
* disable head
* changed Impedance-Controller Parameter for roboter
* Raw3 5 config for ros_canopen (#609 <https://github.com/ipa320/cob_robots/issues/609>)
  * Updated raw3-5 launch and description
  * changes for test raw3-5
  * config for raw 3-5 with ros_canopen
  * uncommenting code and optimizing neutral positions
  * delete .dae and .urdf for raw3-5
  * Cleanded files
  * changed diagnostics_analyzers to match with cob4 config
* change u_max to meet the measured values
* Update raw3-1.urdf.xacro
* Update raw3-1.urdf.xacro
* Update arm_controller.yaml
* set light parameters
* cleanup arm_controller
* fix diagnostics
* requested changes in pull request
* gripper macro name changed and prefix removed as argument
* make simulation work preliminarily
* added vacuum gripper
* adaptations to current configuration for order-picking
* undid old files from ipa-rmb
* update for raw3-1 torso driver configuration
* added arm in bringup, corrected torso mounting angle
* twist controller configuration for raw3-1
* added arm joint limits file
* Added controller for gazebo. Arm gripper removed
* Arm uncommented to be added in the URDF file
* do not specify num_cores for localhost
* added stuck_detector to bringup
* fixed camera down camera calibration for all robots
* disabled head and sensorring
* fixed camera down camera calibration
* updated phidgets config for raw3-3
* move gazebo_ros_control plugin
* use xacro --inorder
* remove cob4-2 leftover
* remove cob4-1
* fix cpu monitor
* upgrade cob4-2
* remove obsolete components and dependencies
* remove unsupported robots - launch and config
* Merge pull request #596 <https://github.com/ipa320/cob_robots/issues/596> from ipa-fmw/feature/bms_diagnostics
  enable bms in diagnostics
* enable bms in diagnostics
* activate 3dof head
* adapt diagnostics
* use latest xacro syntax
* limit for pc monitors
* new bms config
* [WIP] Use grouped low level components for simulation (#583 <https://github.com/ipa320/cob_robots/issues/583>)
  * refactored generic canopen&config into canopen_generic.launch
  * refactored base driver+config into canopen_base.launch
  * added components/cob4_head_camera.launch
  * added components/cam3d_openni2.launch
  * added components/cam3d_r200_rgbd.launch
  * introduce sim arg for components
  * use sim arg in robot.xml
  * remove nodes started within robot.xml from default_controllers_robot.launch
  * introducing legacy components
  * reorganize and sim toggle for more components
  * adjust cob4-1 to latest changes
  * use new structure for cob3-2
  * use new structure for cob3-6
  * use new structure for cob3-9
  * use new structure for cob4-2
  * use new structure for remaining cob4s
  * travis fixes
  * syntax styling
  * use new structure for raws
  * more travis fixes
  * harmonize old vs. new behavior cob4-1
  * guarantee same hw behavior as before
  * add flip argument
* use test_depends where applicable
* use cob_supported_robots_ROBOTLIST in dependent packages
* use additional sensorring argument
* updated BMS config with StatusRegister bits
* Merge pull request #565 <https://github.com/ipa320/cob_robots/issues/565> from ipa-fxm/separate_sensors_actors
  Separate sensors actors
* remove moveit_config files from cob_hardware_config
* upload semantic description using new moveit_config structure
* cob4-10 fixes
* manually fix changelog
* use unified torso xacro
* move sensors from torso xacro to robot xacro
* use unified sensorring xacro
* move sensors from sensorring xacro to robot xacro
* use unified head xacro
* move sensors from head xacro to robot xacro
* fix self-collision for twist control with cob3-6
* disable warning for wireless em stop bridged
* update velocity smoother parameters
* use same velocity smoother settings for all cob4
* smooth acceleration after emergency stop
* cleanup
* setup cob4-10
* cob4-7 setup: final test
* fake monitoring for simulation to work with msh scenario
* fix cob3-9 urdf
* added vacuum gripper
* adaptations to current configuration for order-picking
* increase load threshold
* added phidgets
* undid old files from ipa-rmb
* added arm in bringup, corrected torso mounting angle
* increase load threshold
* twist controller configuration for raw3-1
* added arm joint limits file
* Added controller for gazebo. Arm gripper removed
* fix image_flip to be compatible with head_cam kinematic
* simulation test
* Arm uncommented to be added in the URDF file
* Twist cartesian controller configuration files for cob3-6
* Twist controller configuration files for cob3-6
* realsense as default torso down camera
* build torso with arms
* Merge github.com:ipa320/cob_robots into indigo_dev
  Conflicts:
  cob_default_robot_behavior/CMakeLists.txt
* missing image_flip confog for cob4-5
* added head_cam frame to urdf
* Set enable_sounf to false
* setup cob4-7
* update for raw3-1 torso driver configuration
* Contributors: Andreea Tulbure, Benjamin Maidel, Bruno Brito, Felipe Garcia Lopez, Felix Messmer, Florian Weisshardt, Jannik Abbenseth, Mathias Lüdtke, Nadia Hammoudeh García, Richard Bormann, andreeatulbure, cob4-10, cob4-11, cob4-7, hannes, ipa-cob4-1, ipa-cob4-5, ipa-cob4-7, ipa-cob4-8, ipa-fmw, ipa-fxm, ipa-nhg, ipa-raw3-3, ipa-rmb, msh, robot
```

## cob_moveit_config

```
* switch back to default moveit_config for raw3-1
* Add configs file and update srdf to operate the robot with MoveIt!
* setup cob4-8
* updated the srdf model
* fix CONFIG_TEMPLATE in add_robot
* restructure moveit config
* restructure cob_hardware_config
* Stomp planner (#631 <https://github.com/ipa320/cob_robots/issues/631>)
  * merged stomp configuration with actual indigo_dev
  * controllers for moveit namespace corrected
  * stomp configuration for raw3-1 created and tested
  * few corrections before pull request
  * twist controller config for raw3-1
  * changes from pull request
  * new change from pull request
  * whole-body planning group: robot
  * stomp configuration for robot group
  * pull request changes
  * stomp plannning yaml file correct group names
  * twist controller config file updated to include input limits parameters
  * finalizing PR
* cob4-7 hardware updates
* remove cob4-10
* update collision matrix in moveit_config
* ompl planning file was fixed from last merge process
* update collision matrix in moveit configs
* remove cob4-1
* remove unsupported robots - launch and config
* [WIP] Use grouped low level components for simulation (#583 <https://github.com/ipa320/cob_robots/issues/583>)
  * refactored generic canopen&config into canopen_generic.launch
  * refactored base driver+config into canopen_base.launch
  * added components/cob4_head_camera.launch
  * added components/cam3d_openni2.launch
  * added components/cam3d_r200_rgbd.launch
  * introduce sim arg for components
  * use sim arg in robot.xml
  * remove nodes started within robot.xml from default_controllers_robot.launch
  * introducing legacy components
  * reorganize and sim toggle for more components
  * adjust cob4-1 to latest changes
  * use new structure for cob3-2
  * use new structure for cob3-6
  * use new structure for cob3-9
  * use new structure for cob4-2
  * use new structure for remaining cob4s
  * travis fixes
  * syntax styling
  * use new structure for raws
  * more travis fixes
  * harmonize old vs. new behavior cob4-1
  * guarantee same hw behavior as before
  * add flip argument
* move setup_assistant launch file
* adjust version + add to meta-package
* moved cob_moveit_config
* Contributors: Bruno Brito, Felix Messmer, MattiaRacca, ipa-bfb-sc, ipa-cob4-5, ipa-cob4-8, ipa-fxm, ipa-nhg
```

## cob_robots

```
* moved cob_supported_robots to standalone repo
* remove obsolete package cob_controller_configuration_gazebo
* added cob_supported_robots package
* Merge pull request #573 <https://github.com/ipa320/cob_robots/issues/573> from ipa-fxm/move_cob_moveit_config
  move cob_moveit_config
* add missing cob_default_robot_behavior to meta-package
* adjust version + add to meta-package
* manually fix changelog
* Contributors: Felix Messmer, Mathias Lüdtke, ipa-fxm
```
