### PR TITLE
ros_type_introspection: 0.7.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7066,7 +7066,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/ros_type_introspection-release.git
-      version: 0.6.3-0
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/facontidavide/ros_type_introspection.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_type_introspection` to `0.7.1-0`:

- upstream repository: https://github.com/facontidavide/ros_type_introspection.git
- release repository: https://github.com/facontidavide/ros_type_introspection-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.6.3-0`

## ros_type_introspection

```
* ros Time and Duration fixed
* tests fixed
* important API Change
* might fix issue reported in #5 <https://github.com/facontidavide/ros_type_introspection/issues/5>. print_number made public
* adding inline to fix compilation error #4 <https://github.com/facontidavide/ros_type_introspection/issues/4>
* maintain nanosecond precision for time/duration
* Contributors: Davide Faconti, Ian Taylor
```
