### PR TITLE
mavros: 0.21.5-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1509,7 +1509,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.21.4-0
+      version: 0.21.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.21.5-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.21.4-0`

## libmavconn

- No changes

## mavros

```
* Yet another formatting.
* px4_config.yaml updated. Minor formatting update.
* global_position/raw/gps_vel should still be in earth fixed frame.
* GPS fix's frame_id changed to body-fixed.
* global_position/local angular twist changed from NANs to zeroes to be able to show in RViz.
* readme: source install: add note on fetching all the deps
* geolib_dataset: script: fix interpreter
* Contributors: Pavlo Kolomiiets, TSC21
```

## mavros_extras

```
* extras fix #858 <https://github.com/mavlink/mavros/issues/858>: fix vector copy-paste error
* Contributors: Vladimir Ermakov
```

## mavros_msgs

- No changes

## test_mavros

- No changes
