### PR TITLE
Add python-plyfile

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2029,6 +2029,19 @@ python-planar-pip:
   ubuntu:
     pip:
       packages: [planar]
+python-plyfile-pip:
+  debian:
+    pip:
+      packages: [plyfile]
+  fedora:
+    pip:
+      packages: [plyfile]
+  osx:
+    pip:
+      packages: [plyfile]
+  ubuntu:
+    pip:
+      packages: [plyfile]
 python-progressbar:
   debian: [python-progressbar]
   fedora: [python-progressbar]


### PR DESCRIPTION
Package is only in PyPI. I am only using it to simplify dependency management and have no plans to make a release with it so it should be alright.

PyPI: https://pypi.python.org/pypi/plyfile