### PR TITLE
Adding 'dyn_tune' and 'rqt_dyn_tune' to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1571,11 +1571,11 @@ repositories:
   dyn_tune:
     doc:
       type: git
-      url: https://github.com/mehdish89/dyn_tune
+      url: https://github.com/mehdish89/dyn_tune.git
       version: master
     source:
       type: git
-      url: https://github.com/mehdish89/dyn_tune
+      url: https://github.com/mehdish89/dyn_tune.git
       version: master
   dynamic_reconfigure:
     doc:
@@ -7546,11 +7546,11 @@ repositories:
   rqt_dyn_tune:
     doc:
       type: git
-      url: https://github.com/mehdish89/rqt_dyn_tune
+      url: https://github.com/mehdish89/rqt_dyn_tune.git
       version: master
     source:
       type: git
-      url: https://github.com/mehdish89/rqt_dyn_tune
+      url: https://github.com/mehdish89/rqt_dyn_tune.git
       version: master
   rqt_ez_publisher:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1568,6 +1568,15 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/delftrobotics/dr_base-release.git
       version: 1.0.0-0
+  dyn_tune:
+    doc:
+      type: git
+      url: https://github.com/mehdish89/dyn_tune
+      version: master
+    source:
+      type: git
+      url: https://github.com/mehdish89/dyn_tune
+      version: master
   dynamic_reconfigure:
     doc:
       type: git
@@ -7534,6 +7543,15 @@ repositories:
       url: https://github.com/ros-visualization/rqt_dep.git
       version: master
     status: maintained
+  rqt_dyn_tune:
+    doc:
+      type: git
+      url: https://github.com/mehdish89/rqt_dyn_tune
+      version: master
+    source:
+      type: git
+      url: https://github.com/mehdish89/rqt_dyn_tune
+      version: master
   rqt_ez_publisher:
     doc:
       type: git


### PR DESCRIPTION
i'd like 'dyn_tune' and 'rqt_dyn_tune' to be indexed and documented on ros.org. These are the packages of the tool that I created for generic parameter tuning in ROS, during my internship at OSRF.