### PR TITLE
teb_local_planner_tutorials: 0.2.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3495,6 +3495,21 @@ repositories:
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git
       version: lunar-devel
     status: developed
+  teb_local_planner_tutorials:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials.git
+      version: lunar-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials.git
+      version: lunar-devel
+    status: developed
   unique_identifier:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner_tutorials` to `0.2.1-0`:

- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## teb_local_planner_tutorials

```
* Default parameters updated
* Navigation run-dependencies added
```
