### PR TITLE
rtt_ros_integration: 2.9.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8752,7 +8752,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_ros_integration-release.git
-      version: 2.9.0-0
+      version: 2.9.1-0
     source:
       type: git
       url: https://github.com/orocos/rtt_ros_integration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_ros_integration` to `2.9.1-0`:

- upstream repository: https://github.com/orocos/rtt_ros_integration.git
- release repository: https://github.com/orocos-gbp/rtt_ros_integration-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `2.9.0-0`

## rtt_actionlib

- No changes

## rtt_actionlib_msgs

- No changes

## rtt_common_msgs

- No changes

## rtt_diagnostic_msgs

- No changes

## rtt_dynamic_reconfigure

```
* Merge with version 2.8.6
```

## rtt_geometry_msgs

- No changes

## rtt_kdl_conversions

- No changes

## rtt_nav_msgs

- No changes

## rtt_ros

- No changes

## rtt_ros_comm

- No changes

## rtt_ros_integration

- No changes

## rtt_ros_msgs

- No changes

## rtt_rosclock

```
* Merge pull request #93 <https://github.com/orocos/rtt_ros_integration/issues/93> from ahoarau/xenomai3-support
  Xenomai 3 support
* Contributors: Antoine Hoarau
```

## rtt_roscomm

```
* Merge with version 2.8.6
```

## rtt_rosdeployment

- No changes

## rtt_rosgraph_msgs

- No changes

## rtt_rosnode

- No changes

## rtt_rospack

- No changes

## rtt_rosparam

- No changes

## rtt_sensor_msgs

- No changes

## rtt_shape_msgs

- No changes

## rtt_std_msgs

- No changes

## rtt_std_srvs

- No changes

## rtt_stereo_msgs

- No changes

## rtt_tf

- No changes

## rtt_trajectory_msgs

- No changes

## rtt_visualization_msgs

- No changes
