### PR TITLE
jsk_roseus: 1.6.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3313,7 +3313,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.6.2-0
+      version: 1.6.3-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.6.3-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.6.2-0`

## jsk_roseus

- No changes

## roseus

```
* Fix ros::get-namesapce (#533 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/533>)
  * use ros::names::clean to get sanitized namespace string
  * add test for ros::get-namesapce
* package without msg does not have manifest.l, so skip loading that without  ros::ros-error (#539 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/539>)
  * on jade/kinetic, package without msg does not have manifest.l, so users need to change (load-ros-manifest) target
  * add test to check https://github.com/jsk-ros-pkg/jsk_roseus/pull/537 / https://github.com/jsk-ros-pkg/jsk_robot/issues/823
* [roseus][roseus.cpp] check ros::ok() in ros::spin (#531 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/531> )
* [roseus/euslisp/actionlib.l] fix :wait-for-result is too slow (#528 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/528>)
* Contributors: Kei Okada, Yohei Kakiuchi
```

## roseus_smach

- No changes

## roseus_tutorials

- No changes
