### PR TITLE
sick_tim: 0.0.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9185,7 +9185,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/sick_tim-release.git
-      version: 0.0.10-0
+      version: 0.0.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_tim` to `0.0.11-0`:

- upstream repository: https://github.com/uos/sick_tim
- release repository: https://github.com/uos-gbp/sick_tim-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.0.10-0`

## sick_tim

```
* Make output REP-117 compliant (#54 <https://github.com/uos/sick_tim/issues/54>)
  The laser scan topic now encodes invalid measurements as +inf instead of 0.
  This makes costmap2d treat all invalid measurements as out of range
  measurements and correctly clearing obstacles even when there is no valid
  measurement behind.  This can lead to some obstacles being incorrectly
  cleared (when the "0" returne by the SICK TiM actually means "invalid
  measurement" or "too close to measure" instead of "out of range"), but this
  happens much less frequently in practice than the problem of non-cleared
  obstacles.
* .travis.yml: Add fix for travis-ci/travis-ci#8048 <https://github.com/travis-ci/travis-ci/issues/8048>
* Contributors: Martin Günther
```
