### PR TITLE
baldor: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -854,6 +854,21 @@ repositories:
       url: https://github.com/asmodehn/backports.ssl_match_hostname-rosrelease.git
       version: 3.5.0-5
     status: maintained
+  baldor:
+    doc:
+      type: git
+      url: https://github.com/crigroup/baldor.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/crigroup/baldor-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/crigroup/baldor.git
+      version: master
+    status: developed
   barrett_hand:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `baldor` to `0.1.0-0`:

- upstream repository: https://github.com/crigroup/baldor.git
- release repository: https://github.com/crigroup/baldor-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## baldor

```
* Initial release
* Contributors: fsuarez6
```
