### PR TITLE
mapviz: 0.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6394,7 +6394,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `0.0.8-0`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.7-0`

## mapviz

```
* Add basic profiling to mapviz.
* Handle GL canvas transforms with an invalid target frame
* Add parameter to disable auto-saving functionality.
* Contributors: Elliot Johnson, Marc Alban, P. J. Reed
```

## mapviz_plugins

```
* Add /wgs84 frame to point click publisher when available.
* replaced left_offset with offset_x, offset_y in robot image plugin
* added left_offset to robot image plugin config
* Add plug-in for drawing and publishing a polygon.
* Transform cube and arrow markers properly
* Delete markers that have expired and remove error message.
* Fix segfault in pointcloud2 plug-in when pointcloud is empty.
* Initialize buffer size variable.
* Contributors: Marc Alban, Neal Seegmiller, P. J. Reed
```

## multires_image

```
* Install mapviz_tile_loader (#499 <https://github.com/swri-robotics/mapviz/issues/499>)
* Contributors: Matthew
```

## tile_map

```
* Add missing boost header.
* Contributors: Marc Alban
```
