### PR TITLE
Add rosdep key cppad

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -447,6 +447,10 @@ couchdb:
   fedora: [couchdb]
   gentoo: [dev-db/couchdb]
   ubuntu: [couchdb]
+cppad:
+  debian: [cppad]
+  fedora: [cppad]
+  ubuntu: [cppad]
 cppcheck:
   debian: [cppcheck]
   ubuntu: [cppcheck]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -54,6 +54,10 @@ collada-dom:
   osx:
     homebrew:
       packages: [collada-dom]
+cppad:
+  osx:
+    homebrew:
+      packages: [cppad]
 cppunit:
   osx:
     homebrew:


### PR DESCRIPTION
We use [cppad](https://www.coin-or.org/CppAD/) as an interface and an automatic differentiation tool to work with the famous nonlinear programming solver [Ipopt](https://projects.coin-or.org/Ipopt). It has been tested on macOS and Ubuntu.

References:

- Debian: https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=cppad
- Fedora: https://admin.fedoraproject.org/pkgdb/package/rpms/cppad/
- Ubuntu: https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=cppad&searchon=names