### PR TITLE
[IKL][openni2_launch] Remove before the new release from new repo.

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8519,21 +8519,6 @@ repositories:
       url: https://github.com/ros-drivers/openni2_camera.git
       version: indigo-devel
     status: developed
-  openni2_launch:
-    doc:
-      type: git
-      url: https://github.com/ros-drivers/openni2_launch.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/openni2_launch.git
-      version: 0.2.2-0
-    source:
-      type: git
-      url: https://github.com/ros-drivers/openni2_launch.git
-      version: indigo-devel
-    status: maintained
   openni_camera:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5633,21 +5633,6 @@ repositories:
       url: https://github.com/ros-drivers/openni2_camera.git
       version: indigo-devel
     status: maintained
-  openni2_launch:
-    doc:
-      type: git
-      url: https://github.com/ros-drivers/openni2_launch.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-gbp/openni2_launch.git
-      version: 0.2.2-0
-    source:
-      type: git
-      url: https://github.com/ros-drivers/openni2_launch.git
-      version: indigo-devel
-    status: maintained
   openni_camera:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1924,21 +1924,6 @@ repositories:
       url: https://github.com/ros-drivers/openni2_camera.git
       version: indigo-devel
     status: maintained
-  openni2_launch:
-    doc:
-      type: git
-      url: https://github.com/ros-drivers/openni2_launch.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/lunar/{package}/{version}
-      url: https://github.com/ros-gbp/openni2_launch.git
-      version: 0.2.3-0
-    source:
-      type: git
-      url: https://github.com/ros-drivers/openni2_launch.git
-      version: indigo-devel
-    status: maintained
   openni_camera:
     doc:
       type: git


### PR DESCRIPTION
Repository merged into another repo (detail https://github.com/ros-drivers/openni2_camera/pull/55).

New releases for IKL from the new repo will become ready to be made, as soon as this PR gets merged. But still we cannot avoid "downtime" of `openni2_launch` in rosdistro.

I'll try to stay on alert but if I can't repond, someone with write access to the release repo can make a new release. Artifacts are already pushed so just run:

    bloom-release --rosdistro indigo --track indigo openni2_camera -p
    bloom-release --rosdistro kinetic --track kinetic openni2_camera -p
    bloom-release --rosdistro lunar --track lunar openni2_camera -p