### PR TITLE
repository_name: 1.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6102,6 +6102,19 @@ repositories:
       url: https://github.com/ros-controls/realtime_tools.git
       version: kinetic-devel
     status: maintained
+  repository_name:
+    doc:
+      type: git
+      url: https://github.com/CPFL/Autoware.git
+      version: master
+    release:
+      packages:
+      - autoware_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/CPFL/Autoware-release.git
+      version: 1.4.0-0
+    status: developed
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `repository_name` to `1.4.0-0`:

- upstream repository: https://github.com/CPFL/Autoware.git
- release repository: https://github.com/CPFL/Autoware-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## autoware_msgs

- No changes
