### PR TITLE
cob_android: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -792,6 +792,27 @@ repositories:
       url: https://github.com/ros/cmake_modules.git
       version: 0.4-devel
     status: maintained
+  cob_android:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_android.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_android
+      - cob_android_msgs
+      - cob_android_resource_server
+      - cob_android_script_server
+      - cob_android_settings
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_android-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_android.git
+      version: indigo_dev
+    status: developed
   cob_calibration_data:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_android` to `0.1.3-0`:

- upstream repository: https://github.com/ipa320/cob_android.git
- release repository: https://github.com/ipa320/cob_android-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cob_android

- No changes

## cob_android_msgs

- No changes

## cob_android_resource_server

- No changes

## cob_android_script_server

```
* removed scripts and requires tag from setup.py
* do not use sub folder for installed scripts
* Create CMakeLists.txt
* remove duplicate install_tag
* refactor config structure
* removed planning parameter for trigger service
* Contributors: Benjamin Maidel, Florian Weisshardt, ipa-cob4-2, ipa-fxm
```

## cob_android_settings

```
* refactor config structure
* Contributors: ipa-fxm
```
