### PR TITLE
vrpn: 7.33.1-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3954,11 +3954,22 @@ repositories:
       version: kinetic-devel
     status: maintained
   vrpn:
+    doc:
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: master
     release:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-drivers-gbp/vrpn-release.git
-      version: 0.7.33-0
+      version: 7.33.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: master
+    status: maintained
+    status_description: status
   vrpn_client_ros:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3964,7 +3964,6 @@ repositories:
       url: https://github.com/ros-drivers-gbp/vrpn-release.git
       version: 7.33.1-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/vrpn/vrpn.git
       version: master


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn` to `7.33.1-1`:

- upstream repository: https://github.com/vrpn/vrpn.git
- release repository: https://github.com/ros-drivers-gbp/vrpn-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.7.33-0`
