### PR TITLE
Add logic to help with checking on hooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
   - pip install yamllint
   - pip install unidiff
   - pip install rosdep
+  - pip install PyGithub
 
 # command to run tests
 script:

--- a/test/hook_permissions.py
+++ b/test/hook_permissions.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2017, Open Source Robotics Foundation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+from github import Github, UnknownObjectException
+
+
+def detect_repo_hook(repo, cb_url):
+    for hook in repo.get_hooks():
+        if hook.config.get('url') == cb_url:
+            return True
+    return False
+
+
+class GHPRBHookDetector(object):
+    def __init__(self, github_user, github_token, callback_url):
+        self.callback_url = callback_url
+        self.gh = Github(github_user, github_token)
+
+    def get_repo(self, username, reponame):
+        try:
+            repo = self.gh.get_user(username).get_repo(reponame)
+        except UnknownObjectException as ex:
+            print(
+                'Failed to access repo [ %s/%s ] Reason %s'
+                % (username, reponame, ex),
+                file=sys.stderr
+                )
+            return None
+        return repo
+
+    def check_repo_for_access(self, repo, errors, strict=False):
+        push_access = repo.permissions.push
+        admin_access = repo.permissions.admin
+        try:
+            hook_detected = detect_repo_hook(repo, self.callback_url)
+        except UnknownObjectException as ex:
+            errors.append('Unable to check repo [ %s ] for hooks: Error: %s' % (repo.full_name, ex))
+            hook_detected = False
+        if push_access and hook_detected or admin_access:
+            return True
+        if push_access and not hook_detected:
+            print(
+                'Warning: Push access detected but unable to verify manual hook '
+                'configuration for repo [ %s ]. Please visit ' % repo.full_name +
+                'http://wiki.ros.org/buildfarm/Pull%20request%20testing '
+                'and make sure hooks are setup.',
+                file=sys.stderr)
+            if strict:
+                return False
+            else:
+                errors.append(
+                    'Warning: Push access detected but unable to verify manual hook '
+                    'configuration for repo [ %s ]. Please visit ' % repo.full_name +
+                    'http://wiki.ros.org/buildfarm/Pull%20request%20testing '
+                    'and make sure hooks are setup.')
+                return True
+
+
+def check_hooks_on_repo(user, repo, errors, hook_user='ros-pull-request-builder',
+        callback_url='http://build.ros.org/ghprbhook/', token=None, strict=False):
+    ghprb_detector = GHPRBHookDetector(hook_user, token, callback_url)
+    test_repo = ghprb_detector.get_repo(user, repo)
+
+    if test_repo:
+        hooks_ok = ghprb_detector.check_repo_for_access(test_repo, errors, strict=strict)
+        if hooks_ok:
+            print('Passed ghprb_detector check for hooks access'
+                  ' for repo [ %s ]' % test_repo.full_name)
+            return True
+        else:
+            print('ERROR: Not enough permissions to setup pull request'
+                  ' builds for repo [ %s ] ' % (test_repo.full_name) +
+                  'Please see http://wiki.ros.org/buildfarm/Pull%20request%20testing',
+                  file=sys.stderr
+                  )
+            return False
+    else:
+        print(
+            'ERROR: No github repository found at %s/%s' % (user, repo),
+            file=sys.stderr
+        )
+        return False
+
+
+def main():
+    """A simple main for testing via command line."""
+    parser = argparse.ArgumentParser(
+        description='A manual test for ros-pull-request-builder access'
+                    'to a GitHub repo.')
+    parser.add_argument('user', type=str)
+    parser.add_argument('repo', type=str)
+    parser.add_argument('--callback-url', type=str,
+        default='http://build.ros.org/ghprbhook/')
+    parser.add_argument('--hook-user', type=str,
+        default='ros-pull-request-builder')
+    parser.add_argument('--password-env', type=str,
+        default='ROSGHPRB_TOKEN')
+
+    args = parser.parse_args()
+
+    password = os.getenv(args.password_env)
+    if not password:
+        parser.error(
+            'OAUTH Token with hook and organization read access'
+            'required in ROSGHPRB_TOKEN environment variable')
+    errors = []
+    result = check_hooks_on_repo(
+        args.user,
+        args.repo,
+        errors,
+        args.hook_user,
+        args.callback_url,
+        password)
+    if errors:
+        print('Errors detected:', file=sys.stderr)
+    for e in errors:
+        print(e, file=sys.stderr)
+    if result:
+        return 0
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test/test_url_validity.py
+++ b/test/test_url_validity.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-
+from . import hook_permissions
 
 try:
     from cStringIO import StringIO
