### PR TITLE
ez_interactive_marker: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1995,6 +1995,21 @@ repositories:
       url: https://github.com/ros-visualization/executive_smach_visualization.git
       version: indigo-devel
     status: unmaintained
+  ez_interactive_marker:
+    doc:
+      type: git
+      url: https://github.com/neka-nat/ez_interactive_marker.git
+      version: 0.0.2
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/neka-nat/ez_interactive_marker-release.git
+      version: 0.0.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/neka-nat/ez_interactive_marker.git
+      version: 0.0.2
   fanuc:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1999,7 +1999,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/neka-nat/ez_interactive_marker.git
-      version: 0.0.2
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -2009,7 +2009,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/neka-nat/ez_interactive_marker.git
-      version: 0.0.2
+      version: kinetic-devel
   fanuc:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ez_interactive_marker` to `0.0.2-0`:

- upstream repository: https://github.com/neka-nat/ez_interactive_marker.git
- release repository: https://github.com/neka-nat/ez_interactive_marker-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
