### PR TITLE
rapid_pbd: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10163,6 +10163,17 @@ repositories:
       url: https://github.com/felramfab/rangeonly_driver.git
       version: indigo-devel
     status: developed
+  rapid_pbd:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/jstnhuang-release/rapid_pbd-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/jstnhuang/rapid.git
+      version: indigo-devel
+    status: developed
   razer_hydra:
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10171,7 +10171,7 @@ repositories:
       version: 0.1.2-0
     source:
       type: git
-      url: https://github.com/jstnhuang/rapid.git
+      url: https://github.com/jstnhuang/rapid_pbd.git
       version: indigo-devel
     status: developed
   rapid_pbd_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `rapid_pbd` to `0.1.2-0`:

- upstream repository: https://github.com/jstnhuang/rapid_pbd.git
- release repository: https://github.com/jstnhuang-release/rapid_pbd-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rapid_pbd

```
* Added install targets.
* Contributors: Justin Huang
```
