### PR TITLE
qt_gui_core: 0.3.6-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1913,7 +1913,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.3.5-0
+      version: 0.3.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.3.6-0`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.3.5-0`

## qt_dotgraph

```
* add dhood as maintainer (#101 <https://github.com/ros-visualization/qt_gui_core/issues/101>)
```

## qt_gui

```
* add dhood as maintainer (#101 <https://github.com/ros-visualization/qt_gui_core/issues/101>)
```

## qt_gui_app

```
* add dhood as maintainer (#101 <https://github.com/ros-visualization/qt_gui_core/issues/101>)
```

## qt_gui_cpp

```
* add dhood as maintainer (#101 <https://github.com/ros-visualization/qt_gui_core/issues/101>)
* add missing run_depend on TinyXML (#100 <https://github.com/ros-visualization/qt_gui_core/issues/100>)
* add TinyXML to target_link_libraries (#99 <https://github.com/ros-visualization/qt_gui_core/issues/99>)
```

## qt_gui_py_common

```
* add dhood as maintainer (#101 <https://github.com/ros-visualization/qt_gui_core/issues/101>)
```
