### PR TITLE
cv_camera: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1464,7 +1464,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/OTL/cv_camera-release.git
-      version: 0.1.0-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/OTL/cv_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cv_camera` to `0.3.0-0`:

- upstream repository: https://github.com/OTL/cv_camera
- release repository: https://github.com/OTL/cv_camera-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.0-0`

## cv_camera

```
* Update README.md
* Add device_path support (#8 <https://github.com/OTL/cv_camera/issues/8>)
  * Add device_path support
* Contributors: Maurice Meedendorp, Takashi Ogura
```
