### PR TITLE
lkh: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3818,7 +3818,7 @@ repositories:
     source:
       type: git
       url: https://github.com/crigroup/lkh.git
-      version: 0.1.0
+      version: master
     status: developed
   lms1xx:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3805,6 +3805,21 @@ repositories:
       url: https://github.com/ros-drivers/linux_peripheral_interfaces.git
       version: kinetic
     status: maintained
+  lkh:
+    release:
+      packages:
+      - glkh_solver
+      - lkh
+      - lkh_solver
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/crigroup/lkh-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/crigroup/lkh.git
+      version: 0.1.0
+    status: developed
   lms1xx:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3806,6 +3806,10 @@ repositories:
       version: kinetic
     status: maintained
   lkh:
+    doc:
+      type: git
+      url: https://github.com/crigroup/lkh.git
+      version: master
     release:
       packages:
       - glkh_solver


### PR DESCRIPTION
Increasing version of package(s) in repository `lkh` to `0.1.1-0`:

- upstream repository: https://github.com/crigroup/lkh.git
- release repository: https://github.com/crigroup/lkh-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## glkh_solver

```
* Fix installation bugs
* Contributors: fsuarez6
```

## lkh

```
* Fix installation bugs
* Contributors: fsuarez6
```

## lkh_solver

```
* Fix installation bugs
* Contributors: fsuarez6
```
