### PR TITLE
roch_robot: 2.0.15-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6676,7 +6676,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_robot-release.git
-      version: 2.0.14-0
+      version: 2.0.15-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_robot` to `2.0.15-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch_robot.git
- release repository: https://github.com/SawYerRobotics-release/roch_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.0.14-0`

## roch_base

- No changes

## roch_bringup

- No changes

## roch_capabilities

- No changes

## roch_control

- No changes

## roch_description

- No changes

## roch_ftdi

- No changes

## roch_msgs

- No changes

## roch_safety_controller

- No changes

## roch_sensorpc

- No changes
