### PR TITLE
Drop transitional sparsehash package

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4036,10 +4036,16 @@ sparsehash:
   fedora: [sparsehash-devel]
   gentoo: [dev-cpp/sparsehash]
   ubuntu:
+    artful: [libsparsehash-dev]
     precise: [sparsehash]
+    saucy: [sparsehash]
     trusty: [sparsehash]
+    utopic: [sparsehash]
     vivid: [libsparsehash-dev]
+    wily: [libsparsehash-dev]
     xenial: [libsparsehash-dev]
+    yakkety: [libsparsehash-dev]
+    zesty: [libsparsehash-dev]
 speex:
   debian: [speex]
   fedora: [speex, speex-tools, speexdsp]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4035,7 +4035,11 @@ sparsehash:
   debian: [libsparsehash-dev]
   fedora: [sparsehash-devel]
   gentoo: [dev-cpp/sparsehash]
-  ubuntu: [sparsehash]
+  ubuntu:
+    precise: [sparsehash]
+    trusty: [sparsehash]
+    vivid: [libsparsehash-dev]
+    xenial: [libsparsehash-dev]
 speex:
   debian: [speex]
   fedora: [speex, speex-tools, speexdsp]


### PR DESCRIPTION
In Ubuntu Vivid, support for the `sparsehash` transitional package was dropped (see [the package page](https://launchpad.net/ubuntu/+source/sparsehash) for details), so the apt package is now `libsparsehash-dev`, not `sparsehash`.

For the sake of completeness, `sudo apt-get install sparsehash` now fails with the following error (in Xenial):

    Package sparsehash is not available, but is referred to by another package.
    This may mean that the package is missing, has been obsoleted, or
    is only available from another source
    However the following packages replace it:
      libsparsehash-dev
    
    E: Package 'sparsehash' has no installation candidate

Because `libsparsehash-dev` exists in Precise and Trusty, it may be possible to simply change line 4038 to

    ubuntu: [libsparsehash-dev]

but there's probably a reason for the transitional package.