### PR TITLE
abseil_cpp: 0.2.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -20,7 +20,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/Eurecat/abseil_cpp-release.git
-      version: 0.2.1-0
+      version: 0.2.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `abseil_cpp` to `0.2.3-0`:

- upstream repository: https://github.com/Eurecat/abseil-cpp.git
- release repository: https://github.com/Eurecat/abseil_cpp-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.0`
- previous version for package: `0.2.1-0`

## abseil_cpp

```
* Fix issue #1 <https://github.com/Eurecat/abseil-cpp/issues/1>
* Contributors: Davide Faconti
```
