### PR TITLE
novatel_gps_driver: 3.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7952,7 +7952,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
-      version: 3.3.0-0
+      version: 3.4.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `3.4.0-0`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `3.3.0-0`

## novatel_gps_driver

```
* Fixes RPY orientation in IMU output (based on testing).
* Add service to novatel_gps_nodelet that issues a FRESET command on the indicated target, or STANDARD if none is provided
* Use find_library to look up the location of libpcap.so
* Contributors: Joshua Whitley, Matthew Bries, P. J. Reed
```

## novatel_gps_msgs

```
* Add service to novatel_gps_nodelet that issues a FRESET command on the indicated target, or STANDARD if none is provided
* Contributors: Matthew Bries, P. J. Reed
```