### PR TITLE
Add pocketsphinx for pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2083,6 +2083,19 @@ python-plyfile-pip:
   ubuntu:
     pip:
       packages: [plyfile]
+python-pocketsphinx:
+  debian:
+    pip:
+      packages: [pocketsphinx]
+  fedora:
+    pip:
+      packages: [pocketsphinx]
+  osx:
+    pip:
+      packages: [pocketsphinx]
+  ubuntu:
+    pip:
+      packages: [pocketsphinx]
 python-progressbar:
   debian: [python-progressbar]
   fedora: [python-progressbar]


### PR DESCRIPTION
This package is a python interface for [Pocketsphinx and Sphinxbase](https://cmusphinx.github.io/) which are used for speech recognition. 
- link to package description: https://pypi.python.org/pypi/pocketsphinx/0.1.3
- link to github repository: https://github.com/bambocher/pocketsphinx-python