### PR TITLE
baldor: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -507,6 +507,21 @@ repositories:
       url: https://github.com/po1/axcli-release.git
       version: 0.1.0-0
     status: maintained
+  baldor:
+    doc:
+      type: git
+      url: https://github.com/crigroup/baldor.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/crigroup/baldor-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/crigroup/baldor.git
+      version: master
+    status: developed
   barrett_hand:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `baldor` to `0.1.0-0`:

- upstream repository: https://github.com/crigroup/baldor.git
- release repository: https://github.com/crigroup/baldor-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## baldor

```
* Initial release
* Contributors: fsuarez6
```
