### PR TITLE
cob_robots: 0.6.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1068,6 +1068,26 @@ repositories:
       url: https://github.com/ipa320/cob_perception_common.git
       version: indigo_dev
     status: developed
+  cob_robots:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_robots.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_default_robot_behavior
+      - cob_default_robot_config
+      - cob_hardware_config
+      - cob_moveit_config
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_robots-release.git
+      version: 0.6.7-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_robots.git
+      version: indigo_dev
+    status: maintained
   cob_substitute:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.6.7-0`:

- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cob_default_robot_behavior

```
* missed install tag
* setup cob4-8
* unify default behaviors
* remove pick behavior
* remove cob4-10 behavior
* update cob4-paul-stuttgart
* remove cob4-10
* remove cob4-1
* cob4-7 - update behavior script to move the arms
* manually fix changelog
* setup cob4-10
* Merge github.com:ipa320/cob_robots into indigo_dev
  Conflicts:
  cob_default_robot_behavior/CMakeLists.txt
* setup cob4-7
* Contributors: ipa-cob4-8, ipa-fxm, ipa-nhg, robot
```

## cob_default_robot_config

```
* add initial config for cob4-10
* add initial cob4-11 serodi config
* cob4-8 setup
* setup cob4-8
* removed unsafed positions
* update cob4-5 setup
* final cleanup
* finalize cob4-9
* Setup cob4-9
* added head for cob4-7
* update cob4-5 configs
* added head for cob4-5
* fxm change requests
* restructure cob_default_robot_config
* cob4-7 hardware updates
* update cob4-paul-stuttgart
* remove cob4-10
* remove sound buttons
* arm speed
* added vacuum gripper
* updated the arm configuration (topics, default vel) in cob_default_hardware_config
* remove cob4-1
* upgrade cob4-2
* remove unsupported robots - launch and config
* harmonize default robot config
* remove home button for head
* remove home button for head
* activate 3dof head
* use test_depends where applicable
* use cob_supported_robots_ROBOTLIST in dependent packages
* manually fix changelog
* setup cob4-10
* cob4-7 setup: final test
* added back_left and back_right
* arm speed
* added vacuum gripper
* updated the arm configuration (topics, default vel) in cob_default_hardware_config
* build torso with arms
* Merge github.com:ipa320/cob_robots into indigo_dev
  Conflicts:
  cob_default_robot_behavior/CMakeLists.txt
