### PR TITLE
dynpick_driver: 0.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -481,6 +481,21 @@ repositories:
       url: https://github.com/ros/dynamic_reconfigure.git
       version: master
     status: maintained
+  dynpick_driver:
+    doc:
+      type: git
+      url: https://github.com/tork-a/dynpick_driver.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/tork-a/dynpick_driver-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/tork-a/dynpick_driver.git
+      version: master
+    status: developed
   ecl_lite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynpick_driver` to `0.2.0-0`:

- upstream repository: https://github.com/tork-a/dynpick_driver.git
- release repository: https://github.com/tork-a/dynpick_driver-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## dynpick_driver

```
* Fix ROS buildfarm error
  
    * revert #27 <https://github.com/tork-a/dynpick_driver/issues/27>  (#40 <https://github.com/tork-a/dynpick_driver/issues/40> )
    * add header file and use fputs instaed of fprintf to avoid compile error
      
      warning: implicit declaration of function
      
      warning: format not a string literal and no format arguments
  
* [sample.launch] args improvement (#38 <https://github.com/tork-a/dynpick_driver/issues/38>)
  
    * [sample.launch] Choose running RViz or not.
    * [sample.launch] pass wrench topic name.
  
* Adding more build-in features by sensor (#39 <https://github.com/tork-a/dynpick_driver/issues/39>)
  
    * Fix reading problems with A6200 version
      the reply seems to differ for some reason, however this fix it by cleaning up the socket after sensitivity request and filter request
    * Set built-in filter at startup
    * Add automatical adjustment of LSB/N
      
        * generalized "readFromSocket" function
        * flushing socket at beginning (to avoid byte offset)
        * receiving calibration (LSB/N and LSB/Nm) from sensor and multiplying it to data
        * tabs vs. spaces cleanup
      
  
* Contributors: Isaac I.Y. Saito, Kei Okada, Lorenz Halt
```
