### PR TITLE
grpc: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4029,7 +4029,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/CogRobRelease/catkin_grpc-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/CogRob/catkin_grpc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grpc` to `0.0.5-0`:

- upstream repository: https://github.com/CogRob/catkin_grpc.git
- release repository: https://github.com/CogRobRelease/catkin_grpc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.4-0`

## grpc

```
* Fixes a problem in default SRC_BASE (#18 <https://github.com/CogRob/catkin_grpc/issues/18>)
  * Fix an issue when package directory is not the same as package name, protoc fails to generate files in the correct path
  * Improve the copy src/proto command
  * Revert "Improve the copy src/proto command"
  This reverts commit adfca498b7b3b00fb4c350675d3b4dbcb154fe75.
  * Fixes a problem that src in include is not installed
* Contributors: Shengye Wang
```
