### PR TITLE
romeo_virtual: 0.2.3-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5435,7 +5435,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-aldebaran/romeo_virtual-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/ros-aldebaran/romeo_virtual.git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_virtual` to `0.2.3-0`:

- upstream repository: https://github.com/ros-aldebaran/romeo_virtual.git
- release repository: https://github.com/ros-aldebaran/romeo_virtual-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.2.2-0`

## romeo_control

- No changes

## romeo_gazebo_plugin

```
* Merge pull request #1 <https://github.com/ros-aldebaran/romeo_virtual/issues/1> from ros-aldebaran/mikaelarguedas-clone-using-https-in-readme
  [romeo_gazebo_plugin/README.rst] clone using https
* [romeo_gazebo_plugin/README.rst] clone using https
* Update README.rst
* Update package.xml
* Contributors: Mikael Arguedas, Natalia Lyubova
```
