### PR TITLE
roll back image_pipeline for kinetic sync

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3161,7 +3161,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/image_pipeline-release.git
-      version: 1.12.21-0
+      version: 1.12.20-0
     source:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git


### PR DESCRIPTION
https://discourse.ros.org/t/preparing-for-kinetic-sync-2017-11-29/3275/3

This is rolling back the known regression in https://github.com/ros-perception/image_pipeline/pull/299 pending a new release with the patch. There's a proposed fix here: https://github.com/ros-perception/image_pipeline/pull/311 but while that's not merged and released I'm rolling this back to unblock the release. 

Re: #16276

@vrabaud FYI