### PR TITLE
cob_simulation: 0.6.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1923,7 +1923,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_simulation-release.git
-      version: 0.6.7-0
+      version: 0.6.8-0
     source:
       type: git
       url: https://github.com/ipa320/cob_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.6.8-0`:

- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.6.7-0`

## cob_bringup_sim

```
* refactored the code and added retreating model while on circular motion
* provision for re-spawning the person object to the start, due to presence of obstacle
* use xacro --inorder
* allow single letter option for move_object
* rospy.sleep exception handling
* wait for models and cleanup
* launch argument world_name
* use exported robotlist and envlist
* manually fix changelog
* debug functionality
* continue motion if object is far away enough
* metavars for parser options
* introduce stop_objects list and stop_distance
* remove throttled
* add missing robots to robotlist
* added stopping of objects
* Contributors: fmw-ss, hannes, ipa-fxm
```

## cob_gazebo

```
* remove cob_controller_configuration_gazebo
* use exported robotlist and envlist
* use cob_bringup robot.xml in simulation
* manually fix changelog
* Empty launch file changed and empty urdf created
* wait parameter removed. it was not working when launching a empty world
* Contributors: Bruno Brito, ipa-fxm
```

## cob_gazebo_objects

```
* add station_charger
* correct marker radius
* add reflector_marker_round
* make reflector marker static
* use exported robotlist and envlist
* use latest xacro syntax
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_gazebo_worlds

```
* rename IZS-carpark-top to izs-carpark-top
* add simulation for izs-carpark-top to cob_gazebo_worlds
* remove kitchen unit
* fix ipa-production-plant
* use xacro --inorder
* use xml suffix for non-standalone launch files
* rospy.sleep exception handling
* launch argument world_name
* use exported robotlist and envlist
* use latest xacro syntax
* handle ROSTimeMovedBackwardsException
* manually fix changelog
* add test for empty.urdf.xacro
* remove throttled
* simplify launch files
* conflict between empty launch files and other scenarios solved
* Empty launch file changed and empty urdf created
* Contributors: Bruno Brito, Jannik Abbenseth, ipa-fxm
```

## cob_simulation

```
* manually fix changelog
* Contributors: ipa-fxm
```
