### PR TITLE
m_explore: 2.1.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1359,6 +1359,24 @@ repositories:
       url: https://github.com/orocos-toolchain/log4cpp.git
       version: toolchain-2.9
     status: maintained
+  m_explore:
+    doc:
+      type: git
+      url: https://github.com/hrnr/m-explore.git
+      version: lunar-devel
+    release:
+      packages:
+      - explore_lite
+      - multirobot_map_merge
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/hrnr/m-explore-release.git
+      version: 2.1.0-0
+    source:
+      type: git
+      url: https://github.com/hrnr/m-explore.git
+      version: lunar-devel
+    status: developed
   marti_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `m_explore` to `2.1.0-0`:

- upstream repository: https://github.com/hrnr/m-explore.git
- release repository: https://github.com/hrnr/m-explore-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## explore_lite

```
* explore: get rid of boost
* explore: rework launchfiles
* new visualisation of frontiers
* remove navfn library from dependencies
* use frontier seach algorithm from Paul Bovbel
  * much better than previous version of search
  * https://github.com/paulbovbel/frontier_exploration.git
* fix deadlock in explore
  * reworked expore to use timer instead of separate thread for replanning
  * fix deadlock occuring between makePlan and goal reached callback
* Contributors: Jiri Horner
```

## multirobot_map_merge

```
* no major changes. Released together with explore_lite.
```
