### PR TITLE
remove duplicated python-sip from python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2927,9 +2927,6 @@ python-sip:
   gentoo: [dev-python/sip]
   macports: [py27-sip]
   opensuse: [python-sip-devel]
-  osx:
-    homebrew:
-      packages: [sip]
   rhel: [sip-devel]
   slackware:
     slackpkg:


### PR DESCRIPTION
Identified in https://github.com/ros/rosdistro/pull/15805