### PR TITLE
pointgrey_camera_driver: 0.13.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2070,6 +2070,27 @@ repositories:
       url: https://github.com/ros-perception/pointcloud_to_laserscan.git
       version: indigo-devel
     status: maintained
+  pointgrey_camera_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/pointgrey_camera_driver.git
+      version: master
+    release:
+      packages:
+      - image_exposure_msgs
+      - pointgrey_camera_description
+      - pointgrey_camera_driver
+      - statistics_msgs
+      - wfov_camera_msgs
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
+      version: 0.13.2-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/pointgrey_camera_driver.git
+      version: master
+    status: maintained
   pr2_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointgrey_camera_driver` to `0.13.2-0`:

- upstream repository: https://github.com/ros-drivers/pointgrey_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`

## image_exposure_msgs

- No changes

## pointgrey_camera_description

- No changes

## pointgrey_camera_driver

```
* Adding camera consistency exception. (#142 <https://github.com/ros-drivers/pointgrey_camera_driver/issues/142>)
* Use find_path to look for system headers. (#139 <https://github.com/ros-drivers/pointgrey_camera_driver/issues/139>)
* Added support to RGB8 pixel format and controls for sharpness and saturation (#116 <https://github.com/ros-drivers/pointgrey_camera_driver/issues/116>)
  * Added support to RGB8 pixel format and controls for sharpness and saturation
  * removed whitespaces and reverted changes to camera launch
* Consolidate udev rules. (#131 <https://github.com/ros-drivers/pointgrey_camera_driver/issues/131>)
* Require flycapture library and header files (#112 <https://github.com/ros-drivers/pointgrey_camera_driver/issues/112>)
* Add multi-release support, bump SDK to 2.11.3.121 for xenial and 2.9.3.43 for trusty (#127 <https://github.com/ros-drivers/pointgrey_camera_driver/issues/127>)
* Contributors: Bei Chen Liu, Mike Purvis, Mohammed Al-Qizwini, Vitor Matos, kmhallen
```

## statistics_msgs

- No changes

## wfov_camera_msgs

- No changes
