### PR TITLE
m_explore: 2.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4281,7 +4281,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/hrnr/m-explore-release.git
-      version: 2.1.0-0
+      version: 2.1.1-0
     source:
       type: git
       url: https://github.com/hrnr/m-explore.git


### PR DESCRIPTION
Increasing version of package(s) in repository `m_explore` to `2.1.1-0`:

- upstream repository: https://github.com/hrnr/m-explore.git
- release repository: https://github.com/hrnr/m-explore-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `2.1.0-0`

## explore_lite

```
* explore: fix min_frontier_size bug
  * min_frontier_size parameter was not used to at all
  * adjust min_frontier size filtering according to map resolution
* fix bugs in CMakeLists.txt
  * install nodes in packages, so they get shipped in debian packages. fixes #11 <https://github.com/hrnr/m-explore/issues/11>
* explore: update documentation
* Contributors: Jiri Horner
```

## multirobot_map_merge

```
* fix bugs in CMakeLists.txt: install nodes in packages, so they get shipped in debian packages. fixes #11 <https://github.com/hrnr/m-explore/issues/11>
* map_merge: add bibtex to wiki page
* Contributors: Jiri Horner
```
