### PR TITLE
rtmros_nextage: 0.8.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8866,7 +8866,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.8.2-0
+      version: 0.8.3-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.8.3-0`:

- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.8.2-0`

## nextage_calibration

- No changes

## nextage_description

- No changes

## nextage_gazebo

```
* add model cafe_tabel and mod ar_headcamera.launch to spawn gazebo models in the case of sim:=true (#354 <https://github.com/tork-a/rtmros_nextage/issues/354>)
* Contributors: Yosuke Yamamoto
```

## nextage_ik_plugin

- No changes

## nextage_moveit_config

- No changes

## nextage_ros_bridge

```
* add USE_HAND_JOINT_STATE_PUBLISHER argment, normal nextage does not need this (#355 <https://github.com/tork-a/rtmros_nextage/issues/355>)
* add model cafe_tabel and mod ar_headcamera.launch to spawn gazebo models in the case of sim:=true (#354 <https://github.com/tork-a/rtmros_nextage/issues/354>)
* Contributors: Kei Okada, Yosuke Yamamoto
```

## rtmros_nextage

- No changes
