### PR TITLE
frame_editor: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3430,6 +3430,11 @@ repositories:
       type: git
       url: https://github.com/ipa320/rqt_frame_editor_plugin.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ipa320/rqt_frame_editor_plugin-release.git
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/ipa320/rqt_frame_editor_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `frame_editor` to `1.0.1-0`:

- upstream repository: https://github.com/ipa320/rqt_frame_editor_plugin.git
- release repository: https://github.com/ipa320/rqt_frame_editor_plugin-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## frame_editor

```
* Fix: import rospkg
  Add rviz view to headless demo launch
* headless version
* install
* Contributors: ipa-frn, ipa-lth, ipa-pgt
```
