### PR TITLE
openni2_launch: 0.2.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1901,6 +1901,21 @@ repositories:
       url: https://github.com/ros-drivers/openni2_camera.git
       version: indigo-devel
     status: maintained
+  openni2_launch:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni2_launch.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/openni2_launch.git
+      version: 0.2.3-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni2_launch.git
+      version: indigo-devel
+    status: maintained
   openni_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_launch` to `0.2.3-0`:

- upstream repository: https://github.com/ros-drivers/openni2_launch.git
- release repository: https://github.com/ros-gbp/openni2_launch.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
