### PR TITLE
pheeno_ros: 0.1.1-4 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8974,6 +8974,12 @@ repositories:
       url: https://github.com/RobotnikAutomation/phantomx_reactor_arm.git
       version: indigo-devel
     status: maintained
+  pheeno_ros:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ACSLaboratory/pheeno_ros-release.git
+      version: 0.1.1-4
   phidgets_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pheeno_ros` to `0.1.1-4`:

- upstream repository: https://github.com/ACSLaboratory/pheeno_ros.git
- release repository: https://github.com/ACSLaboratory/pheeno_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## pheeno_ros

```
* Initial release
* Contributors: zmk5
```
