### PR TITLE
brics_actuator: 0.7.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -648,6 +648,20 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: groovy-devel
     status: maintained
+  brics_actuator:
+    doc:
+      type: git
+      url: https://github.com/wnowak/brics_actuator.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/wnowak/brics_actuator-release.git
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/wnowak/brics_actuator.git
+      version: master
   brunel_hand_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `brics_actuator` to `0.7.0-0`:

- upstream repository: https://github.com/wnowak/brics_actuator.git
- release repository: https://github.com/wnowak/brics_actuator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
