### PR TITLE
axis_camera: 0.2.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -132,6 +132,21 @@ repositories:
       url: https://github.com/srv/avt_vimba_camera.git
       version: lunar
     status: maintained
+  axis_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/axis_camera.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/clearpath-gbp/axis_camera-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/axis_camera.git
+      version: master
+    status: unmaintained
   bfl:
     release:
       tags:

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -140,7 +140,7 @@ repositories:
     release:
       tags:
         release: release/lunar/{package}/{version}
-      url: https://github.com/clearpath-gbp/axis_camera-release.git
+      url: https://github.com/ros-drivers-gbp/axis_camera-release.git
       version: 0.2.1-0
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `axis_camera` to `0.2.1-0`:

- upstream repository: https://github.com/ros-drivers/axis_camera.git
- release repository: https://github.com/clearpath-gbp/axis_camera-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## axis_camera

```
* add ros-orphaned-maintaner to package.xml (#50 <https://github.com/ros-drivers/axis_camera/issues/50>)
* Set queue_size to Publishers in axis_camera (#47 <https://github.com/ros-drivers/axis_camera/issues/47>)
* Point package.xml URLs at ros-drivers org. (#39 <https://github.com/ros-drivers/axis_camera/issues/39>)
* sending camera_info (#38 <https://github.com/ros-drivers/axis_camera/issues/38>)
  * copying stamp so rectification happens
  * sending camera_info
* Contributors: Kei Okada, Kentaro Wada, Mike Purvis, Sam Pfeiffer, Micah Corah
```
