### PR TITLE
myahrs_driver: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4570,6 +4570,21 @@ repositories:
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
       version: master
     status: maintained
+  myahrs_driver:
+    doc:
+      type: git
+      url: https://github.com/robotpilot/myahrs_driver.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/robotpilot/myahrs_driver-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/robotpilot/myahrs_driver.git
+      version: kinetic-devel
+    status: maintained
   nao_dcm_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `myahrs_driver` to `0.1.2-0`:

- upstream repository: https://github.com/robotpilot/myahrs_driver.git
- release repository: https://github.com/robotpilot/myahrs_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## myahrs_driver

```
* fixed: make "parent_frame_id_" as true parent frame_id in /tf topic and "parent_frame_id_" as child(for now, "base_link" is parent of "imu_link" as default).
* Contributors: Akio Shigekane, Pyo
```
