### PR TITLE
rosbridge_suite: 0.8.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7677,7 +7677,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.8.4-0
+      version: 0.8.5-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.8.5-0`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.8.4-0`

## rosapi

```
* Add Python3 compatibility (#300 <https://github.com/RobotWebTools/rosbridge_suite/issues/300>)
  * First pass at Python 3 compatibility
  * message_conversion: Only call encode on a Python2 str or bytes type
  * protocol.py: Changes for dict in Python3. Compatible with Python 2 too.
  * More Python 3 fixes, all tests pass
  * Move definition of string_types to rosbridge_library.util
* Contributors: Kartik Mohta
```

## rosbridge_library

```
* Raise if inappropriate bson module is installed (Appease #198 <https://github.com/RobotWebTools/rosbridge_suite/issues/198>) (#270 <https://github.com/RobotWebTools/rosbridge_suite/issues/270>)
  * Raise Exception if inappropriate bson module is installed (Related to #198 <https://github.com/RobotWebTools/rosbridge_suite/issues/198>)
* Add Python3 compatibility (#300 <https://github.com/RobotWebTools/rosbridge_suite/issues/300>)
  * First pass at Python 3 compatibility
  * message_conversion: Only call encode on a Python2 str or bytes type
  * protocol.py: Changes for dict in Python3. Compatible with Python 2 too.
  * More Python 3 fixes, all tests pass
  * Move definition of string_types to rosbridge_library.util
* Contributors: Junya Hayashi, Kartik Mohta
```

## rosbridge_server

```
* Raise if inappropriate bson module is installed (Appease #198 <https://github.com/RobotWebTools/rosbridge_suite/issues/198>) (#270 <https://github.com/RobotWebTools/rosbridge_suite/issues/270>)
  * Raise Exception if inappropriate bson module is installed (Related to #198 <https://github.com/RobotWebTools/rosbridge_suite/issues/198>)
* Add Python3 compatibility (#300 <https://github.com/RobotWebTools/rosbridge_suite/issues/300>)
  * First pass at Python 3 compatibility
  * message_conversion: Only call encode on a Python2 str or bytes type
  * protocol.py: Changes for dict in Python3. Compatible with Python 2 too.
  * More Python 3 fixes, all tests pass
  * Move definition of string_types to rosbridge_library.util
* Contributors: Junya Hayashi, Kartik Mohta
```

## rosbridge_suite

- No changes
