### PR TITLE
multikey_teleop: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7361,6 +7361,13 @@ repositories:
       url: https://github.com/lukscasanova/mtig_driver.git
       version: master
     status: developed
+  multikey_teleop:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/easymov/multikey_teleop-release.git
+      version: 1.0.0-0
+    status: maintained
   multimaster_fkie:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `multikey_teleop` to `1.0.0-0`:

- upstream repository: https://gitlab.com/easymov/multikey_teleop.git
- release repository: https://github.com/easymov/multikey_teleop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## multikey_teleop

- No changes
