### PR TITLE
pointgrey_camera_driver: 0.13.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6135,7 +6135,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
-      version: 0.13.2-0
+      version: 0.13.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointgrey_camera_driver` to `0.13.4-0`:

- upstream repository: https://github.com/ros-drivers/pointgrey_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.0`
- previous version for package: `0.13.2-0`

## image_exposure_msgs

- No changes

## pointgrey_camera_description

- No changes

## pointgrey_camera_driver

```
* Build jessie binaries with the legacy SDK as well.
* Contributors: Mike Purvis
```

## statistics_msgs

- No changes

## wfov_camera_msgs

- No changes
