### PR TITLE
parameter_pa: 1.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8912,7 +8912,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/peterweissig/ros_parameter-release.git
-      version: 1.2.0-0
+      version: 1.2.1-0
     source:
       type: git
       url: https://github.com/peterweissig/ros_parameter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `parameter_pa` to `1.2.1-0`:

- upstream repository: https://github.com/peterweissig/ros_parameter.git
- release repository: https://github.com/peterweissig/ros_parameter-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.2.0-0`

## parameter_pa

```
* bugfixed loadTopic (loaded topic was not resolved)
* bugfixed documentation (some typos)
* Contributors: Peter Weissig
```
