### PR TITLE
fzi_icl_core: 1.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2096,7 +2096,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core-release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fzi_icl_core` to `1.0.6-0`:

- upstream repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core
- release repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.5-0`

## fzi_icl_core

```
* added external tinyxml as dependency
* Contributors: Felix Mauch
```
