### PR TITLE
teraranger-array-converter: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9012,8 +9012,6 @@ repositories:
       version: 1.0.0-1
   teraranger_array_converter:
     release:
-      packages:
-      - teraranger_array_converter
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger_array_converter-release.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9010,6 +9010,14 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger-release.git
       version: 1.0.0-1
+  teraranger-array-converter:
+    release:
+      packages:
+      - teraranger_array_converter
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Terabee/teraranger_array_converter-release.git
+      version: 1.0.0-0
   tf2_web_republisher:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9010,7 +9010,7 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger-release.git
       version: 1.0.0-1
-  teraranger-array-converter:
+  teraranger_array_converter:
     release:
       packages:
       - teraranger_array_converter


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger-array-converter` to `1.0.0-0`:

- upstream repository: https://github.com/Terabee/teraranger_array_converter.git
- release repository: https://github.com/Terabee/teraranger_array_converter-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## teraranger_array_converter

```
* Update package.xml
* Add README.md
* Initial commit
* Contributors: Kabaradjian PL
```
