### PR TITLE
gcloud_speech: 0.0.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -658,6 +658,26 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: lunar-devel
     status: developed
+  gcloud_speech:
+    doc:
+      type: git
+      url: https://github.com/CogRob/gcloud_speech.git
+      version: master
+    release:
+      packages:
+      - gcloud_speech
+      - gcloud_speech_msgs
+      - gcloud_speech_utils
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/CogRobRelease/gcloud_speech-release.git
+      version: 0.0.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/CogRob/gcloud_speech.git
+      version: master
+    status: developed
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gcloud_speech` to `0.0.2-0`:

- upstream repository: https://github.com/CogRob/gcloud_speech.git
- release repository: https://github.com/CogRobRelease/gcloud_speech-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## gcloud_speech

```
* Fixes a problem that gflags is not found in the action server node source (#14 <https://github.com/CogRob/gcloud_speech/issues/14>)
* Contributors: Shengye Wang
```

## gcloud_speech_msgs

- No changes

## gcloud_speech_utils

- No changes
