### PR TITLE
Adding ros_yesense_imu to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7681,7 +7681,7 @@ repositories:
     source:
       type: git
       url: https://github.com/wangzhecoder/ros_yesense_imu.git
-      version: kinetic
+      version: master
     status: maintained
   rosaria:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -31,7 +31,7 @@ repositories:
       - abb_resources
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-industrial-release/abb-release.git
+      url: https://github.com/ros-industrial/abb.git
       version: 1.3.0-1
     source:
       type: git
@@ -7677,6 +7677,12 @@ repositories:
       url: https://github.com/yuma-m/ros_wild.git
       version: master
     status: developed
+  ros_yesense_imu:
+    source:
+      type: git
+      url: https://github.com/wangzhecoder/ros_yesense_imu.git
+      version: kinetic
+    status: maintained
   rosaria:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -35,7 +35,7 @@ repositories:
       version: 1.3.0-1
     source:
       type: git
-      url: https://github.com/ros-industrial/abb.git
+      url: https://github.com/wangzhecoder/ros_yesense_imu.git
       version: kinetic
     status: developed
   abb_experimental:


### PR DESCRIPTION
I'd like my ros_yesense_imu to be indexed and documented on ros.org