### PR TITLE
 Adding velo2cam_calibration & velo2cam_gazebo to documentation index for ROS Lunar

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7626,6 +7626,16 @@ repositories:
       url: https://github.com/ethz-asl/variant.git
       version: master
     status: developed
+  velo2cam_gazebo:
+    doc:
+      type: git
+      url: https://github.com/beltransen/velo2cam_gazebo.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/beltransen/velo2cam_gazebo.git
+      version: master
+    status: maintained
   velodyne_simulator:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7626,6 +7626,16 @@ repositories:
       url: https://github.com/ethz-asl/variant.git
       version: master
     status: developed
+  velo2cam_calibration:
+    doc:
+      type: git
+      url: https://github.com/beltransen/velo2cam_calibration.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/beltransen/velo2cam_calibration.git
+      version: master
+    status: maintained
   velo2cam_gazebo:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3949,6 +3949,26 @@ repositories:
       url: https://github.com/ros-drivers/usb_cam.git
       version: develop
     status: unmaintained
+  velo2cam_calibration:
+    doc:
+      type: git
+      url: https://github.com/beltransen/velo2cam_calibration.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/beltransen/velo2cam_calibration.git
+      version: master
+    status: maintained
+  velo2cam_gazebo:
+    doc:
+      type: git
+      url: https://github.com/beltransen/velo2cam_gazebo.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/beltransen/velo2cam_gazebo.git
+      version: master
+    status: maintained
   vision_msgs:
     release:
       tags:


### PR DESCRIPTION
I'd like velo2cam_calibration & velo2cam_gazebo to be indexed and documented on ros.org