### PR TITLE
ros_explorer: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7228,6 +7228,17 @@ repositories:
       url: https://github.com/code-iai/ros_emacs_utils.git
       version: master
     status: maintained
+  ros_explorer:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/jstnhuang-release/ros_explorer-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/jstnhuang/ros_explorer.git
+      version: kinetic-devel
+    status: developed
   ros_numpy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_explorer` to `0.1.0-0`:

- upstream repository: https://github.com/jstnhuang/ros_explorer.git
- release repository: https://github.com/jstnhuang-release/ros_explorer-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## ros_explorer

```
* Initial release.
* Contributors: Justin Huang
```
