### PR TITLE
Adding enblend and hugin-tools to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -605,6 +605,11 @@ emacs:
   fedora: [emacs]
   gentoo: [virtual/emacs]
   ubuntu: [emacs]
+enblend:
+  debian: [enblend]
+  fedora: [enblend]
+  gentoo: [media-gfx/enblend]
+  ubuntu: [enblend]
 enet:
   debian: [libenet-dev]
   fedora: [enet-devel]
@@ -1122,6 +1127,10 @@ htop:
   fedora: [htop]
   gentoo: [sys-process/htop]
   ubuntu: [htop]
+hugin-tools:
+  debian: [hugin-tools]
+  fedora: [hugin-base]
+  ubuntu: [hugin-tools]
 i2c-tools:
   debian: [i2c-tools]
   fedora: [i2c-tools]


### PR DESCRIPTION
Packages for stitching panoramas needed by http://wiki.ros.org/hugin_panorama

* enblend - Image blending tool

https://packages.gentoo.org/packages/media-gfx/enblend
https://apps.fedoraproject.org/packages/enblend
https://packages.debian.org/stretch/enblend
https://packages.ubuntu.com/xenial/enblend

* hugin-tools - Panorama photo stitcher commandline tools

https://packages.ubuntu.com/xenial/hugin-tools
https://packages.debian.org/stretch/hugin-tools
https://apps.fedoraproject.org/packages/hugin-base