### PR TITLE
remove geographiclib from gentoo

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1680,7 +1680,6 @@ libgeographiclib-dev:
   debian:
     wheezy: [libgeographiclib-dev]
   fedora: [geographiclib]
-  gentoo: [sci-geosciences/geographiclib]
   ubuntu: [libgeographiclib-dev]
 libgeos++-dev:
   arch: [geos]


### PR DESCRIPTION
only available in the pchrist overlay as an ebuild with a banned (or soon to be) EAPI
hope to see in main tree https://bugs.gentoo.org/636338