### PR TITLE
mongodb_store: 0.3.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4671,7 +4671,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.3.6-0
+      version: 0.3.7-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.3.7-0`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.3.6-0`

## libmongocxx_ros

```
* Merge pull request #210 <https://github.com/strands-project/mongodb_store/issues/210> from hawesie/kinetic-devel
  Updated to build on OS X with the mongo client legacy version.
* Updated to build on OS X with the mongo client legacy version.
  This makes a couple of changes. For libmongocxx_ros the paths for openssl are added to the scons command and all ".so" and set to ".so" or ".dylib" depending on platform. For mongodb_log this removes the explicit linking of mongoclient which isn't needed since catkin_libraries includes the lib created by libmongocxx_ros.
* Merge pull request #207 <https://github.com/strands-project/mongodb_store/issues/207> from furushchev/fix-mongocxx
  Use system mongocxx client if possible
* libmongocxx_ros: try to use system mongocxx lib if possible
* Contributors: Nick Hawes, Yuki Furuta
```

## mongodb_log

```
* Merge pull request #210 <https://github.com/strands-project/mongodb_store/issues/210> from hawesie/kinetic-devel
  Updated to build on OS X with the mongo client legacy version.
* Used the openssl libs from find_package.
* Updated to build on OS X with the mongo client legacy version.
  This makes a couple of changes. For libmongocxx_ros the paths for openssl are added to the scons command and all ".so" and set to ".so" or ".dylib" depending on platform. For mongodb_log this removes the explicit linking of mongoclient which isn't needed since catkin_libraries includes the lib created by libmongocxx_ros.
* Contributors: Nick Hawes
```

## mongodb_store

```
* Merge pull request #207 <https://github.com/strands-project/mongodb_store/issues/207> from furushchev/fix-mongocxx
  Use system mongocxx client if possible
* Merge pull request #205 <https://github.com/strands-project/mongodb_store/issues/205> from furushchev/pymongo3
  Support Pymongo 3
* libmongocxx_ros: try to use system mongocxx lib if possible
* Merge pull request #206 <https://github.com/strands-project/mongodb_store/issues/206> from Pikrass/update-rosparam
  Store the updated value to rosparam when calling set_param
* Store the updated value to rosparam when calling set_param
* mongodb_store.util: use rospy.log functions instead of print
* config_manager.py: fix error on exit
* support pymongo 3.X
* Contributors: Bastien Scher, Nick Hawes, Yuki Furuta
```

## mongodb_store_msgs

- No changes
