### PR TITLE
parameter_pa: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5233,7 +5233,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/peterweissig/ros_parameter-release.git
-      version: 1.0.2-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/peterweissig/ros_parameter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `parameter_pa` to `1.1.0-0`:

- upstream repository: https://github.com/peterweissig/ros_parameter.git
- release repository: https://github.com/peterweissig/ros_parameter-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.2-0`

## parameter_pa

```
* moved header from include/ to include/${project_name}
  also fixed related paths
* Contributors: Peter Weissig
```
