### PR TITLE
rapid_pbd_msgs: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10331,7 +10331,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/jstnhuang-release/rapid_pbd_msgs-release.git
-      version: 0.1.1-1
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/jstnhuang/rapid_pbd_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rapid_pbd_msgs` to `0.1.2-0`:

- upstream repository: https://github.com/jstnhuang/rapid_pbd_msgs.git
- release repository: https://github.com/jstnhuang-release/rapid_pbd_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.1.1-1`

## rapid_pbd_msgs

```
* Created a service message for creating a new program (#1 <https://github.com/jstnhuang/rapid_pbd_msgs/issues/1>)
* Contributors: Justin Huang, Yu-Tang Peng
```
