### PR TITLE
nerian_stereo: 2.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5053,6 +5053,21 @@ repositories:
       url: https://github.com/nerian-vision/nerian_sp1.git
       version: master
     status: developed
+  nerian_stereo:
+    doc:
+      type: git
+      url: https://github.com/nerian-vision/nerian_stereo.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/nerian-vision/nerian_stereo-release.git
+      version: 2.0.1-0
+    source:
+      type: git
+      url: https://github.com/nerian-vision/nerian_stereo.git
+      version: master
+    status: developed
   netft_utils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_stereo` to `2.0.1-0`:

- upstream repository: https://github.com/nerian-vision/nerian_stereo.git
- release repository: https://github.com/nerian-vision/nerian_stereo-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## nerian_stereo

```
* Fixed support for 12-bit images
* Fixed build problems
```
