### PR TITLE
grpc: 0.0.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -889,7 +889,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/CogRobRelease/catkin_grpc-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/CogRob/catkin_grpc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grpc` to `0.0.3-0`:

- upstream repository: https://github.com/CogRob/catkin_grpc.git
- release repository: https://github.com/CogRobRelease/catkin_grpc-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.2-0`

## grpc

```
* Allows CMake to choose dynamic/static linking on grpc libraries
* Some fix to grpc package. (#11 <https://github.com/CogRob/catkin_grpc/issues/11>)
  * Use all embedded third_party software, use grpc 1.6.x, use all static linking to avoid conflicts, move include dir
  * Use HTTPS download instead of GIT to speedup downloading
  * Missing libs
  * Adds boringssl with Bazel in third_party
* Contributors: Shengye Wang
```
