### PR TITLE
pointgrey_camera_driver: 0.13.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2135,7 +2135,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
-      version: 0.13.2-0
+      version: 0.13.3-0
     source:
       type: git
       url: https://github.com/ros-drivers/pointgrey_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointgrey_camera_driver` to `0.13.3-0`:

- upstream repository: https://github.com/ros-drivers/pointgrey_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.13.2-0`

## image_exposure_msgs

- No changes

## pointgrey_camera_description

- No changes

## pointgrey_camera_driver

```
* Assume current library version for all OSes other than trusty. (#146 <https://github.com/ros-drivers/pointgrey_camera_driver/issues/146>)
* Contributors: Mike Purvis
```

## statistics_msgs

- No changes

## wfov_camera_msgs

- No changes
