### PR TITLE
Fixes rosdep: portaudio19-dev in debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3729,7 +3729,7 @@ portaudio:
   gentoo: [media-libs/portaudio]
   ubuntu: [libportaudio-dev]
 portaudio19-dev:
-  debian: [libportaudio19-dev]
+  debian: [portaudio19-dev]
   fedora: [libportaudio-devel]
   gentoo: ['=media-libs/portaudio-19*']
   ubuntu: [portaudio19-dev]


### PR DESCRIPTION
There is no [libportaudio19-dev](https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=libportaudio19-dev) in Debian. It is called [portaudio19-dev](https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=portaudio19-dev).

This should fix gcloud_speech utils build in debian: http://build.ros.org/job/Kbin_dj_dJ64__gcloud_speech_utils__debian_jessie_amd64__binary/4/console