### PR TITLE
Adding gepetto-viewer to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3830,6 +3830,16 @@ repositories:
       url: https://github.com/bsb808/geonav_transform.git
       version: master
     status: developed
+  gepetto-viewer:
+    doc:
+      type: git
+      url: https://github.com/humanoid-path-planner/gepetto-viewer.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/humanoid-path-planner/gepetto-viewer.git
+      version: master
+    status: developed
   gl_dependency:
     doc:
       type: git


### PR DESCRIPTION
Hi,

I'm starting to put some packages of my research team on ROS.
gepetto-viewer will be the first.