### PR TITLE
rviz_visual_tools: 3.5.1-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9007,7 +9007,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/davetcoleman/rviz_visual_tools-release.git
-      version: 3.4.1-0
+      version: 3.5.1-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `3.5.1-3`:

- upstream repository: https://github.com/PickNikRobotics/rviz_visual_tools.git
- release repository: https://github.com/davetcoleman/rviz_visual_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `3.4.1-0`

## rviz_visual_tools

```
* Normalize quaternion before storage
* Fix for ambiguous function call to publishAxis
* Add linking to visualization tools library for imarker_simple
* Added arrow pub to take two points
* Document clang-tidy
* catkin lint
* roslint applied
* Clang-format again
* Clang-tidy ALL
* C++11 optimizations
* Fix deprecated calls to convertFromXYZRPY
* Add new convertPoseSafe() function
* New convertFromXYZRPY() function to avoid deprecation warning
* Allow to enable frame locking in the markers/markers arrays
* Update license year
* IMarkerSimple: set name and pose
* New printTransformFull() function
* Removed deprecated warning
* New class for easily using 6dof imarkers
* More options to tf_visual_tools
* Update README.md
* Contributors: Andy McEvoy, Dave Coleman, Fadri Furrer, Victor Lamoine
```
