### PR TITLE
Collapse Ubuntu distributions for python-wstool

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3721,13 +3721,7 @@ python-wstool:
   fedora: [python-wstool]
   gentoo: [dev-python/wstool]
   macports: [py27-wstool]
-  ubuntu:
-    precise: [python-wstool]
-    quantal: [python-wstool]
-    raring: [python-wstool]
-    saucy: [python-wstool]
-    trusty: [python-wstool]
-    trusty_python3: [python-wstool]
+  ubuntu: [python-wstool]
 python-wtforms:
   debian: [python-wtforms]
   fedora: [python-wtforms]


### PR DESCRIPTION
All the distributions use `python-wstool` as the name, so they can be collapsed. This also future-proofs it against (in this case) not adding a `xenial` distribution.