### PR TITLE
removing version from rdl entries

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6849,7 +6849,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.com/jlack/rdl_release.git
-      version: 0.9.1-1
     source:
       type: git
       url: https://gitlab.com/jlack/rdl.git


### PR DESCRIPTION
This is effectively a rollback of the attempted release #16562 The sourcedeb jobs are all failing because the release repo does not have the distro specific tags or branches. This is likely because the discussion [here](https://github.com/ros/rosdistro/pull/16562#issuecomment-350592013) about missing dependencies and bloom was forced to proceed without generating the specific tags.

Example failing build: http://build.ros.org/job/Ksrc_uX__rdl__ubuntu_xenial__source/5/console

@jlack1987 FYI