### PR TITLE
python.yaml: Add a key for a package for pip "flask-appbuilder"

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1013,6 +1013,19 @@ python-flask:
     wily: [python-flask]
     xenial: [python-flask]
     yakkety: [python-flask]
+python-flask-appbuilder-pip:
+  debian:
+    pip:
+      packages: [flask-appbuilder]
+  fedora:
+    pip:
+      packages: [flask-appbuilder]
+  osx:
+    pip:
+      packages: [flask-appbuilder]
+  ubuntu:
+    pip:
+      packages: [flask-appbuilder]
 python-flask-cors-pip:
   debian:
     pip:


### PR DESCRIPTION
This pull request adds a key for a package for `pip`: `flask-appbuilder`
`flask-appbuilder` is a rapid application development framework, built on top of `Flask`