### PR TITLE
rail_face_detector: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10086,7 +10086,6 @@ repositories:
       url: https://github.com/gt-rail-release/rail_face_detector-release.git
       version: 0.0.2-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/GT-RAIL/rail_face_detector.git
       version: publishable_face_det

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10075,6 +10075,22 @@ repositories:
       url: https://github.com/GT-RAIL/rail_collada_models.git
       version: develop
     status: maintained
+  rail_face_detector:
+    doc:
+      type: git
+      url: https://github.com/GT-RAIL/rail_face_detector.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/gt-rail-release/rail_face_detector-release.git
+      version: 0.0.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/GT-RAIL/rail_face_detector.git
+      version: publishable_face_det
+    status: maintained
   rail_manipulation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_face_detector` to `0.0.2-0`:

- upstream repository: https://github.com/GT-RAIL/rail_face_detector.git
- release repository: https://github.com/gt-rail-release/rail_face_detector-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rail_face_detector

```
* Init repo
```
