### PR TITLE
rapid_pbd: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10179,7 +10179,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/jstnhuang-release/rapid_pbd-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/jstnhuang/rapid_pbd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rapid_pbd` to `0.1.4-0`:

- upstream repository: https://github.com/jstnhuang/rapid_pbd.git
- release repository: https://github.com/jstnhuang-release/rapid_pbd-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.3-0`

## rapid_pbd

```
* Changed str to toString, which compiles on ROS buildfarm.
* Contributors: Justin Huang
```
