### PR TITLE
Adding movidius_ncs to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4758,6 +4758,21 @@ repositories:
       url: https://github.com/davetcoleman/moveit_visual_tools.git
       version: kinetic-devel
     status: developed
+  movidius_ncs:
+    doc:
+      type: git
+      url: https://github.com/intel/ros_intel_movidius_ncs.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/intel/ros_intel_movidius_ncs.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/intel/ros_intel_movidius_ncs.git
+      version: master
+    status: maintained
   mqtt_bridge:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4758,6 +4758,16 @@ repositories:
       url: https://github.com/davetcoleman/moveit_visual_tools.git
       version: kinetic-devel
     status: developed
+  movidius_ncs:
+    doc:
+      type: git
+      url: https://github.com/intel/ros_intel_movidius_ncs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/intel/ros_intel_movidius_ncs.git
+      version: master
+    status: maintained
   mqtt_bridge:
     doc:
       type: git


### PR DESCRIPTION
I'd like movidius_ncs to be indexed and documented on ros.org