### PR TITLE
rapid_pbd_msgs: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10351,7 +10351,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/jstnhuang-release/rapid_pbd_msgs-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/jstnhuang/rapid_pbd_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rapid_pbd_msgs` to `0.1.3-0`:

- upstream repository: https://github.com/jstnhuang/rapid_pbd_msgs.git
- release repository: https://github.com/jstnhuang-release/rapid_pbd_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.1.2-0`

## rapid_pbd_msgs

```
* Include detected surface in surface segmentation action result (#2 <https://github.com/jstnhuang/rapid_pbd_msgs/issues/2>)
* Contributors: pengy25
```
