### PR TITLE
pyros_utils: 0.1.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1882,6 +1882,13 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: kinetic-devel
     status: maintained
+  pyros_utils:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/pyros-dev/pyros-utils-release.git
+      version: 0.1.4-0
+    status: developed
   python_qt_binding:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1945,12 +1945,6 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: kinetic-devel
     status: maintained
-  pyros_utils:
-    release:
-      tags:
-        release: release/lunar/{package}/{version}
-      url: https://github.com/pyros-dev/pyros-utils-release.git
-      version: 0.1.4-0
   pyros_test:
     release:
       tags:
@@ -1958,6 +1952,12 @@ repositories:
       url: https://github.com/pyros-dev/pyros-test-release.git
       version: 0.0.6-1
     status: developed
+  pyros_utils:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/pyros-dev/pyros-utils-release.git
+      version: 0.1.4-0
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_utils` to `0.1.4-0`:

- upstream repository: https://github.com/pyros-dev/pyros-utils.git
- release repository: https://github.com/pyros-dev/pyros-utils-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## pyros_utils

```
* catkin > 0.2
* Contributors: alexv
```
