### PR TITLE
sainsmart_relay_usb: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8853,6 +8853,21 @@ repositories:
       url: https://github.com/davetcoleman/rviz_visual_tools.git
       version: kinetic-devel
     status: developed
+  sainsmart_relay_usb:
+    doc:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb
+      version: default
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/sainsmart_relay_usb-release.git
+      version: 0.0.1-0
+    source:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb
+      version: default
+    status: maintained
   sbg_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sainsmart_relay_usb` to `0.0.1-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb
- release repository: https://github.com/DataspeedInc-release/sainsmart_relay_usb-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## sainsmart_relay_usb

```
* Initial release
* Contributors: Kevin Hallenbeck
```
