### PR TITLE
teraranger-array: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9010,7 +9010,7 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger-release.git
       version: 1.0.0-1
-  teraranger-array:
+  teraranger_array:
     release:
       packages:
       - teraranger_array

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9012,8 +9012,6 @@ repositories:
       version: 1.0.0-1
   teraranger_array:
     release:
-      packages:
-      - teraranger_array
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger_array-release.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9010,6 +9010,14 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger-release.git
       version: 1.0.0-1
+  teraranger-array:
+    release:
+      packages:
+      - teraranger_array
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Terabee/teraranger_array-release.git
+      version: 1.0.0-0
   tf2_web_republisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger-array` to `1.0.0-0`:

- upstream repository: https://github.com/Terabee/teraranger_array.git
- release repository: https://github.com/Terabee/teraranger_array-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## teraranger_array

```
* Use ros-serial and remove old serial files
* Standardize topic names
* Use REP 117
* Use RangeArray message, append namespace to frame_id
* Send disable cmd when driver exits
* Refactor trone and multiflex drivers
* Initial commit
* Contributors: Kabaradjian PL, Krzysztof Zurad, Mateusz Sadowski, Potier Baptiste
```
