### PR TITLE
jsk_common: 2.2.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3245,7 +3245,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.2.2-0
+      version: 2.2.5-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common.git
+      version: master
     status: developed
   jsk_common_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.2.5-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.2.2-0`

## dynamic_tf_publisher

- No changes

## image_view2

- No changes

## jsk_common

- No changes

## jsk_data

```
* [jsk_data][download_data] support custom download dir / chmod  (#1530 <https://github.com/jsk-ros-pkg/jsk_common/issues/1530>)
* Contributors: Yuki Furuta
```

## jsk_network_tools

- No changes

## jsk_tilt_laser

- No changes

## jsk_tools

- No changes

## jsk_topic_tools

- No changes

## multi_map_server

- No changes

## virtual_force_publisher

- No changes
