### PR TITLE
grpc: 0.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2565,7 +2565,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/CogRobRelease/catkin_grpc-release.git
-      version: 0.0.2-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/CogRob/catkin_grpc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grpc` to `0.0.4-0`:

- upstream repository: https://github.com/CogRob/catkin_grpc.git
- release repository: https://github.com/CogRobRelease/catkin_grpc-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.2-0`

## grpc

```
* Adds INCLUDE_DIRS and expose grpc/src/proto (#14 <https://github.com/CogRob/catkin_grpc/issues/14>)
  * Allows generate_proto to have specify include_dirs
  * Allow grpc's build-in protos to be used by clients
* Minor documentation fix. (#13 <https://github.com/CogRob/catkin_grpc/issues/13>)
* Contributors: Shengye Wang
```
