### PR TITLE
dnn_detect: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1619,6 +1619,17 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: indigo-devel
     status: maintained
+  dnn_detect:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/UbiquityRobotics-release/dnn_detect-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/UbiquityRobotics/dnn_detect.git
+      version: kinetic-devel
+    status: developed
   dr_base:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `dnn_detect` to `0.0.2-0`:

- upstream repository: https://github.com/UbiquityRobotics/dnn_detect.git
- release repository: https://github.com/UbiquityRobotics-release/dnn_detect-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## dnn_detect

```
* Initial commit
* Contributors: Jim Vaughan
```
