### PR TITLE
pheeno_ros_sim: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8989,6 +8989,20 @@ repositories:
       type: git
       url: https://github.com/ACSLaboratory/pheeno_ros.git
       version: indigo-devel
+  pheeno_ros_sim:
+    doc:
+      type: git
+      url: https://github.com/ACSLaboratory/pheeno_ros_sim.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ACSLaboratory/pheeno_ros_sim-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/ACSLaboratory/pheeno_ros_sim.git
+      version: indigo-devel
   phidgets_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pheeno_ros_sim` to `0.1.1-0`:

- upstream repository: https://github.com/ACSLaboratory/pheeno_ros_sim.git
- release repository: https://github.com/ACSLaboratory/pheeno_ros_sim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## pheeno_ros_sim

```
* Initial release
* Contributors: zmk5
```
