### PR TITLE
geometric_shapes: 0.5.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2530,7 +2530,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.5.2-0
+      version: 0.5.3-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.5.3-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.5.2-0`

## geometric_shapes

```
* [enhance] Add warning about common Assimp bug (#63 <https://github.com/ros-planning/geometric_shapes/issues/63>)
* [maintenance] Update maintainers (#66 <https://github.com/ros-planning/geometric_shapes/issues/66>)
* Contributors: Dave Coleman
```
