### PR TITLE
cartographer: 0.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -240,6 +240,21 @@ repositories:
       url: https://github.com/davetcoleman/cartesian_msgs.git
       version: jade-devel
     status: maintained
+  cartographer:
+    doc:
+      type: git
+      url: https://github.com/googlecartographer/cartographer.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/cartographer-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/googlecartographer/cartographer.git
+      version: master
+    status: developed
   catkin:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -251,6 +251,7 @@ repositories:
       url: https://github.com/ros-gbp/cartographer-release.git
       version: 0.2.0-0
     source:
+      test_commits: false
       type: git
       url: https://github.com/googlecartographer/cartographer.git
       version: master


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer` to `0.2.0-0`:

- upstream repository: https://github.com/googlecartographer/cartographer.git
- release repository: https://github.com/ros-gbp/cartographer-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## cartographer

```
https://github.com/googlecartographer/cartographer/compare/0.1.0...0.2.0
```
