### PR TITLE
imagezero_transport: 0.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4724,6 +4724,10 @@ repositories:
       version: indigo-devel
     status: maintained
   imagezero_transport:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/imagezero_transport.git
+      version: master
     release:
       packages:
       - imagezero
@@ -4732,7 +4736,12 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/imagezero_transport.git
+      version: master
+    status: maintained
   imu_compass:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imagezero_transport` to `0.2.4-0`:

- upstream repository: https://github.com/swri-robotics/imagezero_transport.git
- release repository: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.3-0`

## imagezero

```
* Add documentation; build on Lunar (#12 <https://github.com/pjreed/imagezero_transport/issues/12>)
* Contributors: P. J. Reed
```

## imagezero_image_transport

```
* Add documentation; build on Lunar (#12 <https://github.com/pjreed/imagezero_transport/issues/12>)
* Contributors: P. J. Reed
```

## imagezero_ros

```
* Add documentation; build on Lunar (#12 <https://github.com/pjreed/imagezero_transport/issues/12>)
* Contributors: P. J. Reed
```
