### PR TITLE
vrpn: 7.33.1-3 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3989,7 +3989,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-drivers-gbp/vrpn-release.git
-      version: 7.33.1-2
+      version: 7.33.1-3
     source:
       type: git
       url: https://github.com/vrpn/vrpn.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn` to `7.33.1-3`:

- upstream repository: https://github.com/vrpn/vrpn.git
- release repository: https://github.com/ros-drivers-gbp/vrpn-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `7.33.1-2`
