### PR TITLE
handeye: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2831,6 +2831,21 @@ repositories:
       url: https://github.com/davidfischinger/haf_grasping.git
       version: kinetic
     status: maintained
+  handeye:
+    doc:
+      type: git
+      url: https://github.com/crigroup/handeye.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/crigroup/handeye-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/crigroup/handeye.git
+      version: master
+    status: developed
   hebiros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `handeye` to `0.1.0-0`:

- upstream repository: https://github.com/crigroup/handeye.git
- release repository: https://github.com/crigroup/handeye-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## handeye

```
* Initial release
* Contributors: Francisco, fsuarez6
```
