### PR TITLE
roch_simulator: 2.0.12-5 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6682,6 +6682,24 @@ repositories:
       url: https://github.com/SawYer-Robotics/roch_robot.git
       version: kinetic
     status: maintained
+  roch_simulator:
+    doc:
+      type: git
+      url: https://github.com/SawYer-Robotics/roch_simulator.git
+      version: kinetic
+    release:
+      packages:
+      - roch_gazebo
+      - roch_simulator
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/SawYerRobotics-release/roch_simulator-release.git
+      version: 2.0.12-5
+    source:
+      type: git
+      url: https://github.com/SawYer-Robotics/roch_simulator.git
+      version: kinetic
+    status: maintained
   roch_viz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_simulator` to `2.0.12-5`:

- upstream repository: https://github.com/SawYer-Robotics/roch_simulator.git
- release repository: https://github.com/SawYerRobotics-release/roch_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `null`

## roch_gazebo

- No changes

## roch_simulator

- No changes
