### PR TITLE
nao_dcm_robot: 0.0.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4941,7 +4941,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-naoqi/nao_dcm_robot-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_dcm_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_dcm_robot` to `0.0.5-0`:

- upstream repository: https://github.com/ros-naoqi/nao_dcm_robot.git
- release repository: https://github.com/ros-naoqi/nao_dcm_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.0.4-0`

## nao_dcm_bringup

```
* adding robot_ip parameter in nao_dcm_H25_bringup_position.launch
* fixing nao_dcm_H25_bringup_position.launch
* Contributors: Natalia Lyubova
```
