### PR TITLE
Update indigo/parrot_arsdk to 3.12.61-0

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8613,7 +8613,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/AutonomyLab/parrot_arsdk-release.git
-      version: 3.12.6-1
+      version: 3.12.61-0
     source:
       type: git
       url: https://github.com/AutonomyLab/parrot_arsdk.git


### PR DESCRIPTION
#15769 seems to breaking the source build of this package since it overwrote the release tag. 