### PR TITLE
[rosdep] Add lzma compression library

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2036,6 +2036,7 @@ liblttng-ust-dev:
   ubuntu: [liblttng-ust-dev]
 liblzma-dev:
   debian: [liblzma-dev]
+  fedora: [lzma-devel]
   ubuntu: [liblzma-dev]
 libmagick:
   arch: [imagemagick]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2034,6 +2034,9 @@ liblttng-ust-dev:
   fedora: [lttng-ust]
   gentoo: [dev-util/lttng-ust]
   ubuntu: [liblttng-ust-dev]
+liblzma-dev:
+  debian: [liblzma-dev]
+  ubuntu: [liblzma-dev]
 libmagick:
   arch: [imagemagick]
   debian: [libmagick++-dev]


### PR DESCRIPTION
Adds the lzma compression library

Debian: https://packages.debian.org/en/sid/liblzma-dev
Ubuntu: https://packages.ubuntu.com/en/trusty/liblzma-dev