### PR TITLE
multiwii: 2.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4728,7 +4728,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/christianrauch/ros-multiwii-release.git
-      version: 2.0.1-0
+      version: 2.1.0-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `multiwii` to `2.1.0-0`:

- upstream repository: https://github.com/christianrauch/ros-multiwii.git
- release repository: https://github.com/christianrauch/ros-multiwii-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.0.1-0`
