### PR TITLE
vrpn_client_ros: 0.2.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4005,7 +4005,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-drivers-gbp/vrpn_client_ros-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn_client_ros` to `0.2.2-0`:

- upstream repository: https://github.com/clearpathrobotics/vrpn_client_ros.git
- release repository: https://github.com/ros-drivers-gbp/vrpn_client_ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.2.1-0`

## vrpn_client_ros

```
* Fixup find_package
* Contributors: Paul Bovbel
```
