### PR TITLE
ecl_tools: 0.61.7-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -437,6 +437,25 @@ repositories:
       url: https://github.com/ros/dynamic_reconfigure.git
       version: master
     status: maintained
+  ecl_tools:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: release/0.61-lunar
+    release:
+      packages:
+      - ecl_build
+      - ecl_license
+      - ecl_tools
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_tools-release.git
+      version: 0.61.7-0
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: devel
+    status: maintained
   ecto:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_tools` to `0.61.7-0`:

- upstream repository: https://github.com/stonier/ecl_tools.git
- release repository: https://github.com/yujinrobot-release/ecl_tools-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`
