### PR TITLE
rail_object_detector: 2.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10338,7 +10338,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/rail_object_detector-release.git
-      version: 1.0.4-0
+      version: 2.0.1-0
     source:
       type: git
       url: https://github.com/GT-RAIL/rail_object_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_object_detector` to `2.0.1-0`:

- upstream repository: https://github.com/GT-RAIL/rail_object_detector.git
- release repository: https://github.com/gt-rail-release/rail_object_detector-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.0.4-0`

## rail_object_detector

```
* Added Deformable RFCN detector.
* Change darknet node name.
* Change directory structure and file names for darknet.
* Update README with valid weights file, and fix broken links
* Contributors: Andrew Silva, Ryan Petschek, Siddhartha Banerjee, Weiyu Liu
```
