### PR TITLE
ros_type_introspection: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11872,7 +11872,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/facontidavide/ros_type_introspection-release.git
-      version: 0.9.0-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/facontidavide/ros_type_introspection.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_type_introspection` to `1.0.0-0`:

- upstream repository: https://github.com/facontidavide/ros_type_introspection.git
- release repository: https://github.com/facontidavide/ros_type_introspection-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.9.0-0`

## ros_type_introspection

```
* Complete refactoring
* Contributors: Davide Faconti, Kartik Mohta, Ian Taylor, Mehdi Tlili
```
