### PR TITLE
brics_actuator: 0.7.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -328,6 +328,20 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: groovy-devel
     status: maintained
+  brics_actuator:
+    doc:
+      type: git
+      url: https://github.com/wnowak/brics_actuator.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/wnowak/brics_actuator-release.git
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/wnowak/brics_actuator.git
+      version: master
   bta_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `brics_actuator` to `0.7.0-0`:

- upstream repository: https://github.com/wnowak/brics_actuator.git
- release repository: https://github.com/wnowak/brics_actuator-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
