### PR TITLE
gcloud_speech: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3596,7 +3596,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/CogRobRelease/gcloud_speech-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gcloud_speech` to `0.0.4-0`:

- upstream repository: https://github.com/CogRob/gcloud_speech.git
- release repository: https://github.com/CogRobRelease/gcloud_speech-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.3-0`

## gcloud_speech

```
* Fixes a problem that the binrary/libraries are not packed into deb file (#18 <https://github.com/CogRob/gcloud_speech/issues/18>)
* Contributors: Shengye Wang
```

## gcloud_speech_msgs

- No changes

## gcloud_speech_utils

```
* Fixes a problem that the binrary/libraries are not packed into deb file (#18 <https://github.com/CogRob/gcloud_speech/issues/18>)
* Contributors: Shengye Wang
```
