### PR TITLE
airbus_coop: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -159,6 +159,24 @@ repositories:
       url: https://github.com/RobotnikAutomation/agvs_sim.git
       version: indigo-devel
     status: maintained
+  airbus_coop:
+    release:
+      packages:
+      - airbus_cobot_gui
+      - airbus_coop
+      - airbus_docgen
+      - airbus_plugin_log_manager
+      - airbus_plugin_node_manager
+      - airbus_plugin_rqt
+      - airbus_plugin_rviz
+      - airbus_pyqt_extend
+      - airbus_ssm_core
+      - airbus_ssm_plugin
+      - airbus_ssm_tutorial
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/airbus_coop-release.git
+      version: 0.0.3-0
   alfred_bot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `airbus_coop` to `0.0.3-0`:

- upstream repository: https://github.com/ipa320/airbus_coop.git
- release repository: https://github.com/ipa320/airbus_coop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## airbus_cobot_gui

```
* Merge pull request #34 <https://github.com/ipa320/airbus_coop/issues/34> from ipa-nhg/SeparateTemplates
  Separate templates
* make airbus_cobot_gui independet to the templates
* Merge pull request #33 <https://github.com/ipa320/airbus_coop/issues/33> from ipa-nhg/Rename
  Rename packages
* test cobot_gui renames
* renamed packages
* rename plugin_rviz to airbus_plugin_rviz
* rename plugin_rqt to airbus_plugin_rqt
* rename plugin_node_manager to airbus_plugin_node_manager
* renamed plugin_log_manager to airbus_plugin_log_manager
* rename pyqt_agi_extend to airbus_pyqt_extend
* rename cobot_gui to airbus_cobot_gui
* Contributors: Nadia Hammoudeh García, ipa-nhg
```

## airbus_coop

```
* Merge pull request #33 <https://github.com/ipa320/airbus_coop/issues/33> from ipa-nhg/Rename
  Rename packages
* rename ssm_tutorial to airbus_ssm_tutorial
* renamed ssm_core to airbus_ssm_core
* rename ssm_plugin to airbus_ssm_plugin
* rename plugin_rviz to airbus_plugin_rviz
* rename plugin_rqt to airbus_plugin_rqt
* rename plugin_node_manager to airbus_plugin_node_manager
* renamed plugin_log_manager to airbus_plugin_log_manager
* rename pyqt_agi_extend to airbus_pyqt_extend
* rename cobot_gui to airbus_cobot_gui
* Merge github.com:ipa319/airbus_coop into Rename
  Conflicts:
  airbus_docgen/package.xml
* rename agi_docgen package to airbus_docgen
* Contributors: Nadia Hammoudeh García, ipa-nhg
```

## airbus_docgen

```
* update changelog
* Merge pull request #33 <https://github.com/ipa320/airbus_coop/issues/33> from ipa-nhg/Rename
  Rename packages
* renamed packages
* Merge github.com:ipa319/airbus_coop into Rename
  Conflicts:
  airbus_docgen/package.xml
* rename agi_docgen package to airbus_docgen
* Contributors: Nadia Hammoudeh García, ipa-nhg
* Merge pull request #33 <https://github.com/ipa320/airbus_coop/issues/33> from ipa-nhg/Rename
  Rename packages
* renamed packages
* Merge github.com:ipa319/airbus_coop into Rename
  Conflicts:
  airbus_docgen/package.xml
* rename agi_docgen package to airbus_docgen
* Contributors: Nadia Hammoudeh García, ipa-nhg
```

## airbus_plugin_log_manager

```
* Merge pull request #33 <https://github.com/ipa320/airbus_coop/issues/33> from ipa-nhg/Rename
  Rename packages
* test cobot_gui renames
* renamed plugin_log_manager to airbus_plugin_log_manager
* Contributors: Nadia Hammoudeh García, ipa-nhg
```

## airbus_plugin_node_manager

```
* Merge pull request #33 <https://github.com/ipa320/airbus_coop/issues/33> from ipa-nhg/Rename
  Rename packages
* rename plugin_node_manager to airbus_plugin_node_manager
* Contributors: Nadia Hammoudeh García, ipa-nhg
```

## airbus_plugin_rqt

```
* Merge pull request #33 <https://github.com/ipa320/airbus_coop/issues/33> from ipa-nhg/Rename
  Rename packages
* rename plugin_rqt to airbus_plugin_rqt
* Contributors: Nadia Hammoudeh García, ipa-nhg
```

## airbus_plugin_rviz

```
* Merge pull request #33 <https://github.com/ipa320/airbus_coop/issues/33> from ipa-nhg/Rename
  Rename packages
* rename plugin_rviz to airbus_plugin_rviz
* Contributors: Nadia Hammoudeh García, ipa-nhg
```

## airbus_pyqt_extend

```
* Merge pull request #33 <https://github.com/ipa320/airbus_coop/issues/33> from ipa-nhg/Rename
  Rename packages
* rename pyqt_agi_extend to airbus_pyqt_extend
* Contributors: Nadia Hammoudeh García, ipa-nhg
```

## airbus_ssm_core

```
* Merge pull request #33 <https://github.com/ipa320/airbus_coop/issues/33> from ipa-nhg/Rename
  Rename packages
* rename ssm_tutorial to airbus_ssm_tutorial
* renamed ssm_core to airbus_ssm_core
* Contributors: Nadia Hammoudeh García, ipa-nhg
```

## airbus_ssm_plugin

```
* Merge pull request #33 <https://github.com/ipa320/airbus_coop/issues/33> from ipa-nhg/Rename
  Rename packages
* renamed ssm_core to airbus_ssm_core
* rename ssm_plugin to airbus_ssm_plugin
* Contributors: Nadia Hammoudeh García, ipa-nhg
```

## airbus_ssm_tutorial

```
* Merge pull request #33 <https://github.com/ipa320/airbus_coop/issues/33> from ipa-nhg/Rename
  Rename packages
* rename ssm_tutorial to airbus_ssm_tutorial
* Contributors: Nadia Hammoudeh García, ipa-nhg
```
