### PR TITLE
Update kinetic/parrot_arsdk to 3.12.61-0

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5421,7 +5421,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/AutonomyLab/parrot_arsdk-release.git
-      version: 3.12.6-1
+      version: 3.12.61-0
     source:
       type: git
       url: https://github.com/AutonomyLab/parrot_arsdk.git


### PR DESCRIPTION
#15768 seems to breaking the source build of this package since it overwrote the release tag.