### PR TITLE
Adding pheeno_ros to documentation index for indigo and kinetic

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8975,11 +8975,19 @@ repositories:
       version: indigo-devel
     status: maintained
   pheeno_ros:
+    doc:
+      type: git
+      url: https://github.com/ACSLaboratory/pheeno_ros.git
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ACSLaboratory/pheeno_ros-release.git
       version: 0.1.1-4
+    source:
+      type: git
+      url: https://github.com/ACSLaboratory/pheeno_ros.git
+      version: indigo-devel
   phidgets_drivers:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5778,6 +5778,10 @@ repositories:
       version: kinetic-devel
     status: maintained
   pheeno_ros:
+    doc:
+      type: git
+      url: https://github.com/ACSLaboratory/pheeno_ros.git
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}


### PR DESCRIPTION
I also forgot to add `src` info the first time for the indigo release.