### PR TITLE
grpc: 0.0.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -845,6 +845,21 @@ repositories:
       url: https://github.com/davetcoleman/graph_msgs-release.git
       version: 0.1.0-0
     status: maintained
+  grpc:
+    doc:
+      type: git
+      url: https://github.com/CogRob/catkin_grpc.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/CogRobRelease/catkin_grpc-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/CogRob/catkin_grpc.git
+      version: master
+    status: developed
   gscam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grpc` to `0.0.2-0`:

- upstream repository: https://github.com/CogRob/catkin_grpc.git
- release repository: https://github.com/CogRobRelease/catkin_grpc-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`

## grpc

```
* Lower version requirement for cmake so that the package can be built under
  trusty.
* Contributors: Shengye Wang
```
