### PR TITLE
Adding my_repo_name to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14,7 +14,7 @@ repositories:
   abb:
     doc:
       type: git
-      url: https://github.com/ros-industrial/abb.git
+      url: https://github.com/mikelu-shanghai/rosdistro.git
       version: kinetic-devel
     release:
       packages:


### PR DESCRIPTION
I'd like my _repo to be indexed and documented on ros.org
THANK YOU VERY MUCH!