### PR TITLE
add python-urllib3

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3478,6 +3478,12 @@ python-urlgrabber:
       packages: [pycurl, urlgrabber]
   slackware: [urlgrabber]
   ubuntu: [python-urlgrabber]
+python-urllib3:
+  arch: [python-urllib3]
+  debian: [python-urllib3]
+  fedora: [python-urllib3]
+  gentoo: [dev-python/urllib3]
+  ubuntu: [python-urllib3]
 python-usb:
   debian: [python-usb]
   fedora: [pyusb]


### PR DESCRIPTION
arch: https://www.archlinux.org/packages/extra/any/python-urllib3/
debian: https://packages.debian.org/de/sid/python-urllib3
fedora: https://admin.fedoraproject.org/pkgdb/package/rpms/python-urllib3/
gentoo: https://packages.gentoo.org/packages/dev-python/urllib3
ubuntu: https://packages.ubuntu.com/yakkety/python-urllib3