### PR TITLE
grpc: 0.0.6-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -987,7 +987,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/CogRobRelease/catkin_grpc-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/CogRob/catkin_grpc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grpc` to `0.0.6-0`:

- upstream repository: https://github.com/CogRob/catkin_grpc.git
- release repository: https://github.com/CogRobRelease/catkin_grpc-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.0.5-0`

## grpc

```
* Depend on zlib (#23 <https://github.com/CogRob/catkin_grpc/issues/23>) and link protobuf with zlib (#22 <https://github.com/CogRob/catkin_grpc/issues/22>) (#24 <https://github.com/CogRob/catkin_grpc/issues/24>)
* Depend on absolute path of .proto file (#21 <https://github.com/CogRob/catkin_grpc/issues/21>)
  This should fix #20 <https://github.com/CogRob/catkin_grpc/issues/20>. The original concern was for some reason cmake re-generate protos if .proto is not within src. Initial test shows this is not the case, but should do more tests.
* Contributors: Shengye Wang
```
