### PR TITLE
rospack: 2.4.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2813,7 +2813,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
-      version: 2.4.2-0
+      version: 2.4.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.4.3-0`:

- upstream repository: https://github.com/ros/rospack.git
- release repository: https://github.com/ros-gbp/rospack-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.4.2-0`

## rospack

```
* add README.md with notes about tinyxml2 (#82 <https://github.com/ros/rospack/issues/82>)
* replace references to deprecated Boost.TR1 (#80 <https://github.com/ros/rospack/issues/80>)
* fix Python.h redefining pre-processor definitions (#78 <https://github.com/ros/rospack/issues/78>)
```
