### PR TITLE
mongodb_store: 0.3.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4271,6 +4271,22 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/mobility_base_simulator
       version: default
     status: developed
+  mongodb_store:
+    release:
+      packages:
+      - libmongocxx_ros
+      - mongodb_log
+      - mongodb_store
+      - mongodb_store_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/mongodb_store.git
+      version: 0.3.6-0
+    source:
+      type: git
+      url: https://github.com/strands-project/mongodb_store.git
+      version: kinetic-devel
+    status: developed
   motoman:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.3.6-0`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## libmongocxx_ros

- No changes

## mongodb_log

- No changes

## mongodb_store

- No changes

## mongodb_store_msgs

- No changes
