### PR TITLE
[rosdep] openscenegraph: remove pinned down version for openscenegraph dependencies

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2237,7 +2237,7 @@ libopenni2-dev:
   ubuntu: [libopenni2-dev]
 libopenscenegraph:
   arch: [openscenegraph]
-  debian: [openscenegraph, libopenscenegraph-dev, libopenscenegraph80, libopenthreads-dev, libopenthreads14]
+  debian: [openscenegraph, libopenscenegraph-dev]
   fedora: [OpenSceneGraph, OpenSceneGraph-devel, OpenThreads, OpenThreads-devel]
   gentoo: [dev-games/openscenegraph]
   ubuntu: [openscenegraph, libopenscenegraph-dev]


### PR DESCRIPTION
these explicit dependencies are not necessary as every debian version since at least wheezy declares them:
https://packages.debian.org/wheezy/openscenegraph
https://packages.debian.org/wheezy/libopenscenegraph-dev