### PR TITLE
pose_cov_ops: 0.1.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6292,7 +6292,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pose_cov_ops` to `0.1.6-0`:

- upstream repository: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
- release repository: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.1.5-0`

## pose_cov_ops

```
* Fix catkin dependencies
* Use C++14
* Fix build against MRPT 1.5 and 2.0
* Contributors: Javier G. Monroy, Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco
```
