### PR TITLE
Adding shm_transport to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8846,6 +8846,16 @@ repositories:
       url: https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation.git
       version: hydro-devel
     status: unmaintained
+  shm_transport:
+    doc:
+      type: git
+      url: https://github.com/Jrdevil-Wang/shm_transport
+      version: kinect
+    source:
+      type: git
+      url: https://github.com/Jrdevil-Wang/shm_transport.git
+      version: kinect
+    status: maintained
   sick_ldmrs_laser:
     doc:
       type: git


### PR DESCRIPTION
I'd like my shm_transport package to be indexed and documented on ros.org.