### PR TITLE
imagezero_transport: 0.2.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2955,6 +2955,10 @@ repositories:
       version: indigo-devel
     status: maintained
   imagezero_transport:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/imagezero_transport.git
+      version: master
     release:
       packages:
       - imagezero
@@ -2963,7 +2967,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/imagezero_transport.git
+      version: master
+    status: maintained
   imu_pipeline:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imagezero_transport` to `0.2.4-0`:

- upstream repository: https://github.com/swri-robotics/imagezero_transport.git
- release repository: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.3-0`

## imagezero

```
* Add documentation; build on Lunar (#12 <https://github.com/pjreed/imagezero_transport/issues/12>)
* Contributors: P. J. Reed
```

## imagezero_image_transport

```
* Add documentation; build on Lunar (#12 <https://github.com/pjreed/imagezero_transport/issues/12>)
* Contributors: P. J. Reed
```

## imagezero_ros

```
* Add documentation; build on Lunar (#12 <https://github.com/pjreed/imagezero_transport/issues/12>)
* Contributors: P. J. Reed
```
