### PR TITLE
imagezero_transport: 0.2.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -975,6 +975,25 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: indigo-devel
     status: maintained
+  imagezero_transport:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/imagezero_transport.git
+      version: master
+    release:
+      packages:
+      - imagezero
+      - imagezero_image_transport
+      - imagezero_ros
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
+      version: 0.2.4-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/imagezero_transport.git
+      version: master
+    status: maintained
   imu_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imagezero_transport` to `0.2.4-0`:

- upstream repository: https://github.com/swri-robotics/imagezero_transport.git
- release repository: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## imagezero

```
* Add documentation; build on Lunar (#12 <https://github.com/pjreed/imagezero_transport/issues/12>)
* Contributors: P. J. Reed
```

## imagezero_image_transport

```
* Add documentation; build on Lunar (#12 <https://github.com/pjreed/imagezero_transport/issues/12>)
* Contributors: P. J. Reed
```

## imagezero_ros

```
* Add documentation; build on Lunar (#12 <https://github.com/pjreed/imagezero_transport/issues/12>)
* Contributors: P. J. Reed
```
