### PR TITLE
Rolling robot_localization back to 2.4.0

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6985,7 +6985,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 2.4.1-3
+      version: 2.4.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Bloom PR generation failed