### PR TITLE
teb_local_planner: 0.6.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8957,6 +8957,7 @@ repositories:
       url: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
       version: 0.6.7-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git
       version: kinetic-devel

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8955,7 +8955,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
-      version: 0.6.6-0
+      version: 0.6.7-0
     source:
       type: git
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner` to `0.6.7-0`:

- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.6.6-0`

## teb_local_planner

```
* This update introduces support for dynamic obstacles (thanks to Franz Albers, who implemented and tested the code).
  Dynamic obstacle support requires parameter *include_dynamic_obstacles* to be activated.
  Note, this feature is still experimental and subject to testing.
  Motion prediction is performed using a constant velocity model.
  Dynamic obstacles might be incorporated as follows:
  * via a custom message provided on topic ~/obstacles (warning: we changed the message type from teb_local_planner/ObstacleMsg to costmap_converter/ObstacleArrayMsg).
  * via the CostmapToDynamicObstacles plugin as part of the costmap_converter package (still experimental).
  A tutorial is going to be provided soon.
* FeedbackMsg includes a ObstacleMsg instead of a polygon
* ObstacleMsg removed from package since it is now part of the costmap_converter package.
* Homotopy class planer code update: graph search methods and equivalence classes (h-signatures) are now
  implemented as subclasses of more general interfaces.
* TEB trajectory initialization now uses a max_vel_x argument instead of the desired time difference in order to give the optimizer a better warm start.
  Old methods are marked as deprecated. This change does not affect users settings.
* Inplace rotations removed from trajectory initialization to improve convergence speed of the optimizer
* teb_local_planner::ObstacleMsg removed in favor of costmap_converter::ObstacleArrayMsg. This also requires custom obstacle publishers to update to the new format
* the "new" trajectory resizing method is only activated, if "include_dynamic_obstacles" is set to true.
  We introduced the non-fast mode with the support of dynamic obstacles
  (which leads to better results in terms of x-y-t homotopy planning).
  However, we have not yet tested this mode intensively, so we keep
  the previous mode as default until we finish our tests.
* added parameter and code to update costmap footprint if it is dynamic (#49)
* Contributors: Franz Albers, Christoph Rösmann, procopiostein
```
