### PR TITLE
sick_visionary_t: 0.0.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8135,6 +8135,24 @@ repositories:
       url: https://github.com/uos/sick_tim.git
       version: kinetic
     status: developed
+  sick_visionary_t:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_visionary_t.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - sick_visionary_t
+      - sick_visionary_t_driver
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/SICKAG/sick_visionary_t-release.git
+      version: 0.0.5-0
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_visionary_t.git
+      version: indigo-devel
+    status: maintained
   simple_drive:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_visionary_t` to `0.0.5-0`:

- upstream repository: https://github.com/SICKAG/sick_visionary_t.git
- release repository: https://github.com/SICKAG/sick_visionary_t-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## sick_visionary_t

```
* changed license and web-url
* added metapackage
* Contributors: Richard Bormann
```

## sick_visionary_t_driver

- No changes
