### PR TITLE
Revert "cepton: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1500,13 +1500,6 @@ repositories:
       url: https://github.com/pyros-dev/catkin_pip.git
       version: indigo
     status: developed
-  cepton:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ceptontech/cepton_ros-release.git
-      version: 0.1.0-0
-    status: developed
   certifi:
     release:
       tags:


### PR DESCRIPTION
Reverts ros/rosdistro#14333

@spectralflight following up https://github.com/ros/rosdistro/pull/14333#issuecomment-340035583 without the release repository available being all the release jobs will fail. If the release repository is restored we can add the entry back.

@mikaelarguedas thanks for catching that