### PR TITLE
tork_moveit_tutorial: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15192,6 +15192,21 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/topic_proxy-release.git
       version: 0.1.1-0
     status: maintained
+  tork_moveit_tutorial:
+    doc:
+      type: git
+      url: https://github.com/tork-a/tork_moveit_tutorial.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/tork_moveit_tutorial-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/tork-a/tork_moveit_tutorial.git
+      version: indigo-devel
+    status: maintained
   tork_rpc:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tork_moveit_tutorial` to `0.0.3-0`:

- upstream repository: https://github.com/tork-a/tork_moveit_tutorial.git
- release repository: https://github.com/tork-a/tork_moveit_tutorial-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## tork_moveit_tutorial

```
* Fix python src path (#5 <https://github.com/tork-a/tork_moveit_tutorial/issues/5>)
  * disable virtualenv
  * forget to add setup.py
  * change moveit-tutorial_ja_robot-python_basic.md due to moving demo program in moveit_tutorial_tools.py into script/demo.py
  * move demo program in moveit_tutorial_tools.py into script/demo.py
  * fix doc due to python file format
  * mv script/moveit_tutorial_tools.py to src/tork_moveit_tutorial/
  * clean up files, and add install rule
  * add more depends
* Contributors: Tokyo Opensource Robotics Developer 534
```
