### PR TITLE
Removing grpc from indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3967,7 +3967,6 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/CogRobRelease/catkin_grpc-release.git
-      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/CogRob/catkin_grpc.git


### PR DESCRIPTION
Reverts release part of #15867

Ticketed upstream at https://github.com/CogRob/catkin_grpc/issues/3

Removing the version will keep it indexed but stop the attempted binary builds. This will require a new release and bloom will reinsert the new version number.

@BillWSY FYI