### PR TITLE
tango_ros: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9509,6 +9509,10 @@ repositories:
       version: master
     status: developed
   tango_ros:
+    doc:
+      type: git
+      url: https://github.com/Intermodalics/tango_ros.git
+      version: master
     release:
       packages:
       - tango_ros_messages
@@ -9521,11 +9525,6 @@ repositories:
       url: https://github.com/Intermodalics/tango_ros.git
       version: master
     status: developed
-  tango_ros_streamer:
-    doc:
-      type: git
-      url: https://github.com/Intermodalics/tango_ros.git
-      version: master
   tblib:
     release:
       tags:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9508,6 +9508,19 @@ repositories:
       url: https://github.com/swri-robotics/swri_console.git
       version: master
     status: developed
+  tango_ros:
+    release:
+      packages:
+      - tango_ros_messages
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Intermodalics/tango_ros-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/Intermodalics/tango_ros.git
+      version: master
+    status: developed
   tango_ros_streamer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tango_ros` to `2.0.0-0`:

- upstream repository: https://github.com/Intermodalics/tango_ros.git
- release repository: https://github.com/Intermodalics/tango_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`
