### PR TITLE
rdl: 0.9.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6849,10 +6849,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.com/jlack/rdl_release.git
+      version: 0.9.3-0
     source:
       type: git
       url: https://gitlab.com/jlack/rdl.git
       version: master
+    status: developed
   realsense_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rdl` to `0.9.3-0`:

- upstream repository: https://gitlab.com/jlack/rdl.git
- release repository: https://gitlab.com/jlack/rdl_release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`
