### PR TITLE
pheeno_ros_sim: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8998,7 +8998,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ACSLaboratory/pheeno_ros_sim-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/ACSLaboratory/pheeno_ros_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pheeno_ros_sim` to `0.1.3-0`:

- upstream repository: https://github.com/ACSLaboratory/pheeno_ros_sim.git
- release repository: https://github.com/ACSLaboratory/pheeno_ros_sim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.2-0`

## pheeno_ros_sim

```
* Removed cv_bridge requirement.
* Contributors: zmk5
```
