### PR TITLE
ros_control: 0.13.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2740,7 +2740,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.12.0-0
+      version: 0.13.0-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.13.0-0`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.12.0-0`

## combined_robot_hw

- No changes

## combined_robot_hw_tests

- No changes

## controller_interface

- No changes

## controller_manager

```
* Several spawner-related fixes:
* Remove shutdown_timeout & add deprecation note
* Remove roslib import
* Run wait_for_service on object instead of the hardcoded string version
* Remove wait_for_service and rephrase warning after exception
* Remove sleep(1) as it causes more problems than what it solves
* Contributors: Bence Magyar
```

## controller_manager_msgs

- No changes

## controller_manager_tests

```
* Drop includes from CMake library build.
* Contributors: Mike Purvis
```

## hardware_interface

```
* move CheckIsResourceManager into internal namespace
* remove unused CheckIsResourceManager::value
* do not require default constructors for HardwareInterface classes
  ResourceManager-based interfaces still need a default constructor.
* get rid of warnings for functions returning no values
* test for HW interface without default constructor
* fix constness in ImuSensorHandle
* fix constness in ForceTorqueSensorHandle
* Contributors: Mathias Lüdtke
```

## joint_limits_interface

```
* Add method to populate SoftJointLimits from ROS parameter server. (#292 <https://github.com/ros-controls/ros_control/issues/292>)
* Contributors: Miguel Prada
```

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
