### PR TITLE
magni_robot: 0.2.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4318,7 +4318,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/magni_robot-release.git
-      version: 0.2.1-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/magni_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `magni_robot` to `0.2.4-0`:

- upstream repository: https://github.com/UbiquityRobotics/magni_robot.git
- release repository: https://github.com/UbiquityRobotics-release/magni_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.2.1-0`

## magni_bringup

```
* remove unneeded CMake requires
* Contributors: Rohan Agrawal
```

## magni_demos

- No changes

## magni_description

```
* remove unneeded CMake requires
* Contributors: Rohan Agrawal
```

## magni_nav

- No changes

## magni_robot

- No changes

## magni_teleop

- No changes
