### PR TITLE
libfranka: 0.1.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3785,11 +3785,15 @@ repositories:
       version: master
     status: developed
   libfranka:
+    doc:
+      type: git
+      url: https://github.com/frankaemika/libfranka-release.git
+      version: release/kinetic/libfranka
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/frankaemika/libfranka-release.git
-      version: 0.1.0-1
+      version: 0.1.0-2
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libfranka` to `0.1.0-2`:

- upstream repository: https://github.com/frankaemika/libfranka.git
- release repository: https://github.com/frankaemika/libfranka-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.0-1`

Patched a `rosdoc.yaml` into the release repo so docu can be generated with `rosdoc_lite`.