### PR TITLE
ros_controllers: 0.13.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6908,7 +6908,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.12.3-0
+      version: 0.13.0-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.13.0-0`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.12.3-0`

## diff_drive_controller

```
* Add test for allow_multiple_cmd_vel_publishers param
* add check for multiple publishers on cmd_vel
* Added tests for the odom_frame_id parameter.
* Parameterized diff_drive_controller's odom_frame_id
* Publish executed velocity if publish_cmd
* refactor to remove code duplication
* fixup pointer type for new convention
* Allow diff_drive_controller to use spheres as well as cylinders for wheel collision geometry. Cylinders are not well behaved on Gazebo/ODE heightfields, using spheres works around the issue.
* Contributors: Bence Magyar, Eric Tappan, Jeremie Deray, Karsten Knese, Tully Foote, mallanmba, tappan-at-git
```

## effort_controllers

- No changes

## force_torque_sensor_controller

- No changes

## forward_command_controller

- No changes

## gripper_action_controller

- No changes

## imu_sensor_controller

- No changes

## joint_state_controller

- No changes

## joint_trajectory_controller

```
* Make rqt_plot optional
* Added tests for issue #275 <https://github.com/ros-controls/ros_controllers/issues/275>
* Address Issue  #275 <https://github.com/ros-controls/ros_controllers/issues/275> for kinetic
* Address issue #263 <https://github.com/ros-controls/ros_controllers/issues/263>, joint_trajectory_controller - wraparoundOffset
* Added warning to indicate that the verbose flag is enabled
* Set hold trajectory goal handle when empty trajectory received through action.
  Previously, an empty trajectory received through the action interface would
  set hold trajectory and accept the action goal, but the action would never be
  terminated, leaving clients hanging.
* Contributors: Bence Magyar, Miguel Prada, bponsler, gennaro
```

## position_controllers

- No changes

## ros_controllers

- No changes

## rqt_joint_trajectory_controller

- No changes

## velocity_controllers

- No changes
