### PR TITLE
denso: 2.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1458,6 +1458,28 @@ repositories:
       type: git
       url: https://github.com/lagadic/demo_pioneer.git
       version: master
+  denso:
+    doc:
+      type: git
+      url: https://github.com/start-jsk/denso.git
+      version: kinetic-devel
+    release:
+      packages:
+      - denso
+      - denso_launch
+      - denso_ros_control
+      - vs060
+      - vs060_gazebo
+      - vs060_moveit_config
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/start-jsk/denso-release.git
+      version: 2.0.1-0
+    source:
+      type: git
+      url: https://github.com/start-jsk/denso.git
+      version: kinetic-devel
+    status: developed
   depth_nav_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `denso` to `2.0.1-0`:

- upstream repository: https://github.com/start-jsk/denso.git
- release repository: https://github.com/start-jsk/denso-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.25`
- previous version for package: `null`

## denso

```
* remove denso_pendant_publisher
* Contributors: Kei Okada
```

## denso_launch

- No changes

## denso_ros_control

- No changes

## vs060

- No changes

## vs060_gazebo

- No changes

## vs060_moveit_config

- No changes
