### PR TITLE
pyros: 0.4.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5790,7 +5790,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/asmodehn/pyros-rosrelease.git
-      version: 0.3.2-0
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/asmodehn/pyros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros` to `0.4.1-1`:

- upstream repository: https://github.com/asmodehn/pyros.git
- release repository: https://github.com/asmodehn/pyros-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.3.2-0`

## pyros

```
* Adding pyros.server package to setup.py. [alexv]
* Improving imports to rely on pyros_setup only for ros server test.
  [alexv]
```
