### PR TITLE
Adding alliance to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -232,6 +232,25 @@ repositories:
       url: https://github.com/rosalfred/alfred_sr_linux.git
       version: master
     status: developed
+  alliance:
+    doc:
+      type: git
+      url: https://github.com/adrianohrl/alliance.git
+      version: master
+    release:
+      packages:
+      - alliance
+      - alliance_msgs
+      - rqt_alliance
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/adrianohrl/alliance.git
+      version: indigo
+    source:
+      type: git
+      url: https://github.com/adrianohrl/alliance.git
+      version: master
+    status: maintained
   android_apps:
     doc:
       type: git


### PR DESCRIPTION
Please, add the alliance to indigo.