### PR TITLE
jsk_apc: 4.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5362,7 +5362,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_apc-release.git
-      version: 4.1.4-0
+      version: 4.1.5-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Close https://github.com/start-jsk/jsk_apc/issues/2598

Increasing version of package(s) in repository `jsk_apc` to `4.1.5-0`:

- upstream repository: https://github.com/start-jsk/jsk_apc.git
- release repository: https://github.com/tork-a/jsk_apc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `4.1.4-0`

## jsk_2015_05_baxter_apc

```
* 4.1.4
* Update CHANGELOG
* Contributors: Kentaro Wada
```

## jsk_2016_01_baxter_apc

```
* 4.1.4
* Update CHANGELOG
* Contributors: Kentaro Wada
```

## jsk_apc

```
* 4.1.4
* Update CHANGELOG
* Contributors: Kentaro Wada
```

## jsk_apc2015_common

```
* 4.1.4
* Update CHANGELOG
* Contributors: Kentaro Wada
```

## jsk_apc2016_common

```
* 4.1.4
* Update CHANGELOG
* Contributors: Kentaro Wada
```

## jsk_arc2017_baxter

```
* Install roslint + rostest for testing jsk_arc2017_baxter
* 4.1.4
* Update CHANGELOG
* Contributors: Kentaro Wada
```

## jsk_arc2017_common

```
* 4.1.4
* Update CHANGELOG
* Skip ResourceNotFound error to pass build on build.ros.org
* Contributors: Kentaro Wada
```
