### PR TITLE
[rosdep] Added python-pyro

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -130,6 +130,15 @@ pyqt5-dev-tools:
   fedora: [python-qt5-devel]
   gentoo: [dev-python/PyQt5]
   ubuntu: [pyqt5-dev-tools]
+pyro4:
+  arch: [python2-pyro]
+  debian: [python2-pyro4]
+  fedora: [python-pyro]
+  gentoo: [dev-python/pyro]
+  osx:
+    pip:
+      packages: [pyro4]
+  ubuntu: [python2-pyro4]
 pyros-setup-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
Added rosdep entries for Pyro4, a distributed object middleware for Python (RPC).

Note: the library is called Pyro4 inside the Python ecosystem to preserve the original, discontinued Pyro library. System package managers however provide Pyro4 under pyro. I followed that convention for rosdep.