### PR TITLE
Revert "abseil_cpp: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -67,7 +67,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/Eurecat/abseil_cpp-release.git
-      version: 0.2.1-0
+      version: 0.2.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#16358

This release is breaking all downstream packages.
https://github.com/Eurecat/abseil-cpp/issues/2