### PR TITLE
executive_smach_visualization: 2.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3073,7 +3073,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/jbohren/executive_smach_visualization-release.git
-      version: 2.0.1-0
+      version: 2.0.2-0
     source:
       type: git
       url: https://github.com/ros-visualization/executive_smach_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `executive_smach_visualization` to `2.0.2-0`:

- upstream repository: https://github.com/ros-visualization/executive_smach_visualization.git
- release repository: https://github.com/jbohren/executive_smach_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `2.0.1-0`

## executive_smach_visualization

- No changes

## smach_viewer

```
* Allow launching from a launch file, use rospy.myargv() to remove ROS  remapping arguments (#16 <https://github.com/ros-visualization/executive_smach_visualization/issues/16>)
  * Use rospy.myargv() to remove ROS remapping arguments  Required to allow launching from a launch file, otherwise get errors of the type:
  ```usage: smach_viewer.py [-h] [-f]
  smach_viewer.py: error: unrecognized arguments: __name:=smach_viewer```
  
  <string>:13: (WARNING/2) Inline literal start-string without end-string.
  
  <string>:13: (WARNING/2) Inline interpreted text or phrase reference start-string without end-string.
  
  Solved 'Cannot start smach_viewer.py in launch file' problem #17
* Contributors: Kartik Mohta
```
