### PR TITLE
xpp: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16407,6 +16407,28 @@ repositories:
       url: https://github.com/wavelab/ximea_camera.git
       version: devel-indigo
     status: maintained
+  xpp:
+    release:
+      packages:
+      - biped_description
+      - hyqb_description
+      - monoped_description
+      - quadrotor_description
+      - xpp_examples
+      - xpp_msgs
+      - xpp_ros_conversions
+      - xpp_states
+      - xpp_vis
+      - xpp_vis_hyq
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/leggedrobotics/xpp-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/leggedrobotics/xpp.git
+      version: master
+    status: developed
   xsens_awinda:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xpp` to `0.1.0-0`:

- upstream repository: https://github.com/leggedrobotics/xpp.git
- release repository: https://github.com/leggedrobotics/xpp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`
