### PR TITLE
Added rosdep key zeromq3

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4597,6 +4597,12 @@ zbar:
   fedora: [zbar-devel]
   gentoo: [media-gfx/zbar]
   ubuntu: [libzbar-dev]
+zeromq3:
+  arch: [zeromq3]
+  debian: [libzmq3-dev]
+  fedora: [zeromq3]
+  gentoo: [zeromq]
+  ubuntu: [libzmq3-dev]
 zlib:
   arch: [zlib]
   cygwin: [zlib]


### PR DESCRIPTION
We are using ZeroMQ for a node that bridges from a 3rd-party application using ZeroMQ sockets with ROS. The only tested platforms are Ubuntu Trusty and Xenial, other native package names are purely based on a lookup in the respective package databases.

I added the rosdep key as `zeromq3` including the major version number, but most distributions do already provide ZeroMQ version 4 or newer even if the package name contains `3`. I assume they are API-compatible. However, I thought it might be useful in order to not cause problems once a newer, incompatible version would be added.

References:
- Arch Linux: https://aur.archlinux.org/packages/zeromq3/
- Debian: https://packages.debian.org/search?suite=all&searchon=names&keywords=libzmq3-dev
- Fedora: https://admin.fedoraproject.org/pkgdb/package/rpms/zeromq3/
- Gentoo: https://packages.gentoo.org/packages/net-libs/zeromq
- Ubuntu: https://packages.ubuntu.com/search?keywords=libzmq3-dev&searchon=names&suite=all&section=all