### PR TITLE
jog_arm: 0.0.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3350,6 +3350,22 @@ repositories:
       url: https://github.com/gstavrinos/jaguar-release.git
       version: 0.1.0-0
     status: developed
+  jog_arm:
+    doc:
+      type: git
+      url: http://wiki.ros.org/jog_arm
+      version: kinetic
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/UTNuclearRoboticsPublic/jog_arm-release.git
+      version: 0.0.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/jog_arm.git
+      version: kinetic
+    status: developed
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jog_arm` to `0.0.3-1`:

- upstream repository: https://github.com/UTNuclearRoboticsPublic/jog_arm.git
- release repository: https://github.com/UTNuclearRoboticsPublic/jog_arm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`
