### PR TITLE
mavlink: 2017.8.26-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1297,7 +1297,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: 2017.8.8-0
+      version: 2017.8.26-0
     source:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2017.8.26-0`:

- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/mavlink/mavlink-gbp-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2017.8.8-0`
