### PR TITLE
image_pipeline: 1.12.21-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3047,7 +3047,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/image_pipeline-release.git
-      version: 1.12.20-0
+      version: 1.12.21-0
     source:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `1.12.21-0`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros-gbp/image_pipeline-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.12.20-0`

## camera_calibration

```
* re-add the calibration nodes but now using the Python modules.
  Fixes #298 <https://github.com/ros-perception/image_pipeline/issues/298>
* Move nodes to Python module.
* Contributors: Vincent Rabaud
```

## depth_image_proc

```
* Fix C++11 compilation
  This fixes #292 <https://github.com/ros-perception/image_pipeline/issues/292> and #291 <https://github.com/ros-perception/image_pipeline/issues/291>
* Contributors: Vincent Rabaud
```

## image_pipeline

- No changes

## image_proc

```
* Fix image_resize nodelet (#299 <https://github.com/ros-perception/image_pipeline/issues/299>)
  Update interpolation types
  Add arguments to enable disable each nodelet
  Add default arguments for image_resize and image_rect
  Use toCVShare instead of toCVCopy
  Include image_resize in image_proc
* Updated fix for traits change. (#303 <https://github.com/ros-perception/image_pipeline/issues/303>)
* Fix C++11 compilation
  This fixes #292 <https://github.com/ros-perception/image_pipeline/issues/292> and #291 <https://github.com/ros-perception/image_pipeline/issues/291>
* [image_proc][crop_decimate] support changing target image frame_id (#276 <https://github.com/ros-perception/image_pipeline/issues/276>)
* Contributors: Furushchev, Mike Purvis, Vincent Rabaud, bikramak
```

## image_publisher

- No changes

## image_rotate

```
* [image_rotate] Added TF timeout so that transforms only need to be newer than last frame. (#293 <https://github.com/ros-perception/image_pipeline/issues/293>)
* Contributors: mhosmar-cpr
```

## image_view

```
* call namedWindow from same thread as imshow, need waitKay, now cvStartWindowThreads is null funciton on window_QT.h (#279 <https://github.com/ros-perception/image_pipeline/issues/279>)
* Contributors: Kei Okada
```

## stereo_image_proc

```
* Updated fix for traits change. (#303 <https://github.com/ros-perception/image_pipeline/issues/303>)
* Fix C++11 compilation
  This fixes #292 <https://github.com/ros-perception/image_pipeline/issues/292> and #291 <https://github.com/ros-perception/image_pipeline/issues/291>
* Contributors: Mike Purvis, Vincent Rabaud
```
