### PR TITLE
Revert "ompl: 1.3.2-2 in 'lunar/distribution.yaml' [bloom]"

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1950,7 +1950,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/ompl-release.git
-      version: 1.3.2-2
+      version: 1.3.1-3
     status: maintained
   opencv3:
     release:


### PR DESCRIPTION
Reverts ros/rosdistro#16349

@mamoll FYI
See https://github.com/ros/rosdistro/pull/16349#issuecomment-344441361 for more information