### PR TITLE
web_video_server: 0.0.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10677,7 +10677,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/web_video_server-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/RobotWebTools/web_video_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `web_video_server` to `0.0.7-0`:

- upstream repository: https://github.com/RobotWebTools/web_video_server.git
- release repository: https://github.com/RobotWebTools-release/web_video_server-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.0.6-0`

## web_video_server

```
* Ffmpeg 3 (#43 <https://github.com/RobotWebTools/web_video_server/issues/43>)
  * Correct use of deprecated parameters
  codec_context_->rc_buffer_aggressivity marked as "currently useless", so removed
  codec_context_->frame_skip_threshold access through new priv_data api
  * New names for pixel formats
  * AVPicture is deprecated, use AVFrame
  * Switch to non-deprecated free functions
  * Use new encoding api for newer versions
  * codec_context is deprecated, use packet flags
* Update travis configuration to test against kinetic (#44 <https://github.com/RobotWebTools/web_video_server/issues/44>)
* fixed misuse of remove_if (#35 <https://github.com/RobotWebTools/web_video_server/issues/35>)
* Merge pull request #33 <https://github.com/RobotWebTools/web_video_server/issues/33> from achim-k/patch-1
  web_video_server: fix bool function not returning
  This fix is required when compiling the package with clang. Otherwise a SIGILL (Illegal instruction) is triggered.
* Contributors: Hans-Joachim Krauch, Jan, Jihoon Lee, russelhowe
```
