### PR TITLE
openni2_camera: 0.2.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8490,7 +8490,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 0.2.8-1
+      version: 0.2.9-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `0.2.9-0`:

- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros-gbp/openni2_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.2.8-1`

## openni2_camera

```
* [fix] Device re-connection #53 <https://github.com/ros-drivers/openni2_camera/issues/53>
* [fix] Publish projector/camera_info (fixes disparity img) #48 <https://github.com/ros-drivers/openni2_camera/issues/48>
* Contributors: Isaac I.Y. Saito, Martin Guenther, Shaun Edwards
```
