### PR TITLE
rosserial: 0.7.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6033,14 +6033,13 @@ repositories:
       - rosserial_msgs
       - rosserial_python
       - rosserial_server
-      - rosserial_test
       - rosserial_tivac
       - rosserial_windows
       - rosserial_xbee
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/ros-gbp/rosserial-release.git
-      version: 0.7.6-0
+      version: 0.7.7-0
     source:
       type: git
       url: https://github.com/ros-drivers/rosserial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial` to `0.7.7-0`:

- upstream repository: https://github.com/ros-drivers/rosserial.git
- release repository: https://github.com/ros-gbp/rosserial-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.6.0`
- previous version for package: `0.7.6-0`

## rosserial

- No changes

## rosserial_arduino

```
* Fix catkin lint errors (#296 <https://github.com/ros-drivers/rosserial/issues/296>)
* Add ArduinoTcpHardware to use Arduino Ethernet shield. (#324 <https://github.com/ros-drivers/rosserial/issues/324>)
* Add an example to use Subscriber and ServiceServer as class members. (#321 <https://github.com/ros-drivers/rosserial/issues/321>)
* Added support for the Particle Photon (#292 <https://github.com/ros-drivers/rosserial/issues/292>)
* Fix POLICY CMP0054 unknown (#291 <https://github.com/ros-drivers/rosserial/issues/291>)
* Use ESP8266 header only if defined. (#288 <https://github.com/ros-drivers/rosserial/issues/288>)
* Add Esp8266 support and an example (#279 <https://github.com/ros-drivers/rosserial/issues/279>)
* Add support for STM32F1 with stm32duino. (#281 <https://github.com/ros-drivers/rosserial/issues/281>)
* Contributors: Bei Chen Liu, David Portugal, Dmitry Kargin, Mike Purvis, Romain Reignier, Valentin VERGEZ, khancyr
```

## rosserial_client

```
* Add overall spin timeout to rosserial read. (#334 <https://github.com/ros-drivers/rosserial/issues/334>)
* Fixing formatting on files. (#333 <https://github.com/ros-drivers/rosserial/issues/333>)
* Fix catkin lint errors (#296 <https://github.com/ros-drivers/rosserial/issues/296>)
* fix spinOnce timeout : 5ms -> 5s (#326 <https://github.com/ros-drivers/rosserial/issues/326>)
* [Client] Fix a warning in comparison. (#323 <https://github.com/ros-drivers/rosserial/issues/323>)
* Use const in ros namespace instead of #define for constants. Fix #283 <https://github.com/ros-drivers/rosserial/issues/283> (#318 <https://github.com/ros-drivers/rosserial/issues/318>)
* Fix CMP0046 warnings in catkin-built firmwares (#320 <https://github.com/ros-drivers/rosserial/issues/320>)
* Prevent time variable overflow leading to parameter timeout error (#293 <https://github.com/ros-drivers/rosserial/issues/293>)
* Add class member method callback support for Service Server. (#282 <https://github.com/ros-drivers/rosserial/issues/282>)
* Added capability to specify timeout in getParam methods (#278 <https://github.com/ros-drivers/rosserial/issues/278>)
* Contributors: 1r0b1n0, Alessandro Francescon, Bei Chen Liu, David Portugal, Dmitry Kargin, Mike O'Driscoll, Mike Purvis, Romain Reignier
```

## rosserial_embeddedlinux

```
* Copy src/examples to install dir so make_libraries.py doesn't fail (#336 <https://github.com/ros-drivers/rosserial/issues/336>)
* Fix catkin lint errors (#296 <https://github.com/ros-drivers/rosserial/issues/296>)
* Contributors: Bei Chen Liu, Jonny Dark
```

## rosserial_mbed

```
* Fix catkin lint errors (#296 <https://github.com/ros-drivers/rosserial/issues/296>)
* Contributors: Bei Chen Liu
```

## rosserial_msgs

```
* Fix catkin lint errors (#296 <https://github.com/ros-drivers/rosserial/issues/296>)
* Contributors: Bei Chen Liu
```

## rosserial_python

```
* Fix catkin lint errors (#296 <https://github.com/ros-drivers/rosserial/issues/296>)
* pyserial bug workaround to fix rosserial_test test against SerialClient.py (#313 <https://github.com/ros-drivers/rosserial/issues/313>)
* Add requestTopics to correct publish before setup (#308 <https://github.com/ros-drivers/rosserial/issues/308>)
* Contributors: Bei Chen Liu, Tom O'Connell
```

## rosserial_server

```
* Fix catkin lint errors (#296 <https://github.com/ros-drivers/rosserial/issues/296>)
* Contributors: Bei Chen Liu
```

## rosserial_tivac

```
* Fix catkin lint errors (#296 <https://github.com/ros-drivers/rosserial/issues/296>)
* Contributors: Bei Chen Liu
```

## rosserial_windows

```
* Fix catkin lint errors (#296 <https://github.com/ros-drivers/rosserial/issues/296>)
* Contributors: Bei Chen Liu
```

## rosserial_xbee

```
* Fix catkin lint errors (#296 <https://github.com/ros-drivers/rosserial/issues/296>)
* Contributors: Bei Chen Liu
```
