### PR TITLE
Add denso_robot_ros to documentation index for distro

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1371,6 +1371,33 @@ repositories:
       url: https://github.com/start-jsk/denso.git
       version: hydro-devel
     status: developed
+  denso_robot_ros:
+    doc:
+      type: git
+      url: https://github.com/DENSORobot/denso_robot_ros.git
+      version: hydro-devel
+    release:
+      packages:
+      - bcap_core
+      - bcap_service
+      - bcap_service_test
+      - denso_robot_bringup
+      - denso_robot_control
+      - denso_robot_core
+      - denso_robot_core_test
+      - denso_robot_descriptions
+      - denso_robot_gazebo
+      - denso_robot_moveit_config
+      - denso_robot_ros
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/DENSORobot/denso_robot_ros-release.git
+      version: 3.0.1-0
+    source:
+      type: git
+      url: https://github.com/DENSORobot/denso_robot_ros.git
+      version: hydro-devel
+    status: developed
   depthcloud_encoder:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1371,33 +1371,6 @@ repositories:
       url: https://github.com/start-jsk/denso.git
       version: hydro-devel
     status: developed
-  denso_robot_ros:
-    doc:
-      type: git
-      url: https://github.com/DENSORobot/denso_robot_ros.git
-      version: hydro-devel
-    release:
-      packages:
-      - bcap_core
-      - bcap_service
-      - bcap_service_test
-      - denso_robot_bringup
-      - denso_robot_control
-      - denso_robot_core
-      - denso_robot_core_test
-      - denso_robot_descriptions
-      - denso_robot_gazebo
-      - denso_robot_moveit_config
-      - denso_robot_ros
-      tags:
-        release: release/hydro/{package}/{version}
-      url: https://github.com/DENSORobot/denso_robot_ros-release.git
-      version: 3.0.1-0
-    source:
-      type: git
-      url: https://github.com/DENSORobot/denso_robot_ros.git
-      version: hydro-devel
-    status: developed
   depthcloud_encoder:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2468,6 +2468,33 @@ repositories:
       url: https://github.com/start-jsk/denso.git
       version: indigo-devel
     status: developed
+  denso_robot_ros:
+    doc:
+      type: git
+      url: https://github.com/DENSORobot/denso_robot_ros.git
+      version: indigo-devel
+    release:
+      packages:
+      - bcap_core
+      - bcap_service
+      - bcap_service_test
+      - denso_robot_bringup
+      - denso_robot_control
+      - denso_robot_core
+      - denso_robot_core_test
+      - denso_robot_descriptions
+      - denso_robot_gazebo
+      - denso_robot_moveit_config
+      - denso_robot_ros
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/DENSORobot/denso_robot_ros-release.git
+      version: 3.0.1-0
+    source:
+      type: git
+      url: https://github.com/DENSORobot/denso_robot_ros.git
+      version: indigo-devel
+    status: developed
   depth_nav_tools:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1570,6 +1570,33 @@ repositories:
       url: https://github.com/start-jsk/denso.git
       version: kinetic-devel
     status: developed
+  denso_robot_ros:
+    doc:
+      type: git
+      url: https://github.com/DENSORobot/denso_robot_ros.git
+      version: kinetic-devel
+    release:
+      packages:
+      - bcap_core
+      - bcap_service
+      - bcap_service_test
+      - denso_robot_bringup
+      - denso_robot_control
+      - denso_robot_core
+      - denso_robot_core_test
+      - denso_robot_descriptions
+      - denso_robot_gazebo
+      - denso_robot_moveit_config
+      - denso_robot_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/DENSORobot/denso_robot_ros-release.git
+      version: 3.0.1-0
+    source:
+      type: git
+      url: https://github.com/DENSORobot/denso_robot_ros.git
+      version: kinetic-devel
+    status: developed
   depth_nav_tools:
     doc:
       type: git


### PR DESCRIPTION
I'd like denso_robot_ros to be indexed and documented on ros.org.
This is the package for denso robot developed by DENSO WAVE.
ros.org already has denso package developed by JSK.
We will migrate from the JSK's package to DENSO WAVE's one in the future.