### PR TITLE
jsk_3rdparty: 2.1.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5388,6 +5388,7 @@ repositories:
       - nlopt
       - opt_camera
       - pgm_learner
+      - ros_speech_recognition
       - rospatlite
       - rosping
       - rostwitter
@@ -5396,7 +5397,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.1.4-0
+      version: 2.1.6-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.1.6-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `2.1.4-0`

## assimp_devel

- No changes

## bayesian_belief_networks

- No changes

## collada_urdf_jsk_patch

- No changes

## downward

```
* remove both "g++" "g++-static" from package.xml (#129 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/129>)
* Contributors: Kei Okada
```

## ff

- No changes

## ffha

- No changes

## jsk_3rdparty

- No changes

## julius

- No changes

## julius_ros

- No changes

## laser_filters_jsk_patch

- No changes

## libcmt

- No changes

## libsiftfast

- No changes

## lpg_planner

- No changes

## mini_maxwell

- No changes

## nlopt

- No changes

## opt_camera

- No changes

## pgm_learner

- No changes

## ros_speech_recognition

- No changes

## rospatlite

- No changes

## rosping

- No changes

## rostwitter

- No changes

## slic

- No changes

## voice_text

- No changes
