### PR TITLE
fcl: 0.3.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3094,7 +3094,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/fcl-release.git
-      version: 0.3.3-0
+      version: 0.3.4-0
     status: maintained
   fetch_gazebo:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `fcl` to `0.3.4-0`:

- upstream repository: https://github.com/flexible-collision-library/fcl.git
- release repository: https://github.com/ros-gbp/fcl-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.3.3-0`
