### PR TITLE
gps_umd: 0.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -950,7 +950,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/swri-robotics-gbp/gps_umd-release.git
-      version: 0.1.9-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/gps_umd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `0.2.0-0`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/swri-robotics-gbp/gps_umd-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.1.9-0`

## gps_common

```
* fix xml comments
* add install instructions and documentation
* add node for translating between NavSatFix and GPSFix
* Contributors: Andre Volk, P. J. Reed
```

## gps_umd

- No changes

## gpsd_client

```
* Add include for <cmath> in gpsd_client
* Add parameter to set frame_id.
* Contributors: Kris Kozak, P. J. Reed
```
