### PR TITLE
Add python3-dev definition for gentoo.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4022,6 +4022,7 @@ python3-babeltrace:
     xenial: [python3-babeltrace]
 python3-dev:
   debian: [python3-dev]
+  gentoo: ['=dev-lang/python-3*']
   ubuntu: [python3-dev]
 python3-empy:
   debian:


### PR DESCRIPTION
Needed to create installer for  catkin_virtualenv.