### PR TITLE
fzi_icl_can: 1.0.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2217,7 +2217,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can-release.git
-      version: 1.0.10-0
+      version: 1.0.11-0
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fzi_icl_can` to `1.0.11-0`:

- upstream repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/fzi_icl_can-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.10-0`

## fzi_icl_can

```
* Use the libpcan from the ros package
* Contributors: Felix Mauch
```
