### PR TITLE
fetch_ros: 0.7.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3246,7 +3246,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
-      version: 0.7.12-0
+      version: 0.7.13-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.7.13-0`:

- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.7.12-0`

## fetch_calibration

- No changes

## fetch_depth_layer

- No changes

## fetch_description

- No changes

## fetch_ikfast_plugin

```
* use std::isnan for c++11 support
* Contributors: Shingo Kitagawa
```

## fetch_maps

- No changes

## fetch_moveit_config

```
* add apply_planning_scene
* [moveit_config] Add CHOMP planner demo launch.
  Enabling CHOMP on RViz by following the [tutorial](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/chomp_interface_tutorial.html) (which currently included false information. I'll open a PR right after this).
  Tested on Xenial-Kinetic
  This commit is not necessarily intended to merged in. But would be nice to be kept for the entire MoveIt! community as a reference if possible. At least this will remain on the fork of @130s.
  *This PR is sponsored by [PlusOne Robotics](http://plusonerobotics.com) as part of [World MoveIt! Day 2017 hackathon](http://moveit.ros.org/events/world-moveit-day-2017)*
* Contributors: Isaac I.Y. Saito, Shingo Kitagawa
```

## fetch_navigation

- No changes

## fetch_teleop

- No changes

## freight_calibration

- No changes
