### PR TITLE
hebiros: 0.0.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2783,6 +2783,17 @@ repositories:
       type: git
       url: https://github.com/HebiRobotics/HEBI-ROS.git
       version: master
+    release:
+      packages:
+      - hebiros
+      - hebiros_advanced_examples
+      - hebiros_basic_examples
+      - hebiros_description
+      - x_demo
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/HebiRobotics/hebiros-release.git
+      version: 0.0.4-1
     status: maintained
   hector_gazebo:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `hebiros` to `0.0.4-1`:

- upstream repository: https://github.com/HebiRobotics/HEBI-ROS.git
- release repository: https://github.com/HebiRobotics/hebiros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`
