### PR TITLE
minas: 1.0.7-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4506,7 +4506,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/minas-release.git
-      version: 1.0.7-0
+      version: 1.0.7-1
     source:
       type: git
       url: https://github.com/tork-a/minas.git


### PR DESCRIPTION
Increasing version of package(s) in repository `minas` to `1.0.7-1`:

- upstream repository: https://github.com/tork-a/minas
- release repository: https://github.com/tork-a/minas-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.0.7-0`
