### PR TITLE
gx_sound: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2762,7 +2762,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/groove-x/gx_sound-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/groove-x/gx_sound.git
+      version: master
+    status: maintained
   haf_grasping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gx_sound` to `0.2.1-0`:

- upstream repository: https://github.com/groove-x/gx_sound.git
- release repository: https://github.com/groove-x/gx_sound-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.2.0-0`

## gx_sound

- No changes

## gx_sound_msgs

- No changes

## gx_sound_player

```
* Add missing dependency
* Contributors: Yuma.M
```
