### PR TITLE
pluginlib: 1.11.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2138,7 +2138,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.11.0-0
+      version: 1.11.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.11.1-0`:

- upstream repository: https://github.com/ros/pluginlib
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.11.0-0`

## pluginlib

```
* update macros in tests to not use the deprecated ones (#78 <https://github.com/ros/pluginlib/issues/78>)
* update documentation to use doxygen c++ format (#75 <https://github.com/ros/pluginlib/issues/75>)
* style cleanup (#64 <https://github.com/ros/pluginlib/issues/64>, #68 <https://github.com/ros/pluginlib/issues/68>, #73 <https://github.com/ros/pluginlib/issues/73> and #72 <https://github.com/ros/pluginlib/issues/72>)
* add missing include (#63 <https://github.com/ros/pluginlib/issues/63>)
* Contributors: Mikael Arguedas, William Woodall
```
