### PR TITLE
binpicking_utils: 0.1.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -598,11 +598,12 @@ repositories:
       packages:
       - bin_pose_emulator
       - bin_pose_msgs
+      - binpicking_simple_utils
       - binpicking_utils
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/durovsky/binpicking_utils-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/durovsky/binpicking_utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `binpicking_utils` to `0.1.4-0`:

- upstream repository: https://github.com/durovsky/binpicking_utils.git
- release repository: https://github.com/durovsky/binpicking_utils-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.3-0`

## bin_pose_emulator

```
* adding CHANGELOGS
* syntax fix
* Contributors: Frantisek Durovsky
* syntax fix
* Contributors: Frantisek Durovsky
```

## bin_pose_msgs

```
* adding CHANGELOGS
* Contributors: Frantisek Durovsky
```

## binpicking_simple_utils

```
* adding CHANGELOGS
* adding CHANGELOG
* minor updates
* switched to class representation
* adding basic launch file
* adding tool_pose_tf_broadcaster
* Contributors: Frantisek Durovsky
* adding CHANGELOG
* minor updates
* switched to class representation
* adding basic launch file
* adding tool_pose_tf_broadcaster
* Contributors: Frantisek Durovsky
* minor updates
* switched to class representation
* adding basic launch file
* adding tool_pose_tf_broadcaster
* Contributors: Frantisek Durovsky
```

## binpicking_utils

```
* adding CHANGELOGS
* Contributors: Frantisek Durovsky
```
