### PR TITLE
jsk_apc: 4.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5337,7 +5337,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_apc-release.git
-      version: 4.1.2-0
+      version: 4.1.3-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_apc` to `4.1.3-0`:

- upstream repository: https://github.com/start-jsk/jsk_apc.git
- release repository: https://github.com/tork-a/jsk_apc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `4.1.2-0`

## jsk_2015_05_baxter_apc

- No changes

## jsk_2016_01_baxter_apc

- No changes

## jsk_apc

- No changes

## jsk_apc2015_common

- No changes

## jsk_apc2016_common

- No changes

## jsk_arc2017_baxter

- No changes

## jsk_arc2017_common

- No changes
