### PR TITLE
Add python3-venv

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3979,6 +3979,9 @@ python3-ruamel.yaml:
 python3-setuptools:
   debian: [python3-setuptools]
   ubuntu: [python3-setuptools]
+python3-venv:
+  debian: [python3-venv]
+  ubuntu: [python3-venv]
 python3-yaml:
   ubuntu: [python3-yaml]
 rosbag-metadata-pip:


### PR DESCRIPTION
Follow up to https://github.com/ros/rosdistro/pull/16445

After experimenting with a clean system, it looks like venv is _not_ fully bundled in python3-dev after all, even though it is part of the standard library.

```
# python3 -m venv test
The virtual environment was not created successfully because ensurepip is not
available.  On Debian/Ubuntu systems, you need to install the python3-venv
package using the following command.

    apt-get install python3-venv
```

I'm really not sure what the situation is on fedora, since no python3-venv package exists.

EDIT:

Sources
https://packages.ubuntu.com/search?keywords=python3-venv
https://packages.debian.org/search?keywords=python3-venv
