### PR TITLE
rtmros_nextage: 0.8.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8154,6 +8154,29 @@ repositories:
       url: https://github.com/start-jsk/rtmros_hironx.git
       version: indigo-devel
     status: developed
+  rtmros_nextage:
+    doc:
+      type: git
+      url: https://github.com/tork-a/rtmros_nextage.git
+      version: indigo-devel
+    release:
+      packages:
+      - nextage_calibration
+      - nextage_description
+      - nextage_gazebo
+      - nextage_ik_plugin
+      - nextage_moveit_config
+      - nextage_ros_bridge
+      - rtmros_nextage
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/rtmros_nextage-release.git
+      version: 0.8.0-0
+    source:
+      type: git
+      url: https://github.com/tork-a/rtmros_nextage.git
+      version: indigo-devel
+    status: maintained
   rtshell:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.8.0-0`:

- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## nextage_calibration

```
* Fix for kinetic (#347 <https://github.com/tork-a/rtmros_nextage/issues/347>)
  * fix .travis.yaml to run both indigo/kinetic with docker
  * add time.sleep before call self.tflistener.getFrameString() to wait to initialize listener, see https://github.com/ros/geometry/issues/152
  * increase time-limit
* Contributors: Kei Okada
```

## nextage_description

- No changes

## nextage_gazebo

- No changes

## nextage_ik_plugin

```
* Fix for kinetic (#347 <https://github.com/tork-a/rtmros_nextage/issues/347>)
  * enable c++-11
* Contributors: Kei Okada
```

## nextage_moveit_config

```
* Fix for kinetic (#347 <https://github.com/tork-a/rtmros_nextage/issues/347>)
  *  fix .travis.yaml to run both indigo/kinetic with docker
  * set trajectory_execution/allowed_execution_duration_scaling to 2.0, see https://answers.ros.org/question/196586/how-do-i-disable-execution_duration_monitoring/
  * config/NextageOpen.srdf and test/test_moveit.py: including torso to botharms is not working
  * increase set_planning_time to 30
  * run mvgroup.go() 3 time in test/test_moveit.py (test_planandexecute)
  * nextage_moveit_config/test/test_moveit.py: display content of plan
  * add replanning and set_planning_time to 15
  * increase wait_time for hztest move_group/status
  * we need type: FollowJointTrajecory in controllers.yaml
  * use move_group/MoveGroupExecuteTrajectoryAction instaeed of move_group/MoveGroupExecuteService
  * use moveit_simple_controller_manager/MoveItSimpleControllerManager instead of pr2_moveit_controller_manager/Pr2MoveItControllerManager
* Contributors: Kei Okada
```

## nextage_ros_bridge

```
* Fix for kinetic (#347 <https://github.com/tork-a/rtmros_nextage/issues/347>)
  * fix .travis.yaml to run both indigo/kinetic with docker
  * fix install(CODE for kintic
* [ros_bridge] Missing dependency for using stereo vision. (#331 <https://github.com/tork-a/rtmros_nextage/issues/331> )
  * [ros_bridge] Missing dependency for using stereo vision.This dependency won't be necessary unless stereo vision is in use, but the advantage of having necessary pkg installed without the need for worrying surpasses disadvantage.
* [ros_bridge] Fix a launch file name to appropriately indicate "older than" 315.2.7. (#328)
  
  Hyphen here is used to indicate the file is intended for the mentioned version or larger/smaller."*version-.launch" sounds like the launch is targeted for the version or larger while in fact we wanted to mean the opposite.
* add comments to functions in playPattern example codes (#323 <https://github.com/tork-a/rtmros_nextage/issues/323>)
* Contributors: Isaac I.Y. Saito, Kei Okada, Yosuke Yamamoto
```

## rtmros_nextage

- No changes
