### PR TITLE
abseil_cpp: 0.1.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -58,6 +58,13 @@ repositories:
       url: https://github.com/ros-industrial/abb_experimental.git
       version: indigo-devel
     status: developed
+  abseil_cpp:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/Eurecat/abseil_cpp-release.git
+      version: 0.1.1-1
+    status: maintained
   acado:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `abseil_cpp` to `0.1.1-1`:

- upstream repository: https://github.com/Eurecat/abseil-cpp.git
- release repository: https://github.com/Eurecat/abseil_cpp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## abseil_cpp

```
* Merge branch 'master' of https://github.com/Eurecat/abseil-cpp
* test removed
* Update README.md
* Initial Commit
* Contributors: Abseil Team, Ben Cox, Davide Faconti, Derek Mauro, misterg
```
