### PR TITLE
Removing packages continuously failing to build for Indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5329,10 +5329,8 @@ repositories:
       packages:
       - jsk_2015_05_baxter_apc
       - jsk_2016_01_baxter_apc
-      - jsk_apc
       - jsk_apc2015_common
       - jsk_apc2016_common
-      - jsk_arc2017_baxter
       - jsk_arc2017_common
       tags:
         release: release/indigo/{package}/{version}
@@ -9627,12 +9625,10 @@ repositories:
     release:
       packages:
       - imu_monitor
-      - pr2_bringup
       - pr2_camera_synchronizer
       - pr2_computer_monitor
       - pr2_controller_configuration
       - pr2_ethercat
-      - pr2_robot
       - pr2_run_stop_auto_restart
       tags:
         release: release/indigo/{package}/{version}
@@ -9647,9 +9643,7 @@ repositories:
     release:
       packages:
       - joint_qualification_controllers
-      - pr2_bringup_tests
       - pr2_counterbalance_check
-      - pr2_self_test
       - pr2_self_test_msgs
       tags:
         release: release/indigo/{package}/{version}


### PR DESCRIPTION
pr2_self_test depends on pr2_bringup_tests
pr2_robot depends on pr2_bringup
pr2_bringup depends on pr2_camera_synchronizer
pr2_camera_synchronizer failing pending release with https://github.com/PR2/pr2_robot/pull/252 included

jsk_arc2017_baxter failing to build daily for 1 month.
jsk_apc depends on above
It looks like a missing dependency: 
```
23:34:46 -- catkin 0.6.19
23:34:46 CMake Warning at /opt/ros/indigo/share/catkin/cmake/catkinConfig.cmake:76 (find_package):
23:34:46   Could not find a package configuration file provided by
23:34:46   "force_proximity_ros" with any of the following names:
23:34:46 
23:34:46     force_proximity_rosConfig.cmake
23:34:46     force_proximity_ros-config.cmake
23:34:46 
23:34:46   Add the installation prefix of "force_proximity_ros" to CMAKE_PREFIX_PATH
23:34:46   or set "force_proximity_ros_DIR" to a directory containing one of the above
23:34:46   files.  If "force_proximity_ros" provides a separate development package or
23:34:46   SDK, be sure it has been installed.
23:34:46 Call Stack (most recent call first):
23:34:46   CMakeLists.txt:4 (find_package)
23:34:46 
23:34:46 
23:34:46 -- Could not find the required component 'force_proximity_ros'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
23:34:46 CMake Error at /opt/ros/indigo/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
23:34:46   Could not find a package configuration file provided by
23:34:46   "force_proximity_ros" with any of the following names:
23:34:46 
23:34:46     force_proximity_rosConfig.cmake
23:34:46     force_proximity_ros-config.cmake
23:34:46 
23:34:46   Add the installation prefix of "force_proximity_ros" to CMAKE_PREFIX_PATH
23:34:46   or set "force_proximity_ros_DIR" to a directory containing one of the above
23:34:46   files.  If "force_proximity_ros" provides a separate development package or
23:34:46   SDK, be sure it has been installed.
23:34:46 Call Stack (most recent call first):
23:34:46   CMakeLists.txt:4 (find_package)
23:34:46 
```