### PR TITLE
abseil_cpp: 0.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -71,7 +71,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Eurecat/abseil_cpp-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `abseil_cpp` to `0.2.2-0`:

- upstream repository: https://github.com/Eurecat/abseil-cpp.git
- release repository: https://github.com/Eurecat/abseil_cpp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.0`
- previous version for package: `0.2.1-0`

## abseil_cpp

```
* removing rsync
* Contributors: Davide Faconti
```
