### PR TITLE
python: add RPi.GPIO as pip dependency

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4035,10 +4035,6 @@ rosemacs-el:
     lucid: [rosemacs-el]
     oneiric: [rosemacs-el]
     precise: [rosemacs-el]
-rpi.gpio:
-  ubuntu:
-    pip:
-      packages: [RPi.GPIO]
 rsync:
   arch: [rsync]
   debian: [rsync]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4035,6 +4035,10 @@ rosemacs-el:
     lucid: [rosemacs-el]
     oneiric: [rosemacs-el]
     precise: [rosemacs-el]
+rpi.gpio:
+  ubuntu:
+    pip:
+      packages: [RPi.GPIO]
 rsync:
   arch: [rsync]
   debian: [rsync]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4006,13 +4006,38 @@ rosbag-metadata-pip:
   ubuntu:
     pip:
       packages: [rosbag-metadata]
-rpi.gpio-pip:
+rpi.gpio:
   debian:
-    pip:
-      packages: [RPi.GPIO]
+    buster: [python-rpi.gpio]
+    jessie:
+      pip:
+        packages: [RPi.GPIO]
+    stretch:
+      pip:
+        packages: [RPi.GPIO]
   ubuntu:
-    pip:
-      packages: [RPi.GPIO]
+    artful: [python-rpi.gpio]
+    zesty: [python-rpi.gpio]
+    xenial:
+      pip:
+        packages: [RPi.GPIO]
+    wily:
+      pip:
+        packages: [RPi.GPIO]
+    vivid:
+      pip:
+        packages: [RPi.GPIO]
+    utopic:
+      pip:
+        packages: [RPi.GPIO]
+    trusty:
+      pip:
+        packages: [RPi.GPIO]
+  fedora:
+    '26': [python-rpi-gpio]
+    '25':
+      pip:
+        packages: [RPi.GPIO]
 rpy2:
   arch: [python-rpy2]
   debian: [python-rpy2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4006,7 +4006,7 @@ rosbag-metadata-pip:
   ubuntu:
     pip:
       packages: [rosbag-metadata]
-rpi.gpio:
+python-rpi.gpio:
   debian:
     buster: [python-rpi.gpio]
     jessie:
@@ -4022,6 +4022,7 @@ rpi.gpio:
     '26': [python-rpi-gpio]
   ubuntu:
     artful: [python-rpi.gpio]
+    bionic: [python-rpi.gpio]
     trusty:
       pip:
         packages: [RPi.GPIO]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4006,6 +4006,13 @@ rosbag-metadata-pip:
   ubuntu:
     pip:
       packages: [rosbag-metadata]
+rpi.gpio-pip:
+  debian:
+    pip:
+      packages: [RPi.GPIO]
+  ubuntu:
+    pip:
+      packages: [RPi.GPIO]
 rpy2:
   arch: [python-rpy2]
   debian: [python-rpy2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4015,29 +4015,32 @@ rpi.gpio:
     stretch:
       pip:
         packages: [RPi.GPIO]
+  fedora:
+    '25':
+      pip:
+        packages: [RPi.GPIO]
+    '26': [python-rpi-gpio]
   ubuntu:
     artful: [python-rpi.gpio]
-    zesty: [python-rpi.gpio]
-    xenial:
-      pip:
-        packages: [RPi.GPIO]
-    wily:
-      pip:
-        packages: [RPi.GPIO]
-    vivid:
+    trusty:
       pip:
         packages: [RPi.GPIO]
     utopic:
       pip:
         packages: [RPi.GPIO]
-    trusty:
+    vivid:
       pip:
         packages: [RPi.GPIO]
-  fedora:
-    '26': [python-rpi-gpio]
-    '25':
+    wily:
       pip:
         packages: [RPi.GPIO]
+    xenial:
+      pip:
+        packages: [RPi.GPIO]
+    yakkety:
+      pip:
+        packages: [RPi.GPIO]
+    zesty: [python-rpi.gpio]
 rpy2:
   arch: [python-rpy2]
   debian: [python-rpy2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2868,6 +2868,42 @@ python-rospkg:
     yakkety_python3: [python3-rospkg]
     zesty: [python-rospkg]
     zesty_python3: [python3-rospkg]
+python-rpi.gpio:
+  debian:
+    buster: [python-rpi.gpio]
+    jessie:
+      pip:
+        packages: [RPi.GPIO]
+    stretch:
+      pip:
+        packages: [RPi.GPIO]
+  fedora:
+    '25':
+      pip:
+        packages: [RPi.GPIO]
+    '26': [python-rpi-gpio]
+  ubuntu:
+    artful: [python-rpi.gpio]
+    bionic: [python-rpi.gpio]
+    trusty:
+      pip:
+        packages: [RPi.GPIO]
+    utopic:
+      pip:
+        packages: [RPi.GPIO]
+    vivid:
+      pip:
+        packages: [RPi.GPIO]
+    wily:
+      pip:
+        packages: [RPi.GPIO]
+    xenial:
+      pip:
+        packages: [RPi.GPIO]
+    yakkety:
+      pip:
+        packages: [RPi.GPIO]
+    zesty: [python-rpi.gpio]
 python-rrdtool:
   debian: [python-rrdtool]
   fedora: [rrdtool-python]
@@ -4006,42 +4042,6 @@ rosbag-metadata-pip:
   ubuntu:
     pip:
       packages: [rosbag-metadata]
-python-rpi.gpio:
-  debian:
-    buster: [python-rpi.gpio]
-    jessie:
-      pip:
-        packages: [RPi.GPIO]
-    stretch:
-      pip:
-        packages: [RPi.GPIO]
-  fedora:
-    '25':
-      pip:
-        packages: [RPi.GPIO]
-    '26': [python-rpi-gpio]
-  ubuntu:
-    artful: [python-rpi.gpio]
-    bionic: [python-rpi.gpio]
-    trusty:
-      pip:
-        packages: [RPi.GPIO]
-    utopic:
-      pip:
-        packages: [RPi.GPIO]
-    vivid:
-      pip:
-        packages: [RPi.GPIO]
-    wily:
-      pip:
-        packages: [RPi.GPIO]
-    xenial:
-      pip:
-        packages: [RPi.GPIO]
-    yakkety:
-      pip:
-        packages: [RPi.GPIO]
-    zesty: [python-rpi.gpio]
 rpy2:
   arch: [python-rpy2]
   debian: [python-rpy2]


### PR DESCRIPTION
I didn't see any other examples in base.yaml that capitalizes the dependency names, so I kept it lower-case, even though the pip package itself is not. Please let me know if that should be changed.