### PR TITLE
Adding jariza/netatmo2ros to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5349,6 +5349,16 @@ repositories:
       url: https://github.com/nerian-vision/nerian_stereo.git
       version: master
     status: developed
+  netatmo:
+    doc:
+      type: git
+      url: https://github.com/jariza/netatmo2ros.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/jariza/netatmo2ros.git
+      version: master
+    status: maintained
   netft_utils:
     doc:
       type: git


### PR DESCRIPTION
The packaged was announced in https://discourse.ros.org/t/netatmo-weatherstation-node/3342