### PR TITLE
rostune: 1.0.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7898,7 +7898,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/roboskel/rostune-release.git
-      version: 1.0.5-1
+      version: 1.0.7-0
     source:
       type: git
       url: https://github.com/roboskel/rostune.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rostune` to `1.0.7-0`:

- upstream repository: https://github.com/roboskel/rostune.git
- release repository: https://github.com/roboskel/rostune-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.0.5-1`
