### PR TITLE
repository_name: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10436,6 +10436,19 @@ repositories:
       url: https://github.com/So-Cool/report_card.git
       version: master
     status: maintained
+  repository_name:
+    release:
+      packages:
+      - rapid_pbd_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/jstnhuang-release/rapid_pbd_msgs-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/jstnhuang/rapid_pbd_msgs.git
+      version: indigo-devel
+    status: developed
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `repository_name` to `0.1.1-0`:

- upstream repository: https://github.com/jstnhuang/rapid_pbd_msgs.git
- release repository: https://github.com/jstnhuang-release/rapid_pbd_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rapid_pbd_msgs

```
* Initial release.
* Contributors: Justin Huang
```
