### PR TITLE
jsk_apc: 4.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5329,13 +5329,15 @@ repositories:
       packages:
       - jsk_2015_05_baxter_apc
       - jsk_2016_01_baxter_apc
+      - jsk_apc
       - jsk_apc2015_common
       - jsk_apc2016_common
+      - jsk_arc2017_baxter
       - jsk_arc2017_common
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_apc-release.git
-      version: 4.0.0-0
+      version: 4.1.2-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_apc` to `4.1.2-0`:

- upstream repository: https://github.com/start-jsk/jsk_apc.git
- release repository: https://github.com/tork-a/jsk_apc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `4.0.0-0`

## jsk_2015_05_baxter_apc

- No changes

## jsk_2016_01_baxter_apc

- No changes

## jsk_apc

- No changes

## jsk_apc2015_common

- No changes

## jsk_apc2016_common

- No changes

## jsk_arc2017_baxter

- No changes

## jsk_arc2017_common

```
* Create fcn32s.npz symlink by install_data.py
  In order to avoid error in bloom.
* Contributors: Kentaro Wada
```
