### PR TITLE
rtabmap: 0.13.2-2 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2982,7 +2982,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.13.2-1
+      version: 0.13.2-2
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap` to `0.13.2-2`:

- upstream repository: https://github.com/introlab/rtabmap.git
- release repository: https://github.com/introlab/rtabmap-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.13.2-1`
