### PR TITLE
jsk_visualization: 2.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5609,7 +5609,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 2.1.2-0
+      version: 2.1.3-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `2.1.3-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `2.1.2-0`

## jsk_interactive

- No changes

## jsk_interactive_marker

- No changes

## jsk_interactive_test

- No changes

## jsk_rqt_plugins

```
* PR #672 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/672> needs jsk_gui_msgs 4.3.0 (https://github.com/jsk-ros-pkg/jsk_common_msgs/pull/18) (#673 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/673>)
* Display message on rqt_yn_btn (#672 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/672>)
* Contributors: Kei Okada, Kentaro Wada
```

## jsk_rviz_plugins

```
* [jsk_rviz_plugins] Rviz default font is changed from Arial to LiberationSans (See: https://github.com/ros-visualization/rviz/pull/1141) (#676 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/676>)
* Add exclude regex in rosconsole_overlay (#675 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/675>)
* Contributors: Iori Kumagai, Kentaro Wada
```

## jsk_visualization

- No changes
