### PR TITLE
joystick_drivers: 1.11.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1017,6 +1017,27 @@ repositories:
       url: https://github.com/ros/ivcon.git
       version: kinetic-devel
     status: maintained
+  joystick_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: indigo-devel
+    release:
+      packages:
+      - joy
+      - joystick_drivers
+      - ps3joy
+      - spacenav_node
+      - wiimote
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/joystick_drivers-release.git
+      version: 1.11.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: indigo-devel
+    status: maintained
   jsk_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `1.11.0-0`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros-gbp/joystick_drivers-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## joy

```
* fixed joy/Cmakelists for osx
* Update dependencies to remove warnings
* Contributors: Marynel Vazquez, Mark D Horn
```

## joystick_drivers

- No changes

## ps3joy

```
* Update dependencies to remove warnings
* Contributors: Mark D Horn
```

## spacenav_node

```
* Update dependencies to remove warnings
* Contributors: Mark D Horn
```

## wiimote

```
* Sample Teleop Implementation for Wiimote
* C++ Implementation of Wiimote Controller Node
* Add queue_size to remove ROS Warning
* Update dependencies to remove warnings
* Contributors: Mark D Horn
```
