### PR TITLE
[gentoo] use qt5 use flag for vtk-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3108,7 +3108,7 @@ libvtk-qt:
     stretch: [libvtk6-qt-dev]
     wheezy: [libvtk5-qt4-dev]
   fedora: [vtk-qt]
-  gentoo: ['sci-libs/vtk[qt4,rendering]'] #qt5 is available too
+  gentoo: ['sci-libs/vtk[qt5,rendering]']
   opensuse: [vtk-qt]
   slackware: [VTK]
   ubuntu:


### PR DESCRIPTION
Follow up of https://github.com/ros/rosdistro/pull/16140#pullrequestreview-71367010

gentoo uses vtk with the qt5 use flag for the key [`libvtk`](https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml#L3062). So this uses qt5 for `libvtk-qt` as well.

@allenh1 @Alessandro-Barbieri @concavegit FYI