### PR TITLE
minas: 1.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4265,6 +4265,28 @@ repositories:
       url: https://github.com/ros-drivers/microstrain_3dmgx2_imu.git
       version: indigo-devel
     status: maintained
+  minas:
+    doc:
+      type: git
+      url: https://github.com/tork-a/minas.git
+      version: master
+    release:
+      packages:
+      - ethercat_manager
+      - minas
+      - minas_control
+      - tra1_bringup
+      - tra1_description
+      - tra1_moveit_config
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/minas-release.git
+      version: 1.0.6-0
+    source:
+      type: git
+      url: https://github.com/tork-a/minas.git
+      version: master
+    status: developed
   mobility_base_ros:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `minas` to `1.0.6-0`:

- upstream repository: https://github.com/tork-a/minas
- release repository: https://github.com/tork-a/minas-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## ethercat_manager

- No changes

## minas

```
* add minas meta package(#59 <https://github.com/tork-a/minas/issues/59>)
  * add minas meta package: CMakeLists.txt package.xml
  * Contributors: Ryosuke Tajima, Tokyo Opensource Robotics Developer 534
```

## minas_control

- No changes

## tra1_bringup

- No changes

## tra1_description

- No changes

## tra1_moveit_config

- No changes
