### PR TITLE
rapid_pbd_msgs: 0.1.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10163,6 +10163,17 @@ repositories:
       url: https://github.com/felramfab/rangeonly_driver.git
       version: indigo-devel
     status: developed
+  rapid_pbd_msgs:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/jstnhuang-release/rapid_pbd_msgs-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/jstnhuang/rapid_pbd_msgs.git
+      version: indigo-devel
+    status: developed
   razer_hydra:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rapid_pbd_msgs` to `0.1.1-1`:

- upstream repository: https://github.com/jstnhuang/rapid_pbd_msgs.git
- release repository: https://github.com/jstnhuang-release/rapid_pbd_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rapid_pbd_msgs

```
* Initial release.
* Contributors: Justin Huang
```
