### PR TITLE
navigation: 1.12.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7924,7 +7924,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.12.13-0
+      version: 1.12.14-0
     source:
       test_commits: false
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.12.14-0`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.12.13-0`

## amcl

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* fix order of parameters (closes #553 <https://github.com/ros-planning/navigation/issues/553>)
* Contributors: Martin Günther, Michael Ferguson
```

## base_local_planner

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* Contributors: Lukas Bulwahn, Martin Günther
```

## carrot_planner

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Martin Günther
```

## clear_costmap_recovery

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Martin Günther
```

## costmap_2d

```
* don't update costs if inflation radius is zero
* Speedup (~60%) inflation layer update (#525 <https://github.com/ros-planning/navigation/issues/525>)
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Jorge Santos Simón, Martin Günther, Michael Ferguson
```

## dwa_local_planner

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Martin Günther
```

## fake_localization

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Martin Günther
```

## global_planner

```
* Update gradient_path.cpp (#576 <https://github.com/ros-planning/navigation/issues/576>)
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Martin Günther, junyu LIANG
```

## map_server

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Set default name for uncomplete path (#543 <https://github.com/ros-planning/navigation/issues/543>)
* Contributors: Jntzko, Martin Günther
```

## move_base

```
* Only do a getRobotPose when no start pose is given (#628 <https://github.com/ros-planning/navigation/issues/628>)
* Merge pull request #524 <https://github.com/ros-planning/navigation/issues/524> from corot/call_less_the_planner
  Fix for #523 <https://github.com/ros-planning/navigation/issues/523>: global planner called much more times than expected
* Merge pull request #501 <https://github.com/ros-planning/navigation/issues/501> from selvasamuel/indigo-devel
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Fix: global planner called much more times than max_planning_retries or time allowed by planner_patiente
* Fixed deadlock when changing global planner
* Contributors: Jorge Santos Simón, Martin Günther, Michael Ferguson, ne0
```

## move_base_msgs

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Martin Günther
```

## move_slow_and_clear

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* address gcc6 build error
* Contributors: Lukas Bulwahn, Martin Günther
```

## nav_core

- No changes

## navfn

```
* Update gradient_path.cpp (#576 <https://github.com/ros-planning/navigation/issues/576>)
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* make #549 <https://github.com/ros-planning/navigation/issues/549> alphabetical order
* added message generation and runtime to navfn package.xml (#549 <https://github.com/ros-planning/navigation/issues/549>)
* address gcc6 build error
* Contributors: Lukas Bulwahn, Malcolm Mielle, Martin Günther, Michael Ferguson, junyu LIANG
```

## navigation

- No changes

## robot_pose_ekf

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Martin Günther
```

## rotate_recovery

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Martin Günther
```

## voxel_grid

```
* Fix CMakeLists + package.xmls (#548 <https://github.com/ros-planning/navigation/issues/548>)
* Contributors: Martin Günther
```
