### PR TITLE
franka_ros: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2168,7 +2168,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/frankaemika/franka_ros-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/frankaemika/franka_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `franka_ros` to `0.1.2-0`:

- upstream repository: https://github.com/frankaemika/franka_ros.git
- release repository: https://github.com/frankaemika/franka_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.1-0`

Should hopefully fix the build on build.ros.org.. I didn't catch the error during prerelease testing because it only occurs when building Debian packages separately (although I should have known to look out for this after #15988).