### PR TITLE
teraranger_array_converter: 1.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9649,7 +9649,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger_array_converter-release.git
-      version: 1.1.0-0
+      version: 1.1.1-0
     status: maintained
   teraranger_description:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger_array_converter` to `1.1.1-0`:

- upstream repository: https://github.com/Terabee/teraranger_array_converter.git
- release repository: https://github.com/Terabee/teraranger_array_converter-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.1.0-0`

## teraranger_array_converter

```
* Correct classname and node name
* Add auto-namespacing of default conversion_frame
* Contributors: Pierre-Louis Kabaradjian
```
