### PR TITLE
opencv_apps: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5633,7 +5633,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-perception/opencv_apps-release.git
-      version: 1.12.0-0
+      version: 2.0.0-0
     source:
       type: git
       url: https://github.com/ros-perception/opencv_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `opencv_apps` to `2.0.0-0`:

- upstream repository: https://github.com/ros-perception/opencv_apps.git
- release repository: https://github.com/ros-perception/opencv_apps-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.12.0-0`

## opencv_apps

```
* Fix namespace and pkg name of nodelets (Closes (#21 <https://github.com/ros-perception/opencv_apps/issues/21>)) (#74 <https://github.com/ros-perception/opencv_apps/issues/74>)
  Fix namespace and pkg name of nodelets
* Add pyramids_nodelet (#37 <https://github.com/ros-perception/opencv_apps/issues/37>)
  * use toCvCopy instead of CvShare in adding_images
* adding_images_nodelt :support different size of images (#57 <https://github.com/ros-perception/opencv_apps/issues/57>)
* fix contour moment program (#66 <https://github.com/ros-perception/opencv_apps/issues/66>)
  * contour_moments_nodelet.cpp: remove redundant codes, use input encoding
  * contour_moments_nodelet.cpp: sort contours by the area
  * contour_moments_nodelet.cpp: remove tailing NR from NODELET_INFO
* fix for opencv 3.3.1 (#71 <https://github.com/ros-perception/opencv_apps/issues/71>)
  * fix launch/test fiels for opencv3.3
  * goodFeaturesTrack takes useHarriesDetector == false
  * opencv 3.3.1 has newer FaceRecognizer
* Contributors: Kei Okada, Iori Yanokura
```
