### PR TITLE
openslam_gmapping: 0.1.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1674,6 +1674,19 @@ repositories:
       url: https://github.com/ros-drivers/openni_launch.git
       version: indigo-devel
     status: maintained
+  openslam_gmapping:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/openslam_gmapping-release.git
+      version: 0.1.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/openslam_gmapping.git
+      version: master
+    status: end-of-life
+    status_description: cartographer should be the new standard
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openslam_gmapping` to `0.1.2-0`:

- upstream repository: https://github.com/ros-perception/openslam_gmapping
- release repository: https://github.com/ros-gbp/openslam_gmapping-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## openslam_gmapping

```
* better Windows compilation
  This is taken from #9 <https://github.com/ros-perception/openslam_gmapping/issues/9> which can now be closed.
* fix a few more graphics stuff for Qt5
* get GUI back in shape for those interested
* use srand instead of srand48
  srand48 is non-standard and we are using a seed that is an
  unsigned int so we might as well use srand
* Contributors: Vincent Rabaud
```
