### PR TITLE
qt_gui_core: 0.3.7-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2254,7 +2254,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.3.6-0
+      version: 0.3.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.3.7-0`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.3.6-0`

## qt_dotgraph

```
* Fix for Python 3 compatibility (#106 <https://github.com/ros-visualization/qt_gui_core/issues/106>)
```

## qt_gui

```
* Hide the menu bar when using lock perspective (#103 <https://github.com/ros-visualization/qt_gui_core/issues/103>)
* Fix for Python 3 compatibility (#104 <https://github.com/ros-visualization/qt_gui_core/issues/104>)
```

## qt_gui_app

- No changes

## qt_gui_cpp

- No changes

## qt_gui_py_common

- No changes
