### PR TITLE
libuvc: 0.0.6-2 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1323,7 +1323,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ktossell/libuvc-release.git
-      version: 0.0.6-0
+      version: 0.0.6-2
     source:
       type: git
       url: https://github.com/ktossell/libuvc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc` to `0.0.6-2`:

- upstream repository: https://github.com/ktossell/libuvc.git
- release repository: https://github.com/ktossell/libuvc-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.6-0`
