### PR TITLE
ros_controllers: 0.13.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7429,7 +7429,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.13.0-0
+      version: 0.13.1-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.13.1-0`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.13.0-0`

## diff_drive_controller

- No changes

## effort_controllers

```
* Code cleanup
* Add JointGroupPositionController
* Contributors: Bence Magyar, Maik Mugnai
```

## force_torque_sensor_controller

- No changes

## forward_command_controller

- No changes

## gripper_action_controller

- No changes

## imu_sensor_controller

- No changes

## joint_state_controller

- No changes

## joint_trajectory_controller

```
* Linted pos_vel joint_trajectory_controllers
* Added posvel joint_trajectory_controller
  Added a simple posvel joint_trajectory_controller that forwards
  the desired state at the current point in time of the trajectory
  to the joint.
* Add support for an joint interfaces are not inherited from JointHandle.
  Add JointTrajectoryController specification for SplineJointInterface.
* Contributors: Gennaro Raiola, Igorec, Zach Anderson
```

## position_controllers

- No changes

## ros_controllers

- No changes

## rqt_joint_trajectory_controller

- No changes

## velocity_controllers

- No changes
