### PR TITLE
hrpsys: 315.14.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2700,7 +2700,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/hrpsys-release.git
-      version: 315.12.0-0
+      version: 315.14.0-0
     source:
       type: git
       url: https://github.com/fkanehiro/hrpsys-base.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys` to `315.14.0-0`:

- upstream repository: https://github.com/fkanehiro/hrpsys-base.git
- release repository: https://github.com/tork-a/hrpsys-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `315.12.0-0`

## hrpsys

- No changes
