### PR TITLE
msp: 2.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4667,7 +4667,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/christianrauch/msp-release.git
-      version: 2.0.2-0
+      version: 2.1.0-0
     source:
       type: git
       url: https://github.com/christianrauch/msp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `msp` to `2.1.0-0`:

- upstream repository: https://github.com/christianrauch/msp.git
- release repository: https://github.com/christianrauch/msp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.0.2-0`
