### PR TITLE
Autoware: 1.4.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11,6 +11,23 @@ release_platforms:
   ubuntu:
   - xenial
 repositories:
+  Autoware:
+    doc:
+      type: git
+      url: https://github.com/CPFL/Autoware-Manuals.git
+      version: master
+    release:
+      packages:
+      - autoware_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/CPFL/Autoware-release.git
+      version: 1.4.0-1
+    source:
+      type: git
+      url: https://github.com/CPFL/Autoware.git
+      version: develop
+    status: developed
   abb:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `Autoware` to `1.4.0-1`:

- upstream repository: https://github.com/CPFL/Autoware.git
- release repository: https://github.com/CPFL/Autoware-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## autoware_msgs

- No changes
