### PR TITLE
turtlebot_simulator: 2.2.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9397,7 +9397,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/turtlebot-release/turtlebot_simulator-release.git
-      version: 2.2.2-0
+      version: 2.2.3-0
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_simulator` to `2.2.3-0`:

- upstream repository: https://github.com/turtlebot/turtlebot_simulator.git
- release repository: https://github.com/turtlebot-release/turtlebot_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.2.2-0`

## turtlebot_gazebo

```
* Fix changing amcl.launch.xml and gmapping.launch.xml locations under turtlebot_navigation
* Contributors: Mohamed Al Zaiady, Mohamed Elzaiady, Tully Foote, mzaiady
```

## turtlebot_simulator

- No changes

## turtlebot_stage

```
* Contributors: Clyde McQueen
```

## turtlebot_stdr

```
* add turtlebot_navigation as dependency and fix amcl.launch.xml include path in turtlebot_stdr
* Contributors: Gérald Lelong
```
