### PR TITLE
rqt_topic: 0.4.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8467,7 +8467,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_topic-release.git
-      version: 0.4.8-0
+      version: 0.4.9-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `0.4.9-0`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros-gbp/rqt_topic-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.4.8-0`

## rqt_topic

```
* fix section resize toggle with Qt5 (#2 <https://github.com/ros-visualization/rqt_topic/issues/2>)
```
