### PR TITLE
avt_vimba_camera: 0.0.10-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -97,6 +97,21 @@ repositories:
       url: https://github.com/oceansystemslab/auv_msgs.git
       version: indigo-devel
     status: developed
+  avt_vimba_camera:
+    doc:
+      type: git
+      url: https://github.com/srv/avt_vimba_camera.git
+      version: lunar
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/srv/avt_vimba_camera-release.git
+      version: 0.0.10-0
+    source:
+      type: git
+      url: https://github.com/srv/avt_vimba_camera.git
+      version: lunar
+    status: maintained
   bfl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `avt_vimba_camera` to `0.0.10-0`:

- upstream repository: https://github.com/srv/avt_vimba_camera.git
- release repository: https://github.com/srv/avt_vimba_camera-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## avt_vimba_camera

```
* Merge pull request #26 <https://github.com/srv/avt_vimba_camera/issues/26> from 130s/k/add_ci
  [CI] Add config for ROS Kinetic (and Lunar as an option).
* [CI] Add config for ROS Kinetic (and Lunar as an option).
* Merge pull request #25 <https://github.com/srv/avt_vimba_camera/issues/25> from mintar/fix_open_camera
  Fix opening the camera
* Simplify openCamera() logic
* Open camera on init
  Without this patch, the camera is never opened. This bug was introduced in 63f868791.
* Give more information to the user
* Merge pull request #22 <https://github.com/srv/avt_vimba_camera/issues/22> from plusone-robotics/dyn_reconfig_fix
  Dynamic reconfigure fix
* Fix #21 <https://github.com/srv/avt_vimba_camera/issues/21>: Retry camera opening and handle SIGINT
* Changed file mode in order to build
* Fixed crashing of dynamic reconfigure
* Fixed dynamic reconfigure configuration that did not allow camera parameters to be updated
* Fix call QueueFrame() method
* Fix CPU overhead issue
* Fix #18 <https://github.com/srv/avt_vimba_camera/issues/18>
* Merge pull request #17 <https://github.com/srv/avt_vimba_camera/issues/17> from josepqp/kinetic
  Added ARM 32 to CMakeList.txt
* Stop camera before destroy it
* Added ARM 32
* Merge branch 'kinetic' of github.com:srv/avt_vimba_camera into kinetic
* Change variable scope
* Fix #15 <https://github.com/srv/avt_vimba_camera/issues/15>: do not depend on turbot_configurations
* Merge pull request #14 <https://github.com/srv/avt_vimba_camera/issues/14> from josepqp/kinetic
* Added ARM 32 bits libraries
  
  Modified CMakeList.txt to compile with ARM 32 bits
  
  Added Iris Parameter
* kinetization
* Fix sync problems after camera tests
* Add a sync timer
* Try stereo image sync
* Add a check timer
* Fix #12 <https://github.com/srv/avt_vimba_camera/issues/12>: allow bigger resolutions
* Fix camera info
* Fix camera config
* Fix camera info when decimation
* Make sync node acts as stereo sync checker
* Include a check timer on stereo_camera
* Perform the stereo_sync in a separate node
* Publish camera temperatures
* Change the way of reset
* Increase the initial wait time before checking sync
* Add a sync watcher node
* Fix branch mix
* Remove unused variables
* Left and right callback in a separate thread
* Change default sync time
* change logging messages
* fix binning
* add stereo launchfiles
* removed prints
* set stereo launchfiles
* removed unused params
* calibration epi. 4
* improvements to stereo node
* merge with v2.0 SDK
* upgrade to VIMBA SDK 2.0
* upgrade to 1.4
* changed ros prints from info to debug
* removed comment
* changed stereo camera launchfile
* Merge pull request #11 <https://github.com/srv/avt_vimba_camera/issues/11> from lucasb-eyer/indigo
  Set the frame_id of the image header, too.
* Set the frame_id of the image header, too.
* Contributors: Isaac I.Y. Saito, Martin Günther, Miquel Massot, Shaun Edwards, SparusII, agoins, josep, lucasb-eyer, plnegre, shaun-edwards
```
