### PR TITLE
Add rosdep keys for pyparsing and pytest.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4055,6 +4055,8 @@ python3-pyparsing:
   ubuntu: [python3-pyparsing]
 python3-pytest:
   arch: [python-pytest]
+  ubuntu:
+    bionic: [python3-pytest]
 python3-pytest-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4055,6 +4055,8 @@ python3-pyparsing:
   ubuntu: [python3-pyparsing]
 python3-pytest:
   arch: [python-pytest]
+  debian: [python3-pytest]
+  gentoo: [dev-python/pytest]
   ubuntu: [python3-pytest]
 python3-ruamel.yaml:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4057,7 +4057,6 @@ python3-pytest:
   arch: [python-pytest]
   debian: [python3-pytest]
   fedora: [python3-pytest]
-  gentoo: [dev-python/pytest]
   ubuntu: [python3-pytest]
 python3-ruamel.yaml:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4047,6 +4047,18 @@ python3-pep8:
 python3-pkg-resources:
   debian: [python3-pkg-resources]
   ubuntu: [python3-pkg-resources]
+python3-pyparsing:
+  arch: [python-pyparsing]
+  debian: [python3-pyparsing]
+  fedora: [python3-pyparsing]
+  gentoo: [dev-python/pyparsing]
+  ubuntu: [python3-pyparsing]
+python3-pytest:
+  arch: [python-pytest]
+  debian: [python3-pytest]
+  fedora: [python3-pytest]
+  gentoo: [dev-python/pytest]
+  ubuntu: [python3-pytest]
 python3-ruamel.yaml:
   debian:
     buster: [python3-ruamel.yaml]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4057,16 +4057,6 @@ python3-pytest:
   arch: [python-pytest]
   ubuntu:
     bionic: [python3-pytest]
-python3-pytest-pip:
-  debian:
-    pip:
-      packages: [pytest]
-  fedora:
-    pip:
-      packages: [pytest]
-  ubuntu:
-    pip:
-      packages: [pytest]
 python3-ruamel.yaml:
   debian:
     buster: [python3-ruamel.yaml]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4055,8 +4055,7 @@ python3-pyparsing:
   ubuntu: [python3-pyparsing]
 python3-pytest:
   arch: [python-pytest]
-  ubuntu:
-    bionic: [python3-pytest]
+  ubuntu: [python3-pytest]
 python3-ruamel.yaml:
   debian:
     buster: [python3-ruamel.yaml]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4055,9 +4055,16 @@ python3-pyparsing:
   ubuntu: [python3-pyparsing]
 python3-pytest:
   arch: [python-pytest]
-  debian: [python3-pytest]
-  fedora: [python3-pytest]
-  ubuntu: [python3-pytest]
+python3-pytest-pip:
+  debian:
+    pip:
+      packages: [pytest]
+  fedora:
+    pip:
+      packages: [pytest]
+  ubuntu:
+    pip:
+      packages: [pytest]
 python3-ruamel.yaml:
   debian:
     buster: [python3-ruamel.yaml]


### PR DESCRIPTION
pytest and pyparsing are needed for ROS 2 development.

pytest is the new recommended test runner for ament_python packages (as far as I understand).

pyparsing is used in the current implementation of the conditional dependencies [[1]] for package.xml format 3

[1]: https://github.com/ros-infrastructure/rep/issues/143

Package references:

* pyparsing
    * arch https://www.archlinux.org/packages/extra/any/python-pyparsing/
    * debian https://packages.debian.org/stable/python3-pyparsing
    * fedora https://apps.fedoraproject.org/packages/python3-pyparsing
    * gentoo https://packages.gentoo.org/packages/dev-python/pyparsing
    * ubuntu
        * trusty https://packages.ubuntu.com/trusty/python-pyparsing
        * xenial https://packages.ubuntu.com/xenial/python-pyparsing
        * artful https://packages.ubuntu.com/artful/python-pyparsing
        * bionic https://packages.ubuntu.com/bionic/python-pyparsing

* pytest
    * arch https://www.archlinux.org/packages/community/any/python-pytest/
    * debian https://packages.debian.org/stable/python3-pytest
    * fedora (2)  https://apps.fedoraproject.org/packages/python3-pytest/sources/
    * gentoo https://packages.gentoo.org/packages/dev-python/pytest
    * ubuntu
        * trusty https://packages.ubuntu.com/trusty/python-pytest
        * xenial https://packages.ubuntu.com/xenial/python-pytest
        * artful https://packages.ubuntu.com/artful/python-pytest
        * bionic https://packages.ubuntu.com/bionic/python-pytest

(2) Fedora's python3-pytest is an EPEL-only package.
I'm not sure if it should be included.