### PR TITLE
removing packages failing to build continuously

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6982,14 +6982,10 @@ repositories:
       packages:
       - cm_740_module
       - op3_action_module
-      - op3_base_module
       - op3_direct_control_module
       - op3_head_control_module
       - op3_kinematics_dynamics
-      - op3_manager
-      - op3_walking_module
       - open_cr_module
-      - robotis_op3
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-OP3-release.git


### PR DESCRIPTION
- op3_base_module
- op3_manager
- op3_walking_module

And blocked dependency robotis_op3

Ticketed upstream: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3/issues/24
Partial reversion of https://github.com/ros/rosdistro/pull/16217
A new bloom release will restore these packages.

@robotpilot FYI