### PR TITLE
catkin: 0.7.8-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -265,7 +265,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.7-2
+      version: 0.7.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.8-0`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.7.7-2`

## catkin

```
* handle EOF on raw_input (#888 <https://github.com/ros/catkin/issues/888>)
* dynamically check gtest library type (#885 <https://github.com/ros/catkin/issues/885>)
* remove executable flag since file is not a script (#882 <https://github.com/ros/catkin/issues/882>)
```
