### PR TITLE
slam_gmapping: 1.3.9-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3488,6 +3488,21 @@ repositories:
       url: https://github.com/uos/sick_tim.git
       version: lunar
     status: developed
+  slam_gmapping:
+    release:
+      packages:
+      - gmapping
+      - slam_gmapping
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/slam_gmapping-release.git
+      version: 1.3.9-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/slam_gmapping.git
+      version: hydro-devel
+    status: unmaintained
   soem:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_gmapping` to `1.3.9-0`:

- upstream repository: https://github.com/ros-perception/slam_gmapping
- release repository: https://github.com/ros-gbp/slam_gmapping-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## gmapping

```
* remove unused file
* add missing nodelet dependency to find_package
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* Add nodelet implementation. (#41 <https://github.com/ros-perception/slam_gmapping/issues/41>)
  * Add nodelet implementation.
  Add additional nodelet layer to mirror the node
  implementation. This allows the Slam GMapping
  library to be run as a nodelet instead. This
  would allow you to, for example, run it under
  the same nodelet manager as the nodelet producing
  the /scan output for greater efficiency.
  * Remove superfluous semicolons
  Removed superfluous semicolons and
  mildly clarified info stream output.
* fix comment, change type from double to int (#40 <https://github.com/ros-perception/slam_gmapping/issues/40>)
  * fix comment, change type from double to int
  * fix comment, iterations param is not double but int
* Contributors: David Hodo, Kevin Wells, Lukas Bulwahn, Oscar Lima, Vincent Rabaud
```

## slam_gmapping

- No changes
