### PR TITLE
velodyne: 1.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15792,12 +15792,13 @@ repositories:
       packages:
       - velodyne
       - velodyne_driver
+      - velodyne_laserscan
       - velodyne_msgs
       - velodyne_pointcloud
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/velodyne-release.git
-      version: 1.2.0-0
+      version: 1.3.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `1.3.0-0`:

- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros-drivers-gbp/velodyne-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.2.0-0`

## velodyne

```
* Merge pull request #110 <https://github.com/ros-drivers/velodyne/issues/110> from kmhallen/master
  Added velodyne_laserscan package
* Added velodyne_laserscan package and inserted into existing launch files
* Contributors: Jack O'Quin, Joshua Whitley, Kevin Hallenbeck
```

## velodyne_driver

```
* Merge pull request #129 <https://github.com/ros-drivers/velodyne/issues/129> from kmhallen/pluginlib_macro
  Modern pluginlib macro
* Update to use non deprecated pluginlib macro
* add launch args to support multiple devices (#108 <https://github.com/ros-drivers/velodyne/issues/108>)
* Merge pull request #101 <https://github.com/ros-drivers/velodyne/issues/101> from teosnare/master
  velodyne_driver/src/lib/input.cc : fix for device_ip filter
* Merge pull request #104 <https://github.com/ros-drivers/velodyne/issues/104> from altrouge/launch_options
  Add more options in launch files.
* Rearranged alphabetically.
* Add more options in launch files.
  - rpm, device_ip, port, read_once, read_fast, repeat_delay
* velodyne_driver/src/lib/input.cc : fix for device_ip filter
  Fix for device_ip filter in InputSocket: initialization of devip_ for correct ip filtering in InputSocket::getPacket.
* velodyne_driver: credit @priyankadey for VLP-16 bug fix (#96 <https://github.com/ros-drivers/velodyne/issues/96>)
* Merge pull request #96 <https://github.com/ros-drivers/velodyne/issues/96> from priyankadey/master
  updated VLP-16 packet rate from user manual.
* updated VLP-16 packet rate from user manual.
  Also verified with sensor. It reduced overlap in the pointcloud
* update change history
* Merge pull request #94 <https://github.com/ros-drivers/velodyne/issues/94> from ros-drivers/pcap_port
  velodyne_driver: use port number for PCAP data (#46 <https://github.com/ros-drivers/velodyne/issues/46>, #66 <https://github.com/ros-drivers/velodyne/issues/66>)
* fix g++ 5.3.1 compile errors (#94 <https://github.com/ros-drivers/velodyne/issues/94>)
* merge current master (#94 <https://github.com/ros-drivers/velodyne/issues/94>)
* Merge pull request #91 <https://github.com/ros-drivers/velodyne/issues/91> from chukcha2/master
  update velodyne_driver package description to include all models
* update velodyne_driver package description to include all models
* Merge pull request #89 <https://github.com/ros-drivers/velodyne/issues/89> from Tones29/feat_dynrec_driver
  Add dynamic latency configuration to velodyne_driver
* velodyne_driver: Add dynamic_reconfigure and time_offset correction
  The value of time_offset is added to the calculated time stamp in live mode for each packet.
* velodyne_driver: Make input destructors virtual
* prepare change history for coming Indigo release (#59 <https://github.com/ros-drivers/velodyne/issues/59>)
* velodyne_driver: use port number for PCAP data (#66 <https://github.com/ros-drivers/velodyne/issues/66>)
* Merge pull request #39 <https://github.com/ros-drivers/velodyne/issues/39> from zooxco/multivelodyne
  support for multiple velodynes
* Merge pull request #44 <https://github.com/ros-drivers/velodyne/issues/44> from SISegwayRmp/master
  adding driver and pointcloud support for the VLP16
* adding the VLP16 test scripts and updating the CMakeLists to include the test file from http://download.ros.org/data/velodyne/vlp16.pcap
* adding support for the VLP16
* parameters to set the udp port
* fixed missing header
* cleanup debug line
* parameter and code added for working with multiple velodynes
* Contributors: Andreas Wachaja, Brice Rebsamen, Daniel Jartoux, Denis Dillenberger, Gabor Meszaros, Ilya, Jack O'Quin, Joshua Whitley, Kevin Hallenbeck, Matteo Murtas, Micho Radovnikovich, Priyanka Dey, William Woodall, jack.oquin, junior, phussey
```

## velodyne_laserscan

```
* Merge pull request #110 <https://github.com/ros-drivers/velodyne/issues/110> from kmhallen/master
  Added velodyne_laserscan package
* Added tests for velodyne_laserscan
* Fixed validating PointCloud2 field types
* Package.xml format version 2
* Merge pull request #1 <https://github.com/ros-drivers/velodyne/issues/1> from volkandre/master
  Fixed bug. Laserscans now cover full 360 degrees.
* Fixed bug. Laserscans now cover full 360 degrees.
* Added velodyne_laserscan package and inserted into existing launch files
* Contributors: Joshua Whitley, Kevin Hallenbeck, kmhallen, volkandre
```

## velodyne_msgs

- No changes

## velodyne_pointcloud

```
* Merge pull request #110 <https://github.com/ros-drivers/velodyne/issues/110> from kmhallen/master
  Added velodyne_laserscan package
* Merge remote-tracking branch ros-drivers/master
* Merge pull request #129 <https://github.com/ros-drivers/velodyne/issues/129> from kmhallen/pluginlib_macro
  Modern pluginlib macro
* Update to use non deprecated pluginlib macro
* Merge pull request #127 <https://github.com/ros-drivers/velodyne/issues/127> from swri-robotics/add_vlp16_hires_support
  Add VLP16 Puck Hi-Res config file
* Add VLP16 Puck Hi-Res support
* velodyne_pointcloud: remove incorrect catkin_package() DEPENDS option (#93 <https://github.com/ros-drivers/velodyne/issues/93>)
  This eliminates a CMake warning when building on Xenial.
* Merge pull request #111 <https://github.com/ros-drivers/velodyne/issues/111> from OrebroUniversity/master
  Added an interface to set up raw data processing offline
* Added an interface to set up raw data processing from a locally defined calibration file. This method is useful when processing data offline from a bag file, without starting any ros master
* Added velodyne_laserscan package and inserted into existing launch files
* test multiple nodelet manager support (#108 <https://github.com/ros-drivers/velodyne/issues/108>)
* add launch args to support multiple devices (#108 <https://github.com/ros-drivers/velodyne/issues/108>)
* Merge pull request #105 <https://github.com/ros-drivers/velodyne/issues/105> from fudger/patch-1
  Remove unused constants.
* Merge pull request #104 <https://github.com/ros-drivers/velodyne/issues/104> from altrouge/launch_options
  Add more options in launch files.
* Rearranged alphabetically.
* Remove unused constants.
  DISTANCE_MAX and DISTANCE_MAX_UNITS are not used anywhere in the code.
  Furthermore, using them would lead to errors as both VLP-64 manuals state that returns above 120 m should not be used. The VLP-32 manual allows 70 m as the maximum valid sensor range.
* Merge pull request #103 <https://github.com/ros-drivers/velodyne/issues/103> from fudger/patch-1
  Fix misleading typecasts.
* Add more options in launch files.
  - rpm, device_ip, port, read_once, read_fast, repeat_delay
* Fix misleading typecasts.
  intensity and VPoint::intensity are both of type float.
* update change history
* merge current master (#94 <https://github.com/ros-drivers/velodyne/issues/94>)
* Merge pull request #92 <https://github.com/ros-drivers/velodyne/issues/92> from adasta/master
  GCC Build Warnings
* Modified velodyne_point_cloud/src/lib/rawdata.cc to address warning
  that last_azimuth_diff variable may be used uninitialized.  Variable
  is now initialized to 0 at creation.
  velodyne/velodyne_pointcloud/src/lib/rawdata.cc:328:57: error: ‘last_azimuth_diff’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  azimuth_corrected_f = azimuth + (azimuth_diff * ((dsr*VLP16_DSR_TOFFSET) + (firing*VLP16_FIRING_TOFFSET)) / VLP16_BLOCK_TDURATION);
* Modified  velodyne_pointcloud/src/conversion/colors.cc to remove
  address build warning for strict-aliasing.
  velodyne/velodyne_pointcloud/src/conversions/colors.cc:84:58:
* Merge pull request #89 <https://github.com/ros-drivers/velodyne/issues/89> from Tones29/feat_dynrec_driver
  Add dynamic latency configuration to velodyne_driver
* velodyne_pointcloud: Fix compile warning "Wrong initialization order"
* velodyne_pointcloud: add dynamic reconfig update to change log (#78 <https://github.com/ros-drivers/velodyne/issues/78>)
* Merge branch fudger-reconfigure_transform_node
* velodyne_pointcloud: use recommended add_dependencies() CMake variable #78 <https://github.com/ros-drivers/velodyne/issues/78>
* velodyne_pointcloud: fix transform unit tests
  Use tf2_ros static_transform_publisher for more consistent timing (#2 <https://github.com/ros-drivers/velodyne/issues/2>)
* Merge branch reconfigure_transform_node of https://github.com/fudger/velodyne
* prepare change history for coming Indigo release (#59 <https://github.com/ros-drivers/velodyne/issues/59>)
* calibration: unit test case improvements (#84 <https://github.com/ros-drivers/velodyne/issues/84>)
* calibration: read all intensities as float, then convert (#84 <https://github.com/ros-drivers/velodyne/issues/84>)
* calibration: add gtest for #84 <https://github.com/ros-drivers/velodyne/issues/84>
  This currently fails on 64e_s2.1-sztaki.yaml and on issue_84_float_intensities.yaml.
* calibration: make max_intensity and min_intensity optional (#84 <https://github.com/ros-drivers/velodyne/issues/84>)
  This fixes a regression in the 32e and VLP-16 calibrations which do not contain
  intensity values. There is still a problem with the 64e_s2.1 calibration.
* Merge pull request #76 <https://github.com/ros-drivers/velodyne/issues/76> from pomerlef/master
  Sign inversion in some equations
* Merge pull request #82 <https://github.com/ros-drivers/velodyne/issues/82> from ros-drivers/fix_pr_80
  Fix pr 80; adding travis CI tests.
* fix the yaml-cpp 0.5 code paths
* Merge pull request #80 <https://github.com/ros-drivers/velodyne/issues/80> from ros-drivers/fix_yaml_import
  allow floats in min/max_intensity and make horiz_offset_correction optional
* allow horiz_offset_correction to be optional with 0 as default
* allow floats instead of ints in min/max_intensity
* Resolve frame ID name using tf prefix.
* Improve coding style.
* Set up dynamic reconfiguration for transform_node.
  Previously, transform_node has neither read parameters other than frame_id from the command line nor has it exposed these parameters via dynamic reconfigure. As parameters like max_range and view_width have been initialized to zero, the inconfigurable transform_node has returned an empty point cloud.
  Now, transform_node launches an reconfigure server just as cloud_node. In contrast to cloud_node, transform node exposes another parameter for dynamic reconfiguration: frame_id, i.e. the frame of reference the incoming Velodyne points are transformed to.
* Merge pull request #77 <https://github.com/ros-drivers/velodyne/issues/77> from fudger/pretty_print
  Fix output of calibration data onto console
* Add a missing space.
* Fix line that always indicates use of model VLP-16.
* Align console output of calibration data.
* Merge branch master of https://github.com/ros-drivers/velodyne
* resolve sign error
* Merge pull request #73 <https://github.com/ros-drivers/velodyne/issues/73> from fudger/master
  Correct important data type error for VLP-16
* Fix data type error that distorts the point cloud.
* Fix and add a few comments.
* Merge pull request #68 <https://github.com/ros-drivers/velodyne/issues/68> from jlblancoc/patch-1
  Remove unused variable
* Remove unused variable
  I think that dsr was unused. See line 317:
  for (int dsr=0; ...
* VLP-16: skip badly formatted data packets (#62 <https://github.com/ros-drivers/velodyne/issues/62>, #63 <https://github.com/ros-drivers/velodyne/issues/63>)
* restore VLP-16 min_range setting to 0.4 (#60 <https://github.com/ros-drivers/velodyne/issues/60>)
  NOTE: There is still some other problem keeping that from working.
* permit min_range settings below 0.9 meters (#60 <https://github.com/ros-drivers/velodyne/issues/60>)
  No known models are currently known to return closer measurements.
* Merge pull request #55 <https://github.com/ros-drivers/velodyne/issues/55> from lemiant/azimuth_bug_VLP16
  Fixed azimuth overflow bug.
* Fixed azimuth overflow bug.
  For interpolated azimuth values between 35999.5 and 36000.0 the nested round(fmod())
  yields a value of 36000 which is invalid and overflows the pre-computed sin/cos arrays,
  since they only go form 0..35999
* Merge pull request #51 <https://github.com/ros-drivers/velodyne/issues/51> from kunlileo/master
  Added vertical sin angle correction
* Added vertical sin angle correction
* Merge pull request #47 <https://github.com/ros-drivers/velodyne/issues/47> from prclibo/master
  fixed rounding bug in intensity calculation found by songshiyu
* fixed rounding bug in intensity calculation found by songshiyu
* fix some overly long C++ source lines
* Merge pull request #44 <https://github.com/ros-drivers/velodyne/issues/44> from SISegwayRmp/master
  adding driver and pointcloud support for the VLP16
* missed the space in the file name which caused the build to fail, removed space before extension
* adding the VLP16 test scripts and updating the CMakeLists to include the test file from http://download.ros.org/data/velodyne/vlp16.pcap
* adding support for the VLP16
* Merge pull request #43 <https://github.com/ros-drivers/velodyne/issues/43> from prclibo/fix_rawdata
  fixed point computation according to the 64e_s2(.1) velodyne manual
* fixed point computation according to the 64e_s2(.1) velodyne manual, with luopei"s help
* Merge pull request #41 <https://github.com/ros-drivers/velodyne/issues/41> from prclibo/master
  fixed a calibration file parsing bug
* Merge pull request #42 <https://github.com/ros-drivers/velodyne/issues/42> from prclibo/fix_gen_calibration
  fixed gen_calibration min/max intensity type
* fixed gen_calibration min/max intensity type
* fixed a calibration file parsing bug
* Contributors: Adam Stambler, Alex Rodrigues, Alexander Schaefer, Andreas Wachaja, Bo Li, Daniel Jartoux, Gabor Meszaros, Jack OQuin, Jose Luis Blanco-Claraco, Joshua Whitley, Kevin Hallenbeck, Kris Kozak, Kun Li, Micho Radovnikovich, Scott K Logan, Thomas Solatges, Todor Stoyanov, William Woodall, jack.oquin, libo24, phussey, piyushk, pomerlef
```
