### PR TITLE
mavros: 0.21.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1384,7 +1384,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.21.0-0
+      version: 0.21.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.21.1-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.21.0-0`

## libmavconn

- No changes

## mavros

```
* mavsys: mode: add solutions for setting AUTO.MISSION and AUTO.LOITER modes (#814 <https://github.com/mavlink/mavros/issues/814>)
  * mavsys: add notes on how to change mode to AUTO.MISSION on PX4 Pro
  * enum_to_string: update enums
  * mavsys: mode: move AUTO submodes info to argparser
  * sys_status: leave note that MAV_TYPE_ONBOARD_CONTROLLER will be supported on PX4
  * mavsys: mode: add note on changing to AUTO.LOITER
* Solve the subscriber initialization
* lib frame_tf: Add to_eigen() helper
* Contributors: Alexis Paques, Nuno Marques, Vladimir Ermakov
```

## mavros_extras

- No changes

## mavros_msgs

- No changes

## test_mavros

- No changes
