### PR TITLE
Disable devel builds for repository tango_ros

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14922,6 +14922,7 @@ repositories:
       url: https://github.com/Intermodalics/tango_ros-release.git
       version: 2.0.0-0
     source:
+      test_commits: false
       type: git
       url: https://github.com/Intermodalics/tango_ros.git
       version: master

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9521,6 +9521,7 @@ repositories:
       url: https://github.com/Intermodalics/tango_ros-release.git
       version: 2.0.0-0
     source:
+      test_commits: false
       type: git
       url: https://github.com/Intermodalics/tango_ros.git
       version: master


### PR DESCRIPTION
It requires submodules and Android SDK/NDK to be installed.
See https://github.com/ros/rosdistro/pull/16551#issuecomment-350252076.