### PR TITLE
vision_opencv: 1.12.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10433,7 +10433,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.12.6-0
+      version: 1.12.7-0
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.12.7-0`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.12.6-0`

## cv_bridge

- No changes

## image_geometry

```
* get shared_ptr from boost or C++11
* Contributors: Vincent Rabaud
```

## vision_opencv

- No changes
