### PR TITLE
openni2_camera: 0.2.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5612,7 +5612,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 0.2.8-0
+      version: 0.2.9-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `0.2.9-0`:

- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros-gbp/openni2_camera-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.2.8-0`

## openni2_camera

```
* [fix] Device re-connection #53 <https://github.com/ros-drivers/openni2_camera/issues/53>
* [fix] Publish projector/camera_info (fixes disparity img) #48 <https://github.com/ros-drivers/openni2_camera/issues/48>
* Contributors: Isaac I.Y. Saito, Martin Guenther, Shaun Edwards
```
