### PR TITLE
sick_visionary_t: 0.0.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13545,11 +13545,12 @@ repositories:
       version: indigo_release_candidate
     release:
       packages:
+      - sick_visionary_t
       - sick_visionary_t_driver
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SICKAG/sick_visionary_t-release.git
-      version: 0.0.5-0
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_visionary_t.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_visionary_t` to `0.0.5-1`:

- upstream repository: https://github.com/SICKAG/sick_visionary_t.git
- release repository: https://github.com/SICKAG/sick_visionary_t-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.5-0`

## sick_visionary_t

```
* changed license and web-url
* added metapackage
* Contributors: Richard Bormann
```

## sick_visionary_t_driver

- No changes
