### PR TITLE
gcloud_speech: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2243,6 +2243,26 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: kinetic-devel
     status: maintained
+  gcloud_speech:
+    doc:
+      type: git
+      url: https://github.com/CogRob/gcloud_speech.git
+      version: master
+    release:
+      packages:
+      - gcloud_speech
+      - gcloud_speech_msgs
+      - gcloud_speech_utils
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/CogRobRelease/gcloud_speech-release.git
+      version: 0.0.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/CogRob/gcloud_speech.git
+      version: master
+    status: developed
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gcloud_speech` to `0.0.2-0`:

- upstream repository: https://github.com/CogRob/gcloud_speech.git
- release repository: https://github.com/CogRobRelease/gcloud_speech-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## gcloud_speech

```
* Fixes a problem that gflags is not found in the action server node source (#14 <https://github.com/CogRob/gcloud_speech/issues/14>)
* Contributors: Shengye Wang
```

## gcloud_speech_msgs

- No changes

## gcloud_speech_utils

- No changes
