### PR TITLE
Add dependency to python-naoqi-sdk

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -239,6 +239,8 @@ python-apparmor:
   debian: [python-apparmor]
   gentoo: ['sys-libs/libapparmor[python]']
   ubuntu: [python-apparmor]
+python-naoqi-sdk: 
+  ubuntu: [python-naoqi-sdk]  
 python-argcomplete:
   fedora: [python-argcomplete]
   gentoo: [dev-python/argcomplete]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -23,9 +23,7 @@ cppcheck-junit-pip:
       packages: [cppcheck-junit]
   ubuntu:
     pip:
-      packages: [cppcheck-junit]
-python-naoqi-sdk: 
-  ubuntu: [python-naoqi-sdk]      
+      packages: [cppcheck-junit]      
 cython:
   debian: [cython]
   fedora: [Cython]
@@ -1591,6 +1589,8 @@ python-mysqldb:
   fedora: [python-mysql]
   gentoo: [dev-python/mysqlclient]
   ubuntu: [python-mysqldb]
+python-naoqi-sdk: 
+  ubuntu: [python-naoqi-sdk
 python-netaddr:
   debian: [python-netaddr]
   fedora:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1589,8 +1589,8 @@ python-mysqldb:
   fedora: [python-mysql]
   gentoo: [dev-python/mysqlclient]
   ubuntu: [python-mysqldb]
-python-naoqi-sdk: 
-  ubuntu: [python-naoqi-sdk
+python-naoqi-sdk:
+  ubuntu: [python-naoqi-sdk]
 python-netaddr:
   debian: [python-netaddr]
   fedora:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -238,7 +238,9 @@ python-anyjson:
 python-apparmor:
   debian: [python-apparmor]
   gentoo: ['sys-libs/libapparmor[python]']
-  ubuntu: [python-apparmor]  
+  ubuntu: [python-apparmor] 
+python-naoqi-sdk: 
+  ubuntu: [python-naoqi-sdk]
 python-argcomplete:
   fedora: [python-argcomplete]
   gentoo: [dev-python/argcomplete]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -238,9 +238,7 @@ python-anyjson:
 python-apparmor:
   debian: [python-apparmor]
   gentoo: ['sys-libs/libapparmor[python]']
-  ubuntu: [python-apparmor] 
-python-naoqi-sdk: 
-  ubuntu: [python-naoqi-sdk]
+  ubuntu: [python-apparmor]
 python-argcomplete:
   fedora: [python-argcomplete]
   gentoo: [dev-python/argcomplete]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -238,9 +238,7 @@ python-anyjson:
 python-apparmor:
   debian: [python-apparmor]
   gentoo: ['sys-libs/libapparmor[python]']
-  ubuntu: [python-apparmor]
-python-naoqi-sdk: 
-  ubuntu: [python-naoqi-sdk]  
+  ubuntu: [python-apparmor]  
 python-argcomplete:
   fedora: [python-argcomplete]
   gentoo: [dev-python/argcomplete]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -23,7 +23,7 @@ cppcheck-junit-pip:
       packages: [cppcheck-junit]
   ubuntu:
     pip:
-      packages: [cppcheck-junit]      
+      packages: [cppcheck-junit]
 cython:
   debian: [cython]
   fedora: [Cython]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -24,6 +24,8 @@ cppcheck-junit-pip:
   ubuntu:
     pip:
       packages: [cppcheck-junit]
+python-naoqi-sdk: 
+  ubuntu: [python-naoqi-sdk]      
 cython:
   debian: [cython]
   fedora: [Cython]


### PR DESCRIPTION
python-naoqi-sdk is a pure python package to write remote programs for robots' NAOqi-OS.