### PR TITLE
rqt_topic: 0.4.10-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3376,7 +3376,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rqt_topic-release.git
-      version: 0.4.9-0
+      version: 0.4.10-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `0.4.10-0`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros-gbp/rqt_topic-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.4.9-0`

## rqt_topic

```
* fix order by bandwidth column (#4 <https://github.com/ros-visualization/rqt_topic/issues/4>)
```
