### PR TITLE
franka_ros: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2149,6 +2149,31 @@ repositories:
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
       version: master
     status: developed
+  franka_ros:
+    doc:
+      type: git
+      url: https://github.com/frankaemika/franka_ros.git
+      version: kinetic-devel
+    release:
+      packages:
+      - franka_control
+      - franka_description
+      - franka_example_controllers
+      - franka_gripper
+      - franka_hw
+      - franka_msgs
+      - franka_ros
+      - franka_visualization
+      - panda_moveit_config
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/frankaemika/franka_ros-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/frankaemika/franka_ros.git
+      version: kinetic-devel
+    status: developed
   freenect_stack:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `franka_ros` to `0.1.1-0`:

- upstream repository: https://github.com/frankaemika/franka_ros.git
- release repository: https://github.com/frankaemika/franka_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
