### PR TITLE
grid_map: 1.6.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2711,11 +2711,12 @@ repositories:
       - grid_map_pcl
       - grid_map_ros
       - grid_map_rviz_plugin
+      - grid_map_sdf
       - grid_map_visualization
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ethz-asl/grid_map-release.git
-      version: 1.5.2-0
+      version: 1.6.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `1.6.0-0`:

- upstream repository: https://github.com/ethz-asl/grid_map.git
- release repository: https://github.com/ethz-asl/grid_map-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.5.2-0`

## grid_map

- No changes

## grid_map_core

```
* Added new sliding window iterator.
* Added new thickenLine(), triangulation, and bounding box method to polygon.
* Added unit tests for LineIterator with using move function.
* Fixed cpp-check warnings and errors.
* Fixed line iterator for moved maps (#119 <https://github.com/ethz-asl/grid_map/issues/119>).
* Fixed error in SpiralIterator when center is outside the map (#114 <https://github.com/ethz-asl/grid_map/issues/114>).
* Contributors: Péter Fankhauser, 2scholz, Remo Diethelm, Takahiro Miki, Tanja Baumann
```

## grid_map_costmap_2d

- No changes

## grid_map_cv

```
* Fixed compatibility issue with OpenCV 3 (#140 <https://github.com/ethz-asl/grid_map/issues/140>).
* Makes the OpenCV include a bit more specific and adds in a dependency into the catkin_package call.
* Moved inpaint filter to grid_map_cv, extended filter demo, cleanups.
* Fixed problem where clamp changes were disregarded (#115 <https://github.com/ethz-asl/grid_map/issues/115> from Le-Fix/fix/toImageClamp).
* Contributors: Péter Fankhauser, Perry Franklin, Le-Fix
```

## grid_map_demos

```
* Fixed compatibility issue with OpenCV 3 (#140 <https://github.com/ethz-asl/grid_map/issues/140>).
* Fixing cpp-check warnings and errors.
* Fixed dependencies for grid_map_demos.
* Updated terrain for filters demo.
* Updated filter demo chain.
* Contributors: Perry Franklin, Péter Fankhauser
```

## grid_map_filters

```
* Implemented a set of new filters:
* Math expression filter based on EigenLab
* Sliding window math expression filter
* Normal vector and curvature filter
* Color map, normal color, light intensity filter, added color blending mode
* BufferNormalizerFilter
* Contributors: Péter Fankhauser, Tanja Baumann
```

## grid_map_loader

- No changes

## grid_map_msgs

- No changes

## grid_map_octomap

- No changes

## grid_map_pcl

- No changes

## grid_map_ros

```
* Fixed the constructor for the ros::Time in saveToBag to correctly use fromNSec.
* Fixed cpp-check warnings and errors.
* Removed dependency of grid_map_ros on grid_map_costmap_2d.
* Contributors: Perry Franklin, Péter Fankhauser
```

## grid_map_rviz_plugin

```
* Added option to rviz plugin to hide color faces.
* Fixed bug for RViz plugin.
* Fixing cpp-check warnings and errors.
* Contributors: Péter Fankhauser
```

## grid_map_sdf

```
* Release of new implementation to convert grid maps to signed distance fields.
* Contributors: Takahiro Miki, Péter Fankhauser
```

## grid_map_visualization

- No changes
