### PR TITLE
rtmros_hironx: 2.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12952,7 +12952,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 1.1.25-0
+      version: 2.0.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `2.0.0-0`:

- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.1.25-0`

## hironx_calibration

- No changes

## hironx_moveit_config

```
* Use docker to run tests and add kinetic test (#517 <https://github.com/start-jsk/rtmros_hironx/issues/517>)
  * remove pr2_controller_msgs and use control_msgs
* Contributors: Kei Okada
```

## hironx_ros_bridge

```
* [ros_bridge.py][startImpedance_315_3] More precise error message. (#502 <https://github.com/start-jsk/rtmros_hironx/issues/502>)
  *  When run by itself, getImpedanceControllerParam command at least finishes, so it's not failing. The error message is a bit misleading about what happened internally in startImpedance_315_3 method.
* use docker to run tests and add kinetic test (#517 <https://github.com/start-jsk/rtmros_hironx/issues/517> from k-okada/kinetic)
  * fix install(CDOE
  * use control_msgs is pr2_controllers_msgs is not exists
  * test/test-hironx.test: add retry=4
  * remove pr2_controller_msgs and use control_msgs
* enable to output forcesensor value on simulation (#510 <https://github.com/start-jsk/rtmros_hironx/issues/510>)
* [qnx dynpick] Add a working setting to start sensor drivers connected via USB hub (#509 <https://github.com/start-jsk/rtmros_hironx/issues/509>)
* robot_description before staring ROS_Client (RobotCommander) (#511 <https://github.com/start-jsk/rtmros_hironx/issues/511>)
* clearOfGroup after setTargetPose breaks sequencer (#505 <https://github.com/start-jsk/rtmros_hironx/issues/505>)
  * [ros_bridge] Set hrpsys version limitation to some methods.
  * temporaly workaround utnil https://github.com/fkanehiro/hrpsys-base/pull/1141, send setJointAnglesOfGrup to clear sequencer
  * add test to check https://github.com/tork-a/rtmros_nextage/issues/332 situation
* Contributors: Isaac I.Y. Saito, Kei Okada
```

## rtmros_hironx

- No changes
