### PR TITLE
vision_msgs: 0.0.1-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3902,6 +3902,17 @@ repositories:
       url: https://github.com/ros-drivers/usb_cam.git
       version: develop
     status: unmaintained
+  vision_msgs:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/Kukanani/vision_msgs-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/Kukanani/vision_msgs.git
+      version: lunar-devel
+    status: maintained
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_msgs` to `0.0.1-1`:

- upstream repository: https://github.com/Kukanani/vision_msgs.git
- release repository: https://github.com/Kukanani/vision_msgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## vision_msgs

```
* Initial commit
* Contributors: Adam Allevato, Martin Gunther, procopiostein
```
