### PR TITLE
gmplot_ros: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2574,6 +2574,16 @@ repositories:
       url: https://github.com/ros-visualization/gl_dependency.git
       version: kinetic-devel
     status: maintained
+  gmplot_ros:
+    release:
+      packages:
+      - gmplot
+      - gmplot_msgs
+      - gmplot_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/robustify/gmplot_ros-release.git
+      version: 1.0.1-0
   gps_goal:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gmplot_ros` to `1.0.1-0`:

- upstream repository: https://github.com/robustify/gmplot_ros.git
- release repository: https://github.com/robustify/gmplot_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## gmplot

```
* Initial release
* Contributors: Micho Radovnikovich
```

## gmplot_msgs

```
* Initial release
* Contributors: Micho Radovnikovich
```

## gmplot_ros

```
* Initial release
* Contributors: Micho Radovnikovich
```
