### PR TITLE
rqt_pose_view: 0.5.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12820,7 +12820,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_pose_view-release.git
-      version: 0.5.7-0
+      version: 0.5.8-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_pose_view.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_pose_view` to `0.5.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_pose_view.git
- release repository: https://github.com/ros-gbp/rqt_pose_view-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.5.7-0`

## rqt_pose_view

```
* fix direction of rotations (#3 <https://github.com/ros-visualization/rqt_pose_view/issues/3>)
```
