### PR TITLE
rospilot: 1.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7910,7 +7910,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rospilot/rospilot-release.git
-      version: 1.3.8-0
+      version: 1.4.0-0
     source:
       type: git
       url: https://github.com/rospilot/rospilot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot` to `1.4.0-0`:

- upstream repository: https://github.com/rospilot/rospilot.git
- release repository: https://github.com/rospilot/rospilot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.3.8-0`

## rospilot

```
* Add "follow me" mode
* Add support for direct h264 capture from camera
* Improve automatic camera selection
* Add vibration data to display
  Also includes accelerometer clipping counts
* Add support for battery voltage monitoring
* Enable pre-release tests
* Add Travis integration
* Refactor handling of NPM dependencies
* Add native Systemd service
* Set dns search domain for better compatibility
* Update wifi setup script with proper dnsmasq dependency
* Contributors: Christopher Berner
```
