### PR TITLE
marti_common: 1.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6448,7 +6448,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 1.0.0-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `1.1.0-0`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.0-0`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_geometry_util

```
* Add function for closest point to lines in 3d. (#478 <https://github.com/pjreed/marti_common/issues/478>)
* Add line intersection function. (#473 <https://github.com/pjreed/marti_common/issues/473>)
* Contributors: Edward Venator, Marc Alban, P. J. Reed
```

## swri_image_util

```
* Improving user feedback when checking parameter validity. Breaking apart parameter checks so it is clearer what the error is. Also making sure the user passes in non-negative values for RGB and gray values
* Add a crosshairs nodelet to swri_image_util (#461 <https://github.com/pjreed/marti_common/issues/461>)
* Cloning OpenCV matrices to make sure values are not overwritten
* Fixing conditions which would trigger a warning on node startup
* Fixing problems caused by OpenCV matrices making shallow copies
* Adding compiler flag to correctly include file when using OpenCV 2.x
* Adding ability to recolor image using an OpenCV colormap
* Improving robustness of parameter parsing
* Improving error checking
* Adding color replacer to nodelet list
* Contributors: David Anthony, Edward Venator, Jerry Towler, Marc Alban, P. J. Reed
```

## swri_math_util

```
* Implement RANSAC and least squares model fitting for 3d geometry (#479 <https://github.com/pjreed/marti_common/issues/479>)
* Fix out-of-bounds bug in RANSAC sampling. (#477 <https://github.com/pjreed/marti_common/issues/477>)
* Contributors: Edward Venator, Marc Alban, P. J. Reed
```

## swri_nodelet

- No changes

## swri_opencv_util

```
* Implement RANSAC and least squares model fitting for 3d geometry (#479 <https://github.com/pjreed/marti_common/issues/479>)
* Add missing cv_bridge dependency. (#480 <https://github.com/pjreed/marti_common/issues/480>)
* Contributors: Edward Venator, Marc Alban, P. J. Reed
```

## swri_prefix_tools

- No changes

## swri_roscpp

```
* Add OptionalDiagnosedPublisher class (#483 <https://github.com/pjreed/marti_common/issues/483>)
* Contributors: Edward Venator, P. J. Reed
```

## swri_rospy

- No changes

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Revert "Remove nodelet_plugins.xml from CMakeLists.txt" (#475 <https://github.com/pjreed/marti_common/issues/475>)
* Document swri_transform_util (#456 <https://github.com/pjreed/marti_common/issues/456>)
* Contributors: Edward Venator, Marc Alban, P. J. Reed
```

## swri_yaml_util

- No changes
