### PR TITLE
pluginlib: 1.11.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6113,7 +6113,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.10.5-0
+      version: 1.11.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.11.1-0`:

- upstream repository: https://github.com/ros/pluginlib
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.10.5-0`

## pluginlib

```
* update macros in tests to not use the deprecated ones (#78 <https://github.com/ros/pluginlib/issues/78>)
* update documentation to use doxygen c++ format (#75 <https://github.com/ros/pluginlib/issues/75>)
* style cleanup (#64 <https://github.com/ros/pluginlib/issues/64>, #68 <https://github.com/ros/pluginlib/issues/68>, #73 <https://github.com/ros/pluginlib/issues/73> and #72 <https://github.com/ros/pluginlib/issues/72>)
* add missing include (#63 <https://github.com/ros/pluginlib/issues/63>)
* Contributors: Mikael Arguedas, William Woodall
```
