### PR TITLE
nmea_msgs: 1.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8059,7 +8059,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/nmea_msgs-release.git
-      version: 0.1.1-0
+      version: 1.1.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_msgs` to `1.1.0-0`:

- upstream repository: https://github.com/ros-drivers/nmea_msgs.git
- release repository: https://github.com/ros-drivers-gbp/nmea_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.1-0`

## nmea_msgs

```
* Add specific NMEA messages (#5 <https://github.com/ros-drivers/nmea_msgs/issues/5>)
  Add messages for the following NMEA sentences:
  - GPGGA
  - GPGSA
  - GPGSV (and a submessage GpgsvSatellite)
  - GPRMC
  These messages are useful to GPS drivers that parse NMEA sentences
  into specific ROS messages.
* Update maintainer to Ed Venator
* Contributors: Edward Venator, Eric Perko
```
