### PR TITLE
Add arch definition for python-qt5-bindings-webkit

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2561,6 +2561,7 @@ python-qt5-bindings-gl:
     yakkety: [python-pyqt5.qtopengl]
     zesty: [python-pyqt5.qtopengl]
 python-qt5-bindings-webkit:
+  arch: [python2-pyqt5]
   debian:
     buster: [python-pyqt5.qtwebkit]
     jessie: [python-pyqt5.qtwebkit]


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>