### PR TITLE
vision_opencv: 1.12.5-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3740,7 +3740,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.12.4-0
+      version: 1.12.5-0
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.12.5-0`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.12.4-0`

## cv_bridge

```
* add version_gte for opencv3
  @vrabaud If you'll update opencv3 version as discussed in https://discourse.ros.org/t/opencv-3-3/2674/4, I think we'd better to add 'version_gte' tag so that apt-get install ros-kinetic-cv-bridge also pulls openv3.3 from repository, to avoid API breaking issue between opencv2 and opencv3.
* Simplify the dependency components of cv_bridge
  Fixes #183 <https://github.com/ros-perception/vision_opencv/issues/183>
* Fixes #177 <https://github.com/ros-perception/vision_opencv/issues/177>
  The Python bridge was wrong on OpenCV2 with mono8 (and any Mat
  with only two dimensions btw). Took the official Python bridge
  from OpenCV.
* Add missing test file
  This fixes #171 <https://github.com/ros-perception/vision_opencv/issues/171>
* Properly deal with alpha in image compression.
  That fixes #169 <https://github.com/ros-perception/vision_opencv/issues/169>
* Silence warnings about un-used variables
* export OpenCV variables
* Contributors: Kei Okada, Victor Lamoine, Vincent Rabaud
```

## image_geometry

```
* Fix compilation issues.
  Fix suggested by #173 <https://github.com/ros-perception/vision_opencv/issues/173> comment
* Make sure to initialize the distorted_image Mat.
  Otherwise, valgrind throws errors about accessing uninitialized
  memory.
  Signed-off-by: Chris Lalancette <mailto:clalancette@osrfoundation.org>
* Remove the last remnants of boost from image_geometry.
  All of its functionality can be had from std:: in C++11, so
  use that instead.  This also requires us to add the -std=c++11
  flag.
  Signed-off-by: Chris Lalancette <mailto:clalancette@osrfoundation.org>
* Contributors: Chris Lalancette, Vincent Rabaud
```

## vision_opencv

- No changes
