### PR TITLE
removing sns_ik and sns_ik_examples due to failure to build

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9122,8 +9122,6 @@ repositories:
   sns-ik:
     release:
       packages:
-      - sns_ik
-      - sns_ik_examples
       - sns_ik_lib
       tags:
         release: release/kinetic/{package}/{version}


### PR DESCRIPTION
Ticketed upstream: https://github.com/RethinkRobotics-opensource/sns_ik/issues/60

Partial reversion of #16206
@IanTheEngineer FYI