### PR TITLE
Adding hebiros to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2574,6 +2574,17 @@ repositories:
       url: https://github.com/davidfischinger/haf_grasping.git
       version: kinetic
     status: maintained
+  hebiros:
+    doc:
+      type: git
+      url: https://github.com/HebiRobotics/HEBI-ROS.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/HebiRobotics/HEBI-ROS.git
+      version: 0.0.1-0
+    status: maintained
   hector_gazebo:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2579,11 +2579,6 @@ repositories:
       type: git
       url: https://github.com/HebiRobotics/HEBI-ROS.git
       version: master
-    release:
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/HebiRobotics/HEBI-ROS.git
-      version: 0.0.1-0
     status: maintained
   hector_gazebo:
     doc:


### PR DESCRIPTION
I'd like hebiros to be indexed and documented on ros.org.