### PR TITLE
robot_localization: 2.3.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10986,7 +10986,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 2.3.2-0
+      version: 2.3.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `2.3.3-0`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.3.2-0`

## robot_localization

```
* Zero out rotation in GPS to base_link transform
* Fix typo in reading Mahalanobis thresholds.
* Fixing state history reversion
* Some trivial changes to lessen the differences to lunar
* Fixing critical bug with dynamic process noise covariance
* Fixing datum precision
* Contributors: Jacob Seibert, Pavlo Kolomiiets, Tom Moore
```
