### PR TITLE
robot_localization: 2.4.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6960,7 +6960,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 2.4.0-0
+      version: 2.4.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `2.4.1-0`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `2.4.0-0`

## robot_localization

```
* Fixing datum precision
* Fixing state history reversion
* Silencing unnecessary errors and warnings
* Fixing critical bug with dynamic process noise covariance
* Some trivial changes to lessen the differences to lunar
* Fix typo in reading Mahalanobis thresholds.
* Zero out rotation in GPS to base_link transform
* Update xmlrpcpp includes for Indigo support
* Removing lastUpdateTime
* Fixing timestamps in map->odom transform
* Simplify enabledAtStartup logic
* Add std_srvs dependency
* Add enabling service
* Ensure all raw sensor input orientations are normalized even if messages are not
* Install params directory
* Add robot localization estimator
* Contributors: Jacob Perron, Jacob Seibert, Jiri Hubacek, Mike Purvis, Miquel Massot, Pavlo Kolomiiets, Rein Appeldoorn, Rokus Ottervanger, Tom Moore, stevemacenski
```
