### PR TITLE
Change robot_model from indigo-devel branch to jade-devel tag

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5280,7 +5280,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/robot_model.git
-      version: indigo-devel
+      version: jade-devel
     release:
       packages:
       - joint_state_publisher
@@ -5295,7 +5295,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/robot_model.git
-      version: indigo-devel
+      version: jade-devel
     status: maintained
   robot_pose_publisher:
     doc:


### PR DESCRIPTION
The purpose of this is to not break `rosinstall_generator --upstream-development` for the EOL distro jade once the package `joint_state_publisher` is removed from the `indigo-devel` branch. This changes the version for the repository `robot_model` from the branch `indigo-devel` to a tag `jade-devel`. The tag is set to the state of the repo when [the last jade sync happened](https://discourse.ros.org/t/final-jade-sync-2017-09-03/2559). 

See #15926 
See ros/robot_model#195