### PR TITLE
Revert turtlebot3_simulation release

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9043,7 +9043,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
-      version: 0.1.6-0
+      version: 0.1.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
This reverts #15773 due to regression ticketed at https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/13