### PR TITLE
python-ftputil: 3.3.0-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9746,6 +9746,13 @@ repositories:
       url: https://github.com/andreasBihlmaier/pysdf.git
       version: master
     status: developed
+  python-ftputil:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/ftputil-rosrelease.git
+      version: 3.3.0-3
+    status: maintained
   python-pathtools:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `python-ftputil` to `3.3.0-3`:

- upstream repository: http://hg.sschwarzer.net/ftputil
- release repository: https://github.com/asmodehn/ftputil-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
