### PR TITLE
twistimu: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9820,6 +9820,18 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/twist_mux_msgs-release.git
       version: 2.0.0-0
+  twistimu:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/easymov/twistimu-release.git
+      version: 1.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://gitlab.com/easymov/twistimu.git
+      version: develop
+    status: maintained
   uavc_v4lctl:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9826,11 +9826,6 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/easymov/twistimu-release.git
       version: 1.0.0-0
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://gitlab.com/easymov/twistimu.git
-      version: develop
     status: maintained
   uavc_v4lctl:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `twistimu` to `1.0.0-0`:

- upstream repository: https://gitlab.com/easymov/twistimu.git
- release repository: https://github.com/easymov/twistimu-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## twistimu

- No changes
