### PR TITLE
zbar_ros: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11156,7 +11156,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/zbar_ros-release.git
-      version: 0.0.5-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11151,7 +11151,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git
-      version: hydro-devel
+      version: indigo-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -11160,7 +11160,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git
-      version: hydro-devel
+      version: indigo-devel
     status: maintained
   zeroconf_avahi_suite:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `zbar_ros` to `0.1.0-0`:

- upstream repository: https://github.com/clearpathrobotics/zbar_ros.git
- release repository: https://github.com/ros-drivers-gbp/zbar_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.0.5-0`

## zbar_ros

```
* Update maintainer
* Merge pull request #4 <https://github.com/ros-drivers/zbar_ros/issues/4> from mikaelarguedas/patch-1
  update to use non deprecated pluginlib macro
* update to use non deprecated pluginlib macro
* Some fixes to work (#2 <https://github.com/ros-drivers/zbar_ros/issues/2>)
  * fix wrong encoding
  * fix memory leak
* Update README.md
* Contributors: Furushchev, Mikael Arguedas, Paul Bovbel
```
