### PR TITLE
urdf_geometry_parser: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9335,7 +9335,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/urdf_geometry_parser-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/ros-controls/urdf_geometry_parser.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_geometry_parser` to `0.0.3-0`:

- upstream repository: https://github.com/ros-controls/urdf_geometry_parser.git
- release repository: https://github.com/ros-gbp/urdf_geometry_parser-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.2-0`

## urdf_geometry_parser

```
* add travis config, based on industrial_ci
* Make sure to include urdfdom_compatibility.h.
  This ensures that urdf_geometry_parser will build on all distros
  (including older Debian Jessie).
  Signed-off-by: Chris Lalancette <mailto:clalancette@osrfoundation.org>
* Contributors: Bence Magyar, Chris Lalancette, Mathias Lüdtke
```
