### PR TITLE
myahrs_driver: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7298,7 +7298,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/robotpilot/myahrs_driver-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/robotpilot/myahrs_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `myahrs_driver` to `0.1.2-0`:

- upstream repository: https://github.com/robotpilot/myahrs_driver.git
- release repository: https://github.com/robotpilot/myahrs_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.1-0`

## myahrs_driver

```
* fixed: make "parent_frame_id_" as true parent frame_id in /tf topic and "parent_frame_id_" as child(for now, "base_link" is parent of "imu_link" as default).
* Contributors: Akio Shigekane, Pyo
```
