### PR TITLE
ros_explorer: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11506,6 +11506,17 @@ repositories:
       url: https://github.com/GT-RAIL/ros_ethernet_rmp.git
       version: develop
     status: maintained
+  ros_explorer:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/jstnhuang-release/ros_explorer-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/jstnhuang/ros_explorer.git
+      version: indigo-devel
+    status: developed
   ros_in_hand_scanner:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_explorer` to `0.1.0-0`:

- upstream repository: https://github.com/jstnhuang/ros_explorer.git
- release repository: https://github.com/jstnhuang-release/ros_explorer-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## ros_explorer

```
* Initial release.
* Contributors: Justin Huang
```
