### PR TITLE
libfranka: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3713,6 +3713,18 @@ repositories:
       url: https://github.com/AutonomyLab/libcreate.git
       version: master
     status: developed
+  libfranka:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/frankaemika/libfranka-release.git
+      version: 0.1.0-0
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/frankaemika/libfranka.git
+      version: master
+    status: developed
   libfreenect:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libfranka` to `0.1.0-0`:

- upstream repository: https://github.com/frankaemika/libfranka.git
- release repository: https://github.com/frankaemika/libfranka-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