@@ -107,17 +107,36 @@ def check_git_remote_exists(url, version, tags_valid=False):
 
 
 def check_source_repo_entry_for_errors(source, tags_valid=False):
+    errors = []
     if source['type'] != 'git':
-        print("Cannot verify remote of type[%s] from line [%s] skipping."
+        print('Cannot verify remote of type[%s] from line [%s] skipping.'
               % (source['type'], source['__line__']))
         return None
 
     version = source['version'] if source['version'] else None
     if not check_git_remote_exists(source['url'], version, tags_valid):
-        return ("Could not validate repository with url %s and version %s from"
-                " entry at line '''%s'''" % (source['url'],
-                                             version,
-                                             source['__line__']))
+        errors.append(
+            'Could not validate repository with url %s and version %s from'
+            ' entry at line %s'
+            % (source['url'], version, source['__line__']))
+    test_pr = source['test_pull_requests'] if 'test_pull_requests' in source else None
+    if test_pr:
+        parsedurl = urlparse(source['url'])
+        if 'github.com' in parsedurl.netloc:
+            user = os.path.dirname(parsedurl.path).lstrip('/')
+            repo, _ = os.path.splitext(os.path.basename(parsedurl.path))
+            hook_errors = []
+            rosghprb_token = os.getenv('ROSGHPRB_TOKEN', None)
+            if not rosghprb_token:
+                print('No ROSGHPRB_TOKEN set, continuing without checking hooks')
+            else:
+                hooks_valid = hook_permissions.check_hooks_on_repo(user, repo, hook_errors, hook_user='ros-pull-request-builder', callback_url='http://build.ros.org/ghprbhook/', token=rosghprb_token)
+                if not hooks_valid:
+                    errors += hook_errors
+        else:
+            errors.append('Pull Request builds only supported on GitHub right now. Cannot do pull request against %s' % parsedurl.netloc)
+    if errors:
+        return(" ".join(errors))
     return None
 
 
@@ -126,12 +145,12 @@ def check_repo_for_errors(repo):
     if 'source' in repo:
         source_errors = check_source_repo_entry_for_errors(repo['source'])
         if source_errors:
-            errors.append("Could not validate source entry for repo %s with error [[[%s]]]" %
+            errors.append('Could not validate source entry for repo %s with error [[[%s]]]' %
                           (repo['repo'], source_errors))
     if 'doc' in repo:
         source_errors = check_source_repo_entry_for_errors(repo['doc'], tags_valid=True)
         if source_errors:
-            errors.append("Could not validate doc entry for repo %s with error [[[%s]]]" %
+            errors.append('Could not validate doc entry for repo %s with error [[[%s]]]' %
                           (repo['repo'], source_errors))
     return errors
 
@@ -150,8 +169,8 @@ def detect_post_eol_release(n, repo, lines):
         end_line = release_element['tags']['__line__'] + 3
         matching_lines = [l for l in lines if l >= start_line and l <= end_line]
         if matching_lines:
-            errors.append("There is a change to a release section of an EOLed "
-                          "distribution. Lines: %s" % matching_lines)
+            errors.append('There is a change to a release section of an EOLed '
+                          'distribution. Lines: %s' % matching_lines)
     if 'doc' in repo:
         doc_element = repo['doc']
         start_line = doc_element['__line__']
@@ -160,8 +179,8 @@ def detect_post_eol_release(n, repo, lines):
         # the url and version number
         matching_lines = [l for l in lines if l >= start_line and l <= end_line]
         if matching_lines:
-            errors.append("There is a change to a doc section of an EOLed "
-                          "distribution. Lines: %s" % matching_lines)
+            errors.append('There is a change to a doc section of an EOLed '
+                          'distribution. Lines: %s' % matching_lines)
 
     return errors
 


### PR DESCRIPTION
This will help us make sure that pull request builds will provision correctly.

It checks if ros-pull-request-builder has appropriate permissions. It requires the environment ROSGHPRB_TOKEN to be set to check. But it will skip the test if that's unset.