### PR TITLE
turtlebot3: 0.1.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9007,7 +9007,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3` to `0.1.6-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.5-0`

## turtlebot3

```
* fixed typo
* fixed xacro.py deprecation
* modified file location
* updated nav param
* updated SLAM param
* updated model.launch
* updated IMU link
* updated gazebo config
* Contributors: Darby Lim, Hunter L. Allen
```

## turtlebot3_bringup

```
* updated model.launch
* fixed typo
* fixed xacro.py deprecation
* modified file location
* Contributors: Darby Lim, Hunter L. Allen
```

## turtlebot3_description

```
* modified models
* fixed xacro.py deprecation
* updated IMU link
* updated gazebo config
* Contributors: Darby Lim, Hunter L. Allen
```

## turtlebot3_navigation

```
* updated nav param
* Contributors: Darby Lim
```

## turtlebot3_slam

```
* updated SLAM param
* Contributors: Darby Lim
```

## turtlebot3_teleop

```
* none
```
