### PR TITLE
catkin_grpc-release: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1442,6 +1442,14 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: indigo-devel
     status: maintained
+  catkin_grpc-release:
+    release:
+      packages:
+      - grpc
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/CogRobRelease/catkin_grpc-release.git
+      version: 0.0.1-0
   catkin_pip:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_grpc-release` to `0.0.1-0`:

- upstream repository: https://github.com/CogRob/catkin_grpc.git
- release repository: https://github.com/CogRobRelease/catkin_grpc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`

## grpc

```
* Pre-release commit. (#1 <https://github.com/CogRob/catkin_grpc/issues/1>)
* Contributors: Shengye Wang
```
