### PR TITLE
Adding muse_bldc_motor_drive to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7270,6 +7270,11 @@ repositories:
       url: https://bitbucket.org/crl/multisense_ros
       version: default
     status: developed
+  muse_bldc_motor_drive:
+    doc:
+      type: git
+      url: https://bitbucket.org/muserobotics/muse_ros_package
+      version: default
   mvsim:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7273,7 +7273,7 @@ repositories:
   muse_bldc_motor_drive:
     doc:
       type: git
-      url: https://bitbucket.org/muserobotics/muse_ros_package
+      url: https://bitbucket.org/muserobotics/muse_ros_package.git
       version: default
   mvsim:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7274,7 +7274,7 @@ repositories:
     doc:
       type: git
       url: https://bitbucket.org/muserobotics/muse_ros_package.git
-      version: default
+      version: master
   mvsim:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4366,6 +4366,11 @@ repositories:
       url: https://github.com/christianrauch/ros-multiwii.git
       version: master
     status: developed
+  muse_bldc_motor_drive:
+    doc:
+      type: git
+      url: https://bitbucket.org/muserobotics/muse_ros_package.git
+      version: master
   mvsim:
     doc:
       type: git


### PR DESCRIPTION
I'd like muse_bldc_motor_drive to be indexed and documented on ros.org.