### PR TITLE
xpp: 1.0.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3875,13 +3875,12 @@ repositories:
       - xpp_hyq
       - xpp_msgs
       - xpp_quadrotor
-      - xpp_ros_conversions
       - xpp_states
       - xpp_vis
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/leggedrobotics/xpp-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xpp` to `1.0.3-0`:

- upstream repository: https://github.com/leggedrobotics/xpp.git
- release repository: https://github.com/leggedrobotics/xpp-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.0.2-0`

## xpp

```
* removed xpp_ros_conversions (now in xpp_states)
* 1.0.2
* update changelog
* Contributors: Alexander Winkler
```

## xpp_examples

```
* removed xpp_ros_conversions (now in xpp_states)
* xpp_examples: removed installation of examples lib
* xpp_examples: Install bags and launch files
* 1.0.2
* update changelog
* Contributors: Alexander Winkler
```

## xpp_hyq

```
* removed xpp_ros_conversions (now in xpp_states)
* 1.0.2
* update changelog
* Contributors: Alexander Winkler
```

## xpp_msgs

```
* 1.0.2
* update changelog
* Contributors: Alexander Winkler
```

## xpp_quadrotor

```
* 1.0.2
* update changelog
* Contributors: Alexander Winkler
```

## xpp_states

```
* removed xpp_ros_conversions (now in xpp_states)
* 1.0.2
* update changelog
* Merge pull request #1 from mikaelarguedas/missing_includes
  add missing std includes
* add missing std includes
* Contributors: Alexander W Winkler, Alexander Winkler, Mikael Arguedas
```

## xpp_vis

```
* changed rviz default config name
* removed xpp_ros_conversions (now in xpp_states)
* 1.0.2
* update changelog
* Merge pull request #1 from mikaelarguedas/missing_includes
  add missing std includes
* add missing std includes
* Contributors: Alexander W Winkler, Alexander Winkler, Mikael Arguedas
```
