### PR TITLE
nao_interaction: 0.1.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4972,6 +4972,24 @@ repositories:
       url: https://github.com/ros-naoqi/nao_dcm_robot.git
       version: master
     status: maintained
+  nao_interaction:
+    release:
+      packages:
+      - nao_audio
+      - nao_interaction
+      - nao_interaction_launchers
+      - nao_interaction_msgs
+      - nao_vision
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-naoqi/nao_interaction-release.git
+      version: 0.1.5-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_interaction.git
+      version: master
+    status: maintained
   nao_meshes:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_interaction` to `0.1.5-0`:

- upstream repository: https://github.com/ros-naoqi/nao_interaction.git
- release repository: https://github.com/ros-naoqi/nao_interaction-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## nao_audio

```
* change value to boolean
* Contributors: kochigami
```

## nao_interaction

- No changes

## nao_interaction_launchers

- No changes

## nao_interaction_msgs

```
* add learn face service
* Contributors: tarukosu
```

## nao_vision

```
* add self. to global variables
* add learn face service
* Contributors: Kei Okada, tarukosu
```
