### PR TITLE
openni2_camera: 0.2.8-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1709,6 +1709,22 @@ repositories:
       url: https://github.com/ros-gbp/opencv3-release.git
       version: 3.2.0-6
     status: maintained
+  openni2_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/openni2_camera-release.git
+      version: 0.2.8-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: indigo-devel
+    status: maintained
   openni_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `0.2.8-0`:

- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros-gbp/openni2_camera-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## openni2_camera

```
* [capability] Add exposure time control #46 <https://github.com/ros-drivers/openni2_camera/issues/46>
* [fix] device URI formatting #47 <https://github.com/ros-drivers/openni2_camera/issues/47>
* Contributors: Martin Guenther, Michael Ferguson, Sergey Alexandrov
```
