### PR TITLE
rosbridge_suite: 0.8.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7785,7 +7785,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.8.5-0
+      version: 0.8.6-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.8.6-0`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.8.5-0`

## rosapi

```
* Fixed action_servers filter to allow more than one namespace (#305 <https://github.com/RobotWebTools/rosbridge_suite/issues/305>)
  * Modified action_servers filter to detect topics with more than one namespace
  * Fixed to return the full namespace
* Contributors: milesial
```

## rosbridge_library

```
* Import StringIO from StringIO if python2 and from io if python3 fixes #306 <https://github.com/RobotWebTools/rosbridge_suite/issues/306> (#307 <https://github.com/RobotWebTools/rosbridge_suite/issues/307>)
* Contributors: Jihoon Lee
```

## rosbridge_server

- No changes

## rosbridge_suite

- No changes
