### PR TITLE
parameter_pa: 1.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2198,7 +2198,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/peterweissig/ros_parameter-release.git
-      version: 1.1.0-0
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/peterweissig/ros_parameter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `parameter_pa` to `1.2.0-0`:

- upstream repository: https://github.com/peterweissig/ros_parameter.git
- release repository: https://github.com/peterweissig/ros_parameter-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.1.0-0`

## parameter_pa

```
* removed unnecessary headers
* bugfixed include of xmlrpcpp
  (before kinetic those files were not related to a package)
* update README.md
  bugfixed formatting (missing blanc line before table)
* added new features ("./" and "../" within ressource names)
  added visual studio code config files (for ros kinetic)
  updated documentation
* Contributors: Peter Weissig
```
