### PR TITLE
remove failing Autoware repository

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11,24 +11,6 @@ release_platforms:
   ubuntu:
   - xenial
 repositories:
-  Autoware:
-    doc:
-      type: git
-      url: https://github.com/CPFL/Autoware-Manuals.git
-      version: master
-    release:
-      packages:
-      - autoware_msgs
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/CPFL/Autoware-release.git
-      version: 1.4.0-1
-    source:
-      test_commits: false
-      type: git
-      url: https://github.com/CPFL/Autoware.git
-      version: develop
-    status: developed
   abb:
     doc:
       type: git


### PR DESCRIPTION
manual revert of #15705 and #16051 

@dejanpan FYI. Feel free to submit a new PR when doing a new release and we'll happily merge it. We don't have a check enforcing it, but all the repositories in the distribution files are lowercase with underscores, please consider using `autoware` when doing the next release.
Thanks!