### PR TITLE
ros_comm: 1.13.5-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2528,7 +2528,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.13.4-0
+      version: 1.13.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.13.5-0`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.13.4-0`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

- No changes

## rosbag_storage

- No changes

## rosconsole

- No changes

## roscpp

- No changes

## rosgraph

- No changes

## roslaunch

- No changes

## roslz4

- No changes

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* fix regresssion from 1.13.3 (#1224 <https://github.com/ros/ros_comm/issues/1224>)
```

## rosservice

- No changes

## rostest

- No changes

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

- No changes

## xmlrpcpp

```
* add unit tests and bug fixes for XmlRpcSocket (#1218 <https://github.com/ros/ros_comm/issues/1218>)
* add tests for XmlRpcValue and XML conversion (#1216 <https://github.com/ros/ros_comm/issues/1216>)
```
