### PR TITLE
abseil_cpp: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -61,6 +61,13 @@ repositories:
       url: https://github.com/ros-industrial/abb_experimental.git
       version: kinetic-devel
     status: developed
+  abseil_cpp:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Eurecat/abseil_cpp-release.git
+      version: 0.1.1-0
+    status: maintained
   ackermann_controller:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `abseil_cpp` to `0.1.1-0`:

- upstream repository: https://github.com/Eurecat/abseil-cpp.git
- release repository: https://github.com/Eurecat/abseil_cpp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## abseil_cpp

```
* Merge branch 'master' of https://github.com/Eurecat/abseil-cpp
* test removed
* Update README.md
* Initial Commit
* Contributors: Abseil Team, Ben Cox, Davide Faconti, Derek Mauro, misterg
```
