### PR TITLE
Add gentoo rosdep rule for package `mrpt`

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3427,6 +3427,7 @@ mplayer:
 mrpt:
   debian: [libmrpt-dev]
   fedora: [mrpt-devel]
+  gentoo: [sci-electronics/mrpt]
   ubuntu:
     oneiric: [libmrpt-dev]
     precise: [libmrpt-dev]


### PR DESCRIPTION
This dependency exists as of ros-overlay commit f968b32eee77eb29887f2fe3907e6d1406a1cced