### PR TITLE
rqt_shell: 0.4.9-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3073,7 +3073,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rqt_shell-release.git
-      version: 0.4.8-0
+      version: 0.4.9-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_shell` to `0.4.9-0`:

- upstream repository: https://github.com/ros-visualization/rqt_shell.git
- release repository: https://github.com/ros-gbp/rqt_shell-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.4.8-0`

## rqt_shell

```
* Fixed syntax error when using a startup script with spyder shell
```
