### PR TITLE
ecto_opencv: 0.7.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1907,7 +1907,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ecto_opencv-release.git
-      version: 0.7.1-0
+      version: 0.7.2-0
     source:
       type: git
       url: https://github.com/plasmodic/ecto_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecto_opencv` to `0.7.2-0`:

- upstream repository: https://github.com/plasmodic/ecto_opencv.git
- release repository: https://github.com/ros-gbp/ecto_opencv-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.7.1-0`

## ecto_opencv

```
* Fix compilation on x86 where float is a long double
* Contributors: Vincent Rabaud
```
