### PR TITLE
vrpn_client_ros: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10579,7 +10579,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/vrpn_client_ros.git
-      version: indigo-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -10588,7 +10588,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/vrpn_client_ros.git
-      version: indigo-devel
+      version: kinetic-devel
     status: maintained
   warehouse_ros:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10584,7 +10584,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/vrpn_client_ros-release.git
-      version: 0.1.1-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/vrpn_client_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn_client_ros` to `0.2.0-0`:

- upstream repository: https://github.com/clearpathrobotics/vrpn_client_ros.git
- release repository: https://github.com/ros-drivers-gbp/vrpn_client_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.1.1-0`

## vrpn_client_ros

```
* Merge pull request #8 <https://github.com/ros-drivers/vrpn_client_ros/issues/8> from cjue/indigo-devel
  fix: motive auto generated names are not valid ROS identifiers
* fix: don't ignore second char when first one is illegal
* handlerules for first and subsequent chars in ROS names
* fix problem with auto generated names from motive: "Rigidy Body n" is
  not a valid ROS identifier
* Contributors: Christian Juelg, Paul Bovbel
```
