### PR TITLE
roch_viz: 1.0.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11029,7 +11029,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_viz-release.git
-      version: 1.0.9-3
+      version: 1.0.10-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_viz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_viz` to `1.0.10-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch_viz.git
- release repository: https://github.com/SawYerRobotics-release/roch_viz-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.9-3`

## roch_viz

- No changes
