### PR TITLE
denso: 2.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1552,7 +1552,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/start-jsk/denso-release.git
-      version: 2.0.1-0
+      version: 2.0.2-0
     source:
       type: git
       url: https://github.com/start-jsk/denso.git


### PR DESCRIPTION
Increasing version of package(s) in repository `denso` to `2.0.2-0`:

- upstream repository: https://github.com/start-jsk/denso.git
- release repository: https://github.com/start-jsk/denso-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.0.1-0`

## denso

```
* [kinetic-devel] Update maintainers (#85 <https://github.com/start-jsk/denso/issues/85>)
* Contributors: Isaac I.Y. Saito
```

## denso_launch

```
* Fix kinetic-devel (denso_ros_control) for simulation usage (#88 <https://github.com/start-jsk/denso/issues/88>)
  * test_moveit.py: sleep before retry go()
  * wait for /move_group/goal
  * re-enable vs060.test, add workaround for pyassimp, run go() twice
  * clean up launch file for newer demo.launch in vs060_moveit_config, which accepts dryrun argument
  * rm denso_vs060_startup_*
  * update moveit configuration for new denso_ros_controller package
* [kinetic-devel] Update maintainer (#85 <https://github.com/start-jsk/denso/issues/85>)
* Fix travis (#87 <https://github.com/start-jsk/denso/issues/87>)
  * test/vs060 failing due to missing denso_controller
* Contributors: Isaac I.Y. Saito, Kei Okada
```

## denso_ros_control

```
* Fix kinetic-devel (denso_ros_control) for simulation usage (#88 <https://github.com/start-jsk/denso/issues/88>)
  * add joint_state_controller
  * add joint_trajectory_controller depends denso_ros_control/package.xml
  * add position_controllers depends denso_ros_control/package.xml
  * CMakeLists.txt: add install target
  * position_control.launch: add --shutdown-timeout 0.1 to clean? shutdown of controllers
  * position_control.launch: add server_ip, udp_timeout, server_port, dryrun arguments
  * use position_trajectory_controller (use joint tarjectory action instead of poision conttoller for each joint)
  * loopback read and write for dryrun mode
  * skip fixed joint, see https://github.com/start-jsk/denso/issues/68#issuecomment-338449016
* Contributors: Kei Okada
```

## vs060

```
* Fix kinetic-devel (denso_ros_control) for simulation usage (#88 <https://github.com/start-jsk/denso/issues/88>)
  * import dummy pyassimp: workaround until https://github.com/ros-planning/moveit/pull/581 is released
  * vs060/model/vs060A1_AV6_NNN_NNN.urdf: add missing safety_controller for j4
  * target_compile_features only available on cmake 3
* [kinetic-devel] Update maintainer (#85 <https://github.com/start-jsk/denso/issues/85>)
* Contributors: Isaac I.Y. Saito, Kei Okada
```

## vs060_gazebo

```
* [kinetic-devel] Update maintainer (#85 <https://github.com/start-jsk/denso/issues/85>)
* Contributors: Isaac I.Y. Saito
```

## vs060_moveit_config

```
* Fix kinetic-devel (denso_ros_control) for simulation usage (#88 <https://github.com/start-jsk/denso/issues/88>)
  * remove redundant code from demo_simulation_cage.launch
  * change arg name from mode to dryrun
  * run controller with position_control.launch, not launch in denso_launch
  * Deprecation warning: Trajectory execution service is deprecated (was replaced by an action).Replace 'MoveGroupExecuteService' with 'MoveGroupExecuteTrajectoryAction' in move_group.launch
  
    * update moveit configuration for new denso_ros_controller package
  
* [kinetic-devel] Update maintainer ( #85 <https://github.com/start-jsk/denso/issues/85> )
* Contributors: Isaac I.Y. Saito, Kei Okada
```
