### PR TITLE
teraranger_description: 1.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9105,7 +9105,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger_description-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
   tf2_web_republisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger_description` to `1.0.2-0`:

- upstream repository: https://github.com/Terabee/teraranger_description.git
- release repository: https://github.com/Terabee/teraranger_description-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.1-0`

## teraranger_description

```
* Remove old naming references
* Contributors: Kabaradjian PL
```
