### PR TITLE
robotis_framework: 0.2.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6398,7 +6398,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
-      version: 0.2.5-0
+      version: 0.2.6-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_framework` to `0.2.6-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.5-0`

## robotis_controller

```
* multi thread bug fixed.
* unnecessary debug print removed.
* OpenCR control table item name changed. (torque_enable -> dynamixel_power)
* fixed to not update update_time_stamp_ if bulk read fails.
* Contributors: Zerom
```

## robotis_device

```
* OpenCR control table item name changed. (torque_enable -> dynamixel_power)
* fixed to not update update_time_stamp_ if bulk read fails.
* Contributors: Zerom
```

## robotis_framework

```
* multi thread bug fixed.
* unnecessary debug print removed.
* OpenCR control table item name changed. (torque_enable -> dynamixel_power)
* fixed to not update update_time_stamp_ if bulk read fails.
* Contributors: Zerom
```

## robotis_framework_common

```
* none
```
