### PR TITLE
criutils: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1418,6 +1418,21 @@ repositories:
       url: https://github.com/AutonomyLab/create_autonomy.git
       version: indigo-devel
     status: developed
+  criutils:
+    doc:
+      type: git
+      url: https://github.com/crigroup/criutils.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/crigroup/criutils-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/crigroup/criutils.git
+      version: master
+    status: developed
   csm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `criutils` to `0.1.0-0`:

- upstream repository: https://github.com/crigroup/criutils.git
- release repository: https://github.com/crigroup/criutils-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## criutils

```
* Initial release
* Contributors: fsuarez6
```
