### PR TITLE
rtmros_common: 1.4.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13327,7 +13327,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_common-release.git
-      version: 1.4.1-0
+      version: 1.4.2-0
     source:
       type: git
       url: https://github.com/start-jsk/rtmros_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_common` to `1.4.2-0`:

- upstream repository: https://github.com/start-jsk/rtmros_common.git
- release repository: https://github.com/tork-a/rtmros_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.4.1-0`

## hrpsys_ros_bridge

```
* add test to check #1036 <https://github.com/start-jsk/rtmros_common/issues/1036> situation (#1038 <https://github.com/start-jsk/rtmros_common/issues/1038>)
* duration == 0.0 results unexpected behavior, so force set 0.001 when duration == 0 s set (#1037 <https://github.com/start-jsk/rtmros_common/issues/1037> )
* Contributors: Kei Okada
```

## hrpsys_tools

- No changes

## openrtm_ros_bridge

- No changes

## openrtm_tools

- No changes

## rosnode_rtc

- No changes

## rtmbuild

- No changes

## rtmros_common

- No changes
