### PR TITLE
roscpp_core: 0.6.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7641,7 +7641,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.6.6-0
+      version: 0.6.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.6.7-0`:

- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.6.6-0`

## cpp_common

```
* fix support for console_bridge < 0.3.0 (#70 <https://github.com/ros/roscpp_core/issues/70>, regression of 0.6.6)
```

## roscpp_serialization

- No changes

## roscpp_traits

- No changes

## rostime

- No changes
