### PR TITLE
nodelet_core: 1.9.12-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1528,7 +1528,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.9.11-0
+      version: 1.9.12-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.12-0`:

- upstream repository: https://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.9.11-0`

## nodelet

- No changes

## nodelet_core

- No changes

## nodelet_topic_tools

```
* fix exec_depend that are actually build_export_depends (#65 <https://github.com/ros/nodelet_core/issues/65>)
* Contributors: Mikael Arguedas
```
