### PR TITLE
abseil_cpp: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -59,11 +59,20 @@ repositories:
       version: indigo-devel
     status: developed
   abseil_cpp:
+    doc:
+      type: git
+      url: https://github.com/Eurecat/abseil-cpp.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/Eurecat/abseil_cpp-release.git
-      version: 0.1.1-1
+      version: 0.1.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/Eurecat/abseil-cpp.git
+      version: master
     status: maintained
   acado:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `abseil_cpp` to `0.1.2-0`:

- upstream repository: https://github.com/Eurecat/abseil-cpp.git
- release repository: https://github.com/Eurecat/abseil_cpp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.1-1`

## abseil_cpp

```
* Update CMakeLists.txt
* Contributors: Davide Faconti
```
