### PR TITLE
tracetools: 0.1.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15095,7 +15095,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/bosch-robotics-cr/tracetools-release.git
-      version: 0.1.0-0
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/bosch-robotics-cr/tracetools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tracetools` to `0.1.0-1`:

- upstream repository: https://github.com/bosch-robotics-cr/tracetools.git
- release repository: https://github.com/bosch-robotics-cr/tracetools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.1.0-0`
