### PR TITLE
Use rospack 2.4.3 in kinetic due to breakage with boost 1.65  (ros/rospack#80)

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7759,7 +7759,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
-      version: 2.3.3-0
+      version: 2.4.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
2.4.3, as far as I am concerned, fixes references containing `tr1`.