### PR TITLE
Autoware: 1.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11,6 +11,19 @@ release_platforms:
   ubuntu:
   - xenial
 repositories:
+  Autoware:
+    doc:
+      type: git
+      url: https://github.com/dejanpan/Autoware.git
+      version: 1.3.2
+    release:
+      packages:
+      - autoware_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/dejanpan/Autoware-release.git
+      version: 1.3.2-0
+    status: developed
   abb:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `Autoware` to `1.3.2-0`:

- upstream repository: https://github.com/dejanpan/Autoware.git
- release repository: https://github.com/dejanpan/Autoware-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
