### PR TITLE
visp: 3.0.1-6 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10481,7 +10481,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 3.0.1-3
+      version: 3.0.1-6
     status: maintained
   visp_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `3.0.1-6`:

- upstream repository: https://github.com/lagadic/visp.git
- release repository: https://github.com/lagadic/visp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `3.0.1-3`
