### PR TITLE
adding ros1_template to indigo for source testing

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11265,6 +11265,66 @@ repositories:
       url: https://github.com/ros/ros.git
       version: indigo-devel
     status: maintained
+  ros1_template:
+    doc:
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+  ros1_template_msgs:
+    doc:
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+  ros1_cpptemplate:
+    doc:
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+  ros1_ros_cpptemplate:
+    doc:
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+  ros1_pytemplate:
+    doc:
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+  ros1_pip_pytemplate:
+    doc:
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
   rosR:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11275,56 +11275,7 @@ repositories:
       type: git
       url: https://github.com/pyros-dev/ros1_template.git
       version: master
-  ros1_template_msgs:
-    doc:
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-  ros1_cpptemplate:
-    doc:
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-  ros1_ros_cpptemplate:
-    doc:
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-  ros1_pytemplate:
-    doc:
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-  ros1_pip_pytemplate:
-    doc:
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
+    status: maintained
   rosR:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6800,7 +6800,7 @@ repositories:
       url: https://github.com/ros/ros.git
       version: kinetic-devel
     status: maintained
-ros1_template:
+  ros1_template:
     doc:
       type: git
       url: https://github.com/pyros-dev/ros1_template.git
@@ -6810,56 +6810,7 @@ ros1_template:
       type: git
       url: https://github.com/pyros-dev/ros1_template.git
       version: master
-  ros1_template_msgs:
-    doc:
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-  ros1_cpptemplate:
-    doc:
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-  ros1_ros_cpptemplate:
-    doc:
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-  ros1_pytemplate:
-    doc:
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-  ros1_pip_pytemplate:
-    doc:
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/pyros-dev/ros1_template.git
-      version: master
+    status: maintained
   ros_additive_manufacturing:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6800,6 +6800,66 @@ repositories:
       url: https://github.com/ros/ros.git
       version: kinetic-devel
     status: maintained
+ros1_template:
+    doc:
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+  ros1_template_msgs:
+    doc:
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+  ros1_cpptemplate:
+    doc:
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+  ros1_ros_cpptemplate:
+    doc:
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+  ros1_pytemplate:
+    doc:
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+  ros1_pip_pytemplate:
+    doc:
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/pyros-dev/ros1_template.git
+      version: master
   ros_additive_manufacturing:
     doc:
       type: git


### PR DESCRIPTION
Working on a template ROS1 package and attempting buildfarm integration...
Let me know if I should change anything to get this to work for all ROS LTS releases.