### PR TITLE
ros_comm: 1.12.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7339,7 +7339,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.12.10-0
+      version: 1.12.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.12.11-0`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.12.10-0`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

- No changes

## rosbag_storage

- No changes

## rosconsole

- No changes

## roscpp

- No changes

## rosgraph

- No changes

## roslaunch

- No changes

## roslz4

```
* revert replace deprecated lz4 function call (#1220 <https://github.com/ros/ros_comm/issues/1220>, regression from 1.12.8 on Debian Jessie)
```

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

- No changes

## rosservice

- No changes

## rostest

- No changes

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

- No changes

## xmlrpcpp

- No changes
