### PR TITLE
rtt_ros_control: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8895,6 +8895,24 @@ repositories:
       url: https://github.com/orocos/rtt_geometry.git
       version: toolchain-2.9
     status: maintained
+  rtt_ros_control:
+    doc:
+      type: git
+      url: https://github.com/orocos/rtt_ros_control.git
+      version: master
+    release:
+      packages:
+      - rtt_control_msgs
+      - rtt_controller_manager_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/orocos-gbp/rtt_ros_control-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/orocos/rtt_ros_control.git
+      version: master
+    status: maintained
   rtt_ros_integration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_ros_control` to `0.1.1-0`:

- upstream repository: https://github.com/orocos/rtt_ros_control.git
- release repository: https://github.com/orocos-gbp/rtt_ros_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## rtt_control_msgs

```
* Cleanup typekits and remove unneccessary dependencies
* Merge pull request #1 <https://github.com/orocos/rtt_ros_control/issues/1> from Timple/master
  Package does not depend on controller_manager_msgs
* Contributors: Johannes Meyer, Jonathan Bohren, Tim Clephas
```

## rtt_controller_manager_msgs

```
* Cleanup typekits and remove unneccessary dependencies
* Contributors: Johannes Meyer
```
