### PR TITLE
Remove fcl_catkin from indigo due to libccd2 complexity (issue #16175)

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3165,13 +3165,6 @@ repositories:
       url: https://github.com/ros-gbp/fcl-release.git
       version: 0.3.4-0
     status: maintained
-  fcl_catkin:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/wxmerkt/fcl_catkin-release.git
-      version: 0.5.90-0
-    status: developed
   fetch_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Removes fcl_catkin from the indigo distribution as providing libccd2 is complicated (cf. #16175). The builds for Kinetic passed and I hope we will be upgrading our own code bases to Kinetic soon.