### PR TITLE
vision_opencv: 1.11.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15938,7 +15938,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.11.15-0
+      version: 1.11.16-0
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.11.16-0`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.11.15-0`

## cv_bridge

```
* Silence warnings about un-used variables
* Fixes #177 <https://github.com/ros-perception/vision_opencv/issues/177>
  The Python bridge was wrong on OpenCV2 with mono8 (and any Mat
  with only two dimensions btw). Took the official Python bridge
  from OpenCV.
* Add missing test file
  This fixes #171 <https://github.com/ros-perception/vision_opencv/issues/171>
* export OpenCV variables
* Properly deal with alpha in image compression.
  That fixes #169 <https://github.com/ros-perception/vision_opencv/issues/169>
* Contributors: Kei Okada, Victor Lamoine, Vincent Rabaud
```

## image_geometry

```
* Fix compilation issues.
  Fix suggested by #173 <https://github.com/ros-perception/vision_opencv/issues/173> comment
* Make sure to initialize the distorted_image Mat.
  Otherwise, valgrind throws errors about accessing uninitialized
  memory.
  Signed-off-by: Chris Lalancette <mailto:clalancette@osrfoundation.org>
* Contributors: Chris Lalancette, Vincent Rabaud
```

## vision_opencv

- No changes
