### PR TITLE
cob_manipulation: 0.7.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -999,6 +999,30 @@ repositories:
       url: https://github.com/ipa320/cob_hand.git
       version: indigo_dev
     status: developed
+  cob_manipulation:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_manipulation.git
+      version: kinetic_release_candidate
+    release:
+      packages:
+      - cob_collision_monitor
+      - cob_grasp_generation
+      - cob_lookat_action
+      - cob_manipulation
+      - cob_moveit_bringup
+      - cob_moveit_interface
+      - cob_obstacle_distance_moveit
+      - cob_pick_place_action
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_manipulation-release.git
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_manipulation.git
+      version: kinetic_dev
+    status: maintained
   cob_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_manipulation` to `0.7.0-0`:

- upstream repository: https://github.com/ipa320/cob_manipulation.git
- release repository: https://github.com/ipa320/cob_manipulation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cob_collision_monitor

```
* c+11 support
* Contributors: ipa-fxm
```

## cob_grasp_generation

- No changes

## cob_lookat_action

- No changes

## cob_manipulation

```
* merge with indigo_release_candidate
* remove cob_kinematics
* Contributors: Richard Bormann, ipa-fxm
```

## cob_moveit_bringup

```
* remove stomp configuration
  Conflicts:
  .travis.rosinstall
* Contributors: ipa-fxm
```

## cob_moveit_interface

- No changes

## cob_obstacle_distance_moveit

```
* merge with indigo_release_candidate
* remove obsolete dependencies to cmake_modules
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_manipulation into kinetic_dev
* kinetic migration for cob_obstacle_distance_moveit
* fcl for kinetic
* Contributors: Richard Bormann, ipa-fxm
```

## cob_pick_place_action

```
* merge with indigo_release_candidate
* MoveGroup deprecation warning
* add_definition c++11
* shape_tools migration
* Contributors: Richard Bormann, ipa-fxm
```
