### PR TITLE
jsk_common_msgs: 4.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3424,7 +3424,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_common_msgs-release.git
-      version: 4.2.0-0
+      version: 4.3.1-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common_msgs` to `4.3.1-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common_msgs
- release repository: https://github.com/tork-a/jsk_common_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `4.2.0-0`

## jsk_common_msgs

- No changes

## jsk_footstep_msgs

- No changes

## jsk_gui_msgs

- No changes

## jsk_hark_msgs

- No changes

## posedetection_msgs

```
* add find_packaeg(OpenCV) for compile error with OpenCV 3.3.1 (#20 <https://github.com/jsk-ros-pkg/jsk_common_msgs/issues/20>)
* Contributors: Kei Okada
```

## speech_recognition_msgs

- No changes
