### PR TITLE
Adding ifopt to documentation index for indigo, kinetic and lunar

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4781,6 +4781,16 @@ repositories:
       url: https://github.com/pal-gbp/idolink_node-release.git
       version: 0.1.2-0
     status: developed
+  ifopt:
+    doc:
+      type: git
+      url: https://github.com/ethz-adrl/ifopt.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ethz-adrl/ifopt.git
+      version: master
+    status: developed
   ihmc-ros-control:
     release:
       packages:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3103,6 +3103,16 @@ repositories:
       url: https://github.com/ahornung/humanoid_msgs.git
       version: devel
     status: maintained
+  ifopt:
+    doc:
+      type: git
+      url: https://github.com/ethz-adrl/ifopt.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ethz-adrl/ifopt.git
+      version: master
+    status: developed
   image_common:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1069,6 +1069,16 @@ repositories:
       url: https://github.com/ros-drivers/gscam.git
       version: master
     status: unmaintained
+  ifopt:
+    doc:
+      type: git
+      url: https://github.com/ethz-adrl/ifopt.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ethz-adrl/ifopt.git
+      version: master
+    status: developed
   image_common:
     doc:
       type: git


### PR DESCRIPTION
I'd like my repo "ifopt" to be indexed and documented on ros.org. I would also like to use the CI ros buildfarm.