### PR TITLE
baldor: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -863,7 +863,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/crigroup/baldor-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/crigroup/baldor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `baldor` to `0.1.1-0`:

- upstream repository: https://github.com/crigroup/baldor.git
- release repository: https://github.com/crigroup/baldor-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.1.0-0`

## baldor

```
* Add ROS buildfarm status
* Add coveralls support
* Contributors: Francisco
```
