### PR TITLE
catkin_virtualenv: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -823,6 +823,25 @@ repositories:
       url: https://github.com/pyros-dev/catkin_pip.git
       version: devel
     status: developed
+  catkin_virtualenv:
+    doc:
+      type: git
+      url: https://github.com/locusrobotics/catkin_virtualenv.git
+      version: devel
+    release:
+      packages:
+      - catkin_virtualenv
+      - test_catkin_virtualenv
+      - test_catkin_virtualenv_py3
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/locusrobotics/catkin_virtualenv-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/locusrobotics/catkin_virtualenv.git
+      version: devel
+    status: developed
   certifi:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_virtualenv` to `0.1.3-0`:

- upstream repository: https://github.com/locusrobotics/catkin_virtualenv.git
- release repository: https://github.com/locusrobotics/catkin_virtualenv-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## catkin_virtualenv

```
* Simplify install path
* Clean up vars
* Instantiate both a devel- and install-space venv
* Contributors: Paul Bovbel
```

## test_catkin_virtualenv

- No changes

## test_catkin_virtualenv_py3

- No changes
