### PR TITLE
moveit: 0.9.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4782,7 +4782,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.9.10-0
+      version: 0.9.11-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.9.11-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.9.10-0`

## moveit

```
* [fix][moveit_core] #723; attached bodies are not shown in trajectory visualization anymore #724 <https://github.com/ros-planning/moveit/issues/724>
* [fix][moveit_core] Shortcomings in kinematics plugins #714 <https://github.com/ros-planning/moveit/issues/714>
* Contributors: Henning Kayser, Michael Görner, Robert Haschke
```

## moveit_commander

- No changes

## moveit_controller_manager_example

- No changes

## moveit_core

```
* [fix] #723; attached bodies are not shown in trajectory visualization anymore #724 <https://github.com/ros-planning/moveit/issues/724>
* [fix] Shortcomings in kinematics plugins #714 <https://github.com/ros-planning/moveit/issues/714>
* Contributors: Henning Kayser, Michael Görner, Robert Haschke
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

```
* Merge pull request #714 <https://github.com/ros-planning/moveit/issues/714> from henhenhen/kinetic-devel_lookup-param
  Use lookupParam() in kinematics plugins
* Replace param() with lookupParam() in srv_kinematics_plugin
* Replace param() with lookupParam() in lma_kinematics_plugin
* Replace param() with lookupParam() in kdl_kinematics_plugin
* Replace param() with lookupParam() in ikfast_kinematics_plugin
* Remove redundant parameter query
* Contributors: Henning Kayser, Isaac I.Y. Saito
```

## moveit_planners

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

- No changes

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

- No changes

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_setup_assistant

- No changes

## moveit_simple_controller_manager

- No changes
