### PR TITLE
Adding wsg_32_description to documentation index

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10279,6 +10279,16 @@ repositories:
       url: https://github.com/yujinrobot/world_canvas_msgs.git
       version: kinetic
     status: maintained
+  wsg_32_description:
+    doc:
+      type: git
+      url: https://github.com/si-machines/wsg_32_description.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/si-machines/wsg_32_description.git
+      version: master
+    status: maintained
   wts_driver:
     release:
       tags:


### PR DESCRIPTION
I'd like wsg_32_description to be documented on ROS.