### PR TITLE
readd pyside2 and shiboken to python qt bindings

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2551,10 +2551,11 @@ python-qt5-bindings:
   opensuse: [python-qt5]
   slackware: [PyQt5]
   ubuntu:
+    artful: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
     wily: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
     xenial: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
     yakkety: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
-    zesty: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
+    zesty: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
 python-qt5-bindings-gl:
   arch: [python2-pyqt5]
   debian:


### PR DESCRIPTION
Now that the packages have been imported for zesty and artful: https://github.com/ros-infrastructure/ros_bootstrap_dependencies/issues/5#issuecomment-338821581