### PR TITLE
remove cartographer until dependencies are sorted out

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -280,7 +280,6 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/cartographer-release.git
-      version: 0.3.0-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
cartographer (v0.3.0) now depends on ceres 1.13 and protobuf 3 that are not available upstream on all targeted platforms