### PR TITLE
mavros: 0.21.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1384,7 +1384,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.21.1-0
+      version: 0.21.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.21.2-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.21.1-0`

## libmavconn

- No changes

## mavros

```
* plugin: setpoint_attitude: Finish Andres fix
* fix: attitude callback trigger
* lib uas: remove inline on not inlined method
* odom: general fixes and code tighting
* Use tf2 for odom plugin and set reasoable defaults for local pos cov.
* Contributors: Andres Rengifo, James Goppert, TSC21, Vladimir Ermakov
```

## mavros_extras

```
* odom: fix typo
* odom: general fixes and code tighting
* Use tf2 for odom plugin and set reasoable defaults for local pos cov.
* Contributors: James Goppert, TSC21
```

## mavros_msgs

- No changes

## test_mavros

- No changes
