### PR TITLE
vrpn_client_ros: 0.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3881,6 +3881,22 @@ repositories:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-drivers-gbp/vrpn-release.git
       version: 0.7.33-0
+  vrpn_client_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/vrpn_client_ros.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/vrpn_client_ros-release.git
+      version: 0.2.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/vrpn_client_ros.git
+      version: kinetic-devel
+    status: maintained
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn_client_ros` to `0.2.0-0`:

- upstream repository: https://github.com/clearpathrobotics/vrpn_client_ros.git
- release repository: https://github.com/ros-drivers-gbp/vrpn_client_ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## vrpn_client_ros

```
* Merge pull request #8 <https://github.com/ros-drivers/vrpn_client_ros/issues/8> from cjue/indigo-devel
  fix: motive auto generated names are not valid ROS identifiers
* fix: don't ignore second char when first one is illegal
* handlerules for first and subsequent chars in ROS names
* fix problem with auto generated names from motive: "Rigidy Body n" is
  not a valid ROS identifier
* Contributors: Christian Juelg, Paul Bovbel
```
