### PR TITLE
move_basic: 0.2.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4489,7 +4489,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/move_basic-release.git
-      version: 0.2.1-0
+      version: 0.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_basic` to `0.2.2-1`:

- upstream repository: https://github.com/UbiquityRobotics/move_basic.git
- release repository: https://github.com/UbiquityRobotics-release/move_basic-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.1-0`

## move_basic

```
* Will reverse for small distances without rotating
* Try to operate in the frame the goal is in if no map frame
* Add map_frame param
* Add frane to points in path
* Contributors: Jim Vaughan, Rohan Agrawal
```
