### PR TITLE
add python-rosinstall for additional ubuntu distros

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2694,6 +2694,7 @@ python-rosinstall:
   gentoo: [dev-python/rosinstall]
   macports: [p27-rosinstall]
   ubuntu:
+    artful: [python-rosinstall]
     lucid: [python-rosinstall]
     maverick: [python-rosinstall]
     natty: [python-rosinstall]
@@ -2704,6 +2705,12 @@ python-rosinstall:
     saucy: [python-rosinstall]
     trusty: [python-rosinstall]
     trusty_python3: [python3-rosinstall]
+    utopic: [python-rosinstall]
+    vivid: [python-rosinstall]
+    wily: [python-rosinstall]
+    xenial: [python-rosinstall]
+    yakkety: [python-rosinstall]
+    zesty: [python-rosinstall]
 python-rosinstall-generator:
   arch: [python2-rosinstall-generator]
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2687,9 +2687,7 @@ python-rosdistro:
     trusty_python3: [python3-rosdistro]
 python-rosinstall:
   arch: [python2-rosinstall]
-  debian:
-    buster: [python-rosinstall]
-    stretch: [python-rosinstall]
+  debian: [python-rosinstall]
   fedora: [python-rosinstall]
   gentoo: [dev-python/rosinstall]
   macports: [p27-rosinstall]


### PR DESCRIPTION
[xenial](https://packages.ubuntu.com/search?suite=xenial&arch=any&searchon=names&keywords=python-rosinstall)
[zesty](https://packages.ubuntu.com/search?suite=zesty&arch=any&searchon=names&keywords=python-rosinstall)

or do you want me to introduce a line like this to cover all distros?
```
 ubuntu: [python-rosinstall]
```