### PR TITLE
pheeno_ros_sim: 0.1.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5837,7 +5837,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ACSLaboratory/pheeno_ros_sim-release.git
-      version: 0.1.2-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/ACSLaboratory/pheeno_ros_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pheeno_ros_sim` to `0.1.4-0`:

- upstream repository: https://github.com/ACSLaboratory/pheeno_ros_sim.git
- release repository: https://github.com/ACSLaboratory/pheeno_ros_sim-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.2-0`

## pheeno_ros_sim

```
* Added more build requirements.
* Contributors: zmk5
```
