### PR TITLE
marti_common: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6447,7 +6447,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 0.3.0-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `1.0.0-0`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.3.0-0`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_geometry_util

- No changes

## swri_image_util

```
* Create warp_image Nodelet (#446 <https://github.com/evenator/marti_common/issues/446>)
  Add a nodelet to swri_image util that applies a 3x3 transformation matrix to an image using cv::warpPerspective and publishes the resulting image.
* Contributors: Edward Venator
```

## swri_math_util

- No changes

## swri_nodelet

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

```
* Add support for boost::function callbacks to swri::Subscriber.
* Contributors: Elliot Johnson
```

## swri_rospy

- No changes

## swri_route_util

```
* Add route speed functions (#466 <https://github.com/evenator/marti_common/issues/466>)
  * Add visualization function for swri_route_util.
  * Add code to calculate max speeds based on curvature to swri_route_util.
  * Add speed/obstacle functionality to swri_route_util.
* Add extractSubroute function.
* Contributors: Elliot Johnson, elliotjo
```

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Increase delay before running tests.
* Integrate transformers as static classes instead of plug-ins.
* Add inverse transform implementation to transforms. (#464 <https://github.com/evenator/marti_common/issues/464>)
* Add tests for initialize_origin.py script (#457 <https://github.com/evenator/marti_common/issues/457>)
* Contributors: Edward Venator, Marc Alban
```

## swri_yaml_util

- No changes
