### PR TITLE
marti_messages: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6530,11 +6530,12 @@ repositories:
       - marti_nav_msgs
       - marti_perception_msgs
       - marti_sensor_msgs
+      - marti_status_msgs
       - marti_visualization_msgs
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_messages-release.git
-      version: 0.2.0-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `0.3.0-0`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.0-0`

## marti_can_msgs

- No changes

## marti_common_msgs

- No changes

## marti_nav_msgs

- No changes

## marti_perception_msgs

- No changes

## marti_sensor_msgs

- No changes

## marti_status_msgs

```
* Add marti_status_msgs and ChronyTrackingStatus message
* Contributors: Matthew Bries, P. J. Reed
```

## marti_visualization_msgs

- No changes
