### PR TITLE
parameter_pa: 1.1.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1712,7 +1712,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/peterweissig/ros_parameter-release.git
-      version: 1.0.2-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/peterweissig/ros_parameter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `parameter_pa` to `1.1.0-0`:

- upstream repository: https://github.com/peterweissig/ros_parameter.git
- release repository: https://github.com/peterweissig/ros_parameter-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.2-0`

## parameter_pa

```
* moved header from include/ to include/${project_name}
  also fixed related paths
* Contributors: Peter Weissig
```
