### PR TITLE
moveit: 0.7.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6910,7 +6910,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.7.11-0
+      version: 0.7.12-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.7.12-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.7.11-0`

## moveit

```
* [fix][moveit_ros/planning] Support for MultiDoF only trajectories #553 <https://github.com/ros-planning/moveit/pull/553>
* [fix][moveit_core] segfault due to missing string format parameter. (#547 <https://github.com/ros-planning/moveit/issues/547>)
* [fix][moveit_core] doc-comment for robot_state::computeAABB (#516 <https://github.com/ros-planning/moveit/issues/516>)
* [fix][moveit_commander] numpy.ndarray indices bug (#563 <https://github.com/ros-planning/moveit/issues/563>, from #86 <https://github.com/ros-planning/moveit/issues/86>, #450 <https://github.com/ros-planning/moveit/issues/450>)
* [fix][moveit_ros_visualization] RobotStateVisualization: clear before load to avoid segfault #572 <https://github.com/ros-planning/moveit/pull/572>
* [enhancement][moveit_commander][moveit_ros][moveit_planners] Optional forced use of JointModelStateSpaceFactory (#541 <https://github.com/ros-planning/moveit/issues/541>)
* [enhancement][moveit_setup_assistant] support loading xacros that use Jade+ extensions on Indigo #540 <https://github.com/ros-planning/moveit/issues/540>
* Contributors: Christopher Schindlbeck, G.A. vd. Hoorn, Cyrille Morin, Martin Pecka, gavanderhoorn, henhenhen, v4hn
```

## moveit_commander

```
* [fix] numpy.ndarray indices bug (#563 <https://github.com/ros-planning/moveit/issues/563>, from #86 <https://github.com/ros-planning/moveit/issues/86>, #450 <https://github.com/ros-planning/moveit/issues/450>)
* Contributors: Christopher Schindlbeck
```

## moveit_controller_manager_example

- No changes

## moveit_core

```
* [fix] segfault due to missing string format parameter. (#547 <https://github.com/ros-planning/moveit/issues/547>)
* [fix] doc-comment for robot_state::computeAABB (#516 <https://github.com/ros-planning/moveit/issues/516>)
  The docstring says the format of the vector is (minx, miny, minz, maxx, maxy, maxz), but according to both the method's implementation and use in moveit, the format is rather (minx, maxx, miny, maxy, minz, maxz).
* Contributors: Martin Pecka, henhenhen
```

## moveit_fake_controller_manager

- No changes

## moveit_full

- No changes

## moveit_full_pr2

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_ompl

```
* [moveit_ros] [moveit_planners] Optional forced use of JointModelStateSpaceFactory (#541 <https://github.com/ros-planning/moveit/issues/541>)
  * Implements optional ompl_planning config parameter 'force_joint_model_state_space'.
  * Renames parameter to 'enforce_joint_model_state_space'.
  Expands workaround comment.
* Contributors: henhenhen
```

## moveit_plugins

- No changes

## moveit_ros

```
* Support for MultiDoF only trajectories
* RobotStateVisualization: clear before load to avoid segfault
  rviz::Robot deletes its complete SceneNode structure in the load() method.
  However, RobotStateVisualization::render_shapes_ keeps raw pointers
  to some of these nodes (the attached objects), so these should be cleared
  to avoid broken pointers.
  Additionally the order of clearing was bad: the attached objects should
  be removed first, and rviz::Robot only afterwards to avoid similar problems.
* fixed numpy.ndarray indices bug (from #86 <https://github.com/ros-planning/moveit/issues/86>) (#450 <https://github.com/ros-planning/moveit/issues/450>) (#563 <https://github.com/ros-planning/moveit/issues/563>)
* [moveit_planners] Optional forced use of JointModelStateSpaceFactory (#541 <https://github.com/ros-planning/moveit/issues/541>)
  * Implements optional ompl_planning config parameter 'force_joint_model_state_space'.
  * Renames parameter to 'enforce_joint_model_state_space'.
  Expands workaround comment.
* [moveit_core][moveit_planners] Fixing segfault due to missing string format parameter. (#547 <https://github.com/ros-planning/moveit/issues/547>)
* [moveit_core][moveit_planners] Merge pull request #540 <https://github.com/ros-planning/moveit/issues/540> from gavanderhoorn/msa_add_jade_xacro_enable_chkbox
  MSA: support loading xacros that use Jade+ extensions on Indigo
* [moveit_core][moveit_planners] setup_assistant: explain purpose of the 'Jade+ xacro' checkbox with tooltip.
* [moveit_core][moveit_planners] setup_assistant: only persist 'jade xacro' key if it's been set.
* [moveit_core][moveit_planners] setup_assistant: persist whether Jade+ xacro is needed when loading existing config.
* [moveit_core][moveit_planners] setup_assistant: support enabling Jade+ xacro in wizard.
  This allows loading xacros that make use of the extensions to xacro that were
  added in Jade and newer ROS releases on Indigo.
* [moveit_core][moveit_planners] Fixed doc-comment for robot_state::computeAABB (#516 <https://github.com/ros-planning/moveit/issues/516>)
  The docstring says the format of the vector is (minx, miny, minz, maxx, maxy, maxz), but according to both the method's implementation and use in moveit, the format is rather (minx, maxx, miny, maxy, minz, maxz).
* [moveit_core][moveit_planners] setup assistant: add use_gui param to demo.launch
  It bugged me for quite some time now that one has to edit the launch file
  just to be able to move the "real" robot around in demo mode.
  Thus I want to expose the option as a parameter in the launch file.
* Contributors: Christopher Schindlbeck, G.A. vd. Hoorn, Martin Pecka, Notou, gavanderhoorn, henhenhen, v4hn
```

## moveit_ros_benchmarks

- No changes

## moveit_ros_benchmarks_gui

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* [fix] Support for MultiDoF only trajectories #553 <https://github.com/ros-planning/moveit/pull/553>
* Contributors: Cyrille Morin
```

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* [fix] RobotStateVisualization: clear before load to avoid segfault #572 <https://github.com/ros-planning/moveit/pull/572>
* Contributors: v4hn
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_setup_assistant

```
* [enhancement] support loading xacros that use Jade+ extensions on Indigo #540 <https://github.com/ros-planning/moveit/issues/540>
* Contributors: G.A. vd. Hoorn, v4hn
```

## moveit_simple_controller_manager

- No changes
