### PR TITLE
Revert "Revert "bond_core: 1.8.1-0 in 'kinetic/distribution.yaml' [bloom]""

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -656,7 +656,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/bond_core-release.git
-      version: 1.7.19-0
+      version: 1.8.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#16266

Increasing version of package(s) in repository `bond_core` to `1.8.1-0`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.7.19-0`

## bond

```
* fix package.xml to comply with schema (#30 <https://github.com/ros/bond_core/issues/30>)
* Contributors: Mikael Arguedas
```

## bond_core

- No changes

## bondcpp

```
* fix package.xml to comply with schema (#30 <https://github.com/ros/bond_core/issues/30>)
* Contributors: Mikael Arguedas
```

## bondpy

```
* fix package.xml to comply with schema (#30 <https://github.com/ros/bond_core/issues/30>)
* Contributors: Mikael Arguedas
```

## smclib

```
* fix package.xml to comply with schema (#30 <https://github.com/ros/bond_core/issues/30>)
* Contributors: Mikael Arguedas
```
