### PR TITLE
hls-lfcd-lds-driver: 0.1.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2704,7 +2704,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hls-lfcd-lds-driver` to `0.1.4-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
- release repository: https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.3-0`

## hls_lfcd_lds_driver

```
* modify to stop motor of LDS
* delete unused lfcdstartstop arg of LFCDLaser. Fix an exception error.
* merge pull request #8 <https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/issues/8> from hara-y/stop_motor_in_dtor
* fixed code format
* Contributors: Yoonseok Pyo, Yoshitaka HARA
```
