### PR TITLE
qb_device: 1.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6485,7 +6485,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
-      version: 1.1.0-0
+      version: 1.2.2-0
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbdevice-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_device` to `1.2.2-0`:

- upstream repository: https://bitbucket.org/qbrobotics/qbdevice-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.1.0-0`

## qb_device

- No changes

## qb_device_bringup

```
* Fix launch file
```

## qb_device_control

```
* Add a step (square) wave trajectory generator
```

## qb_device_description

- No changes

## qb_device_driver

```
* Reduce communication errors
```

## qb_device_hardware_interface

```
* Fix possible fault on registration
* Refactor service clients management
```

## qb_device_msgs

- No changes

## qb_device_srvs

- No changes
