### PR TITLE
oxford_gps_eth: 0.0.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5367,7 +5367,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: hg
       url: https://bitbucket.org/DataspeedInc/oxford_gps_eth


### PR DESCRIPTION
Increasing version of package(s) in repository `oxford_gps_eth` to `0.0.5-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/oxford_gps_eth
- release repository: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.4-0`

## oxford_gps_eth

```
* Fixed velocity utm east-north-up orientation
* Properly handle unknown covariance and fields that are not present
* Updated license for year 2017
* Updated package.xml format to version 2
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```
