### PR TITLE
bond_core: 1.7.20-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1090,7 +1090,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/bond_core-release.git
-      version: 1.7.19-0
+      version: 1.7.20-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.7.20-0`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.7.19-0`

## bond

```
* fix package.xml to comply with schema (#31 <https://github.com/ros/bond_core/issues/31>)
* switch to package format 2 (#27 <https://github.com/ros/bond_core/issues/27>)
* Contributors: Mikael Arguedas
```

## bond_core

```
* switch to package format 2 (#27 <https://github.com/ros/bond_core/issues/27>)
* Contributors: Mikael Arguedas
```

## bondcpp

```
* fix package.xml to comply with schema (#31 <https://github.com/ros/bond_core/issues/31>)
* C++ style (#28 <https://github.com/ros/bond_core/issues/28>)
* switch to package format 2 (#27 <https://github.com/ros/bond_core/issues/27>)
* remove trailing whitespaces (#26 <https://github.com/ros/bond_core/issues/26>)
* Contributors: Mikael Arguedas
```

## bondpy

```
* fix package.xml to comply with schema (#31 <https://github.com/ros/bond_core/issues/31>)
* switch to package format 2 (#27 <https://github.com/ros/bond_core/issues/27>)
* Closer to pep8 compliance (#25 <https://github.com/ros/bond_core/issues/25>)
* Python3 compatibility (#24 <https://github.com/ros/bond_core/issues/24>)
* Fixes problem with bondpy not exiting with the node (#21 <https://github.com/ros/bond_core/issues/21>)
  make timer threads daemon threads
* Contributors: Aaron Miller, Mikael Arguedas
```

## smclib

```
* fix package.xml to comply with schema (#31 <https://github.com/ros/bond_core/issues/31>)
* C++ style (#28 <https://github.com/ros/bond_core/issues/28>)
* switch to package format 2 (#27 <https://github.com/ros/bond_core/issues/27>)
* remove trailing whitespaces (#26 <https://github.com/ros/bond_core/issues/26>)
* Closer to pep8 compliance (#25 <https://github.com/ros/bond_core/issues/25>)
* Contributors: Mikael Arguedas
```
