### PR TITLE
robotis_op3: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6895,6 +6895,7 @@ repositories:
       - cm_740_module
       - op3_action_module
       - op3_base_module
+      - op3_direct_control_module
       - op3_head_control_module
       - op3_kinematics_dynamics
       - op3_manager
@@ -6904,7 +6905,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-OP3-release.git
-      version: 0.1.0-1
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_op3` to `0.1.1-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-OP3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.0-1`

## cm_740_module

```
* fixed missing dependence
* Changed License from BSD to Apache 2.0
* Contributors: Kayman
```

## op3_action_module

```
* fixed missing dependence
* Changed License from BSD to Apache 2.0
* fixed action_module bug
* Contributors: Kayman
```

## op3_base_module

```
* fixed missing dependence
* Changed License from BSD to Apache 2.0
* Contributors: Kayman
```

## op3_direct_control_module

```
* fixed missing dependence
* Changed License from BSD to Apache 2.0
* fixed minor bug.
* cleanup code
* modified checking collision
* changed debug print.
* cleanup the code
* modified checking collision in direct_control_module
* annotated some code.
* modified checking collision
* changed some parameter of direct_control_module
* added to check collision
* changed collision range
  fixed some bug
* changed some
* added debug code.
* applied test code for check the collision
* added test code about collision check
* added direct_control_module
* Contributors: Kayman
```

## op3_head_control_module

```
* fixed missing dependence
* Changed License from BSD to Apache 2.0
* Contributors: Kayman
```

## op3_kinematics_dynamics

```
* fixed wrong index of op3 kinematics tree
* Changed License from BSD to Apache 2.0
* added to check collision
* changed collision range
  fixed some bug
* added test code about collision check
* added direct_control_module
* Contributors: Kayman
```

## op3_manager

```
* Changed License from BSD to Apache 2.0
* Added a launch file for gazebo
* fixed typo.
* added test code about collision check
* added direct_control_module
* added direct_control_module
* deleted offset.yaml
* fixed action_module bug.
* Contributors: Kayman, Pyo
```

## op3_walking_module

```
* fixed missing dependence
* Merge branch 'master' into kinetic-devel
* Changed License from BSD to Apache 2.0
* Merge branch 'feature_direct_control' of https://github.com/ROBOTIS-GIT/ROBOTIS-OP3 into feature_direct_control
* added missing package in find_package()
* fixed typo.
* Added op3_walking_module_msgs in find_package() function
* fixed action_module bug.
* Contributors: Kayman, Pyo, Yoshimaru Tanaka
```

## open_cr_module

```
* fixed missing dependence
* Changed License from BSD to Apache 2.0
* Contributors: Kayman
```

## robotis_op3

```
* added op3_direct_control_module package
* Changed License from BSD to Apache 2.0
* Contributors: Kayman, Pyo
```
