### PR TITLE
pid: 0.0.23-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9196,7 +9196,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/AndyZe/pid-release.git
-      version: 0.0.20-0
+      version: 0.0.23-0
     source:
       type: git
       url: https://bitbucket.org/AndyZe/pid.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pid` to `0.0.23-0`:

- upstream repository: https://bitbucket.org/AndyZe/pid
- release repository: https://github.com/AndyZe/pid-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.0.20-0`
