### PR TITLE
remove pyside2 from zesty and artful again

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2563,11 +2563,11 @@ python-qt5-bindings:
   opensuse: [python-qt5]
   slackware: [PyQt5]
   ubuntu:
-    artful: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
+    artful: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
     wily: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
     xenial: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
     yakkety: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
-    zesty: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
+    zesty: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
 python-qt5-bindings-gl:
   arch: [python2-pyqt5]
   debian:


### PR DESCRIPTION
Partially revert #16157.

The upstream packages on these platforms only support Python 3.