### PR TITLE
Replaced Gentoo reference of media-gfx/pydot with dev-python/pydot.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2145,7 +2145,7 @@ python-pydot:
   arch: [python2-pydot]
   debian: [python-pydot]
   fedora: [pydot]
-  gentoo: [media-gfx/pydot]
+  gentoo: [dev-python/pydot]
   macports: [py27-pydot]
   opensuse: [python-pydot]
   osx:


### PR DESCRIPTION
pydot recently changed what category it was listed under:
https://packages.gentoo.org/packages/dev-python/pydot