### PR TITLE
catkin_virtualenv: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1537,14 +1537,10 @@ repositories:
       url: https://github.com/locusrobotics/catkin_virtualenv.git
       version: devel
     release:
-      packages:
-      - catkin_virtualenv
-      - test_catkin_virtualenv
-      - test_catkin_virtualenv_py3
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/locusrobotics/catkin_virtualenv-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/locusrobotics/catkin_virtualenv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_virtualenv` to `0.1.4-0`:

- upstream repository: https://github.com/locusrobotics/catkin_virtualenv.git
- release repository: https://github.com/locusrobotics/catkin_virtualenv-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.1.3-0`

## catkin_virtualenv

```
* Fixup CMake and local directory cleanup
* Merge pull request #9 <https://github.com/locusrobotics/catkin_virtualenv/issues/9> from locusrobotics/python3-compat
  Python 3 compatiblity tweaks
* Add base requirements file for python3 catkin; include extra data about requirement merge failure
* Fix cmake lint errors
* Add XML schema, README badges, fix travis config for debian jessie, and remove legacy scripts
* Contributors: Paul Bovbel
```
