### PR TITLE
[dep] Add yamllint.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4807,6 +4807,19 @@ yaml-cpp:
     xenial: [libyaml-cpp-dev]
     yakkety: [libyaml-cpp-dev]
     zesty: [libyaml-cpp-dev]
+yamllint:
+  arch: [yamllint]
+  debian:
+    buster: [yamllint]
+    stretch: [yamllint]
+  fedora: [yamllint]
+  gentoo: [dev-util/yamllint]
+  ubuntu:
+    artful: [yamllint]
+    bionic: [yamllint]
+    xenial: [yamllint]
+    yakkety: [yamllint]
+    zesty: [yamllint]
 yasm:
   arch: [yasm]
   debian: [yasm]


### PR DESCRIPTION
- Arch  https://aur.archlinux.org/packages/yamllint/  (not sure if there's any difference among distros)
- Gentoo https://gpo.zugaina.org/dev-util/yamllint     (not even sure if this the official website but this is the only one I found)
- Debian https://packages.debian.org/source/buster/yamllint
- Fedora https://admin.fedoraproject.org/pkgdb/package/rpms/yamllint/  (not sure if there's any difference among distros)
- Ubuntu https://packages.ubuntu.com/source/xenial/yamllint  (only available Xenial onward)