### PR TITLE
youbot_driver: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10604,6 +10604,20 @@ repositories:
       url: https://github.com/yujinrobot/yocs_msgs.git
       version: kinetic
     status: developed
+  youbot_driver:
+    doc:
+      type: git
+      url: https://github.com/youbot/youbot_driver.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/youbot-release/youbot_driver-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/youbot/youbot_driver.git
+      version: hydro-devel
   yujin_ocs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `youbot_driver` to `1.1.0-0`:

- upstream repository: https://github.com/youbot/youbot_driver.git
- release repository: https://github.com/youbot-release/youbot_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
