### PR TITLE
marti_common: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4429,7 +4429,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 1.2.0-0
+      version: 2.0.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.0.0-0`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.2.0-0`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_geometry_util

- No changes

## swri_image_util

```
* Add nodelet for drawing a polygon on an image. (#500 <https://github.com/swri-robotics/marti_common/issues/500>)
* update to use non deprecated pluginlib macro (#493 <https://github.com/swri-robotics/marti_common/issues/493>)
* Implement simple image file publisher. (#488 <https://github.com/swri-robotics/marti_common/issues/488>)
* Contributors: Marc Alban, Mikael Arguedas
```

## swri_math_util

- No changes

## swri_nodelet

- No changes

## swri_opencv_util

```
* Link in the "highgui" module for swri_opencv_util (#506 <https://github.com/swri-robotics/marti_common/issues/506>)
* Contributors: P. J. Reed
```

## swri_prefix_tools

- No changes

## swri_roscpp

```
* Ensure all swri::Subscriber members are initialized (#505 <https://github.com/swri-robotics/marti_common/issues/505>)
* Contributors: P. J. Reed
```

## swri_rospy

- No changes

## swri_route_util

```
* Accept '1' or 'true' for stop points. (#489 <https://github.com/swri-robotics/marti_common/issues/489>)
* Contributors: Marc Alban
```

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* expose TransformManager::LocalXyUtil() and LocalXyWgs84Util::ResetInitialization() (#501 <https://github.com/swri-robotics/marti_common/issues/501>)
* Complete rewrite of initialize_origin.py (#491 <https://github.com/swri-robotics/marti_common/issues/491>)
* Normalize TF frames before comparisons. (#492 <https://github.com/swri-robotics/marti_common/issues/492>)
* Add new methods that expose the frame timeout. (#498 <https://github.com/swri-robotics/marti_common/issues/498>)
* Use pkgconfig to include libproj in swri_transform_util
* Contributors: Davide Faconti, Edward Venator, P. J. Reed
```

## swri_yaml_util

- No changes
