### PR TITLE
vrpn: 7.33.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10633,7 +10633,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/vrpn-release.git
-      version: 0.7.33-9
+      version: 7.33.1-1
     source:
       type: git
       url: https://github.com/vrpn/vrpn.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn` to `7.33.1-1`:

- upstream repository: https://github.com/vrpn/vrpn.git
- release repository: https://github.com/ros-drivers-gbp/vrpn-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.7.33-9`
