### PR TITLE
pepper_virtual: 0.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5983,7 +5983,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_virtual-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_virtual.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_virtual` to `0.0.4-0`:

- upstream repository: https://github.com/ros-naoqi/pepper_virtual.git
- release repository: https://github.com/ros-naoqi/pepper_virtual-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.0.3-0`

## pepper_control

```
* removing wheels controllers
* adding Pelvis controller
* adding head controller
* fixed wheels controllers names
* fixing wheels controllers in position_control
* ading a launch file for all controllers
* fixing wheels controllers
* Contributors: Natalia Lyubova
```

## pepper_gazebo_plugin

```
* Merge pull request #13 <https://github.com/ros-naoqi/pepper_virtual/issues/13> from nlyubova/master
  updating README
* removing ros-indigo-humanoid-nav-msgs from README
* updating README
* Update README.rst
* Merge pull request #9 <https://github.com/ros-naoqi/pepper_virtual/issues/9> from ros-naoqi/mikaelarguedas-clone-using-https-in-readme
  [pepper_gazebo_plugin/README.rst] clone using https
* [pepper_gazebo_plugin/README.rst] clone using https
* Merge pull request #5 <https://github.com/ros-naoqi/pepper_virtual/issues/5> from kochigami/add-trajectory-all
  [pepper_gazebo_plugin] enable to launch pepper_control_position_all.launch
* [pepper_gazebo_plugin] enable to launch pepper_control_position_all.launch
* Contributors: Kanae Kochigami, Mikael Arguedas, Natalia Lyubova
```
