### PR TITLE
ros: 1.13.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7272,7 +7272,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.13.5-0
+      version: 1.13.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.13.6-0`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.13.5-0`

## mk

- No changes

## rosbash

```
* add options in completion for roslaunch to roszsh (#147 <https://github.com/ros/ros/issues/147>)
* allow arguments in EDITOR env in zsh rosed (#144 <https://github.com/ros/ros/pull/144>)
```

## rosboost_cfg

- No changes

## rosbuild

- No changes

## rosclean

- No changes

## roscreate

- No changes

## roslang

- No changes

## roslib

- No changes

## rosmake

- No changes

## rosunit

```
* use python constants rather than hardcoded integers for error codes (#153 <https://github.com/ros/ros/issues/153>)
* fix syntax of unicode raw string in Python 3 (#150 <https://github.com/ros/ros/pull/150>)
* ensure cwd exists (#143 <https://github.com/ros/ros/pull/143>)
* more searchable testcase result message (#139 <https://github.com/ros/ros/pull/139>)
```
