### PR TITLE
rtt_ros_integration: 2.8.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13393,7 +13393,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_ros_integration-release.git
-      version: 2.8.5-0
+      version: 2.8.6-0
     source:
       type: git
       url: https://github.com/orocos/rtt_ros_integration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_ros_integration` to `2.8.6-0`:

- upstream repository: https://github.com/orocos/rtt_ros_integration.git
- release repository: https://github.com/orocos-gbp/rtt_ros_integration-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `2.8.5-0`

## rtt_actionlib

- No changes

## rtt_actionlib_msgs

- No changes

## rtt_common_msgs

- No changes

## rtt_diagnostic_msgs

- No changes

## rtt_dynamic_reconfigure

```
* rtt_dynamic_reconfigure: fix a bug that duplicate ids when generating a parameter description from a property tree
  The id field of each groups in a dynamic_reconfigure/ConfigDescription message must be unique and some groups
  might reference another as their parent. Without this patch the ids were assigned locally and were only unique within
  the same group, which confused rqt_reconfigure and the dynparam console client when they try to rebuild the tree
  hierarchy in more complex cases.
* Contributors: Johannes Meyer
```

## rtt_geometry_msgs

- No changes

## rtt_kdl_conversions

- No changes

## rtt_nav_msgs

- No changes

## rtt_ros

- No changes

## rtt_ros_comm

- No changes

## rtt_ros_integration

- No changes

## rtt_ros_msgs

- No changes

## rtt_rosclock

- No changes

## rtt_roscomm

```
* rtt_roscomm: also set ${PROJECT_NAME}_EXPORTED_LIBRARIES in parent scope
  Related to https://github.com/orocos-toolchain/rtt/pull/244.
* Contributors: Johannes Meyer
```

## rtt_rosdeployment

- No changes

## rtt_rosgraph_msgs

- No changes

## rtt_rosnode

- No changes

## rtt_rospack

- No changes

## rtt_rosparam

- No changes

## rtt_sensor_msgs

- No changes

## rtt_shape_msgs

- No changes

## rtt_std_msgs

- No changes

## rtt_std_srvs

- No changes

## rtt_stereo_msgs

- No changes

## rtt_tf

- No changes

## rtt_trajectory_msgs

- No changes

## rtt_visualization_msgs

- No changes
