### PR TITLE
xpp: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10658,6 +10658,31 @@ repositories:
       url: https://github.com/ros/xacro.git
       version: kinetic-devel
     status: developed
+  xpp:
+    doc:
+      type: git
+      url: https://github.com/leggedrobotics/xpp.git
+      version: master
+    release:
+      packages:
+      - xpp
+      - xpp_examples
+      - xpp_hyq
+      - xpp_msgs
+      - xpp_quadrotor
+      - xpp_ros_conversions
+      - xpp_states
+      - xpp_vis
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/leggedrobotics/xpp-release.git
+      version: 1.0.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/leggedrobotics/xpp.git
+      version: master
+    status: developed
   xsens_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xpp` to `1.0.1-0`:

- upstream repository: https://github.com/leggedrobotics/xpp.git
- release repository: https://github.com/leggedrobotics/xpp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## xpp

```
* xpp_vis: add visualization_msg dependency
* Contributors: Alexander Winkler
```

## xpp_examples

- No changes

## xpp_hyq

- No changes

## xpp_msgs

- No changes

## xpp_quadrotor

- No changes

## xpp_ros_conversions

- No changes

## xpp_states

- No changes

## xpp_vis

```
* xpp_vis: add visualization_msg dependency
* Contributors: Alexander Winkler
```
