### PR TITLE
fcl_catkin: 0.5.90-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3157,6 +3157,13 @@ repositories:
       url: https://github.com/ros-gbp/fcl-release.git
       version: 0.3.4-0
     status: maintained
+  fcl_catkin:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/wxmerkt/fcl_catkin-release.git
+      version: 0.5.90-0
+    status: developed
   fetch_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fcl_catkin` to `0.5.90-0`:

- upstream repository: https://github.com/wxmerkt/fcl_catkin.git
- release repository: https://github.com/wxmerkt/fcl_catkin-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
