### PR TITLE
dynamixel-workbench-msgs: 0.1.5-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1591,6 +1591,23 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
       version: kinetic-devel
     status: developed
+  dynamixel-workbench-msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+      version: kinetic-devel
+    release:
+      packages:
+      - dynamixel_workbench_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release.git
+      version: 0.1.5-2
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+      version: kinetic-devel
+    status: developed
   dynamixel_motor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel-workbench-msgs` to `0.1.5-2`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## dynamixel_workbench_msgs

```
* modified the cmake of toolbox
* Contributors: Darby Lim
```
