### PR TITLE
sns-ik: 0.2.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9015,6 +9015,21 @@ repositories:
       url: https://github.com/larics/smartek_camera.git
       version: master
     status: maintained
+  sns-ik:
+    release:
+      packages:
+      - sns_ik
+      - sns_ik_examples
+      - sns_ik_lib
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RethinkRobotics-release/sns_ik-release.git
+      version: 0.2.3-0
+    source:
+      type: git
+      url: https://github.com/RethinkRobotics-opensource/sns_ik.git
+      version: master
+    status: maintained
   soem:
     doc:
       type: git


### PR DESCRIPTION
Initial Public Debian Release of the SNS-IK library: `0.2.3-0`:

- upstream repository: https://github.com/RethinkRobotics-opensource/sns_ik.git
- release repository: https://github.com/RethinkRobotics-release/sns_ik-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## sns_ik

```
* No Updates
```

## sns_ik_examples

```
* CMakeLists Eigen cleanup
  In ROS Kinetic, cmake_modules is deprecated,
  so we will use some alternative CMakeLists
  strategies to find_package the Eigen 3.x library.
* Contributors: Ian McMahon
```

## sns_ik_lib

```
* CMakeLists Eigen cleanup
  In ROS Kinetic, cmake_modules is deprecated,
  so we will use some alternative CMakeLists
  strategies to find_package the Eigen 3.x library.
* Fixes Eigen scalar sum warning
  Eigen doesn't like the fact that we're creating an Array
  of Bools, and then attempting to sum those booleans up.
  Instead, we need to cast the Array into an int, and then
  sum over it to store into the sum integer.
  Resolves https://github.com/RethinkRobotics-opensource/sns_ik/issues/56
* Two small bug fixes
  1) Pass vector by reference in getJointNames
  2) Properly fill in matrix in pinv_forBarP
* Contributors: Forrest Rogers-Marcovitz, Ian McMahon
```
