### PR TITLE
navigation: 1.14.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4681,7 +4681,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.14.0-0
+      version: 1.14.1-0
     source:
       test_commits: false
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.14.1-0`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.14.0-0`

## amcl

```
* Reference Issue #592 <https://github.com/ros-planning/navigation/issues/592> Added warning to AMCL when map is published on ... (#604 <https://github.com/ros-planning/navigation/issues/604>)
* recompute cluster stat when force_publication
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* amcl: fix compilation with gcc v7
* Added deps to amcl costmap_2d move_base (#512 <https://github.com/ros-planning/navigation/issues/512>)
* fix order of parameters (closes #553 <https://github.com/ros-planning/navigation/issues/553>)
* Fix potential string overflow and resource leak
* Contributors: Dmitry Rozhkov, Laurent GEORGE, Martin Günther, Michael Ferguson, Peter Harliman Liem, mryellow, vik748
```

## base_local_planner

```
* Merge pull request #570 <https://github.com/ros-planning/navigation/issues/570> from codebot/add_twirling_cost_function
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Add cost function to prevent unnecessary spinning
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* remove GCC warnings
* Contributors: Lukas Bulwahn, Martin Günther, Michael Ferguson, Morgan Quigley, Vincent Rabaud, lengly
```

## carrot_planner

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Martin Günther, Vincent Rabaud
```

## clear_costmap_recovery

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* remove GCC warnings
* Contributors: Martin Günther, Vincent Rabaud
```

## costmap_2d

```
* Added parameter for allowing inflation in unknown cells (#564 <https://github.com/ros-planning/navigation/issues/564>)
* don't update costs if inflation radius is zero
* Speedup (~60%) inflation layer update (#525 <https://github.com/ros-planning/navigation/issues/525>)
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Added deps to amcl costmap_2d move_base (#512 <https://github.com/ros-planning/navigation/issues/512>)
* remove GCC warnings
* Fix CMake warnings
* renamed targets for message generation (gencpp -> generate_messages_cpp) in order to avoid warnings for non-existing target dependencies
* Fixed race condition with costmaps
* Merge pull request #491 <https://github.com/ros-planning/navigation/issues/491> from alexhenning/kinetic-inflation-fix
* Fixed sign error in inflation layer
* Adds warning when a layer shrinks the bounds
* Fixed bug with inflation layer that caused underinflation
* Fixed bug with artifacts when not current
* Fix bug with inflation artifacts being left behind
* Fixes issue with costmaps shearing
* Made costmap publishing truly lazy
* Contributors: Alex Henning, Hidde Wieringa, Jorge Santos Simón, Martin Günther, Michael Ferguson, Stephan Opfer, Vincent Rabaud, mryellow
```

## dwa_local_planner

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Add cost function to prevent unnecessary spinning
* remove GCC warnings
* Contributors: Martin Günther, Morgan Quigley, Vincent Rabaud
```

## fake_localization

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Martin Günther, Vincent Rabaud
```

## global_planner

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Fix to increment 'cycle' in while loop (#546 <https://github.com/ros-planning/navigation/issues/546>)
* Fix to check index value before accessing to element of potential array (#547 <https://github.com/ros-planning/navigation/issues/547>)
* Set frame_id and stamp on Path message even if path is not found. (#533 <https://github.com/ros-planning/navigation/issues/533>)
* Contributors: Junya Hayashi, Martin Günther
```

## map_server

```
* refactor to not use tf version 1 (#561 <https://github.com/ros-planning/navigation/issues/561>)
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Merge pull request #560 <https://github.com/ros-planning/navigation/issues/560> from wjwwood/map_server_fixup_cmake
* update to support Python 2 and 3 (#559 <https://github.com/ros-planning/navigation/issues/559>)
* remove duplicate and unreferenced file (#558 <https://github.com/ros-planning/navigation/issues/558>)
* remove trailing whitespace from map_server package (#557 <https://github.com/ros-planning/navigation/issues/557>)
* fix cmake use of yaml-cpp and sdl / sdl-image
* Contributors: Martin Günther, Michael Ferguson, Vincent Rabaud, William Woodall
```

## move_base

```
* Add a max_planning_retries parameter to move_base [kinetic] (#539 <https://github.com/ros-planning/navigation/issues/539>)
* Fixed deadlock when changing global planner
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Added deps to amcl costmap_2d move_base (#512 <https://github.com/ros-planning/navigation/issues/512>)
* move_base: Add move_base_msgs to find_package.
* Contributors: Jorge Santos Simón, Maarten de Vries, Martin Günther, Vincent Rabaud, mryellow, ne0
```

## move_slow_and_clear

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* address gcc6 build error
* remove GCC warnings
* Contributors: Lukas Bulwahn, Martin Günther, Vincent Rabaud
```

## nav_core

```
* makePlan overload must return.
* Contributors: Eric Tappan
```

## navfn

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* port #549 <https://github.com/ros-planning/navigation/issues/549> (in alphabetical order)
* address gcc6 build error
* remove GCC warnings
* Contributors: Lukas Bulwahn, Martin Günther, Michael Ferguson, Vincent Rabaud
```

## navigation

- No changes

## robot_pose_ekf

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Initialization of filter with GPS and odometry.
* Contributors: Martin Günther, Vincent Rabaud, azaganidis
```

## rotate_recovery

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Martin Günther, Vincent Rabaud
```

## voxel_grid

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Martin Günther
```
