### PR TITLE
minas: 1.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6824,6 +6824,7 @@ repositories:
     release:
       packages:
       - ethercat_manager
+      - minas
       - minas_control
       - tra1_bringup
       - tra1_description
@@ -6831,7 +6832,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/minas-release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/tork-a/minas.git


### PR DESCRIPTION
Increasing version of package(s) in repository `minas` to `1.0.6-0`:

- upstream repository: https://github.com/tork-a/minas
- release repository: https://github.com/tork-a/minas-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.5-0`

## ethercat_manager

- No changes

## minas

```
* add minas meta package(#59 <https://github.com/tork-a/minas/issues/59>)
  * add minas meta package: CMakeLists.txt package.xml
  * Contributors: Ryosuke Tajima, Tokyo Opensource Robotics Developer 534
```

## minas_control

- No changes

## tra1_bringup

- No changes

## tra1_description

- No changes

## tra1_moveit_config

- No changes
