### PR TITLE
ros_comm: 1.13.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2239,7 +2239,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.13.1-0
+      version: 1.13.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.13.2-0`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.13.1-0`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

- No changes

## rosbag_storage

```
* fix whitespace warnings with g++ 7 (#1138 <https://github.com/ros/ros_comm/issues/1138>)
* remove deprecated dynamic exception specifications (#1137 <https://github.com/ros/ros_comm/issues/1137>)
```

## rosconsole

- No changes

## roscpp

```
* only use CLOCK_MONOTONIC if not on OS X (#1142 <https://github.com/ros/ros_comm/issues/1142>)
* xmlrpc_manager: use SteadyTime for timeout (#1134 <https://github.com/ros/ros_comm/issues/1134>)
* ignore headers with zero stamp in statistics (#1127 <https://github.com/ros/ros_comm/issues/1127>)
```

## rosgraph

```
* fix stack frame identification in rospy logging (#1141 <https://github.com/ros/ros_comm/issues/1141>, regression from 1.13.1)
* make RospyLogger.findCaller compatible with Python 3 (#1121 <https://github.com/ros/ros_comm/issues/1121>)
```

## roslaunch

- No changes

## roslz4

```
* replace deprecated lz4 function call (#1136 <https://github.com/ros/ros_comm/issues/1136>)
```

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* fix stack frame identification in rospy logging (#1141 <https://github.com/ros/ros_comm/issues/1141>, regression from 1.13.1)
```

## rosservice

- No changes

## rostest

- No changes

## rostopic

```
* fix rostopic hz and bw in Python 3 (#1126 <https://github.com/ros/ros_comm/issues/1126>)
* update tests to match stringify changes (#1125 <https://github.com/ros/ros_comm/issues/1125>)
```

## roswtf

- No changes

## topic_tools

- No changes

## xmlrpcpp

```
* use poll() in favor of select() in the XmlRPCDispatcher (#833 <https://github.com/ros/ros_comm/issues/833>)
* fix fall through warnings with g++ 7 (#1139 <https://github.com/ros/ros_comm/issues/1139>)
```
