### PR TITLE
parameter_pa: 1.0.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1708,6 +1708,11 @@ repositories:
       type: git
       url: https://github.com/peterweissig/ros_parameter.git
       version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/peterweissig/ros_parameter-release.git
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/peterweissig/ros_parameter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `parameter_pa` to `1.0.2-0`:

- upstream repository: https://github.com/peterweissig/ros_parameter.git
- release repository: https://github.com/peterweissig/ros_parameter-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## parameter_pa

```
* updated year within license
* updated version number
* added install target to CMakeLists.txt
* Contributors: Peter Weissig
```
