### PR TITLE
Add ruamel.yaml in 'rosdep/python.yaml'

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2836,7 +2836,16 @@ python-rrdtool:
     saucy: [python-rrdtool]
     trusty: [python-rrdtool]
 python-ruamel.yaml:
-  ubuntu: [python-ruamel.yaml]
+  debian:
+    buster: [python-ruamel.yaml]
+    jessie: [python-ruamel.yaml]
+    stretch: [python-ruamel.yaml]
+  fedora: [python-ruamel-yaml]
+  ubuntu:
+    artful: [python-ruamel.yaml]
+    bionic: [python-ruamel.yaml]
+    xenial: [python-ruamel.yaml]
+    zesty: [python-ruamel.yaml]
 python-scapy:
   debian: [python-scapy]
   fedora: [scapy]
@@ -3906,7 +3915,15 @@ python3-pkg-resources:
   debian: [python3-pkg-resources]
   ubuntu: [python3-pkg-resources]
 python3-ruamel.yaml:
-  ubuntu: [python3-ruamel.yaml]
+  debian:
+    buster: [python3-ruamel.yaml]
+    jessie: [python3-ruamel.yaml]
+    stretch: [python3-ruamel.yaml]
+  ubuntu:
+    artful: [python3-ruamel.yaml]
+    bionic: [python3-ruamel.yaml]
+    xenial: [python3-ruamel.yaml]
+    zesty: [python3-ruamel.yaml]
 python3-setuptools:
   debian: [python3-setuptools]
   ubuntu: [python3-setuptools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3842,6 +3842,8 @@ python-yaml:
     yakkety_python3: [python3-yaml]
     zesty: [python-yaml]
     zesty_python3: [python3-yaml]
+python-ruamel.yaml:
+  ubuntu: [python-ruamel.yaml]
 python-zbar:
   debian: [python-zbar]
   fedora: [zbar-pygtk]
@@ -3908,6 +3910,8 @@ python3-setuptools:
   ubuntu: [python3-setuptools]
 python3-yaml:
   ubuntu: [python3-yaml]
+python3-ruamel.yaml:
+  ubuntu: [python3-ruamel.yaml]
 rosbag-metadata-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2835,6 +2835,8 @@ python-rrdtool:
     raring: [python-rrdtool]
     saucy: [python-rrdtool]
     trusty: [python-rrdtool]
+python-ruamel.yaml:
+  ubuntu: [python-ruamel.yaml]
 python-scapy:
   debian: [python-scapy]
   fedora: [scapy]
@@ -3842,8 +3844,6 @@ python-yaml:
     yakkety_python3: [python3-yaml]
     zesty: [python-yaml]
     zesty_python3: [python3-yaml]
-python-ruamel.yaml:
-  ubuntu: [python-ruamel.yaml]
 python-zbar:
   debian: [python-zbar]
   fedora: [zbar-pygtk]
@@ -3905,13 +3905,13 @@ python3-pep8:
 python3-pkg-resources:
   debian: [python3-pkg-resources]
   ubuntu: [python3-pkg-resources]
+python3-ruamel.yaml:
+  ubuntu: [python3-ruamel.yaml]
 python3-setuptools:
   debian: [python3-setuptools]
   ubuntu: [python3-setuptools]
 python3-yaml:
   ubuntu: [python3-yaml]
-python3-ruamel.yaml:
-  ubuntu: [python3-ruamel.yaml]
 rosbag-metadata-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2845,6 +2845,7 @@ python-ruamel.yaml:
     artful: [python-ruamel.yaml]
     bionic: [python-ruamel.yaml]
     xenial: [python-ruamel.yaml]
+    yakkety: [python-ruamel.yaml]
     zesty: [python-ruamel.yaml]
 python-scapy:
   debian: [python-scapy]
@@ -3923,6 +3924,7 @@ python3-ruamel.yaml:
     artful: [python3-ruamel.yaml]
     bionic: [python3-ruamel.yaml]
     xenial: [python3-ruamel.yaml]
+    yakkety: [python3-ruamel.yaml]
     zesty: [python3-ruamel.yaml]
 python3-setuptools:
   debian: [python3-setuptools]


### PR DESCRIPTION
[ruamel.yaml](https://pypi.python.org/pypi/ruamel.yaml) provides much improved YAML parsing over pyyaml.

Use case: it is becoming close to a necessity for continuing work on a new ROS package I've been working on for meta-scripting, templating and code generation of state machine prototypes called [SMACHA](https://github.com/ReconCell/smacha).