### PR TITLE
rviz: 1.12.14-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8990,7 +8990,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.12.13-0
+      version: 1.12.14-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.12.14-0`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.12.13-0`

## rviz

```
* Added global option to disable default light (#1146 <https://github.com/ros-visualization/rviz/issues/1146>)
* Added more checks for invalid quaternion normalization before displaying (#1167 <https://github.com/ros-visualization/rviz/issues/1167>)
* Added MONO8 transformer for point cloud plugin (#1145 <https://github.com/ros-visualization/rviz/issues/1145>)
* Fixed crash when unchecking options of "triangle list" markers #1163 <https://github.com/ros-visualization/rviz/issues/1163> (#1164 <https://github.com/ros-visualization/rviz/issues/1164>)
* Added CMake definition to prevent collision of "check" macro on OS X (#1165 <https://github.com/ros-visualization/rviz/issues/1165>)
* Added copyright notice for icons and graphics (#1155 <https://github.com/ros-visualization/rviz/issues/1155>)
* Contributors: David Gossow, Kentaro Wada, Lucas Walter, Mike Purvis, Stefan Fabian, Terry Welsh
```
