### PR TITLE
Add rosbag_metdata as python rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3859,6 +3859,19 @@ python3-setuptools:
   ubuntu: [python3-setuptools]
 python3-yaml:
   ubuntu: [python3-yaml]
+rosbag-metadata-pip:
+  debian:
+    pip:
+      packages: [rosbag-metadata]
+  fedora:
+    pip:
+      packages: [rosbag-metadata]
+  gentoo:
+    pip:
+      packages: [rosbag-metadata]
+  ubuntu:
+    pip:
+      packages: [rosbag-metadata]
 rpy2:
   arch: [python-rpy2]
   debian: [python-rpy2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3866,9 +3866,6 @@ rosbag-metadata-pip:
   fedora:
     pip:
       packages: [rosbag-metadata]
-  gentoo:
-    pip:
-      packages: [rosbag-metadata]
   ubuntu:
     pip:
       packages: [rosbag-metadata]


### PR DESCRIPTION
I've found this tool handy for adding metadata to bag files.

- https://pypi.python.org/pypi/rosbag_metadata
- https://github.com/hordurk/rosbag_metadata