### PR TITLE
vrpn_client_ros: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10648,7 +10648,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/vrpn_client_ros-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/ros-drivers/vrpn_client_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn_client_ros` to `0.2.1-0`:

- upstream repository: https://github.com/clearpathrobotics/vrpn_client_ros.git
- release repository: https://github.com/ros-drivers-gbp/vrpn_client_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.2.0-0`

## vrpn_client_ros

```
* Fix warnings; update maintainer email; switch to package format 2
* Contributors: Paul Bovbel
```
