### PR TITLE
abseil_cpp: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -62,11 +62,20 @@ repositories:
       version: kinetic-devel
     status: developed
   abseil_cpp:
+    doc:
+      type: git
+      url: https://github.com/Eurecat/abseil-cpp.git
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Eurecat/abseil_cpp-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/Eurecat/abseil-cpp.git
+      version: master
     status: maintained
   ackermann_controller:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `abseil_cpp` to `0.1.2-0`:

- upstream repository: https://github.com/Eurecat/abseil-cpp.git
- release repository: https://github.com/Eurecat/abseil_cpp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.1-0`

## abseil_cpp

```
* Update CMakeLists.txt
* Contributors: Davide Faconti
```
