### PR TITLE
remove yakkety from distribution list

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -9,7 +9,6 @@ release_platforms:
   - '26'
   ubuntu:
   - xenial
-  - yakkety
   - zesty
 repositories:
   ackermann_msgs:


### PR DESCRIPTION
Now that yakkety is EOL and that the yakkety jobs have been [disabled on the buildfarm](https://discourse.ros.org/t/suspension-of-debian-packaging-for-eol-ubuntu-yakkety/2444). Removing it for the rosdistro index will prevent bloom from generating control files for it