### PR TITLE
robotis_op3_msgs: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6885,6 +6885,26 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Math.git
       version: kinetic-devel
     status: maintained
+  robotis_op3_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-msgs.git
+      version: kinetic-devel
+    release:
+      packages:
+      - op3_action_module_msgs
+      - op3_offset_tuner_msgs
+      - op3_walking_module_msgs
+      - robotis_op3_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-OP3-msgs-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-msgs.git
+      version: kinetic-devel
+    status: developed
   robotis_utility:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_op3_msgs` to `0.1.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-OP3-msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## op3_action_module_msgs

```
* added msg package for ROBOTIS OP3
* Contributors: Kayman
```

## op3_offset_tuner_msgs

```
* added msg package for ROBOTIS OP3
* Contributors: Kayman
```

## op3_walking_module_msgs

```
* added msg package for ROBOTIS OP3
* Contributors: Kayman, Yoshimaru Tanaka
```

## robotis_op3_msgs

```
* added msg package for ROBOTIS OP3
* Contributors: Kayman
```
