### PR TITLE
fiducials: 0.7.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2163,7 +2163,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/fiducials-release.git
-      version: 0.7.4-0
+      version: 0.7.5-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/fiducials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fiducials` to `0.7.5-0`:

- upstream repository: https://github.com/UbiquityRobotics/fiducials
- release repository: https://github.com/UbiquityRobotics-release/fiducials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.7.4-0`

## aruco_detect

```
* Move create_markers.py to share directory
* Make corner detection on by default.
* Contributors: Jim Vaughan
```

## fiducial_detect

- No changes

## fiducial_lib

- No changes

## fiducial_msgs

- No changes

## fiducial_pose

- No changes

## fiducial_slam

- No changes

## fiducials

- No changes
