### PR TITLE
Removing continuously failing pheeno_sim.

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5914,7 +5914,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ACSLaboratory/pheeno_ros_sim-release.git
-      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/ACSLaboratory/pheeno_ros_sim.git


### PR DESCRIPTION
It's failing to build repeatedly due to missing dependencies.
Reverts releases ending with https://github.com/ros/rosdistro/pull/15999

@zmk5 FYI

```
sim-0.1.4/src/gazebo_ros_ir_sensor.cpp
23:17:59 In file included from /usr/include/c++/5/random:35:0,
23:17:59                  from
/usr/include/ignition/math2/ignition/math/Rand.hh:20,
23:17:59                  from
/usr/include/ignition/math2/ignition/math.hh:18,
23:17:59                  from
/usr/include/sdformat-4.0/sdf/Param.hh:34,
23:17:59                  from
/usr/include/sdformat-4.0/sdf/Element.hh:24,
23:17:59                  from /usr/include/sdformat-4.0/sdf/sdf.hh:5,
23:17:59                  from
/usr/include/gazebo-7/gazebo/physics/World.hh:35,
23:17:59                  from
/tmp/binarydeb/ros-kinetic-pheeno-ros-sim-0.1.4/src/gazebo_ros_ir_sensor.cpp:5:
23:17:59 /usr/include/c++/5/bits/c++0x_warning.h:32:2: error: #error
This file requires compiler and library support for the ISO C++ 2011
standard. This support must be enabled with the -std=c++11 or
-std=gnu++11 compiler options.
23:17:59  #error This file requires compiler and library support \
23:17:59   ^
23:18:01 In file included from /usr/include/sdformat-4.0/sdf/sdf.hh:3:0,
23:18:01                  from
/usr/include/gazebo-7/gazebo/physics/World.hh:35,
23:18:01                  from
/tmp/binarydeb/ros-kinetic-pheeno-ros-sim-0.1.4/src/gazebo_ros_ir_sensor.cpp:5:
23:18:01 /usr/include/sdformat-4.0/sdf/Console.hh:55:16: error:
‘shared_ptr’ in namespace ‘std’ does not name a template type
23:18:01    typedef std::shared_ptr<Console> ConsolePtr;
23:18:01                 ^
23:18:01 /usr/include/sdformat-4.0/sdf/Console.hh:96:20: error:
‘ConsolePtr’ does not name a type
23:18:01      public: static ConsolePtr Instance();
23:18:01                     ^
23:18:01 /usr/include/sdformat-4.0/sdf/Console.hh:118:19: error:
‘unique_ptr’ in namespace ‘std’ does not name a template type
23:18:01      private: std::unique_ptr<ConsolePrivate> dataPtr;
23:18:01                    ^
23:18:01 /usr/include/sdformat-4.0/sdf/Console.hh: In member function
‘sdf::Console::ConsoleStream&
sdf::Console::ConsoleStream::operator<<(const T&)’:
23:18:01 /usr/include/sdformat-4.0/sdf/Console.hh:145:9: error:
‘Instance’ is not a member of ‘sdf::Console’
23:18:01      if (Console::Instance()->dataPtr->logFileStream.is_open())
23:18:01          ^
23:18:01 /usr/include/sdformat-4.0/sdf/Console.hh:147:7: error:
‘Instance’ is not a member of ‘sdf::Console’
23:18:01        Console::Instance()->dataPtr->logFileStream << _rhs;
23:18:01        ^
23:18:01 /usr/include/sdformat-4.0/sdf/Console.hh:148:7: error:
‘Instance’ is not a member of ‘sdf::Console’
23:18:01        Console::Instance()->dataPtr->logFileStream.flush();
23:18:01        ^
```