### PR TITLE
gcloud_speech: 0.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2256,7 +2256,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/CogRobRelease/gcloud_speech-release.git
-      version: 0.0.3-1
+      version: 0.0.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gcloud_speech` to `0.0.4-0`:

- upstream repository: https://github.com/CogRob/gcloud_speech.git
- release repository: https://github.com/CogRobRelease/gcloud_speech-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.3-1`

## gcloud_speech

```
* Fixes a problem that the binrary/libraries are not packed into deb file (#18 <https://github.com/CogRob/gcloud_speech/issues/18>)
* Contributors: Shengye Wang
```

## gcloud_speech_msgs

- No changes

## gcloud_speech_utils

```
* Fixes a problem that the binrary/libraries are not packed into deb file (#18 <https://github.com/CogRob/gcloud_speech/issues/18>)
* Contributors: Shengye Wang
```
