### PR TITLE
openni2_camera: 0.2.8-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8306,7 +8306,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 0.2.7-0
+      version: 0.2.8-1
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `0.2.8-1`:

- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros-gbp/openni2_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.7-0`

## openni2_camera

```
* [capability] Add exposure time control #46 <https://github.com/ros-drivers/openni2_camera/issues/46>
* [fix] device URI formatting #47 <https://github.com/ros-drivers/openni2_camera/issues/47>
* Contributors: Martin Guenther, Michael Ferguson, Sergey Alexandrov
```
