### PR TITLE
phidgets_drivers: 0.7.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5859,11 +5859,12 @@ repositories:
       - libphidget21
       - phidgets_api
       - phidgets_drivers
+      - phidgets_high_speed_encoder
       - phidgets_imu
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 0.7.3-0
+      version: 0.7.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `0.7.4-0`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.7.3-0`

## libphidget21

- No changes

## phidgets_api

```
* Fix typo and doxygen docs
* Contributors: Jose Luis Blanco Claraco, Martin Günther
```

## phidgets_drivers

```
* Add phidgets_high_speed_encoder to metapackage
* Contributors: Jose Luis Blanco-Claraco, Martin Günther
```

## phidgets_high_speed_encoder

```
* Merge pull request #15 <https://github.com/ros-drivers/phidgets_drivers/issues/15> from jlblancoc/kinetic
  Add Phidgets high-speed encoder package
* Contributors: Jose Luis Blanco-Claraco, Geoff Viola, Martin Günther
```

## phidgets_imu

- No changes
