### PR TITLE
[rosdep] Add optipng.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3665,6 +3665,11 @@ openssl:
   fedora: [openssl]
   gentoo: [dev-libs/openssl]
   ubuntu: [openssl]
+optipng:
+  debian: [optipng]
+  fedora: [optipng]
+  gentoo: [optipng]
+  ubuntu: [optipng]
 osm2pgsql:
   debian: [osm2pgsql]
   fedora: [osm2pgsql]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3668,7 +3668,7 @@ openssl:
 optipng:
   debian: [optipng]
   fedora: [optipng]
-  gentoo: [optipng]
+  gentoo: [media-gfx/optipng]
   ubuntu: [optipng]
 osm2pgsql:
   debian: [osm2pgsql]


### PR DESCRIPTION
For Fedora and Gentoo I can't find how we want to specify per distro so just left one line per each.

Debian: https://packages.debian.org/search?keywords=optipng
Fedora: https://apps.fedoraproject.org/packages/optipng
Gentoo: https://packages.gentoo.org/packages/media-gfx/optipng
Ubuntu: https://packages.ubuntu.com/trusty/optipng