### PR TITLE
Enable python-qt-bindings-webkit rosdep key for newer Ubuntu distros

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2442,11 +2442,7 @@ python-qt-bindings-webkit:
   debian: [python-qt4]
   fedora: [PyQt4]
   gentoo: [dev-python/pyside, dev-python/PyQt4]
-  ubuntu:
-    saucy: [python-qt4]
-    trusty: [python-qt4]
-    utopic: [python-qt4]
-    vivid: [python-qt4]
+  ubuntu: [python-qt4]
 python-qt4-gl:
   debian: [python-qt4-gl]
   fedora: [PyQt4]


### PR DESCRIPTION
The package is still available in newer Ubuntu distros: https://packages.ubuntu.com/search?suite=all&arch=any&searchon=names&keywords=python-qt4

`python-qt-bindings=webkit` is required to build [rqt_web](http://wiki.ros.org/rqt_web) as part of a ROS indigo desktop distribution for Ubuntu Xenial, which actually works almost flawlessly.