### PR TITLE
teraranger_array_converter: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9463,7 +9463,8 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger_array_converter-release.git
-      version: 1.0.0-0
+      version: 1.1.0-0
+    status: maintained
   teraranger_description:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger_array_converter` to `1.1.0-0`:

- upstream repository: https://github.com/Terabee/teraranger_array_converter.git
- release repository: https://github.com/Terabee/teraranger_array_converter-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.0.0-0`

## teraranger_array_converter

```
* Change license to MIT
* Update example bags to teraranger_array/RangeArray message type
* Update launch files with new parameters
* Add .gitignore
* Fix frame param
* Add force_refresh_tf parameter
* Add conversion_frame parameter
* Change default transform to base_hub
* Contributors: Pierre-Louis Kabaradjian
```
