### PR TITLE
point to groovy-devel branch

### DIFF
--- a/groovy/distribution.yaml
+++ b/groovy/distribution.yaml
@@ -304,7 +304,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/bond_core.git
-      version: master
+      version: groovy-devel
     release:
       packages:
       - bond
@@ -319,7 +319,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/bond_core.git
-      version: master
+      version: groovy-devel
   bosch_3rdparty:
     doc:
       type: svn

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -491,7 +491,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/bond_core.git
-      version: master
+      version: groovy-devel
     release:
       packages:
       - bond
@@ -506,7 +506,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/bond_core.git
-      version: master
+      version: groovy-devel
     status: maintained
   boost_numpy:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1005,7 +1005,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/bond_core.git
-      version: master
+      version: groovy-devel
     release:
       packages:
       - bond
@@ -1021,7 +1021,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/bond_core.git
-      version: master
+      version: groovy-devel
     status: maintained
   bowpmap_ros:
     source:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -310,7 +310,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/bond_core.git
-      version: master
+      version: groovy-devel
     release:
       packages:
       - bond
@@ -326,7 +326,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/bond_core.git
-      version: master
+      version: groovy-devel
     status: maintained
   bta_ros:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -597,7 +597,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/bond_core.git
-      version: master
+      version: groovy-devel
     release:
       packages:
       - bond
@@ -613,7 +613,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/bond_core.git
-      version: master
+      version: groovy-devel
     status: maintained
   brunel_hand_ros:
     doc:


### PR DESCRIPTION
Up until lunar the master branch was used for all ros distributions.
Now that there is a `lunar-devel` branch I copied `master` on a `groovy-devel` branch to avoid confusion for users and woud like to remove the master branch.

Should I update all distribution files even for EOL rosdistros to reflect the new branch name ? or should I keep the master branch around and references to it for hydro and older distributions ?