### PR TITLE
python: add gpiozero as pip dependency

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -947,10 +947,6 @@ gperftools:
   fedora: [gperftools, gperftools-devel]
   gentoo: [dev-util/gperf]
   ubuntu: [google-perftools, libgoogle-perftools-dev]
-gpiozero:
-  ubuntu:
-    pip:
-      packages: [gpiozero]
 gpsd:
   debian: [gpsd]
   fedora: [gpsd]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -947,6 +947,10 @@ gperftools:
   fedora: [gperftools, gperftools-devel]
   gentoo: [dev-util/gperf]
   ubuntu: [google-perftools, libgoogle-perftools-dev]
+gpiozero:
+  ubuntu:
+    pip:
+      packages: [gpiozero]
 gpsd:
   debian: [gpsd]
   fedora: [gpsd]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -44,37 +44,6 @@ epydoc:
     pip:
       packages: [epydoc]
   ubuntu: [python-epydoc]
-python-gpiozero:
-  debian:
-    buster: [python-gpiozero]
-    jessie:
-      pip:
-        packages: [gpiozero]
-    stretch:
-      pip:
-        packages: [gpiozero]
-  ubuntu:
-    artful: [python-gpiozero]
-    bionic: [python-gpiozero]
-    trusty:
-      pip:
-        packages: [gpiozero]
-    utopic:
-      pip:
-        packages: [gpiozero]
-    vivid:
-      pip:
-        packages: [gpiozero]
-    wily:
-      pip:
-        packages: [gpiozero]
-    xenial:
-      pip:
-        packages: [gpiozero]
-    yakkety:
-      pip:
-        packages: [gpiozero]
-    zesty: [python-gpiozero]
 gunicorn:
   debian: [gunicorn]
   fedora: [python-gunicorn]
@@ -1221,6 +1190,37 @@ python-googleapi:
     wily_python3: [python3-googleapi]
     xenial: [python-googleapi]
     xenial_python3: [python3-googleapi]
+python-gpiozero:
+  debian:
+    buster: [python-gpiozero]
+    jessie:
+      pip:
+        packages: [gpiozero]
+    stretch:
+      pip:
+        packages: [gpiozero]
+  ubuntu:
+    artful: [python-gpiozero]
+    bionic: [python-gpiozero]
+    trusty:
+      pip:
+        packages: [gpiozero]
+    utopic:
+      pip:
+        packages: [gpiozero]
+    vivid:
+      pip:
+        packages: [gpiozero]
+    wily:
+      pip:
+        packages: [gpiozero]
+    xenial:
+      pip:
+        packages: [gpiozero]
+    yakkety:
+      pip:
+        packages: [gpiozero]
+    zesty: [python-gpiozero]
 python-graphviz-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -44,13 +44,33 @@ epydoc:
     pip:
       packages: [epydoc]
   ubuntu: [python-epydoc]
-gpiozero-pip:
+gpiozero:
   debian:
-    pip:
-      packages: [gpiozero]
+    buster: [python-gpiozero]
+    jessie:
+      pip:
+        packages: [gpiozero]
+    stretch:
+      pip:
+        packages: [gpiozero]
   ubuntu:
-    pip:
-      packages: [gpiozero]
+    artful: [python-gpiozero]
+    zesty: [python-gpiozero]
+    xenial:
+      pip:
+        packages: [gpiozero]
+    wily:
+      pip:
+        packages: [gpiozero]
+    vivid:
+      pip:
+        packages: [gpiozero]
+    utopic:
+      pip:
+        packages: [gpiozero]
+    trusty:
+      pip:
+        packages: [gpiozero]
 gunicorn:
   debian: [gunicorn]
   fedora: [python-gunicorn]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -44,7 +44,7 @@ epydoc:
     pip:
       packages: [epydoc]
   ubuntu: [python-epydoc]
-gpiozero:
+python-gpiozero:
   debian:
     buster: [python-gpiozero]
     jessie:
@@ -55,6 +55,7 @@ gpiozero:
         packages: [gpiozero]
   ubuntu:
     artful: [python-gpiozero]
+    bionic: [python-gpiozero]
     trusty:
       pip:
         packages: [gpiozero]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -44,6 +44,13 @@ epydoc:
     pip:
       packages: [epydoc]
   ubuntu: [python-epydoc]
+gpiozero-pip:
+  debian:
+    pip:
+      packages: [gpiozero]
+  ubuntu:
+    pip:
+      packages: [gpiozero]
 gunicorn:
   debian: [gunicorn]
   fedora: [python-gunicorn]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -55,22 +55,25 @@ gpiozero:
         packages: [gpiozero]
   ubuntu:
     artful: [python-gpiozero]
-    zesty: [python-gpiozero]
-    xenial:
-      pip:
-        packages: [gpiozero]
-    wily:
-      pip:
-        packages: [gpiozero]
-    vivid:
+    trusty:
       pip:
         packages: [gpiozero]
     utopic:
       pip:
         packages: [gpiozero]
-    trusty:
+    vivid:
       pip:
         packages: [gpiozero]
+    wily:
+      pip:
+        packages: [gpiozero]
+    xenial:
+      pip:
+        packages: [gpiozero]
+    yakkety:
+      pip:
+        packages: [gpiozero]
+    zesty: [python-gpiozero]
 gunicorn:
   debian: [gunicorn]
   fedora: [python-gunicorn]


### PR DESCRIPTION
Ubuntu is the only platform I have to test, and it's not packaged.