### PR TITLE
roch_viz: 2.0.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6682,6 +6682,21 @@ repositories:
       url: https://github.com/SawYer-Robotics/roch_robot.git
       version: kinetic
     status: maintained
+  roch_viz:
+    doc:
+      type: git
+      url: https://github.com/SawYer-Robotics/roch_viz.git
+      version: kinetic
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/SawYerRobotics-release/roch_viz-release.git
+      version: 2.0.10-0
+    source:
+      type: git
+      url: https://github.com/SawYer-Robotics/roch_viz.git
+      version: kinetic
+    status: maintained
   rocon_app_platform:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_viz` to `2.0.10-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch_viz.git
- release repository: https://github.com/SawYerRobotics-release/roch_viz-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## roch_viz

- No changes
