### PR TITLE
image_common: 1.11.13-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -961,7 +961,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/image_common-release.git
-      version: 1.11.12-0
+      version: 1.11.13-0
     source:
       type: git
       url: https://github.com/ros-perception/image_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `1.11.13-0`:

- upstream repository: https://github.com/ros-perception/image_common.git
- release repository: https://github.com/ros-gbp/image_common-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.11.12-0`

## camera_calibration_parsers

```
* Use Boost_LIBRARIES instead of Boost_PYTHON_LIBRARY
  This was causing issues when building with python3 since then
  Boost_PYTHON_LIBRARY is not set, instead cmake sets
  Boost_PYTHON3_LIBRARY. So instead of adding each library separately,
  using Boost_LIBRARIES seems to be better. For reference, from the
  cmake docs:
  ```
  Boost_LIBRARIES        - Boost component libraries to be linked
  Boost\_<C>_LIBRARY      - Libraries to link for component <C>
  ```
* Contributors: Kartik Mohta, Vincent Rabaud
```

## camera_info_manager

```
* Fix the find_package(catkin) redundancy
* Add a dependency between the test and the test executable
* Add camera_calibration_parsers dependency to camera_info_manager
* Contributors: Max Schettler, Vincent Rabaud
```

## image_common

- No changes

## image_transport

```
* Disable image publisher plugins by name (#60 <https://github.com/ros-perception/image_common/issues/60>)
  * Disable publisher plugins by name
  * Now have per publisher blacklist instead of image_transport wide.
* update to use non deprecated pluginlib macro
* Extend documentation of getCameraInfoTopic
  Document the fact that the base_topic argument must be resolved in order to build the correct camera info topic.
* Added cv::waitkey(10) for blank popup
  Without the cv::waitkey(10), it results in a blank popup which crashes/ leads to a black popup. This change corrects that problem.
  ROS Kinetic, Ubuntu 16.04.3
* Contributors: Aaditya Saraiya, Lucas Walter, Mikael Arguedas, Thibaud Chupin, Vincent Rabaud
```

## polled_camera

- No changes
