### PR TITLE
pocketsphinx: 1.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5790,6 +5790,22 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: kinetic-devel
     status: maintained
+  pocketsphinx:
+    doc:
+      type: git
+      url: https://github.com/Pankaj-Baranwal/pocketsphinx.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Pankaj-Baranwal/pocketsphinx-release.git
+      version: 1.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/Pankaj-Baranwal/pocketsphinx.git
+      version: kinetic-devel
+    status: maintained
   pointcloud_to_laserscan:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pocketsphinx` to `1.0.1-1`:

- upstream repository: https://github.com/Pankaj-Baranwal/pocketsphinx.git
- release repository: https://github.com/Pankaj-Baranwal/pocketsphinx-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## pocketsphinx

```
* Following PEP8 guidelines
* Adding backward compatibility
* New model for speaker verification
* Examples
* keyword spotting mode and grammar mode dict and kwlist
* speaker verification based continous mode
* simple audio recorder
* continuous mode working
* kws threshold automation working.
* Better false alarm correction
* Background recording using rec accomplished. kws search working!
* Integrated kws
* Contributors: Pankaj Baranwal
```
