### PR TITLE
rosconsole_bridge: 0.5.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2706,7 +2706,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rosconsole_bridge-release.git
-      version: 0.4.4-0
+      version: 0.5.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole_bridge` to `0.5.0-0`:

- upstream repository: https://github.com/ros/rosconsole_bridge.git
- release repository: https://github.com/ros-gbp/rosconsole_bridge-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.4.4-0`

## rosconsole_bridge

```
* replace usage of deprecated logging functions (#14 <https://github.com/ros/rosconsole_bridge/issues/14>)
```
