### PR TITLE
teraranger: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9451,7 +9451,8 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger-release.git
-      version: 1.0.1-0
+      version: 1.1.0-0
+    status: maintained
   teraranger_array:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger` to `1.1.0-0`:

- upstream repository: git@github.com:Terabee/teraranger.git
- release repository: https://github.com/Terabee/teraranger-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.0.1-0`

## teraranger

```
* Change license to MIT
* Put frame_id as a parameter in one, duo, and evo driver
* Update README with correct evo links
* Contributors: Pierre-Louis Kabaradjian, Baptiste Potier
```
