### PR TITLE
teraranger-description: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9010,7 +9010,7 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger-release.git
       version: 1.0.0-1
-  teraranger-description:
+  teraranger_description:
     release:
       packages:
       - teraranger_description

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9012,8 +9012,6 @@ repositories:
       version: 1.0.0-1
   teraranger_description:
     release:
-      packages:
-      - teraranger_description
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger_description-release.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9010,6 +9010,14 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger-release.git
       version: 1.0.0-1
+  teraranger-description:
+    release:
+      packages:
+      - teraranger_description
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Terabee/teraranger_description-release.git
+      version: 1.0.0-0
   tf2_web_republisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger-description` to `1.0.0-0`:

- upstream repository: https://github.com/Terabee/teraranger_description.git
- release repository: https://github.com/Terabee/teraranger_description-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## teraranger_description

```
* Update README.md
* Initial commit
* Contributors: Zurad Krzysztof, Kabaradjian PL, Potier Baptiste
```
