### PR TITLE
costmap_converter: 0.0.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1345,6 +1345,7 @@ repositories:
       url: https://github.com/rst-tu-dortmund/costmap_converter-release.git
       version: 0.0.7-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/rst-tu-dortmund/costmap_converter.git
       version: master

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1343,7 +1343,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/costmap_converter-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/rst-tu-dortmund/costmap_converter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `costmap_converter` to `0.0.7-0`:

- upstream repository: https://github.com/rst-tu-dortmund/costmap_converter.git
- release repository: https://github.com/rst-tu-dortmund/costmap_converter-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.6-0`

## costmap_converter

```
* Fixed some compilation issues (C++11 compiler flags and opencv2 on indigo/jade).
* Dynamic obstacle plugin: obstacle velocity is now published for both x and y coordinates rather than the absolute value
```
