### PR TITLE
rqt_mrta: 0.2.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12881,7 +12881,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/adrianohrl/rqt_mrta.git
-      version: 0.2.5
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -12891,7 +12891,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/adrianohrl/rqt_mrta.git
-      version: 0.2.5
+      version: indigo-devel
     status: developed
   rqt_msg:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12877,6 +12877,22 @@ repositories:
       url: https://github.com/ros-visualization/rqt_moveit.git
       version: master
     status: maintained
+  rqt_mrta:
+    doc:
+      type: git
+      url: https://github.com/adrianohrl/rqt_mrta.git
+      version: 0.2.5
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/adrianohrl/rqt_mrta-release.git
+      version: 0.2.5-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/adrianohrl/rqt_mrta.git
+      version: 0.2.5
+    status: developed
   rqt_msg:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_mrta` to `0.2.5-0`:

- upstream repository: https://github.com/adrianohrl/rqt_mrta.git
- release repository: https://github.com/adrianohrl/rqt_mrta-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## rqt_mrta

- No changes
