### PR TITLE
realtime_tools: 1.11.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6678,7 +6678,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/realtime_tools-release.git
-      version: 1.10.0-0
+      version: 1.11.0-0
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `1.11.0-0`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros-gbp/realtime_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.10.0-0`

## realtime_tools

```
* Updated RT goal handle to handle cancel requests (#22 <https://github.com/ros-controls/realtime_tools/issues/22>)
* switch to industrial_ci (#20 <https://github.com/ros-controls/realtime_tools/issues/20>)
* Contributors: Mathias Lüdtke, Nick Lamprianidis
```
