### PR TITLE
catkin_pip: 0.2.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -237,6 +237,13 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: kinetic-devel
     status: maintained
+  catkin_pip:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/pyros-dev/catkin_pip-release.git
+      version: 0.2.2-0
+    status: developed
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pip` to `0.2.2-0`:

- upstream repository: https://github.com/pyros-dev/catkin_pip.git
- release repository: https://github.com/pyros-dev/catkin_pip-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## catkin_pip

```
* Merge pull request #123 <https://github.com/asmodehn/catkin_pip/issues/123> from yotabits/devel
  Added option NOSE_OPT to catkin_add_nosetests func
* Added option NOSE_OPT to catkin_add_nosetests func
  In order to use some specific option for nosetests we now have a NOSE_OPT
  parameter that allow to use some customs options for launching nosetests
  The same has been done for pytests with the param PYTEST_OPT
* Contributors: AlexV, Thomas
```
