### PR TITLE
moveit: 0.7.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7205,7 +7205,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.7.12-0
+      version: 0.7.13-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.7.13-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.7.12-0`

## moveit

```
* [fix][moveit_ros_planning] Avoid segfault when validating a multidof-only trajectory (#691 <https://github.com/ros-planning/moveit/issues/691>). Fixes #539 <https://github.com/ros-planning/moveit/issues/539>
* [fix][moveit_ros_planning] find and link against tinyxml where needed (#569 <https://github.com/ros-planning/moveit/issues/569>)
* [fix][moveit_ros_visualization] don't crash on empty robot_description in RobotState plugin #688 <https://github.com/ros-planning/moveit/issues/688>
* [fix][moveit_ros_visualization] RobotState rviz previewer: First message from e.g. latching publishers is not applied to robot state correctly (#596 <https://github.com/ros-planning/moveit/issues/596>)
* [fix][moveit_ros_planning_interface] MoveGroupInterface: Fixed computeCartesianPath to use selected end-effector. (#580 <https://github.com/ros-planning/moveit/issues/580>)
* [fix][moveit_ros_move_group] always return true in MoveGroupPlanService callback #674 <https://github.com/ros-planning/moveit/pull/674>
* [fix][moveit_setup_assistant] add moveit_fake_controller_manager to run_depend of moveit_config_pkg_template/package.xml.template (#613 <https://github.com/ros-planning/moveit/issues/613>)
* [fix][moveit_setup_assistant] find and link against tinyxml where needed (#569 <https://github.com/ros-planning/moveit/issues/569>)
* [fix][moveit_kinematics] create_ikfast_moveit_plugin: fixed directory variable for templates that were moved to ikfast_kinematics_plugin #620 <https://github.com/ros-planning/moveit/issues/620>
* [fix][moveit_experimental] remove explicit fcl depends #632 <https://github.com/ros-planning/moveit/pull/632>
* [fix][moveit_core] Add missing logWarn argument (#707 <https://github.com/ros-planning/moveit/issues/707>)
* [fix][moveit_core] IKConstraintSampler: Fixed transform from end-effector to ik chain tip. #582 <https://github.com/ros-planning/moveit/issues/582>
* [fix][moveit_core] robotStateMsgToRobotState: is_diff==true => not empty #589 <https://github.com/ros-planning/moveit/issues/589>
* [fix][moveit_commander] Bugs in moveit_commander/robot.py (#621 <https://github.com/ros-planning/moveit/issues/621>)
* [fix][moveit_commander] pyassimp regression workaround  (#581 <https://github.com/ros-planning/moveit/issues/581>)
* [capability][moveit_ros_planning] Multi DOF Trajectory only providing translation not velocity (#555 <https://github.com/ros-planning/moveit/issues/555>)
* [capability] Multi DOF Trajectory only providing translation not velocity (#555 <https://github.com/ros-planning/moveit/issues/555>)
* [capability] Adds parameter lookup function for kinematics plugins (#701 <https://github.com/ros-planning/moveit/issues/701>)
* [improve][moveit_ros_planning_interface] Disabled copy constructors and added a move constructor to MoveGroupInterface (#664 <https://github.com/ros-planning/moveit/issues/664>)
* [improve][moveit_ros_perception] removed deprecated pluginlib macro (#677 <https://github.com/ros-planning/moveit/issues/677>)
* [improve][moveit_ros_move_group] adding swp's to gitignore and removing redundant capabilites from capability_names.h (#704 <https://github.com/ros-planning/moveit/issues/704>)
* [improve][moveit_kinematics] IKFastTemplate: Expand solutions to full joint range in searchPositionIK #598 <https://github.com/ros-planning/moveit/issues/598>
* [improve][moveit_kinematics] IKFastTemplate: searchPositionIK now returns collision-free solution which is nearest to seed state. (#585 <https://github.com/ros-planning/moveit/issues/585>)
* [improve][moveit_core] Make operator bool() explicit #696 <https://github.com/ros-planning/moveit/pull/696>
* [improve][moveit_core] Get msgs from Planning Scene #663 <https://github.com/ros-planning/moveit/issues/663>
* [improve][moveit_core] moveit_core: export DEPENDS on LIBFCL `#632 https://github.com/ros-planning/moveit/pull/632>`_
* [improve][moveit_core] RobotState: Changed multi-waypoint version of computeCartesianPath to test joint space jumps after all waypoints are generated. (#576 <https://github.com/ros-planning/moveit/issues/576>)
* [improve][moveit_core] Better debug output for IK tip frames (#603 <https://github.com/ros-planning/moveit/issues/603>)
* [improve][moveit_core] New debug console colors YELLOW PURPLE (#604 <https://github.com/ros-planning/moveit/issues/604>)
* [doc][moveit_ros_visualization] Document auto scale in Rviz plugin (#602 <https://github.com/ros-planning/moveit/issues/602>)
* Contributors: axelschroth, 2scholz, Bence Magyar, Bruno Brito, Dave Coleman, Dennis Hartmann, fsuarez6, G.A. vd. Hoorn, Henning Kayser, Isaac I.Y. Saito, Jonathan Meyer, Jorge Nicho, Kei Okada, Konstantin Selyunin, Michael Goerner, Mikael Arguedas, Mike Lautman, Phil, Shingo Kitagawa, Simon Schmeisser, Simon Schmeisser, Sarah Elliott, Shingo Kitagawa, Troy Cordie, William Woodall
```

## moveit_commander

```
* [fix] Bugs in moveit_commander/robot.py (#621 <https://github.com/ros-planning/moveit/issues/621>)
* [fix] pyassimp regression workaround  (#581 <https://github.com/ros-planning/moveit/issues/581>)
* Contributors: Kei Okada, Konstantin Selyunin
```

## moveit_controller_manager_example

- No changes

## moveit_core

```
* [fix] Add missing logWarn argument (#707 <https://github.com/ros-planning/moveit/issues/707>)
* [fix] IKConstraintSampler: Fixed transform from end-effector to ik chain tip. #582 <https://github.com/ros-planning/moveit/issues/582>
* [fix] robotStateMsgToRobotState: is_diff==true => not empty #589 <https://github.com/ros-planning/moveit/issues/589>
* [capability] Multi DOF Trajectory only providing translation not velocity (#555 <https://github.com/ros-planning/moveit/issues/555>)
* [capability] Adds parameter lookup function for kinematics plugins (#701 <https://github.com/ros-planning/moveit/issues/701>)
* [improve] Make operator bool() explicit #696 <https://github.com/ros-planning/moveit/pull/696>
* [improve] Get msgs from Planning Scene #663 <https://github.com/ros-planning/moveit/issues/663>
* [improve] moveit_core: export DEPENDS on LIBFCL `#632 https://github.com/ros-planning/moveit/pull/632>`_
* [improve] RobotState: Changed multi-waypoint version of computeCartesianPath to test joint space jumps after all waypoints are generated. (#576 <https://github.com/ros-planning/moveit/issues/576>)
* [improve] Better debug output for IK tip frames (#603 <https://github.com/ros-planning/moveit/issues/603>)
* [improve] New debug console colors YELLOW PURPLE (#604 <https://github.com/ros-planning/moveit/issues/604>)
* Contributors: Dave Coleman, Dennis Hartmann, Henning Kayser, Isaac I.Y. Saito, Jorge Nicho, Michael Görner, Phil, Sarah Elliott, Simon Schmeisser, TroyCordie, v4hn
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

```
* [fix] create_ikfast_moveit_plugin: fixed directory variable for templates that were moved to ikfast_kinematics_plugin #620 <https://github.com/ros-planning/moveit/issues/620>
* [improve] IKFastTemplate: Expand solutions to full joint range in searchPositionIK #598 <https://github.com/ros-planning/moveit/issues/598>
* [improve] IKFastTemplate: searchPositionIK now returns collision-free solution which is nearest to seed state. (#585 <https://github.com/ros-planning/moveit/issues/585>)
* Contributors: Dennis Hartmann, G.A. vd. Hoorn, Michael Görner, fsuarez6
```

## moveit_planners

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

```
* [fix] always return true in MoveGroupPlanService callback #674 <https://github.com/ros-planning/moveit/pull/674>
* [improve] adding swp's to gitignore and removing redundant capabilites from capability_names.h (#704 <https://github.com/ros-planning/moveit/issues/704>)
* Contributors: Mike Lautman, Shingo Kitagawa
```

## moveit_ros_perception

```
* [improve] removed deprecated pluginlib macro (#677 <https://github.com/ros-planning/moveit/issues/677>)
* Contributors: Mikael Arguedas
```

## moveit_ros_planning

```
* [fix] Avoid segfault when validating a multidof-only trajectory (#691 <https://github.com/ros-planning/moveit/issues/691>). Fixes #539 <https://github.com/ros-planning/moveit/issues/539>
* [fix] find and link against tinyxml where needed (#569 <https://github.com/ros-planning/moveit/issues/569>)
* [capability] Multi DOF Trajectory only providing translation not velocity (#555 <https://github.com/ros-planning/moveit/issues/555>)
* Contributors: Isaac I.Y. Saito, Michael Görner, Mikael Arguedas, Troy Cordie
```

## moveit_ros_planning_interface

```
* [fix] MoveGroupInterface: Fixed computeCartesianPath to use selected end-effector. (#580 <https://github.com/ros-planning/moveit/issues/580>)
* [improve] Disabled copy constructors and added a move constructor to MoveGroupInterface (#664 <https://github.com/ros-planning/moveit/issues/664>)
* Contributors: 2scholz, Dennis Hartmann, Jonathan Meyer, Simon Schmeisser
```

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* [fix] don't crash on empty robot_description in RobotState plugin #688 <https://github.com/ros-planning/moveit/issues/688>
* [fix] RobotState rviz previewer: First message from e.g. latching publishers is not applied to robot state correctly (#596 <https://github.com/ros-planning/moveit/issues/596>)
* [doc] Document auto scale in Rviz plugin (#602 <https://github.com/ros-planning/moveit/issues/602>)
* Contributors: Dave Coleman, Isaac I.Y. Saito, Simon Schmeisser, axelschroth
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_setup_assistant

```
* [fix] add moveit_fake_controller_manager to run_depend of moveit_config_pkg_template/package.xml.template (#613 <https://github.com/ros-planning/moveit/issues/613>)
* [fix] find and link against tinyxml where needed (#569 <https://github.com/ros-planning/moveit/issues/569>)
* Contributors: Kei Okada, Michael Görner, Mikael Arguedas, William Woodall
```

## moveit_simple_controller_manager

```
* [capability][kinetic onward] optionally wait for controllers indefinitely (#695 <https://github.com/ros-planning/moveit/issues/695>)
* Contributors: Bruno Brito, Michael Görner
```
