### PR TITLE
actionlib: 1.11.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -113,7 +113,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.11.9-0
+      version: 1.11.12-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.11.12-0`:

- upstream repository: git@github.com:ros/actionlib.git
- release repository: https://github.com/ros-gbp/actionlib-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.11.9-0`

## actionlib

```
* fix uncrustify mixup (#92 <https://github.com/ros/actionlib/issues/92>)
* Contributors: Mikael Arguedas
```
