### PR TITLE
criutils: 0.1.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2272,6 +2272,21 @@ repositories:
       url: https://github.com/AutonomyLab/create_autonomy.git
       version: indigo-devel
     status: developed
+  criutils:
+    doc:
+      type: git
+      url: https://github.com/crigroup/criutils.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/crigroup/criutils-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/crigroup/criutils.git
+      version: master
+    status: developed
   crsm_slam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `criutils` to `0.1.1-1`:

- upstream repository: https://github.com/crigroup/criutils.git
- release repository: https://github.com/crigroup/criutils-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## criutils

```
* Complete documentation
* Complete tests
* Add parameter module
* Contributors: fsuarez6
```
