### PR TITLE
mavros: 0.21.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4356,7 +4356,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.21.3-0
+      version: 0.21.4-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.21.4-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.21.3-0`

## libmavconn

```
* cmake: do not warn about datasets, only abuse CI where that messages threated as a problem.
* Contributors: Vladimir Ermakov
```

## mavros

```
* lib ftf: update dox, uncrustify
* ENU<->ECEF transforms fix. (#847 <https://github.com/mavlink/mavros/issues/847>)
  * ENU<->ECEF transforms fix.
  * Changes after review. Unit tests added.
* test: fix copy-paste error in frame_tf
* Contributors: Vladimir Ermakov, pavloblindnology
```

## mavros_extras

```
* ENU<->ECEF transforms fix. (#847 <https://github.com/mavlink/mavros/issues/847>)
  * ENU<->ECEF transforms fix.
  * Changes after review. Unit tests added.
* Contributors: pavloblindnology
```

## mavros_msgs

- No changes

## test_mavros

- No changes
