### PR TITLE
Revert "pose_cov_ops: 0.1.6-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6339,7 +6339,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
-      version: 0.1.6-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git


### PR DESCRIPTION
Reverts ros/rosdistro#16535

Ticketed upstream at: https://github.com/mrpt-ros-pkg/pose_cov_ops/issues/3

@jlblancoc FYI