### PR TITLE
cogrob_catkin_grpc: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1964,23 +1964,6 @@ repositories:
       url: https://github.com/ipa320/cob_supported_robots.git
       version: indigo_dev
     status: developed
-  cogrob_catkin_grpc:
-    doc:
-      type: git
-      url: https://github.com/CogRob/catkin_grpc.git
-      version: master
-    release:
-      packages:
-      - grpc
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/CogRobRelease/catkin_grpc-release.git
-      version: 0.0.1-0
-    source:
-      type: git
-      url: https://github.com/CogRob/catkin_grpc.git
-      version: master
-    status: developed
   collada_urdf:
     doc:
       type: git
@@ -3975,6 +3958,21 @@ repositories:
       url: https://github.com/g/grizzly_simulator.git
       version: indigo-devel
     status: maintained
+  grpc:
+    doc:
+      type: git
+      url: https://github.com/CogRob/catkin_grpc.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/CogRobRelease/catkin_grpc-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/CogRob/catkin_grpc.git
+      version: master
+    status: developed
   gscam:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1967,7 +1967,7 @@ repositories:
   cogrob_catkin_grpc:
     doc:
       type: git
-      url: https://github.com/CogRobRelease/catkin_grpc-release.git
+      url: https://github.com/CogRob/catkin_grpc.git
       version: master
     release:
       packages:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1964,6 +1964,23 @@ repositories:
       url: https://github.com/ipa320/cob_supported_robots.git
       version: indigo_dev
     status: developed
+  cogrob_catkin_grpc:
+    doc:
+      type: git
+      url: https://github.com/CogRobRelease/catkin_grpc-release.git
+      version: master
+    release:
+      packages:
+      - grpc
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/CogRobRelease/catkin_grpc-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/CogRob/catkin_grpc.git
+      version: master
+    status: developed
   collada_urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cogrob_catkin_grpc` to `0.0.1-0`:

- upstream repository: https://github.com/CogRob/catkin_grpc.git
- release repository: https://github.com/CogRobRelease/catkin_grpc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`

## grpc

```
* Pre-release commit. (#1 <https://github.com/CogRob/catkin_grpc/issues/1>)
* Contributors: Shengye Wang
```
