### PR TITLE
Add python, boost, qt5 USE flags to vtk.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3025,7 +3025,7 @@ libvtk:
     stretch: [libvtk6-dev]
     wheezy: [libvtk5-dev]
   fedora: [vtk-devel]
-  gentoo: [sci-libs/vtk]
+  gentoo: ['sci-libs/vtk[boost,python,qt5]']
   macports: [vtk-devel]
   opensuse: [vtk-devel]
   ubuntu:


### PR DESCRIPTION
Found that these are necessary for most things, and are not on by default.