### PR TITLE
[dep][py] paramiko: Collapse entries for all Ubuntu distros.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -88,20 +88,7 @@ paramiko:
     pip:
       packages: [paramiko]
   rhel: [python-paramiko]
-  ubuntu:
-    lucid: [python-paramiko]
-    maverick: [python-paramiko]
-    natty: [python-paramiko]
-    oneiric: [python-paramiko]
-    precise: [python-paramiko]
-    quantal: [python-paramiko]
-    raring: [python-paramiko]
-    saucy: [python-paramiko]
-    trusty: [python-paramiko]
-    utopic: [python-paramiko]
-    vivid: [python-paramiko]
-    wily: [python-paramiko]
-    xenial: [python-paramiko]
+  ubuntu: [python-paramiko]
 pika:
   debian: [python-pika]
   gentoo: [dev-python/pika]


### PR DESCRIPTION
Zesty: https://packages.ubuntu.com/zesty/python-paramiko