### PR TITLE
rosbridge_suite: 0.8.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2690,7 +2690,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.8.3-0
+      version: 0.8.4-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.8.4-0`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.8.3-0`

## rosapi

```
* Handles empty globes properly (#297 <https://github.com/RobotWebTools/rosbridge_suite/issues/297>)
  * Refactors get_globs function to a separate module
  * Refactors the filtering that uses the globs
  * Some linting
  * Handles topic types for empty globs
  * Refactors out an any_match function
  * Simplifies filter_action_servers
  * Imports socket for the errors
  * Uses import .glob_helper
* Contributors: Anwar
```

## rosbridge_library

- No changes

## rosbridge_server

- No changes

## rosbridge_suite

- No changes
