### PR TITLE
abseil_cpp: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -67,7 +67,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/Eurecat/abseil_cpp-release.git
-      version: 0.1.4-0
+      version: 0.2.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `abseil_cpp` to `0.2.0-0`:

- upstream repository: https://github.com/Eurecat/abseil-cpp.git
- release repository: https://github.com/Eurecat/abseil_cpp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.4-0`

## abseil_cpp

```
* reorganized the files
* Contributors: Davide Faconti
```
