### PR TITLE
laser_filters: 1.8.5-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1130,7 +1130,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/laser_filters-release.git
-      version: 1.8.4-1
+      version: 1.8.5-0
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `1.8.5-0`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros-gbp/laser_filters-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.8.4-1`

## laser_filters

```
* rename parameter to be more descriptive
* change range_filter to infinity for it to work with obstacle_layer
  if you use the ´inf_is_valid´ parameter raytracing is still possible for
  scans out of the window.
  Usefull for laserscanners that may deliver ranges > range_max ... or
* Fix a small typo in one of the test cases.
* Add LaserScanMaskFilter.
  This commit adds LaserScanMaskFilter that removes points on directions defined in a mask, defined as a parameter, from a laser scan.
  It can be used to remove unreliable points caused by hardware related problems for example scratches on an optical window of the sensor.
* Contributors: Atsushi Watanabe, Hunter L. Allen, Jannik Abbenseth, Jonathan Binney
```
