### PR TITLE
nodelet_core: 1.9.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8104,7 +8104,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.9.10-0
+      version: 1.9.14-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.14-0`:

- upstream repository: git://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.9.10-0`

## nodelet

```
* declared_nodelets: continue on missing plugin xml (#70 <https://github.com/ros/nodelet_core/issues/70>)
* Contributors: Furushchev
```

## nodelet_core

- No changes

## nodelet_topic_tools

- No changes
