### PR TITLE
marti_messages: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6470,7 +6470,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_messages-release.git
-      version: 0.1.0-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `0.2.0-0`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.0-0`

## marti_can_msgs

- No changes

## marti_common_msgs

- No changes

## marti_nav_msgs

```
* AddRouteOffset Message (#86 <https://github.com/swri-robotics/marti_messages/issues/86>)
* Contributors: Matthew
```

## marti_perception_msgs

- No changes

## marti_sensor_msgs

- No changes

## marti_visualization_msgs

- No changes
