### PR TITLE
xpp: 1.0.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 141: http://ros.org/reps/rep-0141.html
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   debian:

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   debian:
@@ -3863,7 +3863,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/leggedrobotics/xpp-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xpp` to `1.0.2-0`:

- upstream repository: https://github.com/leggedrobotics/xpp.git
- release repository: https://github.com/leggedrobotics/xpp-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.0.1-0`

## xpp

- No changes

## xpp_examples

- No changes

## xpp_hyq

- No changes

## xpp_msgs

- No changes

## xpp_quadrotor

- No changes

## xpp_ros_conversions

```
* Merge pull request #1 <https://github.com/leggedrobotics/xpp/issues/1> from mikaelarguedas/missing_includes
  add missing std includes
* add missing std includes
* Contributors: Alexander W Winkler, Mikael Arguedas
```

## xpp_states

```
* Merge pull request #1 <https://github.com/leggedrobotics/xpp/issues/1> from mikaelarguedas/missing_includes
  add missing std includes
* add missing std includes
* Contributors: Alexander W Winkler, Mikael Arguedas
```

## xpp_vis

```
* Merge pull request #1 <https://github.com/leggedrobotics/xpp/issues/1> from mikaelarguedas/missing_includes
  add missing std includes
* add missing std includes
* Contributors: Alexander W Winkler, Mikael Arguedas
```
