### PR TITLE
fanuc: 0.4.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3102,11 +3102,14 @@ repositories:
       - fanuc_m430ia2p_moveit_config
       - fanuc_m430ia_moveit_plugins
       - fanuc_m430ia_support
+      - fanuc_m6ib_moveit_config
+      - fanuc_m6ib_moveit_plugins
+      - fanuc_m6ib_support
       - fanuc_resources
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/fanuc-release.git
-      version: 0.4.2-0
+      version: 0.4.3-0
     source:
       type: git
       url: https://github.com/ros-industrial/fanuc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fanuc` to `0.4.3-0`:

- upstream repository: https://github.com/ros-industrial/fanuc.git
- release repository: https://github.com/ros-industrial-release/fanuc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.4.2-0`

## fanuc

```
* promote experimental packages for M-6iB to main repository.
```

## fanuc_driver

```
* update comment for Pressure Abnormal safety signal in Karel sources.
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_lrmate200ic5h_moveit_config

```
* enable use of Jade+ xacro when loading MoveIt configuration packages. (#217 <https://github.com/ros-industrial/fanuc/issues/217>).
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_lrmate200ic5l_moveit_config

```
* enable use of Jade+ xacro when loading MoveIt configuration packages. (#217 <https://github.com/ros-industrial/fanuc/issues/217>).
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_lrmate200ic_moveit_config

```
* enable use of Jade+ xacro when loading MoveIt configuration packages. (#217 <https://github.com/ros-industrial/fanuc/issues/217>).
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_lrmate200ic_moveit_plugins

```
* enable C++11 for MoveIt on Kinetic (#199 <https://github.com/ros-industrial/fanuc/issues/199>).
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_lrmate200ic_support

```
* no changes.
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_m10ia_moveit_config

```
* enable use of Jade+ xacro when loading MoveIt configuration packages. (#217 <https://github.com/ros-industrial/fanuc/issues/217>).
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_m10ia_moveit_plugins

```
* enable C++11 for MoveIt on Kinetic (#199 <https://github.com/ros-industrial/fanuc/issues/199>).
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_m10ia_support

```
* no changes.
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_m16ib20_moveit_config

```
* enable use of Jade+ xacro when loading MoveIt configuration packages. (#217 <https://github.com/ros-industrial/fanuc/issues/217>).
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_m16ib_moveit_plugins

```
* enable C++11 for MoveIt on Kinetic (#199 <https://github.com/ros-industrial/fanuc/issues/199>).
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_m16ib_support

```
* no changes.
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_m20ia10l_moveit_config

```
* enable use of Jade+ xacro when loading MoveIt configuration packages. (#217 <https://github.com/ros-industrial/fanuc/issues/217>).
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_m20ia_moveit_config

```
* enable use of Jade+ xacro when loading MoveIt configuration packages. (#217 <https://github.com/ros-industrial/fanuc/issues/217>).
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_m20ia_moveit_plugins

```
* enable C++11 for MoveIt on Kinetic (#199 <https://github.com/ros-industrial/fanuc/issues/199>).
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_m20ia_support

```
* no changes.
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_m430ia2f_moveit_config

```
* enable use of Jade+ xacro when loading MoveIt configuration packages. (#217 <https://github.com/ros-industrial/fanuc/issues/217>).
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_m430ia2p_moveit_config

```
* enable use of Jade+ xacro when loading MoveIt configuration packages. (#217 <https://github.com/ros-industrial/fanuc/issues/217>).
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_m430ia_moveit_plugins

```
* enable C++11 for MoveIt on Kinetic (#199 <https://github.com/ros-industrial/fanuc/issues/199>).
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_m430ia_support

```
* no changes.
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_m6ib_moveit_config

```
* first Indigo release of this package.
* promote experimental packages for M-6iB to main repository.
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_m6ib_moveit_plugins

```
* first Indigo release of this package.
* promote experimental packages for M-6iB to main repository.
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_m6ib_support

```
* first Indigo release of this package.
* promote experimental packages for M-6iB to main repository.
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```

## fanuc_resources

```
* no changes.
* for a complete list of changes see the commit log for 0.4.3 <https://github.com/ros-industrial/fanuc/compare/0.4.2...0.4.3>.
```
