### PR TITLE
Add python-gnupg to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1162,6 +1162,12 @@ python-gitpython-pip:
   ubuntu:
     pip:
       packages: [gitpython]
+python-gnupg:
+  arch: [python2-gnupg]
+  debian: [python-gnupg]
+  fedora: [python-gnupg]
+  gentoo: [dev-python/python-gnupg]
+  ubuntu: [python-gnupg]
 python-google-cloud-vision-pip:
   debian:
     pip:


### PR DESCRIPTION
The dependency is required for encryption support of Python `Bag` class: https://github.com/ros/ros_comm/pull/1206.

Web links to packages:
Arch: https://www.archlinux.org/packages/community/any/python2-gnupg/
Debian: https://packages.debian.org/stretch/python-gnupg
Fedora: https://apps.fedoraproject.org/packages/python-gnupg
Gentoo: https://packages.gentoo.org/packages/dev-python/python-gnupg
Ubuntu: https://packages.ubuntu.com/xenial/python-gnupg