### PR TITLE
Adding missing fedora entry for python3-nose

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3955,6 +3955,7 @@ python3-flake8:
   ubuntu: [python3-flake8]
 python3-nose:
   debian: [python3-nose]
+  fedora: [python3-nose]
   ubuntu: [python3-nose]
 python3-pep8:
   debian:


### PR DESCRIPTION
Package reference: https://admin.fedoraproject.org/pkgdb/package/rpms/python3-nose/