### PR TITLE
rosdep: Add libgeographic-dev for Zesty

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -831,9 +831,14 @@ gdal-bin:
   gentoo: [sci-libs/gdal]
   ubuntu: [gdal-bin]
 geographiclib:
-  debian: [libgeographiclib-dev]
+  debian:
+    buster: [libgeographic-dev]
+    jessie: [libgeographic-dev]
+    stretch: [libgeographic-dev]
+    wheezy: [libgeographiclib-dev]
   fedora: [GeographicLib-devel]
   ubuntu:
+    artful: [libgeographic-dev]
     precise: [libgeographiclib-dev]
     quantal: [libgeographiclib-dev]
     raring: [libgeographiclib-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -843,6 +843,8 @@ geographiclib:
     vivid: [libgeographic-dev]
     wily: [libgeographic-dev]
     xenial: [libgeographic-dev]
+    yakkety: [libgeographic-dev]
+    zesty: [libgeographic-dev]
 geographiclib-tools:
   debian: [geographiclib-tools]
   fedora: [GeographicLib]


### PR DESCRIPTION
Required for releasing mavros for Lunar.