### PR TITLE
Add rosdep rule for liburdfdom-tools on MacOS

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -363,6 +363,10 @@ liburdfdom-headers-dev:
   osx:
     homebrew:
       packages: [urdfdom_headers]
+liburdfdom-tools:
+  osx:
+    homebrew:
+      packages: [urdfdom]
 libusb:
   osx:
     homebrew:


### PR DESCRIPTION
liburdfdom-tools is required for kinetic and lunar on MacOS