### PR TITLE
rviz: 1.11.18-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6809,7 +6809,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.11.17-0
+      version: 1.11.18-0
     source:
       type: git
       url: https://github.com/ros-visualization/rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.11.18-0`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.11.17-0`

## rviz

```
* Replaced Arial font with Liberation Sans (#1141 <https://github.com/ros-visualization/rviz/issues/1141>) (#1143 <https://github.com/ros-visualization/rviz/issues/1143>)
* Contributors: William Woodall
```
