### PR TITLE
mapviz: 0.2.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3918,7 +3918,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `0.2.4-0`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.3-0`

## mapviz

```
* Add basic profiling to mapviz.
* Handle GL canvas transforms with an invalid target frame
* Add parameter to disable auto-saving functionality.
* Contributors: Elliot Johnson, Marc Alban, P. J. Reed
```

## mapviz_plugins

```
* Add /wgs84 frame to point click publisher when available.
* Transform cube and arrow markers properly
* Contributors: Marc Alban, P. J. Reed
```

## multires_image

- No changes

## tile_map

```
* add include for boost::algorithm::trim_copy to fix tile_map_plugin.cpp:408:31: error: ‘trim_copy’ is not a member of ‘boost’ (#497 <https://github.com/swri-robotics/mapviz/issues/497>)
* Contributors: Austin Deric
```
