### PR TITLE
Remove failing hebiros packages

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2838,9 +2838,6 @@ repositories:
       version: master
     release:
       packages:
-      - hebiros
-      - hebiros_advanced_examples
-      - hebiros_basic_examples
       - hebiros_description
       - x_demo
       tags:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2839,7 +2839,6 @@ repositories:
     release:
       packages:
       - hebiros_description
-      - x_demo
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/HebiRobotics/hebiros-release.git


### PR DESCRIPTION
Avoid the build: https://github.com/HebiRobotics/HEBI-ROS/issues/18

Partial rollback of #16522