### PR TITLE
mongodb_store: 0.3.6-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6899,13 +6899,14 @@ repositories:
   mongodb_store:
     release:
       packages:
+      - libmongocxx_ros
       - mongodb_log
       - mongodb_store
       - mongodb_store_msgs
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.1.30-1
+      version: 0.3.6-1
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.3.6-1`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.30-1`

## libmongocxx_ros

- No changes

## mongodb_log

- No changes

## mongodb_store

- No changes

## mongodb_store_msgs

- No changes
