### PR TITLE
Add libjack-dev keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1848,6 +1848,9 @@ libiw-dev:
   fedora: [wireless-tools-devel]
   gentoo: [net-wireless/wireless-tools]
   ubuntu: [libiw-dev]
+libjack-dev:
+  debian: [libjack-dev]
+  ubuntu: [libjack-dev]
 libjackson-json-java:
   debian: [libjackson-json-java]
   fedora: [jackson]


### PR DESCRIPTION
Add key for libjack-dev
Wasn't able to find gentoo/fedora packages