### PR TITLE
rtmros_hironx: 2.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8148,7 +8148,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 2.0.0-0
+      version: 2.1.0-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_hironx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `2.1.0-0`:

- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.0.0-0`

## hironx_calibration

- No changes

## hironx_moveit_config

```
* set trajectory_execution/allowed_execution_duration_scaling to 2.0 (#518 <https://github.com/start-jsk/rtmros_hironx/issues/518>)
  - Same as https://github.com/tork-a/rtmros_nextage/commit/b568101055fec975b6130cebf6150f85106e3bee
  - see https://answers.ros.org/question/196586/how-do-i-disable-execution_duration_monitoring/
  * Change to use moveit_simple_controller
* Contributors: Ryosuke Tajima
```

## hironx_ros_bridge

```
* get nshost from rtmnameserver, sometimes nshost is different from rosmaster (#513 <https://github.com/start-jsk/rtmros_hironx/issues/513>)
* hironx_ros_bridge_real.launch: support HRPSYS_PY_{PKG,NAME,ARGS} as https://github.com/start-jsk/rtmros_common/blob/master/hrpsys_tools/launch/hrpsys.launch#L97-L103 (#514 <https://github.com/start-jsk/rtmros_hironx/issues/514>)
* Add hand_joint_state_publisher.py for 2017/Feb? verison of MoveIt, that strictly requrired all robot states for planning (#519 <https://github.com/start-jsk/rtmros_hironx/issues/519>)
* Contributors: Kei Okada, Ryosuke Tajima
```

## rtmros_hironx

- No changes
