### PR TITLE
roch_robot: 1.0.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11159,7 +11159,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_robot-release.git
-      version: 1.0.15-0
+      version: 1.0.16-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_robot` to `1.0.16-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch_robot.git
- release repository: https://github.com/SawYerRobotics-release/roch_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.15-0`

## roch_base

```
* Add PID publish for Roch.
* Add motor encoders publish.
```

## roch_capabilities

- No changes

## roch_control

- No changes

## roch_description

```
* Support sick lms100.
```

## roch_ftdi

- No changes

## roch_msgs

```
* Add PID msg.
* Add motor encoders.
```

## roch_robot

- No changes

## roch_safety_controller

- No changes

## roch_sensorpc

- No changes
