### PR TITLE
class_loader: 0.3.8-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -297,7 +297,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/class_loader-release.git
-      version: 0.3.7-0
+      version: 0.3.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `0.3.8-0`:

- upstream repository: https://github.com/ros/class_loader
- release repository: https://github.com/ros-gbp/class_loader-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.3.7-0`

## class_loader

```
* Fix console_bridge marcos definition (#66 <https://github.com/ros/class_loader/issues/66>)
* Style overhaul (#64 <https://github.com/ros/class_loader/issues/64>) (#62 <https://github.com/ros/class_loader/issues/62>)
* Add copyright notice to unique_ptr_test.cpp (#65 <https://github.com/ros/class_loader/issues/65>)
* Contributors: Maarten de Vries, Mikael Arguedas
```
