### PR TITLE
alliance: 1.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -246,7 +246,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/adrianohrl/alliance.git
-      version: 'master'
+      version: indigo-devel
     status: developed
   android_apps:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -246,7 +246,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/adrianohrl/alliance.git
-      version: '1.05'
+      version: 'master'
     status: developed
   android_apps:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -232,6 +232,22 @@ repositories:
       url: https://github.com/rosalfred/alfred_sr_linux.git
       version: master
     status: developed
+  alliance:
+    release:
+      packages:
+      - alliance
+      - alliance_msgs
+      - rqt_alliance
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/adrianohrl/alliance-release.git
+      version: 1.0.5-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/adrianohrl/alliance.git
+      version: '1.05'
+    status: developed
   android_apps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `alliance` to `1.0.5-0`:

- upstream repository: https://github.com/adrianohrl/alliance.git
- release repository: https://github.com/adrianohrl/alliance-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## alliance

```
* removed rqt_mrta run depend
* Contributors: adrianohrl
```

## alliance_msgs

- No changes

## rqt_alliance

- No changes
