### PR TITLE
minas: 1.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6831,7 +6831,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/minas-release.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/tork-a/minas.git


### PR DESCRIPTION
Increasing version of package(s) in repository `minas` to `1.0.5-0`:

- upstream repository: https://github.com/tork-a/minas
- release repository: https://github.com/tork-a/minas-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.4-0`

## ethercat_manager

- No changes

## minas_control

```
* add .travis.yml using ros_build_farm (#58 <https://github.com/tork-a/minas/issues/58>)
  * add rosdoc.yaml
  * package.xml, CMakeLists.txt: add depends to diagnostic_updater
  * Contributors: Ryosuke Tajima, Tokyo Opensource Robotics Developer 534
```

## tra1_bringup

- No changes

## tra1_description

- No changes

## tra1_moveit_config

- No changes
