### PR TITLE
teraranger: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9031,7 +9031,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger-release.git
-      version: 1.0.0-1
+      version: 1.0.1-0
   teraranger_array:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger` to `1.0.1-0`:

- upstream repository: git@github.com:Terabee/teraranger.git
- release repository: https://github.com/Terabee/teraranger-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.0-1`

## teraranger

```
* Update package.xml
* Contributors: Kabaradjian PL
```
