### PR TITLE
ros_comm: 1.13.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2487,7 +2487,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.13.2-0
+      version: 1.13.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.13.3-0`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.13.2-0`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

```
* fix publishing of selected topics from bag file (#1156 <https://github.com/ros/ros_comm/issues/1156>)
* fix Python 3 compatibility (#1150 <https://github.com/ros/ros_comm/issues/1150>)
```

## rosbag_storage

```
* fix corrupted messages when reopening a rosbag with a different file (#1176 <https://github.com/ros/ros_comm/issues/1176>)
* addd rosbag::Bag::isOpen (#1190 <https://github.com/ros/ros_comm/issues/1190>)
* enable rosbag::Bag move operations if compiler support is available (#1189 <https://github.com/ros/ros_comm/issues/1189>)
* check if bzfile_ and lz4s_ handle is valid before reading/writing/closing (#1183 <https://github.com/ros/ros_comm/issues/1183>)
* fix an out of bounds read in rosbag::View::iterator::increment() (#1191 <https://github.com/ros/ros_comm/issues/1191>)
* replace usage deprecated console_bridge macros (#1149 <https://github.com/ros/ros_comm/issues/1149>)
```

## rosconsole

```
* replace 'while(0)' with 'while(false)' to avoid warnings (#1179 <https://github.com/ros/ros_comm/issues/1179>)
```

## roscpp

```
* avoid unused parameter warning in TransportTCP (#1195 <https://github.com/ros/ros_comm/issues/1195>)
* check if socket options are available before using them (#1172 <https://github.com/ros/ros_comm/issues/1172>)
```

## rosgraph

```
* use defined error codes rather than hardcoded integers (#1174 <https://github.com/ros/ros_comm/issues/1174>)
* improve logger tests (#1144 <https://github.com/ros/ros_comm/issues/1144>)
```

## roslaunch

```
* add --set-master-logger-level option for 'rosmaster' to output LOG_API (#1180 <https://github.com/ros/ros_comm/issues/1180>)
* use defined error codes rather than hardcoded integers (#1174 <https://github.com/ros/ros_comm/issues/1174>, #1181 <https://github.com/ros/ros_comm/issues/1181>)
* fix parameter leaking into sibling scopes (#1158 <https://github.com/ros/ros_comm/issues/1158>)
* avoid full stack trace for ResourceNotFound (#1147 <https://github.com/ros/ros_comm/issues/1147>)
* remove mention of rosmake from error message (#1140 <https://github.com/ros/ros_comm/issues/1140>)
```

## roslz4

- No changes

## rosmaster

```
* add --set-master-logger-level option for 'rosmaster' to output LOG_API (#1180 <https://github.com/ros/ros_comm/issues/1180>)
```

## rosmsg

- No changes

## rosnode

```
* return exit code 1 in case of errors (#1178 <https://github.com/ros/ros_comm/issues/1178>)
* sort output of rosnode info (#1160 <https://github.com/ros/ros_comm/issues/1160>)
* fix Python 3 compatibility (#1166 <https://github.com/ros/ros_comm/issues/1166>)
```

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* change rospy.Rate hz type from int to float (#1177 <https://github.com/ros/ros_comm/issues/1177>)
* use defined error codes rather than hardcoded integers (#1174 <https://github.com/ros/ros_comm/issues/1174>)
* improve log messages when waiting for service (#1026 <https://github.com/ros/ros_comm/issues/1026>)
* improve logger tests (#1144 <https://github.com/ros/ros_comm/issues/1144>)
```

## rosservice

- No changes

## rostest

- No changes

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

```
* add initial_topic param (#1199 <https://github.com/ros/ros_comm/issues/1199>)
* make demux more agile (#1196 <https://github.com/ros/ros_comm/issues/1196>)
* add stealth mode for topic_tools/relay (#1155 <https://github.com/ros/ros_comm/issues/1155>)
```

## xmlrpcpp

```
* fix problem when configuring tests without gtest being available (#1197 <https://github.com/ros/ros_comm/issues/1197>)
```
