### PR TITLE
pyros_test: 0.0.6-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1882,6 +1882,13 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: kinetic-devel
     status: maintained
+  pyros_test:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/asmodehn/pyros-test-release.git
+      version: 0.0.6-0
+    status: developed
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_test` to `0.0.6-0`:

- upstream repository: https://github.com/asmodehn/pyros-test.git
- release repository: https://github.com/asmodehn/pyros-test-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## pyros_test

```
* Merge pull request #5 <https://github.com/asmodehn/pyros-test/issues/5> from asmodehn/string_sub_node
  implementing a simple string_sub_node
* implementing a simple string_sub_node
* now able to name nodes via first command argument.
* Contributors: AlexV, alexv
```
