### PR TITLE
Revert "navigation: 1.14.1-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4734,7 +4734,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.14.1-0
+      version: 1.14.0-0
     source:
       test_commits: false
       test_pull_requests: true


### PR DESCRIPTION
Reverts ros/rosdistro#15730

Filed upstream at ros-planning/navigation#612