### PR TITLE
sainsmart_relay_usb: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13560,6 +13560,21 @@ repositories:
       url: https://github.com/RobotnikAutomation/s3000_laser.git
       version: indigo-devel
     status: maintained
+  sainsmart_relay_usb:
+    doc:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb
+      version: default
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/DataspeedInc-release/sainsmart_relay_usb-release.git
+      version: 0.0.1-0
+    source:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb
+      version: default
+    status: maintained
   sbpl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sainsmart_relay_usb` to `0.0.1-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb
- release repository: https://github.com/DataspeedInc-release/sainsmart_relay_usb-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## sainsmart_relay_usb

```
* Initial release
* Contributors: Kevin Hallenbeck
```
