### PR TITLE
gps_goal: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2441,6 +2441,21 @@ repositories:
       url: https://github.com/ros-visualization/gl_dependency.git
       version: kinetic-devel
     status: maintained
+  gps_goal:
+    doc:
+      type: git
+      url: https://github.com/danielsnider/gps_goal.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/danielsnider/gps_goal-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/danielsnider/gps_goal.git
+      version: master
+    status: maintained
   gps_umd:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_goal` to `0.1.0-0`:

- upstream repository: https://github.com/danielsnider/gps_goal.git
- release repository: https://github.com/danielsnider/gps_goal-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## gps_goal

```
* First release
```
