### PR TITLE
catkin_virtualenv: 0.1.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -303,6 +303,25 @@ repositories:
       url: https://github.com/pyros-dev/catkin_pip.git
       version: devel
     status: developed
+  catkin_virtualenv:
+    doc:
+      type: git
+      url: https://github.com/locusrobotics/catkin_virtualenv.git
+      version: devel
+    release:
+      packages:
+      - catkin_virtualenv
+      - test_catkin_virtualenv
+      - test_catkin_virtualenv_py3
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/locusrobotics/catkin_virtualenv-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/locusrobotics/catkin_virtualenv.git
+      version: devel
+    status: developed
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_virtualenv` to `0.1.3-0`:

- upstream repository: https://github.com/locusrobotics/catkin_virtualenv.git
- release repository: https://github.com/locusrobotics/catkin_virtualenv-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## catkin_virtualenv

```
* Simplify install path
* Clean up vars
* Instantiate both a devel- and install-space venv
* Contributors: Paul Bovbel
```

## test_catkin_virtualenv

- No changes

## test_catkin_virtualenv_py3

- No changes
