### PR TITLE
fluent_logger_ros: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2154,6 +2154,17 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: kinetic-devel
     status: maintained
+  fluent_logger_ros:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/akio/ros_fluent_logger-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/akio/fluent_logger_ros.git
+      version: 0.1.0
+    status: developed
   follow_waypoints:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fluent_logger_ros` to `0.1.0-0`:

- upstream repository: https://github.com/akio/fluent_logger_ros.git
- release repository: https://github.com/akio/ros_fluent_logger-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## fluent_logger_ros

```
* Initial release
```
