### PR TITLE
Added python-numpydoc for several distributions

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1785,6 +1785,15 @@ python-numpy:
     xenial: [python-numpy]
     yakkety: [python-numpy]
     zesty: [python-numpy]
+python-numpydoc:
+  arch: [python2-numpydoc]
+  debian: [python-numpydoc]
+  opensuse: [python-numpydoc]
+  ubuntu:
+    artful: [python-numpydoc]
+    trusty: [python-numpydoc]
+    xenial: [python-numpydoc]
+    zesty: [python-numpydoc]
 python-numpy-stl-pip:
   osx:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1785,6 +1785,13 @@ python-numpy:
     xenial: [python-numpy]
     yakkety: [python-numpy]
     zesty: [python-numpy]
+python-numpy-stl-pip:
+  osx:
+    pip:
+      packages: [numpy-stl]
+  ubuntu:
+    pip:
+      packages: [numpy-stl]
 python-numpydoc:
   arch: [python2-numpydoc]
   debian: [python-numpydoc]
@@ -1794,13 +1801,6 @@ python-numpydoc:
     trusty: [python-numpydoc]
     xenial: [python-numpydoc]
     zesty: [python-numpydoc]
-python-numpy-stl-pip:
-  osx:
-    pip:
-      packages: [numpy-stl]
-  ubuntu:
-    pip:
-      packages: [numpy-stl]
 python-oauth2:
   arch: [python-oauth2]
   debian: [python-oauth2]


### PR DESCRIPTION
For your reference:
- arch: https://aur.archlinux.org/packages/python2-numpydoc/
- debian: https://packages.debian.org/stretch/python-numpydoc
- opensuse: https://software.opensuse.org/package/python-numpydoc
- artful: https://packages.ubuntu.com/artful/python-numpydoc
- trusty: https://packages.ubuntu.com/trusty/python-numpydoc
- xenial: https://packages.ubuntu.com/xenial/python-numpydoc
- zesty: https://packages.ubuntu.com/zesty/python-numpydoc