### PR TITLE
ros_control: 0.12.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2207,7 +2207,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.11.5-0
+      version: 0.12.0-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.12.0-0`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.11.5-0`

## combined_robot_hw

- No changes

## combined_robot_hw_tests

- No changes

## controller_interface

- No changes

## controller_manager

- No changes

## controller_manager_msgs

- No changes

## controller_manager_tests

- No changes

## hardware_interface

- No changes

## joint_limits_interface

- No changes

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Add unit tests for new bidirectional joint interface providers
* Add bidirectional joint interface providers
* Add inverse transmission interfaces to TransmissionLoaderData
* Contributors: Jordan Lack
```
