### PR TITLE
pheeno_ros: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5777,6 +5777,16 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: kinetic-devel
     status: maintained
+  pheeno_ros:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ACSLaboratory/pheeno_ros-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/ACSLaboratory/pheeno_ros.git
+      version: 0.1.1
   phidgets_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pheeno_ros` to `0.1.1-1`:

- upstream repository: https://github.com/ACSLaboratory/pheeno_ros.git
- release repository: https://github.com/ACSLaboratory/pheeno_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## pheeno_ros

```
* Initial release
* Contributors: zmk5
```
