### PR TITLE
Add libilmbase-dev dep for libopenvdb-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2232,9 +2232,9 @@ libopenvdb:
     zesty: [libopenvdb3.2]
 libopenvdb-dev:
   arch: [openvdb]
-  debian: [libopenvdb-dev]
+  debian: [libopenvdb-dev, libilmbase-dev]
   gentoo: [media-gfx/openvdb]
-  ubuntu: [libopenvdb-dev]
+  ubuntu: [libopenvdb-dev, libilmbase-dev]
 libosmesa6-dev:
   arch: [mesa]
   debian: [libosmesa6-dev]


### PR DESCRIPTION
The `libopenvdb-dev` package has a header file (`/usr/include/openvdb/Types.h`) that includes another header file (`<OpenEXR/half.h>`) from the `libilmbase-dev` package.  `libopenvdb-dev` does not declare a dependency on `libilmbase-dev`, which means that any packages that depend on `libopenvdb-dev` and use that header may fail to compile.  This may not have been noticed before because `libopencv-dev` has a transitive dependency on `libilmbase-dev`, so it will already been installed for many packages.

It appears that the Arch and Gentoo packages for this declare their dependency properly (or they do so transitively through `libopenexr-dev`), so it shouldn't be an issue for them:

https://www.archlinux.org/packages/community/x86_64/openvdb/
https://gitweb.gentoo.org/repo/gentoo.git/tree/media-gfx/openvdb/openvdb-4.0.2.ebuild

But neither Debian nor Ubuntu declare it:

https://packages.debian.org/stretch/libopenvdb-dev
https://packages.ubuntu.com/xenial/libopenvdb-dev

And here are the links to the packages that provide the necessary header:

https://packages.debian.org/stretch/libilmbase-dev
https://packages.ubuntu.com/xenial/libilmbase-dev