### PR TITLE
rapid_pbd: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10362,7 +10362,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/jstnhuang-release/rapid_pbd-release.git
-      version: 0.1.6-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/jstnhuang/rapid_pbd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rapid_pbd` to `0.2.0-0`:

- upstream repository: https://github.com/jstnhuang/rapid_pbd.git
- release repository: https://github.com/jstnhuang-release/rapid_pbd-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.1.6-0`

## rapid_pbd

```
* Adds support for the Baxter robot (#18 <https://github.com/jstnhuang/rapid_pbd/issues/18>)
* Added additional runtime deps.
* Contributors: Justin Huang, ysl208
```
