### PR TITLE
gx_sound: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2770,6 +2770,16 @@ repositories:
       url: https://github.com/ros-drivers/gscam.git
       version: master
     status: unmaintained
+  gx_sound:
+    release:
+      packages:
+      - gx_sound
+      - gx_sound_msgs
+      - gx_sound_player
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/groove-x/gx_sound-release.git
+      version: 0.2.0-0
   haf_grasping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gx_sound` to `0.2.0-0`:

- upstream repository: https://github.com/groove-x/gx_sound.git
- release repository: https://github.com/groove-x/gx_sound-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## gx_sound

```
* Initial commit
* Contributors: Yuma.M
```

## gx_sound_msgs

```
* Initial commit
* Contributors: Yuma.M
```

## gx_sound_player

```
* Initial commit
* Contributors: Yuma.M
```
