### PR TITLE
mavros: 0.22.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1585,7 +1585,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.21.5-0
+      version: 0.22.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.22.0-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.21.5-0`

## libmavconn

- No changes

## mavros

```
* scripts: Use non global mavros-ns allow to work __ns parameter
* update script to support cycle_time on cmd trigger_control
* plugin: Fix setpoint_position code style
* Global position setpoint plugin (#764 <https://github.com/mavlink/mavros/issues/764>)
  * fix fake gps rate
  * fix
  * fix plugin_list
  * fix
  * add global position setpoint plugin
  * add plugin to CMakeList
  * fix bugs
  * add altitude
  * move GPS setpoints to setpoint_position plugin
  * fix gps setpoint subscriber name
  * move  GeographicLib::Geocentric earth inside callback
  * add warning msg if timestamp is not updates
  * Fix ROS_WARN
* doc: move contributing.md to root
* tools: add cogall.sh
* split contribuion guide to GH file
* Readme: add help for cog (#876 <https://github.com/mavlink/mavros/issues/876>)
* Setpoints: remove mav_frame string for local variable
* Setpoints: add params for initial frame
* Setpoint_velocity: uncrustify
* Setpoint_position: uncrustify
* Setpoints: add service to specify frame
* Fix typo #867 <https://github.com/mavlink/mavros/issues/867>
* Improve output of script, replace which with more reliable hash #867 <https://github.com/mavlink/mavros/issues/867>
* Ensure dataset files exist, not just directories #867 <https://github.com/mavlink/mavros/issues/867>
* Remove previous duplicated link
* Fixed issue link.
* Fixed section header. Ready for troubleshooting PR.
* Pushing troubleshooting section for Mavros.
* Contributors: Mohamed Abdelkader Zahana, Pierre Kancir, Vladimir Ermakov, andresR8, fnoop, khancyr, pedro-roque
```

## mavros_extras

```
* scripts: Use non global mavros-ns allow to work __ns parameter
* move member variable earth initialization
* Contributors: Shingo Matsuura, Vladimir Ermakov
```

## mavros_msgs

```
* SetMavFrame.srv: add FRAME_ prefix
* Add cog for SetMavFrame.srv
* Setpoints: add service to specify frame
* Contributors: Pierre Kancir, khancyr
```

## test_mavros

- No changes
