### PR TITLE
turtlebot3_simulations: 0.1.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9043,7 +9043,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
-      version: 0.1.5-0
+      version: 0.1.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_simulations` to `0.1.7-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.5-0`

## turtlebot3_fake

```
* none
```

## turtlebot3_gazebo

```
* renamed missed the install rule (worlds -> models)
* Contributors: Darby Lim, Tully Foote
```

## turtlebot3_simulations

```
* renamed missed the install rule (worlds -> models)
* Contributors: Darby Lim, Tully Foote
```
