### PR TITLE
rdl: 0.9.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6863,7 +6863,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.com/jlack/rdl_release.git
-      version: 0.9.4-0
+      version: 0.9.5-0
     source:
       type: git
       url: https://gitlab.com/jlack/rdl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rdl` to `0.9.5-0`:

- upstream repository: https://gitlab.com/jlack/rdl.git
- release repository: https://gitlab.com/jlack/rdl_release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.9.4-0`
