### PR TITLE
Revert "[kinetic] Added release for hebiros"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2783,17 +2783,6 @@ repositories:
       type: git
       url: https://github.com/HebiRobotics/HEBI-ROS.git
       version: master
-    release:
-      packages:
-      - hebiros
-      - hebiros_advanced_examples
-      - hebiros_basic_examples
-      - hebiros_description
-      - x_demo
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/HebiRobotics/hebiros-release.git
-      version: 0.0.3-0
     status: maintained
   hector_gazebo:
     doc:


### PR DESCRIPTION
Reverts ros/rosdistro#16489

Not all build dependencies are declared. Ticketed upstream.

https://github.com/HebiRobotics/HEBI-ROS/issues/11
 Once this is resolved a new run of bloom should readd this entry with the new version.
