### PR TITLE
fiducials: 0.7.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2128,7 +2128,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/fiducials-release.git
-      version: 0.7.3-0
+      version: 0.7.4-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/fiducials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fiducials` to `0.7.4-0`:

- upstream repository: https://github.com/UbiquityRobotics/fiducials
- release repository: https://github.com/UbiquityRobotics-release/fiducials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.7.3-0`

## aruco_detect

```
* Add std=-c++-11 to build.
* Fixes for OpenCV 3.3.1
* handle invalid cameraInfo message in aruco_detect
* Added (multi) pose estimation to fiducial_slam (disabled by default)
* Contributors: Jim Vaughan, Rohan Agrawal
```

## fiducial_detect

```
* Add std=-c++-11 to build.
* handle bad camera_info in fiducial detect
* Contributors: Jim Vaughan, Rohan Agrawal
```

## fiducial_lib

- No changes

## fiducial_msgs

- No changes

## fiducial_pose

- No changes

## fiducial_slam

```
* Fix typos
* Log full 6DOF pose for ALL and MUL
* Pass previous rvec and tvec to solvePnP()
* Added (multi) pose estimation to fiducial_slam (disabled by default)
* Contributors: Jim Vaughan
```

## fiducials

- No changes
