### PR TITLE
fetch_msgs: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3144,7 +3144,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_msgs-release.git
-      version: 0.6.1-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_msgs` to `1.0.0-0`:

- upstream repository: https://github.com/fetchrobotics/fetch_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.6.1-0`

## fetch_auto_dock_msgs

```
* Add LICENSE files.
* Contributors: Mac Mason
```

## fetch_driver_msgs

```
* Add Gyro message that includes more details about gyro.
* Add SafetyLaserState message
* Add LICENSE files.
* Contributors: Derek King, Mac Mason, Michael Ferguson
```
