### PR TITLE
m_explore: 2.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4129,7 +4129,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/hrnr/m-explore-release.git
-      version: 2.0.0-1
+      version: 2.1.0-0
     source:
       type: git
       url: https://github.com/hrnr/m-explore.git


### PR DESCRIPTION
Increasing version of package(s) in repository `m_explore` to `2.1.0-0`:

- upstream repository: https://github.com/hrnr/m-explore.git
- release repository: https://github.com/hrnr/m-explore-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `2.0.0-1`

## explore_lite

```
* explore: get rid of boost
* explore: rework launchfiles
* new visualisation of frontiers
* remove navfn library from dependencies
* use frontier seach algorithm from Paul Bovbel
  * much better than previous version of search
  * https://github.com/paulbovbel/frontier_exploration.git
* fix deadlock in explore
  * reworked expore to use timer instead of separate thread for replanning
  * fix deadlock occuring between makePlan and goal reached callback
* Contributors: Jiri Horner
```

## multirobot_map_merge

```
* no major changes. Released together with explore_lite.
```
