### PR TITLE
naoqi_dcm_driver: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5060,7 +5060,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_dcm_driver-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_dcm_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_dcm_driver` to `0.0.3-0`:

- upstream repository: https://github.com/ros-naoqi/naoqi_dcm_driver.git
- release repository: https://github.com/ros-naoqi/naoqi_dcm_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.0.2-0`

## naoqi_dcm_driver

```
* Update README
* Update README
* Fix typo in README
* changing the speed of set_angles
* changes in stiffness when shutting down
* updating joint comparison
* fixing the diagnostics
* adding electical current and battery info to Diagnostics
* adding a possibility to change stiffness
* few changes in ReadJoints
* Read joints names from pepper_control config
  reading joints names from yaml file
* adding headers
* define controlled joints from ROS controllers
* removed joint publishing from ALMotion
* removing velocity control and adding moveto subscriber since velocity control is already in Naoqi Driver
* Smooth robot motion
* Merge pull request #1 <https://github.com/ros-naoqi/naoqi_dcm_driver/issues/1> from ros-naoqi/update_links
  updated repo URL
* smooth changed in stiffness
* update repo urls
* few changes in log
* reduce Naoqi log
* fix reading motor groups from launch
* fixing crash at shutting down
* clean robot.hpp
* fixing typos
* Contributors: Mikael Arguedas, Natalia Lyubova
```
