### PR TITLE
warthog: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16120,7 +16120,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/warthog-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/warthog-cpr/warthog.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog` to `0.0.2-0`:

- upstream repository: https://github.com/warthog-cpr/warthog.git
- release repository: https://github.com/clearpath-gbp/warthog-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.0.1-0`

## warthog_control

```
* [warthog_control] Set locks to nothing to appease twist_mux.
* Added Novatel Smart6 GPS accessory and updated localization to use IMU.
* Contributors: Michael Hosmar, Tony Baltovski
```

## warthog_description

```
* Added imu link.  Updated inertias for new links
* Changed the URDF_EXTRAS variable so it is more flexible for external packages
* Completely redid most meshes and added the bulkhead and arm mounting point. Added configs for both as well. Took meshes from 4 Mb down to 1 (total)
* Added Novatel Smart6 GPS accessory and updated localization to use IMU.
* [warthog_description] Removed joint_state_publisher as run_depend.
* [warthog_description] Updated URDF colours and links.
* Fixed missing right suspension link.
* Contributors: Dave Niewinski, Tony Baltovski
```

## warthog_msgs

```
* [warthog_msgs] Updated messages for changes to platform.
* Contributors: Tony Baltovski
```
