### PR TITLE
rapid_pbd: 0.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10320,7 +10320,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/jstnhuang-release/rapid_pbd-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/jstnhuang/rapid_pbd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rapid_pbd` to `0.1.5-0`:

- upstream repository: https://github.com/jstnhuang/rapid_pbd.git
- release repository: https://github.com/jstnhuang-release/rapid_pbd-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.1.4-0`

## rapid_pbd

```
* Added a service to create a new program (#22 <https://github.com/jstnhuang/rapid_pbd/issues/22>)
* Upgraded to ros-rviz v3.
* Added rosbridge_server as a runtime dependency.
* Fixed headAction type in frontend.
* Contributors: Justin Huang, Sheryl Liang, Yu-Tang Peng
```
