### PR TITLE
rosbridge_suite: 0.8.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7129,7 +7129,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.8.1-0
+      version: 0.8.1-2
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.8.1-2`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.8.1-0`

## rosapi

- No changes

## rosbridge_library

```
* remove ujson from dependency to build in trusty (#290 <https://github.com/RobotWebTools/rosbridge_suite/issues/290>)
* Contributors: Jihoon Lee
```

## rosbridge_server

- No changes

## rosbridge_suite

- No changes
