### PR TITLE
rosbridge_suite: 0.8.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7169,7 +7169,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.8.1-2
+      version: 0.8.3-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.8.3-0`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.8.1-2`

## rosapi

- No changes

## rosbridge_library

```
* Type conversion convention correction, correcting issue #240 <https://github.com/RobotWebTools/rosbridge_suite/issues/240>
* Contributors: Alexis Paques
```

## rosbridge_server

- No changes

## rosbridge_suite

- No changes
