### PR TITLE
catkin_pip: 0.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1445,16 +1445,16 @@ repositories:
   catkin_pip:
     doc:
       type: git
-      url: https://github.com/asmodehn/catkin_pip.git
+      url: https://github.com/pyros-dev/catkin_pip.git
       version: indigo
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/asmodehn/catkin_pip-release.git
+      url: https://github.com/pyros-dev/catkin_pip-release.git
       version: 0.2.3-0
     source:
       type: git
-      url: https://github.com/asmodehn/catkin_pip.git
+      url: https://github.com/pyros-dev/catkin_pip.git
       version: indigo
     status: developed
   cepton:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1451,7 +1451,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/catkin_pip-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/asmodehn/catkin_pip.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_pip` to `0.2.3-0`:

- upstream repository: https://github.com/asmodehn/catkin_pip.git
- release repository: https://github.com/asmodehn/catkin_pip-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.2-0`

## catkin_pip

```
* Merge pull request #147 <https://github.com/asmodehn/catkin_pip/issues/147> from pyros-dev/lunar
  adding lunar
* adding --ignore-src when calling rosdep on tests,
  to not attempt to download an old (or missing) version of catkin_pip.
* adding lunar
* Merge pull request #144 <https://github.com/asmodehn/catkin_pip/issues/144> from pyros-dev/fix_destinations
  fixing catkin_destination not being called
* tests are now using the new catkin_pip_target and calling catkin_package directly.
* adding catkin_pip_target to API, to allow the user to call catkin_package how he wants.
* splitting catkin_pip_package in function and macro to expose the catkin_destinations variables set in the scope.
* adding install rules to verify catkin variables.
* Merge pull request #128 <https://github.com/asmodehn/catkin_pip/issues/128> from pyros-dev/pyup-update-pytest-3.0.6-to-3.1.3
  Update pytest to 3.1.3
* Update pytest from 3.0.6 to 3.1.3
* Contributors: AlexV, pyup-bot
```
