### PR TITLE
ros_comm: 1.12.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7339,7 +7339,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.12.7-0
+      version: 1.12.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.12.8-0`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.12.7-0`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

```
* fix Python 3 compatibility (#1150 <https://github.com/ros/ros_comm/issues/1150>)
* fix handling connections without indices (#1109 <https://github.com/ros/ros_comm/pull/1109>)
* improve message of check command (#1067 <https://github.com/ros/ros_comm/pull/1067>)
* fix BZip2 inclusion (#1016 <https://github.com/ros/ros_comm/pull/1016>)
```

## rosbag_storage

```
* check if bzfile_ and lz4s_ handle is valid before reading/writing/closing (#1183 <https://github.com/ros/ros_comm/issues/1183>)
* fix an out of bounds read in rosbag::View::iterator::increment() (#1191 <https://github.com/ros/ros_comm/issues/1191>)
* replace usage deprecated console_bridge macros (#1149 <https://github.com/ros/ros_comm/issues/1149>)
* fix whitespace warnings with g++ 7 (#1138 <https://github.com/ros/ros_comm/issues/1138>)
* remove deprecated dynamic exception specifications (#1137 <https://github.com/ros/ros_comm/issues/1137>)
* fix buffer overflow vulnerability (#1092 <https://github.com/ros/ros_comm/issues/1092>)
* fix rosbag::View::iterator copy assignment operator (#1017 <https://github.com/ros/ros_comm/issues/1017>)
* fix open mode on Windows (#1005 <https://github.com/ros/ros_comm/pull/1005>)
* add swap function instead of copy constructor / assignment operator for rosbag::Bag (#1000 <https://github.com/ros/ros_comm/issues/1000>)
```

## rosconsole

```
* replace 'while(0)' with 'while(false)' to avoid warnings (#1179 <https://github.com/ros/ros_comm/issues/1179>)
```

## roscpp

```
* check if socket options are available before using them (#1172 <https://github.com/ros/ros_comm/issues/1172>)
* only use CLOCK_MONOTONIC if not on OS X (#1142 <https://github.com/ros/ros_comm/issues/1142>)
* xmlrpc_manager: use SteadyTime for timeout (#1134 <https://github.com/ros/ros_comm/issues/1134>)
* ignore headers with zero stamp in statistics (#1127 <https://github.com/ros/ros_comm/issues/1127>)
* add SteadyTimer, used in TimerManager (#1014 <https://github.com/ros/ros_comm/issues/1014>)
* include missing header for writev() (#1105 <https://github.com/ros/ros_comm/pull/1105>)
* add missing mutex lock for publisher links (#1090 <https://github.com/ros/ros_comm/pull/1090>)
* fix race condition that lead to miss first message (#1058 <https://github.com/ros/ros_comm/issues/1058>)
* fix bug in transport_tcp on Windows (#1050 <https://github.com/ros/ros_comm/issues/1050>)
* add subscriber to connection log messages (#1023 <https://github.com/ros/ros_comm/issues/1023>)
* avoid deleting XmlRpcClient while being used in another thread (#1013 <https://github.com/ros/ros_comm/issues/1013>)
```

## rosgraph

```
* improve message when roslogging cannot change permissions (#1068 <https://github.com/ros/ros_comm/issues/1068>)
```

## roslaunch

```
* fix parameter leaking into sibling scopes (#1158 <https://github.com/ros/ros_comm/issues/1158>)
* remove mention of rosmake from error message (#1140 <https://github.com/ros/ros_comm/issues/1140>)
* only launch core nodes if master was launched by roslaunch (#1098 <https://github.com/ros/ros_comm/pull/1098>)
* ensure pid file is removed on exit (#1057 <https://github.com/ros/ros_comm/pull/1057>, #1084 <https://github.com/ros/ros_comm/pull/1084>)
* ensure cwd exists (#1031 <https://github.com/ros/ros_comm/pull/1031>)
* respect if/unless for roslaunch-check (#998 <https://github.com/ros/ros_comm/pull/998>)
```

## roslz4

```
* replace deprecated lz4 function call (#1136 <https://github.com/ros/ros_comm/issues/1136>)
```

## rosmaster

```
* catch exception with socket.TCP_INFO on WSL (#1212 <https://github.com/ros/ros_comm/issues/1212>, regression from 1.13.1)
* close CLOSE_WAIT sockets by default (#1104 <https://github.com/ros/ros_comm/issues/1104>)
```

## rosmsg

```
* fix rosmsg show from bag (#1006 <https://github.com/ros/ros_comm/pull/1006>)
```

## rosnode

```
* return exit code 1 in case of errors (#1178 <https://github.com/ros/ros_comm/issues/1178>)
* sort output of rosnode info (#1160 <https://github.com/ros/ros_comm/issues/1160>)
* fix Python 3 compatibility (#1166 <https://github.com/ros/ros_comm/issues/1166>)
```

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* change rospy.Rate hz type from int to float (#1177 <https://github.com/ros/ros_comm/issues/1177>)
* improve rospy.logXXX_throttle performance (#1091 <https://github.com/ros/ros_comm/pull/1091>)
* add option to reset timer when time moved backwards (#1083 <https://github.com/ros/ros_comm/issues/1083>)
* abort topic lookup on connection refused (#1044 <https://github.com/ros/ros_comm/pull/1044>)
* sleep in rospy wait_for_service even if exceptions raised (#1025 <https://github.com/ros/ros_comm/pull/1025>)
```

## rosservice

- No changes

## rostest

```
* check clock publication neatly in publishtest (#973 <https://github.com/ros/ros_comm/issues/973>)
```

## rostopic

```
* fix rostopic hz and bw in Python 3 (#1126 <https://github.com/ros/ros_comm/issues/1126>)
* update tests to match stringify changes (#1125 <https://github.com/ros/ros_comm/issues/1125>)
* fix rostopic prining long integers (#1110 <https://github.com/ros/ros_comm/pull/1110>)
```

## roswtf

```
* improve roswtf tests (#1102 <https://github.com/ros/ros_comm/pull/1102>)
```

## topic_tools

```
* make demux more agile (#1196 <https://github.com/ros/ros_comm/issues/1196>)
```

## xmlrpcpp

```
* use poll() in favor of select() in the XmlRPCDispatcher (#833 <https://github.com/ros/ros_comm/issues/833>)
```
