### PR TITLE
teraranger_array: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9457,7 +9457,8 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger_array-release.git
-      version: 1.0.1-0
+      version: 1.1.0-0
+    status: maintained
   teraranger_array_converter:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger_array` to `1.1.0-0`:

- upstream repository: https://github.com/Terabee/teraranger_array.git
- release repository: https://github.com/Terabee/teraranger_array-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.0.1-0`

## teraranger_array

```
* Change license to MIT
* Update link
* Contributors: Pierre-Louis Kabaradjian, Baptiste Potier
```
