### PR TITLE
xpp: 1.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16435,7 +16435,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/leggedrobotics/xpp-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xpp` to `1.0.1-1`:

- upstream repository: https://github.com/leggedrobotics/xpp.git
- release repository: https://github.com/leggedrobotics/xpp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.0.0-1`

## xpp

```
* xpp_vis: add visualization_msg dependency
* Contributors: Alexander Winkler
```

## xpp_examples

- No changes

## xpp_hyq

- No changes

## xpp_msgs

- No changes

## xpp_quadrotor

- No changes

## xpp_ros_conversions

- No changes

## xpp_states

- No changes

## xpp_vis

```
* xpp_vis: add visualization_msg dependency
* Contributors: Alexander Winkler
```
