### PR TITLE
zbar_ros: 0.1.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4170,5 +4170,21 @@ repositories:
       url: https://github.com/rohbotics/xv_11_laser_driver.git
       version: kinetic-devel
     status: maintained
+  zbar_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/zbar_ros.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/zbar_ros-release.git
+      version: 0.1.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/zbar_ros.git
+      version: indigo-devel
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `zbar_ros` to `0.1.0-0`:

- upstream repository: https://github.com/clearpathrobotics/zbar_ros.git
- release repository: https://github.com/ros-drivers-gbp/zbar_ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## zbar_ros

```
* Update maintainer
* Merge pull request #4 <https://github.com/ros-drivers/zbar_ros/issues/4> from mikaelarguedas/patch-1
  update to use non deprecated pluginlib macro
* update to use non deprecated pluginlib macro
* Some fixes to work (#2 <https://github.com/ros-drivers/zbar_ros/issues/2>)
  * fix wrong encoding
  * fix memory leak
* Update README.md
* Contributors: Furushchev, Mikael Arguedas, Paul Bovbel
```
