### PR TITLE
zbar_ros: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16815,7 +16815,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git
-      version: hydro-devel
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -16824,7 +16824,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git
-      version: hydro-devel
+      version: indigo-devel
     status: developed
   zeroconf_avahi_suite:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16820,7 +16820,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/zbar_ros-release.git
-      version: 0.0.5-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zbar_ros` to `0.1.0-0`:

- upstream repository: https://github.com/clearpathrobotics/zbar_ros.git
- release repository: https://github.com/ros-drivers-gbp/zbar_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.0.5-0`

## zbar_ros

```
* Update maintainer
* Merge pull request #4 <https://github.com/ros-drivers/zbar_ros/issues/4> from mikaelarguedas/patch-1
  update to use non deprecated pluginlib macro
* update to use non deprecated pluginlib macro
* Some fixes to work (#2 <https://github.com/ros-drivers/zbar_ros/issues/2>)
  * fix wrong encoding
  * fix memory leak
* Update README.md
* Contributors: Furushchev, Mikael Arguedas, Paul Bovbel
```
