### PR TITLE
xpp: 1.0.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16417,6 +16417,31 @@ repositories:
       url: https://github.com/wavelab/ximea_camera.git
       version: devel-indigo
     status: maintained
+  xpp:
+    doc:
+      type: git
+      url: https://github.com/leggedrobotics/xpp.git
+      version: master
+    release:
+      packages:
+      - xpp
+      - xpp_examples
+      - xpp_hyq
+      - xpp_msgs
+      - xpp_quadrotor
+      - xpp_ros_conversions
+      - xpp_states
+      - xpp_vis
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/leggedrobotics/xpp-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/leggedrobotics/xpp.git
+      version: master
+    status: developed
   xsens_awinda:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xpp` to `1.0.0-1`:

- upstream repository: https://github.com/leggedrobotics/xpp.git
- release repository: https://github.com/leggedrobotics/xpp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## xpp

```
* changed email adresse to mailto:winklera@ethz.ch
* added xpp metapackage
* Contributors: Alexander Winkler
```

## xpp_examples

```
* added example bag files (150MB)
* added separate xpp_example package and Readme.md
* Contributors: Alexander Winkler
```

## xpp_hyq

```
* added separate xpp_example package and Readme.md
* included install space in CMakeLists.txt
* explicitly listing ros dependencies (not through catkin_package macro)
* Added license to files and giving credit to contributors.
* cleaned up package.xml and CMakeLists.txt files
* cleaned up endeffector and joint representation
* showed close connection of mono/bi/quad to hyq
* added doxygen comments to header files
* made xpp_vis robot independent. Added sample hopper executables
* Contributors: Alexander Winkler
```

## xpp_msgs

```
* removed robot specific bag files from xpp_msgs
* added separate xpp_example package and Readme.md
* included install space in CMakeLists.txt
* changed catkin pkg dependencies to roscpp
* formatting
* Added license to files and giving credit to contributors.
* cleaned up package.xml and CMakeLists.txt files
* removed biped and quadruped joint identifier
* Merge remote-tracking branch 'xpp_msgs/master'
  Conflicts:
  .gitignore
* Contributors: Alexander Winkler
```

## xpp_quadrotor

```
* Added license to files and giving credit to contributors.
* cleaned up package.xml and CMakeLists.txt files
* showed close connection of mono/bi/quad to hyq
* renamed urdf parent folder to robots
* Contributors: Alexander Winkler
```

## xpp_ros_conversions

```
* included install space in CMakeLists.txt
* explicitly listing ros dependencies (not through catkin_package macro)
* removed user interface node and deprecated keyboard dependency.
* removed find_package in ros conversions, as only contains headers
* Added license to files and giving credit to contributors.
* cleaned up package.xml and CMakeLists.txt files
* cleaned up endeffector and joint representation
* showed close connection of mono/bi/quad to hyq
* added doxygen comments to header files
* moved includes into subfolder xpp_vis
* added xpp_ros_conversions pkg
* Contributors: Alexander Winkler
```

## xpp_states

```
* removed robot specific bag files from xpp_msgs
* included install space in CMakeLists.txt
* changed catkin pkg dependencies to roscpp
* formatting
* Added license to files and giving credit to contributors.
* removed some unneccessary dependencies.
* cleaned up package.xml and CMakeLists.txt files
* cleaned up endeffector and joint representation
* showed close connection of mono/bi/quad to hyq
* made xpp_vis robot independent. Added sample hopper executables
* removed biped and quadruped joint identifier
* added xpp_states
* Contributors: Alexander Winkler
```

## xpp_vis

```
* removed robot specific bag files from xpp_msgs
* added separate xpp_example package and Readme.md
* fixed unit test
* included install space in CMakeLists.txt
* explicitly listing ros dependencies (not through catkin_package macro)
* removed user interface node and deprecated keyboard dependency.
* changed catkin pkg dependencies to roscpp
* Added license to files and giving credit to contributors.
* removed some unneccessary dependencies.
* cleaned up package.xml and CMakeLists.txt files
* cleaned up endeffector and joint representation
* showed close connection of mono/bi/quad to hyq
* added doxygen comments to header files
* made xpp_vis robot independent. Added sample hopper executables
* removed biped and quadruped joint identifier
* moved includes into subfolder xpp_vis
* added xpp_vis
* Contributors: Alexander Winkler
```
