### PR TITLE
remove pr2_camera_synchronizer

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9630,7 +9630,6 @@ repositories:
     release:
       packages:
       - imu_monitor
-      - pr2_camera_synchronizer
       - pr2_computer_monitor
       - pr2_controller_configuration
       - pr2_ethercat


### PR DESCRIPTION
It has been continuously failing to build pending the release of a version with https://github.com/PR2/pr2_robot/pull/252

@TheDash FYI

Example failing job: http://build.ros.org/view/Ibin_uT64/job/Ibin_uT64__pr2_camera_synchronizer__ubuntu_trusty_amd64__binary/