### PR TITLE
magni_robot: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3883,8 +3883,8 @@ repositories:
       version: 0.2.0-0
     source:
       type: git
-      url: git
-      version: https://github.com/UbiquityRobotics/magni_robot.git
+      url: https://github.com/UbiquityRobotics/magni_robot.git
+      version: indigo-devel
     status: developed
   manipulation_msgs:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3880,7 +3880,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/magni_robot-release.git
-      version: 0.1.1-0
+      version: 0.2.0-0
+    source:
+      type: git
+      url: git
+      version: https://github.com/UbiquityRobotics/magni_robot.git
     status: developed
   manipulation_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `magni_robot` to `0.2.0-0`:

- upstream repository: https://github.com/UbiquityRobotics/magni_robot.git
- release repository: https://github.com/UbiquityRobotics-release/magni_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.1-0`

## magni_bringup

```
* use remap instead of republish and remove topic_tools dep
* Contributors: Rohan Agrawal
```

## magni_demos

```
* add teleop launch that starts rosbridge. replaces joystick launch
* Contributors: Rohan Agrawal
```

## magni_description

- No changes

## magni_nav

- No changes

## magni_robot

```
* have exec dep on sub-packages so they are installed
* Contributors: Rohan Agrawal
```

## magni_teleop

- No changes
