### PR TITLE
trac_ik: 1.4.7-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -7410,7 +7410,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/traclabs/trac_ik-release.git
-      version: 1.4.5-0
+      version: 1.4.7-0
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `trac_ik` to `1.4.7-0`:

- upstream repository: https://bitbucket.org/traclabs/trac_ik.git
- release repository: https://github.com/traclabs/trac_ik-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.4.5-0`

## trac_ik

```
* Fixed bug introduced in 1.4.6 where threaded function call should be returning a bool but was not returning anything
```
