### PR TITLE
rviz: 1.12.11-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3048,7 +3048,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.12.10-0
+      version: 1.12.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.12.11-0`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.12.10-0`

## rviz

```
* Added dhood as maintainer (#1131 <https://github.com/ros-visualization/rviz/issues/1131>)
* Fixed finding and linking of tinyxml (#1130 <https://github.com/ros-visualization/rviz/issues/1130>)
* Changed to only update window title if necessary (#1124 <https://github.com/ros-visualization/rviz/issues/1124>)
* Added option to invert Z axis for orbit-based view controllers (#1128 <https://github.com/ros-visualization/rviz/issues/1128>)
* Fixed visualization of collada markers with texture (#1084 <https://github.com/ros-visualization/rviz/issues/1084>) (#1129 <https://github.com/ros-visualization/rviz/issues/1129>)
* Fixed bug where Ogre::ItemIdentityException occurred while loading mesh (#1105 <https://github.com/ros-visualization/rviz/issues/1105>)
* Fixed bug caused by combination of Qt and Boost (#1114 <https://github.com/ros-visualization/rviz/issues/1114>)
* Fixed bug with map_display where it ignored resolution changes in OccupancyGrid maps (#1115 <https://github.com/ros-visualization/rviz/issues/1115>)
* Fixed bug where keyboard shortcuts sometimes didn't work (#1117 <https://github.com/ros-visualization/rviz/issues/1117>)
* Contributors: 1r0b1n0, Adam Allevato, Adrian Böckenkamp, Kartik Mohta, Michael Görner, Mikael Arguedas, William Woodall, dhood, gerkey
```
