### PR TITLE
fetch_ros: 0.7.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3161,6 +3161,7 @@ repositories:
       - fetch_calibration
       - fetch_depth_layer
       - fetch_description
+      - fetch_ikfast_plugin
       - fetch_maps
       - fetch_moveit_config
       - fetch_navigation
@@ -3169,7 +3170,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
-      version: 0.7.9-0
+      version: 0.7.12-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.7.12-0`:

- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.7.9-0`

## fetch_calibration

- No changes

## fetch_depth_layer

- No changes

## fetch_description

- No changes

## fetch_ikfast_plugin

- No changes

## fetch_maps

- No changes

## fetch_moveit_config

```
* add dependency for moveit
* Contributors: Michael Ferguson
```

## fetch_navigation

- No changes

## fetch_teleop

- No changes

## freight_calibration

- No changes
