### PR TITLE
catkin: 0.7.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -804,7 +804,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.6-0
+      version: 0.7.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.8-0`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.7.6-0`

## catkin

```
* handle EOF on raw_input (#888 <https://github.com/ros/catkin/issues/888>)
* dynamically check gtest library type (#885 <https://github.com/ros/catkin/issues/885>)
* remove executable flag since file is not a script (#882 <https://github.com/ros/catkin/issues/882>)
```
