### PR TITLE
actionlib: 1.11.11-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -51,7 +51,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.11.10-0
+      version: 1.11.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.11.11-0`:

- upstream repository: https://github.com/ros/actionlib.git
- release repository: https://github.com/ros-gbp/actionlib-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.11.10-0`

## actionlib

```
* fix typo in server_goal_handle_imp.h (#89 <https://github.com/ros/actionlib/issues/89>)
* Use RAII to handle mutexes (#87 <https://github.com/ros/actionlib/issues/87>)
* Contributors: Cong Liu, Esteve Fernandez, Mikael Arguedas
```
