### PR TITLE
openni2_camera 0.3.0-0 for IKL

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8510,10 +8510,13 @@ repositories:
       url: https://github.com/ros-drivers/openni2_camera.git
       version: indigo-devel
     release:
+      packages:
+      - openni2_camera
+      - openni2_launch
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 0.2.9-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5624,10 +5624,13 @@ repositories:
       url: https://github.com/ros-drivers/openni2_camera.git
       version: indigo-devel
     release:
+      packages:
+      - openni2_camera
+      - openni2_launch
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 0.2.9-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1914,10 +1914,13 @@ repositories:
       url: https://github.com/ros-drivers/openni2_camera.git
       version: indigo-devel
     release:
+      packages:
+      - openni2_camera
+      - openni2_launch
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 0.2.9-0
+      version: 0.3.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Internet was too slow for bloom to successfully clone and open the PRs so I open it manually.

Pull Request Title: openni2_camera: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]
Pull Request Body : 
Increasing version of package(s) in repository `openni2_camera` to `0.3.0-0`:
- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros-gbp/openni2_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.2.9-0`

## openni2_camera

- No changes

## openni2_launch

```
* Move openni2_launch package into openni2_camera repository #55 <https://github.com/ros-drivers/openni2_camera/issues/55>
* Add rosdoc-based document.
* Contributors: Isaac I.Y. Saito
```
