### PR TITLE
costmap_converter: 0.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1343,7 +1343,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/costmap_converter-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/rst-tu-dortmund/costmap_converter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `costmap_converter` to `0.0.6-0`:

- upstream repository: https://github.com/rst-tu-dortmund/costmap_converter.git
- release repository: https://github.com/rst-tu-dortmund/costmap_converter-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.5-0`

## costmap_converter

```
* This pull request adds the costmap to dynamic obstacles plugin (written by Franz Albers).
  It detects the dynamic foreground of the costmap (based on the temporal evolution of the costmap)
  including blobs representing the obstacles. Furthermore, Kalman-based tracking is applied to estimate
  the current velocity for each obstacle.
  **Note, this plugin is still experimental.**
* New message types are introduced: costmap_converter::ObstacleMsg and costmap_converter::ObstacleArrayMsg.
  These types extend the previous polygon representation by additional velocity, orientation and id information.
* The API has been extended to provide obstacles via the new ObstacleArrayMsg type instead of vector of polygons.
* Contributors: Franz Albers, Christoph Rösmann
```
