### PR TITLE
control_toolbox: 1.16.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1337,7 +1337,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/control_toolbox-release.git
-      version: 1.15.0-0
+      version: 1.16.0-0
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `1.16.0-0`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros-gbp/control_toolbox-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.15.0-0`

## control_toolbox

```
* switched to industrial_ci
* Add control_msgs to CATKIN_DEPENDS.
* Contributors: Bence Magyar, Mathias Luedtke, Mike Purvis
```
