### PR TITLE
tf2_web_republisher: 0.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9507,7 +9507,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/tf2_web_republisher-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/RobotWebTools/tf2_web_republisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_web_republisher` to `0.3.2-0`:

- upstream repository: https://github.com/RobotWebTools/tf2_web_republisher.git
- release repository: https://github.com/RobotWebTools-release/tf2_web_republisher-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.3.1-0`

## tf2_web_republisher

```
* Merge pull request #25 <https://github.com/RobotWebTools/tf2_web_republisher/issues/25> from VictorLamoine/develop
  Fix compilation with c++11
* add rostest
* Update travis configuration to test against kinetic (#24 <https://github.com/RobotWebTools/tf2_web_republisher/issues/24>)
* Merge pull request #22 <https://github.com/RobotWebTools/tf2_web_republisher/issues/22> from daniel86/develop
  Added dependency to message_generation and message_runtime
* Contributors: Daniel Bessler, Jihoon Lee, Nils Berg, Victor Lamoine
```