* setup cob4-7
* Contributors: Mathias Lüdtke, Richard Bormann, cob4-10, cob4-11, cob4-7, hannes, ipa-cob4-5, ipa-cob4-8, ipa-fxm, ipa-nhg, robot
```

## cob_hardware_config

```
* Update teleop.yaml
* add initial config for cob4-10
* add initial cob4-11 serodi config
* use cob4-b12 for paul-stuttgart
* use cob4-b2 instead of cob4-b7 for paul-ingolstadt
* cob4-8 setup
* renamed sensorring camera
* renamed sensorring camera
* setup cob4-8
* tune sensorring parameters for cob4-5 (kinect+sick sensor)
* revert docking distance_tolerance introduced in https://github.com/ipa320/cob_robots/commit/814d3947bd4c01098f509db98e92acd9fb40aea3
* update teleop config to init the head
* reset pc monitors
* reset hz monitor for cam3d
* local changes from cob4-7
* update cob4-5 setup
* merge
* invert right wheels and change ordering of config (needed after retuning and UM=2)
* steer_ctrl param handling
* final cleanup
* canopen config for raw3-3 base
* cleanup files
* finalize cob4-9
* remove obsolete scan_unifier parameter
* Setup cob4-9
* finalizing configs
* added head for cob4-7
* update cob4-5 configs
* added joint_states for the head
* added head for cob4-5
* larger data_skip for simulation
* pass camera settings to gazebo plugins
* parameterizable usb_cam
* added 10 Hz heartbeat to Schunk DCF
* adjust pc_monitor
* fxm change requests
* fixed path
* copy the rviz config file
* fix identantion
* rename display launch file
* added a launch file to display a urdf.xacro model
* remove obsolete files raw3-5
* remove obsolete rviz displays
* remove obsolete laser config files
* separate laser scanner from base
* fix typo
* restructure cob_hardware_config
* configuration via yaml file
* Stomp planner (#631 <https://github.com/ipa320/cob_robots/issues/631>)
  * merged stomp configuration with actual indigo_dev
  * controllers for moveit namespace corrected
  * stomp configuration for raw3-1 created and tested
  * few corrections before pull request
  * twist controller config for raw3-1
  * changes from pull request
  * new change from pull request
  * whole-body planning group: robot
  * stomp configuration for robot group
  * pull request changes
  * stomp plannning yaml file correct group names
  * twist controller config file updated to include input limits parameters
  * finalizing PR
* harmonize cob4-2 and cob4-7
* unify tests
* reduce station tolerance
* cob4-7 hardware updates
* renamed voltage_max to voltage_divider_factor
* update cartesian controller parameters
* disable head and sensorring for cob4-2
* read current from Elmos, add it to base joint states
* unified ros control base driver and controller config
* update cob4-paul-stuttgart
* remove cob4-10
* speedup docking process
* changed docker position
* Revert "added stuck_detector to bringup"
  This reverts commit 8c06a19ff64510837c9f127e3dc2d121c143972e.
* disable head
* changed Impedance-Controller Parameter for roboter
* Raw3 5 config for ros_canopen (#609 <https://github.com/ipa320/cob_robots/issues/609>)
  * Updated raw3-5 launch and description
  * changes for test raw3-5
  * config for raw 3-5 with ros_canopen
  * uncommenting code and optimizing neutral positions
  * delete .dae and .urdf for raw3-5
  * Cleanded files
  * changed diagnostics_analyzers to match with cob4 config
* change u_max to meet the measured values
* Update raw3-1.urdf.xacro
* Update raw3-1.urdf.xacro
* Update arm_controller.yaml
* set light parameters
* cleanup arm_controller
* fix diagnostics
* requested changes in pull request
* gripper macro name changed and prefix removed as argument
* make simulation work preliminarily
* added vacuum gripper
* adaptations to current configuration for order-picking
* undid old files from ipa-rmb
* update for raw3-1 torso driver configuration
* added arm in bringup, corrected torso mounting angle
* twist controller configuration for raw3-1
* added arm joint limits file
* Added controller for gazebo. Arm gripper removed
* Arm uncommented to be added in the URDF file
* do not specify num_cores for localhost
* added stuck_detector to bringup
* fixed camera down camera calibration for all robots
* disabled head and sensorring
* fixed camera down camera calibration
* updated phidgets config for raw3-3
* move gazebo_ros_control plugin
* use xacro --inorder
* remove cob4-2 leftover
* remove cob4-1
* fix cpu monitor
* upgrade cob4-2
* remove obsolete components and dependencies
* remove unsupported robots - launch and config
* Merge pull request #596 <https://github.com/ipa320/cob_robots/issues/596> from ipa-fmw/feature/bms_diagnostics
  enable bms in diagnostics
* enable bms in diagnostics
* activate 3dof head
* adapt diagnostics
* use latest xacro syntax
* limit for pc monitors
* new bms config
* [WIP] Use grouped low level components for simulation (#583 <https://github.com/ipa320/cob_robots/issues/583>)
  * refactored generic canopen&config into canopen_generic.launch
  * refactored base driver+config into canopen_base.launch
  * added components/cob4_head_camera.launch
  * added components/cam3d_openni2.launch
  * added components/cam3d_r200_rgbd.launch
  * introduce sim arg for components
  * use sim arg in robot.xml
  * remove nodes started within robot.xml from default_controllers_robot.launch
  * introducing legacy components
  * reorganize and sim toggle for more components
  * adjust cob4-1 to latest changes
  * use new structure for cob3-2
  * use new structure for cob3-6
  * use new structure for cob3-9
  * use new structure for cob4-2
  * use new structure for remaining cob4s
  * travis fixes
  * syntax styling
  * use new structure for raws
  * more travis fixes
  * harmonize old vs. new behavior cob4-1
  * guarantee same hw behavior as before
  * add flip argument
* use test_depends where applicable
* use cob_supported_robots_ROBOTLIST in dependent packages
* use additional sensorring argument
* updated BMS config with StatusRegister bits
* Merge pull request #565 <https://github.com/ipa320/cob_robots/issues/565> from ipa-fxm/separate_sensors_actors
  Separate sensors actors
* remove moveit_config files from cob_hardware_config
* upload semantic description using new moveit_config structure
* cob4-10 fixes
* manually fix changelog
* use unified torso xacro
* move sensors from torso xacro to robot xacro
* use unified sensorring xacro
* move sensors from sensorring xacro to robot xacro
* use unified head xacro
* move sensors from head xacro to robot xacro
* fix self-collision for twist control with cob3-6
* disable warning for wireless em stop bridged
* update velocity smoother parameters
* use same velocity smoother settings for all cob4
* smooth acceleration after emergency stop
* cleanup
* setup cob4-10
* cob4-7 setup: final test
* fake monitoring for simulation to work with msh scenario
* fix cob3-9 urdf
* added vacuum gripper
* adaptations to current configuration for order-picking
* increase load threshold
* added phidgets
* undid old files from ipa-rmb
* added arm in bringup, corrected torso mounting angle
* increase load threshold
* twist controller configuration for raw3-1
* added arm joint limits file
* Added controller for gazebo. Arm gripper removed
* fix image_flip to be compatible with head_cam kinematic
* simulation test
* Arm uncommented to be added in the URDF file
* Twist cartesian controller configuration files for cob3-6
* Twist controller configuration files for cob3-6
* realsense as default torso down camera
* build torso with arms
* Merge github.com:ipa320/cob_robots into indigo_dev
  Conflicts:
  cob_default_robot_behavior/CMakeLists.txt
* missing image_flip confog for cob4-5
* added head_cam frame to urdf
* Set enable_sounf to false
* setup cob4-7
* update for raw3-1 torso driver configuration
* Contributors: Andreea Tulbure, Benjamin Maidel, Bruno Brito, Felipe Garcia Lopez, Felix Messmer, Florian Weisshardt, Jannik Abbenseth, Mathias Lüdtke, Nadia Hammoudeh García, Richard Bormann, andreeatulbure, cob4-10, cob4-11, cob4-7, hannes, ipa-cob4-1, ipa-cob4-5, ipa-cob4-7, ipa-cob4-8, ipa-fmw, ipa-fxm, ipa-nhg, ipa-raw3-3, ipa-rmb, msh, robot
```

## cob_moveit_config

```
* switch back to default moveit_config for raw3-1
* Add configs file and update srdf to operate the robot with MoveIt!
* setup cob4-8
* updated the srdf model
* fix CONFIG_TEMPLATE in add_robot
* restructure moveit config
* restructure cob_hardware_config
* Stomp planner (#631 <https://github.com/ipa320/cob_robots/issues/631>)
  * merged stomp configuration with actual indigo_dev
  * controllers for moveit namespace corrected
  * stomp configuration for raw3-1 created and tested
  * few corrections before pull request
  * twist controller config for raw3-1
  * changes from pull request
  * new change from pull request
  * whole-body planning group: robot
  * stomp configuration for robot group
  * pull request changes
  * stomp plannning yaml file correct group names
  * twist controller config file updated to include input limits parameters
  * finalizing PR
* cob4-7 hardware updates
* remove cob4-10
* update collision matrix in moveit_config
* ompl planning file was fixed from last merge process
* update collision matrix in moveit configs
* remove cob4-1
* remove unsupported robots - launch and config
* [WIP] Use grouped low level components for simulation (#583 <https://github.com/ipa320/cob_robots/issues/583>)
  * refactored generic canopen&config into canopen_generic.launch
  * refactored base driver+config into canopen_base.launch
  * added components/cob4_head_camera.launch
  * added components/cam3d_openni2.launch
  * added components/cam3d_r200_rgbd.launch
  * introduce sim arg for components
  * use sim arg in robot.xml
  * remove nodes started within robot.xml from default_controllers_robot.launch
  * introducing legacy components
  * reorganize and sim toggle for more components
  * adjust cob4-1 to latest changes
  * use new structure for cob3-2
  * use new structure for cob3-6
  * use new structure for cob3-9
  * use new structure for cob4-2
  * use new structure for remaining cob4s
  * travis fixes
  * syntax styling
  * use new structure for raws
  * more travis fixes
  * harmonize old vs. new behavior cob4-1
  * guarantee same hw behavior as before
  * add flip argument
* move setup_assistant launch file
* adjust version + add to meta-package
* moved cob_moveit_config
* Contributors: Bruno Brito, Felix Messmer, MattiaRacca, ipa-bfb-sc, ipa-cob4-5, ipa-cob4-8, ipa-fxm, ipa-nhg
```
