### PR TITLE
catkin_virtualenv: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1531,6 +1531,26 @@ repositories:
       url: https://github.com/pyros-dev/catkin_pip.git
       version: indigo
     status: developed
+  catkin_virtualenv:
+    doc:
+      type: git
+      url: https://github.com/locusrobotics/catkin_virtualenv-release.git
+      version: devel
+    release:
+      packages:
+      - catkin_virtualenv
+      - test_catkin_virtualenv
+      - test_catkin_virtualenv_py3
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/locusrobotics/catkin_virtualenv-release.git
+      version: 0.1.3-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/locusrobotics/catkin_virtualenv-release.git
+      version: devel
+    status: developed
   certifi:
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1534,7 +1534,7 @@ repositories:
   catkin_virtualenv:
     doc:
       type: git
-      url: https://github.com/locusrobotics/catkin_virtualenv-release.git
+      url: https://github.com/locusrobotics/catkin_virtualenv.git
       version: devel
     release:
       packages:
@@ -1547,7 +1547,7 @@ repositories:
       version: 0.1.3-0
     source:
       type: git
-      url: https://github.com/locusrobotics/catkin_virtualenv-release.git
+      url: https://github.com/locusrobotics/catkin_virtualenv.git
       version: devel
     status: developed
   certifi:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1546,7 +1546,6 @@ repositories:
       url: https://github.com/locusrobotics/catkin_virtualenv-release.git
       version: 0.1.3-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/locusrobotics/catkin_virtualenv-release.git
       version: devel


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_virtualenv` to `0.1.3-0`:

- upstream repository: https://github.com/locusrobotics/catkin_virtualenv.git
- release repository: https://github.com/locusrobotics/catkin_virtualenv-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## catkin_virtualenv

```
* Simplify install path
* Clean up vars
* Instantiate both a devel- and install-space venv
* Contributors: Paul Bovbel
```

## test_catkin_virtualenv

- No changes

## test_catkin_virtualenv_py3

- No changes
