### PR TITLE
rosbridge_suite: 0.8.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2481,6 +2481,26 @@ repositories:
       url: https://github.com/ros-gbp/rosbag_migration_rule-release.git
       version: 1.0.0-0
     status: maintained
+  rosbridge_suite:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/rosbridge_suite.git
+      version: master
+    release:
+      packages:
+      - rosapi
+      - rosbridge_library
+      - rosbridge_server
+      - rosbridge_suite
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
+      version: 0.8.1-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/rosbridge_suite.git
+      version: develop
+    status: maintained
   rosconsole_bridge:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.8.1-0`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rosapi

- No changes

## rosbridge_library

```
* remove ujson from dependency to build in trusty (#290 <https://github.com/RobotWebTools/rosbridge_suite/issues/290>)
* Contributors: Jihoon Lee
```

## rosbridge_server

- No changes

## rosbridge_suite

- No changes
