### PR TITLE
hugin_panorama: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2706,6 +2706,21 @@ repositories:
       url: https://github.com/fkanehiro/hrpsys-base.git
       version: master
     status: developed
+  hugin_panorama:
+    doc:
+      type: git
+      url: https://github.com/danielsnider/hugin_panorama.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/danielsnider/hugin_panorama-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/danielsnider/hugin_panorama.git
+      version: master
+    status: maintained
   humanoid_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hugin_panorama` to `0.1.0-0`:

- upstream repository: https://github.com/danielsnider/hugin_panorama.git
- release repository: https://github.com/danielsnider/hugin_panorama-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## hugin_panorama

```
* First release
```
