### PR TITLE
roch_simulator: 1.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11014,7 +11014,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_simulator-release.git
-      version: 1.0.11-0
+      version: 1.0.12-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_simulator` to `1.0.12-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch_simulator.git
- release repository: https://github.com/SawYerRobotics-release/roch_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.11-0`

## roch_gazebo

- No changes

## roch_simulator

- No changes
