### PR TITLE
romeo_moveit_config: 0.2.8-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -5397,7 +5397,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-aldebaran/romeo_moveit_config-release.git
-      version: 0.2.7-0
+      version: 0.2.8-0
     source:
       type: git
       url: https://github.com/ros-aldebaran/romeo_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `romeo_moveit_config` to `0.2.8-0`:

- upstream repository: https://github.com/ros-aldebaran/romeo_moveit_config.git
- release repository: https://github.com/ros-aldebaran/romeo_moveit_config-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.2.7-0`

## romeo_moveit_config

```
* cleaning MoveIt config
* Merge pull request #7 <https://github.com/ros-aldebaran/romeo_moveit_config/issues/7> from ros-aldebaran/fix_warnings
  Fix deprecated warnings
* put parameter in right namespace
* remove unnecessary tabs
* remove deprecated service, use action instead
* fix deprecated xacro call
* fix allowed_execution_duration_scaling
* Update README.rst
* adding RRT as default planner
* Merge pull request #6 <https://github.com/ros-aldebaran/romeo_moveit_config/issues/6> from nlyubova/master
  fixing legs planning groups
* fixing legs planning groups
* Contributors: Mikael Arguedas, Natalia Lyubova
```
