### PR TITLE
Add Gentoo resolution for bloom and for python-omniorb

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -398,6 +398,7 @@ python-bloom:
     buster: [python-bloom]
     stretch: [python-bloom]
   fedora: [python-bloom]
+  gentoo: [dev-python/bloom]
   ubuntu:
     precise: [python-bloom]
     quantal: [python-bloom]
@@ -1763,6 +1764,7 @@ python-omniorb:
   arch: [omniorbpy]
   debian: [python-omniorb, python-omniorb-omg, omniidl-python]
   fedora: [python-omniORB, omniORB-devel]
+  gentoo: ['net-misc/omniORB[python]']
   ubuntu:
     lucid: [python-omniorb2, python-omniorb2-omg, omniidl4-python]
     maverick: [python-omniorb, python-omniorb-omg, omniidl-python]


### PR DESCRIPTION
After this, I'll be missing only 36 keys for Lunar, Kinetic and Indigo.