### PR TITLE
rtmros_common: 1.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13189,7 +13189,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.3.2-0
+      version: 1.4.1-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.4.1-0`:

- upstream repository: https://github.com/start-jsk/rtmros_common.git
- release repository: https://github.com/tork-a/rtmros_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.3.2-0`

## hrpsys_ros_bridge

```
* Update of sensor_ros_bridge_connect.py
  * Connect ReferenceForceUpdater's ref_force (#1033 <https://github.com/start-jsk/rtmros_common/pull/1033>)[hrpsys_ros_bridge/scripts/sensor_ros_bridge_connect.py] connect reference force port to ReferenceForceUpdater or EmergencyStopper if exists.
  
    * Add wait for rmfo and vs (#1029 <https://github.com/start-jsk/rtmros_common/pull/1029>)
      * [hrpsys_ros_bridge, sensor_ros_bridge_connect.py] add wait for initalizinig all components
  
* HrpsysSeqStateROSBridge (#1027 <https://github.com/start-jsk/rtmros_common/pull/1027>)
  * [HrpsysSeqStateROSBridge] fix for using virtual force sensor
* Update rtm-ros-robot-interface.l (#1030 <https://github.com/start-jsk/rtmros_common/pull/1030>)
  * [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Add documentation string for new arguments (set-ref-force-linear-p, return-value-mode)
  * [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Add argument to set linear interpolation during increasing force
  * [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Enable to set return value mode
  * [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Enable to get fric coefficient wrench add update print messages
  * [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Update otd checking loop for moment. Exit from do-until-key loop immediately when otd detection. Fix valiables for set ref force
  * [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Use euslisp symbol as detector total wrench parameter
  * [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Enable to access detector total wrench as euslisp symbol.
  * [hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l] Update otd checking loop. Exit from do-until-key loop immediately when otd detection.
* Contributors: MasakiMurooka, Shunichi Nozawa, YoheiKakiuchi
```

## hrpsys_tools

- No changes

## openrtm_ros_bridge

- No changes

## openrtm_tools

- No changes

## rosnode_rtc

- No changes

## rtmbuild

```
* Fix bug of servicebridge.cmake (#1031 <https://github.com/start-jsk/rtmros_common/pull/1031>)
  * [rtmbuild/cmake/servicebridge.cmake] Fix bug of argument passing to avoid unnecessary addition of '' : https://github.com/start-jsk/rtmros_common/pull/1031#issuecomment-338370927
  * [rtmbuild/cmake/servicebridge.cmake] Fix typo. rand_str -> _rand_str
* Contributors: Shunichi Nozawa
```

## rtmros_common

- No changes
