### PR TITLE
Disable automatic builds for ensenso_driver

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1967,6 +1967,7 @@ repositories:
       url: https://github.com/ensenso/ros_driver.git
       version: master
     source:
+      test_commits: false
       type: git
       url: https://github.com/ensenso/ros_driver.git
       version: master

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1961,6 +1961,16 @@ repositories:
       url: https://github.com/ros/eigen_stl_containers.git
       version: master
     status: maintained
+  ensenso_driver:
+    doc:
+      type: git
+      url: https://github.com/ensenso/ros_driver.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ensenso/ros_driver.git
+      version: master
+    status: developed
   ethercat_grant:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -581,6 +581,16 @@ repositories:
       url: https://github.com/ros/eigen_stl_containers.git
       version: master
     status: maintained
+  ensenso_driver:
+    doc:
+      type: git
+      url: https://github.com/ensenso/ros_driver.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ensenso/ros_driver.git
+      version: master
+    status: developed
   executive_smach:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -587,6 +587,7 @@ repositories:
       url: https://github.com/ensenso/ros_driver.git
       version: master
     source:
+      test_commits: false
       type: git
       url: https://github.com/ensenso/ros_driver.git
       version: master


### PR DESCRIPTION
The package needs an external library that is currently not available in rosdep, so I'd like to disable the builds for now.