### PR TITLE
navigation: 1.15.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1531,7 +1531,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.15.0-0
+      version: 1.15.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.15.1-0`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.15.0-0`

## amcl

- No changes

## base_local_planner

- No changes

## carrot_planner

- No changes

## clear_costmap_recovery

- No changes

## costmap_2d

- No changes

## dwa_local_planner

- No changes

## fake_localization

- No changes

## global_planner

- No changes

## map_server

```
* remove offending library export (fixes #612 <https://github.com/ros-planning/navigation/issues/612>)
* Contributors: Michael Ferguson
```

## move_base

- No changes

## move_slow_and_clear

- No changes

## nav_core

- No changes

## navfn

- No changes

## navigation

- No changes

## robot_pose_ekf

- No changes

## rotate_recovery

- No changes

## voxel_grid

- No changes
