### PR TITLE
novatel_gps_driver: 3.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5164,7 +5164,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
-      version: 3.3.0-0
+      version: 3.4.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `3.4.0-0`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `3.3.0-0`

## novatel_gps_driver

```
* Fixes RPY orientation in IMU output (based on testing).
* Add service to novatel_gps_nodelet that issues a FRESET command on the indicated target, or STANDARD if none is provided
* Use find_library to look up the location of libpcap.so
* Contributors: Joshua Whitley, Matthew Bries, P. J. Reed
```

## novatel_gps_msgs

```
* Add service to novatel_gps_nodelet that issues a FRESET command on the indicated target, or STANDARD if none is provided
* Contributors: Matthew Bries, P. J. Reed
```
