### PR TITLE
magni_robot: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4151,7 +4151,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/magni_robot-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/magni_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `magni_robot` to `0.2.1-0`:

- upstream repository: https://github.com/UbiquityRobotics/magni_robot.git
- release repository: https://github.com/UbiquityRobotics-release/magni_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.0-0`

## magni_bringup

- No changes

## magni_demos

```
* Add launch file for fiducial_follow (#40 <https://github.com/UbiquityRobotics/magni_robot/issues/40>)
  * Add launch file for fiducial_follow
  * Update camera for front facing
  * Use low res image for faster tracking
* Contributors: Jim Vaughan
```

## magni_description

```
* Add launch file for fiducial_follow (#40 <https://github.com/UbiquityRobotics/magni_robot/issues/40>)
  * Add launch file for fiducial_follow
  * Update camera for front facing
  * Use low res image for faster tracking
* Contributors: Jim Vaughan
```

## magni_nav

- No changes

## magni_robot

- No changes

## magni_teleop

- No changes
