### PR TITLE
teraranger: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8940,6 +8940,12 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  teraranger:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: git@github.com:Terabee/teraranger-release.git
+      version: 1.0.0-1
   tf2_web_republisher:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8944,7 +8944,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: git@github.com:Terabee/teraranger-release.git
+      url: https://github.com/Terabee/teraranger-release.git
       version: 1.0.0-1
   tf2_web_republisher:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger` to `1.0.0-1`:

- upstream repository: git@github.com:Terabee/teraranger.git
- release repository: git@github.com:Terabee/teraranger-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## teraranger

```
* Create README.md
* Handle infinite values
* Add One and Duo support
* Fix frame dropping on 'T'
* Clean files and change to pragma once
* Implement REP 117 for teraranger duo
* Implement REP 117 for teraranger one
* Use helper lib and clean header of one
* Use helper lib and clean header of duo
* Remove old erial library files
* Update drivers to ros-serial
* Enable outdoor mode in reconfigure for one and duo
* Initialize repository
* Contributors: BaptistePotier, Mateusz Sadowski, pl-kabaradjian
```
