### PR TITLE
tango_ros: 2.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14910,6 +14910,10 @@ repositories:
       version: indigo-devel
     status: developed
   tango_ros:
+    doc:
+      type: git
+      url: https://github.com/Intermodalics/tango_ros.git
+      version: master
     release:
       packages:
       - tango_ros_messages
@@ -14922,11 +14926,6 @@ repositories:
       url: https://github.com/Intermodalics/tango_ros.git
       version: master
     status: developed
-  tango_ros_streamer:
-    doc:
-      type: git
-      url: https://github.com/Intermodalics/tango_ros.git
-      version: master
   tblib:
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14909,6 +14909,19 @@ repositories:
       url: https://github.com/openrobotics/talos_description.git
       version: indigo-devel
     status: developed
+  tango_ros:
+    release:
+      packages:
+      - tango_ros_messages
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/Intermodalics/tango_ros-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/Intermodalics/tango_ros.git
+      version: master
+    status: developed
   tango_ros_streamer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tango_ros` to `2.0.0-0`:

- upstream repository: https://github.com/Intermodalics/tango_ros.git
- release repository: https://github.com/Intermodalics/tango_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`
