### PR TITLE
cost_map: 0.3.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2155,7 +2155,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/stonier/cost_map-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/stonier/cost_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cost_map` to `0.3.2-0`:

- upstream repository: https://github.com/stonier/cost_map.git
- release repository: https://github.com/stonier/cost_map-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.3.1-0`

## cost_map_ros

```
* refactor includes against grid_map_costmap_2d changes
* new convenience constructor with nodehandle
```
