### PR TITLE
gcloud_speech: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3583,6 +3583,26 @@ repositories:
       url: https://github.com/JenniferBuehler/gazebo-pkgs.git
       version: master
     status: developed
+  gcloud_speech:
+    doc:
+      type: git
+      url: https://github.com/CogRob/gcloud_speech.git
+      version: master
+    release:
+      packages:
+      - gcloud_speech
+      - gcloud_speech_msgs
+      - gcloud_speech_utils
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/CogRobRelease/gcloud_speech-release.git
+      version: 0.0.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/CogRob/gcloud_speech.git
+      version: master
+    status: developed
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gcloud_speech` to `0.0.1-0`:

- upstream repository: https://github.com/CogRob/gcloud_speech.git
- release repository: https://github.com/CogRobRelease/gcloud_speech-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## gcloud_speech

```
* Removes the clicking sound in playback microphone node (#9 <https://github.com/CogRob/gcloud_speech/issues/9>)
* Adds a playback node to gcloud_speech_utils (#7 <https://github.com/CogRob/gcloud_speech/issues/7>)
  * Adds a microphone playback node
  * Use a newer version of record_audio.cc, and adds a playback node to utils
* Adds documents and examples, fixes bugs. (#6 <https://github.com/CogRob/gcloud_speech/issues/6>)
  * Move print_rms exclusively to utils package
  * Implements auto retrying if failed prematurely within 300ms (default)
  * Adds some information in README file
  * Documentation
  * Document update
  * URL better to be link
  * Adds a All-In-One launch file that demos the program
* Adds googleapis/.GIT_STATUS file to record the source googleapis version. (#5 <https://github.com/CogRob/gcloud_speech/issues/5>)
* Adds channel connect and channel check to google_speech (#3 <https://github.com/CogRob/gcloud_speech/issues/3>)
* Initial commit. (#1 <https://github.com/CogRob/gcloud_speech/issues/1>)
* Contributors: Shengye Wang
```

## gcloud_speech_msgs

```
* Initial commit. (#1 <https://github.com/CogRob/gcloud_speech/issues/1>)
* Contributors: Shengye Wang
```

## gcloud_speech_utils

```
* Fixes missing Copyright text in README (#12 <https://github.com/CogRob/gcloud_speech/issues/12>)
  * Fixes missing Copyright text in README
  * Use Logitech instead of Samson in example launch file
* Kills the microphone node when it fails to publish samples (#10 <https://github.com/CogRob/gcloud_speech/issues/10>)
  * Kills the microphone node when it fails to publish samples
  * Makes the fatal timeout a flag
  * Add respawn to launch file to allow microphone plug in/plug out
* Removes the clicking sound in playback microphone node (#9 <https://github.com/CogRob/gcloud_speech/issues/9>)
* gcloud_speech_utils was missing python-pyaudio dependency (#8 <https://github.com/CogRob/gcloud_speech/issues/8>)
  * gcloud_speech_utils missing python-pyaudio dependency
  * Remove unused Queue import
* Adds a playback node to gcloud_speech_utils (#7 <https://github.com/CogRob/gcloud_speech/issues/7>)
  * Adds a microphone playback node
  * Use a newer version of record_audio.cc, and adds a playback node to utils
* Adds documents and examples, fixes bugs. (#6 <https://github.com/CogRob/gcloud_speech/issues/6>)
  * Move print_rms exclusively to utils package
  * Implements auto retrying if failed prematurely within 300ms (default)
  * Adds some information in README file
  * Documentation
  * Document update
  * URL better to be link
  * Adds a All-In-One launch file that demos the program
* Adds channel connect and channel check to google_speech (#3 <https://github.com/CogRob/gcloud_speech/issues/3>)
* Initial commit. (#1 <https://github.com/CogRob/gcloud_speech/issues/1>)
* Contributors: Shengye Wang
```
