### PR TITLE
navigation: 1.15.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1522,7 +1522,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.14.0-0
+      version: 1.15.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.15.0-0`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.14.0-0`

## amcl

```
* Reference Issue #592 <https://github.com/ros-planning/navigation/issues/592> Added warning to AMCL when map is published on ... (#604 <https://github.com/ros-planning/navigation/issues/604>)
* rebase fixups
* convert packages to format2
* recompute cluster stat when force_publication
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* amcl: fix compilation with gcc v7
* Added deps to amcl costmap_2d move_base (#512 <https://github.com/ros-planning/navigation/issues/512>)
* fix order of parameters (closes #553 <https://github.com/ros-planning/navigation/issues/553>)
* Fix potential string overflow and resource leak
* Contributors: Dmitry Rozhkov, Laurent GEORGE, Martin Günther, Michael Ferguson, Mikael Arguedas, Peter Harliman Liem, mryellow, vik748
```

## base_local_planner

```
* set message_generation build and runtime dependency
* convert packages to format2
* cleaner logic, fixes #156 <https://github.com/ros-planning/navigation/issues/156>
* Merge pull request #596 <https://github.com/ros-planning/navigation/issues/596> from ros-planning/lunar_548
* Add cost function to prevent unnecessary spinning
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* add missing deps on libpcl
* import only PCL common
* pcl proagate -lQt5::Widgets flag so we need to find_package Qt5Widgets (#578 <https://github.com/ros-planning/navigation/issues/578>)
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* remove GCC warnings
* Contributors: Lukas Bulwahn, Martin Günther, Michael Ferguson, Mikael Arguedas, Morgan Quigley, Vincent Rabaud, lengly
```

## carrot_planner

```
* convert packages to format2
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Martin Günther, Mikael Arguedas, Vincent Rabaud
```

## clear_costmap_recovery

```
* convert packages to format2
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* import only PCL common
* remove GCC warnings
* Contributors: Martin Günther, Mikael Arguedas, Vincent Rabaud
```

## costmap_2d

```
* Added parameter for allowing inflation in unknown cells (#564 <https://github.com/ros-planning/navigation/issues/564>)
* Inflation Layer protected members and virtual computeCost [ABI BREAKING]
* Fix for #517 <https://github.com/ros-planning/navigation/issues/517>: create a getRobotPose method on move_base instead of using that on the costmaps
* don't update costs if inflation radius is zero
* rebase fixups
* convert packages to format2
* Speedup (~60%) inflation layer update (#525 <https://github.com/ros-planning/navigation/issues/525>)
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* add missing deps on libpcl
* import only PCL common
* pcl proagate -lQt5::Widgets flag so we need to find_package Qt5Widgets (#578 <https://github.com/ros-planning/navigation/issues/578>)
* Added deps to amcl costmap_2d move_base (#512 <https://github.com/ros-planning/navigation/issues/512>)
* remove GCC warnings
* Fix CMake warnings
* renamed targets for message generation (gencpp -> generate_messages_cpp) in order to avoid warnings for non-existing target dependencies
* Fixed race condition with costmaps
* Merge pull request #491 <https://github.com/ros-planning/navigation/issues/491> from alexhenning/kinetic-inflation-fix
* Fixed sign error in inflation layer
* Adds warning when a layer shrinks the bounds
* Fixed bug with inflation layer that caused underinflation
* Fixed bug with artifacts when not current
* Fix bug with inflation artifacts being left behind
* Fixes issue with costmaps shearing
* Made costmap publishing truly lazy
* Contributors: Alex Henning, Alexander Reimann, Hidde Wieringa, Jorge Santos, Jorge Santos Simón, Martin Günther, Michael Ferguson, Mikael Arguedas, Stephan Opfer, Vincent Rabaud, mryellow
```

## dwa_local_planner

```
* convert packages to format2
* Add cost function to prevent unnecessary spinning
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* import only PCL common
* remove GCC warnings
* Fix CMake warnings
* Contributors: Martin Günther, Mikael Arguedas, Morgan Quigley, Vincent Rabaud
```

## fake_localization

```
* convert packages to format2
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Martin Günther, Mikael Arguedas, Vincent Rabaud
```

## global_planner

```
* convert packages to format2
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Fix to increment 'cycle' in while loop (#546 <https://github.com/ros-planning/navigation/issues/546>)
* Fix to check index value before accessing to element of potential array (#547 <https://github.com/ros-planning/navigation/issues/547>)
* Set frame_id and stamp on Path message even if path is not found. (#533 <https://github.com/ros-planning/navigation/issues/533>)
* Contributors: Junya Hayashi, Martin Günther, Mikael Arguedas
```

## map_server

```
* Fix compiler warning for GCC 8.
* convert packages to format2
* Merge pull request #596 <https://github.com/ros-planning/navigation/issues/596> from ros-planning/lunar_548
* refactor to not use tf version 1 (#561 <https://github.com/ros-planning/navigation/issues/561>)
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Merge pull request #560 <https://github.com/ros-planning/navigation/issues/560> from wjwwood/map_server_fixup_cmake
* update to support Python 2 and 3 (#559 <https://github.com/ros-planning/navigation/issues/559>)
* remove duplicate and unreferenced file (#558 <https://github.com/ros-planning/navigation/issues/558>)
* remove trailing whitespace from map_server package (#557 <https://github.com/ros-planning/navigation/issues/557>)
* fix cmake use of yaml-cpp and sdl / sdl-image
* Fix CMake warnings
* Contributors: Hunter L. Allen, Martin Günther, Michael Ferguson, Mikael Arguedas, Vincent Rabaud, William Woodall
```

## move_base

```
* Add a max_planning_retries parameter to move_base [kinetic] (#539 <https://github.com/ros-planning/navigation/issues/539>)
* Fix for #517 <https://github.com/ros-planning/navigation/issues/517>: create a getRobotPose method on move_base instead of using that on the costmaps
* Fixed deadlock when changing global planner
* rebase fixups
* convert packages to format2
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Added deps to amcl costmap_2d move_base (#512 <https://github.com/ros-planning/navigation/issues/512>)
* Fix CMake warnings
* move_base: Add move_base_msgs to find_package.
* Contributors: Jorge Santos, Jorge Santos Simón, Maarten de Vries, Martin Günther, Mikael Arguedas, Vincent Rabaud, mryellow, ne0
```

## move_slow_and_clear

```
* convert packages to format2
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* import only PCL common
* address gcc6 build error
* remove GCC warnings
* Fix CMake warnings
* Contributors: Lukas Bulwahn, Martin Günther, Mikael Arguedas, Vincent Rabaud
```

## nav_core

```
* convert packages to format2
* makePlan overload must return.
* Contributors: Eric Tappan, Mikael Arguedas
```

## navfn

```
* convert packages to format2
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* import only PCL common
* port #549 <https://github.com/ros-planning/navigation/issues/549> (in alphabetical order)
* address gcc6 build error
* remove GCC warnings
* Contributors: Lukas Bulwahn, Martin Günther, Michael Ferguson, Mikael Arguedas, Vincent Rabaud
```

## navigation

```
* convert packages to format2
* Contributors: Mikael Arguedas
```

## robot_pose_ekf

```
* convert packages to format2
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Initialization of filter with GPS and odometry.
* Contributors: Martin Günther, Mikael Arguedas, Vincent Rabaud, azaganidis
```

## rotate_recovery

```
* convert packages to format2
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Martin Günther, Mikael Arguedas, Vincent Rabaud
```

## voxel_grid

```
* convert packages to format2
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Martin Günther, Mikael Arguedas
```
