### PR TITLE
pcdfilter_pa: 1.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8634,6 +8634,11 @@ repositories:
       type: git
       url: https://github.com/peterweissig/ros_pcdfilter.git
       version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/peterweissig/ros_pcdfilter-release.git
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/peterweissig/ros_pcdfilter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcdfilter_pa` to `1.1.0-0`:

- upstream repository: https://github.com/peterweissig/ros_pcdfilter.git
- release repository: https://github.com/peterweissig/ros_pcdfilter-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## pcdfilter_pa

```
* bugfix (added laser_geometry)
* moved header from include/ to include/${project_name}
  also fixed related paths
* updated CMakeLists.txt (added install)
* updated license to 2017
* updated README.md
  Added general explanation and description from doxygen.h to readme.md
* added mainpage to doxygen documentation
  also removed filter description from service definition
* updated package.xml to format version 2
* minor changes to CMakeLists.txt
* updated git policies
* initial commit
* Contributors: Peter Weissig
```
