### PR TITLE
Adding shm_transport to indigo documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13807,6 +13807,16 @@ repositories:
       url: https://github.com/wcaarls/shared_serial.git
       version: master
     status: maintained
+  shm_transport:
+    doc:
+      type: git
+      url: https://github.com/Jrdevil-Wang/shm_transport.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/Jrdevil-Wang/shm_transport.git
+      version: master
+    status: maintained
   sick_ldmrs_laser:
     doc:
       type: git


### PR DESCRIPTION
I'd like shm_transport to be indexed and documented on ros.org.