### PR TITLE
Adding eigenpy to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2901,6 +2901,16 @@ repositories:
       url: https://github.com/ros/eigen_stl_containers.git
       version: master
     status: maintained
+  eigenpy:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/eigenpy.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/nim65s/eigenpy.git
+      version: ros
+    status: maintained
   ekf_localization:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2904,7 +2904,7 @@ repositories:
   eigenpy:
     doc:
       type: git
-      url: https://github.com/stack-of-tasks/eigenpy.git
+      url: https://github.com/nim65s/eigenpy.git
       version: master
     source:
       type: git


### PR DESCRIPTION
Eigenpy gives bindings between numpy and eigen using boost::python.