### PR TITLE
moveit: 0.9.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4233,7 +4233,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.9.8-0
+      version: 0.9.9-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.9.9-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.9.8-0`

## moveit

```
* Fixation in the contained packages:
  * [fix][moveit_ros_planning] Change getCurrentExpectedTrajectory index so collision detection is still performed even if the path timing is not known (#550 <https://github.com/ros-planning/moveit/issues/550>)
  * [fix][moveit_ros_planning] check plan size for plan length=0 #535 <https://github.com/ros-planning/moveit/issues/535>
  * [fix][moveit_ros_planning] ros_error macro name (#544 <https://github.com/ros-planning/moveit/issues/544>)
  * [fix][moveit_ros_visualization] RobotStateVisualization: clear before load to avoid segfault #572 <https://github.com/ros-planning/moveit/pull/572>
  * [fix][setup_assistant] Fix for lunar (#542 <https://github.com/ros-planning/moveit/issues/542>) (fix #506 <https://github.com/ros-planning/moveit/issues/506>)
  * [fix][moveit_core] segfault due to missing string format parameter. (#547 <https://github.com/ros-planning/moveit/issues/547>)
  * [fix][moveit_core] doc-comment for robot_state::computeAABB (#516 <https://github.com/ros-planning/moveit/issues/516>)
* Improvement in the contained packages:
  * [improve][moveit_ros_planning] Chomp use PlanningScene (#546 <https://github.com/ros-planning/moveit/issues/546>) to partially address #305 <https://github.com/ros-planning/moveit/issues/305>
  * [improve][moveit_ros_control_interface] add backward compatibility patch for indigo (#551 <https://github.com/ros-planning/moveit/issues/551>)
  * [improve][moveit_planners_ompl] Optional forced use of JointModelStateSpaceFactory (#541 <https://github.com/ros-planning/moveit/issues/541>)
  * [improve][moveit_kinematics] Modify ikfast_template for getPositionIK single solution results (#537 <https://github.com/ros-planning/moveit/issues/537>)
* Contributors: Cyrille Morin, henhenhen, Martin Pecka, Simon Schmeisser, Michael Goerner, Mikael Arguedas, nsnitish
```

## moveit_commander

- No changes

## moveit_controller_manager_example

- No changes

## moveit_core

```
* [fix][moveit_core] segfault due to missing string format parameter. (#547 <https://github.com/ros-planning/moveit/issues/547>)
* [fix][moveit_core] doc-comment for robot_state::computeAABB (#516 <https://github.com/ros-planning/moveit/issues/516>)
* Contributors: Martin Pecka, henhenhen
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

```
* [improve] Modify ikfast_template for getPositionIK single solution results (#537 <https://github.com/ros-planning/moveit/issues/537>)
* Contributors: nsnitish
```

## moveit_planners

- No changes

## moveit_planners_ompl

```
* [improve][moveit_planners_ompl] Optional forced use of JointModelStateSpaceFactory (#541 <https://github.com/ros-planning/moveit/issues/541>)
* Contributors: henhenhen
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

```
* [improve] add backward compatibility patch for indigo (#551 <https://github.com/ros-planning/moveit/issues/551>)
* Contributors: Michael Görner
```

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* [fix] Change getCurrentExpectedTrajectory index so collision detection is still performed even if the path timing is not known (#550 <https://github.com/ros-planning/moveit/issues/550>)
* [fix] Support for MultiDoF only trajectories #553 <https://github.com/ros-planning/moveit/pull/553>
* [fix] ros_error macro name (#544 <https://github.com/ros-planning/moveit/issues/544>)
* [fix] check plan size for plan length=0 #535 <https://github.com/ros-planning/moveit/issues/535>
* Contributors: Cyrille Morin, Michael Görner, Mikael Arguedas, Notou, Unknown
```

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* [fix] RobotStateVisualization: clear before load to avoid segfault #572 <https://github.com/ros-planning/moveit/pull/572>
* Contributors: v4hn
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_setup_assistant

```
* [setup_assistant] Fix for lunar (#542 <https://github.com/ros-planning/moveit/issues/542>) (fix #506 <https://github.com/ros-planning/moveit/issues/506>)
* Contributors: Dave Coleman
```

## moveit_simple_controller_manager

- No changes
