### PR TITLE
rviz: 1.11.17-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6805,7 +6805,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.11.16-0
+      version: 1.11.17-0
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.11.17-0`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.11.16-0`

## rviz

```
* Add dhood as maintainer (#1133 <https://github.com/ros-visualization/rviz/issues/1133>)
* Fixed rendering of markers as reported in #1120 (#1132 <https://github.com/ros-visualization/rviz/issues/1132>)
* Contributors: William Woodall
```
