### PR TITLE
geometric_shapes: 0.4.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3804,7 +3804,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.4.5-0
+      version: 0.4.6-0
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.4.6-0`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.4.5-0`

## geometric_shapes

```
* [enhance] Add warning about common Assimp bug (#63 <https://github.com/ros-planning/geometric_shapes/issues/63>)
* [maintenance] Update maintainers (#66 <https://github.com/ros-planning/geometric_shapes/issues/66>)
* Contributors: Dave Coleman
```
