### PR TITLE
pluginlib: 1.11.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2206,7 +2206,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.11.1-0
+      version: 1.11.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.11.2-0`:

- upstream repository: https://github.com/ros/pluginlib
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.11.1-0`

## pluginlib

```
* Fix cpplint and lint_cmake errors (backport 84) (#87 <https://github.com/ros/pluginlib/issues/87>)
  * fix line length
  add back NOLINT on test header to avoid 'should include its header file' cpplint error
  * lint cmake
* Continue loading classes on error (#85 <https://github.com/ros/pluginlib/issues/85>)
  * continue loading classes on error
  * construct string with file rather than adding new API
  * match style of the rest of the file
  * missing whitespace
* Backport 70 to kinetic (#82 <https://github.com/ros/pluginlib/issues/82>)
  * rename header files to make clear they are c++
  * fixup to support new header file names
  * restore old header names with deprecation warnings for API stability
  * remove deprecation warnings
* alphabetize includes (#80 <https://github.com/ros/pluginlib/issues/80>)
* Contributors: Furushchev, Mikael Arguedas
```
