### PR TITLE
nodelet_core: 1.9.13-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5289,7 +5289,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.9.10-0
+      version: 1.9.13-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.13-0`:

- upstream repository: https://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.9.10-0`

## nodelet

```
* Drop unneeded forward declaration. (#68 <https://github.com/ros/nodelet_core/issues/68>)
* Contributors: Mike Purvis
```

## nodelet_core

- No changes

## nodelet_topic_tools

- No changes
