### PR TITLE
ros_controllers: 0.13.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7657,6 +7657,7 @@ repositories:
       - effort_controllers
       - force_torque_sensor_controller
       - forward_command_controller
+      - four_wheel_steering_controller
       - gripper_action_controller
       - imu_sensor_controller
       - joint_state_controller
@@ -7668,7 +7669,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.13.1-0
+      version: 0.13.2-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.13.2-0`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.13.1-0`

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_controller

- No changes

## forward_command_controller

- No changes

## four_wheel_steering_controller

```
* Add four_wheel_steering_controller
* Contributors: Vincent Rousseau
```

## gripper_action_controller

- No changes

## imu_sensor_controller

- No changes

## joint_state_controller

- No changes

## joint_trajectory_controller

```
* Changend the implementation of joint_trajectory_controller to enable the forwarding of the acceleration values from the trajectory
* Contributors: Bence Magyar, Mart Moerdijk
```

## position_controllers

- No changes

## ros_controllers

- No changes

## rqt_joint_trajectory_controller

- No changes

## velocity_controllers

- No changes
