### PR TITLE
dynamic_transform_publisher: 1.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2672,6 +2672,17 @@ repositories:
       url: https://github.com/ros/dynamic_reconfigure.git
       version: master
     status: maintained
+  dynamic_transform_publisher:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/athackst/dynamic_transform_publisher-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/athackst/dynamic_transform_publisher.git
+      version: master
+    status: maintained
   dynamicvoronoi:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_transform_publisher` to `1.0.1-1`:

- upstream repository: https://github.com/athackst/dynamic_transform_publisher.git
- release repository: https://github.com/athackst/dynamic_transform_publisher-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## dynamic_transform_publisher

```
* removed tf from CMakelists.txt
* updated package.xml to format 2
* marker and rqt_reconfigure update sync
* Updated x,y,z limits to 100
* added interactive marker
* renamed library files
* added documentation, updated namespacing
* fixed startup with command line arguments
* changed to broacasting on timer
* moved reconfigure server to base class, moved base class to own header
* updated dynamic_tranform_publisher to use dynamic_reconfigure
* created dynamic reconfigure based static transform publisher
* Contributors: Allison Thackston
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ros/rosdistro/16468)
<!-- Reviewable:end -->
