### PR TITLE
fzi_icl_can: 1.0.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3429,7 +3429,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can-release.git
-      version: 1.0.9-0
+      version: 1.0.10-0
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fzi_icl_can` to `1.0.10-0`:

- upstream repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.9-0`

## fzi_icl_can

```
* find system tinyxml
* remove unreachable error codes from parsing
* Contributors: Felix Mauch
```
