### PR TITLE
aubo_robot: 0.3.18-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -427,6 +427,35 @@ repositories:
       url: https://github.com/iirob/ati_force_torque.git
       version: kinetic-devel
     status: developed
+  aubo_robot:
+    doc:
+      type: git
+      url: https://github.com/auboliuxin/aubo_robot.git
+      version: kinetic-devel
+    release:
+      packages:
+      - aubo_control
+      - aubo_description
+      - aubo_driver
+      - aubo_gazebo
+      - aubo_i5_moveit_config
+      - aubo_kinematics
+      - aubo_msgs
+      - aubo_new_driver
+      - aubo_panel
+      - aubo_robot
+      - aubo_trajectory
+      - aubo_trajectory_filters
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/auboliuxin/aubo_robot-release.git
+      version: 0.3.18-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/auboliuxin/aubo_robot.git
+      version: kinetic-devel
+    status: developed
   auction_methods_stack:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aubo_robot` to `0.3.18-0`:

- upstream repository: https://github.com/auboliuxin/aubo_robot.git
- release repository: https://github.com/auboliuxin/aubo_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
