### PR TITLE
ros_type_introspection: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7551,7 +7551,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/ros_type_introspection-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/facontidavide/ros_type_introspection.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_type_introspection` to `1.0.1-0`:

- upstream repository: https://github.com/facontidavide/ros_type_introspection.git
- release repository: https://github.com/facontidavide/ros_type_introspection-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.0`
- previous version for package: `1.0.0-0`

## ros_type_introspection

```
* added return value to deserializeIntoFlatContainer
* bug fix
* fix compilation issue
* fix potential issue with static variables
* Contributors: Davide Faconti
```
