### PR TITLE
[lunar] Removing naoqi_libqi

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1792,13 +1792,6 @@ repositories:
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
       version: master
     status: maintained
-  naoqi_libqi:
-    release:
-      tags:
-        release: release/lunar/{package}/{version}
-      url: https://github.com/ros-naoqi/libqi-release.git
-      version: 2.5.0-1
-    status: maintained
   nav_pcontroller:
     doc:
       type: git


### PR DESCRIPTION
As discussed in https://github.com/ros/rosdistro/pull/16471 this reverts the release of `naoqi_libqi` for the upcoming sync and waiting for a new release building on all platforms
@suryaambrose FYI