### PR TITLE
Use wxpython instead of python-wxtools on Arch

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3829,6 +3829,7 @@ python-wtforms:
   gentoo: [dev-python/wtforms]
   ubuntu: [python-wtforms]
 python-wxtools:
+  arch: [wxpython]
   debian: [python-wxtools]
   fedora: [wxPython]
   gentoo: [dev-python/wxpython]


### PR DESCRIPTION
There is no package named `python-wxtools` in the Arch repository, neither in the AUR. Instead it's called [wxpython](https://www.archlinux.org/packages/community/x86_64/wxpython/) and provides similar tools as [Ubuntu's package](https://packages.ubuntu.com/xenial/all/python-wxtools/filelist) (e.g. `img2xpm`, `xrced`, `pywxrc`)