### PR TITLE
python_trep: 1.0.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9901,6 +9901,7 @@ repositories:
       url: https://github.com/MurpheyLab/trep-release.git
       version: 1.0.3-0
     source:
+      test_commits: false
       type: git
       url: https://github.com/MurpheyLab/trep.git
       version: master

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6162,6 +6162,21 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: kinetic-devel
     status: maintained
+  python_trep:
+    doc:
+      type: git
+      url: https://github.com/MurpheyLab/trep-release.git
+      version: release/kinetic/python_trep
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/MurpheyLab/trep-release.git
+      version: 1.0.3-1
+    source:
+      type: git
+      url: https://github.com/MurpheyLab/trep.git
+      version: master
+    status: developed
   pyzmp:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6173,6 +6173,7 @@ repositories:
       url: https://github.com/MurpheyLab/trep-release.git
       version: 1.0.3-1
     source:
+      test_commits: false
       type: git
       url: https://github.com/MurpheyLab/trep.git
       version: master


### PR DESCRIPTION
Increasing version of package(s) in repository `python_trep` to `1.0.3-1`:

- upstream repository: https://github.com/MurpheyLab/trep.git
- release repository: https://github.com/MurpheyLab/trep-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
