### PR TITLE
pyros_config: 0.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1945,6 +1945,13 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: kinetic-devel
     status: maintained
+  pyros_config:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/pyros-dev/pyros-config-rosrelease.git
+      version: 0.2.0-0
+    status: developed
   pyros_test:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_config` to `0.2.0-0`:

- upstream repository: https://github.com/pyros-dev/pyros-config.git
- release repository: https://github.com/pyros-dev/pyros-config-rosrelease.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## pyros_config

```
* Getting rid of config import to avoid deep complex behavior. Lets not
  care about imports here... [AlexV]
* Update gitchangelog from 2.4.1 to 2.5.1. [pyup-bot]
* Pin pytest to latest version 3.0.4. [pyup-bot]
* Pin gitchangelog to latest version 2.4.1. [pyup-bot]
```
