### PR TITLE
gcloud_speech: 0.0.3-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -671,7 +671,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/CogRobRelease/gcloud_speech-release.git
-      version: 0.0.3-0
+      version: 0.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gcloud_speech` to `0.0.3-1`:

- upstream repository: https://github.com/CogRob/gcloud_speech.git
- release repository: https://github.com/CogRobRelease/gcloud_speech-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.3-0`

## gcloud_speech

```
* Adds catkin_INCLUDE_DIRS to include_directories (#16 <https://github.com/CogRob/gcloud_speech/issues/16>)
* Contributors: Shengye Wang
```

## gcloud_speech_msgs

- No changes

## gcloud_speech_utils

```
* Adds catkin_INCLUDE_DIRS to include_directories (#16 <https://github.com/CogRob/gcloud_speech/issues/16>)
* Removes documentation about the project name command line flag (#15 <https://github.com/CogRob/gcloud_speech/issues/15>)
  * Removes documentation about the project name command line flag
  * Removes extra comments in launch file
* Contributors: Shengye Wang
```
