### PR TITLE
Add wmctrl; fix autossh/fedora typo

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -170,7 +170,7 @@ autopoint:
 autossh:
   arch: [autossh]
   debian: [autossh]
-  fedora: [autosss]
+  fedora: [autossh]
   freebsd: [autossh]
   gentoo: [net-misc/autossh]
   macports: [autossh]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4495,6 +4495,14 @@ wkhtmltopdf:
   fedora: [wkhtmltopdf]
   gentoo: [media-gfx/wkhtmltopdf]
   ubuntu: [wkhtmltopdf]
+wmctrl:
+  arch: [wmctrl]
+  debian: [wmctrl]
+  fedora: [wmctrl]
+  gentoo: [x11-misc/wmctrl]
+  opensuse: [wmctrl]
+  rhel: [wmctrl]
+  ubuntu: [wmctrl]
 workrave:
   debian: [workrave]
   fedora: [workrave]


### PR DESCRIPTION
* arch: https://www.archlinux.org/packages/community/i686/wmctrl/
* debian: https://packages.debian.org/wheezy/wmctrl
* fedora: https://admin.fedoraproject.org/pkgdb/package/rpms/wmctrl/
* gentoo: https://packages.gentoo.org/packages/x11-misc/wmctrl
* opensuse: https://software.opensuse.org/package/wmctrl
* rhel: https://rpmfind.net/linux/rpm2html/search.php?query=wmctrl
* ubuntu: https://launchpad.net/ubuntu/+source/wmctrl

I used my previous PR as a guide and found a typo as a result :neutral_face: 