### PR TITLE
vision_msgs: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10435,6 +10435,22 @@ repositories:
       url: https://github.com/team-vigir/vigir_step_control.git
       version: master
     status: maintained
+  vision_msgs:
+    doc:
+      type: git
+      url: https://github.com/Kukanani/vision_msgs.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Kukanani/vision_msgs-release.git
+      version: 0.0.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/Kukanani/vision_msgs.git
+      version: kinetic-devel
+    status: developed
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_msgs` to `0.0.1-0`:

- upstream repository: https://github.com/Kukanani/vision_msgs.git
- release repository: https://github.com/Kukanani/vision_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## vision_msgs

```
* Initial commit
* Contributors: Adam Allevato, Martin Gunther, procopiostein
```
