### PR TITLE
enforce version conventions

### DIFF
--- a/test/test_build_caches.py
+++ b/test/test_build_caches.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-# import re
 import os
 
 from catkin_pkg.package import parse_package_string
@@ -40,20 +39,14 @@ If this fails you can run 'rosdistro_build_cache index.yaml' to perform the same
             pkgs = {}
             print("Parsing manifest files for '%s'" % dist_name)
             for pkg_name, pkg_xml in cache.release_package_xmls.items():
-
-                # # Option 1 duplicate test for version
-                # pkgs[pkg_name] = parse_package_string(pkg_xml)
-                # if not re.match('^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$', pkgs[pkg_name].version):
-                #     errors.append('%s: %s' % (dist_name, 'Package "%s" does not follow the version conventions. It should not contain leading zeros (unless the number is 0).' % pkg_name))
-
-                # Option 2 test for specific catkin_pkg warning
+                # Collect parsing warnings and fail if version convention are not respected
                 warnings = []
                 pkgs[pkg_name] = parse_package_string(pkg_xml, warnings=warnings)
                 for warning in warnings:
                     if 'version conventions' in warning:
-                        errors.append('%s: %s' % (dist_name, warning))
+                        errors.append('%s: %s' % (pkg_name, warning))
                     else:
-                        print('WARNING: ' + warning)
+                        print('%s: WARNING: %s' % (pkg_name, warning))
 
             print("Order all packages in '%s' topologically" % dist_name)
             try:

--- a/test/test_build_caches.py
+++ b/test/test_build_caches.py
@@ -47,7 +47,6 @@ If this fails you can run 'rosdistro_build_cache index.yaml' to perform the same
                         errors.append('%s: %s' % (pkg_name, warning))
                     else:
                         print('%s: WARNING: %s' % (pkg_name, warning))
-
             print("Order all packages in '%s' topologically" % dist_name)
             try:
                 topological_order_packages(pkgs)

--- a/test/test_build_caches.py
+++ b/test/test_build_caches.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+# import re
 import os
 
 from catkin_pkg.package import parse_package_string
@@ -39,7 +40,21 @@ If this fails you can run 'rosdistro_build_cache index.yaml' to perform the same
             pkgs = {}
             print("Parsing manifest files for '%s'" % dist_name)
             for pkg_name, pkg_xml in cache.release_package_xmls.items():
-                pkgs[pkg_name] = parse_package_string(pkg_xml)
+
+                # # Option 1 duplicate test for version
+                # pkgs[pkg_name] = parse_package_string(pkg_xml)
+                # if not re.match('^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$', pkgs[pkg_name].version):
+                #     errors.append('%s: %s' % (dist_name, 'Package "%s" does not follow the version conventions. It should not contain leading zeros (unless the number is 0).' % pkg_name))
+
+                # Option 2 test for specific catkin_pkg warning
+                warnings = []
+                pkgs[pkg_name] = parse_package_string(pkg_xml, warnings=warnings)
+                for warning in warnings:
+                    if 'version conventions' in warning:
+                        errors.append('%s: %s' % (dist_name, warning))
+                    else:
+                        print('WARNING: ' + warning)
+
             print("Order all packages in '%s' topologically" % dist_name)
             try:
                 topological_order_packages(pkgs)


### PR DESCRIPTION
This is a suggestion to address #11852 

Option 1 Performs the check of the version format in this scripts directly
Option 2 Parses the warnings from catkin_pkg.parse_package_string and add an error if the warning about version conventions is present

Looking for feedback regarding which approach is preferred