### PR TITLE
Moved urdf and urdf_parser_plugin from robot_model to a new repo (indigo/kinetic/lunar)

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10912,10 +10912,6 @@ repositories:
       url: https://github.com/ros/robot_model.git
       version: indigo-devel
     release:
-      packages:
-      - robot_model
-      - urdf
-      - urdf_parser_plugin
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
@@ -15579,6 +15575,25 @@ repositories:
       type: git
       url: https://github.com/ThomasTimm/ur_modern_driver.git
       version: master
+    status: maintained
+  urdf:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf.git
+      version: indigo-devel
+    release:
+      packages:
+      - urdf
+      - urdf_parser_plugin
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ros-gbp/urdf-release.git
+      version: 1.11.15-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf.git
+      version: indigo-devel
     status: maintained
   urdf_tools:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15588,7 +15588,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/urdf-release.git
-      version: 1.11.15-0
+      version: 1.11.15-1
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6777,10 +6777,6 @@ repositories:
       url: https://github.com/ros/robot_model.git
       version: kinetic-devel
     release:
-      packages:
-      - robot_model
-      - urdf
-      - urdf_parser_plugin
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
@@ -10106,6 +10102,25 @@ repositories:
       type: git
       url: https://github.com/uos/uos_tools.git
       version: kinetic
+  urdf:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf.git
+      version: kinetic-devel
+    release:
+      packages:
+      - urdf
+      - urdf_parser_plugin
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/urdf-release.git
+      version: 1.12.12-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf.git
+      version: kinetic-devel
+    status: maintained
   urdf_geometry_parser:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2388,10 +2388,6 @@ repositories:
       url: https://github.com/ros/robot_model.git
       version: kinetic-devel
     release:
-      packages:
-      - robot_model
-      - urdf
-      - urdf_parser_plugin
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/robot_model-release.git
@@ -3672,6 +3668,25 @@ repositories:
       type: git
       url: https://github.com/ros-geographic-info/unique_identifier.git
       version: master
+    status: maintained
+  urdf:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf.git
+      version: kinetic-devel
+    release:
+      packages:
+      - urdf
+      - urdf_parser_plugin
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/urdf-release.git
+      version: 1.12.12-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf.git
+      version: kinetic-devel
     status: maintained
   urdf_geometry_parser:
     doc:


### PR DESCRIPTION
Part of ros/robot_model#195

This is both a new release of the package `urdf` and movement of the packages `urdf` and `urdf_parser_plugin` from the repository [ros/robot_model](https://github.com/ros/robot_model) to  a new repository [ros/urdf](https://github.com/ros/urdf) in indigo, kinetic, and lunar.

Jade is EOL, but `rosinstall_generator --upstream-development` should continue to work because the `jade-devel` branch has not been changed (#15927).

**Indigo** Changelog for `urdf`
```
* Switched to package format 2 and made rostest a test_depend (`#221 <https://github.com/ros/robot_model/pull/221>`_)
* Made rostest a test_depend (`#221 <https://github.com/ros/robot_model/pull/221>`_)
* Added missing dependency on tinyxml (`#213 <https://github.com/ros/robot_model/pull/213>`_)
```

**Kinetic/Lunar** Changelog for `urdf`
```
* Switched to package format 2 and made rostest a test_depend (`#221 <https://github.com/ros/robot_model/pull/221>`_)
* Made rostest a test_depend (`#221 <https://github.com/ros/robot_model/pull/221>`_)
* Added missing dependency on tinyxml (`#213 <https://github.com/ros/robot_model/pull/213>`_)
```

No changes to `urdf_parser_plugin`