### PR TITLE
open_street_map: 0.2.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5713,6 +5713,15 @@ repositories:
       type: git
       url: https://github.com/ros-geographic-info/open_street_map.git
       version: master
+    release:
+      packages:
+      - osm_cartography
+      - route_network
+      - test_osm
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-geographic-info/open_street_map-release.git
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/ros-geographic-info/open_street_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_street_map` to `0.2.4-0`:

- upstream repository: https://github.com/ros-geographic-info/open_street_map.git
- release repository: https://github.com/ros-geographic-info/open_street_map-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## osm_cartography

```
* Convert to package xml format 2 and add launch file dependencies
* Possibility to compute paths between GeoPoints.
* Remove unused map file.
* Add Ixtapa testing map.
* Add default configuration for RVIZ.
* Create new launch file to start all the needed nodes to plan on a map.
* Contributors: Bence Magyar, Diego Ramos
```

## route_network

```
* Convert to package xml format 2 and add launch file dependencies
* Create new launch file to start all the needed nodes to plan on a map.
* Update to use the original version of the GeoPath msg and the new version of the GetGeoPath srv.
* Complete function documentation/comments for the new features.
* Add an RVIZ interface to plan and directly select start and goal positions by clicking on the map.
* Add the possibility to plan from and to geographic points that are not nodes of the graph, but rather lie nearby.
* Contributors: Bence Magyar, Diego Ramos
```

## test_osm

```
* Convert to package xml format 2, add rostest dependency
* Contributors: Bence Magyar
```
