### PR TITLE
Adding trac_ik to documentation index for lunar

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3873,6 +3873,26 @@ repositories:
       url: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials.git
       version: lunar-devel
     status: developed
+  trac_ik:
+    doc:
+      type: git
+      url: https://bitbucket.org/traclabs/trac_ik.git
+      version: master
+    release:
+      packages:
+      - trac_ik
+      - trac_ik_examples
+      - trac_ik_kinematics_plugin
+      - trac_ik_lib
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/traclabs/trac_ik-release.git
+      version: 1.4.7-0
+    source:
+      type: git
+      url: https://bitbucket.org/traclabs/trac_ik.git
+      version: master
+    status: developed
   unique_identifier:
     doc:
       type: git


### PR DESCRIPTION
I'd like trac_ik to be indexed on ros.org in preparation for a release on lunar