### PR TITLE
Add nvidia-ml-py as pip dependency

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1866,9 +1866,6 @@ python-numpydoc:
     xenial: [python-numpydoc]
     zesty: [python-numpydoc]
 python-nvidia-ml-py-pip:
-  osx:
-    pip:
-      packages: [nvidia-ml-py]
   ubuntu:
     pip:
       packages: [nvidia-ml-py]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1865,6 +1865,13 @@ python-numpydoc:
     trusty: [python-numpydoc]
     xenial: [python-numpydoc]
     zesty: [python-numpydoc]
+python-nvidia-ml-py-pip:
+  osx:
+    pip:
+      packages: [nvidia-ml-py]
+  ubuntu:
+    pip:
+      packages: [nvidia-ml-py]
 python-oauth2:
   arch: [python-oauth2]
   debian:


### PR DESCRIPTION
Adds [nvidia-ml-py](https://pypi.python.org/pypi/nvidia-ml-py/7.352.0) which can be used to retrieve information from an NVIDIA GPU.

Required by this [PR](https://github.com/ros/diagnostics/pull/70) which add a GPU monitor to the diagnostic tools.