### PR TITLE
Revert "abseil_cpp: 0.2.1-0 in 'lunar/distribution.yaml' [bloom]"

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -20,7 +20,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/Eurecat/abseil_cpp-release.git
-      version: 0.2.1-0
+      version: 0.1.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#16360

https://github.com/Eurecat/abseil-cpp/issues/2 @mikaelarguedas I recommend this in parallel with reversions in Indigo and jade : https://github.com/ros/rosdistro/pull/16369 https://github.com/ros/rosdistro/pull/16368