### PR TITLE
fetch_pbd: 0.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3145,7 +3145,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics/fetch_pbd-release.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_pbd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_pbd` to `0.0.8-0`:

- upstream repository: https://github.com/fetchrobotics/fetch_pbd.git
- release repository: https://github.com/fetchrobotics/fetch_pbd-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.0.7-0`

## fetch_arm_control

```
* Namespace topics and services, some marker fixes
* Change World node to C++ and add Grasp suggestion integration
* Contributors: Sarah Elliott
```

## fetch_pbd_interaction

```
* Update README and CMakeLists
* Do reachability check for ref_type PREVIOUS_TARGET
* Interface improvements: update markers more efficiently, etc
* Implemented pre-conditions for primitives
* Interface improvements: object labels, marker fixes
* Namespace topics and services, some marker fixes
* Install specific version of polymer-cli to not get issues when polymer changes
* Change World node to C++ and add Grasp suggestion integration
* Contributors: Sarah Elliott
```

## fetch_social_gaze

```
* Do reachability check for ref_type PREVIOUS_TARGET
* Namespace topics and services, some marker fixes
* Contributors: Sarah Elliott
```
