### PR TITLE
rtmros_nextage: 0.8.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13391,7 +13391,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.7.16-0
+      version: 0.8.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.8.3-0`:

- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.7.16-0`

## nextage_calibration

- No changes

## nextage_description

- No changes

## nextage_gazebo

```
* add model cafe_tabel and mod ar_headcamera.launch to spawn gazebo models in the case of sim:=true (#354 <https://github.com/tork-a/rtmros_nextage/issues/354>)
* Contributors: Yosuke Yamamoto
```

## nextage_ik_plugin

- No changes

## nextage_moveit_config

- No changes

## nextage_ros_bridge

```
* add USE_HAND_JOINT_STATE_PUBLISHER argment, normal nextage does not need this (#355 <https://github.com/tork-a/rtmros_nextage/issues/355>)
* add model cafe_tabel and mod ar_headcamera.launch to spawn gazebo models in the case of sim:=true (#354 <https://github.com/tork-a/rtmros_nextage/issues/354>)
* Contributors: Kei Okada, Yosuke Yamamoto
```

## rtmros_nextage

- No changes
