### PR TITLE
python_qt_binding: 0.3.3-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2232,7 +2232,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/python_qt_binding-release.git
-      version: 0.3.2-2
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `0.3.3-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros-gbp/python_qt_binding-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.3.2-2`

## python_qt_binding

```
* Prefer qmake-qt5 over qmake when available (#43 <https://github.com/ros-visualization/python_qt_binding/issues/43>)
```
