### PR TITLE
Use pip for `python-oauth2`

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1820,10 +1820,18 @@ python-numpydoc:
     zesty: [python-numpydoc]
 python-oauth2:
   arch: [python-oauth2]
-  debian: [python-oauth2]
+  debian:
+    wheezy:  [python-oauth2]
   fedora: [python-oauth2]
   gentoo: [dev-python/oauth2]
-  ubuntu: [python-oauth2]
+  ubuntu:
+    precise: [python-oauth2]
+    quantal: [python-oauth2]
+    raring: [python-oauth2]
+    saucy: [python-oauth2]
+    trusty: [python-oauth2]
+    utopic: [python-oauth2]
+    vivid: [python-oauth2]
 python-oauth2client:
   debian: [python-oauth2client]
   fedora: [python-oauth2client]


### PR DESCRIPTION
Since ubuntu from wily no apt package `python-oauth2` is available, this package should be installed via `pip`.