### PR TITLE
dynamixel-workbench: 0.1.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1672,7 +1672,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
-      version: 0.1.7-0
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel-workbench` to `0.1.8-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
- release repository: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.7-0`

## dynamixel_workbench

```
* deleted install inst
* Contributors: Darby Lim
```

## dynamixel_workbench_controllers

```
* None
```

## dynamixel_workbench_operators

```
* deleted install inst
* Contributors: Darby Lim
```

## dynamixel_workbench_single_manager

```
* None
```

## dynamixel_workbench_single_manager_gui

```
* None
```

## dynamixel_workbench_toolbox

```
* None
```
