### PR TITLE
minas: 1.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6816,6 +6816,27 @@ repositories:
       url: https://github.com/ros-drivers/microstrain_3dmgx2_imu.git
       version: indigo-devel
     status: maintained
+  minas:
+    doc:
+      type: git
+      url: https://github.com/tork-a/minas.git
+      version: master
+    release:
+      packages:
+      - ethercat_manager
+      - minas_control
+      - tra1_bringup
+      - tra1_description
+      - tra1_moveit_config
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/minas-release.git
+      version: 1.0.4-0
+    source:
+      type: git
+      url: https://github.com/tork-a/minas.git
+      version: master
+    status: developed
   mjpeg_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `minas` to `1.0.4-0`:

- upstream repository: https://github.com/tork-a/minas
- release repository: https://github.com/tork-a/minas-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## ethercat_manager

```
* set license as GPLv2/CC-BY-SA,add LICENSE for meshes (#55 <https://github.com/tork-a/minas/issues/55>)
  * set license as GPLv2/CC-BY-SA,add LICENSE for meshes
  * cleanup code
  * fix wrong license data, add LICENSE information to xacro files
  * cleanup package.xml
* Contributors: Ryosuke Tajima, Tokyo Opensource Robotics Developer 534
```

## minas_control

```
* set license as GPLv2/CC-BY-SA,add LICENSE for meshes (#55 <https://github.com/tork-a/minas/issues/55>)
  * set license as GPLv2/CC-BY-SA,add LICENSE for meshes
  * cleanup code
  * fix wrong license data, add LICENSE information to xacro files
  * cleanup package.xml
* Contributors: Ryosuke Tajima, Tokyo Opensource Robotics Developer 534
```

## tra1_bringup

```
* set license as GPLv2/CC-BY-SA,add LICENSE for meshes (#55 <https://github.com/tork-a/minas/issues/55>)
  * set license as GPLv2/CC-BY-SA,add LICENSE for meshes
  * cleanup code
  * fix wrong license data, add LICENSE information to xacro files
  * cleanup package.xml
* Contributors: Ryosuke Tajima, Tokyo Opensource Robotics Developer 534
```

## tra1_description

```
* set license as GPLv2/CC-BY-SA,add LICENSE for meshes (#55 <https://github.com/tork-a/minas/issues/55>)
  * set license as GPLv2/CC-BY-SA,add LICENSE for meshes
  * cleanup code
  * fix wrong license data, add LICENSE information to xacro files
  * cleanup package.xml
* Contributors: Ryosuke Tajima, Tokyo Opensource Robotics Developer 534
```

## tra1_moveit_config

```
* set license as GPLv2/CC-BY-SA,add LICENSE for meshes (#55 <https://github.com/tork-a/minas/issues/55>)
  * set license as GPLv2/CC-BY-SA,add LICENSE for meshes
  * cleanup code
  * fix wrong license data, add LICENSE information to xacro files
  * cleanup package.xml
* Contributors: Ryosuke Tajima, Tokyo Opensource Robotics Developer 534
```
