### PR TITLE
handeye: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4181,6 +4181,21 @@ repositories:
       url: https://github.com/tork-a/hakuto.git
       version: master
     status: developed
+  handeye:
+    doc:
+      type: git
+      url: https://github.com/crigroup/handeye.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/crigroup/handeye-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/crigroup/handeye.git
+      version: master
+    status: developed
   handle_detector:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `handeye` to `0.1.0-0`:

- upstream repository: https://github.com/crigroup/handeye.git
- release repository: https://github.com/crigroup/handeye-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## handeye

```
* Initial release
* Contributors: Francisco, fsuarez6
```
