### PR TITLE
restore libgazebo7-dev to jessie.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1666,6 +1666,7 @@ libgazebo7-dev:
   arch: [gazebo]
   debian:
     buster: [libgazebo7-dev]
+    jessie: [libgazebo7-dev]
     stretch: [libgazebo7-dev]
   fedora:
     '25': [gazebo-devel]


### PR DESCRIPTION
It's backported in the ROS repositories for Kinetic support

@j-rivero FYI

Regression from: https://github.com/ros/rosdistro/pull/15349 which means the latest gazebo_ros_pkgs was missing jessie targets. https://github.com/ros/rosdistro/pull/16569