### PR TITLE
pluginlib: 1.10.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9337,7 +9337,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.10.5-0
+      version: 1.10.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.10.6-0`:

- upstream repository: https://github.com/ros/pluginlib
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.10.5-0`

## pluginlib

```
* do not use popen to solve catkin_path. (#49 <https://github.com/ros/pluginlib/issues/49>)
* switch to package format 2 (#55 <https://github.com/ros/pluginlib/issues/55>)
* Merge pull request #54 <https://github.com/ros/pluginlib/issues/54> from ros/trailing_whitespaces
  trailing whitespaces
* Contributors: Dmitry Rozhkov, Koji Terada, Mikael Arguedas
```
