### PR TITLE
auv_msgs: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -805,7 +805,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/oceansystemslab/auv_msgs-release.git
-      version: 0.0.1-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/oceansystemslab/auv_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `auv_msgs` to `0.1.0-0`:

- upstream repository: https://github.com/oceansystemslab/auv_msgs.git
- release repository: https://github.com/oceansystemslab/auv_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.0.1-0`

## auv_msgs

```
* updated maintainers list
* Added WorldWaypointRequest and renamed Requested msgs
* Contributors: Bence Magyar, Ignacio Carlucho
```
