### PR TITLE
Feature/libjack

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1848,6 +1848,9 @@ libiw-dev:
   fedora: [wireless-tools-devel]
   gentoo: [net-wireless/wireless-tools]
   ubuntu: [libiw-dev]
+libjack-dev:
+  debian: [libjack-dev]
+  ubuntu: [libjack-dev]
 libjackson-json-java:
   debian: [libjackson-json-java]
   fedora: [jackson]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2159,16 +2159,7 @@ python-pylint:
   osx:
     pip:
       packages: [pylint]
-  ubuntu:
-    lucid: [pylint]
-    maverick: [pylint]
-    natty: [pylint]
-    oneiric: [pylint]
-    precise: [pylint]
-    quantal: [pylint]
-    raring: [pylint]
-    saucy: [pylint]
-    trusty: [pylint]
+  ubuntu: [pylint]
 python-pymavlink:
   fedora:
     pip:


### PR DESCRIPTION
Add key for libjack-dev
Wasn't able to find gentoo/fedora packages