### PR TITLE
cob_simulation: 0.6.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1047,6 +1047,27 @@ repositories:
       url: https://github.com/ipa320/cob_perception_common.git
       version: indigo_dev
     status: developed
+  cob_simulation:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_simulation.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_bringup_sim
+      - cob_gazebo
+      - cob_gazebo_objects
+      - cob_gazebo_worlds
+      - cob_simulation
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_simulation-release.git
+      version: 0.6.8-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_simulation.git
+      version: indigo_dev
+    status: maintained
   cob_substitute:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1114,6 +1114,27 @@ repositories:
       url: https://github.com/ipa320/cob_robots.git
       version: indigo_dev
     status: maintained
+  cob_simulation:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_simulation.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_bringup_sim
+      - cob_gazebo
+      - cob_gazebo_objects
+      - cob_gazebo_worlds
+      - cob_simulation
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_simulation-release.git
+      version: 0.6.8-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_simulation.git
+      version: indigo_dev
+    status: maintained
   cob_substitute:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.6.8-0`:

- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cob_bringup_sim

```
* refactored the code and added retreating model while on circular motion
* provision for re-spawning the person object to the start, due to presence of obstacle
* use xacro --inorder
* allow single letter option for move_object
* rospy.sleep exception handling
* wait for models and cleanup
* launch argument world_name
* use exported robotlist and envlist
* manually fix changelog
* debug functionality
* continue motion if object is far away enough
* metavars for parser options
* introduce stop_objects list and stop_distance
* remove throttled
* add missing robots to robotlist
* added stopping of objects
* Contributors: fmw-ss, hannes, ipa-fxm
```

## cob_gazebo

```
* remove cob_controller_configuration_gazebo
* use exported robotlist and envlist
* use cob_bringup robot.xml in simulation
* manually fix changelog
* Empty launch file changed and empty urdf created
* wait parameter removed. it was not working when launching a empty world
* Contributors: Bruno Brito, ipa-fxm
```

## cob_gazebo_objects

```
* add station_charger
* correct marker radius
* add reflector_marker_round
* make reflector marker static
* use exported robotlist and envlist
* use latest xacro syntax
* manually fix changelog
* Contributors: ipa-fxm
```

## cob_gazebo_worlds

```
* rename IZS-carpark-top to izs-carpark-top
* add simulation for izs-carpark-top to cob_gazebo_worlds
* remove kitchen unit
* fix ipa-production-plant
* use xacro --inorder
* use xml suffix for non-standalone launch files
* rospy.sleep exception handling
* launch argument world_name
* use exported robotlist and envlist
* use latest xacro syntax
* handle ROSTimeMovedBackwardsException
* manually fix changelog
* add test for empty.urdf.xacro
* remove throttled
* simplify launch files
* conflict between empty launch files and other scenarios solved
* Empty launch file changed and empty urdf created
* Contributors: Bruno Brito, Jannik Abbenseth, ipa-fxm
```

## cob_simulation

```
* manually fix changelog
* Contributors: ipa-fxm
```
