### PR TITLE
velodyne_simulator: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15546,7 +15546,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_simulator` to `0.0.3-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
- release repository: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.2-0`

## velodyne_description

```
* Increased minimum collision range to prevent self-clipping when in motion
* Added many URDF parameters, and set example sample count to reasonable values
* Launch rviz with gazebo
* Updated package.xml format to version 2
* Contributors: Kevin Hallenbeck
```

## velodyne_gazebo_plugins

```
* Fixed ground plane projection by removing interpolation
* Updated package.xml format to version 2
* Removed gazebo_plugins dependency
* Gazebo7 integration
* Contributors: Kevin Hallenbeck, Micho Radovnikovich, Konstantin Sorokin
```

## velodyne_simulator

```
* Updated package.xml format to version 2
* Contributors: Kevin Hallenbeck
```
