### PR TITLE
rtmros_nextage: 0.7.16-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13391,7 +13391,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.7.16-0
+      version: 0.7.16-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.7.16-2`:

- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.7.16-0`

## nextage_calibration

```
* [fix] error "libgazebo_ros_openni_kinect.so: cannot open shared object file" #324 <https://github.com/tork-a/rtmros_nextage/pull/324>
* [maintenance] Add simple testcases.
* Contributors: Kei Okada, Yamamoto Yosuke, Isaac I.Y. Saito
```

## nextage_description

- No changes

## nextage_gazebo

```
* [enhance] nextage_gazebo/launch/nextage_gazebo_control.launch : add --shutdown-timeout
* [enhance] nextage_gazebo/test/gz.test: add retry=2
* Contributors: Isaac I.Y. Saito, Kei Okada
```

## nextage_ik_plugin

- No changes

## nextage_moveit_config

- No changes

## nextage_ros_bridge

```
* [fix] Temporary revert getRTCList calling from the parent class, HIRONX #317 <https://github.com/tork-a/rtmros_nextage/pull/317>
* [enhance][ros_bridge] Improve error message when no running ROS found. #309 <https://github.com/tork-a/rtmros_nextage/pull/309>
* Contributors: Isaac I.Y. Saito
```

## rtmros_nextage

```
* [fix][nextage_ros_bridge] Temporary revert getRTCList calling from the parent class, HIRONX #317 <https://github.com/tork-a/rtmros_nextage/pull/317>
* [enhance][nextage_ros_bridge] Improve error message when no running ROS found. #309 <https://github.com/tork-a/rtmros_nextage/pull/309>
* [fix][nextage_calibration] error "libgazebo_ros_openni_kinect.so: cannot open shared object file" #324 <https://github.com/tork-a/rtmros_nextage/pull/324>
* [maintenance][nextage_calibration] Add simple testcases.
* Contributors: Kei Okada, Yamamoto Yosuke, Isaac I.Y. Saito
```
