### PR TITLE
Revert "cartographer: 0.2.0-0 in 'lunar/distribution.yaml' [bloom]"

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -240,22 +240,6 @@ repositories:
       url: https://github.com/davetcoleman/cartesian_msgs.git
       version: jade-devel
     status: maintained
-  cartographer:
-    doc:
-      type: git
-      url: https://github.com/googlecartographer/cartographer.git
-      version: master
-    release:
-      tags:
-        release: release/lunar/{package}/{version}
-      url: https://github.com/ros-gbp/cartographer-release.git
-      version: 0.2.0-0
-    source:
-      test_commits: false
-      type: git
-      url: https://github.com/googlecartographer/cartographer.git
-      version: master
-    status: developed
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#15983

Actually 0.2.0 is missing at least some cmake changes to support debian packaging (e.g. https://github.com/googlecartographer/cartographer/commit/e345ae8280e9f595ba21432288a33d323e2e9fcd). I'm going to remove this from the index and make a new release when 0.3.0 is tagged