### PR TITLE
gcloud_speech: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2256,7 +2256,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/CogRobRelease/gcloud_speech-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gcloud_speech` to `0.0.3-0`:

- upstream repository: https://github.com/CogRob/gcloud_speech.git
- release repository: https://github.com/CogRobRelease/gcloud_speech-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.2-0`

## gcloud_speech

```
* Adds catkin_INCLUDE_DIRS to include_directories (#16 <https://github.com/CogRob/gcloud_speech/issues/16>)
* Contributors: Shengye Wang
```

## gcloud_speech_msgs

- No changes

## gcloud_speech_utils

```
* Adds catkin_INCLUDE_DIRS to include_directories (#16 <https://github.com/CogRob/gcloud_speech/issues/16>)
* Removes documentation about the project name command line flag (#15 <https://github.com/CogRob/gcloud_speech/issues/15>)
  * Removes documentation about the project name command line flag
  * Removes extra comments in launch file
* Contributors: Shengye Wang
```
