### PR TITLE
universal_robot: 1.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9202,6 +9202,32 @@ repositories:
       url: https://github.com/ros-geographic-info/unique_identifier.git
       version: master
     status: maintained
+  universal_robot:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/universal_robot.git
+      version: kinetic
+    release:
+      packages:
+      - universal_robot
+      - ur10_moveit_config
+      - ur3_moveit_config
+      - ur5_moveit_config
+      - ur_bringup
+      - ur_description
+      - ur_driver
+      - ur_gazebo
+      - ur_kinematics
+      - ur_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/universal_robot-release.git
+      version: 1.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros-industrial/universal_robot.git
+      version: kinetic-devel
+    status: developed
   uos_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robot` to `1.2.0-0`:

- upstream repository: https://github.com/ros-industrial/universal_robot.git
- release repository: https://github.com/ros-industrial-release/universal_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## universal_robot

- No changes

## ur10_moveit_config

```
* Fix Deprecated warning in MoveIt: parameter moved into namespace 'trajectory_execution'
* Contributors: Dave Coleman
```

## ur3_moveit_config

```
* Fix Deprecated warning in MoveIt: parameter moved into namespace 'trajectory_execution'
* Contributors: Dave Coleman
```

## ur5_moveit_config

```
* Fix Deprecated warning in MoveIt: parameter moved into namespace 'trajectory_execution'
* Contributors: Dave Coleman
```

## ur_bringup

- No changes

## ur_description

- No changes

## ur_driver

- No changes

## ur_gazebo

```
* Remove dependency on ros_controllers metapackage.
  As per http://www.ros.org/reps/rep-0127.html, packages are not allowed to
  depend on metapackages.
* Contributors: Miguel Prada
```

## ur_kinematics

```
* Fixup for MoveIt! Kinetic
* Contributors: Dave Coleman
```

## ur_msgs

- No changes
