### PR TITLE
mavros: 0.21.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1444,7 +1444,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.21.2-0
+      version: 0.21.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.21.3-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.21.2-0`

## libmavconn

- No changes

## mavros

```
* Update geographiclib script to work with zsh
* scripts: fix typos and improve help messages consistency
  commad -> command
  safty -> safety
  Start help messages with a capital letter.
* uncrustify
* plugin waypoints: Use stamped message
* plugin waypoint: Add MISSION_ITEM_REACHED publisher
  * Changes to be committed:
  modified:   mavros/src/plugins/waypoint.cpp
  modified:   mavros_msgs/CMakeLists.txt
  new file:   mavros_msgs/srv/WaypointReached.srv
  * change reached service name to classic topic
  * Changed reached service to topic
  * removed unused file
  * Removed WaypointReached service
  * Change reached message type to std_msgs::UInt16
  * Delete WaypointReached.srv
  * Restore WaypointPush.srv
  * Fix tipo
  * Update waypoint.cpp
* launch: sync APM and PX4 configs
* add debug plugin
* Contributors: Jonas Vautherin, Patrick José Pereira, TSC21, Vladimir Ermakov, gui2dev
```

## mavros_extras

```
* mavteleop: Move from iteritems to items for python3 support
  Items work with python3 and python2.7
  Signed-off-by: Patrick José Pereira <mailto:patrickelectric@gmail.com>
* extras: Configurable base frame id on distance_sensor
  Fix #835 <https://github.com/mavlink/mavros/issues/835>
* debug_msgs: fix typo
* debug_msgs: fix typo
* extras: Use cog to reduce common msg filler code
* add debug plugin
* Contributors: Nuno Marques, Patrick José Pereira, TSC21, Vladimir Ermakov
```

## mavros_msgs

```
* plugin waypoints: Use stamped message
* add debug plugin
* Contributors: TSC21, Vladimir Ermakov
```

## test_mavros

- No changes
