### PR TITLE
libuvc: 0.0.6-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1323,7 +1323,11 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ktossell/libuvc-release.git
-      version: 0.0.5-3
+      version: 0.0.6-0
+    source:
+      type: git
+      url: https://github.com/ktossell/libuvc.git
+      version: 0.0.6
     status: unmaintained
   libuvc_ros:
     doc:

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1327,7 +1327,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ktossell/libuvc.git
-      version: 0.0.6
+      version: master
     status: unmaintained
   libuvc_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc` to `0.0.6-0`:

- upstream repository: https://github.com/ktossell/libuvc.git
- release repository: https://github.com/ktossell/libuvc-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.5-3`
