### PR TITLE
find_object_2d: 0.6.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -635,6 +635,21 @@ repositories:
       url: https://github.com/ros/filters.git
       version: hydro-devel
     status: maintained
+  find_object_2d:
+    doc:
+      type: git
+      url: https://github.com/introlab/find-object.git
+      version: lunar-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/introlab/find_object_2d-release.git
+      version: 0.6.2-0
+    source:
+      type: git
+      url: https://github.com/introlab/find-object.git
+      version: lunar-devel
+    status: maintained
   gazebo_ros_pkgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `find_object_2d` to `0.6.2-0`:

- upstream repository: https://github.com/introlab/find-object.git
- release repository: https://github.com/introlab/find_object_2d-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`
