### PR TITLE
rtmros_common: 1.4.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7962,6 +7962,29 @@ repositories:
       url: https://github.com/tork-a/rtctree-release.git
       version: 3.0.1-0
     status: developed
+  rtmros_common:
+    doc:
+      type: git
+      url: https://github.com/start-jsk/rtmros_common.git
+      version: master
+    release:
+      packages:
+      - hrpsys_ros_bridge
+      - hrpsys_tools
+      - openrtm_ros_bridge
+      - openrtm_tools
+      - rosnode_rtc
+      - rtmbuild
+      - rtmros_common
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/rtmros_common-release.git
+      version: 1.4.0-1
+    source:
+      type: git
+      url: https://github.com/start-jsk/rtmros_common.git
+      version: master
+    status: developed
   rtshell:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.4.0-1`:

- upstream repository: https://github.com/start-jsk/rtmros_common.git
- release repository: https://github.com/tork-a/rtmros_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## hrpsys_ros_bridge

```
* display error message when body->sensor(j, i) is null (#1014 <https://github.com/start-jsk/rtmros_common/issues/1014>)
* sensor_ros_bridge_connect.py : add more debug message (#1015 <https://github.com/start-jsk/rtmros_common/issues/1015>)
* Update AutoBalancer and ReferenceForceUpdater euslisp method symbols (#1026 <https://github.com/start-jsk/rtmros_common/issues/1026>)
  * [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Supprot :FootOriginExtMoment for RFU methods.
  * [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Support UseForceMode setting as euslisp symbol in :set-auto-balancer-param.
* fix code to run both Indido and Kinetic (#1025 <https://github.com/start-jsk/rtmros_common/issues/1025>)
  * /test/test-samplerobot-hcf.launch: increase time-limit to 600
  * test/{test-samplerobot.py,test-pa10.py} support both pr2_controllers_msgs and controllr_msgs
  * src/hrpsys_ros_bridge/hrpsys_dashboard.py: fix for qt5
  * add USE_PR2_CONTROLLERS_MSGS definition
  * CMakeLists.txt : we do not use pr2_msgs on build time
  * CMakeLists.txt : remove code to download wet pr2_controllers_msgs for groovy
* Support stride parameter with different length (#1022 <https://github.com/start-jsk/rtmros_common/issues/1022>)
  * [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Support stride_parameter of different length
  * [hrpsys_ros_bridge/test/hrpsys-samples/samplerobot-auto-balancer.l] Add test to check stride parameter 4 and 6
* [HrpsysSeqStateROSBridge] fix stamp of joint_state. add stamp after reading m_rsangle (#1019 <https://github.com/start-jsk/rtmros_common/issues/1019>)
  * [HrpsysSeqStateROSBridge] fix stamp of joint_state. add stamp after reading m_rsangle
* [HrpsysSeqStateROSBridge] remove subtraction magic number (#1013 <https://github.com/start-jsk/rtmros_common/issues/1013>)
  * [HrpsysSeqStateROSBridge] remove subtraction magic number
* Support argumen t for setting duration of calibration. For :remove-xx methods, 8.0 by default[s]. For :reset-xx methods, 0.1[s] by default for compatibility (#1011 <https://github.com/start-jsk/rtmros_common/issues/1011>)
  * [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Support argument for setting duration of calibration. For :remove-xx methods, 8.0 by default[s]. For :reset-xx methods, 0.1[s] by default for compatibility
* Add new methods for :remove-force-sensor-offset using RMFO (#1010 <https://github.com/start-jsk/rtmros_common/issues/1010>)
  * [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Add new methods for :remove-force-sensor-offset using RMFO. Add warning message for deprecated remove-force methods.
* Update euslisp hrpsysbase samples (#1009 <https://github.com/start-jsk/rtmros_common/issues/1009>)
  * [hrpsys_ros_bridge/test/hrpsys-samples] Add README for Euslisp hrpsys example basically copied from ros wiki (http://wiki.ros.org/rtmros_common/Tutorials/WorkingWithEusLisp)
  * [hrpsys_ros_bridge/test/hrpsys-samples/samplerobot-carry-object.l] Update carry demo euslisp sample.
  * [hrpsys_ros_bridge/test/hrpsys-samples/samplerobot-stabilizer.l] Update stabilizer euslisp sample according to hrpsys-base stabilizer sample update.
* Fix bug of sample4leg robot end-coords setting for arms. (#1008 <https://github.com/start-jsk/rtmros_common/issues/1008>)
  * [hrpsys_ros_bridge/models/sample4legrobot.yaml] Fix bug of sample4legrobot end-coords setting for arms.
* Update project generator and refforce (#1007 <https://github.com/start-jsk/rtmros_common/issues/1007>)
  * [hrpsys_ros_bridge/euslisp] Update README for openhrp-project-generator
  * [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Fix orientation for openhrp-project-generator
  * [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Update for object turnaround detection to use initial ref forces
  * [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Update dump function for openhrp project generator. Use openhrp-project-generator in openhrp3 package instead of _gen_project.launch
* Add forgotten update for robot.launch (https://github.com/start-jsk/rtmros_common/pull/1004) (#1005 <https://github.com/start-jsk/rtmros_common/issues/1005>)
  * [hrpsys_ros_bridge/scripts/default_robot.launch.in] Add forgotten update in https://github.com/start-jsk/rtmros_common/pull/1004. Add USE_XXX of under-development RTCs for robot.launch such as samplerobot.launch to pass arguments to robot_ros_bridge.launch
* set USE_UNSTABLE_RTC as not all unstable rtc defiend in hrpsys_config.py, just for basic walking test, other latest development rtc is passed by arg (#1004 <https://github.com/start-jsk/rtmros_common/issues/1004>)
  * set USE_UNSTABLE_RTC as not getUnstableRTC defined in hrpsys_config.py, it is for a basic walking test, other latest development rtc is passed by arg from test_samplerobot_euslisp_unittests.launch
  * [hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch,hrpsys_ros_bridge/scripts/default_robot_ros_bridge.launch.in,hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l,hrpsys_tools/launch/hrpsys.launch] Update for ObjectTurnaroundDetector RTC. add USE_REFERENCEFORCEUDPATER and USE_OBJECTCONTACTTURNAROUNDDETECTOR.
* Contributors: Kei Okada, Shunichi Nozawa, Yohei Kakiuchi
```

## hrpsys_tools

```
* fix code to run both Indido and Kinetic (#1025 <https://github.com/start-jsk/rtmros_common/issues/1025>)
  * hrpsys_tools/test/test-pa10.test: increase sleep time to 10
* set USE_UNSTABLE_RTC as not all unstable rtc defiend in hrpsys_config.py, just for basic walking test, other latest development rtc is passed by arg (#1004 <https://github.com/start-jsk/rtmros_common/issues/1004>)
  * [hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch,hrpsys_ros_bridge/scripts/default_robot_ros_bridge.launch.in,hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l,hrpsys_tools/launch/hrpsys.launch] Update for ObjectTurnaroundDetector RTC. add USE_REFERENCEFORCEUDPATER and USE_OBJECTCONTACTTURNAROUNDDETECTOR.
* Contributors: Kei Okada, Shunichi Nozawa
```

## openrtm_ros_bridge

- No changes

## openrtm_tools

```
* fix code to run both Indido and Kinetic (#1025 <https://github.com/start-jsk/rtmros_common/issues/1025>)
  * add retry=3 to openrtm_tools/test/test-rtmlaunch.test
* Contributors: Kei Okada
```

## rosnode_rtc

- No changes

## rtmbuild

```
* fix code to run both Indido and Kinetic (#1025 <https://github.com/start-jsk/rtmros_common/issues/1025>)
  * rtmbuild/test/test-compile-idl.test: add retry=4 and time-limit=120
* Contributors: Kei Okada
```

## rtmros_common

- No changes
