### PR TITLE
sainsmart_relay_usb: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13569,7 +13569,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/DataspeedInc-release/sainsmart_relay_usb-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: hg
       url: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb


### PR DESCRIPTION
Increasing version of package(s) in repository `sainsmart_relay_usb` to `0.0.2-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb
- release repository: https://github.com/DataspeedInc-release/sainsmart_relay_usb-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.0.1-0`

## sainsmart_relay_usb

```
* Added build dependency on roslib, needed for the ROS_DISTRO environment variable
* Contributors: Kevin Hallenbeck
```
