### PR TITLE
simple_arm: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8370,6 +8370,21 @@ repositories:
       url: https://github.com/SICKAG/sick_visionary_t.git
       version: indigo-devel
     status: maintained
+  simple_arm:
+    doc:
+      type: git
+      url: https://github.com/danielsnider/simple_arm.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/danielsnider/simple_arm-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/danielsnider/simple_arm.git
+      version: master
+    status: maintained
   simple_drive:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_arm` to `0.1.0-0`:

- upstream repository: https://github.com/danielsnider/simple_arm.git
- release repository: https://github.com/danielsnider/simple_arm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## simple_arm

```
* First release
```
