### PR TITLE
Added mkdocs.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3439,6 +3439,70 @@ meshlab:
   fedora: [meshlab]
   gentoo: [media-gfx/meshlab]
   ubuntu: [meshlab]
+mkdocs:
+  debian:
+    buster: [mkdocs]
+    jessie:
+      pip:
+        packages: [mkdocs]
+    stretch: [mkdocs]
+    wheezy:
+      pip:
+        packages: [mkdocs]
+  fedora: [mkdocs]
+  gentoo: [dev-python/mkdocs]
+  ubuntu:
+    artful: [mkdocs]
+    bionic: [mkdocs]
+    trusty:
+      pip:
+        packages: [mkdocs]
+    xenial: [mkdocs]
+    zesty: [mkdocs]
+mkdocs-bootstrap:
+  debian:
+    buster: [mkdocs-bootstrap]
+    jessie:
+      pip:
+        packages: [mkdocs-bootstrap]
+    stretch: [mkdocs-bootstrap]
+    wheezy:
+      pip:
+        packages: [mkdocs-bootstrap]
+  fedora: [mkdocs-bootstrap]
+  gentoo: [dev-python/mkdocs-bootstrap]
+  ubuntu:
+    artful: [mkdocs-bootstrap]
+    bionic: [mkdocs-bootstrap]
+    trusty:
+      pip:
+        packages: [mkdocs-bootstrap]
+    xenial:
+      pip:
+        packages: [mkdocs-bootstrap]
+    zesty: [mkdocs-bootstrap]
+mkdocs-bootswatch:
+  debian:
+    buster: [mkdocs-bootswatch]
+    jessie:
+      pip:
+        packages: [mkdocs-bootswatch]
+    stretch: [mkdocs-bootswatch]
+    wheezy:
+      pip:
+        packages: [mkdocs-bootswatch]
+  fedora: [mkdocs-bootswatch]
+  gentoo: [dev-python/mkdocs-bootswatch]
+  ubuntu:
+    artful: [mkdocs-bootswatch]
+    bionic: [mkdocs-bootswatch]
+    trusty:
+      pip:
+        packages: [mkdocs-bootswatch]
+    xenial:
+      pip:
+        packages: [mkdocs-bootswatch]
+    zesty: [mkdocs-bootswatch]
 mongodb:
   debian: [mongodb]
   fedora: [mongodb]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3457,7 +3457,12 @@ mkdocs:
     trusty:
       pip:
         packages: [mkdocs]
+    utopic:
+      pip:
+        packages: [mkdocs]
+    wily: [mkdocs]
     xenial: [mkdocs]
+    yakkty: [mkdocs]
     zesty: [mkdocs]
 mkdocs-bootstrap:
   debian:
@@ -3477,9 +3482,16 @@ mkdocs-bootstrap:
     trusty:
       pip:
         packages: [mkdocs-bootstrap]
+    utopic:
+      pip:
+        packages: [mkdocs-bootswatch]
+    wily:
+      pip:
+        packages: [mkdocs-bootswatch]
     xenial:
       pip:
         packages: [mkdocs-bootstrap]
+    yakkety: [mkdocs-bootstrap]
     zesty: [mkdocs-bootstrap]
 mkdocs-bootswatch:
   debian:
@@ -3499,7 +3511,16 @@ mkdocs-bootswatch:
     trusty:
       pip:
         packages: [mkdocs-bootswatch]
+    utopic:
+      pip:
+        packages: [mkdocs-bootswatch]
+    wily:
+      pip:
+        packages: [mkdocs-bootswatch]
     xenial:
+      pip:
+        packages: [mkdocs-bootswatch]
+    yakkety:
       pip:
         packages: [mkdocs-bootswatch]
     zesty: [mkdocs-bootswatch]


### PR DESCRIPTION
A library for generating end-user documentation and its skins.

https://pypi.python.org/pypi/mkdocs
https://pypi.python.org/pypi/mkdocs-bootstrap
https://pypi.python.org/pypi/mkdocs-bootswatch
https://packages.ubuntu.com/search?keywords=mkdocs&searchon=names&suite=all&section=all
https://admin.fedoraproject.org/pkgdb/package/rpms/mkdocs
https://admin.fedoraproject.org/pkgdb/package/rpms/mkdocs-bootstrap
https://admin.fedoraproject.org/pkgdb/package/rpms/mkdocs-bootswatch/
https://packages.debian.org/search?searchon=names&keywords=mkdocs
https://packages.gentoo.org/packages/dev-python/mkdocs
https://packages.gentoo.org/packages/dev-python/mkdocs-bootstrap
https://packages.gentoo.org/packages/dev-python/mkdocs-bootswatch