### PR TITLE
Move joint_state_publisher from robot_model to it's own repository (indigo/kinetic/lunar)

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5196,8 +5196,6 @@ repositories:
       url: https://github.com/ros/joint_state_publisher.git
       version: indigo-devel
     release:
-      packages:
-      - joint_state_publisher
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/joint_state_publisher-release.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5190,6 +5190,24 @@ repositories:
       url: https://github.com/JenniferBuehler/general-message-pkgs.git
       version: master
     status: maintained
+  joint_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: indigo-devel
+    release:
+      packages:
+      - joint_state_publisher
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/joint_state_publisher-release.git
+      version: 1.11.15-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: indigo-devel
+    status: maintained
   joystick_drivers:
     doc:
       type: git
@@ -10761,7 +10779,6 @@ repositories:
       version: indigo-devel
     release:
       packages:
-      - joint_state_publisher
       - robot_model
       - urdf
       - urdf_parser_plugin

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3115,6 +3115,22 @@ repositories:
       url: https://github.com/gstavrinos/jaguar-release.git
       version: 0.1.0-0
     status: developed
+  joint_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/joint_state_publisher-release.git
+      version: 1.12.12-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: kinetic-devel
+    status: maintained
   joystick_drivers:
     doc:
       type: git
@@ -6450,7 +6466,6 @@ repositories:
       version: kinetic-devel
     release:
       packages:
-      - joint_state_publisher
       - robot_model
       - urdf
       - urdf_parser_plugin

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1043,7 +1043,7 @@ repositories:
       version: kinetic-devel
     release:
       tags:
-        release: release/kinetic/{package}/{version}
+        release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/joint_state_publisher-release.git
       version: 1.12.12-0
     source:

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1036,6 +1036,22 @@ repositories:
       url: https://github.com/ros/ivcon.git
       version: kinetic-devel
     status: maintained
+  joint_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/joint_state_publisher-release.git
+      version: 1.12.12-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: kinetic-devel
+    status: maintained
   joystick_drivers:
     doc:
       type: git
@@ -2213,7 +2229,6 @@ repositories:
       version: kinetic-devel
     release:
       packages:
-      - joint_state_publisher
       - robot_model
       - urdf
       - urdf_parser_plugin


### PR DESCRIPTION
part of ros/robot_model#195

To indigo this releases 1.11.15-0
To kinetic/lunar this releases 1.12.12-0

This moves joint_state_publisher out of the robot_model repository. Bloom was used up to the point of creating this pull request.

```
$ bloom-release --version
0.5.26
```