### PR TITLE
abseil_cpp: 0.1.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -11,6 +11,22 @@ release_platforms:
   - xenial
   - zesty
 repositories:
+  abseil_cpp:
+    doc:
+      type: git
+      url: https://github.com/Eurecat/abseil-cpp.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/Eurecat/abseil_cpp-release.git
+      version: 0.1.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/Eurecat/abseil-cpp.git
+      version: master
+    status: maintained
   ackermann_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `abseil_cpp` to `0.1.1-0`:

- upstream repository: https://github.com/Eurecat/abseil-cpp.git
- release repository: https://github.com/Eurecat/abseil_cpp-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## abseil_cpp

```
* Merge branch 'master' of https://github.com/Eurecat/abseil-cpp
* test removed
* Update README.md
* Initial Commit
* Contributors: Abseil Team, Ben Cox, Davide Faconti, Derek Mauro, misterg
```
