### PR TITLE
teraranger_array: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9037,7 +9037,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger_array-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
   teraranger_array_converter:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger_array` to `1.0.1-0`:

- upstream repository: https://github.com/Terabee/teraranger_array.git
- release repository: https://github.com/Terabee/teraranger_array-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.0-0`

## teraranger_array

```
* Update package.xml
* Contributors: Kabaradjian PL
```
