### PR TITLE
realsense_camera: 1.8.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6893,7 +6893,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/intel-ros/realsense-release.git
-      version: 1.8.0-0
+      version: 1.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_camera` to `1.8.1-1`:

- upstream repository: https://github.com/intel-ros/realsense.git
- release repository: https://github.com/intel-ros/realsense-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.8.0-0`

## realsense_camera

```
* Added missing ZR300 launch file arguments (#259)
* Fixed ZR300 launch file typo (#244)
* Added LR200 support (#245)
* Added RGDB launch file for the ZR300
* Updated code to cache ZR300 IMU data (#186)
* Contributors: Benjamin Maidel, Dinesh Bolkensteyn, Itay Carpis, Junya Hayashi, Matt Curfman, Murilo Belluzzo, Reagan Lopez, Sergey Dorodnicov
```
