### PR TITLE
pyzmp: 0.0.15-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5883,7 +5883,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/asmodehn/pyzmp-rosrelease.git
-      version: 0.0.14-7
+      version: 0.0.15-0
     source:
       type: git
       url: https://github.com/asmodehn/pyzmp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyzmp` to `0.0.15-0`:

- upstream repository: https://github.com/asmodehn/pyzmp.git
- release repository: https://github.com/asmodehn/pyzmp-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.14-7`
