### PR TITLE
bond_core: 1.8.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -156,7 +156,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/bond_core-release.git
-      version: 1.8.0-0
+      version: 1.8.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.8.1-0`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.8.0-0`

## bond

```
* fix package.xml to comply with schema (#30 <https://github.com/ros/bond_core/issues/30>)
* Contributors: Mikael Arguedas
```

## bond_core

- No changes

## bondcpp

```
* fix package.xml to comply with schema (#30 <https://github.com/ros/bond_core/issues/30>)
* Contributors: Mikael Arguedas
```

## bondpy

```
* fix package.xml to comply with schema (#30 <https://github.com/ros/bond_core/issues/30>)
* Contributors: Mikael Arguedas
```

## smclib

```
* fix package.xml to comply with schema (#30 <https://github.com/ros/bond_core/issues/30>)
* Contributors: Mikael Arguedas
```
