### PR TITLE
gazebo_ros_pkgs: 2.5.14-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2400,7 +2400,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.5.14-0
+      version: 2.5.14-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.5.14-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `2.5.14-0`

## gazebo_dev

- No changes

## gazebo_msgs

- No changes

## gazebo_plugins

```
* for gazebo8+, call functions without Get (#639 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/639>)
* Fix gazebo8 warnings part 4: convert remaining local variables in plugins to ign-math (#633 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/633>)
* Fix gazebo8 warnings part 3: more ign-math in plugins (#631 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/631>)
* Fix gazebo8 warnings part 2: replace private member gazebo::math types with ignition (#628 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/628>)
* Replace Events::Disconnect* with pointer reset (#623 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/623>)
* Merge pull request #542 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/542> from davetcoleman/kinetic-gazebo7-only
  Remove compiler directive flags for < GAZEBO 7
* Contributors: Dave Coleman, Steven Peters
```

## gazebo_ros

```
* for gazebo8+, call functions without Get (#639 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/639>)
* Fix gazebo8 warnings part 5: ignition math in gazebo_ros (#635 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/635>)
* Fix gazebo8 warnings part 4: convert remaining local variables in plugins to ign-math (#633 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/633>)
* gazebo_ros: fix support for python3 (#622 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/622>)
* gazebo_ros_api_plugin: improve plugin xml parsing (#625 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/625>)
* Replace Events::Disconnect* with pointer reset (#623 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/623>)
* Install spawn_model using catkin_install_python (#621 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/621>)
* [gazebo_ros] don't overwrite parameter "use_sim_time" (#606 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/606>)
  * Parameter /use_sim_time is only set if not present on Parameter Server
* Contributors: Jose Luis Rivero, Manuel Ilg, Mike Purvis, Nils Rokita, Steven Peters
```

## gazebo_ros_control

```
* Replace Events::Disconnect* with pointer reset (#623 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/623>)
* Contributors: Steven Peters
```

## gazebo_ros_pkgs

- No changes
