### PR TITLE
Add vorbis-tools

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4026,6 +4026,7 @@ vorbis-tools:
   arch: [vorbis-tools]
   debian: [vorbis-tools]
   fedora: [vorbis-tools]
+  gentoo: [media-sound/vorbis-tools]
   ubuntu: [vorbis-tools]
 vrep:
   ubuntu:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4022,6 +4022,11 @@ vlc:
   debian: [vlc]
   fedora: [vlc]
   ubuntu: [vlc]
+vorbis-tools:
+  arch: [vorbis-tools]
+  debian: [vorbis-tools]
+  fedora: [vorbis-tools]
+  ubuntu: [vorbis-tools]
 vrep:
   ubuntu:
     trusty:


### PR DESCRIPTION
Related to #16444, vorbis-tools is added to rosdep.

Arch: https://www.archlinux.org/packages/?q=vorbis-tools
Debian: https://packages.debian.org/search?keywords=vorbis-tools
Fedora: https://www.rpmfind.net/linux/rpm2html/search.php?query=vorbis-tools
Ubuntu: https://packages.ubuntu.com/search?lang=ja&keywords=vorbis-tools&searchon=names