### PR TITLE
universal_robot: 1.1.10-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15220,7 +15220,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/universal_robot-release.git
-      version: 1.1.9-0
+      version: 1.1.10-1
     source:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robot` to `1.1.10-1`:

- upstream repository: https://github.com/ros-industrial/universal_robot.git
- release repository: https://github.com/ros-industrial-release/universal_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.1.9-0`

## universal_robot

- No changes

## ur10_moveit_config

```
* Fix Deprecated warning in MoveIt: parameter moved into namespace 'trajectory_execution'
* Contributors: Dave Coleman
```

## ur3_moveit_config

```
* Fix Deprecated warning in MoveIt: parameter moved into namespace 'trajectory_execution'
* Contributors: Dave Coleman
```

## ur5_moveit_config

```
* Fix Deprecated warning in MoveIt: parameter moved into namespace 'trajectory_execution'
* Contributors: Dave Coleman
```

## ur_bringup

- No changes

## ur_description

- No changes

## ur_driver

- No changes

## ur_gazebo

```
* Remove dependency on ros_controllers metapackage.
  As per http://www.ros.org/reps/rep-0127.html, packages are not allowed to
  depend on metapackages.
* Contributors: Miguel Prada
```

## ur_kinematics

- No changes

## ur_msgs

- No changes
